### PR TITLE
feat: Backend Sprint 2 — unlock remaining contracts

### DIFF
--- a/backend/app/core/db/migrations/versions/40fbf263e427_merge_heads_0011_and_0019.py
+++ b/backend/app/core/db/migrations/versions/40fbf263e427_merge_heads_0011_and_0019.py
@@ -1,0 +1,25 @@
+"""merge heads 0011 and 0019
+
+Revision ID: 40fbf263e427
+Revises: 0011, 0019
+Create Date: 2026-03-18 13:41:13.224181
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '40fbf263e427'
+down_revision: Union[str, None] = ('0011', '0019')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/core/db/migrations/versions/f5aca0aa8f32_add_change_summary_to_prompt_override_.py
+++ b/backend/app/core/db/migrations/versions/f5aca0aa8f32_add_change_summary_to_prompt_override_.py
@@ -1,0 +1,28 @@
+"""add change_summary to prompt_override_versions
+
+Revision ID: f5aca0aa8f32
+Revises: 40fbf263e427
+Create Date: 2026-03-18 13:41:51.569566
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f5aca0aa8f32'
+down_revision: Union[str, None] = '40fbf263e427'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "prompt_override_versions",
+        sa.Column("change_summary", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("prompt_override_versions", "change_summary")

--- a/backend/app/core/prompts/prompt_service.py
+++ b/backend/app/core/prompts/prompt_service.py
@@ -285,6 +285,7 @@ class PromptService:
         org_id: UUID | None,
         content: str,
         actor_id: str,
+        change_summary: str | None = None,
     ) -> dict:
         """Write prompt override, bump version, write history row."""
         # Pre-save validation
@@ -325,6 +326,7 @@ class PromptService:
                     version=new_version,
                     content=content,
                     updated_by=actor_id,
+                    change_summary=change_summary,
                 )
             )
         else:
@@ -342,6 +344,7 @@ class PromptService:
                     version=new_version,
                     content=content,
                     updated_by=actor_id,
+                    change_summary=change_summary,
                 )
             ]
             self._db.add(override)
@@ -524,9 +527,12 @@ class PromptService:
         return {
             "versions": [
                 {
+                    "id": v.id,
                     "version": v.version,
                     "content": v.content,
                     "updated_by": v.updated_by,
+                    "actor_id": v.updated_by,
+                    "change_summary": v.change_summary,
                     "created_at": v.created_at.isoformat() if v.created_at else None,
                 }
                 for v in versions

--- a/backend/app/domains/admin/models.py
+++ b/backend/app/domains/admin/models.py
@@ -102,6 +102,7 @@ class PromptOverrideVersion(Base, IdMixin):
     version: Mapped[int] = mapped_column(Integer, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     updated_by: Mapped[str] = mapped_column(Text, nullable=False)
+    change_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/domains/admin/routes/prompts.py
+++ b/backend/app/domains/admin/routes/prompts.py
@@ -15,6 +15,7 @@ from app.core.prompts.schemas import (
     PromptPreviewResponse,
     PromptValidateResponse,
 )
+from app.domains.admin.schemas import PromptVersionsResponse
 from app.core.security.admin_auth import require_super_admin
 from app.core.security.clerk_auth import Actor
 from app.core.tenancy.admin_middleware import get_db_admin
@@ -62,8 +63,9 @@ async def update_prompt(
 ):
     """Update prompt override (auto-version, history)."""
     content = body.get("content", "")
+    change_summary = body.get("change_summary")
     svc = PromptService(db)
-    return await svc.put(vertical, name, org_id, content, actor.actor_id)
+    return await svc.put(vertical, name, org_id, content, actor.actor_id, change_summary=change_summary)
 
 
 @router.delete("/{vertical}/{name}")
@@ -105,7 +107,7 @@ async def validate_prompt(
     return {"valid": len(errors) == 0, "errors": errors}
 
 
-@router.get("/{vertical}/{name}/versions")
+@router.get("/{vertical}/{name}/versions", response_model=PromptVersionsResponse)
 async def get_versions(
     vertical: str,
     name: str,

--- a/backend/app/domains/admin/schemas.py
+++ b/backend/app/domains/admin/schemas.py
@@ -8,6 +8,27 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict
 
 
+class PromptVersionOut(BaseModel):
+    """Single version entry from prompt override history."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    version: int
+    content: str
+    updated_by: str
+    actor_id: str | None = None  # alias of updated_by for frontend consistency
+    change_summary: str | None = None
+    created_at: datetime
+
+
+class PromptVersionsResponse(BaseModel):
+    """Paginated response for prompt version history."""
+
+    versions: list[PromptVersionOut]
+    has_more: bool
+
+
 class BrandingResponse(BaseModel):
     """Branding config returned to frontends. Merged default + override.
 

--- a/backend/app/domains/credit/documents/routes/review.py
+++ b/backend/app/domains/credit/documents/routes/review.py
@@ -21,7 +21,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -83,11 +83,49 @@ class AssignReviewer(BaseModel):
 class ReviewDecisionPayload(BaseModel):
     decision: str = Field(description="APPROVED | REJECTED | REVISION_REQUESTED")
     comments: str | None = None
+    rationale: str = Field(min_length=1, description="Justification for the decision (min 20 chars)")
+    actor_capacity: str = Field(description="reviewer | lead_reviewer | gp_override")
+    actor_email: EmailStr
+
+    @field_validator("rationale")
+    @classmethod
+    def rationale_min_length(cls, v: str) -> str:
+        v = v.strip()
+        if len(v) < 20:
+            raise ValueError("rationale must be at least 20 characters after stripping whitespace")
+        return v
+
+    @field_validator("actor_capacity")
+    @classmethod
+    def validate_actor_capacity(cls, v: str) -> str:
+        allowed = {"reviewer", "lead_reviewer", "gp_override"}
+        if v not in allowed:
+            raise ValueError(f"actor_capacity must be one of {sorted(allowed)}")
+        return v
 
 
 class FinalizePayload(BaseModel):
     decision: str = Field(description="APPROVED | REJECTED")
     comments: str | None = None
+    rationale: str = Field(min_length=1, description="Justification for the decision (min 20 chars)")
+    actor_capacity: str = Field(description="gp | admin_override")
+    actor_email: EmailStr
+
+    @field_validator("rationale")
+    @classmethod
+    def rationale_min_length(cls, v: str) -> str:
+        v = v.strip()
+        if len(v) < 20:
+            raise ValueError("rationale must be at least 20 characters after stripping whitespace")
+        return v
+
+    @field_validator("actor_capacity")
+    @classmethod
+    def validate_actor_capacity(cls, v: str) -> str:
+        allowed = {"gp", "admin_override"}
+        if v not in allowed:
+            raise ValueError(f"actor_capacity must be one of {sorted(allowed)}")
+        return v
 
 
 # -- Submit ------------------------------------------------------------------

--- a/backend/app/domains/credit/documents/schemas.py
+++ b/backend/app/domains/credit/documents/schemas.py
@@ -59,6 +59,8 @@ class DocumentReviewOut(BaseModel):
     final_decision: str | None = None
     decided_by: str | None = None
     decided_at: datetime | None = None
+    rationale: str | None = None
+    actor_capacity: str | None = None
 
     revision_count: int
     current_round: int

--- a/backend/app/domains/wealth/routes/strategy_drift.py
+++ b/backend/app/domains/wealth/routes/strategy_drift.py
@@ -23,6 +23,8 @@ from app.domains.wealth.models.instrument import Instrument
 from app.domains.wealth.models.risk import FundRiskMetrics
 from app.domains.wealth.models.strategy_drift_alert import StrategyDriftAlert
 from app.domains.wealth.schemas.strategy_drift import (
+    DriftEventOut,
+    DriftHistoryOut,
     StrategyDriftRead,
     StrategyDriftScanRead,
 )
@@ -280,6 +282,75 @@ async def list_drift_alerts(
         )
         for a in alerts
     ]
+
+
+@router.get(
+    "/{instrument_id}/history",
+    response_model=DriftHistoryOut,
+    summary="Drift history for an instrument",
+    description=(
+        "Returns historical drift alerts for a single instrument, ordered by "
+        "detected_at descending. Supports date range and severity filtering."
+    ),
+)
+async def get_drift_history(
+    instrument_id: uuid.UUID,
+    from_date: datetime | None = Query(None, description="Start date filter (inclusive)"),
+    to_date: datetime | None = Query(None, description="End date filter (inclusive)"),
+    severity: str | None = Query(None, pattern="^(none|moderate|severe)$"),
+    limit: int = Query(100, ge=1, le=500),
+    db: AsyncSession = Depends(get_db_with_rls),
+    user: CurrentUser = Depends(get_current_user),
+) -> DriftHistoryOut:
+    # Verify instrument exists
+    inst_result = await db.execute(
+        select(Instrument.name).where(Instrument.instrument_id == instrument_id)
+    )
+    inst_name = inst_result.scalar()
+    if inst_name is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Instrument not found"
+        )
+
+    # Build query with filters
+    stmt = select(StrategyDriftAlert).where(
+        StrategyDriftAlert.instrument_id == instrument_id,
+    )
+    if from_date is not None:
+        stmt = stmt.where(StrategyDriftAlert.detected_at >= from_date)
+    if to_date is not None:
+        stmt = stmt.where(StrategyDriftAlert.detected_at <= to_date)
+    if severity is not None:
+        stmt = stmt.where(StrategyDriftAlert.severity == severity)
+
+    stmt = stmt.order_by(StrategyDriftAlert.detected_at.desc()).limit(limit)
+
+    result = await db.execute(stmt)
+    alerts = result.scalars().all()
+
+    events = [
+        DriftEventOut(
+            id=a.id,
+            instrument_id=a.instrument_id,
+            status=a.status,
+            severity=a.severity,
+            anomalous_count=a.anomalous_count,
+            total_metrics=a.total_metrics,
+            metric_details=a.metric_details,
+            is_current=a.is_current,
+            detected_at=a.detected_at,
+            created_at=a.created_at,
+        )
+        for a in alerts
+    ]
+
+    return DriftHistoryOut(
+        instrument_id=instrument_id,
+        instrument_name=inst_name,
+        events=events,
+        total=len(events),
+        computed_at=datetime.now(timezone.utc),
+    )
 
 
 # ── Parameterized route MUST come after literal routes (/alerts, /scan) ──

--- a/backend/app/domains/wealth/schemas/strategy_drift.py
+++ b/backend/app/domains/wealth/schemas/strategy_drift.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -42,3 +42,37 @@ class StrategyDriftScanRead(BaseModel):
     stable_count: int
     insufficient_data_count: int
     scan_timestamp: datetime
+
+
+class DriftEventOut(BaseModel):
+    """Single drift event from strategy_drift_alerts history."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    instrument_id: UUID
+    status: str
+    severity: str
+    anomalous_count: int
+    total_metrics: int
+    metric_details: list[dict[str, Any]] | None = None
+    is_current: bool = False
+    detected_at: datetime
+    created_at: datetime | None = None
+    # TODO: snapshot_date — not in model yet
+    # TODO: drift_magnitude — not in model yet
+    # TODO: threshold — not in model yet
+    # TODO: breached — not in model yet
+    # TODO: rebalance_triggered — not in model yet
+    # TODO: asset_class_breakdown — not in model yet
+
+
+class DriftHistoryOut(BaseModel):
+    """Drift history for a single instrument (mapped from 'profile' concept)."""
+
+    instrument_id: UUID
+    instrument_name: str
+    events: list[DriftEventOut]
+    total: int
+    # TODO: computed_at — no model-level field; using query time instead
+    computed_at: datetime | None = None

--- a/packages/ui/src/types/api.d.ts
+++ b/packages/ui/src/types/api.d.ts
@@ -78,6 +78,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/jobs/{job_id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Job Status
+         * @description Poll terminal job state from Redis — fallback when SSE connection drops.
+         *
+         *     Returns the persisted terminal state (success/degraded/failed) with
+         *     chunk counts, or 404 if the job hasn't reached a terminal state yet.
+         *     Clients should poll this when SSE disconnects before receiving a
+         *     terminal event (done/error/ingestion_complete).
+         */
+        get: operations["get_job_status_api_v1_jobs__job_id__status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/test/sse/{job_id}/emit": {
         parameters: {
             query?: never;
@@ -615,8 +640,9 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Fund scoring within block
-         * @description Returns funds ranked by manager score within an allocation block.
+         * [DEPRECATED] Fund scoring within block
+         * @deprecated
+         * @description DEPRECATED — use /instruments endpoints instead. Returns funds ranked by manager score within an allocation block.
          */
         get: operations["get_fund_scoring_api_v1_funds_scoring_get"];
         put?: never;
@@ -635,8 +661,9 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List fund universe
-         * @description Returns funds with optional filters by block, geography, asset class.
+         * [DEPRECATED] List fund universe
+         * @deprecated
+         * @description DEPRECATED — use GET /instruments instead. Returns funds with optional filters by block, geography, asset class.
          */
         get: operations["list_funds_api_v1_funds_get"];
         put?: never;
@@ -655,8 +682,9 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Fund detail
-         * @description Returns full metadata for a single fund.
+         * [DEPRECATED] Fund detail
+         * @deprecated
+         * @description DEPRECATED — use GET /instruments/{instrument_id} instead. Returns full metadata for a single fund.
          */
         get: operations["get_fund_api_v1_funds__fund_id__get"];
         put?: never;
@@ -675,8 +703,9 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Fund risk metrics
-         * @description Returns the latest risk metrics (CVaR, VaR, returns, ratios) for a fund.
+         * [DEPRECATED] Fund risk metrics
+         * @deprecated
+         * @description DEPRECATED — use /instruments endpoints instead. Returns the latest risk metrics (CVaR, VaR, returns, ratios) for a fund.
          */
         get: operations["get_fund_risk_api_v1_funds__fund_id__risk_get"];
         put?: never;
@@ -695,8 +724,9 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Fund NAV time-series
-         * @description Returns NAV history for a fund within a date range.
+         * [DEPRECATED] Fund NAV time-series
+         * @deprecated
+         * @description DEPRECATED — use /instruments endpoints instead. Returns NAV history for a fund within a date range.
          */
         get: operations["get_fund_nav_api_v1_funds__fund_id__nav_get"];
         put?: never;
@@ -2140,6 +2170,26 @@ export interface paths {
         };
         /** List persisted drift alerts */
         get: operations["list_drift_alerts_api_v1_analytics_strategy_drift_alerts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/analytics/strategy-drift/{instrument_id}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Drift history for an instrument
+         * @description Returns historical drift alerts for a single instrument, ordered by detected_at descending. Supports date range and severity filtering.
+         */
+        get: operations["get_drift_history_api_v1_analytics_strategy_drift__instrument_id__history_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6326,6 +6376,65 @@ export interface components {
             /** Knowledgeanchors */
             knowledgeAnchors: number;
         };
+        /**
+         * DriftEventOut
+         * @description Single drift event from strategy_drift_alerts history.
+         */
+        DriftEventOut: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Instrument Id
+             * Format: uuid
+             */
+            instrument_id: string;
+            /** Status */
+            status: string;
+            /** Severity */
+            severity: string;
+            /** Anomalous Count */
+            anomalous_count: number;
+            /** Total Metrics */
+            total_metrics: number;
+            /** Metric Details */
+            metric_details?: {
+                [key: string]: unknown;
+            }[] | null;
+            /**
+             * Is Current
+             * @default false
+             */
+            is_current: boolean;
+            /**
+             * Detected At
+             * Format: date-time
+             */
+            detected_at: string;
+            /** Created At */
+            created_at?: string | null;
+        };
+        /**
+         * DriftHistoryOut
+         * @description Drift history for a single instrument (mapped from 'profile' concept).
+         */
+        DriftHistoryOut: {
+            /**
+             * Instrument Id
+             * Format: uuid
+             */
+            instrument_id: string;
+            /** Instrument Name */
+            instrument_name: string;
+            /** Events */
+            events: components["schemas"]["DriftEventOut"][];
+            /** Total */
+            total: number;
+            /** Computed At */
+            computed_at?: string | null;
+        };
         /** EffectiveAllocationRead */
         EffectiveAllocationRead: {
             /** Profile */
@@ -6670,6 +6779,21 @@ export interface components {
             decision: string;
             /** Comments */
             comments?: string | null;
+            /**
+             * Rationale
+             * @description Justification for the decision (min 20 chars)
+             */
+            rationale: string;
+            /**
+             * Actor Capacity
+             * @description gp | admin_override
+             */
+            actor_capacity: string;
+            /**
+             * Actor Email
+             * Format: email
+             */
+            actor_email: string;
         };
         /** FundFreshness */
         FundFreshness: {
@@ -8257,6 +8381,42 @@ export interface components {
             /** Errors */
             errors: string[];
         };
+        /**
+         * PromptVersionOut
+         * @description Single version entry from prompt override history.
+         */
+        PromptVersionOut: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Version */
+            version: number;
+            /** Content */
+            content: string;
+            /** Updated By */
+            updated_by: string;
+            /** Actor Id */
+            actor_id?: string | null;
+            /** Change Summary */
+            change_summary?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+        };
+        /**
+         * PromptVersionsResponse
+         * @description Paginated response for prompt version history.
+         */
+        PromptVersionsResponse: {
+            /** Versions */
+            versions: components["schemas"]["PromptVersionOut"][];
+            /** Has More */
+            has_more: boolean;
+        };
         /** QualificationResultOut */
         QualificationResultOut: {
             /**
@@ -8560,6 +8720,21 @@ export interface components {
             decision: string;
             /** Comments */
             comments?: string | null;
+            /**
+             * Rationale
+             * @description Justification for the decision (min 20 chars)
+             */
+            rationale: string;
+            /**
+             * Actor Capacity
+             * @description reviewer | lead_reviewer | gp_override
+             */
+            actor_capacity: string;
+            /**
+             * Actor Email
+             * Format: email
+             */
+            actor_email: string;
         };
         /** ReviewSubmit */
         ReviewSubmit: {
@@ -9581,6 +9756,37 @@ export interface operations {
             };
         };
     };
+    get_job_status_api_v1_jobs__job_id__status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     test_emit_event_api_v1_test_sse__job_id__emit_post: {
         parameters: {
             query?: {
@@ -10415,7 +10621,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["PromptVersionsResponse"];
                 };
             };
             /** @description Validation Error */
@@ -13117,6 +13323,44 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["StrategyDriftRead"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_drift_history_api_v1_analytics_strategy_drift__instrument_id__history_get: {
+        parameters: {
+            query?: {
+                /** @description Start date filter (inclusive) */
+                from_date?: string | null;
+                /** @description End date filter (inclusive) */
+                to_date?: string | null;
+                severity?: string | null;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                instrument_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DriftHistoryOut"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- **Credit:** Enrich `ReviewDecisionPayload` and `FinalizePayload` with `rationale` (min 20 chars validator), `actor_capacity` (enum-validated), and `actor_email` (EmailStr). Add `rationale` + `actor_capacity` to `DocumentReviewOut`.
- **Wealth:** Add `DriftEventOut` + `DriftHistoryOut` schemas and `GET /{instrument_id}/history` endpoint with date range + severity filters. 6 fields marked TODO (not yet in model).
- **Admin:** Add `change_summary` nullable TEXT column to `PromptOverrideVersion` with Alembic migration. Create `PromptVersionOut` + `PromptVersionsResponse` schemas. Wire through service + route.
- **Types:** Regenerate `api.d.ts` — all new fields confirmed in TS types.

## Test plan
- [ ] `make check` passes (lint + typecheck + test)
- [ ] `alembic upgrade head` applies new migration cleanly
- [ ] Verify `rationale` validator rejects < 20 chars on `/decide` and `/finalize`
- [ ] Verify `actor_capacity` validator rejects invalid values
- [ ] Verify `GET /{instrument_id}/history` returns drift events with filters
- [ ] Verify `PromptVersionOut` includes `change_summary` and `actor_id` fields
- [ ] Confirm `api.d.ts` has `DriftEventOut`, `DriftHistoryOut`, `PromptVersionOut`, `rationale`, `actor_capacity`, `change_summary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)