### PR TITLE
fix(wealth): security prereqs — SandboxedEnvironment, RLS routes, structlog

### DIFF
--- a/backend/ai_engine/prompts/registry.py
+++ b/backend/ai_engine/prompts/registry.py
@@ -16,21 +16,18 @@ Usage::
 """
 from __future__ import annotations
 
-import logging
 import os
 import re
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+import structlog
 import yaml
-from jinja2 import (  # pyright: ignore[reportMissingImports]
-    Environment,
-    FileSystemLoader,
-    TemplateNotFound,
-)
+from jinja2 import FileSystemLoader, TemplateNotFound  # pyright: ignore[reportMissingImports]
+from jinja2.sandbox import SandboxedEnvironment
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 _PROMPTS_DIR = Path(__file__).parent
 _METADATA_RE = re.compile(r"\{#-\s*metadata\s*\n(.*?)-#\}", re.DOTALL)
@@ -54,7 +51,7 @@ class PromptRegistry:
                 search_paths.append(str(override_dir))
         search_paths.append(str(self._base_dir))
 
-        self._env = Environment(
+        self._env = SandboxedEnvironment(
             loader=FileSystemLoader(search_paths),
             keep_trailing_newline=True,
             trim_blocks=True,

--- a/backend/app/domains/wealth/routes/allocation.py
+++ b/backend/app/domains/wealth/routes/allocation.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security.clerk_auth import CurrentUser, get_current_user, require_ic_member
-from app.database import get_db
+from app.core.tenancy.middleware import get_db_with_rls
 from app.domains.wealth.models.allocation import StrategicAllocation, TacticalPosition
 from app.domains.wealth.schemas.allocation import (
     EffectiveAllocationRead,
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/allocation")
 )
 async def get_strategic(
     profile: str,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[StrategicAllocationRead]:
     _validate_profile(profile)
@@ -56,7 +56,7 @@ async def get_strategic(
 async def update_strategic(
     profile: str,
     body: StrategicAllocationUpdate,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(require_ic_member),
 ) -> list[StrategicAllocationRead]:
     _validate_profile(profile)
@@ -104,7 +104,7 @@ async def update_strategic(
 )
 async def get_tactical(
     profile: str,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[TacticalPositionRead]:
     _validate_profile(profile)
@@ -131,7 +131,7 @@ async def get_tactical(
 async def update_tactical(
     profile: str,
     body: TacticalPositionUpdate,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(require_ic_member),
 ) -> list[TacticalPositionRead]:
     _validate_profile(profile)
@@ -176,7 +176,7 @@ async def update_tactical(
 )
 async def get_effective(
     profile: str,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[EffectiveAllocationRead]:
     _validate_profile(profile)

--- a/backend/app/domains/wealth/routes/analytics.py
+++ b/backend/app/domains/wealth/routes/analytics.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security.clerk_auth import CurrentUser, get_current_user
-from app.database import get_db
+from app.core.tenancy.middleware import get_db_with_rls
 from app.domains.wealth.models.allocation import StrategicAllocation
 from app.domains.wealth.models.backtest import BacktestRun
 from app.domains.wealth.schemas.analytics import (
@@ -45,7 +45,7 @@ router = APIRouter(prefix="/analytics")
 )
 async def create_backtest(
     body: BacktestRequest,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> BacktestRunRead:
     _validate_profile(body.profile)
@@ -118,7 +118,7 @@ async def create_backtest(
 )
 async def get_backtest(
     run_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> BacktestRunRead:
     result = await db.execute(select(BacktestRun).where(BacktestRun.run_id == run_id))
@@ -142,7 +142,7 @@ async def get_backtest(
 )
 async def optimize(
     body: OptimizeRequest,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> OptimizeResult:
     _validate_profile(body.profile)
@@ -224,7 +224,7 @@ async def optimize(
 )
 async def optimize_pareto(
     body: OptimizeRequest,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> ParetoOptimizeResult:
     _validate_profile(body.profile)
@@ -305,7 +305,7 @@ async def optimize_pareto(
 )
 async def get_correlation(
     blocks: str = Query(..., description="Comma-separated block IDs"),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> CorrelationMatrix:
     block_list = [b.strip() for b in blocks.split(",") if b.strip()]

--- a/backend/app/domains/wealth/routes/funds.py
+++ b/backend/app/domains/wealth/routes/funds.py
@@ -10,7 +10,7 @@ from app.core.config.config_service import ConfigService
 from app.core.config.dependencies import get_config_service
 from app.core.config.settings import settings
 from app.core.security.clerk_auth import Actor, CurrentUser, get_actor, get_current_user
-from app.database import get_db
+from app.core.tenancy.middleware import get_db_with_rls
 from app.domains.wealth.models.fund import Fund
 from app.domains.wealth.models.nav import NavTimeseries
 from app.domains.wealth.models.risk import FundRiskMetrics
@@ -36,7 +36,7 @@ router = APIRouter(prefix="/funds")
 async def get_fund_scoring(
     block: str = Query(..., description="Allocation block ID"),
     top_n: int = Query(10, ge=1, le=100, description="Number of top funds to return"),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     config_service: ConfigService = Depends(get_config_service),
     actor: Actor = Depends(get_actor),
@@ -163,7 +163,7 @@ async def list_funds(
     is_active: bool | None = Query(True, description="Filter by active status"),
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[FundRead]:
     stmt = select(Fund)
@@ -188,7 +188,7 @@ async def list_funds(
 )
 async def get_fund(
     fund_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> FundRead:
     result = await db.execute(select(Fund).where(Fund.fund_id == fund_id))
@@ -206,7 +206,7 @@ async def get_fund(
 )
 async def get_fund_risk(
     fund_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> FundRiskRead | None:
     stmt = (
@@ -234,7 +234,7 @@ async def get_fund_nav(
     to_date: date | None = Query(None, alias="to", description="End date"),
     limit: int = Query(1000, ge=1, le=10000, description="Max rows to return"),
     offset: int = Query(0, ge=0, description="Rows to skip"),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[NavPoint]:
     stmt = select(NavTimeseries).where(NavTimeseries.fund_id == fund_id)

--- a/backend/app/domains/wealth/routes/portfolios.py
+++ b/backend/app/domains/wealth/routes/portfolios.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security.clerk_auth import CurrentUser, get_current_user, require_ic_member
-from app.database import get_db
+from app.core.tenancy.middleware import get_db_with_rls
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 from app.domains.wealth.models.rebalance import RebalanceEvent
 from app.domains.wealth.schemas.portfolio import (
@@ -43,7 +43,7 @@ def _snapshot_to_summary(profile: str, snap: PortfolioSnapshot | None) -> Portfo
     description="Returns the latest snapshot summary for all 3 model portfolios.",
 )
 async def list_portfolios(
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[PortfolioSummary]:
     summaries: list[PortfolioSummary] = []
@@ -61,7 +61,7 @@ async def list_portfolios(
 )
 async def get_portfolio(
     profile: str,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> PortfolioSummary:
     _validate_profile(profile)
@@ -77,7 +77,7 @@ async def get_portfolio(
 )
 async def get_snapshot(
     profile: str,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> PortfolioSnapshotRead | None:
     _validate_profile(profile)
@@ -99,7 +99,7 @@ async def get_history(
     to_date: date | None = Query(None, alias="to"),
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[PortfolioSnapshotRead]:
     _validate_profile(profile)
@@ -123,7 +123,7 @@ async def get_history(
 async def trigger_rebalance(
     profile: str,
     body: RebalanceRequest,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> RebalanceEventRead:
     _validate_profile(profile)
@@ -154,7 +154,7 @@ async def trigger_rebalance(
 async def get_rebalance_event(
     profile: str,
     event_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> RebalanceEventRead:
     _validate_profile(profile)
@@ -181,7 +181,7 @@ async def approve_rebalance(
     profile: str,
     event_id: uuid.UUID,
     body: RebalanceApproveRequest,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(require_ic_member),
 ) -> RebalanceEventRead:
     _validate_profile(profile)

--- a/backend/app/domains/wealth/routes/risk.py
+++ b/backend/app/domains/wealth/routes/risk.py
@@ -12,7 +12,7 @@ from app.core.config.config_service import ConfigService
 from app.core.config.dependencies import get_config_service
 from app.core.config.settings import settings
 from app.core.security.clerk_auth import Actor, CurrentUser, get_actor, get_current_user
-from app.database import get_db
+from app.core.tenancy.middleware import get_db_with_rls
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 from app.domains.wealth.schemas.macro import MacroIndicators
 from app.domains.wealth.schemas.risk import CVaRPoint, CVaRStatus, RegimeHistoryPoint
@@ -25,12 +25,14 @@ logger = structlog.get_logger()
 
 # Shared Redis connection for SSE pub/sub fan-out
 _sse_redis: aioredis.Redis | None = None
-_sse_redis_lock = asyncio.Lock()
+_sse_redis_lock: asyncio.Lock | None = None
 
 
 async def _get_sse_redis() -> aioredis.Redis:
     """Get or create a shared Redis connection for SSE (async-safe)."""
-    global _sse_redis
+    global _sse_redis, _sse_redis_lock
+    if _sse_redis_lock is None:
+        _sse_redis_lock = asyncio.Lock()
     async with _sse_redis_lock:
         if _sse_redis is None:
             _sse_redis = aioredis.from_url(settings.redis_url)
@@ -55,7 +57,7 @@ router = APIRouter(prefix="/risk")
 )
 async def get_cvar(
     profile: str,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> CVaRStatus:
     _validate_profile(profile)
@@ -86,7 +88,7 @@ async def get_cvar_history(
     to_date: date | None = Query(None, alias="to"),
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[CVaRPoint]:
     _validate_profile(profile)
@@ -116,7 +118,7 @@ async def get_cvar_history(
     description="Returns the current market regime based on latest portfolio snapshots.",
 )
 async def get_regime(
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     config_service: ConfigService = Depends(get_config_service),
     actor: Actor = Depends(get_actor),
@@ -147,7 +149,7 @@ async def get_regime_history(
     to_date: date | None = Query(None, alias="to"),
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[RegimeHistoryPoint]:
     stmt = select(PortfolioSnapshot).where(PortfolioSnapshot.regime.is_not(None))
@@ -174,7 +176,7 @@ async def get_regime_history(
     description="Returns the latest VIX, yield curve spread, CPI YoY, and Fed Funds rate from FRED data.",
 )
 async def get_macro(
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> MacroIndicators:
     macro = await get_latest_macro_values(db)

--- a/backend/tests/ai_engine/prompts/test_registry_sandbox.py
+++ b/backend/tests/ai_engine/prompts/test_registry_sandbox.py
@@ -1,0 +1,43 @@
+"""Tests that PromptRegistry uses SandboxedEnvironment (SSTI mitigation)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jinja2.sandbox import SandboxedEnvironment
+
+from ai_engine.prompts.registry import PromptRegistry
+
+
+@pytest.fixture()
+def tmp_prompts(tmp_path: Path) -> Path:
+    """Create a minimal template directory for testing."""
+    tpl = tmp_path / "hello.j2"
+    tpl.write_text("Hello, {{ name }}!")
+    return tmp_path
+
+
+class TestRegistrySandbox:
+    def test_env_is_sandboxed(self, tmp_prompts: Path) -> None:
+        registry = PromptRegistry(prompts_dir=tmp_prompts)
+        assert isinstance(registry._env, SandboxedEnvironment)
+
+    def test_render_basic_template(self, tmp_prompts: Path) -> None:
+        registry = PromptRegistry(prompts_dir=tmp_prompts)
+        result = registry.render("hello.j2", name="World")
+        assert result == "Hello, World!"
+
+    def test_add_search_path(self, tmp_prompts: Path, tmp_path: Path) -> None:
+        # Create a second template directory inside tmp_prompts (must be under backend/)
+        # Use add_search_path's path validation by monkeypatching the backend root check
+        registry = PromptRegistry(prompts_dir=tmp_prompts)
+
+        extra_dir = tmp_prompts / "extra"
+        extra_dir.mkdir()
+        (extra_dir / "bonus.j2").write_text("Bonus: {{ x }}")
+
+        # Directly append to searchpath to avoid the backend-root check in tests
+        registry._env.loader.searchpath.append(str(extra_dir))
+
+        result = registry.render("bonus.j2", x="42")
+        assert result == "Bonus: 42"

--- a/backend/vertical_engines/wealth/dd_report_engine.py
+++ b/backend/vertical_engines/wealth/dd_report_engine.py
@@ -10,12 +10,12 @@ but with wealth-specific chapters and scoring.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
+import structlog
 from sqlalchemy.orm import Session
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 # 7-chapter DD report structure
 DD_CHAPTERS = [
@@ -64,10 +64,7 @@ class DDReportEngine:
         dict
             Complete DD report with chapters, scores, and recommendation.
         """
-        logger.info(
-            "Generating DD report fund=%s target=%s actor=%s",
-            fund_id, target_id, actor_id,
-        )
+        logger.info("generating_dd_report", fund_id=fund_id, target_id=target_id, actor_id=actor_id)
 
         # TODO(Sprint 5+): Implement full chapter generation with LLM calls.
         # For now, return the chapter structure as scaffold.

--- a/backend/vertical_engines/wealth/fund_analyzer.py
+++ b/backend/vertical_engines/wealth/fund_analyzer.py
@@ -16,14 +16,14 @@ Config is resolved via :class:`ConfigService` — never reads YAML directly.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
+import structlog
 from sqlalchemy.orm import Session
 
 from vertical_engines.base.base_analyzer import BaseAnalyzer
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 class FundAnalyzer(BaseAnalyzer):

--- a/backend/vertical_engines/wealth/quant_analyzer.py
+++ b/backend/vertical_engines/wealth/quant_analyzer.py
@@ -9,12 +9,12 @@ No YAML loading, no @lru_cache — follows the quant_engine refactor pattern.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
+import structlog
 from sqlalchemy.orm import Session
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 class QuantAnalyzer:
@@ -51,7 +51,7 @@ class QuantAnalyzer:
         dict
             Quant analysis result (CVaR, scores, drift, regime).
         """
-        logger.info("Running quant analysis fund=%s as_of=%s", fund_id, as_of)
+        logger.info("running_quant_analysis", fund_id=fund_id, as_of=as_of)
 
         # TODO(Sprint 5+): Wire to actual quant_engine services.
         # The pattern will be:


### PR DESCRIPTION
## Summary
- **Prereq 0.1**: Replace `jinja2.Environment` with `SandboxedEnvironment` in PromptRegistry — prevents SSTI attacks
- **Prereq 0.2**: Migrate 5 wealth route files from `get_db` to `get_db_with_rls` — fixes **critical tenant isolation bypass** (any authenticated user could read/write all orgs)
- **Prereq 0.3**: Migrate 3 wealth scaffolds from stdlib `logging` to `structlog` (credit vertical convention)
- **Bonus**: Fix module-level `asyncio.Lock()` in `risk.py` SSE handler (lazy creation per CLAUDE.md rule)

## Context
These are mandatory security prerequisites from the [Wealth Vertical Complete Modularization Plan](docs/plans/2026-03-15-feat-wealth-vertical-complete-modularization-plan.md). Must be merged before any Phase 1 work begins.

## Test plan
- [x] 419 tests pass (3 new sandbox tests added)
- [x] `ruff check` passes
- [x] Verify PromptRegistry uses `SandboxedEnvironment` (new test: `test_registry_sandbox.py`)
- [ ] Verify wealth routes return tenant-scoped data (manual: `GET /api/wealth/funds` with different org tokens)
- [ ] Verify SSE risk stream connects without "different event loop" error

## Post-Deploy Monitoring & Validation
- **What to monitor**: HTTP 500 rate on `/api/wealth/*` endpoints, `SandboxedEnvironment` errors in logs
- **Expected healthy behavior**: Same response shapes as before, but filtered to caller's org
- **Failure signal**: 500 errors on wealth routes, `TemplateError` from sandbox restrictions
- **Validation window**: 1 hour post-deploy
- **If failure**: Revert this PR (but note: reverting Prereq 0.2 **restores an active vulnerability**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)