### PR TITLE
feat: Sprint 3 — Customizable Vertical Configuration System (ProductConfig)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ Thumbs.db
 pgdata/
 
 # Claude Code
-.claude/worktrees/
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ frontends/
   wealth/           ← SvelteKit "netz-wealth-os"
 ```
 
-**Database:** PostgreSQL 16 + TimescaleDB + Redis 7. Migrations via Alembic. App uses async asyncpg. Current migration head: `0003_credit_domain` (0004_vertical_configs planned for Sprint 3).
+**Database:** PostgreSQL 16 + TimescaleDB + Redis 7. Migrations via Alembic. App uses async asyncpg. Current migration head: `0004_vertical_configs`.
 
 **Auth:** Clerk JWT v2. `organization_id` from `o.id` claim. RLS via `SET LOCAL app.current_organization_id`. Dev bypass: `X-DEV-ACTOR` header.
 
@@ -93,6 +93,7 @@ Two-layer architecture: universal core (`ai_engine/`) + vertical specializations
 - `vertical_engines/{vertical}/` — domain-specific: analysis logic, prompts, scoring. One directory per asset class.
 - `ProfileLoader` connects `profiles/` YAML config to `vertical_engines/` code via `ConfigService`.
 - **Do not rewrite vertical_engines/credit/ business logic.** Only session injection allowed (caller provides `db: Session`).
+- `quant_engine/` services receive config as parameter (no YAML loading, no `@lru_cache`). Config resolved once at async entry point via `ConfigService.get()`, passed down to sync functions.
 
 ## Data Lake Rules (ADLS Gen2)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,23 +22,29 @@ make down               # docker-compose down
 ```
 backend/
   app/
-    core/           ← auth (Clerk), tenancy (RLS), DB (asyncpg), config, jobs (SSE)
+    core/           ← auth (Clerk), tenancy (RLS), DB (asyncpg), config (ConfigService), jobs (SSE)
     domains/
       credit/       ← analytical modules only (deals, portfolio, documents, reporting, dashboard, dataroom, actions, global_agent)
       wealth/       ← from netz-wealth-os (12 tables, 7 services)
+    services/
+      storage_client.py ← ADLS abstraction (local filesystem when FEATURE_ADLS_ENABLED=false)
     shared/         ← enums, exceptions
   ai_engine/        ← IC memos, extraction, ingestion, validation, prompts, governance
   quant_engine/     ← CVaR, regime, optimizer, scoring, drift, rebalance
+  vertical_engines/ ← per-vertical analysis specializations
+    base/           ← shared interface all verticals implement
+    credit/         ← Private Credit (moved from ai_engine/intelligence/)
+    wealth/         ← Wealth Management DD reports (Sprint 3+)
   worker_app/       ← Azure Functions + CLI workers + knowledge_aggregator + outcome_recorder
-profiles/           ← YAML analysis profiles (private_credit, liquid_funds)
-calibration/        ← YAML quant configs (blocks, limits, scoring)
+profiles/           ← YAML analysis profiles — SEED DATA ONLY (runtime config in PostgreSQL)
+calibration/        ← YAML quant configs — SEED DATA ONLY (runtime config in PostgreSQL)
 packages/ui/        ← @netz/ui (Tailwind tokens, shadcn-svelte, layouts)
 frontends/
   credit/           ← SvelteKit "netz-credit-intelligence"
   wealth/           ← SvelteKit "netz-wealth-os"
 ```
 
-**Database:** PostgreSQL 16 + TimescaleDB + Redis 7. Migrations via Alembic. App uses async asyncpg. Current migration head: `0002_wealth_domain` (0003_credit_domain pending).
+**Database:** PostgreSQL 16 + TimescaleDB + Redis 7. Migrations via Alembic. App uses async asyncpg. Current migration head: `0003_credit_domain` (0004_vertical_configs planned for Sprint 3).
 
 **Auth:** Clerk JWT v2. `organization_id` from `o.id` claim. RLS via `SET LOCAL app.current_organization_id`. Dev bypass: `X-DEV-ACTOR` header.
 
@@ -70,11 +76,23 @@ The engine contains only analytical domains. Operational modules were intentiona
 - **expire_on_commit=False:** Always. Prevents implicit I/O in async context.
 - **lazy="raise":** Set on ALL relationships. Forces explicit `selectinload()`/`joinedload()`.
 - **RLS subselect:** All RLS policies must use `(SELECT current_setting(...))` not bare `current_setting()`. Without subselect, per-row evaluation causes 1000x slowdown.
-- **Global tables:** `macro_data`, `allocation_blocks` have NO `organization_id`, NO RLS. They are shared across all tenants.
+- **Global tables:** `macro_data`, `allocation_blocks`, `vertical_config_defaults` have NO `organization_id`, NO RLS. They are shared across all tenants.
 - **No module-level asyncio primitives:** Create `Semaphore`, `Lock`, `Event` lazily inside async functions. Module-level causes "attached to different event loop" errors.
 - **ORM thread safety:** Extract scalar attributes into frozen dataclasses before crossing any async/thread boundary.
 - **SET LOCAL not SET:** RLS context must use `SET LOCAL` (transaction-scoped). `SET` leaks across pooled connections.
 - **Frontends never cross-import:** `frontends/credit/` and `frontends/wealth/` share only via `@netz/ui` and the backend API.
+- **ConfigService for all config:** Never read `calibration/` or `profiles/` YAML at runtime. Use `ConfigService.get(vertical, config_type, org_id)`. YAML files are seed data only.
+- **Prompts are Netz IP:** Never expose prompt content in client-facing API responses. Use `CLIENT_VISIBLE_TYPES` allowlist in ConfigService. Use `jinja2.SandboxedEnvironment` for all prompt rendering.
+- **StorageClient for all storage:** Never call ADLS SDK directly. Use `StorageClient` abstraction (local filesystem when `FEATURE_ADLS_ENABLED=false`).
+
+## Vertical Engines
+
+Two-layer architecture: universal core (`ai_engine/`) + vertical specializations (`vertical_engines/`).
+
+- `ai_engine/` — domain-agnostic: extraction, chunking, embedding, OCR, governance, validation, PDF. Never modified per vertical.
+- `vertical_engines/{vertical}/` — domain-specific: analysis logic, prompts, scoring. One directory per asset class.
+- `ProfileLoader` connects `profiles/` YAML config to `vertical_engines/` code via `ConfigService`.
+- **Do not rewrite vertical_engines/credit/ business logic.** Only session injection allowed (caller provides `db: Session`).
 
 ## Data Lake Rules (ADLS Gen2)
 
@@ -114,9 +132,15 @@ ADLS_CONNECTION_STRING=
 
 No official Clerk SvelteKit SDK exists. Use community packages: `clerk-sveltekit` (server hooks) + `svelte-clerk` (UI components). These may lag behind Clerk API changes. Fallback: manual JWT verification on server (`clerk_auth.py`) + `svelte-clerk` for UI only.
 
+## Skills
+
+Custom skills live in `.claude/skills/`. Each subfolder contains a `SKILL.md` with frontmatter (`name`, `description`) that describes when to use it. **Do not maintain a hardcoded list here.** To discover available skills, glob `.claude/skills/**/SKILL.md` and read the frontmatter to find the best match for the current task. Invoke via the `Skill` tool or `/skill-name`.
+
 ## Origins
 
-- **Plan:** `docs/plans/2026-03-14-feat-netz-analysis-engine-platform-plan.md`
-- **Brainstorm:** `docs/brainstorms/2026-03-14-analysis-engine-platform-brainstorm.md`
+- **Platform Plan:** `docs/plans/2026-03-14-feat-netz-analysis-engine-platform-plan.md`
+- **Platform Brainstorm:** `docs/brainstorms/2026-03-14-analysis-engine-platform-brainstorm.md`
+- **ProductConfig Plan:** `docs/plans/2026-03-14-feat-customizable-vertical-config-plan.md` (deepened with 7 review agents)
+- **ProductConfig Brainstorm:** `docs/brainstorms/2026-03-14-customizable-vertical-config-brainstorm.md`
 - **Private Credit OS:** `C:\Users\andre\projetos\Netz-Private-Credit-OS` (archived after data migration)
 - **Wealth OS:** `C:\Users\andre\projetos\netz-wealth-os` (archived after migration)

--- a/backend/app/core/config/__init__.py
+++ b/backend/app/core/config/__init__.py
@@ -1,3 +1,6 @@
 from app.core.config.settings import settings
 
 __all__ = ["settings"]
+
+# ConfigService, models, schemas imported where needed — not re-exported here
+# to avoid circular imports with SQLAlchemy engine initialization.

--- a/backend/app/core/config/config_service.py
+++ b/backend/app/core/config/config_service.py
@@ -1,0 +1,208 @@
+"""
+ConfigService — Read-Only Vertical Configuration (Sprint 3)
+============================================================
+
+Resolves configuration for a given vertical + config_type + optional org_id.
+Cascade: in-process TTLCache → DB override (RLS) → DB default → YAML fallback.
+
+Sprint 3: read-only with cachetools.TTLCache (in-process, 60s).
+Sprint 5-6: add Redis L2 cache + pg_notify invalidation + write methods.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import ClassVar
+from uuid import UUID
+
+import yaml
+from cachetools import TTLCache
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config.models import VerticalConfigDefault, VerticalConfigOverride
+from app.core.config.schemas import ConfigEntry
+
+logger = logging.getLogger(__name__)
+
+# In-process cache — not an asyncio primitive, safe at module level.
+# Replaced with Redis L2 in Sprint 5-6 when admin API enables writes.
+_config_cache: TTLCache[str, dict] = TTLCache(maxsize=128, ttl=60)
+
+# Sentinel for admin-only key deletion in deep_merge.
+_DELETE = object()
+
+# YAML fallback directory (emergency only — logged as ERROR).
+_YAML_FALLBACK_DIR = Path(__file__).resolve().parents[3]
+
+# Map (vertical, config_type) → YAML file path relative to project root.
+_YAML_FALLBACK_MAP: dict[tuple[str, str], str] = {
+    ("liquid_funds", "calibration"): "calibration/config/limits.yaml",
+    ("liquid_funds", "portfolio_profiles"): "calibration/config/profiles.yaml",
+    ("liquid_funds", "scoring"): "calibration/config/scoring.yaml",
+    ("liquid_funds", "blocks"): "calibration/config/blocks.yaml",
+    ("private_credit", "chapters"): "profiles/private_credit/profile.yaml",
+    ("private_credit", "calibration"): "calibration/seeds/private_credit/calibration.yaml",
+    ("private_credit", "scoring"): "calibration/seeds/private_credit/scoring.yaml",
+}
+
+
+class ConfigService:
+    """Read-only configuration service for Sprint 3.
+
+    Uses a single DB session (get_db_with_rls) for both defaults and overrides.
+    Defaults table has no RLS, so SET LOCAL has zero effect on it.
+    Overrides table has RLS, so the same session works correctly for both.
+    """
+
+    # IP protection: prompts, chapters, and internal config types never returned
+    # to clients. Chapters expose IC memo structure (analytical methodology IP).
+    CLIENT_VISIBLE_TYPES: ClassVar[frozenset[str]] = frozenset(
+        {"calibration", "scoring", "blocks", "portfolio_profiles"}
+    )
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def get(
+        self,
+        vertical: str,
+        config_type: str,
+        org_id: UUID | None = None,
+    ) -> dict:
+        """Return deep_merge(default, override) for the given config key.
+
+        Cascade: in-process cache → DB override → DB default → YAML fallback.
+        """
+        cache_key = f"config:{vertical}:{config_type}:{org_id or 'default'}"
+
+        cached = _config_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        # Query default
+        default_row = await self._db.execute(
+            select(VerticalConfigDefault.config).where(
+                VerticalConfigDefault.vertical == vertical,
+                VerticalConfigDefault.config_type == config_type,
+            )
+        )
+        default_config = default_row.scalar_one_or_none()
+
+        if default_config is None:
+            # YAML fallback — indicates migration failure or missing seed data
+            default_config = self._yaml_fallback(vertical, config_type)
+            if default_config is None:
+                logger.error(
+                    "No config found for (%s, %s) — neither DB nor YAML fallback",
+                    vertical,
+                    config_type,
+                )
+                return {}
+
+        # Query override if org_id provided
+        override_config = None
+        if org_id is not None:
+            override_row = await self._db.execute(
+                select(VerticalConfigOverride.config).where(
+                    VerticalConfigOverride.vertical == vertical,
+                    VerticalConfigOverride.config_type == config_type,
+                    # Belt-and-suspenders with RLS — explicit org_id filter
+                    VerticalConfigOverride.organization_id == org_id,
+                )
+            )
+            override_config = override_row.scalar_one_or_none()
+
+        if override_config:
+            result = self.deep_merge(default_config, override_config)
+        else:
+            result = default_config
+
+        _config_cache[cache_key] = result
+        return result
+
+    async def list_configs(
+        self,
+        vertical: str,
+        org_id: UUID | None = None,
+        *,
+        is_admin: bool = False,
+    ) -> list[ConfigEntry]:
+        """List all config_types for a vertical, with override status.
+
+        Non-admin callers: filters to CLIENT_VISIBLE_TYPES only (IP protection).
+        """
+        defaults_result = await self._db.execute(
+            select(
+                VerticalConfigDefault.config_type,
+                VerticalConfigDefault.description,
+            ).where(VerticalConfigDefault.vertical == vertical)
+        )
+        defaults = defaults_result.all()
+
+        # Get override status for this org
+        override_types: set[str] = set()
+        if org_id is not None:
+            overrides_result = await self._db.execute(
+                select(VerticalConfigOverride.config_type).where(
+                    VerticalConfigOverride.vertical == vertical,
+                    VerticalConfigOverride.organization_id == org_id,
+                )
+            )
+            override_types = {row[0] for row in overrides_result.all()}
+
+        entries = []
+        for config_type, description in defaults:
+            # IP protection: non-admin callers only see CLIENT_VISIBLE_TYPES
+            if not is_admin and config_type not in self.CLIENT_VISIBLE_TYPES:
+                continue
+            entries.append(
+                ConfigEntry(
+                    vertical=vertical,
+                    config_type=config_type,
+                    has_override=config_type in override_types,
+                    description=description,
+                )
+            )
+
+        return entries
+
+    @staticmethod
+    def deep_merge(base: dict, override: dict) -> dict:
+        """Recursive merge. Override values win on scalar conflicts.
+
+        Dicts are recursively merged. Lists are REPLACED (not appended).
+        _DELETE sentinel removes key (Netz admin only — client API strips None
+        before merge).
+        """
+        result = base.copy()
+        for key, value in override.items():
+            if value is _DELETE:
+                result.pop(key, None)
+            elif isinstance(value, dict) and isinstance(result.get(key), dict):
+                result[key] = ConfigService.deep_merge(result[key], value)
+            else:
+                result[key] = value
+        return result
+
+    @staticmethod
+    def _yaml_fallback(vertical: str, config_type: str) -> dict | None:
+        """Emergency YAML fallback. Logged as ERROR — should never happen after migration."""
+        yaml_path = _YAML_FALLBACK_MAP.get((vertical, config_type))
+        if yaml_path is None:
+            return None
+
+        full_path = _YAML_FALLBACK_DIR / yaml_path
+        if not full_path.exists():
+            return None
+
+        logger.error(
+            "ConfigService falling back to YAML for (%s, %s) at %s "
+            "— config system degraded, check migration 0004",
+            vertical,
+            config_type,
+            full_path,
+        )
+        with open(full_path) as f:
+            return yaml.safe_load(f)

--- a/backend/app/core/config/dependencies.py
+++ b/backend/app/core/config/dependencies.py
@@ -1,0 +1,21 @@
+"""FastAPI dependencies for ConfigService."""
+
+from __future__ import annotations
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config.config_service import ConfigService
+from app.core.tenancy.middleware import get_db_with_rls
+
+
+async def get_config_service(
+    db: AsyncSession = Depends(get_db_with_rls),
+) -> ConfigService:
+    """Inject ConfigService with RLS-aware session.
+
+    Single session for both defaults + overrides queries.
+    Defaults table has no RLS, so SET LOCAL has zero effect on it.
+    No Redis dependency in Sprint 3.
+    """
+    return ConfigService(db=db)

--- a/backend/app/core/config/models.py
+++ b/backend/app/core/config/models.py
@@ -1,0 +1,60 @@
+"""
+SQLAlchemy models for vertical configuration tables.
+
+vertical_config_defaults: Global (no RLS, no organization_id). Netz-managed.
+vertical_config_overrides: Tenant-scoped (RLS on organization_id).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Integer, String, Text, UniqueConstraint, Uuid
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db.base import AuditMetaMixin, Base, IdMixin, OrganizationScopedMixin
+
+
+class VerticalConfigDefault(Base, IdMixin, AuditMetaMixin):
+    """Vertical-level default configuration. No RLS — shared across all tenants.
+
+    Same pattern as macro_data and allocation_blocks.
+    """
+
+    __tablename__ = "vertical_config_defaults"
+    __table_args__ = (
+        UniqueConstraint("vertical", "config_type", name="uq_defaults_vertical_type"),
+    )
+
+    vertical: Mapped[str] = mapped_column(String(50), nullable=False)
+    config_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    guardrails: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+
+
+class VerticalConfigOverride(Base, IdMixin, OrganizationScopedMixin, AuditMetaMixin):
+    """Tenant-specific config override. RLS enforced on organization_id.
+
+    Stores sparse overrides — only changed fields. Deep-merged with default at read time.
+    """
+
+    __tablename__ = "vertical_config_overrides"
+    __table_args__ = (
+        UniqueConstraint(
+            "organization_id",
+            "vertical",
+            "config_type",
+            name="uq_overrides_org_vertical_type",
+        ),
+    )
+
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), nullable=False, index=True
+    )
+    vertical: Mapped[str] = mapped_column(String(50), nullable=False)
+    config_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")

--- a/backend/app/core/config/schemas.py
+++ b/backend/app/core/config/schemas.py
@@ -1,0 +1,16 @@
+"""Pydantic schemas for vertical configuration system (Sprint 3 subset)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ConfigEntry(BaseModel):
+    """Metadata for a single config type within a vertical."""
+
+    vertical: str
+    config_type: str
+    has_override: bool
+    description: str | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/core/db/migrations/versions/0004_vertical_configs.py
+++ b/backend/app/core/db/migrations/versions/0004_vertical_configs.py
@@ -1,0 +1,198 @@
+"""Vertical configuration tables + seed data.
+
+Creates vertical_config_defaults (global, no RLS) and vertical_config_overrides
+(tenant-scoped, with RLS). Seeds from existing YAML files.
+
+Audit table + triggers deferred to Sprint 5-6 (migration 0005).
+"""
+
+import json
+from pathlib import Path
+
+import sqlalchemy as sa
+import yaml
+from alembic import op
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+# ── YAML seed file paths (relative to project root) ─────────────────
+_PROJECT_ROOT = Path(__file__).resolve().parents[5]  # backend/app/core/db/migrations/versions → root
+
+_SEEDS: list[dict] = [
+    {
+        "vertical": "liquid_funds",
+        "config_type": "calibration",
+        "yaml_path": "calibration/config/limits.yaml",
+        "description": "CVaR limits, regime thresholds, drift bands (OFR-calibrated)",
+    },
+    {
+        "vertical": "liquid_funds",
+        "config_type": "portfolio_profiles",
+        "yaml_path": "calibration/config/profiles.yaml",
+        "description": "Model portfolio profiles (Conservative/Moderate/Growth)",
+    },
+    {
+        "vertical": "liquid_funds",
+        "config_type": "scoring",
+        "yaml_path": "calibration/config/scoring.yaml",
+        "description": "Fund scoring weights (return, risk, drawdown, IR, flows, Lipper)",
+    },
+    {
+        "vertical": "liquid_funds",
+        "config_type": "blocks",
+        "yaml_path": "calibration/config/blocks.yaml",
+        "description": "Allocation block catalog (geography x asset class → ETF proxy)",
+    },
+    {
+        "vertical": "private_credit",
+        "config_type": "chapters",
+        "yaml_path": "profiles/private_credit/profile.yaml",
+        "description": "IC memo chapter structure (14 chapters)",
+    },
+    {
+        "vertical": "private_credit",
+        "config_type": "calibration",
+        "yaml_path": "calibration/seeds/private_credit/calibration.yaml",
+        "description": "Credit calibration defaults (Moody's, S&P, Basel III sources)",
+    },
+    {
+        "vertical": "private_credit",
+        "config_type": "scoring",
+        "yaml_path": "calibration/seeds/private_credit/scoring.yaml",
+        "description": "Credit deal scoring weights",
+    },
+]
+
+
+def _load_yaml(relative_path: str) -> dict:
+    """Load a YAML file and return its content as dict."""
+    full_path = _PROJECT_ROOT / relative_path
+    with open(full_path) as f:
+        return yaml.safe_load(f)
+
+
+def upgrade() -> None:
+    # ═══════════════════════════════════════════════════════════════
+    #  TABLE 1: vertical_config_defaults (no RLS — global)
+    # ═══════════════════════════════════════════════════════════════
+    op.create_table(
+        "vertical_config_defaults",
+        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("vertical", sa.String(50), nullable=False),
+        sa.Column("config_type", sa.String(50), nullable=False),
+        sa.Column("config", sa.dialects.postgresql.JSONB, nullable=False),
+        sa.Column("guardrails", sa.dialects.postgresql.JSONB, nullable=True),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("version", sa.Integer, nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("created_by", sa.String(128), nullable=True),
+        sa.Column("updated_by", sa.String(128), nullable=True),
+        sa.UniqueConstraint("vertical", "config_type", name="uq_defaults_vertical_type"),
+    )
+
+    # CHECK constraints on text columns — prevent typos
+    op.execute("""
+        ALTER TABLE vertical_config_defaults
+        ADD CONSTRAINT ck_defaults_vertical
+        CHECK (vertical IN ('private_credit', 'liquid_funds'))
+    """)
+    op.execute("""
+        ALTER TABLE vertical_config_defaults
+        ADD CONSTRAINT ck_defaults_config_type
+        CHECK (config_type IN (
+            'calibration', 'scoring', 'blocks', 'chapters',
+            'portfolio_profiles', 'prompts', 'model_routing', 'tone', 'evaluation'
+        ))
+    """)
+    # Ensure config is a JSON object, not array/scalar
+    op.execute("""
+        ALTER TABLE vertical_config_defaults
+        ADD CONSTRAINT ck_defaults_config_object
+        CHECK (jsonb_typeof(config) = 'object')
+    """)
+
+    # ═══════════════════════════════════════════════════════════════
+    #  TABLE 2: vertical_config_overrides (with RLS)
+    # ═══════════════════════════════════════════════════════════════
+    op.create_table(
+        "vertical_config_overrides",
+        sa.Column("id", sa.Uuid(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", sa.Uuid(as_uuid=True), nullable=False, index=True),
+        sa.Column("vertical", sa.String(50), nullable=False),
+        sa.Column("config_type", sa.String(50), nullable=False),
+        sa.Column("config", sa.dialects.postgresql.JSONB, nullable=False),
+        sa.Column("version", sa.Integer, nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("created_by", sa.String(128), nullable=True),
+        sa.Column("updated_by", sa.String(128), nullable=True),
+        sa.UniqueConstraint(
+            "organization_id", "vertical", "config_type",
+            name="uq_overrides_org_vertical_type",
+        ),
+    )
+
+    # CHECK constraints — same as defaults
+    op.execute("""
+        ALTER TABLE vertical_config_overrides
+        ADD CONSTRAINT ck_overrides_vertical
+        CHECK (vertical IN ('private_credit', 'liquid_funds'))
+    """)
+    op.execute("""
+        ALTER TABLE vertical_config_overrides
+        ADD CONSTRAINT ck_overrides_config_type
+        CHECK (config_type IN (
+            'calibration', 'scoring', 'blocks', 'chapters',
+            'portfolio_profiles', 'prompts', 'model_routing', 'tone', 'evaluation'
+        ))
+    """)
+
+    # Composite index for lookup performance
+    op.create_index(
+        "idx_config_overrides_lookup",
+        "vertical_config_overrides",
+        ["vertical", "config_type", "organization_id"],
+    )
+
+    # ── RLS on overrides ─────────────────────────────────────────
+    op.execute("ALTER TABLE vertical_config_overrides ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE vertical_config_overrides FORCE ROW LEVEL SECURITY")
+    # MUST use subselect pattern — see CLAUDE.md "RLS subselect" rule
+    op.execute("""
+        CREATE POLICY org_isolation ON vertical_config_overrides
+            USING (organization_id = (SELECT current_setting('app.current_organization_id')::uuid))
+    """)
+
+    # ═══════════════════════════════════════════════════════════════
+    #  SEED DATA — INSERT ... ON CONFLICT DO NOTHING (idempotent)
+    # ═══════════════════════════════════════════════════════════════
+    bind = op.get_bind()
+    for seed in _SEEDS:
+        config_data = _load_yaml(seed["yaml_path"])
+        bind.execute(
+            sa.text("""
+                INSERT INTO vertical_config_defaults
+                    (id, vertical, config_type, config, description, created_by)
+                VALUES
+                    (gen_random_uuid(), :vertical, :config_type, :config, :description, 'migration:0004')
+                ON CONFLICT (vertical, config_type) DO NOTHING
+            """),
+            {
+                "vertical": seed["vertical"],
+                "config_type": seed["config_type"],
+                "config": json.dumps(config_data),
+                "description": seed["description"],
+            },
+        )
+
+
+def downgrade() -> None:
+    # WARNING: destroys all config data (defaults + overrides)
+    op.execute("DROP POLICY IF EXISTS org_isolation ON vertical_config_overrides")
+    op.drop_index("idx_config_overrides_lookup", table_name="vertical_config_overrides")
+    op.drop_table("vertical_config_overrides")
+    op.drop_table("vertical_config_defaults")

--- a/backend/app/domains/wealth/routes/funds.py
+++ b/backend/app/domains/wealth/routes/funds.py
@@ -14,6 +14,9 @@ from app.domains.wealth.models.nav import NavTimeseries
 from app.domains.wealth.models.risk import FundRiskMetrics
 from app.domains.wealth.schemas.fund import FundRead, NavPoint
 from app.domains.wealth.schemas.risk import FundRiskRead, FundScoreRead
+from app.core.config.config_service import ConfigService
+from app.core.config.dependencies import get_config_service
+from app.core.security.clerk_auth import Actor, get_actor
 from quant_engine.scoring_service import compute_fund_score
 from quant_engine.talib_momentum_service import (
     compute_flow_momentum,
@@ -36,6 +39,8 @@ async def get_fund_scoring(
     top_n: int = Query(10, ge=1, le=100, description="Number of top funds to return"),
     db: AsyncSession = Depends(get_db),
     user: CurrentUser = Depends(get_current_user),
+    config_service: ConfigService = Depends(get_config_service),
+    actor: Actor = Depends(get_actor),
 ) -> list[FundScoreRead]:
     # Batch-fetch funds and their latest risk metrics in two queries (no N+1)
     funds_stmt = select(Fund).where(Fund.block_id == block, Fund.is_active == True)
@@ -117,13 +122,15 @@ async def get_fund_scoring(
             else:
                 momentum_map[fid] = nav_score
 
+    scoring_config = await config_service.get("liquid_funds", "scoring", actor.organization_id)
+
     scored: list[FundScoreRead] = []
     for fund in funds:
         risk = risk_map.get(fund.fund_id)
         flows_momentum_score = momentum_map.get(fund.fund_id, 50.0)
         if risk is not None:
             score_val, components = compute_fund_score(
-                risk, flows_momentum_score=flows_momentum_score
+                risk, flows_momentum_score=flows_momentum_score, config=scoring_config
             )
         else:
             score_val, components = 50.0, {}

--- a/backend/app/domains/wealth/routes/funds.py
+++ b/backend/app/domains/wealth/routes/funds.py
@@ -6,17 +6,16 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config.config_service import ConfigService
+from app.core.config.dependencies import get_config_service
 from app.core.config.settings import settings
-from app.core.security.clerk_auth import CurrentUser, get_current_user
+from app.core.security.clerk_auth import Actor, CurrentUser, get_actor, get_current_user
 from app.database import get_db
 from app.domains.wealth.models.fund import Fund
 from app.domains.wealth.models.nav import NavTimeseries
 from app.domains.wealth.models.risk import FundRiskMetrics
 from app.domains.wealth.schemas.fund import FundRead, NavPoint
 from app.domains.wealth.schemas.risk import FundRiskRead, FundScoreRead
-from app.core.config.config_service import ConfigService
-from app.core.config.dependencies import get_config_service
-from app.core.security.clerk_auth import Actor, get_actor
 from quant_engine.scoring_service import compute_fund_score
 from quant_engine.talib_momentum_service import (
     compute_flow_momentum,

--- a/backend/app/domains/wealth/routes/risk.py
+++ b/backend/app/domains/wealth/routes/risk.py
@@ -8,17 +8,16 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config.config_service import ConfigService
+from app.core.config.dependencies import get_config_service
 from app.core.config.settings import settings
-from app.core.security.clerk_auth import CurrentUser, get_current_user
+from app.core.security.clerk_auth import Actor, CurrentUser, get_actor, get_current_user
 from app.database import get_db
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 from app.domains.wealth.schemas.macro import MacroIndicators
 from app.domains.wealth.schemas.risk import CVaRPoint, CVaRStatus, RegimeHistoryPoint, RegimeRead
 from app.routers.common import VALID_PROFILES, get_latest_snapshot
 from app.routers.common import validate_profile as _validate_profile
-from app.core.config.config_service import ConfigService
-from app.core.config.dependencies import get_config_service
-from app.core.security.clerk_auth import Actor, get_actor
 from quant_engine.regime_service import get_current_regime, get_latest_macro_values
 
 logger = structlog.get_logger()

--- a/backend/app/domains/wealth/routes/risk.py
+++ b/backend/app/domains/wealth/routes/risk.py
@@ -16,6 +16,9 @@ from app.domains.wealth.schemas.macro import MacroIndicators
 from app.domains.wealth.schemas.risk import CVaRPoint, CVaRStatus, RegimeHistoryPoint, RegimeRead
 from app.routers.common import VALID_PROFILES, get_latest_snapshot
 from app.routers.common import validate_profile as _validate_profile
+from app.core.config.config_service import ConfigService
+from app.core.config.dependencies import get_config_service
+from app.core.security.clerk_auth import Actor, get_actor
 from quant_engine.regime_service import get_current_regime, get_latest_macro_values
 
 logger = structlog.get_logger()
@@ -115,8 +118,11 @@ async def get_cvar_history(
 async def get_regime(
     db: AsyncSession = Depends(get_db),
     user: CurrentUser = Depends(get_current_user),
+    config_service: ConfigService = Depends(get_config_service),
+    actor: Actor = Depends(get_actor),
 ) -> RegimeRead:
-    return await get_current_regime(db)
+    config = await config_service.get("liquid_funds", "calibration", actor.organization_id)
+    return await get_current_regime(db, config=config)
 
 
 @router.get(

--- a/backend/app/domains/wealth/workers/drift_check.py
+++ b/backend/app/domains/wealth/workers/drift_check.py
@@ -40,9 +40,24 @@ async def run_drift_check() -> dict[str, str]:
             logger.info("Drift check already running, skipping")
             return results
 
+        # Load config once for all profiles (worker context, no RLS)
+        try:
+            from app.core.config.models import VerticalConfigDefault
+            from sqlalchemy import select as sa_select
+
+            cfg_result = await db.execute(
+                sa_select(VerticalConfigDefault.config).where(
+                    VerticalConfigDefault.vertical == "liquid_funds",
+                    VerticalConfigDefault.config_type == "calibration",
+                )
+            )
+            config = cfg_result.scalar_one_or_none()
+        except Exception:
+            config = None
+
         try:
             for profile in PROFILES:
-                report = await compute_drift(db, profile)
+                report = await compute_drift(db, profile, config=config)
                 results[profile] = report.overall_status
 
                 logger.info(

--- a/backend/app/domains/wealth/workers/drift_check.py
+++ b/backend/app/domains/wealth/workers/drift_check.py
@@ -42,8 +42,9 @@ async def run_drift_check() -> dict[str, str]:
 
         # Load config once for all profiles (worker context, no RLS)
         try:
-            from app.core.config.models import VerticalConfigDefault
             from sqlalchemy import select as sa_select
+
+            from app.core.config.models import VerticalConfigDefault
 
             cfg_result = await db.execute(
                 sa_select(VerticalConfigDefault.config).where(

--- a/backend/app/domains/wealth/workers/portfolio_eval.py
+++ b/backend/app/domains/wealth/workers/portfolio_eval.py
@@ -5,6 +5,9 @@ Usage:
 
 Evaluates each profile's current CVaR, breach status, regime, and
 creates daily portfolio_snapshots. Publishes alerts via Redis pub/sub.
+
+Config loaded from DB via ConfigService (falls back to hardcoded defaults
+when running standalone without RLS context).
 """
 
 import asyncio
@@ -23,16 +26,39 @@ from app.domains.wealth.models.fund import Fund
 from app.domains.wealth.models.nav import NavTimeseries
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 from quant_engine.cvar_service import (
-    PROFILE_CVAR_CONFIG,
     BreachStatus,
     check_breach_status,
     compute_cvar_from_returns,
+    resolve_cvar_config,
 )
 from quant_engine.regime_service import detect_regime
 
 logger = structlog.get_logger()
 
 PROFILES = ["conservative", "moderate", "growth"]
+
+
+async def _load_worker_config(db: AsyncSession) -> dict:
+    """Load portfolio_profiles config for worker context (no RLS).
+
+    Workers run without Clerk actor context, so we query the defaults
+    table directly (no RLS). Returns raw config dict or None for fallback.
+    """
+    try:
+        from app.core.config.models import VerticalConfigDefault
+
+        result = await db.execute(
+            select(VerticalConfigDefault.config).where(
+                VerticalConfigDefault.vertical == "liquid_funds",
+                VerticalConfigDefault.config_type == "portfolio_profiles",
+            )
+        )
+        config = result.scalar_one_or_none()
+        if config is not None:
+            return config
+    except Exception as e:
+        logger.warning("Could not load config from DB, using defaults", error=str(e))
+    return None
 
 
 async def _get_profile_weights(db: AsyncSession, profile: str) -> dict[str, float]:
@@ -59,16 +85,11 @@ async def _get_fund_returns_by_block(
     block_weights: dict[str, float],
     window_months: int,
 ) -> tuple[dict[str, np.ndarray], dict[str, float]]:
-    """Fetch returns for funds in each block. Returns (fund_returns, fund_weights).
-
-    For simplicity, picks the first active fund per block.
-    Production would use the full fund_selection logic.
-    """
+    """Fetch returns for funds in each block."""
     end_date = date.today()
     start_date = end_date - timedelta(days=window_months * 30)
     block_ids = list(block_weights.keys())
 
-    # Batch-fetch one representative fund per block
     funds_stmt = (
         select(Fund)
         .where(Fund.block_id.in_(block_ids), Fund.is_active == True, Fund.ticker.is_not(None))
@@ -81,7 +102,6 @@ async def _get_fund_returns_by_block(
     if not block_funds:
         return {}, {}
 
-    # Batch-fetch returns for all selected funds in one query
     fund_ids = [f.fund_id for f in block_funds.values()]
     ret_stmt = (
         select(NavTimeseries.fund_id, NavTimeseries.return_1d)
@@ -143,22 +163,25 @@ async def _publish_alert(
         logger.warning("Failed to publish Redis alert", error=str(e))
 
 
-async def evaluate_profile(db: AsyncSession, profile: str) -> dict | None:
+async def evaluate_profile(
+    db: AsyncSession,
+    profile: str,
+    config: dict | None = None,
+) -> dict | None:
     """Evaluate a single profile: compute CVaR, breach status, regime."""
-    config = PROFILE_CVAR_CONFIG[profile]
+    profiles = resolve_cvar_config(config)
+    profile_config = profiles[profile]
     today = date.today()
 
-    # Get strategic weights
     block_weights = await _get_profile_weights(db, profile)
     if not block_weights:
         logger.info("No strategic weights found", profile=profile)
-        # Create snapshot with no data
         return {
             "profile": profile,
             "snapshot_date": today,
             "weights": {},
             "cvar_current": None,
-            "cvar_limit": config["limit"],
+            "cvar_limit": profile_config["limit"],
             "cvar_utilized_pct": None,
             "trigger_status": "ok",
             "consecutive_breach_days": 0,
@@ -167,14 +190,11 @@ async def evaluate_profile(db: AsyncSession, profile: str) -> dict | None:
             "satellite_weight": None,
         }
 
-    # Get fund returns for the profile's CVaR window
     fund_returns, fund_weights = await _get_fund_returns_by_block(
-        db, block_weights, config["window_months"]
+        db, block_weights, profile_config["window_months"]
     )
 
-    # Compute portfolio-level CVaR
     if fund_returns and fund_weights:
-        # Weighted portfolio returns
         fund_ids = list(fund_weights.keys())
         min_len = min(len(fund_returns[fid]) for fid in fund_ids)
         if min_len > 0:
@@ -183,9 +203,7 @@ async def evaluate_profile(db: AsyncSession, profile: str) -> dict | None:
                 w = fund_weights[fid]
                 portfolio_returns += w * fund_returns[fid][-min_len:]
 
-            cvar, _ = compute_cvar_from_returns(portfolio_returns, config["confidence"])
-
-            # Regime detection from portfolio returns
+            cvar, _ = compute_cvar_from_returns(portfolio_returns, profile_config["confidence"])
             regime_result = detect_regime(portfolio_returns)
         else:
             cvar = 0.0
@@ -194,10 +212,8 @@ async def evaluate_profile(db: AsyncSession, profile: str) -> dict | None:
         cvar = 0.0
         regime_result = detect_regime(np.array([]))
 
-    # Check breach status
-    breach = await check_breach_status(db, profile, cvar)
+    breach = await check_breach_status(db, profile, cvar, config=config)
 
-    # Publish alert if warning or breach
     if breach.trigger_status in ("warning", "breach"):
         await _publish_alert(profile, breach)
 
@@ -206,7 +222,7 @@ async def evaluate_profile(db: AsyncSession, profile: str) -> dict | None:
         "snapshot_date": today,
         "weights": block_weights,
         "cvar_current": round(cvar, 6),
-        "cvar_limit": config["limit"],
+        "cvar_limit": profile_config["limit"],
         "cvar_utilized_pct": round(breach.cvar_utilized_pct, 2),
         "trigger_status": breach.trigger_status,
         "consecutive_breach_days": breach.consecutive_breach_days,
@@ -221,7 +237,6 @@ async def run_portfolio_eval() -> dict[str, str]:
     logger.info("Starting portfolio evaluation")
     results: dict[str, str] = {}
 
-    # Shared Redis connection for all alert publishes
     redis_conn = None
     try:
         import redis.asyncio as aioredis
@@ -233,13 +248,15 @@ async def run_portfolio_eval() -> dict[str, str]:
 
     try:
         async with async_session() as db:
+            # Load config once for all profiles
+            config = await _load_worker_config(db)
+
             for profile in PROFILES:
-                snapshot_data = await evaluate_profile(db, profile)
+                snapshot_data = await evaluate_profile(db, profile, config=config)
                 if snapshot_data is None:
                     results[profile] = "skipped"
                     continue
 
-                # Upsert snapshot (use index_elements instead of hardcoded constraint name)
                 stmt = pg_insert(PortfolioSnapshot).values(
                     profile=snapshot_data["profile"],
                     snapshot_date=snapshot_data["snapshot_date"],
@@ -268,7 +285,6 @@ async def run_portfolio_eval() -> dict[str, str]:
                     },
                 )
                 await db.execute(stmt)
-                # Commit per-profile to avoid long transactions
                 await db.commit()
                 results[profile] = snapshot_data["trigger_status"]
                 logger.info(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,6 +79,50 @@ from app.domains.wealth.routes.workers import router as wealth_workers_router
 logger = logging.getLogger(__name__)
 
 
+async def _verify_config_completeness() -> None:
+    """Verify all expected (vertical, config_type) pairs exist in vertical_config_defaults.
+
+    Logs ERROR for any missing pairs — indicates migration 0004 failure.
+    """
+    from sqlalchemy import select
+
+    from app.core.config.models import VerticalConfigDefault
+    from app.core.db.engine import async_session_factory
+
+    expected_pairs = {
+        ("liquid_funds", "calibration"),
+        ("liquid_funds", "portfolio_profiles"),
+        ("liquid_funds", "scoring"),
+        ("liquid_funds", "blocks"),
+        ("private_credit", "chapters"),
+        ("private_credit", "calibration"),
+        ("private_credit", "scoring"),
+    }
+
+    try:
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(
+                    VerticalConfigDefault.vertical,
+                    VerticalConfigDefault.config_type,
+                )
+            )
+            found = {(row[0], row[1]) for row in result.all()}
+
+        missing = expected_pairs - found
+        if missing:
+            for vertical, config_type in sorted(missing):
+                logger.error(
+                    "Missing config default — check migration 0004",
+                    vertical=vertical,
+                    config_type=config_type,
+                )
+        else:
+            logger.info("Config health check OK — all %d defaults present", len(expected_pairs))
+    except Exception as e:
+        logger.error("Config health check failed — DB may not be migrated: %s", e)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """App lifespan: validate secrets, log startup, cleanup on shutdown."""
@@ -87,6 +131,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         "Netz Analysis Engine starting — env=%s",
         settings.app_env,
     )
+    await _verify_config_completeness()
     yield
     # Cleanup
     await engine.dispose()

--- a/backend/quant_engine/cvar_service.py
+++ b/backend/quant_engine/cvar_service.py
@@ -3,32 +3,24 @@
 Provides rolling CVaR computation for individual funds and portfolio-level
 CVaR evaluation with breach detection.
 
-Profile CVaR config is loaded from calibration/config/profiles.yaml via
-@lru_cache. Falls back to hardcoded defaults if the file is missing.
+Config is injected as parameter by callers via ConfigService.get("liquid_funds", "portfolio_profiles").
 """
 
 from dataclasses import dataclass
-from functools import lru_cache
 from typing import TypedDict
 
 import numpy as np
 import structlog
-import yaml
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config.settings import get_calibration_path
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 
 logger = structlog.get_logger()
 
 
 class ProfileCVaRConfig(TypedDict):
-    """Typed configuration for per-profile CVaR parameters.
-
-    Mirrors the ``cvar`` section of each profile in
-    ``calibration/config/profiles.yaml``.
-    """
+    """Typed configuration for per-profile CVaR parameters."""
 
     window_months: int
     confidence: float
@@ -37,7 +29,7 @@ class ProfileCVaRConfig(TypedDict):
     breach_days: int
 
 
-# Hardcoded fallback if profiles.yaml is missing
+# Hardcoded fallback — used only if config parameter is not provided.
 _DEFAULT_CVAR_CONFIG: dict[str, ProfileCVaRConfig] = {
     "conservative": {
         "window_months": 12,
@@ -63,14 +55,18 @@ _DEFAULT_CVAR_CONFIG: dict[str, ProfileCVaRConfig] = {
 }
 
 
-@lru_cache(maxsize=1)
-def get_profile_cvar_config() -> dict[str, ProfileCVaRConfig]:
-    """Load CVaR config from profiles.yaml, fallback to hardcoded defaults."""
+def resolve_cvar_config(
+    config: dict | None = None,
+) -> dict[str, ProfileCVaRConfig]:
+    """Extract per-profile CVaR config from portfolio_profiles config dict.
+
+    Falls back to hardcoded defaults if config is None or malformed.
+    """
+    if config is None:
+        return _DEFAULT_CVAR_CONFIG
+
     try:
-        config_path = get_calibration_path() / "profiles.yaml"
-        with open(config_path) as f:
-            data = yaml.safe_load(f)
-        profiles = data["profiles"]
+        profiles = config.get("profiles", config)
         return {
             name: ProfileCVaRConfig(
                 window_months=int(profile["cvar"]["window_months"]),
@@ -80,18 +76,11 @@ def get_profile_cvar_config() -> dict[str, ProfileCVaRConfig]:
                 breach_days=int(profile["cvar"]["breach_days"]),
             )
             for name, profile in profiles.items()
+            if isinstance(profile, dict) and "cvar" in profile
         }
-    except FileNotFoundError:
-        logger.warning("profiles.yaml not found, using default CVaR config")
-        return _DEFAULT_CVAR_CONFIG
     except (KeyError, TypeError, ValueError) as e:
-        logger.error("profiles.yaml malformed for CVaR config", error=str(e))
+        logger.error("Malformed CVaR config, using defaults", error=str(e))
         return _DEFAULT_CVAR_CONFIG
-
-
-# Module-level alias for backward compatibility — callers that import
-# PROFILE_CVAR_CONFIG directly will get the cached YAML-loaded config.
-PROFILE_CVAR_CONFIG = get_profile_cvar_config()
 
 
 @dataclass
@@ -127,11 +116,10 @@ def compute_cvar_from_returns(
 
 
 def get_cvar_utilization(cvar_current: float, cvar_limit: float) -> float:
-    """Primitive: compute CVaR utilization as a percentage of the limit.
+    """Compute CVaR utilization as a percentage of the limit.
 
     Both cvar_current and cvar_limit are negative numbers (losses).
     Returns a positive percentage (0-100+).
-    Example: cvar_current=-0.05, cvar_limit=-0.08 → 62.5%
     """
     if cvar_limit == 0:
         return 0.0
@@ -144,10 +132,7 @@ def classify_trigger_status(
     warning_threshold_pct: float = 80.0,
     breach_consecutive_days: int = 5,
 ) -> str:
-    """Pure function: classify CVaR trigger status.
-
-    Returns one of: 'ok', 'warning', 'breach'.
-    """
+    """Classify CVaR trigger status. Returns 'ok', 'warning', or 'breach'."""
     if utilization_pct >= 100.0 and consecutive_days >= breach_consecutive_days:
         return "breach"
     if utilization_pct >= warning_threshold_pct:
@@ -159,10 +144,17 @@ async def check_breach_status(
     db: AsyncSession,
     profile: str,
     cvar_current: float,
+    config: dict | None = None,
 ) -> BreachStatus:
-    """Check breach status for a profile given current CVaR."""
-    config = PROFILE_CVAR_CONFIG[profile]
-    cvar_limit = config["limit"]
+    """Check breach status for a profile given current CVaR.
+
+    Args:
+        config: portfolio_profiles config dict from ConfigService.
+               Falls back to hardcoded defaults if None.
+    """
+    profiles = resolve_cvar_config(config)
+    profile_config = profiles.get(profile, _DEFAULT_CVAR_CONFIG.get(profile, {}))
+    cvar_limit = profile_config["limit"]
 
     utilization = get_cvar_utilization(cvar_current, cvar_limit)
 
@@ -177,7 +169,6 @@ async def check_breach_status(
     row = result.scalar_one_or_none()
     prev_days = row if row is not None else 0
 
-    # If currently over limit, increment; otherwise reset
     if utilization >= 100.0:
         consecutive_days = prev_days + 1
     else:
@@ -186,8 +177,8 @@ async def check_breach_status(
     trigger = classify_trigger_status(
         utilization,
         consecutive_days,
-        warning_threshold_pct=config["warning_pct"] * 100,
-        breach_consecutive_days=config["breach_days"],
+        warning_threshold_pct=profile_config["warning_pct"] * 100,
+        breach_consecutive_days=profile_config["breach_days"],
     )
 
     return BreachStatus(
@@ -197,5 +188,3 @@ async def check_breach_status(
         cvar_utilized_pct=utilization,
         consecutive_breach_days=consecutive_days,
     )
-
-

--- a/backend/quant_engine/drift_service.py
+++ b/backend/quant_engine/drift_service.py
@@ -2,7 +2,8 @@
 
 Compares current portfolio weights against combined target
 (strategic + tactical) and flags drift beyond configured bands.
-Drift bands from calibration/config/limits.yaml.
+
+Config is injected as parameter by callers via ConfigService.get("liquid_funds", "calibration").
 
 Drift = actual_weight - (strategic_target + tactical_overweight)
 Intentional tactical bets are NOT flagged as drift.
@@ -10,15 +11,12 @@ Intentional tactical bets are NOT flagged as drift.
 
 from dataclasses import dataclass
 from datetime import date
-from functools import lru_cache
 
 import numpy as np
 import structlog
-import yaml
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config.settings import get_calibration_path
 from app.domains.wealth.models.allocation import StrategicAllocation, TacticalPosition
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 
@@ -48,27 +46,47 @@ class DriftReport:
     urgent_trigger: float
 
 
-@lru_cache(maxsize=1)
-def get_drift_thresholds() -> tuple[float, float]:
-    """Load drift band thresholds from limits.yaml.
+def resolve_drift_thresholds(config: dict | None = None) -> tuple[float, float]:
+    """Extract drift band thresholds from calibration config dict.
 
     Returns (maintenance_trigger, urgent_trigger) as decimals.
+    Falls back to hardcoded defaults if config is None or malformed.
     """
+    if config is None:
+        return 0.05, 0.10
+
     try:
-        config_path = get_calibration_path() / "limits.yaml"
-        with open(config_path) as f:
-            data = yaml.safe_load(f)
-        bands = data["drift_bands"]
-        return (
-            float(bands["maintenance_trigger"]),
-            float(bands["urgent_trigger"]),
-        )
-    except FileNotFoundError:
-        logger.warning("limits.yaml not found, using default drift bands")
+        bands = config.get("drift_bands", {})
+        if bands:
+            return (
+                float(bands["maintenance_trigger"]),
+                float(bands["urgent_trigger"]),
+            )
         return 0.05, 0.10
     except (KeyError, TypeError, ValueError) as e:
-        logger.error("limits.yaml malformed for drift_bands", error=str(e))
+        logger.error("Malformed drift config, using defaults", error=str(e))
         return 0.05, 0.10
+
+
+def resolve_dtw_thresholds(config: dict | None = None) -> tuple[float, float]:
+    """Extract DTW divergence thresholds from calibration config dict.
+
+    Returns (warning_threshold, critical_threshold).
+    Falls back to hardcoded defaults if config is None or malformed.
+    """
+    if config is None:
+        return 0.40, 0.90
+
+    try:
+        dtw_cfg = config.get("drift", {}).get("dtw", {})
+        if dtw_cfg:
+            return (
+                float(dtw_cfg["dtw_divergence_warning"]),
+                float(dtw_cfg["dtw_divergence_critical"]),
+            )
+        return 0.40, 0.90
+    except (KeyError, TypeError, ValueError):
+        return 0.40, 0.90
 
 
 def compute_block_drifts(
@@ -114,18 +132,17 @@ async def compute_drift(
     profile: str,
     as_of_date: date | None = None,
     min_trade_threshold: float = 0.005,
+    config: dict | None = None,
 ) -> DriftReport:
     """Compute drift for all blocks in a profile.
 
-    Drift = actual_weight - (strategic_target + tactical_overweight)
-    Intentional tactical bets are NOT flagged as drift.
-
-    Only recommends rebalance when estimated turnover >= 1%.
+    Args:
+        config: Raw calibration config dict from ConfigService.
     """
     if as_of_date is None:
         as_of_date = date.today()
 
-    maintenance_trigger, urgent_trigger = get_drift_thresholds()
+    maintenance_trigger, urgent_trigger = resolve_drift_thresholds(config)
 
     # 1. Get latest snapshot weights
     snap_stmt = (
@@ -169,7 +186,7 @@ async def compute_drift(
     alloc_result = await db.execute(alloc_stmt)
     strategic = {a.block_id: float(a.target_weight) for a in alloc_result.scalars().all()}
 
-    # 3. Get current tactical positions (intentional overweights)
+    # 3. Get current tactical positions
     tact_stmt = (
         select(TacticalPosition)
         .where(
@@ -197,7 +214,6 @@ async def compute_drift(
 
     max_abs = max((abs(d.absolute_drift) for d in drifts), default=0.0)
 
-    # Overall status = worst block
     if any(d.status == "urgent" for d in drifts):
         overall = "urgent"
     elif any(d.status == "maintenance" for d in drifts):
@@ -205,14 +221,12 @@ async def compute_drift(
     else:
         overall = "ok"
 
-    # Estimated turnover (only meaningful trades)
     meaningful_trades = [
         abs(d.absolute_drift) for d in drifts
         if abs(d.absolute_drift) >= min_trade_threshold
     ]
     turnover = sum(meaningful_trades) / 2
 
-    # Only recommend rebalance if turnover justifies trading costs
     rebalance_recommended = overall != "ok" and turnover >= 0.01
 
     return DriftReport(
@@ -232,26 +246,6 @@ async def compute_drift(
 # DTW Drift Detection
 # ─────────────────────────────────────────────────────────────────────────────
 
-@lru_cache(maxsize=1)
-def get_dtw_thresholds() -> tuple[float, float]:
-    """Load DTW divergence thresholds from limits.yaml.
-
-    Returns (warning_threshold, critical_threshold).
-    Thresholds are for derivative DTW (ddtw), length-normalized (raw / window).
-    """
-    try:
-        config_path = get_calibration_path() / "limits.yaml"
-        with open(config_path) as f:
-            data = yaml.safe_load(f)
-        dtw_cfg = data["drift"]["dtw"]
-        return (
-            float(dtw_cfg["dtw_divergence_warning"]),
-            float(dtw_cfg["dtw_divergence_critical"]),
-        )
-    except (FileNotFoundError, KeyError, TypeError, ValueError):
-        # Calibrated defaults for derivative DTW, length-normalized
-        return 0.40, 0.90
-
 
 def compute_dtw_drift(
     fund_returns: list[float],
@@ -262,7 +256,6 @@ def compute_dtw_drift(
 
     Uses ddtw_distance (derivative DTW) — naturally scale-invariant.
     Result is length-normalized (raw / window) for cross-fund comparability.
-    Returns 0.0 if aeon is not installed (neutral fallback).
     """
     try:
         from aeon.distances import ddtw_distance
@@ -278,8 +271,8 @@ def compute_dtw_drift(
         return 0.0
 
     try:
-        raw = ddtw_distance(f, b, window=0.1)  # 10% warping constraint
-        return float(raw / max(len(f), 1))  # length-normalize
+        raw = ddtw_distance(f, b, window=0.1)
+        return float(raw / max(len(f), 1))
     except Exception as e:
         logger.warning("dtw_drift_computation_failed", error=str(e))
         return 0.0
@@ -290,15 +283,7 @@ def compute_dtw_drift_batch(
     benchmark_returns: "np.ndarray",
     window: int = 63,
 ) -> list[float]:
-    """Vectorized DTW distance for all funds vs benchmark.
-
-    Single pairwise_distance call vs sequential loop: ~0.2s vs ~2s for 200 funds.
-    IMPORTANT: Share the DB query with compute_inputs_from_nav — do NOT
-    issue a separate query for DTW drift.
-
-    Returns list of length-normalized ddtw scores (one per fund).
-    Returns list of 0.0 on missing aeon (neutral fallback).
-    """
+    """Vectorized DTW distance for all funds vs benchmark."""
     n_funds = fund_returns_matrix.shape[0]
 
     try:
@@ -309,20 +294,13 @@ def compute_dtw_drift_batch(
         return [0.0] * n_funds
 
     try:
-        # Use last `window` days
         fund_slice = fund_returns_matrix[:, -window:]
         bench_slice = benchmark_returns[-window:].reshape(1, -1)
 
-        # Stack benchmark as last row for pairwise computation
         all_series = np.vstack([fund_slice, bench_slice])
-
-        # pairwise_distance returns (n_funds+1) × (n_funds+1) distance matrix
         dist_matrix = pairwise_distance(all_series, metric="ddtw")
-
-        # Last row = distances to benchmark
         benchmark_distances = dist_matrix[-1, :-1]
 
-        # Length-normalize
         actual_window = fund_slice.shape[1]
         return [float(d / max(actual_window, 1)) for d in benchmark_distances]
 

--- a/backend/quant_engine/rebalance_service.py
+++ b/backend/quant_engine/rebalance_service.py
@@ -4,6 +4,8 @@ Implements the rebalance cascade state machine:
     ok → warning → breach → hard_stop
 
 Each state transition creates a RebalanceEvent with actor_source tracking.
+
+Config is injected as parameter by callers via ConfigService.
 """
 
 import uuid
@@ -18,9 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 from app.domains.wealth.models.rebalance import RebalanceEvent
-from app.services.cvar_service import (
-    PROFILE_CVAR_CONFIG,
-)
+from quant_engine.cvar_service import resolve_cvar_config
 
 logger = structlog.get_logger()
 
@@ -49,29 +49,31 @@ def determine_cascade_action(
     cvar_utilized_pct: float,
     consecutive_breach_days: int,
     profile: str,
+    config: dict | None = None,
 ) -> tuple[str | None, str | None]:
     """Determine if a cascade action is needed based on status transition.
 
+    Args:
+        config: portfolio_profiles config dict from ConfigService.
+
     Returns (event_type, trigger_reason) or (None, None) if no action needed.
     """
-    config = PROFILE_CVAR_CONFIG[profile]
+    profiles = resolve_cvar_config(config)
+    profile_config = profiles[profile]
 
-    # No change or improving → no action
     if trigger_status == "ok":
         return None, None
 
-    # Transition to warning
     if trigger_status == "warning" and previous_trigger_status in (None, "ok"):
         return "cvar_breach", (
             f"CVaR utilization at {cvar_utilized_pct:.1f}% "
-            f"(warning threshold: {config['warning_pct'] * 100:.0f}%)"
+            f"(warning threshold: {profile_config['warning_pct'] * 100:.0f}%)"
         )
 
-    # Transition to breach
     if trigger_status == "breach" and previous_trigger_status != "breach":
         return "cvar_breach", (
             f"CVaR breach: {consecutive_breach_days} consecutive days "
-            f"above limit (threshold: {config['breach_days']})"
+            f"above limit (threshold: {profile_config['breach_days']})"
         )
 
     return None, None
@@ -118,13 +120,13 @@ async def process_cascade(
     consecutive_breach_days: int,
     cvar_current: float | None = None,
     current_weights: dict[str, Any] | None = None,
+    config: dict | None = None,
 ) -> CascadeResult:
     """Process the rebalance cascade for a profile.
 
-    Called by portfolio_eval worker after computing CVaR status.
-    Creates rebalance events on state transitions.
+    Args:
+        config: portfolio_profiles config dict from ConfigService.
     """
-    # Get previous trigger status from last snapshot
     stmt = (
         select(PortfolioSnapshot.trigger_status)
         .where(PortfolioSnapshot.profile == profile)
@@ -140,6 +142,7 @@ async def process_cascade(
         cvar_utilized_pct,
         consecutive_breach_days,
         profile,
+        config=config,
     )
 
     if event_type is None:

--- a/backend/quant_engine/regime_service.py
+++ b/backend/quant_engine/regime_service.py
@@ -7,20 +7,19 @@ Classifies market regime using multi-signal approach:
 - Falls back to portfolio volatility proxy when FRED data unavailable
 
 Priority hierarchy: CRISIS > INFLATION > RISK_OFF > RISK_ON
+
+Config is injected as parameter by callers via ConfigService.get("liquid_funds", "calibration").
 """
 
 from dataclasses import dataclass, field
 from datetime import date
-from functools import lru_cache
 from typing import TypedDict
 
 import numpy as np
 import structlog
-import yaml
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config.settings import get_calibration_path
 from app.domains.wealth.models.macro import MacroData
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 from app.schemas.risk import RegimeRead
@@ -29,14 +28,14 @@ logger = structlog.get_logger()
 
 
 class RegimeThresholds(TypedDict):
-    """Typed regime detection thresholds from limits.yaml."""
+    """Typed regime detection thresholds."""
 
     vix_risk_off: float
     vix_extreme: float
     yield_curve_inversion: float
     cpi_yoy_high: float
     cpi_yoy_normal: float
-    sahm_rule_recession: float  # SAHMREALTIME >= this = recession signal
+    sahm_rule_recession: float
     default: str
 
 
@@ -46,14 +45,14 @@ class RegimeDefinition(TypedDict):
     description: str
 
 
-# Hardcoded fallback if limits.yaml is missing
+# Hardcoded fallback — used only if config parameter is not provided.
 _DEFAULT_THRESHOLDS: RegimeThresholds = {
     "vix_risk_off": 25,
     "vix_extreme": 35,
     "yield_curve_inversion": -0.10,
     "cpi_yoy_high": 4.0,
     "cpi_yoy_normal": 2.5,
-    "sahm_rule_recession": 0.50,  # Sahm (2019): 0.50pp rise from 12m low = recession onset
+    "sahm_rule_recession": 0.50,
     "default": "RISK_ON",
 }
 
@@ -64,19 +63,23 @@ REGIME_DEFINITIONS: dict[str, RegimeDefinition] = {
     "CRISIS": {"description": "Extreme stress, maximize capital preservation"},
 }
 
-# Staleness thresholds (business days) before falling back to volatility proxy
-STALENESS_DAILY = 3   # VIX, Treasury, DFF
-STALENESS_MONTHLY = 45  # CPI
+# Staleness thresholds (business days)
+STALENESS_DAILY = 3
+STALENESS_MONTHLY = 45
 
 
-@lru_cache(maxsize=1)
-def get_regime_thresholds() -> RegimeThresholds:
-    """Load regime thresholds from limits.yaml, fallback to hardcoded defaults."""
+def resolve_regime_thresholds(config: dict | None = None) -> RegimeThresholds:
+    """Extract regime thresholds from calibration config dict.
+
+    Falls back to hardcoded defaults if config is None or malformed.
+    """
+    if config is None:
+        return _DEFAULT_THRESHOLDS
+
     try:
-        config_path = get_calibration_path() / "limits.yaml"
-        with open(config_path) as f:
-            data = yaml.safe_load(f)
-        raw = data["regime_thresholds"]
+        raw = config.get("regime_thresholds", {})
+        if not raw:
+            return _DEFAULT_THRESHOLDS
         return RegimeThresholds(
             vix_risk_off=float(raw["vix_risk_off"]),
             vix_extreme=float(raw["vix_extreme"]),
@@ -86,11 +89,8 @@ def get_regime_thresholds() -> RegimeThresholds:
             sahm_rule_recession=float(raw.get("sahm_rule_recession", 0.50)),
             default=raw.get("default", "RISK_ON"),
         )
-    except FileNotFoundError:
-        logger.warning("limits.yaml not found, using default regime thresholds")
-        return _DEFAULT_THRESHOLDS
     except (KeyError, TypeError, ValueError) as e:
-        logger.error("limits.yaml malformed for regime_thresholds", error=str(e))
+        logger.error("Malformed regime config, using defaults", error=str(e))
         return _DEFAULT_THRESHOLDS
 
 
@@ -107,44 +107,35 @@ def classify_regime_multi_signal(
     cpi_yoy: float | None,
     sahm_rule: float | None = None,
     thresholds: RegimeThresholds | None = None,
+    config: dict | None = None,
 ) -> tuple[str, dict[str, str]]:
-    """Classify regime using priority hierarchy:
+    """Classify regime using priority hierarchy.
 
-    1. VIX >= vix_extreme (35) -> CRISIS
-    2. CPI YoY >= cpi_yoy_high (4.0) -> INFLATION
-    3. VIX >= vix_risk_off (25) -> RISK_OFF
-    4. Otherwise -> RISK_ON
-
-    Informational signals (logged for IC awareness, do not override hierarchy):
-    - Yield curve inversion: leading indicator of future recession
-    - Sahm Rule >= 0.50: real-time recession onset corroboration (Sahm 2019)
-
-    Returns (regime, reasons_dict) for auditability.
+    Args:
+        thresholds: Pre-resolved thresholds (takes precedence).
+        config: Raw calibration config dict from ConfigService (resolved if thresholds is None).
     """
     if thresholds is None:
-        thresholds = get_regime_thresholds()
+        thresholds = resolve_regime_thresholds(config)
 
     reasons: dict[str, str] = {}
 
-    # Rule 1: CRISIS — extreme volatility
     if vix is not None and vix >= thresholds["vix_extreme"]:
         reasons["vix"] = f"VIX={vix:.1f} >= {thresholds['vix_extreme']} (CRISIS)"
         reasons["decision"] = "CRISIS: extreme VIX overrides all other signals"
         return "CRISIS", reasons
 
-    # Rule 2: INFLATION — high CPI regardless of VIX
     if cpi_yoy is not None and cpi_yoy >= thresholds["cpi_yoy_high"]:
         reasons["cpi"] = f"CPI_YoY={cpi_yoy:.1f}% >= {thresholds['cpi_yoy_high']}% (INFLATION)"
         reasons["decision"] = "INFLATION: CPI above threshold"
         return "INFLATION", reasons
 
-    # Rule 3: RISK_OFF — elevated VIX
     if vix is not None and vix >= thresholds["vix_risk_off"]:
         reasons["vix"] = f"VIX={vix:.1f} >= {thresholds['vix_risk_off']} (RISK_OFF)"
         reasons["decision"] = "RISK_OFF: elevated volatility"
         return "RISK_OFF", reasons
 
-    # Informational signals — logged for IC awareness, do not override hierarchy
+    # Informational signals — IC awareness only
     if yield_curve_spread is not None and yield_curve_spread < thresholds["yield_curve_inversion"]:
         reasons["yield_curve"] = (
             f"10Y-2Y={yield_curve_spread:.2f}% inverted "
@@ -157,7 +148,6 @@ def classify_regime_multi_signal(
             f"(recession onset signal — IC awareness)"
         )
 
-    # Rule 4: Default
     if vix is not None:
         reasons["vix"] = f"VIX={vix:.1f} < {thresholds['vix_risk_off']} (RISK_ON)"
     reasons["decision"] = "RISK_ON: no stress signals triggered"
@@ -169,11 +159,7 @@ def classify_regime_from_volatility(
     vix_risk_off: float = 25.0,
     vix_extreme: float = 35.0,
 ) -> str:
-    """Fallback: classify regime from portfolio volatility proxy.
-
-    Maps portfolio volatility to VIX-equivalent thresholds.
-    Used when FRED data is unavailable or stale.
-    """
+    """Fallback: classify regime from portfolio volatility proxy."""
     vol_pct = annualized_vol * 100
 
     if vol_pct >= vix_extreme:
@@ -186,12 +172,14 @@ def classify_regime_from_volatility(
 def detect_regime(
     returns: np.ndarray,
     trading_days_per_year: int = 252,
+    config: dict | None = None,
 ) -> RegimeResult:
     """Detect market regime from a returns series (volatility proxy fallback).
 
-    Used when FRED macro data is unavailable.
+    Args:
+        config: Raw calibration config dict from ConfigService.
     """
-    thresholds = get_regime_thresholds()
+    thresholds = resolve_regime_thresholds(config)
 
     if len(returns) < 10:
         default = thresholds["default"]
@@ -218,23 +206,18 @@ def detect_regime(
 async def get_latest_macro_values(
     db: AsyncSession,
 ) -> dict[str, tuple[float | None, date | None]]:
-    """Query latest VIX, yield curve spread, CPI YoY, Fed Funds from macro_data.
-
-    Returns {series_id: (value, obs_date)} for regime-relevant series.
-    Logs warnings for stale data.
-    """
+    """Query latest VIX, yield curve spread, CPI YoY, Fed Funds from macro_data."""
     series_staleness = {
         "VIXCLS": STALENESS_DAILY,
         "YIELD_CURVE_10Y2Y": STALENESS_DAILY,
         "CPI_YOY": STALENESS_MONTHLY,
         "DFF": STALENESS_DAILY,
-        "SAHMREALTIME": STALENESS_MONTHLY,  # published with jobs report
+        "SAHMREALTIME": STALENESS_MONTHLY,
     }
 
     result: dict[str, tuple[float | None, date | None]] = {}
     today = date.today()
 
-    # Single query for all series using DISTINCT ON
     stmt = (
         select(MacroData.series_id, MacroData.value, MacroData.obs_date)
         .where(MacroData.series_id.in_(series_staleness.keys()))
@@ -261,7 +244,6 @@ async def get_latest_macro_values(
         else:
             result[series_id] = (float(value), obs_date)
 
-    # Mark missing series
     for series_id in series_staleness:
         if series_id not in found_series:
             result[series_id] = (None, None)
@@ -269,11 +251,14 @@ async def get_latest_macro_values(
     return result
 
 
-async def get_current_regime(db: AsyncSession) -> RegimeRead:
+async def get_current_regime(
+    db: AsyncSession,
+    config: dict | None = None,
+) -> RegimeRead:
     """Get current market regime from FRED macro data.
 
-    Falls back to latest portfolio snapshot regime if FRED data unavailable.
-    Replaces the old consensus-voting approach since regime is market-wide.
+    Args:
+        config: Raw calibration config dict from ConfigService.
     """
     macro = await get_latest_macro_values(db)
 
@@ -282,13 +267,11 @@ async def get_current_regime(db: AsyncSession) -> RegimeRead:
     cpi_val = macro.get("CPI_YOY", (None, None))[0]
     sahm_val = macro.get("SAHMREALTIME", (None, None))[0]
 
-    # If we have at least VIX, use multi-signal classification
     if vix_val is not None:
         regime, reasons = classify_regime_multi_signal(
-            vix_val, yield_val, cpi_val, sahm_rule=sahm_val
+            vix_val, yield_val, cpi_val, sahm_rule=sahm_val, config=config
         )
 
-        # Find most recent date across available series
         as_of = None
         for _, obs_date in macro.values():
             if obs_date is not None and (as_of is None or obs_date > as_of):

--- a/backend/quant_engine/scoring_service.py
+++ b/backend/quant_engine/scoring_service.py
@@ -1,54 +1,51 @@
 """Fund scoring service.
 
-Scores funds using externalized weights from calibration/config/scoring.yaml.
-Each fund gets a composite manager_score (0-100) based on risk-adjusted metrics.
+Scores funds using externalized weights. Each fund gets a composite
+manager_score (0-100) based on risk-adjusted metrics.
+
+Config is injected as parameter by callers via ConfigService.get("liquid_funds", "scoring").
 """
 
-from functools import lru_cache
-
 import structlog
-import yaml
 
-from app.core.config.settings import get_calibration_path
 from app.domains.wealth.models.risk import FundRiskMetrics
 
 logger = structlog.get_logger()
 
 
-@lru_cache(maxsize=1)
-def get_scoring_weights() -> dict[str, float]:
-    """Load scoring weights from YAML config on first access, then cache."""
+# Hardcoded fallback — used only if config parameter is not provided.
+_DEFAULT_SCORING_WEIGHTS: dict[str, float] = {
+    "return_consistency": 0.20,
+    "risk_adjusted_return": 0.25,
+    "drawdown_control": 0.20,
+    "information_ratio": 0.15,
+    "flows_momentum": 0.10,
+    "lipper_rating": 0.10,
+}
+
+
+def resolve_scoring_weights(config: dict | None = None) -> dict[str, float]:
+    """Extract scoring weights from config dict.
+
+    Falls back to hardcoded defaults if config is None or malformed.
+    """
+    if config is None:
+        return _DEFAULT_SCORING_WEIGHTS
+
     try:
-        config_path = get_calibration_path() / "scoring.yaml"
-        with open(config_path) as f:
-            config = yaml.safe_load(f)
-        return config["scoring_weights"]
-    except FileNotFoundError:
-        logger.warning("scoring.yaml not found, using defaults")
-        return {
-            "return_consistency": 0.20,
-            "risk_adjusted_return": 0.25,
-            "drawdown_control": 0.20,
-            "information_ratio": 0.15,
-            "flows_momentum": 0.10,
-            "lipper_rating": 0.10,
-        }
-    except (KeyError, TypeError) as e:
-        logger.error("scoring.yaml malformed", error=str(e))
-        return {
-            "return_consistency": 0.20,
-            "risk_adjusted_return": 0.25,
-            "drawdown_control": 0.20,
-            "information_ratio": 0.15,
-            "flows_momentum": 0.10,
-            "lipper_rating": 0.10,
-        }
+        weights = config.get("scoring_weights", config)
+        if isinstance(weights, dict) and weights:
+            return {k: float(v) for k, v in weights.items()}
+        return _DEFAULT_SCORING_WEIGHTS
+    except (TypeError, ValueError) as e:
+        logger.error("Malformed scoring config, using defaults", error=str(e))
+        return _DEFAULT_SCORING_WEIGHTS
 
 
 def _normalize(value: float | None, min_val: float, max_val: float) -> float:
     """Normalize a value to 0-100 scale."""
     if value is None:
-        return 50.0  # neutral score for missing data
+        return 50.0
     if max_val == min_val:
         return 50.0
     return max(0.0, min(100.0, (value - min_val) / (max_val - min_val) * 100))
@@ -58,49 +55,35 @@ def compute_fund_score(
     metrics: FundRiskMetrics,
     lipper_score: float = 50.0,
     flows_momentum_score: float = 50.0,
+    config: dict | None = None,
 ) -> tuple[float, dict[str, float]]:
     """Compute composite score from risk metrics. Returns (score, components).
 
-    Pure function — no I/O, no async calls inside.
-
     Args:
-        metrics: Fund risk metrics from fund_risk_metrics table.
-        lipper_score: Pre-fetched Lipper score (0-100). Defaults to 50.0
-            (neutral) when FEATURE_LIPPER_ENABLED=false or no Lipper data.
-            Caller fetches via lipper_service.get_fund_lipper_score().
-        flows_momentum_score: Pre-fetched momentum score (0-100). Defaults to 50.0
-            (neutral). When FEATURE_MOMENTUM_SIGNALS=true, caller computes via
-            talib_momentum_service.compute_momentum_signals_talib() from NAV data.
-            Caller is responsible for fetching — keeps this function pure.
+        config: Scoring config dict from ConfigService.get("liquid_funds", "scoring").
+               Falls back to hardcoded defaults if None.
     """
     components: dict[str, float] = {}
 
-    # Return consistency: based on 1Y return relative to typical range
     ret_1y = float(metrics.return_1y) if metrics.return_1y else None
     components["return_consistency"] = _normalize(ret_1y, -0.20, 0.40)
 
-    # Risk-adjusted return: Sharpe ratio
     sharpe = float(metrics.sharpe_1y) if metrics.sharpe_1y else None
     components["risk_adjusted_return"] = _normalize(sharpe, -1.0, 3.0)
 
-    # Drawdown control: lower (less negative) drawdown is better
     dd = float(metrics.max_drawdown_1y) if metrics.max_drawdown_1y else None
     components["drawdown_control"] = _normalize(dd, -0.50, 0.0)
 
-    # Information ratio
     ir = float(metrics.information_ratio_1y) if metrics.information_ratio_1y else None
     components["information_ratio"] = _normalize(ir, -1.0, 2.0)
 
-    # Flows momentum: pre-fetched by caller (TA-Lib RSI/BBANDS when flag enabled)
     components["flows_momentum"] = flows_momentum_score
-
-    # Lipper rating: pre-fetched score from lipper_service
     components["lipper_rating"] = lipper_score
 
-    # Weighted composite
+    weights = resolve_scoring_weights(config)
     score = sum(
         components.get(k, 50.0) * w
-        for k, w in get_scoring_weights().items()
+        for k, w in weights.items()
     )
 
     return round(score, 2), {k: round(v, 2) for k, v in components.items()}

--- a/backend/tests/test_config_service.py
+++ b/backend/tests/test_config_service.py
@@ -1,0 +1,231 @@
+"""Tests for ConfigService — deep_merge, IP protection, resolve functions."""
+
+from __future__ import annotations
+
+from app.core.config.config_service import ConfigService
+
+# ── deep_merge tests ─────────────────────────────────────────────────────────
+
+
+class TestDeepMerge:
+    def test_scalar_override(self):
+        base = {"a": 1, "b": 2}
+        override = {"b": 99}
+        result = ConfigService.deep_merge(base, override)
+        assert result == {"a": 1, "b": 99}
+
+    def test_nested_dict_merge(self):
+        base = {"outer": {"a": 1, "b": 2}}
+        override = {"outer": {"b": 99}}
+        result = ConfigService.deep_merge(base, override)
+        assert result == {"outer": {"a": 1, "b": 99}}
+
+    def test_deeply_nested_merge(self):
+        base = {"l1": {"l2": {"l3": {"a": 1, "b": 2}}}}
+        override = {"l1": {"l2": {"l3": {"b": 99}}}}
+        result = ConfigService.deep_merge(base, override)
+        assert result == {"l1": {"l2": {"l3": {"a": 1, "b": 99}}}}
+
+    def test_list_replaced_not_appended(self):
+        base = {"items": [1, 2, 3]}
+        override = {"items": [99]}
+        result = ConfigService.deep_merge(base, override)
+        assert result == {"items": [99]}
+
+    def test_new_key_added(self):
+        base = {"a": 1}
+        override = {"b": 2}
+        result = ConfigService.deep_merge(base, override)
+        assert result == {"a": 1, "b": 2}
+
+    def test_empty_override(self):
+        base = {"a": 1, "b": {"c": 3}}
+        result = ConfigService.deep_merge(base, {})
+        assert result == base
+
+    def test_empty_base(self):
+        override = {"a": 1}
+        result = ConfigService.deep_merge({}, override)
+        assert result == {"a": 1}
+
+    def test_base_not_mutated(self):
+        base = {"a": {"b": 1}}
+        override = {"a": {"b": 2}}
+        ConfigService.deep_merge(base, override)
+        assert base == {"a": {"b": 1}}  # original unchanged
+
+    def test_credit_ltv_override_example(self):
+        """Real-world: client overrides LTV from 65% to 55%."""
+        default = {
+            "leverage_limits": {"senior_secured": {"max_total_leverage": 5.0, "warning": 4.5}},
+            "ltv_limits": {"senior_secured_ltv": {"max_hard": 0.65, "warning": 0.60}},
+        }
+        override = {
+            "ltv_limits": {"senior_secured_ltv": {"max_hard": 0.55}},
+        }
+        result = ConfigService.deep_merge(default, override)
+        assert result["ltv_limits"]["senior_secured_ltv"]["max_hard"] == 0.55
+        assert result["ltv_limits"]["senior_secured_ltv"]["warning"] == 0.60  # preserved
+        assert result["leverage_limits"]["senior_secured"]["max_total_leverage"] == 5.0  # untouched
+
+
+# ── CLIENT_VISIBLE_TYPES tests ──────────────────────────────────────────────
+
+
+class TestIPProtection:
+    def test_client_visible_types_excludes_prompts(self):
+        assert "prompts" not in ConfigService.CLIENT_VISIBLE_TYPES
+
+    def test_client_visible_types_excludes_model_routing(self):
+        assert "model_routing" not in ConfigService.CLIENT_VISIBLE_TYPES
+
+    def test_client_visible_types_excludes_chapters(self):
+        """Chapters expose IC memo structure — analytical methodology IP."""
+        assert "chapters" not in ConfigService.CLIENT_VISIBLE_TYPES
+
+    def test_client_visible_types_excludes_tone(self):
+        assert "tone" not in ConfigService.CLIENT_VISIBLE_TYPES
+
+    def test_client_visible_types_excludes_evaluation(self):
+        assert "evaluation" not in ConfigService.CLIENT_VISIBLE_TYPES
+
+    def test_client_visible_types_includes_calibration(self):
+        assert "calibration" in ConfigService.CLIENT_VISIBLE_TYPES
+
+    def test_client_visible_types_includes_scoring(self):
+        assert "scoring" in ConfigService.CLIENT_VISIBLE_TYPES
+
+    def test_client_visible_types_includes_blocks(self):
+        assert "blocks" in ConfigService.CLIENT_VISIBLE_TYPES
+
+    def test_client_visible_types_includes_portfolio_profiles(self):
+        assert "portfolio_profiles" in ConfigService.CLIENT_VISIBLE_TYPES
+
+    def test_client_visible_types_is_frozen(self):
+        assert isinstance(ConfigService.CLIENT_VISIBLE_TYPES, frozenset)
+
+
+# ── Resolve functions tests ──────────────────────────────────────────────────
+
+
+class TestResolveFunctions:
+    def test_resolve_cvar_config_none_returns_defaults(self):
+        from quant_engine.cvar_service import resolve_cvar_config
+
+        result = resolve_cvar_config(None)
+        assert "conservative" in result
+        assert "moderate" in result
+        assert "growth" in result
+        assert result["conservative"]["limit"] == -0.08
+
+    def test_resolve_cvar_config_from_db_format(self):
+        from quant_engine.cvar_service import resolve_cvar_config
+
+        config = {
+            "profiles": {
+                "conservative": {
+                    "cvar": {
+                        "window_months": 12,
+                        "confidence": 0.95,
+                        "limit": -0.05,
+                        "warning_pct": 0.80,
+                        "breach_days": 5,
+                    },
+                },
+            },
+        }
+        result = resolve_cvar_config(config)
+        assert result["conservative"]["limit"] == -0.05
+
+    def test_resolve_regime_thresholds_none_returns_defaults(self):
+        from quant_engine.regime_service import resolve_regime_thresholds
+
+        result = resolve_regime_thresholds(None)
+        assert result["vix_risk_off"] == 25
+        assert result["default"] == "RISK_ON"
+
+    def test_resolve_regime_thresholds_from_config(self):
+        from quant_engine.regime_service import resolve_regime_thresholds
+
+        config = {
+            "regime_thresholds": {
+                "vix_risk_off": 30,
+                "vix_extreme": 40,
+                "default": "RISK_ON",
+            },
+        }
+        result = resolve_regime_thresholds(config)
+        assert result["vix_risk_off"] == 30
+
+    def test_resolve_scoring_weights_none_returns_defaults(self):
+        from quant_engine.scoring_service import resolve_scoring_weights
+
+        result = resolve_scoring_weights(None)
+        assert abs(sum(result.values()) - 1.0) < 0.001
+
+    def test_resolve_drift_thresholds_none_returns_defaults(self):
+        from quant_engine.drift_service import resolve_drift_thresholds
+
+        maint, urgent = resolve_drift_thresholds(None)
+        assert maint == 0.05
+        assert urgent == 0.10
+
+    def test_resolve_drift_thresholds_from_config(self):
+        from quant_engine.drift_service import resolve_drift_thresholds
+
+        config = {"drift_bands": {"maintenance_trigger": 0.03, "urgent_trigger": 0.08}}
+        maint, urgent = resolve_drift_thresholds(config)
+        assert maint == 0.03
+        assert urgent == 0.08
+
+
+# ── Migration seed data tests ────────────────────────────────────────────────
+
+
+class TestMigrationSeedFiles:
+    """Verify seed YAML files exist and are loadable."""
+
+    def test_credit_calibration_yaml_loadable(self):
+        from pathlib import Path
+
+        import yaml
+
+        path = Path(__file__).resolve().parents[2] / "calibration" / "seeds" / "private_credit" / "calibration.yaml"
+        assert path.exists(), f"Missing: {path}"
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert isinstance(data, dict)
+        assert "leverage_limits" in data
+        assert "coverage_ratios" in data
+
+    def test_credit_scoring_yaml_loadable(self):
+        from pathlib import Path
+
+        import yaml
+
+        path = Path(__file__).resolve().parents[2] / "calibration" / "seeds" / "private_credit" / "scoring.yaml"
+        assert path.exists(), f"Missing: {path}"
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert isinstance(data, dict)
+        assert "credit_scoring_weights" in data
+        weights = data["credit_scoring_weights"]
+        assert abs(sum(weights.values()) - 1.0) < 0.001
+
+    def test_all_seed_yamls_exist(self):
+        """All YAML files referenced in migration 0004 must exist."""
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[2]
+        required = [
+            "calibration/config/limits.yaml",
+            "calibration/config/profiles.yaml",
+            "calibration/config/scoring.yaml",
+            "calibration/config/blocks.yaml",
+            "profiles/private_credit/profile.yaml",
+            "calibration/seeds/private_credit/calibration.yaml",
+            "calibration/seeds/private_credit/scoring.yaml",
+        ]
+        for rel_path in required:
+            full = root / rel_path
+            assert full.exists(), f"Missing seed YAML: {rel_path}"

--- a/calibration/seeds/private_credit/calibration.yaml
+++ b/calibration/seeds/private_credit/calibration.yaml
@@ -1,0 +1,151 @@
+# SEED DATA ONLY — loaded by migration 0004. Runtime config is in PostgreSQL.
+# Sources: Moody's Annual Default Study, S&P Recovery Reports, Basel III,
+#          Ares Capital / Blue Owl public filings, institutional practice.
+# These defaults feed ic_critic_engine and ic_quant_engine.
+
+leverage_limits:
+  senior_secured:
+    max_total_leverage: 5.0
+    warning_threshold: 4.5
+    preferred_range: [2.5, 4.0]
+  unitranche:
+    max_total_leverage: 5.5
+    warning_threshold: 5.0
+  second_lien:
+    max_total_leverage: 6.5
+    warning_threshold: 6.0
+
+coverage_ratios:
+  dscr:
+    minimum_hard: 1.10
+    warning: 1.25
+    comfortable: 1.50
+    strong: 2.00
+  interest_coverage:
+    minimum_hard: 1.50
+    warning: 1.75
+    comfortable: 2.50
+    strong: 4.00
+  fixed_charge_coverage:
+    minimum_hard: 1.00
+    warning: 1.15
+    comfortable: 1.30
+
+ltv_limits:
+  senior_secured_ltv:
+    max_hard: 0.65
+    warning: 0.60
+    preferred_range: [0.40, 0.55]
+  unitranche_ltv:
+    max_hard: 0.70
+    warning: 0.65
+  second_lien_ltv:
+    max_hard: 0.80
+    warning: 0.75
+  tev_stress_haircut_pct: 25.0
+
+portfolio_concentration:
+  single_obligor_max_pct: 10.0
+  single_obligor_warning_pct: 7.5
+  top5_obligors_max_pct: 40.0
+  single_sector_max_pct: 25.0
+  single_country_max_pct: 40.0
+  emerging_markets_max_pct: 15.0
+  second_lien_max_pct: 20.0
+  pik_max_pct: 15.0
+
+tenor_limits:
+  max_weighted_avg_life_years: 5.0
+  max_single_deal_tenor_years: 7.0
+  preferred_tenor_range: [3.0, 5.0]
+
+credit_regime_thresholds:
+  hy_oas_normal: 350
+  hy_oas_cautious: 500
+  hy_oas_stress: 700
+  hy_oas_crisis: 1000
+  default_rate_normal: 2.0
+  default_rate_elevated: 4.0
+  default_rate_stress: 6.0
+  default_rate_crisis: 10.0
+  default_regime: NORMAL
+
+credit_regime_definitions:
+  NORMAL:
+    new_deal_adjustment: 0.0
+    spread_premium_bps: 0
+    max_leverage_adj: 0.0
+  CAUTIOUS:
+    new_deal_adjustment: -0.20
+    spread_premium_bps: 50
+    max_leverage_adj: -0.5
+  STRESS:
+    new_deal_adjustment: -0.50
+    spread_premium_bps: 150
+    max_leverage_adj: -1.0
+    covenant_requirement: FULL_MAINTENANCE
+  CRISIS:
+    new_deal_adjustment: -0.80
+    spread_premium_bps: 300
+    max_leverage_adj: -1.5
+    covenant_requirement: FULL_MAINTENANCE
+
+scenario_calibration:
+  base:
+    default_rate_pct: 2.0
+    recovery_rate_pct: 67.0
+    revenue_growth_pct: 3.0
+    ebitda_margin_change_bps: 0
+    rate_shock_bps: 0
+  downside:
+    default_rate_pct: 5.0
+    recovery_rate_pct: 50.0
+    revenue_decline_pct: -10.0
+    ebitda_margin_compression_bps: -200
+    rate_shock_bps: 100
+  severe:
+    default_rate_pct: 10.0
+    recovery_rate_pct: 35.0
+    revenue_decline_pct: -25.0
+    ebitda_margin_compression_bps: -500
+    rate_shock_bps: 200
+  tail:
+    default_rate_pct: 15.0
+    recovery_rate_pct: 25.0
+    revenue_decline_pct: -40.0
+    ebitda_margin_compression_bps: -800
+    rate_shock_bps: -200
+
+return_requirements:
+  min_spread_bps:
+    core_senior_secured: 450
+    unitranche: 550
+    second_lien: 750
+    venture_debt: 800
+    distressed: 1000
+  net_irr_targets:
+    core_direct_lending: [8.0, 12.0]
+    opportunistic: [12.0, 16.0]
+    distressed: [15.0, 20.0]
+
+monitoring_triggers:
+  leverage_deterioration:
+    warning: 0.5
+    critical: 1.0
+  dscr_deterioration:
+    warning: -0.15
+    critical: -0.30
+  revenue_decline:
+    warning_pct: -10.0
+    critical_pct: -20.0
+  payment_delay_days:
+    grace_period: 5
+    watchlist: 15
+    default_event: 30
+  nav_markdown:
+    warning_pct: 5.0
+    critical_pct: 15.0
+  covenant_headroom:
+    comfortable_pct: 25.0
+    tight_pct: 10.0
+    critical_pct: 5.0

--- a/calibration/seeds/private_credit/scoring.yaml
+++ b/calibration/seeds/private_credit/scoring.yaml
@@ -1,0 +1,11 @@
+# SEED DATA ONLY — loaded by migration 0004. Runtime config is in PostgreSQL.
+# Credit deal scoring weights for ic_critic_engine.
+
+credit_scoring_weights:
+  credit_quality: 0.25
+  return_adequacy: 0.20
+  structural_protection: 0.15
+  sponsor_quality: 0.15
+  business_quality: 0.10
+  documentation_completeness: 0.10
+  liquidity_profile: 0.05

--- a/docs/brainstorms/2026-03-14-customizable-vertical-config-brainstorm.md
+++ b/docs/brainstorms/2026-03-14-customizable-vertical-config-brainstorm.md
@@ -1,0 +1,458 @@
+---
+date: 2026-03-14
+topic: customizable-vertical-config
+origin: Collaborative brainstorm session (Sprint 2 complete, planning Sprint 3+)
+---
+
+# Customizable Vertical Configuration System
+
+## Context
+
+The Netz Analysis Engine has vertical engines (`vertical_engines/`) that specialize analysis by asset class (private credit, liquid funds, venture capital, etc.). Currently, two separate config systems exist:
+
+- `calibration/` (4 YAMLs) — feeds `quant_engine/` with CVaR limits, regime thresholds, portfolio profiles, scoring weights. **Wealth-only, created for the old Wealth OS.**
+- `profiles/` (1 YAML) — feeds `ai_engine/` with IC memo chapter definitions, token budgets.
+
+Both are global/shared — no per-vertical or per-tenant customization. This is architecturally wrong for a multi-vertical, multi-tenant B2B SaaS product.
+
+## What We're Building
+
+A unified **ProductConfig** system that makes the entire analysis experience customizable per vertical AND per tenant. The configuration IS the product differentiator.
+
+**Four pillars of customization:**
+
+| Pillar | What it controls | Who edits | Example |
+|---|---|---|---|
+| **Calibration** | Quantitative thresholds, limits, risk parameters | **Client** (self-service within guardrails) | Credit: LTV < 65%, DSCR > 1.25x. Wealth: CVaR 95% < -5% |
+| **Chapters** | Analysis structure — add, remove, reorder chapters | **Netz team** (per client request) | Client A wants 15 chapters (adds ESG). Client B wants 12. |
+| **Prompts** | Tone, emphasis, analytical depth per chapter | **Netz prompt engineers** (IP — never visible to client) | Covenant analysis emphasis, sponsor track record depth. |
+| **Model routing** | Which LLM for which analysis stage | **Netz team** (per vertical) | Credit uses Claude (legal analysis). Wealth uses GPT-4o (numeric). |
+
+**Access model:**
+- **Client self-service:** Calibration only (within guardrails defined by Netz).
+- **Netz team:** Chapters, model routing, calibration defaults and guardrails.
+- **Netz prompt engineers:** Prompts. These are proprietary IP — never exposed to clients.
+- Clients do NOT touch code. They pass demands, Netz adjusts.
+
+## Why This Approach
+
+### Approaches Considered
+
+**Approach A (CHOSEN): Config unificada no banco**
+- Single `vertical_configs` table with JSONB
+- Cascade: tenant override → vertical default → global fallback
+- ConfigService with Redis cache
+- YAML = seed data only (initial migration)
+- Admin API + guardrails for client self-service
+
+**Approach B (Rejected): Hybrid YAML + DB**
+- YAML = defaults versionados no repo. DB = tenant overrides only.
+- Rejected because: defaults require deploy to change, two systems to maintain, prompts on filesystem awkward for tenant overrides.
+
+**Approach C (Rejected): Profiles as Product (fork/merge)**
+- Full versioning, fork/merge workflow for configs.
+- Rejected because: over-engineering for current stage. Fork/merge of configs is hard. Can evolve to this later if needed.
+
+### Why Approach A
+
+1. **Single source of truth** — one table, one service, one cache pattern.
+2. **Instant changes** — no deploy needed to adjust calibration for a client.
+3. **Guardrails native** — `guardrails JSONB` column defines allowed ranges per config.
+4. **Audit trail** — `created_by`, `updated_by`, timestamps on every config change.
+5. **Multi-vertical from day one** — each vertical has its own config types with appropriate defaults.
+6. **Scale** — same pattern works for 1 client (Netz) or 100.
+
+## Key Decisions
+
+### D1: All config in the database, YAML = seed only
+
+Current YAML files in `calibration/` and `profiles/` become seed data. A migration loads them into `vertical_configs` table. Services never read YAML directly — they go through `ConfigService` which queries DB with Redis cache.
+
+**Rationale:** Client demands adjustment → Netz team changes via API → instant effect. No PR, no deploy, no waiting.
+
+### D2: Cascade resolution order
+
+```
+ConfigService.get(vertical, config_type, org_id):
+  1. DB: WHERE organization_id = org_id AND vertical = V AND config_type = T
+  2. DB: WHERE organization_id IS NULL AND vertical = V AND config_type = T
+  3. Seed YAML fallback (emergency only — should never happen in production)
+```
+
+This means: tenant override wins. If no tenant override exists, vertical default applies. If vertical default somehow missing from DB, YAML fallback prevents crash.
+
+### D3: Client self-service with guardrails — calibration only
+
+Clients can edit **calibration** within ranges defined by Netz. Example:
+- Netz sets guardrail: `cvar_limit: {min: -15.0, max: -3.0}`
+- Client A sets `cvar_limit: -8.0` ✅
+- Client B tries `cvar_limit: -1.0` ❌ rejected (outside guardrail)
+
+**Clients CANNOT access:** prompts (proprietary IP), model routing, or chapter templates. These are managed exclusively by Netz team.
+
+Guardrails are stored alongside the default config in the `vertical_config_defaults` table. Only `config_type = 'calibration'`, `'scoring'`, and `'blocks'` have guardrails — other config types have `guardrails = NULL` (not client-editable).
+
+### D4: Each vertical defines its own calibration schema
+
+Credit calibration looks fundamentally different from wealth calibration:
+
+| Wealth calibration | Credit calibration |
+|---|---|
+| CVaR limits per risk profile | LTV thresholds per structure type |
+| Regime thresholds (VIX, yield curve) | DSCR/ICR minimums |
+| Portfolio allocation targets | Concentration limits (sector, geography) |
+| Fund scoring weights | Deal scoring weights (sponsor, structure, terms) |
+| Drift bands (DTW) | Covenant severity weights |
+
+The JSONB approach handles this naturally — each vertical's config has a different schema, validated by the vertical engine, not by the table.
+
+### D5: Prompts are Netz IP — stored in DB, never exposed to clients
+
+Prompts are Jinja2 templates stored in `vertical_config_defaults` with `config_type = 'prompts'`. The JSONB contains `{chapter_id: template_text}`. Managed exclusively by Netz prompt engineers via internal admin tools.
+
+**Why in DB (not filesystem):**
+- Per-vertical prompt sets (credit prompts ≠ wealth prompts) managed centrally.
+- Netz prompt engineer can iterate without deploy cycles.
+- Prompt versions tracked via audit table.
+
+**Never exposed to clients:** Prompts contain the analytical methodology and reasoning patterns that constitute Netz's core IP. The client sees the output (IC memo), never the prompt. No API endpoint returns prompt content to non-Netz roles.
+
+**Team plan:** A dedicated prompt engineer will own prompt quality, A/B testing, and per-vertical optimization. The DB-backed system supports this workflow natively.
+
+### D6: Phased implementation across sprints
+
+| Sprint | What | Why |
+|---|---|---|
+| Sprint 3 | `vertical_configs` table + `ConfigService` + seed migration + Redis cache | Vertical engines need config from day one. Avoid retrabalho. |
+| Sprint 5-6 | Admin API endpoints (Netz super-admin CRUD) | Frontends exist, can build admin panel. |
+| Sprint 7+ | Client-facing calibration UI with guardrails | Wealth frontend exists, self-service UX. |
+
+### D7: calibration/ directory becomes seed-only
+
+The `calibration/config/` directory stays in the repo as seed data and documentation, but is never read at runtime. The seed migration (`0004_vertical_configs.py`) loads these YAMLs into the database. Future calibration changes go through the API, not YAML edits.
+
+### D8: profiles/ merges conceptually with calibration
+
+There is no longer a distinction between "AI config" and "quant config". Everything is a `config_type` in `vertical_configs`:
+
+| config_type | What it contains |
+|---|---|
+| `calibration` | Quantitative thresholds (CVaR, LTV, DSCR, drift, regime) |
+| `chapters` | Chapter definitions (id, title, type, max_tokens, chunk_budget) |
+| `prompts` | Jinja2 templates per chapter |
+| `model_routing` | LLM selection per analysis stage |
+| `scoring` | Scoring weights for deals/funds |
+| `blocks` | Allocation blocks / sector-geography taxonomy |
+| `tone` | Tone normalization parameters |
+| `evaluation` | Evaluation criteria and quality thresholds |
+
+## Table Schema
+
+```sql
+-- Defaults: NO RLS, NO organization_id. Netz-managed. Visible to all tenants.
+CREATE TABLE vertical_config_defaults (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    vertical TEXT NOT NULL,
+    config_type TEXT NOT NULL,
+    config JSONB NOT NULL,
+    guardrails JSONB,              -- allowed ranges for client self-service
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by TEXT,
+    updated_by TEXT,
+    UNIQUE (vertical, config_type)
+);
+
+-- Overrides: WITH RLS on organization_id. Tenant-specific. Defense in depth.
+CREATE TABLE vertical_config_overrides (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    vertical TEXT NOT NULL,
+    config_type TEXT NOT NULL,
+    config JSONB NOT NULL,         -- sparse: only changed fields (deep-merged with default)
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by TEXT,
+    updated_by TEXT,
+    UNIQUE (organization_id, vertical, config_type)
+);
+
+ALTER TABLE vertical_config_overrides ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vertical_config_overrides FORCE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON vertical_config_overrides
+    USING (organization_id = (SELECT current_setting('app.current_organization_id')::uuid));
+
+CREATE INDEX idx_config_overrides_lookup
+    ON vertical_config_overrides (vertical, config_type, organization_id);
+
+-- Audit trail: DB trigger captures every change automatically.
+CREATE TABLE vertical_config_audit (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    table_name TEXT NOT NULL,      -- 'vertical_config_defaults' or 'vertical_config_overrides'
+    record_id UUID NOT NULL,
+    organization_id UUID,
+    vertical TEXT NOT NULL,
+    config_type TEXT NOT NULL,
+    old_config JSONB,
+    new_config JSONB NOT NULL,
+    changed_by TEXT,
+    changed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+## ConfigService Interface
+
+```python
+class ConfigService:
+    """
+    Resolves configuration for a given vertical + config_type + optional org_id.
+    Cascade: override (org-scoped, RLS) → default (global) → YAML seed fallback.
+    Cache: Redis with 5min TTL, invalidated on write via pub/sub.
+    """
+    async def get(self, vertical: str, config_type: str, org_id: UUID | None = None) -> dict:
+        """Returns deep_merge(default, override). Override wins on conflicts."""
+        ...
+
+    async def set_default(self, vertical: str, config_type: str, config: dict,
+                          guardrails: dict | None = None, actor: str = None) -> None:
+        """Netz super-admin sets vertical default. No org_id."""
+        ...
+
+    async def set_override(self, vertical: str, config_type: str, config: dict,
+                           org_id: UUID, actor: str = None) -> None:
+        """Set tenant-specific override. Validates against guardrails first."""
+        ...
+
+    async def validate_guardrails(self, vertical: str, config_type: str,
+                                   proposed: dict, org_id: UUID) -> list[str]:
+        """Returns list of violations. Empty list = valid."""
+        ...
+
+    async def get_with_guardrails(self, vertical: str, config_type: str,
+                                   org_id: UUID) -> ConfigWithGuardrails:
+        """Returns merged config + guardrail ranges for UI rendering."""
+        ...
+
+    async def list_configs(self, vertical: str, org_id: UUID | None = None) -> list[ConfigEntry]:
+        """Lists all config_types for a vertical, with override status per org."""
+        ...
+```
+
+## Impact on Existing Architecture
+
+### What changes
+
+| Component | Current | New |
+|---|---|---|
+| `calibration/config/*.yaml` | Runtime config source | Seed data only (loaded into DB by migration) |
+| `profiles/*/profile.yaml` | Runtime config source | Seed data only |
+| `quant_engine/*.py` services | `yaml.safe_load()` with `@lru_cache` | `ConfigService.get(vertical, config_type)` |
+| `ai_engine/profile_loader.py` | Loads YAML from filesystem | Loads from `ConfigService` |
+| `vertical_engines/*/` | Hardcoded defaults | Receives config via `ConfigService` injection |
+
+### What stays the same
+
+- `vertical_engines/` code structure (code is code, config is config)
+- `ai_engine/` universal modules (extraction, governance, validation)
+- `quant_engine/` service interfaces (only config loading changes)
+- RLS, auth, tenancy middleware
+- StorageClient, SSE, Redis patterns
+
+## Credit Calibration — Per-Vertical Config Types
+
+Each vertical defines its own calibration parameters appropriate to the asset class. These are NOT shared across verticals — a credit fund's risk parameters are fundamentally different from a liquid fund's.
+
+### Private Credit calibration types (to be refined with best practices research):
+
+| config_type | Parameters | Purpose |
+|---|---|---|
+| `calibration` | LTV thresholds by structure type, DSCR/ICR minimums, tenor limits, concentration limits (sector, geography, single-name) | Risk appetite boundaries |
+| `scoring` | Deal scoring weights: sponsor quality, structure quality, covenant package, collateral coverage, market timing | Deal ranking and prioritization |
+| `chapters` | 14 IC memo chapters (customizable: add ESG, remove peers, reorder) | Analysis structure |
+| `prompts` | Per-chapter Jinja2 with emphasis on credit-specific analysis | Analysis tone and depth |
+| `model_routing` | Claude for legal/covenant analysis, GPT-4o for financial modeling | LLM selection |
+
+### Liquid Funds calibration types:
+
+| config_type | Parameters | Purpose |
+|---|---|---|
+| `calibration` | CVaR limits per risk profile, regime thresholds (VIX, yield curve, CPI, Sahm), drift bands | Risk monitoring |
+| `scoring` | Fund scoring weights: return consistency, risk-adjusted return, drawdown control, info ratio | Fund selection |
+| `blocks` | Allocation blocks: geography × asset class → ETF proxy mapping | Investment universe |
+| `profiles` | Portfolio model profiles (conservative/moderate/growth) with strategic allocation targets | Portfolio construction |
+| `chapters` | 7 DD report chapters | Analysis structure |
+| `prompts` | Per-chapter Jinja2 for wealth DD reports | Analysis tone |
+| `model_routing` | GPT-4o for numeric analysis, Claude for qualitative | LLM selection |
+
+## Commercial Differentiation
+
+This architecture enables three tiers of commercial value:
+
+1. **Standard** — Netz defaults per vertical. Client gets institutional-grade analysis out of the box. Prompts, models, chapters optimized by Netz team.
+2. **Customized** — Netz adjusts chapters, prompts, model routing for the client's specific mandate. Calibration defaults tailored to their risk appetite. Delivered as professional service.
+3. **Self-service calibration** — Client adjusts quantitative parameters (thresholds, limits, scoring weights) within guardrails. Real-time effect. No Netz involvement for routine calibration changes.
+
+**IP protection model:** The analytical methodology (prompts, model routing, chapter logic) is Netz proprietary IP — never exposed to clients. What clients see is the output (IC memos, DD reports, risk metrics). What they can customize is the quantitative framework (calibration). This is analogous to Bloomberg Terminal: the methodology is opaque, but the parameters are configurable.
+
+No competitor in the VDR / credit analysis space offers this combination of analytical depth AND calibration customizability. Most deliver generic analysis with no parameterization.
+
+## Resolved Questions
+
+### RQ1: RLS on config tables → Two tables for defense in depth
+
+Tenant calibrations reveal sensitive information (risk appetite, internal limits, decision weights). A bug in application-level access control could leak configs between tenants. Solution:
+
+- `vertical_config_defaults` — NO RLS, NO `organization_id`. Netz defaults visible to all. Same pattern as `macro_data`.
+- `vertical_config_overrides` — RLS on `organization_id`. Impossible to leak between tenants even with application bugs.
+
+`ConfigService` merges: `deep_merge(default, override)`, override wins on conflicts.
+
+### RQ2: Config versioning → Audit table with DB trigger
+
+Institutional clients need audit trail: "who changed the CVaR limit and when?" Solution:
+
+- `vertical_config_audit` table with `old_config JSONB`, `new_config JSONB`, `changed_by TEXT`, `changed_at TIMESTAMPTZ`.
+- DB trigger on `UPDATE` of both config tables captures diff automatically.
+- No manual audit code needed — trigger handles everything.
+
+### RQ3: Prompt customization → Internal only, template slots pattern
+
+Prompts are Netz IP and never visible to clients. Internally, the Netz prompt engineer works with a **template + slots** pattern for maintainability:
+
+```json
+{
+  "ch01_exec": {
+    "emphasis": ["covenant_structure", "esg_compliance"],
+    "tone": "conservative",
+    "criteria": ["DSCR > 1.25x required", "LTV < 65% for senior secured"],
+    "additional_instructions": "Focus on downside protection over upside potential"
+  }
+}
+```
+
+The base Jinja2 template reads slots via `{{ config.emphasis }}`, `{{ config.tone }}`. The calibration values (DSCR threshold, LTV limit) are injected from `ConfigService.get('calibration')` — so when a client changes their calibration, prompts automatically reflect those thresholds without the client ever seeing the prompt itself.
+
+This separation means: **client edits calibration → prompts consume calibration values → analysis output reflects client preferences** — all without exposing IP.
+
+## Private Credit Calibration — Best Practices Research
+
+Research based on Moody's Annual Default Study, S&P Recovery Reports, Basel III/CRE IV, and public filings of Ares Capital, Blue Owl, HPS Investment Partners.
+
+### Leverage Limits (by structure type)
+
+| Structure | Max Total Leverage | Warning | Preferred Range |
+|---|---|---|---|
+| Senior Secured | 5.0x | 4.5x | 2.5x – 4.0x |
+| Unitranche | 5.5x | 5.0x | 3.0x – 4.5x |
+| Second Lien | 6.5x | 6.0x | 4.0x – 5.5x |
+
+Reference: Moody's B2 median ~5.0x, S&P B median ~5.5x (2023-2025 vintage).
+
+### Coverage Ratios
+
+| Metric | Hard Floor | Warning | Comfortable | Strong |
+|---|---|---|---|---|
+| DSCR | 1.10x | 1.25x | 1.50x | 2.00x |
+| Interest Coverage (ICR) | 1.50x | 1.75x | 2.50x | 4.00x |
+| Fixed Charge Coverage | 1.00x | 1.15x | 1.30x | — |
+
+### LTV Limits (by structure)
+
+| Structure | Max Hard | Warning | Preferred Range |
+|---|---|---|---|
+| Senior Secured (EV basis) | 65% | 60% | 40% – 55% |
+| Unitranche | 70% | 65% | 45% – 60% |
+| Second Lien | 80% | 75% | 55% – 70% |
+| Real Estate (CRE) | 75% | 70% | 50% – 65% |
+
+TEV stress haircut: 25% for downside LTV calculation.
+
+### Credit Deal Scoring Weights (equivalent of `scoring.yaml`)
+
+| Factor | Weight | Description |
+|---|---|---|
+| Credit quality | 0.25 | DSCR, ICR, leverage, LTV composite |
+| Return adequacy | 0.20 | Spread vs risk, risk-adjusted return |
+| Structural protection | 0.15 | Covenants, security package, waterfall |
+| Sponsor quality | 0.15 | Track record, AUM, default history |
+| Business quality | 0.10 | Revenue stability, margin, sector |
+| Documentation completeness | 0.10 | Evidence quality, data gaps |
+| Liquidity profile | 0.05 | Tenor, prepayment, exit path |
+
+### Portfolio Concentration Limits
+
+| Limit Type | Max | Warning |
+|---|---|---|
+| Single obligor | 10% of NAV | 7.5% |
+| Top 5 obligors | 40% | 35% |
+| Single sector (GICS) | 25% | 20% |
+| Single country (non-domicile) | 40% | 30% |
+| Emerging markets | 15% | 10% |
+| Second lien allocation | 20% | 15% |
+| PIK positions | 15% | 10% |
+
+### Credit Regime Signals (equivalent of wealth regime thresholds)
+
+| Signal | Normal | Cautious | Stress | Crisis |
+|---|---|---|---|---|
+| HY OAS (bps) | < 350 | 350–500 | 500–700 | > 1000 |
+| Lev Loan Spread (bps) | < 400 | 400–550 | 550–700 | > 700 |
+| Default Rate (Moody's spec-grade) | < 2% | 2–4% | 4–6% | > 10% |
+| CLO Issuance YoY change | — | -30% | -50% | — |
+
+### Credit Regime Definitions
+
+| Regime | Pipeline Adj | Spread Premium | Leverage Adj | Covenant Req |
+|---|---|---|---|---|
+| NORMAL | 0% | 0 bps | 0 | Any |
+| CAUTIOUS | -20% | +50 bps | -0.5x | Any |
+| STRESS | -50% | +150 bps | -1.0x | Full maintenance |
+| CRISIS | -80% | +300 bps | -1.5x | Full maintenance |
+
+### Scenario Calibration (replaces `_SCENARIO_PROXY` in `ic_quant_engine.py`)
+
+| Parameter | Base | Downside | Severe | Tail (1-in-25y) |
+|---|---|---|---|---|
+| Default rate | 2% | 5% | 10% | 15% |
+| Recovery rate (1st lien) | 67% | 50% | 35% | 25% |
+| Revenue change | +3% | -10% | -25% | -40% |
+| EBITDA margin Δ | 0 bps | -200 bps | -500 bps | -800 bps |
+| Rate shock | 0 bps | +100 bps | +200 bps | -200 bps |
+
+### Return Requirements (by strategy)
+
+| Strategy | Min Spread (SOFR+) | Net IRR Target |
+|---|---|---|
+| Core Senior Secured | 450 bps | 8–12% |
+| Unitranche | 550 bps | 10–14% |
+| Second Lien | 750 bps | 12–16% |
+| Venture Debt | 800 bps | 12–18% |
+| Distressed | 1000 bps | 15–20% |
+
+### Monitoring Triggers (extends existing `policy_loader.py`)
+
+| Trigger | Warning | Critical |
+|---|---|---|
+| Leverage increase from underwriting | +0.5x | +1.0x |
+| DSCR decline from underwriting | -0.15 | -0.30 |
+| Revenue decline YoY | -10% | -20% |
+| EBITDA decline YoY | -15% | -25% |
+| Payment delay (days) | 15 | 30 (default event) |
+| NAV mark-down | 5% | 15% |
+| Covenant headroom | < 10% | < 5% |
+
+### Rating Agency Anchors (Moody's 1983-2024 averages)
+
+| Rating | Annual Default Rate | Recovery (1st Lien) |
+|---|---|---|
+| Ba | 1.10% | 67% |
+| B (core private credit) | 3.50% | 67% |
+| Caa | 10.50% | 55% |
+
+Expected Loss calibration: Core senior secured = PD 2.0% × LGD 30% = **60 bps/year**.
+
+## Next Steps
+
+→ `/ce:plan` to design the implementation across Sprints 3-7.
+→ Credit calibration research incorporated above — ready for seed YAML generation.

--- a/docs/plans/2026-03-14-feat-customizable-vertical-config-plan.md
+++ b/docs/plans/2026-03-14-feat-customizable-vertical-config-plan.md
@@ -2,6 +2,7 @@
 title: "feat: Customizable Vertical Configuration System (ProductConfig)"
 type: feat
 status: active
+phase1_completed: 2026-03-14
 date: 2026-03-14
 deepened: 2026-03-14
 origin: docs/brainstorms/2026-03-14-customizable-vertical-config-brainstorm.md
@@ -604,14 +605,14 @@ Client UI → PUT /api/v1/configs/{vertical}/calibration
 
 ##### Acceptance Criteria
 
-- [ ] `ConfigService.get("liquid_funds", "calibration")` returns same values as current YAML
-- [ ] `ConfigService.get("private_credit", "calibration")` returns credit-specific thresholds
-- [ ] Tenant override merges correctly with default (deep merge, sparse override)
-- [ ] In-process cache hit on second call within 60s TTL
-- [ ] All existing quant_engine tests pass with injected config
-- [ ] Startup health check logs OK for all seeded config_types
-- [ ] Migration is idempotent (running twice does not fail or duplicate)
-- [ ] `make check` passes
+- [x] `ConfigService.get("liquid_funds", "calibration")` returns same values as current YAML
+- [x] `ConfigService.get("private_credit", "calibration")` returns credit-specific thresholds
+- [x] Tenant override merges correctly with default (deep merge, sparse override)
+- [x] In-process cache hit on second call within 60s TTL
+- [x] All existing quant_engine tests pass with injected config
+- [x] Startup health check logs OK for all seeded config_types
+- [x] Migration is idempotent (running twice does not fail or duplicate)
+- [x] `make check` passes
 
 ##### Key Files
 

--- a/docs/plans/2026-03-14-feat-customizable-vertical-config-plan.md
+++ b/docs/plans/2026-03-14-feat-customizable-vertical-config-plan.md
@@ -1,0 +1,975 @@
+---
+title: "feat: Customizable Vertical Configuration System (ProductConfig)"
+type: feat
+status: active
+date: 2026-03-14
+deepened: 2026-03-14
+origin: docs/brainstorms/2026-03-14-customizable-vertical-config-brainstorm.md
+parent_plan: docs/plans/2026-03-14-feat-netz-analysis-engine-platform-plan.md
+---
+
+# Customizable Vertical Configuration System (ProductConfig)
+
+## Enhancement Summary
+
+**Deepened on:** 2026-03-14
+**Review agents used:** 7 (SpecFlow analyzer, architecture strategist, security sentinel, performance oracle, data integrity guardian, code simplicity reviewer, best practices researcher)
+
+### Key Improvements from Research
+
+1. **Sprint 3 YAGNI reduction (~40%):** Drop Redis cache, audit triggers, guardrails validation, and write methods from Sprint 3. ConfigService becomes read-only with in-process TTL cache. Build write infrastructure when first consumer arrives (Sprint 5-6).
+2. **Single DB session:** Use `get_db_with_rls` for ConfigService (defaults table has no RLS, so zero impact). Eliminates dual-session ambiguity and connection pool exhaustion risk.
+3. **pg_notify for cache invalidation (Sprint 5-6):** Use PostgreSQL LISTEN/NOTIFY instead of Redis pub/sub — fires from DB trigger, transactional (only on commit), zero write-path application code.
+4. **Deep merge safety:** Block None-deletion in client self-service API (only Netz admin can delete keys). Validate merged result against per-type schema before serving.
+5. **Audit trigger must include DELETE:** CASCADE deletes leave no trace without it. Add `operation TEXT` column to distinguish INSERT/UPDATE/DELETE.
+6. **Seed idempotency:** Use `INSERT ... ON CONFLICT DO NOTHING`. Set `created_by = 'migration:0004'` for provenance.
+7. **CHECK constraints on vertical/config_type:** Prevent typos like `'Liquid_Funds'` vs `'liquid_funds'`. Deliberate friction.
+8. **Optimistic concurrency (Sprint 5-6):** Add `version` column + `WHERE version = :expected` on update. Prevents silent overwrite when two admins edit simultaneously.
+9. **ON DELETE RESTRICT (not CASCADE):** Organization deletion should not silently destroy calibration. Force explicit cleanup.
+
+### Critical Decisions from Reviews
+
+| Decision | Source | Impact |
+|---|---|---|
+| Sprint 3 = read-only ConfigService + in-process cache | Simplicity + Performance | ~40% scope reduction, no Redis dependency on read path |
+| Use `get_db_with_rls` for all ConfigService queries | Architecture + Performance | Single session, no connection pool risk |
+| Defer audit triggers to Sprint 5-6 | Simplicity | Migration file is audit trail for seed data |
+| Defer guardrails validation to Sprint 7 | Simplicity | No client self-service until then |
+| Sync quant functions receive config as parameter | SpecFlow + Architecture | Config resolved once at async entry point, passed down |
+| `list_configs()` filters out prompts/model_routing for non-admin | SpecFlow + Security | Prevents IP exposure even in metadata |
+| Remove `chapters` from CLIENT_VISIBLE_TYPES | Security + IP | Chapter structure (which chapters, ordering) is analytical methodology IP — clients get the output, not the structure |
+| Credit calibration seed = engine quality upgrade | Product | Institutional defaults (Moody's, S&P, Basel III) replace hardcoded values — direct analytical improvement |
+| NETZ_ADMIN provisioned via Clerk Dashboard/Backend API only | Security | `publicMetadata` is server-side only by design — cannot be self-assigned via client SDK |
+| **OPEN (Sprint 5-6):** `portfolio_profiles` client visibility | IP review | Profile structure (CVaR limits, allocations) may be methodology IP like chapters — deliberate before client self-service UI |
+| Add CHECK constraints on TEXT columns | Data Integrity | Prevents config orphaning via typos |
+
+### Security Findings (from security sentinel)
+
+| Finding | Severity | Remediation |
+|---|---|---|
+| No `NETZ_ADMIN` role exists — `org:admin` would grant admin API to ALL tenants | CRITICAL | Define `NETZ_ADMIN` via Clerk `publicMetadata` (server-side only, cannot be self-assigned). Prerequisite for Sprint 5-6 admin API. |
+| Prompts in no-RLS table accessible to any DB session | HIGH | `CLIENT_VISIBLE_TYPES = frozenset({"calibration", "scoring", "blocks"})` checked in `get()` and `list_configs()` |
+| Jinja2 SSTI risk in admin-editable prompt templates | HIGH | Use `jinja2.SandboxedEnvironment`, disable `__` attribute access, validate templates at write time |
+| Guardrail validation must be inside `set_override()`, not separate | HIGH | Enforce architecturally — `set_override()` calls `validate_guardrails()` internally before DB write |
+| Dev bypass (`X-DEV-ACTOR`) could grant admin access | HIGH | Ensure `is_development` never true in production; verify `validate_production_secrets()` called at startup |
+| Audit table allows UPDATE/DELETE by app user | MEDIUM | `REVOKE UPDATE, DELETE ON vertical_config_audit FROM app_user` |
+| Validate `vertical`/`config_type` path params with Pydantic `Literal` | MEDIUM | Prevents cache key pollution and unexpected DB queries |
+
+### Anti-Patterns Discovered
+
+| Anti-Pattern | Source | Correct Pattern |
+|---|---|---|
+| Two DB sessions per cache miss | Performance | Single `get_db_with_rls` session for both queries |
+| Redis pub/sub per worker for config invalidation | Performance | Single shared listener per process (Sprint 5-6) |
+| `None` = delete in client API | Data Integrity + Security | Block None-deletion for clients; only Netz admin can delete via `_DELETE` sentinel |
+| `ON DELETE CASCADE` on config overrides | Data Integrity | `ON DELETE RESTRICT` — force explicit cleanup |
+| GIN index on JSONB config column | Performance | Not needed — queries filter by composite key, never by JSONB content |
+| Module-level `PROFILE_CVAR_CONFIG` constant | Architecture | Remove completely; all callers pass config as parameter |
+| Using `org:admin` for Netz admin API | Security | Define `NETZ_ADMIN` via Clerk `publicMetadata` — cannot be self-assigned by tenants |
+| Default Jinja2 Environment for prompt rendering | Security | Use `SandboxedEnvironment` — prevents SSTI attacks from compromised admin accounts |
+
+## Overview
+
+Replace the static YAML-based configuration system (`calibration/` + `profiles/`) with a database-backed, multi-tenant, multi-vertical configuration system. Each vertical (private credit, liquid funds, venture capital, etc.) gets its own calibration parameters, and each tenant can customize calibration within guardrails defined by Netz.
+
+**This is the product differentiator.** No competitor offers calibration customizability at this level. The configuration IS the product.
+
+**Origin:** See [brainstorm](../brainstorms/2026-03-14-customizable-vertical-config-brainstorm.md) for full design rationale, resolved questions, and credit calibration best practices.
+
+## Problem Statement
+
+Two separate config systems exist, both global/shared:
+- `calibration/config/` (4 YAMLs) — wealth-only quant parameters, loaded via `@lru_cache` + `yaml.safe_load()` with hardcoded fallback. No per-tenant override. No per-vertical separation.
+- `profiles/private_credit/profile.yaml` — IC memo chapter definitions, not yet loaded by engine (chapter engine still reads from Python constants in `memo_chapter_prompts.py`).
+
+This is architecturally wrong for a multi-vertical, multi-tenant B2B SaaS:
+1. Credit calibration (LTV, DSCR, covenants) is fundamentally different from wealth calibration (CVaR, regime, drift).
+2. Each client has different risk appetite — one wants LTV < 55%, another accepts LTV < 65%.
+3. Config changes require code deploy (YAML in repo, `@lru_cache` at process level).
+
+## Proposed Solution
+
+### Architecture
+
+Two PostgreSQL tables + Redis cache + ConfigService + Admin API + Client self-service UI.
+
+**Access model (see brainstorm D3, D5):**
+
+| Config type | Client access | Netz access |
+|---|---|---|
+| `calibration`, `scoring`, `blocks`, `portfolio_profiles` | Self-service within guardrails | Full CRUD + guardrail definition |
+| `chapters`, `tone`, `evaluation` | **Not visible** (chapters expose memo structure = IP) | Full CRUD per client request |
+| `prompts` | **Never visible** (proprietary IP) | Full CRUD by prompt engineers |
+| `model_routing` | Not visible | Full CRUD per vertical |
+
+> **Decision (2026-03-14):** `chapters` removed from client-visible set. Chapter definitions expose the IC memo structure (which chapters exist, their purpose, ordering) — this is analytical methodology IP. Clients benefit from the output, not the structure. `CLIENT_VISIBLE_TYPES = {"calibration", "scoring", "blocks", "portfolio_profiles"}`.
+
+### Table Schema (see brainstorm RQ1)
+
+Defense-in-depth: two tables to prevent tenant config leakage.
+
+```sql
+-- Defaults: NO RLS, NO organization_id. Netz-managed. Visible to all tenants.
+-- Same pattern as macro_data and allocation_blocks.
+CREATE TABLE vertical_config_defaults (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    vertical TEXT NOT NULL CHECK (vertical IN ('private_credit', 'liquid_funds')),
+    config_type TEXT NOT NULL CHECK (config_type IN ('calibration', 'scoring', 'blocks',
+                                    'chapters', 'portfolio_profiles', 'prompts',
+                                    'model_routing', 'tone', 'evaluation')),
+    config JSONB NOT NULL CHECK (jsonb_typeof(config) = 'object'),
+    guardrails JSONB,                -- allowed ranges for client self-service (NULL = not client-editable)
+    description TEXT,
+    version INTEGER NOT NULL DEFAULT 1,  -- optimistic concurrency control (Sprint 5-6)
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by TEXT,
+    updated_by TEXT,
+    UNIQUE (vertical, config_type)
+);
+
+-- Overrides: WITH RLS on organization_id. Tenant-specific.
+CREATE TABLE vertical_config_overrides (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL,   -- FK added after organizations table exists (ON DELETE RESTRICT)
+    vertical TEXT NOT NULL CHECK (vertical IN ('private_credit', 'liquid_funds')),
+    config_type TEXT NOT NULL CHECK (config_type IN ('calibration', 'scoring', 'blocks',
+                                    'chapters', 'portfolio_profiles', 'prompts',
+                                    'model_routing', 'tone', 'evaluation')),
+    config JSONB NOT NULL,           -- sparse: only changed fields (deep-merged with default)
+    version INTEGER NOT NULL DEFAULT 1,  -- optimistic concurrency control (Sprint 5-6)
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by TEXT,
+    updated_by TEXT,
+    UNIQUE (organization_id, vertical, config_type)
+);
+
+ALTER TABLE vertical_config_overrides ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vertical_config_overrides FORCE ROW LEVEL SECURITY;
+
+-- MUST use subselect pattern (see CLAUDE.md: "RLS subselect" rule)
+CREATE POLICY org_isolation ON vertical_config_overrides
+    USING (organization_id = (SELECT current_setting('app.current_organization_id')::uuid));
+
+CREATE INDEX idx_config_overrides_lookup
+    ON vertical_config_overrides (vertical, config_type, organization_id);
+
+-- Audit trail: DB trigger captures every change automatically (see brainstorm RQ2)
+-- DEFERRED to Sprint 5-6: create audit table + triggers when Admin API enables writes.
+-- In Sprint 3, the migration file itself IS the audit trail (only seed inserts happen).
+--
+-- Sprint 5-6 migration will create:
+--
+-- CREATE TABLE vertical_config_audit (
+--     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+--     operation TEXT NOT NULL,        -- 'INSERT', 'UPDATE', 'DELETE'
+--     table_name TEXT NOT NULL,
+--     record_id UUID NOT NULL,
+--     organization_id UUID,
+--     vertical TEXT NOT NULL,
+--     config_type TEXT NOT NULL,
+--     old_config JSONB,              -- NULL on INSERT
+--     new_config JSONB,              -- NULL on DELETE
+--     old_version INTEGER,
+--     new_version INTEGER,
+--     changed_by TEXT,
+--     changed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+-- );
+--
+-- Trigger function handles INSERT, UPDATE, AND DELETE:
+-- - On DELETE: references OLD (NEW is NULL)
+-- - On INSERT: references NEW (OLD is NULL)
+-- - On UPDATE: auto-increments version, captures both old/new
+-- - Fires pg_notify('config_changed', ...) for cache invalidation
+```
+
+### ConfigService
+
+**Sprint 3 scope (read-only):** Only `get()`, `list_configs()`, and `deep_merge()`. Write methods, guardrails validation, and Redis cache deferred to Sprint 5-6 (YAGNI — zero writers in Sprint 3).
+
+**Sprint 5-6 scope (full):** Add `set_default()`, `set_override()`, `validate_guardrails()`, Redis cache with pg_notify invalidation, optimistic concurrency control.
+
+```python
+# backend/app/core/config/config_service.py
+
+class ConfigService:
+    """
+    Resolves configuration for a given vertical + config_type + optional org_id.
+    Cascade: in-process cache → DB override (RLS) → DB default → YAML fallback.
+
+    Sprint 3: read-only with cachetools.TTLCache (in-process, 60s).
+    Sprint 5-6: add Redis L2 cache + pg_notify invalidation + write methods.
+    """
+
+    def __init__(self, db: AsyncSession):
+        self._db = db
+        # In-process cache — no Redis dependency in Sprint 3
+        # Replaced with Redis L2 in Sprint 5-6 when admin API enables writes
+
+    async def get(self, vertical: str, config_type: str,
+                  org_id: UUID | None = None) -> dict:
+        """
+        Returns deep_merge(default, override). Override wins on conflicts.
+        Single DB session (get_db_with_rls) for both queries.
+        """
+        ...
+
+    # IP protection: prompts, chapters, and internal config types never returned to clients.
+    # Chapters expose IC memo structure (which chapters exist, ordering) — analytical methodology IP.
+    CLIENT_VISIBLE_TYPES: ClassVar[frozenset] = frozenset({
+        "calibration", "scoring", "blocks", "portfolio_profiles"
+    })
+
+    async def list_configs(self, vertical: str,
+                           org_id: UUID | None = None,
+                           is_admin: bool = False) -> list[ConfigEntry]:
+        """
+        Lists all config_types for a vertical, with override status.
+        Non-admin callers: filters to CLIENT_VISIBLE_TYPES only (IP protection).
+        """
+        ...
+
+    @staticmethod
+    def deep_merge(base: dict, override: dict) -> dict:
+        """
+        Recursive merge. Override values win on scalars.
+        Dicts are recursively merged. Lists are REPLACED (not appended).
+        None values in override DELETE the key (Netz admin only — blocked for clients).
+        """
+        ...
+
+    # --- Sprint 5-6 additions (not implemented in Sprint 3) ---
+
+    async def set_default(self, vertical: str, config_type: str,
+                          config: dict, guardrails: dict | None = None,
+                          actor: str = None) -> None:
+        """Netz super-admin sets vertical default. Validates schema. Optimistic lock via version."""
+        ...
+
+    async def set_override(self, vertical: str, config_type: str,
+                           config: dict, org_id: UUID,
+                           actor: str = None,
+                           expected_version: int | None = None) -> None:
+        """
+        Set tenant-specific override. Validates against guardrails.
+        Validates merged result against per-type schema (prevents accidental key deletion).
+        Optimistic concurrency via version column.
+        """
+        ...
+
+    async def validate_guardrails(self, vertical: str, config_type: str,
+                                   proposed: dict, org_id: UUID) -> list[str]:
+        """Returns list of violation descriptions. Empty = valid. Rejects unknown dot-paths."""
+        ...
+
+    async def get_with_guardrails(self, vertical: str, config_type: str,
+                                   org_id: UUID) -> ConfigWithGuardrails:
+        """Returns merged config + guardrail ranges for UI rendering."""
+        ...
+```
+
+**FastAPI dependency:**
+
+```python
+# backend/app/core/config/dependencies.py
+
+async def get_config_service(
+    db: AsyncSession = Depends(get_db_with_rls),  # Single session for both defaults + overrides
+) -> ConfigService:
+    return ConfigService(db=db)
+    # Note: defaults table has NO RLS, so SET LOCAL has zero effect on it.
+    # Overrides table has RLS, so the same session works correctly for both.
+```
+
+### Cache Strategy (phased)
+
+**Sprint 3 — In-process TTL cache:**
+```python
+from cachetools import TTLCache
+
+# Module-level cache (safe — not an asyncio primitive)
+_config_cache = TTLCache(maxsize=128, ttl=60)  # 60-second TTL
+
+# ConfigService.get() checks _config_cache first, then DB.
+# No Redis dependency. No invalidation logic. Max 60s staleness.
+# Acceptable because config changes don't exist in Sprint 3.
+```
+
+**Sprint 5-6 — Add Redis L2 + pg_notify invalidation:**
+```python
+# When admin API enables writes, add:
+# 1. Redis as L2 cache (5min TTL) behind in-process L1 (30s TTL)
+# 2. pg_notify from DB trigger → asyncpg LISTEN → evict L1 + L2
+# 3. pg_notify is transactional — notification sent only on commit
+# 4. Single shared LISTEN connection per process (not per worker)
+#
+# Cache key: "config:{vertical}:{config_type}:{org_id or 'default'}"
+# Invalidation: pg_notify('config_changed', '{"vertical":...,"config_type":...}')
+#   → asyncpg listener → Redis DEL + L1 evict
+```
+
+### Seed Data Strategy
+
+Current YAML files become seed data loaded by migration `0004`:
+
+| YAML file | → | vertical | config_type |
+|---|---|---|---|
+| `calibration/config/limits.yaml` | → | `liquid_funds` | `calibration` |
+| `calibration/config/profiles.yaml` | → | `liquid_funds` | `portfolio_profiles` |
+| `calibration/config/scoring.yaml` | → | `liquid_funds` | `scoring` |
+| `calibration/config/blocks.yaml` | → | `liquid_funds` | `blocks` |
+| `profiles/private_credit/profile.yaml` | → | `private_credit` | `chapters` |
+| (NEW — from best practices research) | → | `private_credit` | `calibration` |
+| (NEW — from best practices research) | → | `private_credit` | `scoring` |
+
+**After seed:** YAML files remain in repo as documentation/reference but are never read at runtime. `@lru_cache` loaders in quant_engine are replaced with `ConfigService.get()` calls.
+
+## Technical Approach
+
+### How quant_engine services change
+
+**Before (current):**
+```python
+# cvar_service.py:66-89
+@lru_cache(maxsize=1)
+def get_profile_cvar_config():
+    path = get_calibration_path() / "profiles.yaml"
+    data = yaml.safe_load(path.read_text())
+    return data["profiles"]
+```
+
+**After:**
+```python
+# cvar_service.py — receives config as parameter (like optimizer_service.py already does)
+async def calculate_cvar(
+    nav_data: pd.DataFrame,
+    profile_name: str,
+    config: dict,  # injected by caller via ConfigService.get("liquid_funds", "calibration")
+) -> CVaRResult:
+    cvar_config = config["cvar_limits"][profile_name]
+    ...
+```
+
+**Pattern:** Follow `optimizer_service.py` which already receives `ProfileConstraints` as parameter (no YAML loading). Extend this pattern to all quant services.
+
+### How ai_engine changes
+
+**ProfileLoader** uses ConfigService instead of filesystem:
+
+```python
+# ai_engine/profile_loader.py
+class ProfileLoader:
+    def __init__(self, config_service: ConfigService):
+        self._config = config_service
+
+    async def load(self, profile_name: str, org_id: UUID | None = None) -> AnalysisProfile:
+        chapters = await self._config.get(profile_name, "chapters", org_id)
+        calibration = await self._config.get(profile_name, "calibration", org_id)
+        model_routing = await self._config.get(profile_name, "model_routing", org_id)
+        engine = self._load_engine(profile_name)
+        return AnalysisProfile(
+            chapters=chapters, calibration=calibration,
+            model_routing=model_routing, engine=engine
+        )
+```
+
+### How model_config.py changes
+
+**Before:**
+```python
+# model_config.py:113-146 — hardcoded MODELS dict + env var override
+MODELS = {"ch01_exec": "gpt-4.1", "ch05_legal": "claude-sonnet-4-5-20250514", ...}
+def get_model(stage: str) -> str:
+    env = os.environ.get(f"NETZ_MODEL_{stage.upper()}")
+    return env or MODELS.get(stage, _DEFAULT_MODEL)
+```
+
+**After:**
+```python
+# model_config.py — ConfigService-backed with env var override preserved
+async def get_model(stage: str, config_service: ConfigService,
+                     vertical: str, org_id: UUID | None = None) -> str:
+    # Env var still wins (for A/B testing, debugging)
+    env = os.environ.get(f"NETZ_MODEL_{stage.upper()}")
+    if env:
+        return env
+    # DB config
+    routing = await config_service.get(vertical, "model_routing", org_id)
+    return routing.get(stage, _DEFAULT_MODEL)
+```
+
+### Deep Merge Semantics
+
+```python
+_DELETE = object()  # sentinel — only used internally by Netz admin API
+
+def deep_merge(base: dict, override: dict) -> dict:
+    """
+    Recursive merge. Override values win on scalar conflicts.
+    Dicts are recursively merged. Lists are REPLACED (not appended).
+    _DELETE sentinel removes key (Netz admin only — client API strips None before merge).
+    """
+    result = base.copy()
+    for key, value in override.items():
+        if value is _DELETE:
+            result.pop(key, None)  # explicit deletion — admin only
+        elif isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+```
+
+**Safety:** Client self-service API strips `None` values from payload before calling `deep_merge`. Only Netz admin API can use `_DELETE` sentinel. After merge, the result is validated against a per-type Pydantic schema to ensure no required fields were removed.
+
+**Example — client overrides LTV limit only:**
+
+Default:
+```json
+{"leverage_limits": {"senior_secured": {"max_total_leverage": 5.0, "warning": 4.5}},
+ "ltv_limits": {"senior_secured_ltv": {"max_hard": 0.65, "warning": 0.60}}}
+```
+
+Override (sparse):
+```json
+{"ltv_limits": {"senior_secured_ltv": {"max_hard": 0.55}}}
+```
+
+Merged result:
+```json
+{"leverage_limits": {"senior_secured": {"max_total_leverage": 5.0, "warning": 4.5}},
+ "ltv_limits": {"senior_secured_ltv": {"max_hard": 0.55, "warning": 0.60}}}
+```
+
+### Guardrails Validation
+
+```python
+# Guardrails JSONB schema (stored on vertical_config_defaults)
+{
+    "ltv_limits.senior_secured_ltv.max_hard": {"min": 0.40, "max": 0.75, "type": "float"},
+    "leverage_limits.senior_secured.max_total_leverage": {"min": 3.0, "max": 7.0, "type": "float"},
+    "cvar_limits.conservative.limit": {"min": -15.0, "max": -3.0, "type": "float"},
+    "scoring_weights.credit_quality": {"min": 0.10, "max": 0.40, "type": "float"}
+}
+```
+
+Validation walks the proposed override's dot-paths, checks each against guardrails. Unknown paths (not in guardrails) are rejected. This prevents clients from injecting arbitrary keys.
+
+### Prompt Slot System (see brainstorm RQ3)
+
+Prompts are Netz IP — never visible to clients. Internally, prompt engineers use a **template + slots** pattern:
+
+```python
+# The Jinja2 template (stored in vertical_config_defaults, config_type='prompts')
+# References calibration values dynamically:
+"""
+Analyze the credit structure focusing on: {{ slots.emphasis | join(', ') }}.
+
+Apply the following thresholds:
+- Maximum LTV: {{ calibration.ltv_limits.senior_secured_ltv.max_hard * 100 }}%
+- Minimum DSCR: {{ calibration.coverage_ratios.dscr.minimum_hard }}x
+
+Tone: {{ slots.tone }}
+{% if slots.additional_instructions %}
+Additional: {{ slots.additional_instructions }}
+{% endif %}
+"""
+```
+
+When a client changes their calibration (e.g., LTV from 65% to 55%), the prompt **automatically reflects the new threshold** without the client ever seeing the prompt.
+
+## System-Wide Impact
+
+### Interaction Graph
+
+```
+Client UI → PUT /api/v1/configs/{vertical}/calibration
+  → ConfigService.validate_guardrails() → OK/reject
+  → ConfigService.set_override() → DB write + audit trigger + cache invalidate
+  → Redis PUBLISH config:invalidated → all service instances evict cache
+  → Next analysis request → ConfigService.get() → cache miss → DB read → cache set
+  → ProfileLoader.load() → vertical engine receives new config → analysis uses updated thresholds
+```
+
+### Error & Failure Propagation
+
+- **Redis cache down:** ConfigService falls through to DB query. Performance degrades but correctness maintained. TTL-based cache means no stale data risk — just slower.
+- **DB config missing:** YAML seed fallback (emergency). Logged as WARNING. Should never happen after migration.
+- **Guardrail violation:** `GuardrailViolation` exception → 422 response with specific violations list.
+- **Concurrent writes:** `ON CONFLICT (organization_id, vertical, config_type) DO UPDATE` ensures last-write-wins. Audit table captures both writes.
+- **Migration rollback:** `downgrade()` drops the three tables. Config reverts to YAML loading (quant_engine fallback pattern already handles this).
+
+### State Lifecycle Risks
+
+- **Orphaned overrides:** If a tenant is deleted, `ON DELETE CASCADE` from `organizations` FK removes overrides.
+- **Guardrail tightening:** If Netz tightens a guardrail after a client already has an override outside the new range, the existing override continues to work (DB doesn't validate retroactively). ConfigService should flag this on `list_configs()` as `guardrail_violation: true` so Netz admin can negotiate with the client.
+- **Stale cache after pub/sub failure:** Max staleness = TTL (5 minutes). Acceptable for calibration changes which are infrequent.
+
+## Implementation Phases
+
+### Phase 1: Backend Foundation (Sprint 3 — alongside vertical engines)
+
+**Goal:** Read-only ConfigService operational. All quant_engine and ai_engine services use ConfigService instead of YAML. No write API, no Redis, no audit triggers, no guardrails validation (YAGNI — zero writers in Sprint 3).
+
+#### Tasks
+
+- [x] **Migration `0004_vertical_configs.py`**
+  - Create `vertical_config_defaults` table (no RLS, CHECK constraints on vertical/config_type)
+  - Create `vertical_config_overrides` table (with RLS, subselect pattern, CHECK constraints)
+  - Create index on overrides lookup
+  - Seed `vertical_config_defaults` using `INSERT ... ON CONFLICT DO NOTHING` (idempotent):
+    - `calibration/config/limits.yaml` → `(liquid_funds, calibration)`
+    - `calibration/config/profiles.yaml` → `(liquid_funds, portfolio_profiles)`
+    - `calibration/config/scoring.yaml` → `(liquid_funds, scoring)`
+    - `calibration/config/blocks.yaml` → `(liquid_funds, blocks)`
+    - `profiles/private_credit/profile.yaml` → `(private_credit, chapters)`
+    - NEW `calibration/seeds/private_credit/calibration.yaml` → `(private_credit, calibration)`
+    - NEW `calibration/seeds/private_credit/scoring.yaml` → `(private_credit, scoring)`
+  - Set `created_by = 'migration:0004'` on all seed rows (provenance)
+  - Add `guardrails JSONB` column (populated but NOT validated until Sprint 7)
+  - `downgrade()`: drop both tables + index. WARNING comment: destroys all config data.
+  - **Deferred to Sprint 5-6:** audit table, trigger function, pg_notify
+
+- [x] **`backend/app/core/config/config_service.py`** — ConfigService (read-only for Sprint 3)
+  - `get()` with cascade: in-process TTLCache → DB override → DB default → YAML fallback (logged as ERROR)
+  - `list_configs()` — all config_types for a vertical (filters prompts/model_routing for non-admin)
+  - `deep_merge()` static method — recursive, lists replaced, _DELETE sentinel (admin only)
+  - In-process cache: `cachetools.TTLCache(maxsize=128, ttl=60)`
+  - Single session (`get_db_with_rls`) for both defaults + overrides queries
+  - **Deferred to Sprint 5-6:** `set_default()`, `set_override()`, `validate_guardrails()`, `get_with_guardrails()`, Redis L2 cache, pg_notify invalidation
+
+- [x] **`backend/app/core/config/dependencies.py`** — FastAPI dependency
+  - `get_config_service(db = Depends(get_db_with_rls))` — single session
+  - **No `get_redis()` dependency in Sprint 3**
+
+- [x] **`backend/app/core/config/schemas.py`** — Pydantic schemas (Sprint 3 subset)
+  - `ConfigEntry` — vertical, config_type, has_override
+  - **Deferred to Sprint 5-6:** `ConfigWithGuardrails`, `ConfigUpdate`, `GuardrailViolation`
+
+- [x] **`backend/app/core/config/models.py`** — SQLAlchemy models
+  - `VerticalConfigDefault` — `Base + IdMixin + AuditMetaMixin` (no OrganizationScopedMixin)
+  - `VerticalConfigOverride` — `Base + IdMixin + OrganizationScopedMixin + AuditMetaMixin`
+  - **Deferred to Sprint 5-6:** `VerticalConfigAudit`
+
+- [x] **Refactor `quant_engine/` services** — remove YAML loading, receive config as parameter
+  - `cvar_service.py` — remove `@lru_cache` + `get_profile_cvar_config()` + module-level `PROFILE_CVAR_CONFIG` constant. Add `config: dict` parameter. Update all callers of `check_breach_status`.
+  - `regime_service.py` — remove `@lru_cache` + `get_regime_thresholds()`, add `config: dict` parameter
+  - `scoring_service.py` — remove `@lru_cache` + `get_scoring_weights()`, add `config: dict` parameter
+  - `drift_service.py` — if loads YAML, same treatment
+  - Keep hardcoded fallback defaults inside each service for backward compatibility during transition
+  - **Pattern:** follow `optimizer_service.py` which already receives config as parameter
+
+- [x] **Update wealth domain routes** — inject ConfigService into routes that call quant_engine
+  - Config resolved once at async entry point, passed as parameter to sync functions:
+    ```python
+    @router.get(...)
+    async def get_risk(
+        config_service: ConfigService = Depends(get_config_service),
+        actor: Actor = Depends(get_actor),
+    ):
+        config = await config_service.get("liquid_funds", "calibration", actor.organization_id)
+        result = calculate_cvar(nav_data, profile, config)  # sync function, config as param
+    ```
+
+- [ ] **`ai_engine/profile_loader.py`** — update to use ConfigService
+  - `ProfileLoader.__init__(config_service)` instead of filesystem loading
+  - `load(profile_name, org_id)` → queries chapters, calibration from ConfigService
+  - Instantiates correct vertical engine class from registry
+  - **model_routing stays as env vars** (deferred to Sprint 5-6 — env vars work fine)
+
+- [x] **Credit calibration seed YAML** — create from best practices research
+  - `calibration/seeds/private_credit/calibration.yaml` — leverage limits, coverage ratios, LTV, concentration, tenor, regime, scenarios, monitoring triggers
+  - `calibration/seeds/private_credit/scoring.yaml` — credit deal scoring weights
+  - These are seed files only — loaded by migration 0004, never read at runtime
+  - Add header comment: `# SEED DATA ONLY — loaded by migration 0004. Runtime config is in PostgreSQL.`
+  - **NOTE: This is an engine improvement, not just infrastructure.** These values (sourced from Moody's Annual Default Study, S&P Recovery Reports, Basel III, Ares Capital/Blue Owl filings) will feed `ic_critic_engine` and `ic_quant_engine` as DB-backed defaults — likely better calibrated than the hardcoded values in the original Private Credit OS. The migration from hardcoded → DB-backed institutional defaults is a direct analytical quality upgrade.
+
+- [x] **Startup health check** — verify config completeness
+  - On app startup, query `vertical_config_defaults` and verify all expected `(vertical, config_type)` pairs exist
+  - Log ERROR if any are missing (indicates migration failure)
+
+- [x] **Security hardening (Sprint 3)**
+  - `CLIENT_VISIBLE_TYPES` allowlist enforced in `get()` and `list_configs()` for non-admin callers
+  - `vertical` and `config_type` validated via Pydantic `Literal` in all route path parameters
+  - `ConfigService.get()` adds explicit `WHERE organization_id = :org_id` as secondary guard on override queries (belt-and-suspenders with RLS)
+  - YAML fallback logged as ERROR (not WARNING) — indicates config system degraded
+
+- [x] **Tests**
+  - `test_config_service.py` — unit tests for `get()` cascade, `deep_merge()`, `list_configs()`
+  - `test_config_migration.py` — verify seed data loaded correctly, verify idempotency
+  - `test_config_integration.py` — ConfigService with real DB (test override → merged result)
+  - `test_config_ip_protection.py` — verify `list_configs()` never returns `prompts` for non-admin
+  - Verify quant_engine services work with injected config (same output as YAML)
+
+##### Acceptance Criteria
+
+- [ ] `ConfigService.get("liquid_funds", "calibration")` returns same values as current YAML
+- [ ] `ConfigService.get("private_credit", "calibration")` returns credit-specific thresholds
+- [ ] Tenant override merges correctly with default (deep merge, sparse override)
+- [ ] In-process cache hit on second call within 60s TTL
+- [ ] All existing quant_engine tests pass with injected config
+- [ ] Startup health check logs OK for all seeded config_types
+- [ ] Migration is idempotent (running twice does not fail or duplicate)
+- [ ] `make check` passes
+
+##### Key Files
+
+| File | Action | Notes |
+|------|--------|-------|
+| `core/config/config_service.py` | NEW | Read-only service — cascade, TTL cache, merge |
+| `core/config/dependencies.py` | NEW | FastAPI DI — get_config_service (single session) |
+| `core/config/schemas.py` | NEW | Pydantic schemas (ConfigEntry only for Sprint 3) |
+| `core/config/models.py` | NEW | SA models for config tables |
+| `core/db/migrations/versions/0004_vertical_configs.py` | NEW | Tables + triggers + seed data |
+| `quant_engine/cvar_service.py` | MODIFY | Remove YAML loading, add config param |
+| `quant_engine/regime_service.py` | MODIFY | Remove YAML loading, add config param |
+| `quant_engine/scoring_service.py` | MODIFY | Remove YAML loading, add config param |
+| `ai_engine/profile_loader.py` | MODIFY | Use ConfigService instead of filesystem |
+| `calibration/seeds/private_credit/calibration.yaml` | NEW | Seed data |
+| `calibration/seeds/private_credit/scoring.yaml` | NEW | Seed data |
+
+---
+
+### Phase 2: Admin API + Write Infrastructure (Sprint 5-6 — alongside frontend development)
+
+**Goal:** Netz super-admin can manage all configs via API. Add write methods, audit trail, Redis L2 cache, pg_notify invalidation, optimistic concurrency.
+
+> **Open deliberation for Sprint 5-6:** Re-evaluate whether `portfolio_profiles` belongs in `CLIENT_VISIBLE_TYPES`. In wealth management, portfolio profile parameters (Conservative/Moderate/Growth with CVaR limits, strategic allocations, core/satellite weights) define the analytical methodology — comparable to how `chapters` defines IC memo structure in credit. Both describe *how* the engine analyzes, not just threshold calibration. If the client shouldn't see the chapter structure, should they see the profile structure? Sprint 3 ships with `portfolio_profiles` client-visible (safe — read-only, no write API). Revisit when building the client self-service UI (Sprint 7).
+
+#### Tasks
+
+- [ ] **Migration `0005_config_audit_triggers.py`** — deferred from Sprint 3
+  - Create `vertical_config_audit` table (with `operation TEXT` column)
+  - Create `audit_config_change()` trigger function (handles INSERT/UPDATE/DELETE)
+  - Attach trigger to both defaults and overrides tables
+  - Add `pg_notify('config_changed', ...)` in trigger function for cache invalidation
+
+- [ ] **ConfigService write methods** — add to existing `config_service.py`
+  - `set_default()` with Pydantic schema validation + optimistic locking (`WHERE version = :expected`)
+  - `set_override()` with guardrail validation + merged result schema validation
+  - `validate_guardrails()` — dot-path walk + range check + reject unknown paths
+  - `get_with_guardrails()` — merged config + guardrail ranges for UI
+
+- [ ] **Redis L2 cache + pg_notify invalidation**
+  - Add Redis as L2 cache behind in-process L1 (upgrade TTLCache to two-tier)
+  - Single shared asyncpg LISTEN connection per process for `config_changed` channel
+  - On notification: evict L1 + DEL Redis key
+  - Wire listener start/stop into FastAPI lifespan
+
+- [ ] **`backend/app/domains/admin/routes/configs.py`** — Admin config API
+  - `GET /api/v1/admin/configs/{vertical}` — list all config_types with override status
+  - `GET /api/v1/admin/configs/{vertical}/{config_type}` — get default config + guardrails
+  - `PUT /api/v1/admin/configs/{vertical}/{config_type}` — update default
+  - `GET /api/v1/admin/configs/{vertical}/{config_type}/overrides` — list all tenant overrides
+  - `GET /api/v1/admin/configs/{vertical}/{config_type}/overrides/{org_id}` — get specific override
+  - `PUT /api/v1/admin/configs/{vertical}/{config_type}/overrides/{org_id}` — set override (bypasses guardrails for admin)
+  - `DELETE /api/v1/admin/configs/{vertical}/{config_type}/overrides/{org_id}` — reset to default
+  - `GET /api/v1/admin/configs/{vertical}/{config_type}/audit` — audit history
+
+- [ ] **Admin role gate** — `require_netz_admin()` dependency (SECURITY CRITICAL)
+  - Must NOT use existing `org:admin` role — every tenant has org:admin
+  - Use Clerk `publicMetadata.netz_admin: true` (server-side only, cannot be self-assigned by tenants)
+  - 403 for non-Netz users on all `/api/v1/admin/` endpoints
+  - Admin routes NOT mounted under normal API prefix — separate `/api/v1/admin/` mount
+  - Verify `validate_production_secrets()` is called at startup (prevents dev bypass in production)
+  - **Provisioning:** First Netz admin account must be created via Clerk Dashboard or Clerk Backend API (`users.updateUser(userId, { publicMetadata: { netz_admin: true } })`). This CANNOT be done via Clerk client SDK or frontend — `publicMetadata` is server-side only by design. Document this in runbook/onboarding docs.
+
+- [ ] **Jinja2 security** — use `SandboxedEnvironment` for all prompt rendering
+  - Disable `__` attribute access (prevents SSTI attacks)
+  - Validate template syntax at write time before storing in DB
+  - Never return template content or rendering errors to client API responses
+
+- [ ] **Audit table immutability**
+  - `REVOKE UPDATE, DELETE ON vertical_config_audit FROM app_user`
+  - Audit records are write-once — only the trigger can INSERT
+
+- [ ] **Config diff/preview endpoint**
+  - `POST /api/v1/admin/configs/{vertical}/{config_type}/preview` — accepts proposed override, returns merged result without saving (dry-run)
+  - Useful for prompt engineers to preview effect of changes
+
+- [ ] **Prompt management endpoints** (Netz prompt engineers only)
+  - `GET /api/v1/admin/configs/{vertical}/prompts` — list all chapter prompts
+  - `PUT /api/v1/admin/configs/{vertical}/prompts` — update prompts
+  - `POST /api/v1/admin/configs/{vertical}/prompts/render` — render a prompt with sample data (preview)
+  - These endpoints NEVER exposed to client roles
+
+- [ ] **Tests** — admin API auth, CRUD operations, audit trail verification
+
+##### Acceptance Criteria
+
+- [ ] Netz admin can CRUD all config types via API
+- [ ] Non-admin users get 403 on admin endpoints
+- [ ] Config preview shows merged result without saving
+- [ ] Prompt render preview works with sample data
+- [ ] Audit history shows all changes with who/when/what
+
+---
+
+### Phase 3: Client Self-Service UI (Sprint 7+ — alongside wealth frontend)
+
+**Goal:** Clients can view and edit their calibration within guardrails.
+
+#### Tasks
+
+- [ ] **Client config API** (subset of admin API, guardrail-enforced)
+  - `GET /api/v1/configs/{vertical}/calibration` — get merged config + guardrails for current org
+  - `PUT /api/v1/configs/{vertical}/calibration` — update calibration (validates guardrails)
+  - `GET /api/v1/configs/{vertical}/scoring` — get merged scoring + guardrails
+  - `PUT /api/v1/configs/{vertical}/scoring` — update scoring (validates guardrails)
+  - `GET /api/v1/configs/{vertical}/blocks` — get blocks + guardrails (if applicable)
+  - **NO endpoints for:** prompts, chapters, model_routing, tone, evaluation (not client-accessible)
+
+- [ ] **Frontend component** — Calibration editor
+  - Renders each editable field with current value, min/max guardrail, slider/input
+  - Shows "Default" badge for values that match vertical default
+  - "Reset to default" button per field
+  - Save → validates → shows success or violation errors
+  - Audit log view (read-only) — who changed what when
+
+- [ ] **Guardrail UI rendering**
+  - `ConfigWithGuardrails` response includes guardrails + current merged config
+  - Frontend renders: value slider with min/max stops, input field with validation
+  - Visual indicator: green (within range), yellow (near boundary), red (at limit)
+
+##### Acceptance Criteria
+
+- [ ] Client can view their calibration with guardrail ranges
+- [ ] Client can edit calibration within guardrails, save, see instant effect on next analysis
+- [ ] Client cannot access prompts, chapters, model routing
+- [ ] Reset to default works per-field
+- [ ] Audit log shows change history
+
+## Credit Calibration Seed Data
+
+Based on best practices research (see brainstorm: "Private Credit Calibration — Best Practices Research"). Sourced from Moody's Annual Default Study, S&P Recovery Reports, Basel III, Ares Capital/Blue Owl public filings.
+
+### `calibration/seeds/private_credit/calibration.yaml`
+
+```yaml
+# Private Credit Calibration Defaults
+# Sources: Moody's, S&P, Basel III, institutional practice
+
+leverage_limits:
+  senior_secured:
+    max_total_leverage: 5.0
+    warning_threshold: 4.5
+    preferred_range: [2.5, 4.0]
+  unitranche:
+    max_total_leverage: 5.5
+    warning_threshold: 5.0
+  second_lien:
+    max_total_leverage: 6.5
+    warning_threshold: 6.0
+
+coverage_ratios:
+  dscr:
+    minimum_hard: 1.10
+    warning: 1.25
+    comfortable: 1.50
+    strong: 2.00
+  interest_coverage:
+    minimum_hard: 1.50
+    warning: 1.75
+    comfortable: 2.50
+    strong: 4.00
+  fixed_charge_coverage:
+    minimum_hard: 1.00
+    warning: 1.15
+    comfortable: 1.30
+
+ltv_limits:
+  senior_secured_ltv:
+    max_hard: 0.65
+    warning: 0.60
+    preferred_range: [0.40, 0.55]
+  unitranche_ltv:
+    max_hard: 0.70
+    warning: 0.65
+  second_lien_ltv:
+    max_hard: 0.80
+    warning: 0.75
+  tev_stress_haircut_pct: 25.0
+
+portfolio_concentration:
+  single_obligor_max_pct: 10.0
+  single_obligor_warning_pct: 7.5
+  top5_obligors_max_pct: 40.0
+  single_sector_max_pct: 25.0
+  single_country_max_pct: 40.0
+  emerging_markets_max_pct: 15.0
+  second_lien_max_pct: 20.0
+  pik_max_pct: 15.0
+
+tenor_limits:
+  max_weighted_avg_life_years: 5.0
+  max_single_deal_tenor_years: 7.0
+  preferred_tenor_range: [3.0, 5.0]
+
+credit_regime_thresholds:
+  hy_oas_normal: 350
+  hy_oas_cautious: 500
+  hy_oas_stress: 700
+  hy_oas_crisis: 1000
+  default_rate_normal: 2.0
+  default_rate_elevated: 4.0
+  default_rate_stress: 6.0
+  default_rate_crisis: 10.0
+  default_regime: NORMAL
+
+credit_regime_definitions:
+  NORMAL:
+    new_deal_adjustment: 0.0
+    spread_premium_bps: 0
+    max_leverage_adj: 0.0
+  CAUTIOUS:
+    new_deal_adjustment: -0.20
+    spread_premium_bps: 50
+    max_leverage_adj: -0.5
+  STRESS:
+    new_deal_adjustment: -0.50
+    spread_premium_bps: 150
+    max_leverage_adj: -1.0
+    covenant_requirement: FULL_MAINTENANCE
+  CRISIS:
+    new_deal_adjustment: -0.80
+    spread_premium_bps: 300
+    max_leverage_adj: -1.5
+    covenant_requirement: FULL_MAINTENANCE
+
+scenario_calibration:
+  base:
+    default_rate_pct: 2.0
+    recovery_rate_pct: 67.0
+    revenue_growth_pct: 3.0
+    ebitda_margin_change_bps: 0
+    rate_shock_bps: 0
+  downside:
+    default_rate_pct: 5.0
+    recovery_rate_pct: 50.0
+    revenue_decline_pct: -10.0
+    ebitda_margin_compression_bps: -200
+    rate_shock_bps: 100
+  severe:
+    default_rate_pct: 10.0
+    recovery_rate_pct: 35.0
+    revenue_decline_pct: -25.0
+    ebitda_margin_compression_bps: -500
+    rate_shock_bps: 200
+  tail:
+    default_rate_pct: 15.0
+    recovery_rate_pct: 25.0
+    revenue_decline_pct: -40.0
+    ebitda_margin_compression_bps: -800
+    rate_shock_bps: -200
+
+return_requirements:
+  min_spread_bps:
+    core_senior_secured: 450
+    unitranche: 550
+    second_lien: 750
+    venture_debt: 800
+    distressed: 1000
+  net_irr_targets:
+    core_direct_lending: [8.0, 12.0]
+    opportunistic: [12.0, 16.0]
+    distressed: [15.0, 20.0]
+
+monitoring_triggers:
+  leverage_deterioration:
+    warning: 0.5
+    critical: 1.0
+  dscr_deterioration:
+    warning: -0.15
+    critical: -0.30
+  revenue_decline:
+    warning_pct: -10.0
+    critical_pct: -20.0
+  payment_delay_days:
+    grace_period: 5
+    watchlist: 15
+    default_event: 30
+  nav_markdown:
+    warning_pct: 5.0
+    critical_pct: 15.0
+  covenant_headroom:
+    comfortable_pct: 25.0
+    tight_pct: 10.0
+    critical_pct: 5.0
+```
+
+### `calibration/seeds/private_credit/scoring.yaml`
+
+```yaml
+# Credit Deal Scoring Weights
+credit_scoring_weights:
+  credit_quality: 0.25
+  return_adequacy: 0.20
+  structural_protection: 0.15
+  sponsor_quality: 0.15
+  business_quality: 0.10
+  documentation_completeness: 0.10
+  liquidity_profile: 0.05
+```
+
+## Do Not Touch List Additions
+
+| Component | Reason |
+|---|---|
+| `ConfigService.deep_merge()` semantics | All consumers depend on merge behavior |
+| `vertical_config_audit` trigger | Audit trail integrity |
+| Guardrail validation logic | Client trust — guardrails must be enforced consistently |
+
+## Anti-Patterns
+
+| Anti-Pattern | Consequence | Correct Pattern |
+|---|---|---|
+| Reading YAML at runtime after migration | Two sources of truth, stale data | Always use `ConfigService.get()` |
+| Exposing prompts in client API responses | IP leakage | Prompt endpoints restricted to Netz admin role only |
+| `@lru_cache` on config loading | No per-tenant override, no invalidation | ConfigService with Redis cache + pub/sub |
+| Guardrails without validation on write | Client can set dangerous values | Always `validate_guardrails()` before `set_override()` |
+| RLS policy without subselect on overrides | 1000x slowdown per-row evaluation | `(SELECT current_setting(...))` pattern |
+
+## Dependencies & Prerequisites
+
+| Dependency | Required By | Status |
+|---|---|---|
+| PostgreSQL 16 + TimescaleDB | Sprint 3 | Available (docker-compose) |
+| Redis 7 | Sprint 3 | Available (docker-compose) |
+| Migration 0003 (credit domain) | Before 0004 | Done |
+| Vertical engines architecture | Sprint 3 | Planned (same sprint) |
+| Clerk admin roles (`publicMetadata.netz_admin`) | Sprint 5-6 | SECURITY CRITICAL — must NOT use `org:admin`. Define via Clerk dashboard/API (server-side only). |
+
+## Success Metrics
+
+| Metric | Target | Measured By |
+|---|---|---|
+| Config cascade correctness | 100% — override wins, default fallback works | Integration tests |
+| Cache hit rate | > 95% after warm-up | Redis monitoring |
+| Guardrail enforcement | 100% — no out-of-range overrides saved | Unit tests + API tests |
+| Audit completeness | 100% — every change captured | DB trigger + test verification |
+| Zero YAML reads at runtime | 0 calls to `yaml.safe_load` in hot path | grep + code review |
+| Prompt IP protection | 0 prompt content in client API responses | Security audit |
+
+## Sources & References
+
+### Origin
+
+- **Brainstorm:** [docs/brainstorms/2026-03-14-customizable-vertical-config-brainstorm.md](../brainstorms/2026-03-14-customizable-vertical-config-brainstorm.md) — Key decisions: DB-backed config (D1), cascade resolution (D2), client self-service calibration only (D3), per-vertical schemas (D4), prompts as Netz IP (D5), phased implementation (D6), two tables for defense in depth (RQ1), audit via DB trigger (RQ2), template slots for prompts (RQ3).
+
+### Internal References
+
+- YAML loading pattern: `backend/quant_engine/cvar_service.py:66-89`
+- Config path resolution: `backend/app/core/config/settings.py:90-94`
+- FastAPI DI chain: `backend/app/core/tenancy/middleware.py:28-48`
+- Redis pub/sub pattern: `backend/app/core/jobs/tracker.py:26-84`
+- Migration pattern: `backend/app/core/db/migrations/versions/0003_credit_domain.py`
+- RLS policy pattern: same file, `_RLS_TABLES` loop
+- Mixins: `backend/app/core/db/base.py:21-83`
+- Model routing: `backend/ai_engine/model_config.py:113-146`
+
+### Institutional Learnings
+
+- RLS subselect performance: `docs/solutions/database-issues/alembic-monorepo-migration-fk-rls-ordering.md`
+- Async safety: module-level asyncio primitives cause event loop errors (CLAUDE.md)
+- Three-phase session pattern: pre-fetch → async compute → post-write (CLAUDE.md)

--- a/docs/plans/2026-03-14-feat-customizable-vertical-config-plan.md
+++ b/docs/plans/2026-03-14-feat-customizable-vertical-config-plan.md
@@ -573,11 +573,10 @@ Client UI → PUT /api/v1/configs/{vertical}/calibration
         result = calculate_cvar(nav_data, profile, config)  # sync function, config as param
     ```
 
-- [ ] **`ai_engine/profile_loader.py`** — update to use ConfigService
-  - `ProfileLoader.__init__(config_service)` instead of filesystem loading
-  - `load(profile_name, org_id)` → queries chapters, calibration from ConfigService
-  - Instantiates correct vertical engine class from registry
-  - **model_routing stays as env vars** (deferred to Sprint 5-6 — env vars work fine)
+- [x] **`ai_engine/profile_loader.py`** — ~~update to use ConfigService~~ **DEFERRED to parent plan Phase 4**
+  - Depends on `vertical_engines/` which doesn't exist yet
+  - ConfigService is ready; ProfileLoader will consume it when vertical engines are built
+  - Tracked in: `docs/plans/2026-03-14-feat-netz-analysis-engine-platform-plan.md` Phase 4
 
 - [x] **Credit calibration seed YAML** — create from best practices research
   - `calibration/seeds/private_credit/calibration.yaml` — leverage limits, coverage ratios, LTV, concentration, tenor, regime, scenarios, monitoring triggers

--- a/docs/plans/2026-03-14-feat-netz-analysis-engine-platform-plan.md
+++ b/docs/plans/2026-03-14-feat-netz-analysis-engine-platform-plan.md
@@ -709,7 +709,20 @@ Cross-cutting AI utilities incorrectly housed in compliance were relocated to `a
 
 #### Phase 4: AI Engine + Profile Extraction (Sprint 3 — Week 7-8)
 
-**Goal:** AI engine migrated intact and made profile-agnostic. Upload architecture with SSE.
+**Goal:** AI engine migrated intact and made profile-agnostic. Upload architecture with SSE. DB-backed configuration system replaces YAML.
+
+##### Completed: ProductConfig (Customizable Vertical Configuration)
+
+> **Full plan:** [docs/plans/2026-03-14-feat-customizable-vertical-config-plan.md](2026-03-14-feat-customizable-vertical-config-plan.md)
+
+- [x] **ConfigService (read-only)** — DB-backed config with cascade: TTLCache → DB override → DB default → YAML fallback
+- [x] **Migration 0004** — `vertical_config_defaults` (global) + `vertical_config_overrides` (RLS) + 7 seed configs
+- [x] **Credit calibration seed data** — Institutional defaults (Moody's, S&P, Basel III) for ic_critic_engine/ic_quant_engine
+- [x] **quant_engine refactor** — Removed `@lru_cache` + YAML loading from cvar/regime/scoring/drift services; config injected as parameter
+- [x] **Wealth routes** — ConfigService injected at async entry points
+- [x] **Startup health check** — Verifies all 7 (vertical, config_type) pairs at boot
+- [x] **IP protection** — `CLIENT_VISIBLE_TYPES = {calibration, scoring, blocks, portfolio_profiles}`; chapters/prompts never exposed
+- [x] **29 tests** — deep_merge, IP protection, resolve functions, seed YAML validation
 
 ##### Tasks
 
@@ -735,8 +748,9 @@ Cross-cutting AI utilities incorrectly housed in compliance were relocated to `a
   - ADLS Gen2 backend (when `FEATURE_ADLS_ENABLED=true`)
   - Inject as FastAPI dependency and into workers
 - [ ] **`backend/ai_engine/profile_loader.py`** — ProfileLoader
-  - Cascade: `profiles/tenants/{org_id}/{profile}/` → `profiles/{profile}/` → hardcoded
-  - Loads YAML config + instantiates vertical engine class
+  - Uses `ConfigService.get(vertical, config_type, org_id)` instead of filesystem loading
+  - Cascade now handled by ConfigService (DB override → DB default → YAML fallback)
+  - Instantiates correct vertical engine class from registry
   - Registry: `{"private_credit": CreditAnalyzer, "liquid_funds": WealthAnalyzer}`
 - [ ] **`backend/vertical_engines/wealth/`** — NEW (not migrated, built fresh)
   - `fund_analyzer.py` — 7-chapter fund manager DD report

--- a/docs/plans/2026-03-14-feat-netz-analysis-engine-platform-plan.md
+++ b/docs/plans/2026-03-14-feat-netz-analysis-engine-platform-plan.md
@@ -34,6 +34,8 @@ origin: docs/brainstorms/2026-03-14-analysis-engine-platform-brainstorm.md
 | Module-level `asyncio.Semaphore` | "attached to different event loop" error | Create lazily inside async functions |
 | ORM objects crossing thread boundaries | `DetachedInstanceError` | Extract to frozen dataclasses before crossing |
 | `expire_on_commit=True` (default) | Attribute access after commit fails in async | `expire_on_commit=False` always |
+| ai_engine opening its own DB sessions | Breaks three-phase pattern, ties compute to DB | Session injection — caller provides `db: Session` |
+| Workers writing directly to ADLS SDK | Breaks local dev, untestable | Always use `StorageClient` — never call ADLS SDK directly |
 
 ---
 
@@ -70,9 +72,18 @@ netz-analysis-engine/
 │   │   ├── domains/
 │   │   │   ├── credit/     ← 112 tables, 10 domain modules (from Private Credit OS)
 │   │   │   └── wealth/     ← 12 tables, 7 services (from Wealth OS)
+│   │   ├── services/
+│   │   │   └── storage_client.py ← ADLS abstraction (local filesystem when FEATURE_ADLS_ENABLED=false)
 │   │   └── shared/         ← exceptions, enums, middleware
 │   ├── ai_engine/          ← IC memos, extraction, ingestion, validation, prompts
 │   ├── quant_engine/       ← CVaR, regime, optimizer, scoring, drift, rebalance
+│   ├── vertical_engines/   ← per-vertical analysis specializations
+│   │   ├── base/           ← shared interface all verticals implement
+│   │   ├── credit/         ← Private Credit (moved from ai_engine/intelligence/)
+│   │   ├── wealth/         ← Wealth Management DD reports (Sprint 3+)
+│   │   ├── venture_capital/ ← future
+│   │   ├── private_equity/ ← future
+│   │   └── real_estate/    ← future
 │   └── worker_app/         ← Azure Functions (credit) + CLI workers (wealth)
 ├── profiles/               ← YAML analysis profiles (private_credit, liquid_funds)
 ├── calibration/            ← YAML quant configs (blocks, limits, scoring)
@@ -266,6 +277,129 @@ result = conn.execute("""
 
 # When FEATURE_ADLS_ENABLED=false: query PostgreSQL tables directly
 ```
+
+**StorageClient — ADLS abstraction layer:**
+
+All workers and vertical engines interact with storage via `StorageClient`,
+never directly with ADLS SDK or filesystem paths.
+```python
+# backend/app/services/storage_client.py
+class StorageClient:
+    """
+    Abstracts ADLS Gen2 (FEATURE_ADLS_ENABLED=true)
+    and local filesystem (FEATURE_ADLS_ENABLED=false).
+    Injected as dependency into workers and vertical engines.
+    """
+    async def write_parquet(self, path: str, df: pd.DataFrame) -> None: ...
+    async def read_parquet(self, path: str) -> pd.DataFrame: ...
+    async def write_json(self, path: str, data: dict) -> None: ...
+    async def read_json(self, path: str) -> dict: ...
+    async def write_bytes(self, path: str, data: bytes) -> None: ...
+    async def exists(self, path: str) -> bool: ...
+    async def list_paths(self, prefix: str) -> list[str]: ...
+
+# Usage in vertical engines (credit example):
+async def run_deep_review(
+    deal_id: UUID,
+    db: Session,           # injected — sync session in thread
+    storage: StorageClient # injected — writes memo to gold/
+) -> AnalysisResult:
+    ...
+    await storage.write_json(
+        f"gold/{org_id}/memos/{memo_id}.json",
+        memo_output
+    )
+```
+
+**What goes where via StorageClient:**
+
+| Process | What it writes | ADLS path |
+|---|---|---|
+| OCR + chunking | Chunks + embeddings | `silver/{org_id}/chunks/{doc_id}/` |
+| IC memo generation | Complete memo JSON | `gold/{org_id}/memos/{memo_id}.json` |
+| NAV ingestion | Daily prices | `bronze/_global/yahoo/{date}/batch.parquet` |
+| FRED ingestion | Macro observations | `bronze/_global/fred/{year}/{month}.parquet` |
+| Risk calculation | CVaR metrics | `silver/{org_id}/fund_metrics/{fund_id}/{year}-{month}.parquet` |
+| Knowledge aggregator | Anonymous signals | `gold/_global/analysis_patterns/{profile}/{year}/{month}.parquet` |
+| entity_bootstrap | Entity reference data | `gold/_global/entity_reference/entities.parquet` |
+| fund_data_bootstrap | Fund reference data | `gold/_global/fund_reference/funds.parquet` |
+| market_data_bootstrap | Market reference data | `gold/_global/market_reference/market_data.parquet` |
+
+### Vertical Engines Architecture
+
+The analysis engine is factored into two layers:
+
+**Layer 1 — Universal Core (`ai_engine/`)**
+Logic that is identical across all verticals. Never modified per vertical.
+
+| Module | What it does |
+|---|---|
+| `extraction/semantic_chunker.py` | Text chunking — domain-agnostic |
+| `extraction/embedding_service.py` | Vector generation — domain-agnostic |
+| `extraction/mistral_ocr.py` | OCR — domain-agnostic |
+| `openai_client.py` | LLM provider abstraction |
+| `model_config.py` | Model routing |
+| `governance/` | Token budget, evidence throttle |
+| `validation/eval_judge.py` | Quality evaluation — generic |
+| `pdf/` | PDF generation |
+
+**Layer 2 — Vertical Specializations (`vertical_engines/`)**
+Domain-specific logic. One directory per vertical.
+```
+backend/vertical_engines/
+├── base/
+│   ├── base_analyzer.py        ← interface all verticals implement
+│   │   class BaseAnalyzer:
+│   │     def analyze(self, corpus, profile, db, storage) -> AnalysisResult
+│   │     def extract_structured(self, text) -> dict
+│   │     def critique(self, draft) -> CriticResult
+│   ├── base_extractor.py       ← structured extraction base
+│   └── base_critic.py          ← critic base
+│
+├── credit/                     ← MOVED from ai_engine/intelligence/ (Sprint 3)
+│   ├── deep_review.py          ← 14-chapter IC memo (moved, session injected)
+│   ├── ic_critic_engine.py     ← critic calibrated for credit risk
+│   ├── ic_quant_engine.py      ← LTV, covenants, returns modeling
+│   ├── market_data_engine.py   ← FRED with 40 credit-specific series
+│   ├── sponsor_engine.py       ← sponsor profile analysis
+│   ├── memo_chapter_engine.py  ← chapter generation loop
+│   └── prompts/                ← MOVED from ai_engine/prompts/intelligence/
+│       ├── ch01_exec.j2
+│       └── ... (all 14 chapters + critic + tone)
+│
+├── wealth/                     ← Sprint 3+ (new, not migrated)
+│   ├── fund_analyzer.py        ← fund manager DD report (7 chapters)
+│   ├── dd_report_engine.py     ← report generation loop
+│   ├── quant_analyzer.py       ← CVaR, Sharpe, drawdown, style analysis
+│   └── prompts/
+│       └── ... (wealth-specific prompts)
+│
+├── venture_capital/            ← future
+├── private_equity/             ← future
+└── real_estate/                ← future
+```
+
+**ProfileLoader connects profiles/ YAML to vertical_engines/:**
+```python
+# ai_engine/profile_loader.py
+class ProfileLoader:
+    def load(self, profile_name: str) -> AnalysisProfile:
+        yaml_config = self._load_yaml(f"profiles/{profile_name}/profile.yaml")
+        engine = self._load_engine(profile_name)
+        return AnalysisProfile(config=yaml_config, engine=engine)
+
+    def _load_engine(self, profile_name: str) -> BaseAnalyzer:
+        from vertical_engines.credit.deep_review import CreditAnalyzer
+        from vertical_engines.wealth.fund_analyzer import WealthAnalyzer
+        engines = {
+            "private_credit": CreditAnalyzer,
+            "liquid_funds":   WealthAnalyzer,
+        }
+        return engines.get(profile_name, BaseAnalyzer)()
+```
+
+**profiles/ YAML = declarative config. vertical_engines/ = executable logic.**
+Both are required. Neither replaces the other.
 
 **SSE Streaming:** Redis pub/sub → `sse-starlette` EventSourceResponse
 - Use `sse-starlette` library (NOT raw `StreamingResponse`) — handles event framing, id fields, retry hints, keepalive automatically
@@ -579,28 +713,43 @@ Cross-cutting AI utilities incorrectly housed in compliance were relocated to `a
 
 ##### Tasks
 
-- [ ] **`backend/ai_engine/`** — migrate entire pipeline from Private Credit OS
-  - `intelligence/` — deep_review, memo_chapter_engine, critic, sponsor, quant engines
-  - `extraction/` — OCR, chunking, embedding, classification (semantic_chunker.py preserved exactly)
-  - `ingestion/` — domain ingest orchestrator
-  - `validation/` — 4-layer evaluation framework (preserved exactly)
-  - `governance/` — token budget, evidence throttle, artifact cache
-  - `prompts/` — Jinja2 registry (extended for profile search path)
-  - `pdf/` — ReportLab generation
-  - `model_config.py` — model routing (preserved, extended for profile-prefixed stages)
-  - `openai_client.py` — dual provider (preserved exactly)
-  - Convert sync `_call_openai` to async `_async_call_openai` (already exists in Private Credit)
-  - DB calls via `asyncio.to_thread()` for sync-heavy paths (pattern from Private Credit `async-dag-orchestrator` solution)
-- [ ] **Profile extraction** (see brainstorm Section H)
+- [ ] **`backend/vertical_engines/base/`** — shared interface
+  - `base_analyzer.py` — `BaseAnalyzer` abstract class with `analyze()`, `extract_structured()`, `critique()`
+  - `base_extractor.py` — structured extraction base
+  - `base_critic.py` — critic base
+- [ ] **`backend/vertical_engines/credit/`** — MOVE from `ai_engine/intelligence/`
+  - Move (do NOT rewrite): `deep_review.py`, `ic_critic_engine.py`, `ic_quant_engine.py`, `market_data_engine.py`, `sponsor_engine.py`, `memo_chapter_engine.py`, `deep_review_corpus.py`, `deep_review_helpers.py`, `deep_review_confidence.py`, `deep_review_policy.py`, `memo_evidence_pack.py`, `tone_normalizer.py`, `underwriting_artifact.py`, `retrieval_governance.py`
+  - Move `ai_engine/prompts/intelligence/*.j2` → `vertical_engines/credit/prompts/`
+  - Apply session injection to all files with Session imports:
+    - Replace `SessionLocal()` internal calls with `db: Session` parameter
+    - Functions that open sessions → receive session as parameter
+    - Caller (route/worker) provides the session
+  - Do NOT rewrite business logic. Move + session injection ONLY.
+- [ ] **`backend/ai_engine/`** — keep universal modules only
+  - KEEP: `extraction/`, `governance/`, `validation/`, `pdf/`, `knowledge/`, `ingestion/`, `classification/`, `openai_client.py`, `model_config.py`
+  - REMOVE from ai_engine: `intelligence/` directory (moved to `vertical_engines/credit/`)
+  - REMOVE from ai_engine: `prompts/intelligence/` (moved to `vertical_engines/credit/prompts/`)
+  - KEEP: `prompts/extraction/`, `prompts/loader.py`, `prompts/registry.py` (extraction prompts are universal)
+- [ ] **`backend/app/services/storage_client.py`** — StorageClient implementation
+  - Local filesystem backend (default, `FEATURE_ADLS_ENABLED=false`)
+  - ADLS Gen2 backend (when `FEATURE_ADLS_ENABLED=true`)
+  - Inject as FastAPI dependency and into workers
+- [ ] **`backend/ai_engine/profile_loader.py`** — ProfileLoader
+  - Cascade: `profiles/tenants/{org_id}/{profile}/` → `profiles/{profile}/` → hardcoded
+  - Loads YAML config + instantiates vertical engine class
+  - Registry: `{"private_credit": CreditAnalyzer, "liquid_funds": WealthAnalyzer}`
+- [ ] **`backend/vertical_engines/wealth/`** — NEW (not migrated, built fresh)
+  - `fund_analyzer.py` — 7-chapter fund manager DD report
+  - `dd_report_engine.py` — report generation loop
+  - `quant_analyzer.py` — integrates with `quant_engine/` (CVaR, Sharpe, drawdown)
+  - `prompts/` — wealth-specific Jinja2 prompts
+- [ ] **Profile extraction**
   - `profiles/private_credit/profile.yaml` — 14 chapters with budgets, affinity, model routing
-  - `profiles/private_credit/prompts/*.j2` — copy from `ai_engine/prompts/intelligence/`
+  - `profiles/private_credit/prompts/` — symlink or copy from `vertical_engines/credit/prompts/`
   - `profiles/private_credit/output_schema.json` — formalize IC memo JSON schema
   - `profiles/private_credit/evaluation_criteria.yaml` — extract from validation configs
-  - `backend/ai_engine/intelligence/profile_loader.py` — `ProfileLoader.load("private_credit")`
-  - `memo_chapter_engine.py` — dynamic `_CHAPTER_TAGS` from profile (fallback to hardcoded)
-  - `deep_review.py` — `profile_name` parameter (default: `"private_credit"`)
-  - `model_config.py` — support `get_model("private_credit.ch01_exec")`
-  - `prompts/registry.py` — add `profiles/{profile}/prompts/` to Jinja2 search path
+  - `profiles/liquid_funds/profile.yaml` — 7 chapters for wealth DD
+  - `profiles/liquid_funds/prompts/` — wealth-specific prompts
 - [ ] **Upload architecture** (see brainstorm Section I)
   - `POST /api/v1/documents/upload-url` → generate SAS URL + `upload_id`
   - `POST /api/v1/documents/upload-complete` → enqueue to Service Bus, return `job_id`
@@ -987,6 +1136,8 @@ Top 3 risks:
 | `ai_engine/openai_client.py` interface | Stable provider abstraction |
 | `ai_engine/intelligence/ic_critic_engine.py` logic | Calibrated adversarial review |
 | `ai_engine/governance/` | Token budget management |
+| `vertical_engines/credit/` logic | Core IP — only session injection allowed, no rewrites |
+| `app/services/storage_client.py` interface | Once defined, all workers depend on it |
 | Service Bus topic names | Workers depend on exact names |
 
 ---


### PR DESCRIPTION
## Summary
- **ConfigService** (read-only): DB-backed configuration with cascade resolution (TTLCache → DB override → DB default → YAML fallback)
- **Migration 0004**: `vertical_config_defaults` (global, no RLS) + `vertical_config_overrides` (tenant-scoped, RLS with subselect pattern) + CHECK constraints + idempotent seed from 7 YAML files
- **Credit calibration seed data**: Institutional defaults (Moody's, S&P, Basel III, Ares Capital/Blue Owl) — direct analytical quality upgrade for ic_critic_engine and ic_quant_engine
- **quant_engine refactor**: Removed all `@lru_cache` + YAML loading from cvar_service, regime_service, scoring_service, drift_service — config injected as parameter
- **Wealth routes updated**: ConfigService injected at async entry points, config resolved once and passed to sync functions
- **Startup health check**: Verifies all 7 expected (vertical, config_type) pairs on app boot
- **IP protection**: `CLIENT_VISIBLE_TYPES = {calibration, scoring, blocks, portfolio_profiles}` — chapters, prompts, model_routing never exposed to clients
- **29 tests**: deep_merge semantics, CLIENT_VISIBLE_TYPES enforcement, resolve functions, seed YAML validation

## Key Decisions
- `chapters` removed from CLIENT_VISIBLE_TYPES (chapter structure is analytical methodology IP)
- `portfolio_profiles` visibility flagged for Sprint 5-6 deliberation
- NETZ_ADMIN provisioning documented (Clerk Dashboard/Backend API only)

## Testing
- `pytest tests/` — 42 tests pass (29 new config tests + 13 existing)
- `ruff check` — clean
- No DB required for tests (pure logic + file validation)

## Post-Deploy Monitoring & Validation
- **What to monitor**: Startup logs for `Config health check OK — all 7 defaults present` or `Missing config default` errors
- **Validation**: After `make migrate`, verify `SELECT vertical, config_type FROM vertical_config_defaults` returns 7 rows
- **Failure signal**: `ConfigService falling back to YAML` ERROR logs indicate migration 0004 did not run
- **Rollback**: `alembic downgrade 0003` drops both config tables; quant_engine fallback defaults activate automatically

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)