### PR TITLE
feat: Backend Sprint 5 — AI engine provenance typing

### DIFF
--- a/backend/ai_engine/classification/hybrid_classifier.py
+++ b/backend/ai_engine/classification/hybrid_classifier.py
@@ -698,6 +698,7 @@ async def classify(
     vehicle_type: str = "other"
     confidence: float = 1.0
     layer: int = 1
+    model_name: str = "rules"
 
     # ── Layer 1: Filename rules ──────────────────────────────────────
     for pattern, dt in _FILENAME_RULES:
@@ -718,6 +719,7 @@ async def classify(
     # ── Layer 2: TF-IDF cosine similarity ────────────────────────────
     if doc_type is None and text:
         layer = 2
+        model_name = "embedding-v2"
         window = _ocr_window(text)
         query = f"Filename: {filename}\n\n{window}"
 
@@ -744,6 +746,7 @@ async def classify(
     # ── Layer 3: LLM fallback ────────────────────────────────────────
     if doc_type is None:
         layer = 3
+        model_name = "gpt-4.1-mini"
         doc_type, confidence = await _classify_llm(
             text, filename, title=title, container=container,
         )
@@ -783,4 +786,5 @@ async def classify(
         vehicle_type=vehicle_type,
         confidence=confidence,
         layer=layer,
+        model_name=model_name,
     )

--- a/backend/ai_engine/pipeline/models.py
+++ b/backend/ai_engine/pipeline/models.py
@@ -67,6 +67,7 @@ class HybridClassificationResult:
     vehicle_type: str
     confidence: float             # 0.0–1.0 unified scale
     layer: int                    # 1=rules, 2=cosine_similarity, 3=LLM
+    model_name: str               # e.g. "rules", "embedding-v2", "gpt-4.1-mini"
 
 
 @dataclass(frozen=True)

--- a/backend/ai_engine/pipeline/unified_pipeline.py
+++ b/backend/ai_engine/pipeline/unified_pipeline.py
@@ -572,19 +572,22 @@ async def process(
     metrics["vehicle_type"] = classification.vehicle_type
     metrics["classification_confidence"] = classification.confidence
     metrics["classification_layer"] = classification.layer
+    metrics["classification_model"] = classification.model_name
 
     await _emit(request.version_id, "classification_complete", {
         "doc_type": classification.doc_type,
         "vehicle_type": classification.vehicle_type,
         "confidence": classification.confidence,
         "layer": classification.layer,
+        "model_name": classification.model_name,
     })
     await _audit(db, fund_id=request.fund_id, actor_id=actor_id,
                  action="DOCUMENT_CLASSIFIED", entity_id=request.document_id,
                  after={"doc_type": classification.doc_type,
                         "vehicle_type": classification.vehicle_type,
                         "confidence": classification.confidence,
-                        "layer": classification.layer})
+                        "layer": classification.layer,
+                        "model_name": classification.model_name})
 
     # ── Gate: Classification validation ─────────────────────────
     cls_gate = validate_classification(classification)
@@ -776,6 +779,7 @@ async def process(
         "vehicle_type": classification.vehicle_type,
         "classification_confidence": classification.confidence,
         "classification_layer": classification.layer,
+        "classification_model": classification.model_name,
         "governance_critical": gov_critical,
         "governance_flags": gov_flags,
         "metadata": extraction_metadata,
@@ -974,6 +978,7 @@ async def process(
         "vehicle_type": classification.vehicle_type,
         "classification_confidence": classification.confidence,
         "classification_layer": classification.layer,
+        "classification_model": classification.model_name,
         "governance_critical": gov_critical,
         "governance_flags": gov_flags,
         "chunk_count": len(chunks),

--- a/backend/app/core/db/migrations/versions/b2c3d4e5f6a7_add_classification_layer_model_to_.py
+++ b/backend/app/core/db/migrations/versions/b2c3d4e5f6a7_add_classification_layer_model_to_.py
@@ -1,0 +1,23 @@
+"""add classification_layer and classification_model to document_reviews
+
+Revision ID: b2c3d4e5f6a7
+Revises: f5aca0aa8f32
+Create Date: 2026-03-18
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "b2c3d4e5f6a7"
+down_revision = "f5aca0aa8f32"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("document_reviews", sa.Column("classification_layer", sa.Integer(), nullable=True))
+    op.add_column("document_reviews", sa.Column("classification_model", sa.String(100), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("document_reviews", "classification_model")
+    op.drop_column("document_reviews", "classification_layer")

--- a/backend/app/domains/credit/deals/schemas/deals.py
+++ b/backend/app/domains/credit/deals/schemas/deals.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, field_validator, model_validator
 
 from app.domains.credit.deals.enums import DealStage, DealType, RejectionCode
 
@@ -69,6 +69,23 @@ class DealOut(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class CommitteeMemberOut(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    email: str
+    name: str | None = None
+    role: str | None = None  # "ic_member", "observer", "chair"
+
+
+class CommitteeVoteOut(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    email: str
+    vote: str  # "APPROVED", "REJECTED", "ABSTAINED", "PENDING"
+    signed_at: datetime | None = None
+    signer_status: str | None = None  # "signed", "pending", "declined"
+    actor_capacity: str | None = None
+    rationale: str | None = None
+
+
 class ICMemoOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -85,12 +102,20 @@ class ICMemoOut(BaseModel):
     memo_blob_url: str | None
     condition_history: list[dict[str, Any]]
 
-    committee_members: list[dict[str, Any]] | None = None
-    committee_votes: list[dict[str, Any]] | None = None
+    committee_members: list[CommitteeMemberOut] | None = None
+    committee_votes: list[CommitteeVoteOut] | None = None
     esignature_status: str | None = None
 
     created_at: datetime
     updated_at: datetime
+
+    @model_validator(mode="after")
+    def coerce_committee_fields(self) -> "ICMemoOut":
+        if self.committee_votes and isinstance(self.committee_votes[0], dict):
+            self.committee_votes = [CommitteeVoteOut(**v) for v in self.committee_votes]
+        if self.committee_members and isinstance(self.committee_members[0], dict):
+            self.committee_members = [CommitteeMemberOut(**m) for m in self.committee_members]
+        return self
 
 
 class ConditionResolvePayload(BaseModel):

--- a/backend/app/domains/credit/documents/models/review.py
+++ b/backend/app/domains/credit/documents/models/review.py
@@ -98,6 +98,10 @@ class DocumentReview(Base, IdMixin, OrganizationScopedMixin, FundScopedMixin, Au
         comment="Why this was routed to specific reviewers (AI classification, manual, etc.)",
     )
     classification_confidence: Mapped[float | None] = mapped_column(nullable=True)
+    classification_layer: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # 1=rules, 2=embeddings, 3=llm
+    classification_model: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    # e.g. "rules", "embedding-v2", "gpt-4.1-mini"
 
     metadata_json: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)
 

--- a/backend/app/domains/credit/documents/routes/review.py
+++ b/backend/app/domains/credit/documents/routes/review.py
@@ -26,6 +26,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.audit import write_audit_event
+from app.domains.credit.documents.schemas import DocumentReviewListOut, DocumentReviewOut
 from app.core.security.clerk_auth import Actor, get_actor, require_fund_access, require_role
 from app.core.tenancy.middleware import get_db_with_rls
 from app.domains.credit.documents.models.review import (
@@ -205,7 +206,7 @@ async def submit_for_review(
 
 # -- List & Detail -----------------------------------------------------------
 
-@router.get("")
+@router.get("", response_model=DocumentReviewListOut)
 async def list_reviews(
     fund_id: uuid.UUID,
     status: str | None = None,
@@ -232,7 +233,7 @@ async def list_reviews(
     )
     rows = list(result.scalars().all())
 
-    return {"total": total, "reviews": [_review_to_dict(r) for r in rows]}
+    return {"total": total, "reviews": [DocumentReviewOut.model_validate(r) for r in rows]}
 
 
 @router.get("/pending")
@@ -897,5 +898,8 @@ def _review_to_dict(r: DocumentReview) -> dict[str, Any]:
         "revisionCount": r.revision_count,
         "currentRound": r.current_round,
         "routingBasis": r.routing_basis,
+        "classificationConfidence": r.classification_confidence,
+        "classificationLayer": r.classification_layer,
+        "classificationModel": r.classification_model,
         "createdAt": r.created_at.isoformat() if r.created_at else None,
     }

--- a/backend/app/domains/credit/documents/schemas.py
+++ b/backend/app/domains/credit/documents/schemas.py
@@ -67,6 +67,8 @@ class DocumentReviewOut(BaseModel):
 
     routing_basis: str | None = None
     classification_confidence: float | None = None
+    classification_layer: int | None = None
+    classification_model: str | None = None
 
     metadata_json: dict[str, Any] | None = None
 

--- a/backend/app/domains/credit/documents/schemas.py
+++ b/backend/app/domains/credit/documents/schemas.py
@@ -76,6 +76,11 @@ class DocumentReviewOut(BaseModel):
     updated_at: datetime
 
 
+class DocumentReviewListOut(BaseModel):
+    total: int
+    reviews: list[DocumentReviewOut]
+
+
 # ---------------------------------------------------------------------------
 # ReviewAssignment schemas
 # ---------------------------------------------------------------------------

--- a/backend/app/domains/wealth/schemas/analytics.py
+++ b/backend/app/domains/wealth/schemas/analytics.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class BacktestParams(BaseModel):
@@ -24,6 +24,28 @@ class BacktestRequest(BaseModel):
     params: BacktestParams = Field(default_factory=BacktestParams)
 
 
+class BacktestFoldMetrics(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    fold: int
+    train_start: date | None = None
+    train_end: date | None = None
+    test_start: date | None = None
+    test_end: date | None = None
+    sharpe: float | None = None
+    cvar_95: float | None = None
+    max_drawdown: float | None = None
+    n_obs: int = 0
+
+
+class BacktestResultDetail(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    folds: list[BacktestFoldMetrics] = []
+    mean_sharpe: float | None = None
+    std_sharpe: float | None = None
+    positive_folds: int = 0
+    n_splits_computed: int = 0
+
+
 class BacktestRunRead(BaseModel):
     model_config = ConfigDict(from_attributes=True, extra="ignore")
 
@@ -31,11 +53,17 @@ class BacktestRunRead(BaseModel):
     profile: str
     params: dict[str, Any]
     status: str
-    results: dict[str, Any] | None = None
+    results: BacktestResultDetail | None = None
     cv_metrics: dict[str, Any] | None = None
     error_message: str | None = None
     started_at: datetime
     completed_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def coerce_results(self) -> "BacktestRunRead":
+        if self.results and isinstance(self.results, dict):
+            self.results = BacktestResultDetail(**self.results)
+        return self
 
 
 class OptimizeRequest(BaseModel):

--- a/packages/ui/src/types/api.d.ts
+++ b/packages/ui/src/types/api.d.ts
@@ -5129,6 +5129,30 @@ export interface components {
             /** Offset */
             offset: number;
         };
+        /** BacktestFoldMetrics */
+        BacktestFoldMetrics: {
+            /** Fold */
+            fold: number;
+            /** Train Start */
+            train_start?: string | null;
+            /** Train End */
+            train_end?: string | null;
+            /** Test Start */
+            test_start?: string | null;
+            /** Test End */
+            test_end?: string | null;
+            /** Sharpe */
+            sharpe?: number | null;
+            /** Cvar 95 */
+            cvar_95?: number | null;
+            /** Max Drawdown */
+            max_drawdown?: number | null;
+            /**
+             * N Obs
+             * @default 0
+             */
+            n_obs: number;
+        };
         /**
          * BacktestParams
          * @description Typed, bounded parameters for a backtest run.
@@ -5161,6 +5185,28 @@ export interface components {
             profile: string;
             params?: components["schemas"]["BacktestParams"];
         };
+        /** BacktestResultDetail */
+        BacktestResultDetail: {
+            /**
+             * Folds
+             * @default []
+             */
+            folds: components["schemas"]["BacktestFoldMetrics"][];
+            /** Mean Sharpe */
+            mean_sharpe?: number | null;
+            /** Std Sharpe */
+            std_sharpe?: number | null;
+            /**
+             * Positive Folds
+             * @default 0
+             */
+            positive_folds: number;
+            /**
+             * N Splits Computed
+             * @default 0
+             */
+            n_splits_computed: number;
+        };
         /** BacktestRunRead */
         BacktestRunRead: {
             /**
@@ -5176,10 +5222,7 @@ export interface components {
             };
             /** Status */
             status: string;
-            /** Results */
-            results?: {
-                [key: string]: unknown;
-            } | null;
+            results?: components["schemas"]["BacktestResultDetail"] | null;
             /** Cv Metrics */
             cv_metrics?: {
                 [key: string]: unknown;
@@ -5451,6 +5494,30 @@ export interface components {
         CheckItemPayload: {
             /** Notes */
             notes?: string | null;
+        };
+        /** CommitteeMemberOut */
+        CommitteeMemberOut: {
+            /** Email */
+            email: string;
+            /** Name */
+            name?: string | null;
+            /** Role */
+            role?: string | null;
+        };
+        /** CommitteeVoteOut */
+        CommitteeVoteOut: {
+            /** Email */
+            email: string;
+            /** Vote */
+            vote: string;
+            /** Signed At */
+            signed_at?: string | null;
+            /** Signer Status */
+            signer_status?: string | null;
+            /** Actor Capacity */
+            actor_capacity?: string | null;
+            /** Rationale */
+            rationale?: string | null;
         };
         /** ConcentrationRead */
         ConcentrationRead: {
@@ -7061,13 +7128,9 @@ export interface components {
                 [key: string]: unknown;
             }[];
             /** Committee Members */
-            committee_members?: {
-                [key: string]: unknown;
-            }[] | null;
+            committee_members?: components["schemas"]["CommitteeMemberOut"][] | null;
             /** Committee Votes */
-            committee_votes?: {
-                [key: string]: unknown;
-            }[] | null;
+            committee_votes?: components["schemas"]["CommitteeVoteOut"][] | null;
             /** Esignature Status */
             esignature_status?: string | null;
             /**

--- a/packages/ui/src/types/api.d.ts
+++ b/packages/ui/src/types/api.d.ts
@@ -6357,6 +6357,92 @@ export interface components {
              */
             updated_at: string;
         };
+        /** DocumentReviewListOut */
+        DocumentReviewListOut: {
+            /** Total */
+            total: number;
+            /** Reviews */
+            reviews: components["schemas"]["DocumentReviewOut"][];
+        };
+        /** DocumentReviewOut */
+        DocumentReviewOut: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Fund Id
+             * Format: uuid
+             */
+            fund_id: string;
+            /**
+             * Document Id
+             * Format: uuid
+             */
+            document_id: string;
+            /** Document Version Id */
+            document_version_id?: string | null;
+            /** Deal Id */
+            deal_id?: string | null;
+            /** Asset Id */
+            asset_id?: string | null;
+            /** Title */
+            title: string;
+            /** Document Type */
+            document_type: string;
+            /** Status */
+            status: string;
+            /** Priority */
+            priority: string;
+            /** Submitted By */
+            submitted_by: string;
+            /**
+             * Submitted At
+             * Format: date-time
+             */
+            submitted_at: string;
+            /** Due Date */
+            due_date?: string | null;
+            /** Review Notes */
+            review_notes?: string | null;
+            /** Final Decision */
+            final_decision?: string | null;
+            /** Decided By */
+            decided_by?: string | null;
+            /** Decided At */
+            decided_at?: string | null;
+            /** Rationale */
+            rationale?: string | null;
+            /** Actor Capacity */
+            actor_capacity?: string | null;
+            /** Revision Count */
+            revision_count: number;
+            /** Current Round */
+            current_round: number;
+            /** Routing Basis */
+            routing_basis?: string | null;
+            /** Classification Confidence */
+            classification_confidence?: number | null;
+            /** Classification Layer */
+            classification_layer?: number | null;
+            /** Classification Model */
+            classification_model?: string | null;
+            /** Metadata Json */
+            metadata_json?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
         /** DocumentVersionCreate */
         DocumentVersionCreate: {
             /** Version Number */
@@ -14388,9 +14474,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["DocumentReviewListOut"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- **Credit A:** Add `classification_layer` (int) and `classification_model` (str) to `DocumentReview` model + `DocumentReviewOut` schema. Wire hybrid classifier to persist `model_name` per layer (rules/embedding-v2/gpt-4.1-mini). Pipeline writes both fields alongside `classification_confidence`. Migration `b2c3d4e5f6a7`.
- **Credit B:** Type `committee_votes` and `committee_members` in `ICMemoOut` with `CommitteeVoteOut` and `CommitteeMemberOut` schemas. `@model_validator` coerces JSONB dicts. `extra="ignore"` for forward compat.
- **Wealth C:** Type `BacktestRunRead.results` with `BacktestResultDetail` and `BacktestFoldMetrics`. `@model_validator` coerces JSONB. `extra="ignore"` for quant engine evolution.
- **Types:** `api.d.ts` regenerated — `CommitteeVoteOut`, `CommitteeMemberOut`, `BacktestResultDetail`, `BacktestFoldMetrics` confirmed. `classification_layer`/`classification_model` in model+schema but not in TS (review routes use inline dicts — future migration to `response_model`).

## Test plan
- [ ] `alembic upgrade head` applies classification migration cleanly
- [ ] `make check` passes (lint + typecheck + test)
- [ ] Verify `CommitteeVoteOut` coerces JSONB dicts with extra fields without error
- [ ] Verify `BacktestResultDetail` coerces from raw dict with fold data
- [ ] Verify hybrid classifier returns `model_name` per layer
- [ ] Confirm `api.d.ts` has `CommitteeVoteOut`, `CommitteeMemberOut`, `BacktestResultDetail`, `BacktestFoldMetrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)