### PR TITLE
feat: Backend Sprint 4 — drift model fields

### DIFF
--- a/backend/app/core/db/migrations/versions/a1b2c3d4e5f6_add_drift_event_fields_to_strategy_.py
+++ b/backend/app/core/db/migrations/versions/a1b2c3d4e5f6_add_drift_event_fields_to_strategy_.py
@@ -1,0 +1,28 @@
+"""add drift event fields to strategy_drift_alerts
+
+Revision ID: a1b2c3d4e5f6
+Revises: f5aca0aa8f32
+Create Date: 2026-03-18
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "a1b2c3d4e5f6"
+down_revision = "f5aca0aa8f32"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("strategy_drift_alerts", sa.Column("snapshot_date", sa.Date(), nullable=True))
+    op.add_column("strategy_drift_alerts", sa.Column("drift_magnitude", sa.Numeric(10, 6), nullable=True))
+    op.add_column("strategy_drift_alerts", sa.Column("drift_threshold", sa.Numeric(10, 6), nullable=True))
+    op.add_column("strategy_drift_alerts", sa.Column("rebalance_triggered", sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("strategy_drift_alerts", "rebalance_triggered")
+    op.drop_column("strategy_drift_alerts", "drift_threshold")
+    op.drop_column("strategy_drift_alerts", "drift_magnitude")
+    op.drop_column("strategy_drift_alerts", "snapshot_date")

--- a/backend/app/domains/wealth/models/strategy_drift_alert.py
+++ b/backend/app/domains/wealth/models/strategy_drift_alert.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import datetime as dt
 import uuid
+from decimal import Decimal
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Uuid, func
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, Numeric, String, Uuid, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -39,6 +40,10 @@ class StrategyDriftAlert(OrganizationScopedMixin, Base):
     detected_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )
+    snapshot_date: Mapped[dt.date | None] = mapped_column(Date, nullable=True)
+    drift_magnitude: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
+    drift_threshold: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
+    rebalance_triggered: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     created_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/domains/wealth/schemas/strategy_drift.py
+++ b/backend/app/domains/wealth/schemas/strategy_drift.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class MetricDriftRead(BaseModel):
@@ -59,12 +60,20 @@ class DriftEventOut(BaseModel):
     is_current: bool = False
     detected_at: datetime
     created_at: datetime | None = None
-    # TODO: snapshot_date — not in model yet
-    # TODO: drift_magnitude — not in model yet
-    # TODO: threshold — not in model yet
-    # TODO: breached — not in model yet
-    # TODO: rebalance_triggered — not in model yet
-    # TODO: asset_class_breakdown — not in model yet
+    snapshot_date: date | None = None
+    drift_magnitude: Decimal | None = None
+    drift_threshold: Decimal | None = None
+    rebalance_triggered: bool | None = None
+    breached: bool = False
+    asset_class_breakdown: list[dict[str, Any]] | None = None
+
+    @model_validator(mode="after")
+    def derive_computed_fields(self) -> DriftEventOut:
+        if self.status in ("breach", "critical"):
+            self.breached = True
+        if self.asset_class_breakdown is None and self.metric_details:
+            self.asset_class_breakdown = self.metric_details
+        return self
 
 
 class DriftHistoryOut(BaseModel):
@@ -74,5 +83,4 @@ class DriftHistoryOut(BaseModel):
     instrument_name: str
     events: list[DriftEventOut]
     total: int
-    # TODO: computed_at — no model-level field; using query time instead
     computed_at: datetime | None = None

--- a/packages/ui/src/types/api.d.ts
+++ b/packages/ui/src/types/api.d.ts
@@ -6415,6 +6415,23 @@ export interface components {
             detected_at: string;
             /** Created At */
             created_at?: string | null;
+            /** Snapshot Date */
+            snapshot_date?: string | null;
+            /** Drift Magnitude */
+            drift_magnitude?: string | null;
+            /** Drift Threshold */
+            drift_threshold?: string | null;
+            /** Rebalance Triggered */
+            rebalance_triggered?: boolean | null;
+            /**
+             * Breached
+             * @default false
+             */
+            breached: boolean;
+            /** Asset Class Breakdown */
+            asset_class_breakdown?: {
+                [key: string]: unknown;
+            }[] | null;
         };
         /**
          * DriftHistoryOut


### PR DESCRIPTION
## Summary
- **Model:** Add 4 nullable columns to `StrategyDriftAlert`: `snapshot_date` (Date), `drift_magnitude` (Numeric 10,6), `drift_threshold` (Numeric 10,6), `rebalance_triggered` (Boolean)
- **Schema:** Resolve all 6 TODOs in `DriftEventOut` — 4 map to new columns, `breached` derived via `@model_validator` from `status in ("breach", "critical")`, `asset_class_breakdown` aliased from `metric_details`
- **Migration:** Hand-crafted `a1b2c3d4e5f6` — 4 `add_column` ops with clean downgrade
- **Types:** `api.d.ts` regenerated — `snapshot_date`, `drift_magnitude`, `drift_threshold`, `rebalance_triggered`, `breached`, `asset_class_breakdown` all confirmed

## Test plan
- [ ] `alembic upgrade head` applies migration cleanly
- [ ] `make check` passes (lint + typecheck + test)
- [ ] Verify `DriftEventOut` derives `breached=True` when status is "breach" or "critical"
- [ ] Verify `asset_class_breakdown` falls back to `metric_details` when None
- [ ] Confirm `api.d.ts` has all 6 new fields on `DriftEventOut`

🤖 Generated with [Claude Code](https://claude.com/claude-code)