### PR TITLE
feat: Backend Sprint 3 — deal terms, allocation simulate, config diff

### DIFF
--- a/backend/app/core/db/migrations/versions/636e0de04bf7_add_financial_term_fields_to_deals.py
+++ b/backend/app/core/db/migrations/versions/636e0de04bf7_add_financial_term_fields_to_deals.py
@@ -1,0 +1,35 @@
+"""add financial term fields to deals
+
+Revision ID: 636e0de04bf7
+Revises: f5aca0aa8f32
+Create Date: 2026-03-18
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "636e0de04bf7"
+down_revision = "f5aca0aa8f32"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("deals", sa.Column("tenor_months", sa.Integer(), nullable=True))
+    op.add_column("deals", sa.Column("spread_bps", sa.Integer(), nullable=True))
+    op.add_column("deals", sa.Column("covenant_type", sa.String(length=100), nullable=True))
+    op.add_column("deals", sa.Column("covenant_frequency", sa.String(length=50), nullable=True))
+    op.add_column("deals", sa.Column("collateral_description", sa.Text(), nullable=True))
+    op.add_column("deals", sa.Column("ltv_ratio", sa.Numeric(precision=5, scale=4), nullable=True))
+    op.add_column("deals", sa.Column("agreement_language", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("deals", "agreement_language")
+    op.drop_column("deals", "ltv_ratio")
+    op.drop_column("deals", "collateral_description")
+    op.drop_column("deals", "covenant_frequency")
+    op.drop_column("deals", "covenant_type")
+    op.drop_column("deals", "spread_bps")
+    op.drop_column("deals", "tenor_months")

--- a/backend/app/domains/admin/routes/configs.py
+++ b/backend/app/domains/admin/routes/configs.py
@@ -12,6 +12,7 @@ from app.core.config.registry import ConfigRegistry
 from app.core.security.admin_auth import require_super_admin
 from app.core.security.clerk_auth import Actor
 from app.core.tenancy.admin_middleware import get_db_admin
+from app.domains.admin.schemas import ConfigDiffOut
 from app.domains.admin.services.config_writer import ConfigWriter
 
 router = APIRouter(
@@ -125,7 +126,7 @@ async def delete_config(
     return {"status": "deleted"}
 
 
-@router.get("/{vertical}/{config_type}/diff")
+@router.get("/{vertical}/{config_type}/diff", response_model=ConfigDiffOut)
 async def get_config_diff(
     vertical: str,
     config_type: str,

--- a/backend/app/domains/admin/schemas.py
+++ b/backend/app/domains/admin/schemas.py
@@ -130,3 +130,23 @@ class PipelineStatsOut(BaseModel):
     queue_depth: int
     error_rate: float
     checked_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Config diff schema
+# ---------------------------------------------------------------------------
+
+
+class ConfigDiffOut(BaseModel):
+    """Typed response for config diff endpoint (default vs override)."""
+
+    vertical: str
+    config_type: str
+    org_id: uuid.UUID | None = None
+    default: dict[str, object]
+    override: dict[str, object] | None = None
+    merged: dict[str, object]
+    changed_keys: list[str]
+    tenant_count_affected: int = 1  # always 1 for now — org_id scoped
+    has_override: bool
+    computed_at: datetime

--- a/backend/app/domains/admin/services/config_writer.py
+++ b/backend/app/domains/admin/services/config_writer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from datetime import datetime, timezone
 from uuid import UUID
 
 from fastapi import HTTPException, status
@@ -19,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config.models import VerticalConfigDefault, VerticalConfigOverride
 from app.domains.admin.models import AdminAuditLog
+from app.domains.admin.schemas import ConfigDiffOut
 
 logger = logging.getLogger(__name__)
 
@@ -275,8 +277,8 @@ class ConfigWriter:
         vertical: str,
         config_type: str,
         org_id: UUID,
-    ) -> dict:
-        """Return {default, override, merged, changed_keys}."""
+    ) -> ConfigDiffOut:
+        """Return typed diff: default vs override with context fields."""
         from app.core.config.config_service import ConfigService
 
         default_row = await self._db.execute(
@@ -299,18 +301,24 @@ class ConfigWriter:
         merged = ConfigService.deep_merge(default_config, override_config) if override_config else default_config
 
         # Calculate changed keys
-        changed_keys = []
+        changed_keys: list[str] = []
         if override_config:
             for key in override_config:
                 if default_config.get(key) != override_config[key]:
                     changed_keys.append(key)
 
-        return {
-            "default": default_config,
-            "override": override_config,
-            "merged": merged,
-            "changed_keys": changed_keys,
-        }
+        return ConfigDiffOut(
+            vertical=vertical,
+            config_type=config_type,
+            org_id=org_id,
+            default=default_config,
+            override=override_config,
+            merged=merged,
+            changed_keys=changed_keys,
+            tenant_count_affected=1,  # TODO: count tenants without override when org_id is None
+            has_override=override_config is not None,
+            computed_at=datetime.now(timezone.utc),
+        )
 
     async def validate_override(
         self,

--- a/backend/app/domains/credit/deals/models/deals.py
+++ b/backend/app/domains/credit/deals/models/deals.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import Enum, ForeignKey, String, Text, Uuid
+from decimal import Decimal
+
+from sqlalchemy import Enum, ForeignKey, Integer, Numeric, String, Text, Uuid
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -65,4 +67,13 @@ class Deal(Base, IdMixin, OrganizationScopedMixin, FundScopedMixin, AuditMetaMix
         nullable=True,
         index=True,
     )
+
+    # --- Financial term fields (populated during structuring) ---
+    tenor_months: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    spread_bps: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    covenant_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    covenant_frequency: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    collateral_description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    ltv_ratio: Mapped[Decimal | None] = mapped_column(Numeric(5, 4), nullable=True)
+    agreement_language: Mapped[str | None] = mapped_column(Text, nullable=True)
 

--- a/backend/app/domains/credit/deals/schemas/deals.py
+++ b/backend/app/domains/credit/deals/schemas/deals.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from decimal import Decimal
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
@@ -59,6 +60,15 @@ class DealOut(BaseModel):
     decided_at: datetime | None = None
 
     pipeline_deal_id: uuid.UUID | None = None
+
+    # --- Financial term fields ---
+    tenor_months: int | None = None
+    spread_bps: int | None = None
+    covenant_type: str | None = None
+    covenant_frequency: str | None = None
+    collateral_description: str | None = None
+    ltv_ratio: Decimal | None = None
+    agreement_language: str | None = None
 
     created_at: datetime
     updated_at: datetime

--- a/backend/app/domains/wealth/routes/allocation.py
+++ b/backend/app/domains/wealth/routes/allocation.py
@@ -1,7 +1,7 @@
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -9,13 +9,15 @@ from app.core.security.clerk_auth import CurrentUser, get_current_user, require_
 from app.core.tenancy.middleware import get_db_with_rls
 from app.domains.wealth.models.allocation import StrategicAllocation, TacticalPosition
 from app.domains.wealth.schemas.allocation import (
+    AllocationProposal,
     EffectiveAllocationRead,
+    SimulationResult,
     StrategicAllocationRead,
     StrategicAllocationUpdate,
     TacticalPositionRead,
     TacticalPositionUpdate,
 )
-from app.routers.common import validate_profile as _validate_profile
+from app.routers.common import get_latest_snapshot, validate_profile as _validate_profile
 
 router = APIRouter(prefix="/allocation")
 
@@ -224,3 +226,89 @@ async def get_effective(
             )
         )
     return effective
+
+
+@router.post(
+    "/{profile}/simulate",
+    response_model=SimulationResult,
+    summary="Simulate allocation change",
+    description=(
+        "Accepts a proposed weight map and returns projected CVaR impact "
+        "against the profile's risk limit. Synchronous — no background jobs."
+    ),
+)
+async def simulate_allocation(
+    profile: str,
+    body: AllocationProposal,
+    db: AsyncSession = Depends(get_db_with_rls),
+    user: CurrentUser = Depends(get_current_user),
+) -> SimulationResult:
+    _validate_profile(profile)
+
+    # --- validate weights sum ≈ 1.0 ---
+    weights_sum = sum(body.weights.values())
+    if abs(weights_sum - Decimal("1")) > Decimal("0.001"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"weights must sum to ~1.0 (tolerance 0.001), got {weights_sum}",
+        )
+
+    # --- fetch current snapshot for CVaR limit + current level ---
+    snap = await get_latest_snapshot(db, profile)
+    cvar_limit = snap.cvar_limit if snap else None
+    cvar_current = snap.cvar_current if snap else None
+
+    warnings: list[str] = []
+
+    # --- attempt proposed CVaR computation ---
+    proposed_cvar_95_3m: Decimal | None = None
+    cvar_delta_vs_current: Decimal | None = None
+    cvar_utilization_pct: Decimal | None = None
+    tracking_error_expected: Decimal | None = None  # TODO: requires full quant pipeline
+
+    try:
+        from app.domains.wealth.services.quant_queries import compute_inputs_from_nav
+
+        block_ids = list(body.weights.keys())
+        _cov_matrix, _expected_returns = await compute_inputs_from_nav(db, block_ids)
+
+        # TODO: requires full quant pipeline — CVaR calculation from
+        # covariance matrix + weights needs the optimizer / CVaR engine
+        # integration which is not wired here yet.
+        warnings.append(
+            "Full CVaR projection not yet available; "
+            "covariance data was fetched but CVaR calculation requires quant pipeline integration."
+        )
+    except (ValueError, ImportError) as exc:
+        warnings.append(f"Could not compute proposed CVaR: {exc}")
+
+    # --- compute delta if both values are available ---
+    if proposed_cvar_95_3m is not None and cvar_current is not None:
+        cvar_delta_vs_current = proposed_cvar_95_3m - cvar_current
+
+    # --- compute utilization if limit is known ---
+    if proposed_cvar_95_3m is not None and cvar_limit is not None and cvar_limit != 0:
+        cvar_utilization_pct = (proposed_cvar_95_3m / cvar_limit) * Decimal("100")
+
+    # --- determine within_limit ---
+    if proposed_cvar_95_3m is not None and cvar_limit is not None:
+        within_limit = abs(proposed_cvar_95_3m) <= abs(cvar_limit)
+    elif cvar_limit is None:
+        within_limit = True
+        warnings.append("No CVaR limit configured for this profile; cannot validate constraint.")
+    else:
+        # proposed CVaR unavailable — optimistic default with warning
+        within_limit = True
+        warnings.append("Proposed CVaR could not be computed; within_limit is assumed true.")
+
+    return SimulationResult(
+        profile=profile,
+        proposed_cvar_95_3m=proposed_cvar_95_3m,
+        cvar_limit=cvar_limit,
+        cvar_utilization_pct=cvar_utilization_pct,
+        cvar_delta_vs_current=cvar_delta_vs_current,
+        tracking_error_expected=tracking_error_expected,
+        within_limit=within_limit,
+        warnings=warnings,
+        computed_at=datetime.now(timezone.utc),
+    )

--- a/backend/app/domains/wealth/schemas/allocation.py
+++ b/backend/app/domains/wealth/schemas/allocation.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class StrategicAllocationRead(BaseModel):
@@ -85,3 +85,27 @@ class EffectiveAllocationRead(BaseModel):
     effective_weight: Decimal | None = None
     min_weight: Decimal | None = None
     max_weight: Decimal | None = None
+
+
+class AllocationProposal(BaseModel):
+    weights: dict[str, Decimal]  # instrument_id -> weight (0-1, sum must ~ 1.0)
+    rationale: str  # min 20 chars
+
+    @field_validator("rationale")
+    @classmethod
+    def rationale_min_length(cls, v: str) -> str:
+        if len(v.strip()) < 20:
+            raise ValueError("rationale must be at least 20 characters (after stripping whitespace)")
+        return v.strip()
+
+
+class SimulationResult(BaseModel):
+    profile: str
+    proposed_cvar_95_3m: Decimal | None = None
+    cvar_limit: Decimal | None = None
+    cvar_utilization_pct: Decimal | None = None
+    cvar_delta_vs_current: Decimal | None = None  # positive = worse
+    tracking_error_expected: Decimal | None = None
+    within_limit: bool
+    warnings: list[str] = []
+    computed_at: datetime

--- a/packages/ui/src/types/api.d.ts
+++ b/packages/ui/src/types/api.d.ts
@@ -874,6 +874,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/allocation/{profile}/simulate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Simulate allocation change
+         * @description Accepts a proposed weight map and returns projected CVaR impact against the profile's risk limit. Synchronous — no background jobs.
+         */
+        post: operations["simulate_allocation_api_v1_allocation__profile__simulate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/analytics/backtest": {
         parameters: {
             query?: never;
@@ -5013,6 +5033,15 @@ export interface components {
          * @enum {string}
          */
         AlertType: "OBLIGATION_OVERDUE" | "COVENANT_BREACH" | "NAV_DEVIATION" | "MANUAL";
+        /** AllocationProposal */
+        AllocationProposal: {
+            /** Weights */
+            weights: {
+                [key: string]: number | string;
+            };
+            /** Rationale */
+            rationale: string;
+        };
         /**
          * AssetType
          * @enum {string}
@@ -5487,6 +5516,44 @@ export interface components {
             evidence_docs: string[];
             /** Notes */
             notes?: string | null;
+        };
+        /**
+         * ConfigDiffOut
+         * @description Typed response for config diff endpoint (default vs override).
+         */
+        ConfigDiffOut: {
+            /** Vertical */
+            vertical: string;
+            /** Config Type */
+            config_type: string;
+            /** Org Id */
+            org_id?: string | null;
+            /** Default */
+            default: {
+                [key: string]: unknown;
+            };
+            /** Override */
+            override?: {
+                [key: string]: unknown;
+            } | null;
+            /** Merged */
+            merged: {
+                [key: string]: unknown;
+            };
+            /** Changed Keys */
+            changed_keys: string[];
+            /**
+             * Tenant Count Affected
+             * @default 1
+             */
+            tenant_count_affected: number;
+            /** Has Override */
+            has_override: boolean;
+            /**
+             * Computed At
+             * Format: date-time
+             */
+            computed_at: string;
         };
         /** ContentSummary */
         ContentSummary: {
@@ -8954,6 +9021,33 @@ export interface components {
              */
             checked_at: string;
         };
+        /** SimulationResult */
+        SimulationResult: {
+            /** Profile */
+            profile: string;
+            /** Proposed Cvar 95 3M */
+            proposed_cvar_95_3m?: string | null;
+            /** Cvar Limit */
+            cvar_limit?: string | null;
+            /** Cvar Utilization Pct */
+            cvar_utilization_pct?: string | null;
+            /** Cvar Delta Vs Current */
+            cvar_delta_vs_current?: string | null;
+            /** Tracking Error Expected */
+            tracking_error_expected?: string | null;
+            /** Within Limit */
+            within_limit: boolean;
+            /**
+             * Warnings
+             * @default []
+             */
+            warnings: string[];
+            /**
+             * Computed At
+             * Format: date-time
+             */
+            computed_at: string;
+        };
         /** SponsorImpact */
         SponsorImpact: {
             /**
@@ -9509,6 +9603,20 @@ export interface components {
             decided_at?: string | null;
             /** Pipeline Deal Id */
             pipeline_deal_id?: string | null;
+            /** Tenor Months */
+            tenor_months?: number | null;
+            /** Spread Bps */
+            spread_bps?: number | null;
+            /** Covenant Type */
+            covenant_type?: string | null;
+            /** Covenant Frequency */
+            covenant_frequency?: string | null;
+            /** Collateral Description */
+            collateral_description?: string | null;
+            /** Ltv Ratio */
+            ltv_ratio?: string | null;
+            /** Agreement Language */
+            agreement_language?: string | null;
             /**
              * Created At
              * Format: date-time
@@ -10065,7 +10173,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["ConfigDiffOut"];
                 };
             };
             /** @description Validation Error */
@@ -11295,6 +11403,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EffectiveAllocationRead"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    simulate_allocation_api_v1_allocation__profile__simulate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                profile: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AllocationProposal"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SimulationResult"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- **Credit:** Add 7 financial term fields to `Deal` model (`tenor_months`, `spread_bps`, `covenant_type`, `covenant_frequency`, `collateral_description`, `ltv_ratio`, `agreement_language`) — all nullable. Migration included. `DealOut` schema enriched.
- **Wealth:** Add `POST /{profile}/simulate` endpoint with `AllocationProposal` (weights sum validation, 20-char rationale) and `SimulationResult` response. Fetches `cvar_limit` from `PortfolioSnapshot`. Full CVaR calculation fields marked TODO (requires quant pipeline).
- **Admin:** Add `ConfigDiffOut` typed schema replacing raw dict return on `GET /{vertical}/{config_type}/diff`. Adds `vertical`, `config_type`, `org_id`, `has_override`, `computed_at` context fields.
- **Types:** Regenerate `api.d.ts` — all new types confirmed (`AllocationProposal`, `SimulationResult`, `ConfigDiffOut`, `tenor_months`, `spread_bps`, `ltv_ratio`).

## Test plan
- [ ] `make check` passes (lint + typecheck + test)
- [ ] `alembic upgrade head` applies deal term migration cleanly
- [ ] Verify `DealOut` includes all 7 financial term fields
- [ ] Verify `POST /{profile}/simulate` rejects weights sum != 1.0 with 422
- [ ] Verify `POST /{profile}/simulate` rejects rationale < 20 chars
- [ ] Verify `GET /{vertical}/{config_type}/diff` returns `ConfigDiffOut` shape
- [ ] Confirm `api.d.ts` has `AllocationProposal`, `SimulationResult`, `ConfigDiffOut`

🤖 Generated with [Claude Code](https://claude.com/claude-code)