### PR TITLE
feat: ship UX remediation batch for admin, credit, and shared UI

### DIFF
--- a/frontends/admin/package.json
+++ b/frontends/admin/package.json
@@ -10,7 +10,15 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/language": "^6.12.2",
+    "@codemirror/lint": "^6.9.5",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.40.0",
+    "@lezer/common": "^1.5.1",
     "@netz/ui": "workspace:*",
+    "codemirror-json-schema": "^0.8.1",
     "dompurify": "^3.3.3"
   },
   "devDependencies": {

--- a/frontends/admin/src/json-schema.d.ts
+++ b/frontends/admin/src/json-schema.d.ts
@@ -1,0 +1,3 @@
+declare module "json-schema" {
+	export type JSONSchema7 = Record<string, unknown>;
+}

--- a/frontends/admin/src/lib/components/CodeEditor.svelte
+++ b/frontends/admin/src/lib/components/CodeEditor.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import type { EditorView } from "@codemirror/view";
+
+	interface Props {
+		value?: string;
+		schema: Record<string, unknown>;
+		ariaLabel: string;
+		class?: string;
+	}
+
+	let {
+		value = $bindable(""),
+		schema,
+		ariaLabel,
+		class: className,
+	}: Props = $props();
+
+	let editorHost: HTMLDivElement | undefined;
+	let view: EditorView | undefined;
+	let applySchema:
+		| ((target: EditorView, nextSchema?: Record<string, unknown>) => void)
+		| undefined;
+	let isInternalUpdate = false;
+	let editorReady = $state(false);
+
+	const instructionsId = "code-editor-instructions";
+
+	function syncExternalValue(nextValue: string) {
+		if (!view) {
+			return;
+		}
+
+		const currentValue = view.state.doc.toString();
+		if (nextValue === currentValue) {
+			return;
+		}
+
+		isInternalUpdate = true;
+		try {
+			view.dispatch({
+				changes: {
+					from: 0,
+					to: currentValue.length,
+					insert: nextValue,
+				},
+			});
+		} finally {
+			isInternalUpdate = false;
+		}
+	}
+
+	$effect(() => {
+		syncExternalValue(value ?? "");
+	});
+
+	$effect(() => {
+		if (view && applySchema) {
+			applySchema(view, schema);
+		}
+	});
+
+	onMount(() => {
+		let disposed = false;
+		let cleanup = () => {};
+		void (async () => {
+			const [
+				{ EditorState },
+				{ EditorView, keymap },
+				{ json, jsonParseLinter },
+				{ linter },
+				{ indentWithTab },
+				{ jsonSchemaLinter, handleRefresh, stateExtensions, updateSchema: setSchema },
+			] = await Promise.all([
+				import("@codemirror/state"),
+				import("@codemirror/view"),
+				import("@codemirror/lang-json"),
+				import("@codemirror/lint"),
+				import("@codemirror/commands"),
+				import("codemirror-json-schema"),
+			]);
+
+			if (disposed || !editorHost) {
+				return;
+			}
+
+			const extensions = [
+				EditorView.lineWrapping,
+				EditorView.theme({
+					"&": {
+						backgroundColor: "var(--netz-surface)",
+						color: "var(--netz-text-primary)",
+					},
+					"&.cm-focused": {
+						outline: "2px solid var(--netz-brand-secondary)",
+						outlineOffset: "2px",
+					},
+					".cm-content": {
+						caretColor: "var(--netz-brand-primary)",
+						fontFamily:
+							"ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, monospace",
+					},
+					".cm-gutters": {
+						backgroundColor: "var(--netz-surface-alt)",
+						color: "var(--netz-text-secondary)",
+						borderRight: "1px solid var(--netz-border)",
+					},
+				}),
+				EditorView.contentAttributes.of({
+					role: "textbox",
+					"aria-multiline": "true",
+					"aria-label": ariaLabel,
+					"aria-describedby": instructionsId,
+					spellcheck: "false",
+					autocapitalize: "off",
+					autocorrect: "off",
+				}),
+				json(),
+				linter(jsonParseLinter(), { delay: 300 }),
+				linter(jsonSchemaLinter(), { delay: 750, needsRefresh: handleRefresh }),
+				keymap.of([indentWithTab]),
+				stateExtensions(schema as never),
+				EditorView.updateListener.of((update) => {
+					if (!update.docChanged || isInternalUpdate) {
+						return;
+					}
+
+					value = update.state.doc.toString();
+				}),
+			];
+
+			view = new EditorView({
+				state: EditorState.create({
+					doc: value ?? "",
+					extensions,
+				}),
+				parent: editorHost,
+			});
+			applySchema = setSchema;
+			editorReady = true;
+			applySchema(view, schema);
+
+			cleanup = () => {
+				view?.destroy();
+				view = undefined;
+				applySchema = undefined;
+			};
+
+			if (disposed) {
+				cleanup();
+			}
+		})();
+
+		return () => {
+			disposed = true;
+			cleanup();
+		};
+	});
+</script>
+
+<div class={className}>
+	<div
+		bind:this={editorHost}
+		class="min-h-72 overflow-hidden rounded-xl border border-[var(--netz-border)] bg-[var(--netz-surface)]"
+		aria-busy={editorReady ? "false" : "true"}
+	></div>
+	<p
+		id={instructionsId}
+		class="mt-3 text-sm leading-6 text-[var(--netz-text-secondary)]"
+	>
+		Press Escape to leave the editor, Tab to indent.
+	</p>
+</div>

--- a/frontends/admin/src/lib/components/ConfigEditor.svelte
+++ b/frontends/admin/src/lib/components/ConfigEditor.svelte
@@ -10,12 +10,22 @@
 		configType,
 		token,
 		orgId,
+		tenantName,
 	}: {
 		vertical: string;
 		configType: string;
 		token: string;
 		orgId?: string;
+		tenantName?: string;
 	} = $props();
+
+	const scopeLabel = $derived(
+		orgId && tenantName
+			? `${tenantName} (${orgId})`
+			: orgId
+				? orgId
+				: "ALL tenants",
+	);
 
 	let content = $state("{}");
 	let version = $state(0);
@@ -167,7 +177,7 @@
 						</Button>
 					{/if}
 					<Button variant="ghost" size="sm" onclick={() => (showDefaultConfirm = true)} disabled={!jsonValid}>
-						Update Default
+						Update Default for ALL tenants
 					</Button>
 				</div>
 				<div class="flex gap-2">
@@ -176,7 +186,7 @@
 					</Button>
 					{#if orgId}
 						<ActionButton onclick={save} loading={saving} loadingText="Saving..." disabled={!jsonValid}>
-							Save Override
+							Save Override for {tenantName ?? "this tenant"}
 						</ActionButton>
 					{/if}
 				</div>
@@ -188,17 +198,17 @@
 <ConfirmDialog
 	bind:open={showDeleteConfirm}
 	title="Revert to Default"
-	message="This will delete the config override and revert to the global default. Continue?"
-	confirmLabel="Revert"
+	message="This will delete the config override for {scopeLabel} and revert to the global default. Continue?"
+	confirmLabel="Revert for {tenantName ?? 'this tenant'}"
 	confirmVariant="destructive"
 	onConfirm={deleteOverride}
 />
 
 <ConfirmDialog
 	bind:open={showDefaultConfirm}
-	title="Update Global Default"
-	message="This will update the global default config for all tenants without overrides. This is a high-impact action."
-	confirmLabel="Update Default"
+	title="Update Global Default — affects ALL tenants"
+	message="This will update the global default {configType} config for ALL tenants without overrides. Every tenant using the default will receive this change immediately."
+	confirmLabel="Update Default for ALL tenants"
 	confirmVariant="destructive"
 	onConfirm={updateDefault}
 />

--- a/frontends/admin/src/lib/components/PromptEditor.svelte
+++ b/frontends/admin/src/lib/components/PromptEditor.svelte
@@ -294,7 +294,7 @@
 					Revert Override
 				</Button>
 				<ActionButton onclick={save} loading={saving} loadingText="Saving..." disabled={!syntaxValid}>
-					Save
+					Save for ALL tenants
 				</ActionButton>
 			</div>
 		{/if}
@@ -303,18 +303,18 @@
 
 <ConfirmDialog
 	bind:open={showRevertConfirm}
-	title="Revert to Version"
-	message="This will revert the prompt to version {revertTarget}. Current content will be overwritten."
-	confirmLabel="Revert"
+	title="Revert to Version — affects ALL tenants"
+	message="This will revert the {templateName} prompt to version {revertTarget} for ALL tenants. Current content will be overwritten."
+	confirmLabel="Revert for ALL tenants"
 	confirmVariant="destructive"
 	onConfirm={doRevertToVersion}
 />
 
 <ConfirmDialog
 	bind:open={showDeleteConfirm}
-	title="Remove Override"
-	message="This will remove the override. The prompt will fall back to the next cascade level."
-	confirmLabel="Remove"
+	title="Remove Override — affects ALL tenants"
+	message="This will remove the {templateName} prompt override for {vertical}. All tenants will fall back to the filesystem template. This is a global-impact action."
+	confirmLabel="Remove for ALL tenants"
 	confirmVariant="destructive"
 	onConfirm={deleteOverride}
 />

--- a/frontends/admin/src/routes/(admin)/tenants/[orgId=orgId]/+layout.svelte
+++ b/frontends/admin/src/routes/(admin)/tenants/[orgId=orgId]/+layout.svelte
@@ -5,7 +5,7 @@
 <script lang="ts">
 	import { page } from "$app/state";
 	import { useContextNav } from "$lib/state/context-nav.svelte";
-	import EntityContextHeader from "../../../../../../../packages/ui/src/lib/components/EntityContextHeader.svelte";
+	import { EntityContextHeader } from "@netz/ui";
 
 	let { children }: { children: import("svelte").Snippet } = $props();
 	const nav = useContextNav();

--- a/frontends/credit/src/lib/utils/status-maps.ts
+++ b/frontends/credit/src/lib/utils/status-maps.ts
@@ -1,0 +1,25 @@
+import type { StatusConfig } from "@netz/ui";
+
+export const creditStatusMap: Record<string, StatusConfig> = {
+	screening: { label: "Screening", severity: "neutral", color: "var(--netz-text-secondary)" },
+	qualified: { label: "Qualified", severity: "info", color: "var(--netz-info)" },
+	ic_review: { label: "IC Review", severity: "warning", color: "var(--netz-warning)" },
+	approved: { label: "Approved", severity: "success", color: "var(--netz-success)" },
+	declined: { label: "Declined", severity: "danger", color: "var(--netz-danger)" },
+	pending: { label: "Pending", severity: "warning", color: "var(--netz-warning)" },
+	in_progress: { label: "In Progress", severity: "info", color: "var(--netz-info)" },
+	rejected: { label: "Rejected", severity: "danger", color: "var(--netz-danger)" },
+	revision_requested: {
+		label: "Revision Requested",
+		severity: "warning",
+		color: "var(--netz-warning)",
+	},
+	low: { label: "Low", severity: "success", color: "var(--netz-success)" },
+	medium: { label: "Medium", severity: "warning", color: "var(--netz-warning)" },
+	high: { label: "High", severity: "danger", color: "var(--netz-danger)" },
+	critical: { label: "Critical", severity: "danger", color: "var(--netz-danger)" },
+};
+
+export function resolveCreditStatus(token: string): StatusConfig | undefined {
+	return creditStatusMap[token.trim().toLowerCase()];
+}

--- a/frontends/credit/src/routes/(team)/dashboard/+page.svelte
+++ b/frontends/credit/src/routes/(team)/dashboard/+page.svelte
@@ -111,7 +111,13 @@
     <h2 class="mb-4 text-lg font-semibold text-[var(--netz-text-primary)]">
       Action Queue
     </h2>
-    <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+    {#if data.taskInbox}
+      <div class="mt-4">
+        <TaskInbox tasks={data.taskInbox as TaskItem[]} />
+      </div>
+    {/if}
+
+    <div class="mt-4 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
       <DataCard
         label="Deals Awaiting IC"
         value={String(pipeline?.pending_ic ?? 0)}
@@ -133,12 +139,6 @@
         trend="flat"
       />
     </div>
-
-    {#if data.taskInbox}
-      <div class="mt-4">
-        <TaskInbox tasks={data.taskInbox as TaskItem[]} />
-      </div>
-    {/if}
   </section>
 
   <!-- Tier 2: Analytical -->

--- a/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/+page.svelte
+++ b/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/+page.svelte
@@ -9,7 +9,7 @@
 	import { getContext } from "svelte";
 	import { createClientApiClient } from "$lib/api/client";
 	import type { PageData } from "./$types";
-	import type { DealType } from "$lib/types/api";
+	import type { DealStage, DealType } from "$lib/types/api";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 
@@ -17,6 +17,17 @@
 
 	let selectedDeal = $state<Record<string, unknown> | null>(null);
 	let panelOpen = $derived(selectedDeal !== null);
+	const stageFilters: Array<{ value: DealStage | "ALL"; label: string }> = [
+		{ value: "ALL", label: "All stages" },
+		{ value: "INTAKE", label: "Intake" },
+		{ value: "QUALIFIED", label: "Qualified" },
+		{ value: "IC_REVIEW", label: "IC review" },
+		{ value: "CONDITIONAL", label: "Conditional" },
+		{ value: "APPROVED", label: "Approved" },
+		{ value: "CONVERTED_TO_ASSET", label: "Converted" },
+		{ value: "REJECTED", label: "Rejected" },
+		{ value: "CLOSED", label: "Closed" },
+	];
 
 	// ── Create Deal Dialog ──
 	let showCreate = $state(false);
@@ -72,12 +83,33 @@
 	function handleRowClick(row: Record<string, unknown>) {
 		selectedDeal = row;
 	}
+
+	function selectStageFilter(stage: DealStage | "ALL") {
+		goto(
+			stage === "ALL"
+				? `/funds/${data.fundId}/pipeline`
+				: `/funds/${data.fundId}/pipeline?stage=${encodeURIComponent(stage)}`,
+		);
+	}
 </script>
 
 <div class="flex h-full">
 	<div class="flex-1 p-6">
-		<div class="mb-4 flex items-center justify-between">
-			<h2 class="text-xl font-semibold text-[var(--netz-text-primary)]">Deal Pipeline</h2>
+		<div class="mb-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+			<div class="space-y-3">
+				<h2 class="text-xl font-semibold text-[var(--netz-text-primary)]">Deal Pipeline</h2>
+				<div class="flex flex-wrap gap-2">
+					{#each stageFilters as stage}
+						<Button
+							onclick={() => selectStageFilter(stage.value)}
+							size="sm"
+							variant="outline"
+						>
+							{stage.label}
+						</Button>
+					{/each}
+				</div>
+			</div>
 			<Button onclick={() => { resetForm(); showCreate = true; }}>New Deal</Button>
 		</div>
 

--- a/frontends/wealth/src/lib/utils/status-maps.ts
+++ b/frontends/wealth/src/lib/utils/status-maps.ts
@@ -1,0 +1,19 @@
+import type { StatusConfig } from "@netz/ui";
+
+export const wealthStatusMap: Record<string, StatusConfig> = {
+	risk_on: { label: "Risk On", severity: "success", color: "var(--netz-success)" },
+	risk_off: { label: "Risk Off", severity: "warning", color: "var(--netz-warning)" },
+	inflation: { label: "Inflation", severity: "warning", color: "var(--netz-warning)" },
+	crisis: { label: "Crisis", severity: "danger", color: "var(--netz-danger)" },
+	pass: { label: "Pass", severity: "success", color: "var(--netz-success)" },
+	watchlist: { label: "Watchlist", severity: "warning", color: "var(--netz-warning)" },
+	fail: { label: "Fail", severity: "danger", color: "var(--netz-danger)" },
+	approved: { label: "Approved", severity: "success", color: "var(--netz-success)" },
+	published: { label: "Published", severity: "success", color: "var(--netz-success)" },
+	warning: { label: "Warning", severity: "warning", color: "var(--netz-warning)" },
+	breach: { label: "Breach", severity: "danger", color: "var(--netz-danger)" },
+};
+
+export function resolveWealthStatus(token: string): StatusConfig | undefined {
+	return wealthStatusMap[token.trim().toLowerCase()];
+}

--- a/packages/ui/src/lib/components/AuditTrailPanel.svelte
+++ b/packages/ui/src/lib/components/AuditTrailPanel.svelte
@@ -1,0 +1,303 @@
+<script lang="ts">
+	import Card from "./Card.svelte";
+	import Button from "./Button.svelte";
+	import { cn } from "../utils/cn.js";
+	import { formatDate, formatDateTime } from "../utils/format.js";
+
+	export type AuditTrailStatus = "success" | "warning" | "error" | "info" | "pending";
+
+	export interface AuditTrailFieldChange {
+		field: string;
+		from?: string | null;
+		to?: string | null;
+	}
+
+	export interface AuditTrailEntry {
+		id?: string;
+		actor: string;
+		actorCapacity?: string;
+		actorEmail?: string;
+		timestamp: string | number | Date;
+		action: string;
+		scope: string;
+		rationale?: string;
+		outcome: string;
+		status?: AuditTrailStatus;
+		immutable?: boolean;
+		sourceSystem?: string;
+		changedFields?: AuditTrailFieldChange[];
+	}
+
+	interface RenderedAuditTrailEntry {
+		entry: AuditTrailEntry;
+		key: string;
+		groupLabel: string | null;
+		timestampLabel: string;
+		datetimeValue: string;
+	}
+
+	interface Props {
+		entries?: AuditTrailEntry[];
+		title?: string;
+		description?: string;
+		emptyMessage?: string;
+		maxVisible?: number;
+		class?: string;
+	}
+
+	let {
+		entries = [],
+		title = "Audit trail",
+		description = "Visible post-mutation record for consequential actions.",
+		emptyMessage = "No audit events are available yet.",
+		maxVisible = 50,
+		class: className,
+	}: Props = $props();
+
+	let showAll = $state(false);
+
+	const statusStyles: Record<AuditTrailStatus, string> = {
+		success: "bg-emerald-50 text-emerald-700 border-emerald-200",
+		warning: "bg-amber-50 text-amber-700 border-amber-200",
+		error: "bg-rose-50 text-rose-700 border-rose-200",
+		info: "bg-slate-100 text-slate-700 border-slate-200",
+		pending: "bg-blue-50 text-blue-700 border-blue-200",
+	};
+
+	const locale = Intl.DateTimeFormat().resolvedOptions().locale || "en-US";
+	const millisecondsPerDay = 24 * 60 * 60 * 1000;
+
+	function resolveMaxVisible(value: number): number {
+		return Number.isFinite(value) && value > 0 ? Math.floor(value) : 50;
+	}
+
+	function toDate(value: AuditTrailEntry["timestamp"]): Date | null {
+		const date = value instanceof Date ? value : new Date(value);
+		return Number.isNaN(date.getTime()) ? null : date;
+	}
+
+	function toStartOfDay(value: Date): number {
+		return new Date(value.getFullYear(), value.getMonth(), value.getDate()).getTime();
+	}
+
+	function getTitleId(value: string): string {
+		const slug = value
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-+|-+$/g, "");
+
+		return `audit-trail-panel-${slug || "title"}`;
+	}
+
+	function formatDateGroup(date: Date): string {
+		const today = new Date();
+		const delta = Math.round((toStartOfDay(today) - toStartOfDay(date)) / millisecondsPerDay);
+
+		if (delta === 0) {
+			return "Today";
+		}
+
+		if (delta === 1) {
+			return "Yesterday";
+		}
+
+		return formatDate(date, "medium", locale);
+	}
+
+	function getHiddenEntryCount(source: AuditTrailEntry[], expanded: boolean, limit: number): number {
+		if (expanded) {
+			return 0;
+		}
+
+		return Math.max(0, source.length - resolveMaxVisible(limit));
+	}
+
+	function getVisibleEntries(
+		source: AuditTrailEntry[],
+		expanded: boolean,
+		limit: number,
+	): RenderedAuditTrailEntry[] {
+		const safeMaxVisible = resolveMaxVisible(limit);
+		const startIndex = expanded || source.length <= safeMaxVisible ? 0 : source.length - safeMaxVisible;
+		const visibleEntries = source.slice(startIndex);
+		const showDateGroups = source.length > 3;
+		let previousGroupLabel: string | null = null;
+
+		return visibleEntries.map((entry, index) => {
+			const date = toDate(entry.timestamp);
+			const dateGroup = date ? formatDateGroup(date) : null;
+			const nextGroupLabel =
+				showDateGroups && dateGroup && dateGroup !== previousGroupLabel ? dateGroup : null;
+
+			previousGroupLabel = dateGroup;
+
+			return {
+				entry,
+				key: entry.id ?? `${entry.action}-${entry.actor}-${startIndex + index}`,
+				groupLabel: nextGroupLabel,
+				timestampLabel: date ? formatDateTime(date, locale) : String(entry.timestamp),
+				datetimeValue: date ? date.toISOString() : String(entry.timestamp),
+			};
+		});
+	}
+</script>
+
+<Card class={cn("p-5", className)}>
+	<div class="space-y-5">
+		<div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+			<div class="space-y-1">
+				<h2 id={getTitleId(title)} class="text-lg font-semibold text-[var(--netz-text-primary)]">
+					{title}
+				</h2>
+				<p class="text-sm text-[var(--netz-text-secondary)]">{description}</p>
+			</div>
+
+			{#if getHiddenEntryCount(entries, showAll, maxVisible) > 0}
+				<Button variant="ghost" size="sm" type="button" onclick={() => (showAll = true)}>
+					Load earlier entries ({getHiddenEntryCount(entries, showAll, maxVisible)})
+				</Button>
+			{/if}
+		</div>
+
+		{#if entries.length === 0}
+			<div class="rounded-lg border border-dashed border-[var(--netz-border)] p-4 text-sm text-[var(--netz-text-secondary)]">
+				{emptyMessage}
+			</div>
+		{:else}
+			<ul
+				class="space-y-4"
+				role="log"
+				aria-labelledby={getTitleId(title)}
+				aria-live="polite"
+				aria-atomic="false"
+			>
+				{#each getVisibleEntries(entries, showAll, maxVisible) as row (row.key)}
+					{#if row.groupLabel}
+						<li class="pt-2">
+							<h3
+								class="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--netz-text-secondary)]"
+							>
+								{row.groupLabel}
+							</h3>
+						</li>
+					{/if}
+
+					<li class="rounded-lg border border-[var(--netz-border)] bg-[var(--netz-surface-alt)] p-4">
+						<div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+							<div class="space-y-1">
+								<p class="text-sm font-semibold text-[var(--netz-text-primary)]">
+									{row.entry.action}
+								</p>
+								<p class="text-sm text-[var(--netz-text-secondary)]">{row.entry.scope}</p>
+							</div>
+
+							<div class="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
+								{#if row.entry.immutable}
+									<span
+										class="inline-flex w-fit items-center rounded-full border border-[var(--netz-border)] bg-[var(--netz-surface)] px-2.5 py-1 text-xs font-medium text-[var(--netz-text-secondary)]"
+									>
+										Immutable
+									</span>
+								{/if}
+
+								<span
+									class={cn(
+										"inline-flex w-fit items-center rounded-full border px-2.5 py-1 text-xs font-medium",
+										statusStyles[row.entry.status ?? "info"],
+									)}
+								>
+									{row.entry.outcome}
+								</span>
+							</div>
+						</div>
+
+						<dl class="mt-4 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
+							<div>
+								<dt class="text-xs font-medium uppercase tracking-[0.14em] text-[var(--netz-text-secondary)]">
+									Actor
+								</dt>
+								<dd class="mt-1 text-[var(--netz-text-primary)]">{row.entry.actor}</dd>
+							</div>
+
+							{#if row.entry.actorCapacity}
+								<div>
+									<dt class="text-xs font-medium uppercase tracking-[0.14em] text-[var(--netz-text-secondary)]">
+										Capacity
+									</dt>
+									<dd class="mt-1 text-[var(--netz-text-primary)]">{row.entry.actorCapacity}</dd>
+								</div>
+							{/if}
+
+							{#if row.entry.actorEmail}
+								<div>
+									<dt class="text-xs font-medium uppercase tracking-[0.14em] text-[var(--netz-text-secondary)]">
+										Actor email
+									</dt>
+									<dd class="mt-1 text-[var(--netz-text-primary)]">{row.entry.actorEmail}</dd>
+								</div>
+							{/if}
+
+							<div>
+								<dt class="text-xs font-medium uppercase tracking-[0.14em] text-[var(--netz-text-secondary)]">
+									Timestamp
+								</dt>
+								<dd class="mt-1 text-[var(--netz-text-primary)]">
+									<time datetime={row.datetimeValue}>{row.timestampLabel}</time>
+								</dd>
+							</div>
+
+							{#if row.entry.sourceSystem}
+								<div>
+									<dt class="text-xs font-medium uppercase tracking-[0.14em] text-[var(--netz-text-secondary)]">
+										Source system
+									</dt>
+									<dd class="mt-1 text-[var(--netz-text-primary)]">{row.entry.sourceSystem}</dd>
+								</div>
+							{/if}
+						</dl>
+
+						{#if row.entry.rationale}
+							<div class="mt-4 rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] p-3">
+								<p class="text-xs font-medium uppercase tracking-[0.14em] text-[var(--netz-text-secondary)]">
+									Rationale
+								</p>
+								<p class="mt-2 text-sm leading-6 text-[var(--netz-text-primary)]">
+									{row.entry.rationale}
+								</p>
+							</div>
+						{/if}
+
+						{#if row.entry.changedFields && row.entry.changedFields.length > 0}
+							<div class="mt-4 space-y-3">
+								<p class="text-xs font-medium uppercase tracking-[0.14em] text-[var(--netz-text-secondary)]">
+									Changed fields
+								</p>
+								<ul class="space-y-2">
+									{#each row.entry.changedFields as change}
+										<li class="rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] p-3">
+											<p class="text-sm font-medium text-[var(--netz-text-primary)]">{change.field}</p>
+											<div class="mt-2 grid gap-2 text-sm sm:grid-cols-2">
+												<div>
+													<p class="text-xs uppercase tracking-[0.12em] text-[var(--netz-text-secondary)]">
+														From
+													</p>
+													<p class="mt-1 text-[var(--netz-text-primary)]">{change.from ?? "Not set"}</p>
+												</div>
+												<div>
+													<p class="text-xs uppercase tracking-[0.12em] text-[var(--netz-text-secondary)]">
+														To
+													</p>
+													<p class="mt-1 text-[var(--netz-text-primary)]">{change.to ?? "Not set"}</p>
+												</div>
+											</div>
+										</li>
+									{/each}
+								</ul>
+							</div>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
+</Card>

--- a/packages/ui/src/lib/components/ConsequenceDialog.svelte
+++ b/packages/ui/src/lib/components/ConsequenceDialog.svelte
@@ -1,0 +1,273 @@
+<script lang="ts" module>
+	let consequenceDialogId = 0;
+</script>
+
+<script lang="ts">
+	import { AlertDialog } from "bits-ui";
+	import type { Snippet } from "svelte";
+
+	export interface ConsequenceDialogMetadataItem {
+		label: string;
+		value: string;
+		emphasis?: boolean;
+	}
+
+	export interface ConsequenceDialogPayload {
+		rationale?: string;
+		typedConfirmation?: string;
+	}
+
+	interface Props {
+		open?: boolean;
+		title: string;
+		impactSummary: string;
+		scopeText?: string;
+		destructive?: boolean;
+		requireRationale?: boolean;
+		rationaleLabel?: string;
+		rationalePlaceholder?: string;
+		rationaleMinLength?: number;
+		typedConfirmationText?: string;
+		typedConfirmation?: string;
+		typedConfirmationLabel?: string;
+		confirmLabel?: string;
+		cancelLabel?: string;
+		metadata?: ConsequenceDialogMetadataItem[];
+		consequenceList?: Snippet;
+		children?: Snippet;
+		onConfirm: (payload: ConsequenceDialogPayload) => void | Promise<void>;
+		onCancel?: () => void;
+	}
+
+	let {
+		open = $bindable(false),
+		title,
+		impactSummary,
+		scopeText,
+		destructive = false,
+		requireRationale = false,
+		rationaleLabel = "Rationale",
+		rationalePlaceholder = "Record the operational or policy basis for this action.",
+		rationaleMinLength = 12,
+		typedConfirmationText,
+		typedConfirmation: typedConfirmationPrompt,
+		typedConfirmationLabel = "Typed confirmation",
+		confirmLabel = "Confirm action",
+		cancelLabel = "Cancel",
+		metadata = [],
+		consequenceList,
+		children,
+		onConfirm,
+		onCancel,
+	}: Props = $props();
+
+	let rationale = $state("");
+	let typedConfirmation = $state("");
+	let submitting = $state(false);
+	let cancelRef = $state<HTMLButtonElement | null>(null);
+
+	const instanceId = ++consequenceDialogId;
+	const rationaleId = `consequence-rationale-${instanceId}`;
+	const typedConfirmationId = `consequence-typed-${instanceId}`;
+
+	function resetForm() {
+		rationale = "";
+		typedConfirmation = "";
+	}
+
+	function handleOpenChange(nextOpen: boolean) {
+		if (submitting && !nextOpen) {
+			open = true;
+			return;
+		}
+
+		const wasOpen = open;
+		open = nextOpen;
+
+		if (!nextOpen && wasOpen) {
+			resetForm();
+			onCancel?.();
+		}
+	}
+
+	function handleOpenAutoFocus(event: Event) {
+		if (!destructive || !cancelRef) {
+			return;
+		}
+
+		event.preventDefault();
+		cancelRef.focus();
+	}
+
+	function handleEscapeKeyDown(event: KeyboardEvent) {
+		if (submitting) {
+			event.preventDefault();
+		}
+	}
+
+	let rationaleValue = $derived(rationale.trim());
+	let typedConfirmationValue = $derived(typedConfirmation.trim());
+	let rationaleSatisfied = $derived(!requireRationale || rationaleValue.length >= rationaleMinLength);
+	let confirmationPrompt = $derived(typedConfirmationText ?? typedConfirmationPrompt);
+	let typedConfirmationSatisfied = $derived(
+		!confirmationPrompt || typedConfirmationValue === confirmationPrompt,
+	);
+	let canConfirm = $derived(rationaleSatisfied && typedConfirmationSatisfied);
+
+	async function handleConfirm() {
+		if (!canConfirm || submitting) {
+			return;
+		}
+
+		submitting = true;
+
+		try {
+			await onConfirm({
+				rationale: rationaleValue || undefined,
+				typedConfirmation: typedConfirmationValue || undefined,
+			});
+			resetForm();
+			open = false;
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<AlertDialog.Root bind:open onOpenChange={handleOpenChange}>
+	<AlertDialog.Portal>
+		<AlertDialog.Overlay
+			class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm netz-animate-fade-in data-[state=closed]:netz-animate-fade-out"
+		/>
+		<AlertDialog.Content
+			class="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-lg border border-[var(--netz-border)] bg-[var(--netz-surface)] p-6 shadow-lg netz-animate-scale-in data-[state=closed]:netz-animate-scale-out"
+			onOpenAutoFocus={handleOpenAutoFocus}
+			onEscapeKeydown={handleEscapeKeyDown}
+		>
+			<div class="space-y-5">
+				<div class="space-y-2 pr-8">
+					<p
+						class={`text-xs font-semibold uppercase tracking-[0.18em] ${
+							destructive ? "text-[var(--netz-danger)]" : "text-[var(--netz-text-secondary)]"
+						}`}
+					>
+						{destructive ? "Destructive action" : "Consequence-aware confirmation"}
+					</p>
+					<AlertDialog.Title class="text-xl font-semibold text-[var(--netz-text-primary)]">
+						{title}
+					</AlertDialog.Title>
+					<AlertDialog.Description class="text-sm leading-6 text-[var(--netz-text-secondary)]">
+						{impactSummary}
+					</AlertDialog.Description>
+				</div>
+
+				{#if scopeText}
+					<section class="rounded-lg border border-[var(--netz-border)] bg-[var(--netz-surface-alt)] p-4">
+						<h3 class="text-sm font-semibold text-[var(--netz-text-primary)]">Scope</h3>
+						<p class="mt-2 text-sm leading-6 text-[var(--netz-text-secondary)]">{scopeText}</p>
+					</section>
+				{/if}
+
+				{#if consequenceList}
+					<section class="rounded-lg border border-[var(--netz-border)] bg-[var(--netz-surface-alt)] p-4">
+						<h3 class="text-sm font-semibold text-[var(--netz-text-primary)]">Consequences</h3>
+						<div class="mt-3 text-sm leading-6 text-[var(--netz-text-secondary)]">
+							{@render consequenceList()}
+						</div>
+					</section>
+				{/if}
+
+				{#if metadata.length > 0}
+					<section class="rounded-lg border border-[var(--netz-border)] bg-[var(--netz-surface)] p-4">
+						<div class="grid gap-3 sm:grid-cols-2">
+							{#each metadata as item}
+								<div class="space-y-1">
+									<p class="text-xs font-medium uppercase tracking-[0.16em] text-[var(--netz-text-secondary)]">
+										{item.label}
+									</p>
+									<p class={item.emphasis
+										? "text-sm font-semibold text-[var(--netz-text-primary)]"
+										: "text-sm text-[var(--netz-text-primary)]"}>
+										{item.value}
+									</p>
+								</div>
+							{/each}
+						</div>
+					</section>
+				{/if}
+
+				{#if requireRationale}
+					<div class="space-y-2">
+						<label for={rationaleId} class="text-sm font-medium text-[var(--netz-text-primary)]">
+							{rationaleLabel}
+						</label>
+						<textarea
+							id={rationaleId}
+							bind:value={rationale}
+							rows="4"
+							class="w-full rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] px-3 py-2 text-sm text-[var(--netz-text-primary)] outline-none transition focus:border-[var(--netz-brand-secondary)] focus:ring-2 focus:ring-[var(--netz-brand-secondary)]/20"
+							placeholder={rationalePlaceholder}
+							aria-invalid={rationale.length > 0 && !rationaleSatisfied}
+							aria-required={requireRationale}
+						></textarea>
+						<p class="text-xs text-[var(--netz-text-secondary)]">
+							Provide at least {rationaleMinLength} characters before continuing.
+						</p>
+					</div>
+				{/if}
+
+				{#if confirmationPrompt}
+					<div class="space-y-2">
+						<label for={typedConfirmationId} class="text-sm font-medium text-[var(--netz-text-primary)]">
+							{typedConfirmationLabel}
+						</label>
+						<p class="text-sm text-[var(--netz-text-secondary)]">
+							Type <span class="font-semibold text-[var(--netz-text-primary)]">{confirmationPrompt}</span>
+							to continue.
+						</p>
+						<input
+							id={typedConfirmationId}
+							bind:value={typedConfirmation}
+							type="text"
+							class="w-full rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] px-3 py-2 text-sm text-[var(--netz-text-primary)] outline-none transition focus:border-[var(--netz-brand-secondary)] focus:ring-2 focus:ring-[var(--netz-brand-secondary)]/20"
+							aria-invalid={typedConfirmation.length > 0 && !typedConfirmationSatisfied}
+						/>
+					</div>
+				{/if}
+
+				{#if children}
+					<div class="space-y-3 border-t border-[var(--netz-border)] pt-4">
+						{@render children()}
+					</div>
+				{/if}
+
+				<div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+					<AlertDialog.Cancel
+						bind:ref={cancelRef}
+						disabled={submitting}
+						class="inline-flex h-9 items-center justify-center rounded-md border border-[var(--netz-border)] bg-transparent px-4 text-sm font-medium text-[var(--netz-text-primary)] transition-colors hover:bg-[var(--netz-surface-alt)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--netz-brand-secondary)] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+					>
+						{cancelLabel}
+					</AlertDialog.Cancel>
+					<AlertDialog.Action
+						disabled={!canConfirm || submitting}
+						onclick={handleConfirm}
+						class={`inline-flex h-9 items-center justify-center rounded-md px-4 text-sm font-medium text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--netz-brand-secondary)] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${
+							destructive
+								? "bg-[var(--netz-danger)] hover:bg-[var(--netz-danger)]/90"
+								: "bg-[var(--netz-brand-primary)] hover:bg-[var(--netz-brand-primary)]/90"
+						}`}
+					>
+						{#if submitting}
+							<svg class="mr-2 h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+								<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+								<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+							</svg>
+						{/if}
+						{confirmLabel}
+					</AlertDialog.Action>
+				</div>
+			</div>
+		</AlertDialog.Content>
+	</AlertDialog.Portal>
+</AlertDialog.Root>

--- a/packages/ui/src/lib/components/DataTable.svelte
+++ b/packages/ui/src/lib/components/DataTable.svelte
@@ -5,14 +5,21 @@
 		createTable,
 		FlexRender,
 		getCoreRowModel,
-		getSortedRowModel,
+		getExpandedRowModel,
 		getFilteredRowModel,
 		getPaginationRowModel,
+		getSortedRowModel,
 		type ColumnDef,
-		type SortingState,
 		type ColumnFiltersState,
-		type TableOptions,
+		type ExpandedState,
+		type SortingState,
 	} from "@tanstack/svelte-table";
+
+	type RowData = Record<string, unknown>;
+
+	function clampPageSize(value: number): number {
+		return Math.min(Math.max(value, 1), 100);
+	}
 
 	let {
 		data,
@@ -21,224 +28,260 @@
 		pageSize = 10,
 		filterColumn,
 		filterPlaceholder = "Filter...",
+		filterBar,
 		toolbar,
 		emptyState,
+		expandedRow,
 	}: {
-		data: Record<string, unknown>[];
-		columns: ColumnDef<Record<string, unknown>, unknown>[];
+		data: RowData[];
+		columns: ColumnDef<RowData, unknown>[];
 		class?: string;
 		pageSize?: number;
 		filterColumn?: string;
 		filterPlaceholder?: string;
+		filterBar?: Snippet<[unknown]>;
 		toolbar?: Snippet<[unknown]>;
 		emptyState?: Snippet;
+		expandedRow?: Snippet<[RowData]>;
 	} = $props();
-
-	let effectivePageSize = $derived(Math.min(Math.max(pageSize, 1), 100));
 
 	let sorting = $state<SortingState>([]);
 	let columnFilters = $state<ColumnFiltersState>([]);
+	let expanded = $state<ExpandedState>({});
+	let pagination = $state({
+		pageIndex: 0,
+		pageSize: 10,
+	});
+	let effectivePageSize = $derived(clampPageSize(pageSize));
 
 	let table = createTable({
-		get data() { return data; },
-		get columns() { return columns; },
-		state: {
-			get sorting() { return sorting; },
-			get columnFilters() { return columnFilters; },
+		get data() {
+			return data;
 		},
+		get columns() {
+			return columns;
+		},
+		state: {
+			get sorting() {
+				return sorting;
+			},
+			get columnFilters() {
+				return columnFilters;
+			},
+			get expanded() {
+				return expanded;
+			},
+			get pagination() {
+				return pagination;
+			},
+		},
+		enableMultiSort: true,
+		getRowCanExpand: () => Boolean(expandedRow),
 		onSortingChange: (updater) => {
 			sorting = typeof updater === "function" ? updater(sorting) : updater;
 		},
 		onColumnFiltersChange: (updater) => {
-			columnFilters =
-				typeof updater === "function" ? updater(columnFilters) : updater;
+			columnFilters = typeof updater === "function" ? updater(columnFilters) : updater;
+		},
+		onExpandedChange: (updater) => {
+			expanded = typeof updater === "function" ? updater(expanded) : updater;
+		},
+		onPaginationChange: (updater) => {
+			pagination = typeof updater === "function" ? updater(pagination) : updater;
 		},
 		getCoreRowModel: getCoreRowModel(),
 		getSortedRowModel: getSortedRowModel(),
 		getFilteredRowModel: getFilteredRowModel(),
+		getExpandedRowModel: getExpandedRowModel(),
 		getPaginationRowModel: getPaginationRowModel(),
-		initialState: {
-			pagination: { pageSize: effectivePageSize },
-		},
+	});
+
+	$effect(() => {
+		if (pagination.pageSize !== effectivePageSize) {
+			pagination = {
+				...pagination,
+				pageIndex: 0,
+				pageSize: effectivePageSize,
+			};
+		}
 	});
 </script>
 
 <div class={cn("w-full", className)}>
-		<!-- Toolbar -->
-		{#if toolbar}
-			{@render toolbar(table)}
-		{:else if filterColumn}
-			<div class="flex items-center py-4">
-				<input
-					class="flex h-9 w-full max-w-sm rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] px-3 py-1 text-sm text-[var(--netz-text-primary)] placeholder:text-[var(--netz-text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--netz-brand-secondary)]"
-					placeholder={filterPlaceholder}
-					value={(table.getColumn(filterColumn)?.getFilterValue() as string) ?? ""}
-					oninput={(e) => {
-						table
-							.getColumn(filterColumn!)
-							?.setFilterValue((e.target as HTMLInputElement).value);
-					}}
-				/>
+	{#if filterBar || toolbar || filterColumn}
+		<div class="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+			<div class="flex flex-1 items-center gap-3">
+				{#if filterBar}
+					{@render filterBar(table)}
+				{:else if filterColumn}
+					<input
+						class="flex h-9 w-full max-w-sm rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] px-3 py-1 text-sm text-[var(--netz-text-primary)] placeholder:text-[var(--netz-text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--netz-brand-secondary)]"
+						placeholder={filterPlaceholder}
+						value={(table.getColumn(filterColumn)?.getFilterValue() as string) ?? ""}
+						oninput={(event) => {
+							table
+								.getColumn(filterColumn!)
+								?.setFilterValue((event.target as HTMLInputElement).value);
+						}}
+					/>
+				{/if}
 			</div>
-		{/if}
 
-		<!-- Table -->
-		<div class="rounded-md border border-[var(--netz-border)]">
-			<table class="w-full caption-bottom text-sm">
-				<thead class="bg-[var(--netz-brand-primary)]">
-					{#each table.getHeaderGroups() as headerGroup}
-						<tr>
-							{#each headerGroup.headers as header}
-								<th
-									class="h-10 px-4 text-left align-middle text-xs font-medium text-white"
-								>
-									{#if !header.isPlaceholder}
-										{#if header.column.getCanSort()}
-											<button
-												class="flex items-center gap-1 hover:opacity-80"
-												onclick={() =>
-													header.column.toggleSorting(
-														header.column.getIsSorted() === "asc",
-													)}
-											>
-												<FlexRender content={header.column.columnDef.header} context={header.getContext()} />
-												{#if header.column.getIsSorted() === "asc"}
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="12"
-														height="12"
-														viewBox="0 0 24 24"
-														fill="none"
-														stroke="currentColor"
-														stroke-width="2"
-														><path d="m5 15 7-7 7 7" /></svg
-													>
-												{:else if header.column.getIsSorted() === "desc"}
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="12"
-														height="12"
-														viewBox="0 0 24 24"
-														fill="none"
-														stroke="currentColor"
-														stroke-width="2"
-														><path d="m19 9-7 7-7-7" /></svg
-													>
-												{:else}
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														width="12"
-														height="12"
-														viewBox="0 0 24 24"
-														fill="none"
-														stroke="currentColor"
-														stroke-width="2"
-														opacity="0.4"
-														><path d="m7 15 5 5 5-5" /><path
-															d="m7 9 5-5 5 5"
-														/></svg
-													>
-												{/if}
-											</button>
-										{:else}
-<FlexRender content={header.column.columnDef.header} context={header.getContext()} />
-										{/if}
+			{#if toolbar}
+				<div class="flex items-center gap-3">
+					{@render toolbar(table)}
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	<div class="rounded-md border border-[var(--netz-border)]">
+		<table class="w-full caption-bottom text-sm">
+			<thead class="bg-[var(--netz-brand-primary)]">
+				{#each table.getHeaderGroups() as headerGroup}
+					<tr>
+						{#each headerGroup.headers as header}
+							<th class="h-10 px-4 text-left align-middle text-xs font-medium text-white">
+								{#if !header.isPlaceholder}
+									{#if header.column.getCanSort()}
+										<button
+											class="flex items-center gap-1 hover:opacity-80"
+											onclick={(event) =>
+												header.column.toggleSorting(
+													header.column.getIsSorted() === "asc",
+													event.shiftKey,
+												)}
+										>
+											<FlexRender content={header.column.columnDef.header} context={header.getContext()} />
+											{#if header.column.getIsSorted() === "asc"}
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													width="12"
+													height="12"
+													viewBox="0 0 24 24"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="2"
+													><path d="m5 15 7-7 7 7" /></svg
+												>
+											{:else if header.column.getIsSorted() === "desc"}
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													width="12"
+													height="12"
+													viewBox="0 0 24 24"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="2"
+													><path d="m19 9-7 7-7-7" /></svg
+												>
+											{:else}
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													width="12"
+													height="12"
+													viewBox="0 0 24 24"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="2"
+													opacity="0.4"
+													><path d="m7 15 5 5 5-5" /><path d="m7 9 5-5 5 5" /></svg
+												>
+											{/if}
+										</button>
+									{:else}
+										<FlexRender content={header.column.columnDef.header} context={header.getContext()} />
 									{/if}
-								</th>
-							{/each}
-						</tr>
-					{/each}
-				</thead>
-				<tbody>
-					{#each table.getRowModel().rows as row}
-						<tr
-							class="border-b border-[var(--netz-border)] transition-colors hover:bg-[var(--netz-surface-alt)]"
-						>
-							{#each row.getVisibleCells() as cell}
-								<td class="px-4 py-3 align-middle text-[var(--netz-text-primary)]">
-									<FlexRender content={cell.column.columnDef.cell} context={cell.getContext()} />
-								</td>
-							{/each}
-						</tr>
-					{:else}
-						<tr>
-							<td
-								colspan={columns.length}
-								class="h-24 text-center text-[var(--netz-text-muted)]"
-							>
-								{#if emptyState}
-									{@render emptyState()}
-								{:else}
-									No results.
 								{/if}
+							</th>
+						{/each}
+					</tr>
+				{/each}
+			</thead>
+			<tbody>
+				{#each table.getRowModel().rows as row}
+					<tr class="border-b border-[var(--netz-border)] transition-colors hover:bg-[var(--netz-surface-alt)]">
+						{#each row.getVisibleCells() as cell}
+							<td class="px-4 py-3 align-middle text-[var(--netz-text-primary)]">
+								<FlexRender content={cell.column.columnDef.cell} context={cell.getContext()} />
+							</td>
+						{/each}
+					</tr>
+					{#if expandedRow && row.getIsExpanded()}
+						<tr class="border-b border-[var(--netz-border)] bg-[var(--netz-surface-alt)]/60">
+							<td colspan={columns.length} class="px-4 py-3">
+								{@render expandedRow(row.original)}
 							</td>
 						</tr>
-					{/each}
-				</tbody>
-			</table>
-		</div>
-
-		<!-- Pagination -->
-		{#if table.getPageCount() > 1}
-			<div
-				class="flex items-center justify-between px-2 py-4 text-sm text-[var(--netz-text-secondary)]"
-			>
-				<span>
-					Showing {table.getState().pagination.pageIndex *
-						table.getState().pagination.pageSize +
-						1}-{Math.min(
-						(table.getState().pagination.pageIndex + 1) *
-							table.getState().pagination.pageSize,
-						table.getFilteredRowModel().rows.length,
-					)} of {table.getFilteredRowModel().rows.length}
-				</span>
-				<div class="flex items-center gap-2">
-					<select
-						class="h-8 rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] px-2 text-xs"
-						value={table.getState().pagination.pageSize}
-						onchange={(e) =>
-							table.setPageSize(Number((e.target as HTMLSelectElement).value))}
-					>
-						{#each [10, 20, 50, 100] as size}
-							<option value={size}>{size} / page</option>
-						{/each}
-					</select>
-					<button
-						class="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--netz-border)] disabled:opacity-50"
-						onclick={() => table.previousPage()}
-						disabled={!table.getCanPreviousPage()}
-						aria-label="Previous page"
-					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="14"
-							height="14"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"><path d="m15 18-6-6 6-6" /></svg
-						>
-					</button>
-					<span class="text-xs">
-						{table.getState().pagination.pageIndex + 1} / {table.getPageCount()}
-					</span>
-					<button
-						class="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--netz-border)] disabled:opacity-50"
-						onclick={() => table.nextPage()}
-						disabled={!table.getCanNextPage()}
-						aria-label="Next page"
-					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="14"
-							height="14"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"><path d="m9 18 6-6-6-6" /></svg
-						>
-					</button>
-				</div>
-			</div>
-		{/if}
+					{/if}
+				{:else}
+					<tr>
+						<td colspan={columns.length} class="h-24 text-center text-[var(--netz-text-muted)]">
+							{#if emptyState}
+								{@render emptyState()}
+							{:else}
+								No results.
+							{/if}
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
 	</div>
+
+	{#if table.getPageCount() > 1}
+		<div class="flex items-center justify-between px-2 py-4 text-sm text-[var(--netz-text-secondary)]">
+			<span>
+				Showing {table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1}-{Math.min(
+					(table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize,
+					table.getFilteredRowModel().rows.length,
+				)} of {table.getFilteredRowModel().rows.length}
+			</span>
+			<div class="flex items-center gap-2">
+				<select
+					class="h-8 rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] px-2 text-xs"
+					value={table.getState().pagination.pageSize}
+					onchange={(event) =>
+						table.setPageSize(clampPageSize(Number((event.target as HTMLSelectElement).value)))}
+				>
+					{#each [10, 20, 50, 100] as size}
+						<option value={size}>{size} / page</option>
+					{/each}
+				</select>
+				<button
+					class="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--netz-border)] disabled:opacity-50"
+					onclick={() => table.previousPage()}
+					disabled={!table.getCanPreviousPage()}
+					aria-label="Previous page"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="14"
+						height="14"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"><path d="m15 18-6-6 6-6" /></svg
+					>
+				</button>
+				<span class="text-xs">{table.getState().pagination.pageIndex + 1} / {table.getPageCount()}</span>
+				<button
+					class="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--netz-border)] disabled:opacity-50"
+					onclick={() => table.nextPage()}
+					disabled={!table.getCanNextPage()}
+					aria-label="Next page"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="14"
+						height="14"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"><path d="m9 18 6-6-6-6" /></svg
+					>
+				</button>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/packages/ui/src/lib/components/EntityContextHeader.svelte
+++ b/packages/ui/src/lib/components/EntityContextHeader.svelte
@@ -8,6 +8,7 @@
 		planTier,
 		status,
 		freshness,
+		scopeLabel = "Tenant scope",
 		actions,
 		class: className,
 	}: {
@@ -17,21 +18,37 @@
 		planTier?: string | null;
 		status?: string | null;
 		freshness?: string | null;
+		scopeLabel?: string;
 		actions?: import("svelte").Snippet;
 		class?: string;
 	} = $props();
+
+	const statusStyle = $derived.by(() => {
+		switch (status) {
+			case "active":
+				return { border: "border-l-[var(--netz-info)]", dot: "bg-[var(--netz-info)]", label: "Active" };
+			case "suspended":
+				return { border: "border-l-[var(--netz-warning)]", dot: "bg-[var(--netz-warning)]", label: "Suspended" };
+			case "archived":
+				return { border: "border-l-[var(--netz-text-muted)]", dot: "bg-[var(--netz-text-muted)]", label: "Archived" };
+			default:
+				return { border: "border-l-[var(--netz-info)]", dot: "bg-[var(--netz-info)]", label: status ?? "" };
+		}
+	});
 </script>
 
 <section
 	class={cn(
 		"sticky top-0 z-20 border-b border-[var(--netz-border)] bg-[var(--netz-surface)]/95 px-6 py-4 backdrop-blur",
+		"border-l-4",
+		statusStyle.border,
 		className,
 	)}
 >
 	<div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
 		<div class="min-w-0 space-y-2">
 			<p class="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--netz-text-muted)]">
-				Tenant scope
+				{scopeLabel}
 			</p>
 			<div class="flex flex-wrap items-center gap-x-3 gap-y-2">
 				<h1 class="text-xl font-semibold text-[var(--netz-text-primary)]">{title}</h1>
@@ -47,7 +64,10 @@
 					<span>Plan: {planTier}</span>
 				{/if}
 				{#if status}
-					<span>Status: {status}</span>
+					<span class="inline-flex items-center gap-1.5">
+						<span class="h-1.5 w-1.5 rounded-full {statusStyle.dot}"></span>
+						{statusStyle.label}
+					</span>
 				{/if}
 				{#if freshness}
 					<span>{freshness}</span>

--- a/packages/ui/src/lib/components/StatusBadge.svelte
+++ b/packages/ui/src/lib/components/StatusBadge.svelte
@@ -1,58 +1,92 @@
 <script lang="ts">
 	import { cn } from "../utils/cn.js";
 
-	type StatusType = "deal_stage" | "regime" | "risk" | "review" | "content";
+	export type StatusSeverity = "neutral" | "info" | "success" | "warning" | "danger";
+
+	export interface StatusConfig {
+		label: string;
+		severity: StatusSeverity;
+		color: string;
+	}
+
+	export type StatusResolver = (token: string) => StatusConfig | undefined;
 
 	interface Props {
 		status: string;
-		type?: StatusType;
+		type?: string;
+		label?: string;
+		resolve?: StatusResolver;
 		class?: string;
 	}
 
-	let { status, type = "risk", class: className }: Props = $props();
+	let { status, type = "default", label, resolve, class: className }: Props = $props();
 
-	const colorMaps: Record<StatusType, Record<string, string>> = {
-		deal_stage: {
-			screening: "#94A3B8",
-			qualified: "#3B82F6",
-			ic_review: "#8B5CF6",
-			approved: "#10B981",
-			declined: "#EF4444",
-		},
-		regime: {
-			RISK_ON: "#10B981",
-			RISK_OFF: "#F59E0B",
-			INFLATION: "#F97316",
-			CRISIS: "#EF4444",
-		},
-		risk: {
-			low: "#10B981",
-			medium: "#F59E0B",
-			high: "#EF4444",
-			critical: "#991B1B",
-		},
-		review: {
-			pending: "#94A3B8",
-			in_progress: "#3B82F6",
-			approved: "#10B981",
-			rejected: "#EF4444",
-		},
-		content: {
-			draft: "#94A3B8",
-			generated: "#3B82F6",
-			approved: "#10B981",
-			published: "#059669",
-		},
+	const severityColorMap: Record<StatusSeverity, string> = {
+		neutral: "var(--netz-text-secondary)",
+		info: "var(--netz-info)",
+		success: "var(--netz-success)",
+		warning: "var(--netz-warning)",
+		danger: "var(--netz-danger)",
 	};
 
-	let color = $derived(colorMaps[type]?.[status] ?? "#94A3B8");
+	const successTokens = new Set([
+		"approved",
+		"completed",
+		"healthy",
+		"ok",
+		"pass",
+		"published",
+		"ready",
+		"resolved",
+		"success",
+	]);
+	const warningTokens = new Set(["pending", "warning", "warn"]);
+	const dangerTokens = new Set(["critical", "declined", "danger", "error", "failed", "rejected"]);
+	const infoTokens = new Set(["active", "generated", "in_progress", "info", "processing", "running"]);
 
-	/** Format label: replace underscores, capitalize first letter */
-	function formatLabel(s: string): string {
-		return s
-			.replace(/_/g, " ")
-			.replace(/\b\w/g, (c) => c.toUpperCase());
+	function formatLabel(value: string): string {
+		if (!value) {
+			return "Unknown";
+		}
+
+		return value.replace(/_/g, " ").replace(/\b\w/g, (character) => character.toUpperCase());
 	}
+
+	function inferSeverity(token: string): StatusSeverity {
+		const normalizedToken = token.trim().toLowerCase();
+
+		if (dangerTokens.has(normalizedToken)) {
+			return "danger";
+		}
+
+		if (warningTokens.has(normalizedToken)) {
+			return "warning";
+		}
+
+		if (successTokens.has(normalizedToken)) {
+			return "success";
+		}
+
+		if (infoTokens.has(normalizedToken)) {
+			return "info";
+		}
+
+		return "neutral";
+	}
+
+	let fallbackConfig = $derived.by<StatusConfig>(() => {
+		const resolvedLabel = label ?? formatLabel(status);
+		const severity = inferSeverity(status);
+
+		return {
+			label: resolvedLabel,
+			severity,
+			color: severityColorMap[severity],
+		};
+	});
+
+	let config = $derived.by<StatusConfig>(() => resolve?.(status) ?? fallbackConfig);
+	let badgeColor = $derived(config.color || severityColorMap[config.severity]);
 </script>
 
 <span
@@ -60,11 +94,10 @@
 		"inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium",
 		className,
 	)}
-	style="background-color: {color}20; color: {color};"
+	data-status-type={type}
+	data-status-severity={config.severity}
+	style={`background-color: color-mix(in srgb, ${badgeColor} 14%, transparent); color: ${badgeColor};`}
 >
-	<span
-		class="h-1.5 w-1.5 rounded-full"
-		style="background-color: {color};"
-	></span>
-	{formatLabel(status)}
+	<span class="h-1.5 w-1.5 rounded-full" style={`background-color: ${badgeColor};`}></span>
+	{config.label}
 </span>

--- a/packages/ui/src/lib/components/__tests__/AuditTrailPanel.test.ts
+++ b/packages/ui/src/lib/components/__tests__/AuditTrailPanel.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import AuditTrailPanel, { type AuditTrailEntry } from "../AuditTrailPanel.svelte";
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date("2026-03-18T15:00:00Z"));
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function buildEntries(): AuditTrailEntry[] {
+	return [
+		{
+			id: "entry-1",
+			actor: "Maria Admin",
+			timestamp: "2026-03-16T09:00:00Z",
+			action: "Created mandate",
+			scope: "Portfolio setup",
+			outcome: "Recorded",
+		},
+		{
+			id: "entry-2",
+			actor: "Maria Admin",
+			timestamp: "2026-03-17T11:00:00Z",
+			action: "Reviewed mandate",
+			scope: "Portfolio setup",
+			outcome: "Approved",
+			actorCapacity: "Investment Committee",
+			actorEmail: "maria@netz.test",
+			immutable: true,
+			sourceSystem: "manual",
+		},
+		{
+			id: "entry-3",
+			actor: "Joao Operator",
+			timestamp: "2026-03-18T10:00:00Z",
+			action: "Published decision",
+			scope: "Credit approval",
+			outcome: "Published",
+		},
+		{
+			id: "entry-4",
+			actor: "Ana Reviewer",
+			timestamp: "2026-03-18T12:00:00Z",
+			action: "Shared report",
+			scope: "Credit approval",
+			outcome: "Delivered",
+		},
+	];
+}
+
+describe("AuditTrailPanel", () => {
+	it("adds log accessibility and renders grouped dates with metadata", () => {
+		const { container } = render(AuditTrailPanel, {
+			props: {
+				title: "Recent actions",
+				entries: buildEntries(),
+				maxVisible: 4,
+			},
+		});
+
+		expect(screen.getByRole("log", { name: "Recent actions" })).toBeTruthy();
+		expect(screen.getByText("Today")).toBeTruthy();
+		expect(screen.getByText("Yesterday")).toBeTruthy();
+		expect(screen.getByText("Investment Committee")).toBeTruthy();
+		expect(screen.getByText("maria@netz.test")).toBeTruthy();
+		expect(screen.getByText("manual")).toBeTruthy();
+		expect(screen.getByText("Immutable")).toBeTruthy();
+		expect(container.querySelector("time[datetime]")).toBeTruthy();
+	});
+
+	it("caps visible entries and reveals older history on demand", async () => {
+		render(AuditTrailPanel, {
+			props: {
+				entries: buildEntries(),
+				maxVisible: 2,
+			},
+		});
+
+		expect(screen.queryByText("Created mandate")).toBeNull();
+		expect(screen.getByRole("button", { name: "Load earlier entries (2)" })).toBeTruthy();
+
+		await fireEvent.click(screen.getByRole("button", { name: "Load earlier entries (2)" }));
+
+		expect(screen.getByText("Created mandate")).toBeTruthy();
+	});
+});

--- a/packages/ui/src/lib/components/__tests__/ConsequenceDialog.test.ts
+++ b/packages/ui/src/lib/components/__tests__/ConsequenceDialog.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import ConsequenceDialog from "../ConsequenceDialog.svelte";
+
+describe("ConsequenceDialog", () => {
+	it("renders as an alertdialog and marks rationale as required", () => {
+		render(ConsequenceDialog, {
+			props: {
+				open: true,
+				title: "Approve tenant change",
+				impactSummary: "This will publish a tenant-scoped configuration.",
+				destructive: true,
+				requireRationale: true,
+				onConfirm: vi.fn(),
+			},
+		});
+
+		expect(screen.getByRole("alertdialog")).toBeTruthy();
+		expect(screen.getByLabelText("Rationale").getAttribute("aria-required")).toBe("true");
+		expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+	});
+
+	it("blocks confirm until rationale satisfies the minimum length", async () => {
+		const onConfirm = vi.fn();
+
+		render(ConsequenceDialog, {
+			props: {
+				open: true,
+				title: "Approve tenant change",
+				impactSummary: "This will publish a tenant-scoped configuration.",
+				requireRationale: true,
+				rationaleMinLength: 12,
+				onConfirm,
+			},
+		});
+
+		const confirmButton = screen.getByRole("button", { name: "Confirm action" });
+		expect((confirmButton as HTMLButtonElement).disabled).toBe(true);
+
+		await fireEvent.input(screen.getByLabelText("Rationale"), {
+			target: { value: "Documented basis for approval." },
+		});
+
+		expect((confirmButton as HTMLButtonElement).disabled).toBe(false);
+	});
+});

--- a/packages/ui/src/lib/components/__tests__/DataTable.test.ts
+++ b/packages/ui/src/lib/components/__tests__/DataTable.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import DataTable from "../DataTable.svelte";
+
+const columns = [
+	{
+		accessorKey: "group",
+		header: "Group",
+		cell: ({ getValue }: { getValue: () => unknown }) => String(getValue()),
+		enableSorting: true,
+	},
+	{
+		accessorKey: "name",
+		header: "Name",
+		cell: ({ getValue }: { getValue: () => unknown }) => String(getValue()),
+		enableSorting: true,
+	},
+];
+
+describe("DataTable", () => {
+	it("caps page size at 100 rows", () => {
+		const data = Array.from({ length: 150 }, (_, index) => ({
+			group: `G${index}`,
+			name: `Row ${index}`,
+		}));
+
+		const { container } = render(DataTable, {
+			props: {
+				data,
+				columns,
+				pageSize: 150,
+			},
+		});
+
+		expect(container.querySelectorAll("tbody tr").length).toBe(100);
+		expect(screen.getByText(/Showing 1-100 of 150/)).toBeTruthy();
+	});
+
+	it("supports multi-sort with shift-click", async () => {
+		const data = [
+			{ group: "B", name: "Alpha" },
+			{ group: "A", name: "Alpha" },
+			{ group: "A", name: "Beta" },
+		];
+
+		const { container } = render(DataTable, {
+			props: {
+				data,
+				columns,
+				pageSize: 10,
+			},
+		});
+
+		await fireEvent.click(screen.getByRole("button", { name: "Name" }));
+		await fireEvent.click(screen.getByRole("button", { name: "Group" }), { shiftKey: true });
+
+		const rows = Array.from(container.querySelectorAll("tbody tr")).map((row) =>
+			row.textContent?.replace(/\s+/g, " ").trim(),
+		);
+
+		expect(rows[0]).toBe("AAlpha");
+		expect(rows[1]).toBe("BAlpha");
+		expect(rows[2]).toBe("ABeta");
+	});
+});

--- a/packages/ui/src/lib/components/__tests__/StatusBadge.test.ts
+++ b/packages/ui/src/lib/components/__tests__/StatusBadge.test.ts
@@ -8,7 +8,7 @@ describe("StatusBadge", () => {
 		expect(screen.getByText("Approved")).toBeTruthy();
 	});
 
-	it("renders with deal_stage type", () => {
+	it("keeps compatibility with legacy type props", () => {
 		const { container } = render(StatusBadge, {
 			props: { status: "qualified", type: "deal_stage" },
 		});
@@ -16,29 +16,32 @@ describe("StatusBadge", () => {
 		expect(screen.getByText("Qualified")).toBeTruthy();
 	});
 
-	it("renders with regime type (uppercase preserved)", () => {
-		render(StatusBadge, { props: { status: "RISK_ON", type: "regime" } });
-		// formatLabel: "RISK_ON" → "RISK ON" → first letter caps → "RISK ON"
-		expect(screen.getByText("RISK ON")).toBeTruthy();
+	it("uses an explicit label override when provided", () => {
+		render(StatusBadge, { props: { status: "warning", label: "Override" } });
+		expect(screen.getByText("Override")).toBeTruthy();
 	});
 
-	it("renders with risk type", () => {
-		render(StatusBadge, { props: { status: "high", type: "risk" } });
-		expect(screen.getByText("High")).toBeTruthy();
-	});
-
-	it("renders with review type", () => {
-		render(StatusBadge, { props: { status: "pending", type: "review" } });
-		expect(screen.getByText("Pending")).toBeTruthy();
-	});
-
-	it("renders with content type", () => {
-		render(StatusBadge, { props: { status: "published", type: "content" } });
-		expect(screen.getByText("Published")).toBeTruthy();
+	it("uses the resolver output when provided", () => {
+		render(StatusBadge, {
+			props: {
+				status: "qualified",
+				resolve: () => ({
+					label: "Qualified for IC",
+					severity: "info",
+					color: "var(--netz-info)",
+				}),
+			},
+		});
+		expect(screen.getByText("Qualified for IC")).toBeTruthy();
 	});
 
 	it("renders unknown status with default styling", () => {
 		render(StatusBadge, { props: { status: "unknown_status" } });
 		expect(screen.getByText("Unknown Status")).toBeTruthy();
+	});
+
+	it("infers severity attributes from generic status tokens", () => {
+		const { container } = render(StatusBadge, { props: { status: "approved" } });
+		expect(container.querySelector("[data-status-severity='success']")).toBeTruthy();
 	});
 });

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -91,6 +91,8 @@ export { createSSEStream, createSSEWithSnapshot } from "./utils/sse-client.svelt
 export type { SSEConfig, SSEConnection, SSEStatus, SSEEvent, SSESnapshotConfig, SSESnapshotConnection } from "./utils/sse-client.svelte.js";
 export { createPoller } from "./utils/poller.svelte.js";
 export type { PollerConfig, PollerState } from "./utils/poller.svelte.js";
+export { createOptimisticMutation } from "./utils/optimistic.svelte.js";
+export type { OptimisticMutation, OptimisticMutationConfig } from "./utils/optimistic.svelte.js";
 export { canOpenSSE, registerSSE, unregisterSSE, getActiveSSECount } from "./utils/sse-registry.svelte.js";
 export {
 	formatAUM,

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -44,6 +44,7 @@ export type { WealthAlert } from "./components/AlertFeed.svelte";
 export { default as SectionCard } from "./components/SectionCard.svelte";
 export { default as HeatmapTable } from "./components/HeatmapTable.svelte";
 export { default as PeriodSelector } from "./components/PeriodSelector.svelte";
+export { default as EntityContextHeader } from "./components/EntityContextHeader.svelte";
 
 // ── Layouts ─────────────────────────────────────────────────
 export { default as AppLayout } from "./layouts/AppLayout.svelte";

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -28,6 +28,7 @@ export { default as FormField } from "./components/FormField.svelte";
 // ── Netz Composites ─────────────────────────────────────────
 export { default as DataCard } from "./components/DataCard.svelte";
 export { default as StatusBadge } from "./components/StatusBadge.svelte";
+export type { StatusConfig, StatusResolver, StatusSeverity } from "./components/StatusBadge.svelte";
 export { default as EmptyState } from "./components/EmptyState.svelte";
 export { default as PDFDownload } from "./components/PDFDownload.svelte";
 export { default as LanguageToggle } from "./components/LanguageToggle.svelte";

--- a/packages/ui/src/lib/utils/__tests__/optimistic.test.ts
+++ b/packages/ui/src/lib/utils/__tests__/optimistic.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { createOptimisticMutation } from "../optimistic.svelte.js";
+
+describe("createOptimisticMutation", () => {
+	it("applies optimistic state immediately and keeps the server response", async () => {
+		let state = { status: "idle" };
+
+		const mutation = createOptimisticMutation({
+			getState: () => state,
+			setState: (value) => {
+				state = value;
+			},
+			request: async () => ({ status: "confirmed" }),
+		});
+
+		const promise = mutation.mutate({ status: "pending" });
+
+		expect(state.status).toBe("pending");
+		expect(mutation.isPending).toBe(true);
+
+		await promise;
+
+		expect(state.status).toBe("confirmed");
+		expect(mutation.isPending).toBe(false);
+		expect(mutation.error).toBeNull();
+	});
+
+	it("rolls back state and exposes the error on failure", async () => {
+		let state = { status: "idle" };
+
+		const mutation = createOptimisticMutation({
+			getState: () => state,
+			setState: (value) => {
+				state = value;
+			},
+			request: async () => {
+				throw new Error("Save failed");
+			},
+		});
+
+		await expect(mutation.mutate({ status: "pending" })).rejects.toThrow("Save failed");
+
+		expect(state.status).toBe("idle");
+		expect(mutation.isPending).toBe(false);
+		expect(mutation.error).toBe("Save failed");
+	});
+});

--- a/packages/ui/src/lib/utils/index.ts
+++ b/packages/ui/src/lib/utils/index.ts
@@ -60,3 +60,7 @@ export type { Actor, ClerkHookOptions } from "./auth.js";
 
 // Theme — SSR theme injection hook
 export { createThemeHook } from "./theme.js";
+
+// Optimistic mutations
+export { createOptimisticMutation } from "./optimistic.svelte.js";
+export type { OptimisticMutation, OptimisticMutationConfig } from "./optimistic.svelte.js";

--- a/packages/ui/src/lib/utils/optimistic.svelte.ts
+++ b/packages/ui/src/lib/utils/optimistic.svelte.ts
@@ -1,0 +1,70 @@
+export interface OptimisticMutationConfig<T> {
+	getState: () => T;
+	setState: (value: T) => void;
+	request: (optimisticValue: T, previousValue: T) => Promise<T>;
+}
+
+export interface OptimisticMutation<T> {
+	mutate: (optimisticValue: T) => Promise<T>;
+	rollback: () => void;
+	readonly isPending: boolean;
+	readonly error: string | null;
+}
+
+function cloneValue<T>(value: T): T {
+	try {
+		return structuredClone(value);
+	} catch {
+		return value;
+	}
+}
+
+export function createOptimisticMutation<T>(
+	config: OptimisticMutationConfig<T>,
+): OptimisticMutation<T> {
+	let isPending = $state(false);
+	let error = $state<string | null>(null);
+	let snapshot = $state<T | null>(null);
+
+	function rollback() {
+		if (snapshot === null) {
+			return;
+		}
+
+		config.setState(cloneValue(snapshot));
+		snapshot = null;
+		isPending = false;
+	}
+
+	async function mutate(optimisticValue: T): Promise<T> {
+		const previousValue = cloneValue(config.getState());
+		snapshot = previousValue;
+		error = null;
+		isPending = true;
+		config.setState(optimisticValue);
+
+		try {
+			const result = await config.request(optimisticValue, previousValue);
+			config.setState(result);
+			snapshot = null;
+			return result;
+		} catch (reason) {
+			rollback();
+			error = reason instanceof Error ? reason.message : "Optimistic mutation failed";
+			throw reason;
+		} finally {
+			isPending = false;
+		}
+	}
+
+	return {
+		mutate,
+		rollback,
+		get isPending() {
+			return isPending;
+		},
+		get error() {
+			return error;
+		},
+	};
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,33 @@ importers:
 
   frontends/admin:
     dependencies:
+      '@codemirror/commands':
+        specifier: ^6.10.3
+        version: 6.10.3
+      '@codemirror/lang-json':
+        specifier: ^6.0.2
+        version: 6.0.2
+      '@codemirror/language':
+        specifier: ^6.12.2
+        version: 6.12.2
+      '@codemirror/lint':
+        specifier: ^6.9.5
+        version: 6.9.5
+      '@codemirror/state':
+        specifier: ^6.6.0
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: ^6.40.0
+        version: 6.40.0
+      '@lezer/common':
+        specifier: ^1.5.1
+        version: 1.5.1
       '@netz/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      codemirror-json-schema:
+        specifier: ^0.8.1
+        version: 0.8.1(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(@lezer/common@1.5.1)
       dompurify:
         specifier: ^3.3.3
         version: 3.3.3
@@ -29,13 +53,13 @@ importers:
         version: 5.2.8
       '@sveltejs/adapter-node':
         specifier: ^5.0.0
-        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))
+        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))
       '@sveltejs/kit':
         specifier: ^2.0.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
@@ -53,7 +77,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
   frontends/credit:
     dependencies:
@@ -66,16 +90,16 @@ importers:
         version: 5.2.8
       '@sveltejs/adapter-node':
         specifier: ^5.0.0
-        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))
+        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))
       '@sveltejs/kit':
         specifier: ^2.0.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@tailwindcss/vite':
         specifier: ^4.2.1
-        version: 4.2.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.2.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       svelte:
         specifier: ^5.0.0
         version: 5.53.12
@@ -90,7 +114,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
   frontends/wealth:
     dependencies:
@@ -109,16 +133,16 @@ importers:
         version: 5.2.8
       '@sveltejs/adapter-node':
         specifier: ^5.0.0
-        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))
+        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))
       '@sveltejs/kit':
         specifier: ^2.0.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@tailwindcss/vite':
         specifier: ^4.2.1
-        version: 4.2.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.2.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
@@ -136,7 +160,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
   packages/ui:
     dependencies:
@@ -161,13 +185,13 @@ importers:
         version: 5.2.8
       '@sveltejs/kit':
         specifier: ^2.0.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@sveltejs/package':
         specifier: ^2.0.0
         version: 2.5.7(svelte@5.53.12)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@tanstack/svelte-table':
         specifier: ^9.0.0-alpha.10
         version: 9.0.0-alpha.10(svelte@5.53.12)
@@ -179,7 +203,7 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.0.0
-        version: 5.3.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))(vitest@3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1))
+        version: 5.3.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))(vitest@3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1)(yaml@2.8.2))
       happy-dom:
         specifier: ^20.8.4
         version: 20.8.4
@@ -200,10 +224,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1)
+        version: 3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
 packages:
 
@@ -224,6 +248,30 @@ packages:
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-yaml@6.1.2':
+    resolution: {integrity: sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==}
+
+  '@codemirror/language@6.12.2':
+    resolution: {integrity: sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.40.0':
+    resolution: {integrity: sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -440,6 +488,24 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@lezer/common@1.5.1':
+    resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.8':
+    resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -613,6 +679,36 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@sagold/json-pointer@5.1.2':
+    resolution: {integrity: sha512-+wAhJZBXa6MNxRScg6tkqEbChEHMgVZAhTHVJ60Y7sbtXtu9XA49KfUkdWlS2x78D6H9nryiKePiYozumauPfA==}
+
+  '@sagold/json-query@6.2.0':
+    resolution: {integrity: sha512-7bOIdUE6eHeoWtFm8TvHQHfTVSZuCs+3RpOKmZCDBIOrxpvF/rNFTeuvIyjHva/RR0yVS3kQtr+9TW72LQEZjA==}
+
+  '@shikijs/core@1.29.2':
+    resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
+
+  '@shikijs/engine-javascript@1.29.2':
+    resolution: {integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==}
+
+  '@shikijs/engine-oniguruma@1.29.2':
+    resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
+
+  '@shikijs/langs@1.29.2':
+    resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
+
+  '@shikijs/markdown-it@1.29.2':
+    resolution: {integrity: sha512-RPHqGU8RGQZ2TGMnEqLnSyM9CjPSjb0f8bwSLnJgBmWPWguoygoaFyYkXG0kwMtBtChNYsqQz1C0fLcbo6dY8g==}
+
+  '@shikijs/themes@1.29.2':
+    resolution: {integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==}
+
+  '@shikijs/types@1.29.2':
+    resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -822,6 +918,12 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -830,6 +932,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -840,6 +945,9 @@ packages:
   '@typescript-eslint/types@8.57.0':
     resolution: {integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -915,6 +1023,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  best-effort-json-parser@1.4.0:
+    resolution: {integrity: sha512-gYmXQicIXaaspBdCLqok3t0JXYdi3Cr9oIgYh2+9rEWiNhLvi/89cguCWXZJWp0FgBR6YoEE9YkbZEfqKdqs+Q==}
+
   bits-ui@1.8.0:
     resolution: {integrity: sha512-CXD6Orp7l8QevNDcRPLXc/b8iMVgxDWT2LyTwsdLzJKh9CxesOmPuNePSPqAxKoT59FIdU4aFPS1k7eBdbaCxg==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
@@ -932,12 +1043,21 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -955,6 +1075,18 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  codemirror-json-schema@0.8.1:
+    resolution: {integrity: sha512-4lKPjW+nugNAmM5MsggJyn6TUxYdCCwAJIr9T4cZeTFPdkbBvPteCOGtDedrTOIeTC2ZFJtVg7VHIXnYU32t8w==}
+    peerDependencies:
+      '@codemirror/language': ^6.10.2
+      '@codemirror/lint': ^6.8.0
+      '@codemirror/state': ^6.4.1
+      '@codemirror/view': ^6.27.0
+      '@lezer/common': ^1.2.1
+
+  codemirror-json5@1.0.3:
+    resolution: {integrity: sha512-HmmoYO2huQxoaoG5ARKjqQc9mz7/qmNPvMbISVfIE2Gk1+4vZQg9X3G6g49MYM5IK00Ol3aijd7OKrySuOkA7Q==}
+
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
@@ -962,12 +1094,21 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -1018,6 +1159,12 @@ packages:
   devalue@5.6.4:
     resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  discontinuous-range@1.0.0:
+    resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
@@ -1031,12 +1178,23 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ebnf@1.9.1:
+    resolution: {integrity: sha512-uW2UKSsuty9ANJ3YByIQE4ANkD8nqUPO7r6Fwcc1ADKPe9FRdcPpMl3VEput4JSvKBJ4J86npIC2MLP0pYkCuw==}
+    hasBin: true
+
   echarts@5.6.0:
     resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1085,6 +1243,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1141,9 +1302,18 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1214,12 +1384,26 @@ packages:
       canvas:
         optional: true
 
+  json-schema-library@9.3.5:
+    resolution: {integrity: sha512-5eBDx7cbfs+RjylsVO+N36b0GOPtv78rfqgf2uON+uaHUIC62h63Y8pkV2ovKbaL4ZpQcHp21968x5nx/dFwqQ==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lezer-json5@2.0.2:
+    resolution: {integrity: sha512-NRmtBlKW/f8mA7xatKq8IUOq045t8GVHI4kZXrUtYYUdiVeGiO6zKGAV7/nUAnf5q+rYTY+SWX/gvQdFXMjNxQ==}
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -1291,8 +1475,15 @@ packages:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1307,9 +1498,34 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1327,6 +1543,9 @@ packages:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
+  moo@0.5.3:
+    resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -1343,8 +1562,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nearley@2.20.1:
+    resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
+    hasBin: true
+
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  oniguruma-to-es@2.3.0:
+    resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
 
   openapi-typescript@7.13.0:
     resolution: {integrity: sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==}
@@ -1388,9 +1614,23 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  railroad-diagrams@1.0.0:
+    resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
+
+  randexp@0.4.6:
+    resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
+    engines: {node: '>=0.12'}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -1407,6 +1647,15 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  regex-recursion@5.1.1:
+    resolution: {integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@5.1.1:
+    resolution: {integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1415,6 +1664,10 @@ packages:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  ret@0.1.15:
+    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
+    engines: {node: '>=0.12'}
 
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
@@ -1454,6 +1707,9 @@ packages:
   set-cookie-parser@3.0.1:
     resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
 
+  shiki@1.29.2:
+    resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1461,9 +1717,16 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  smtp-address-parser@1.0.10:
+    resolution: {integrity: sha512-Osg9LmvGeAG/hyao4mldbflLOkkr3a+h4m1lwKCK5U8M6ZAr7tdXEz/+/vr752TSGE4MNUlUl9cIK2cB8cgzXg==}
+    engines: {node: '>=0.10'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1471,12 +1734,18 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
@@ -1570,6 +1839,9 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
 
@@ -1619,11 +1891,38 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   uri-js-replace@1.0.1:
     resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
+
+  valid-url@1.0.9:
+    resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1706,6 +2005,9 @@ packages:
       jsdom:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -1758,6 +2060,11 @@ packages:
   yaml-ast-parser@0.0.43:
     resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
 
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -1767,6 +2074,9 @@ packages:
 
   zrender@5.6.1:
     resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -1789,6 +2099,63 @@ snapshots:
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/runtime@7.28.6': {}
+
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+    optional: true
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-yaml@6.1.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+      '@lezer/yaml': 1.0.4
+    optional: true
+
+  '@codemirror/language@6.12.2':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.40.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -1923,6 +2290,31 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lezer/common@1.5.1': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
+  '@lezer/lr@1.4.8':
+    dependencies:
+      '@lezer/common': 1.5.1
+
+  '@lezer/yaml@1.0.4':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+    optional: true
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -2060,25 +2452,72 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@sagold/json-pointer@5.1.2': {}
+
+  '@sagold/json-query@6.2.0':
+    dependencies:
+      '@sagold/json-pointer': 5.1.2
+      ebnf: 1.9.1
+
+  '@shikijs/core@1.29.2':
+    dependencies:
+      '@shikijs/engine-javascript': 1.29.2
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 2.3.0
+
+  '@shikijs/engine-oniguruma@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+
+  '@shikijs/markdown-it@1.29.2':
+    dependencies:
+      markdown-it: 14.1.1
+      shiki: 1.29.2
+
+  '@shikijs/themes@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+
+  '@shikijs/types@1.29.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
-      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       rollup: 4.59.0
 
-  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -2090,7 +2529,7 @@ snapshots:
       set-cookie-parser: 3.0.1
       sirv: 3.0.2
       svelte: 5.53.12
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2105,25 +2544,25 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       debug: 4.4.3(supports-color@10.2.2)
       svelte: 5.53.12
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       debug: 4.4.3(supports-color@10.2.2)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.53.12
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
-      vitefu: 1.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      vitefu: 1.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -2192,12 +2631,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@tailwindcss/vite@4.2.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
   '@tanstack/svelte-table@9.0.0-alpha.10(svelte@5.53.12)':
     dependencies:
@@ -2237,14 +2676,14 @@ snapshots:
     dependencies:
       svelte: 5.53.12
 
-  '@testing-library/svelte@5.3.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))(vitest@3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1))':
+  '@testing-library/svelte@5.3.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))(vitest@3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.53.12)
       svelte: 5.53.12
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
-      vitest: 3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      vitest: 3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
   '@types/aria-query@5.0.4': {}
 
@@ -2263,6 +2702,14 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -2270,6 +2717,8 @@ snapshots:
   '@types/resolve@1.20.2': {}
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -2279,6 +2728,8 @@ snapshots:
 
   '@typescript-eslint/types@8.57.0': {}
 
+  '@ungap/structured-clone@1.3.0': {}
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -2287,13 +2738,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2347,6 +2798,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  best-effort-json-parser@1.4.0: {}
+
   bits-ui@1.8.0(svelte@5.53.12):
     dependencies:
       '@floating-ui/core': 1.7.5
@@ -2370,6 +2823,8 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  ccount@2.0.1: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -2379,6 +2834,10 @@ snapshots:
       pathval: 2.0.1
 
   change-case@5.4.4: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   check-error@2.1.3: {}
 
@@ -2392,15 +2851,55 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  codemirror-json-schema@0.8.1(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)(@lezer/common@1.5.1):
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@sagold/json-pointer': 5.1.2
+      '@shikijs/markdown-it': 1.29.2
+      best-effort-json-parser: 1.4.0
+      json-schema: 0.4.0
+      json-schema-library: 9.3.5
+      loglevel: 1.9.2
+      markdown-it: 14.1.1
+      shiki: 1.29.2
+      yaml: 2.8.2
+    optionalDependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-yaml': 6.1.2
+      codemirror-json5: 1.0.3
+      json5: 2.2.3
+
+  codemirror-json5@1.0.3:
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      json5: 2.2.3
+      lezer-json5: 2.0.2
+    optional: true
+
   colorette@1.4.0: {}
 
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
+  comma-separated-tokens@2.0.3: {}
+
+  commander@2.20.3: {}
+
   commondir@1.0.1: {}
 
   cookie@0.6.0: {}
+
+  crelt@1.0.6: {}
 
   css.escape@1.5.1: {}
 
@@ -2436,6 +2935,12 @@ snapshots:
 
   devalue@5.6.4: {}
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  discontinuous-range@1.0.0: {}
+
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
@@ -2450,15 +2955,21 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ebnf@1.9.1: {}
+
   echarts@5.6.0:
     dependencies:
       tslib: 2.3.0
       zrender: 5.6.1
 
+  emoji-regex-xs@1.0.0: {}
+
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -2525,6 +3036,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-copy@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fdir@6.5.0(picomatch@4.0.3):
@@ -2588,9 +3101,29 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-void-elements@3.0.0: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -2674,9 +3207,29 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  json-schema-library@9.3.5:
+    dependencies:
+      '@sagold/json-pointer': 5.1.2
+      '@sagold/json-query': 6.2.0
+      deepmerge: 4.3.1
+      fast-copy: 3.0.2
+      fast-deep-equal: 3.1.3
+      smtp-address-parser: 1.0.10
+      valid-url: 1.0.9
+
   json-schema-traverse@1.0.0: {}
 
+  json-schema@0.4.0: {}
+
+  json5@2.2.3:
+    optional: true
+
   kleur@4.1.5: {}
+
+  lezer-json5@2.0.2:
+    dependencies:
+      '@lezer/lr': 1.4.8
+    optional: true
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -2727,7 +3280,13 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-character@3.0.0: {}
+
+  loglevel@1.9.2: {}
 
   loupe@3.2.1: {}
 
@@ -2739,7 +3298,47 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdurl@2.0.0: {}
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   mime-db@1.52.0: {}
 
@@ -2753,6 +3352,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  moo@0.5.3: {}
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -2761,7 +3362,20 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nearley@2.20.1:
+    dependencies:
+      commander: 2.20.3
+      moo: 0.5.3
+      railroad-diagrams: 1.0.0
+      randexp: 0.4.6
+
   nwsapi@2.2.23: {}
+
+  oniguruma-to-es@2.3.0:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 5.1.1
+      regex-recursion: 5.1.1
 
   openapi-typescript@7.13.0(typescript@5.9.3):
     dependencies:
@@ -2807,7 +3421,18 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  property-information@7.1.0: {}
+
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
+
+  railroad-diagrams@1.0.0: {}
+
+  randexp@0.4.6:
+    dependencies:
+      discontinuous-range: 1.0.0
+      ret: 0.1.15
 
   react-is@17.0.2: {}
 
@@ -2820,6 +3445,17 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  regex-recursion@5.1.1:
+    dependencies:
+      regex: 5.1.1
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@5.1.1:
+    dependencies:
+      regex-utilities: 2.3.0
+
   require-from-string@2.0.2: {}
 
   resolve@1.22.11:
@@ -2827,6 +3463,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  ret@0.1.15: {}
 
   rollup@4.59.0:
     dependencies:
@@ -2884,6 +3522,17 @@ snapshots:
 
   set-cookie-parser@3.0.1: {}
 
+  shiki@1.29.2:
+    dependencies:
+      '@shikijs/core': 1.29.2
+      '@shikijs/engine-javascript': 1.29.2
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/langs': 1.29.2
+      '@shikijs/themes': 1.29.2
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   siginfo@2.0.0: {}
 
   sirv@3.0.2:
@@ -2892,11 +3541,22 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  smtp-address-parser@1.0.10:
+    dependencies:
+      nearley: 2.20.1
+
   source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-indent@3.0.0:
     dependencies:
@@ -2905,6 +3565,8 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  style-mod@4.1.3: {}
 
   style-to-object@1.0.14:
     dependencies:
@@ -3000,6 +3662,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
   tslib@2.3.0: {}
 
   tslib@2.8.1: {}
@@ -3035,17 +3699,54 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uc.micro@2.1.0: {}
+
   undici-types@7.18.2: {}
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   uri-js-replace@1.0.1: {}
 
-  vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1):
+  valid-url@1.0.9: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3060,7 +3761,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1):
+  vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3073,16 +3774,17 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.31.1
+      yaml: 2.8.2
 
-  vitefu@1.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)):
+  vitefu@1.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
-  vitest@3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1):
+  vitest@3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3100,8 +3802,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
-      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
@@ -3120,6 +3822,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:
@@ -3153,6 +3857,8 @@ snapshots:
 
   yaml-ast-parser@0.0.43: {}
 
+  yaml@2.8.2: {}
+
   yargs-parser@21.1.1: {}
 
   zimmerframe@1.1.4: {}
@@ -3160,3 +3866,5 @@ snapshots:
   zrender@5.6.1:
     dependencies:
       tslib: 2.3.0
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- add admin tenant scope clarity and the admin-local CodeEditor
- move the credit dashboard and pipeline toward an action-first layout
- harden shared UI primitives: AuditTrailPanel, ConsequenceDialog, StatusBadge, DataTable, and optimistic mutation utility

## Validation
- pnpm --filter @netz/ui test -- src/lib/components/__tests__/AuditTrailPanel.test.ts
- pnpm --filter @netz/ui test -- src/lib/components/__tests__/ConsequenceDialog.test.ts
- pnpm --filter @netz/ui test -- src/lib/components/__tests__/StatusBadge.test.ts
- pnpm --filter @netz/ui test -- src/lib/components/__tests__/DataTable.test.ts
- pnpm --filter @netz/ui test -- src/lib/utils/__tests__/optimistic.test.ts

## Known check status
- pnpm --filter @netz/ui check still fails on pre-existing unrelated issues in uth.ts and pi-client.test.ts, with existing warnings in FormField.svelte, PDFDownload.svelte, and SectionCard.svelte
- pnpm --filter netz-admin check still has pre-existing unrelated admin issues
- pnpm --filter netz-credit-intelligence check still has pre-existing unrelated credit issues