### PR TITLE
refactor: add import-linter DAG enforcement to CI gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: check test lint typecheck architecture serve migrate migration help pipeline
 
 # ── Unified gate ──────────────────────────────────────────
-check: lint typecheck test architecture
+check: lint architecture typecheck test
 	@echo "All checks passed."
 
 # ── Python backend ────────────────────────────────────────
@@ -37,7 +37,7 @@ down:
 
 # ── Help ──────────────────────────────────────────────────
 help:
-	@echo "make check       - Full gate: lint + typecheck + test"
+	@echo "make check       - Full gate: lint + architecture + typecheck + test"
 	@echo "make test        - pytest (ARGS for extra flags)"
 	@echo "make lint        - ruff check"
 	@echo "make typecheck   - mypy"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: check test lint typecheck serve migrate migration help pipeline
+.PHONY: check test lint typecheck architecture serve migrate migration help pipeline
 
 # ── Unified gate ──────────────────────────────────────────
-check: lint typecheck test
+check: lint typecheck test architecture
 	@echo "All checks passed."
 
 # ── Python backend ────────────────────────────────────────
@@ -13,6 +13,9 @@ typecheck:
 
 test:
 	cd backend && python -m pytest tests/ $(ARGS)
+
+architecture:
+	cd backend && lint-imports --config ../pyproject.toml
 
 # ── Serve (dev) ───────────────────────────────────────────
 serve:
@@ -38,6 +41,7 @@ help:
 	@echo "make test        - pytest (ARGS for extra flags)"
 	@echo "make lint        - ruff check"
 	@echo "make typecheck   - mypy"
+	@echo "make architecture - import-linter DAG enforcement"
 	@echo "make serve       - uvicorn dev server on :8000"
 	@echo "make migrate     - alembic upgrade head"
 	@echo "make migration   - generate new migration (MSG=description)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ ignore_missing_imports = true
 # ── Import architecture enforcement (import-linter) ──────────────────
 [tool.importlinter]
 root_packages = ["vertical_engines", "quant_engine", "app"]
-include_external_packages = true
 
 [[tool.importlinter.contracts]]
 name = "Verticals must not import each other"
@@ -117,14 +116,18 @@ modules = [
     "vertical_engines.wealth",
 ]
 
+# Forward-looking: currently matches edgar/ only. Covers all engine packages
+# as Wave 1 PRs convert flat files to edgar-style subdirectories.
 [[tool.importlinter.contracts]]
 name = "Engine domain modules must not import service"
 type = "forbidden"
 source_modules = ["vertical_engines.credit.*.models"]
 forbidden_modules = ["vertical_engines.credit.*.service"]
 
+# Phase A ratchet (bdabdc8): regime + cvar are vertical-agnostic.
+# Other quant services still depend on app.domains.wealth — subsequent phases.
 [[tool.importlinter.contracts]]
-name = "quant_engine must not import wealth domain models"
+name = "Vertical-agnostic quant services must not import wealth domain models"
 type = "forbidden"
 source_modules = ["quant_engine.regime_service", "quant_engine.cvar_service"]
 forbidden_modules = ["app.domains.wealth"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "httpx>=0.28",
     "ruff>=0.9",
     "mypy>=1.14",
+    "import-linter>=2.1",
 ]
 ai = [
     "openai>=1.60",
@@ -102,3 +103,28 @@ warn_unused_configs = true
 [[tool.mypy.overrides]]
 module = ["redis.*", "sse_starlette.*", "edgar.*", "rapidfuzz.*"]
 ignore_missing_imports = true
+
+# ── Import architecture enforcement (import-linter) ──────────────────
+[tool.importlinter]
+root_packages = ["vertical_engines", "quant_engine", "app"]
+include_external_packages = true
+
+[[tool.importlinter.contracts]]
+name = "Verticals must not import each other"
+type = "independence"
+modules = [
+    "vertical_engines.credit",
+    "vertical_engines.wealth",
+]
+
+[[tool.importlinter.contracts]]
+name = "Engine domain modules must not import service"
+type = "forbidden"
+source_modules = ["vertical_engines.credit.*.models"]
+forbidden_modules = ["vertical_engines.credit.*.service"]
+
+[[tool.importlinter.contracts]]
+name = "quant_engine must not import wealth domain models"
+type = "forbidden"
+source_modules = ["quant_engine.regime_service", "quant_engine.cvar_service"]
+forbidden_modules = ["app.domains.wealth"]


### PR DESCRIPTION
## Summary
- Adds `import-linter>=2.1` to dev dependencies
- Defines 3 architectural contracts in `pyproject.toml`:
  1. **Vertical independence** — `credit/` and `wealth/` must not import each other
  2. **No domain→service imports** — `models.py` must not import `service.py` (enforces DAG within packages)
  3. **quant_engine isolation** — `regime_service` and `cvar_service` must not import `app.domains.wealth` (guards Phase A parity refactor from bdabdc8)
- New `make architecture` target runs `lint-imports`
- `make check` now includes `architecture` (lint + typecheck + test + architecture)

All 3 contracts pass on current `main` (334 files, 1654 dependencies analyzed).

## Motivation
Prerequisite for Wave 1 modular alignment (12 engine PRs). Locking the layer hierarchy BEFORE restructuring ensures every PR enforces the DAG — not just the later ones.

## Test plan
- [x] `make architecture` — 3 contracts kept, 0 broken
- [x] `make test` — 280 passed
- [x] No engine files touched — zero behavioral change

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: CI-only tooling change, no runtime impact.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)