### PR TITLE
feat(frontend): UX Sprint 4 — governance, drift workbench, config diff

### DIFF
--- a/frontends/admin/package.json
+++ b/frontends/admin/package.json
@@ -14,6 +14,7 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/language": "^6.12.2",
     "@codemirror/lint": "^6.9.5",
+    "@codemirror/merge": "^6.12.1",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.40.0",
     "@lezer/common": "^1.5.1",

--- a/frontends/admin/src/lib/components/ConfigDiffView.svelte
+++ b/frontends/admin/src/lib/components/ConfigDiffView.svelte
@@ -1,0 +1,220 @@
+<!--
+  ConfigDiffView — CodeMirror merge view for config diff (default vs override).
+  Uses @codemirror/merge for split/unified side-by-side rendering.
+  Takes a ConfigDiffOut payload from the API.
+-->
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { SectionCard } from "@netz/ui";
+
+	/** Mirrors components["schemas"]["ConfigDiffOut"] from packages/ui/src/types/api.d.ts */
+	export interface ConfigDiffOut {
+		vertical: string;
+		config_type: string;
+		org_id?: string | null;
+		default: Record<string, unknown>;
+		override?: Record<string, unknown> | null;
+		merged: Record<string, unknown>;
+		changed_keys: string[];
+		tenant_count_affected: number;
+		has_override: boolean;
+		computed_at: string;
+	}
+
+	interface Props {
+		diff: ConfigDiffOut;
+		class?: string;
+	}
+
+	let { diff, class: className }: Props = $props();
+
+	let mergeHost: HTMLDivElement | undefined;
+	let viewMode = $state<"split" | "unified">("split");
+	let mergeView: { destroy: () => void } | undefined;
+
+	// Summary text: count changed keys
+	const summaryText = $derived(
+		diff.changed_keys.length === 0
+			? "Nenhuma propriedade alterada"
+			: diff.changed_keys.length === 1
+				? "1 propriedade alterada"
+				: `${diff.changed_keys.length} propriedades alteradas`,
+	);
+
+	const beforeDoc = $derived(JSON.stringify(diff.default, null, 2));
+	const afterDoc = $derived(JSON.stringify(diff.override ?? diff.default, null, 2));
+	const hasOverride = $derived(diff.override !== null && diff.override !== undefined);
+
+	function buildMergeTheme(EditorView: typeof import("@codemirror/view").EditorView) {
+		return EditorView.theme({
+			"&": {
+				backgroundColor: "var(--netz-surface)",
+				color: "var(--netz-text-primary)",
+				fontSize: "12px",
+				fontFamily:
+					"ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, monospace",
+			},
+			".cm-gutters": {
+				backgroundColor: "var(--netz-surface-alt)",
+				color: "var(--netz-text-secondary)",
+				borderRight: "1px solid var(--netz-border)",
+			},
+			".cm-deletedChunk .cm-deletedLine": {
+				backgroundColor: "color-mix(in srgb, var(--netz-danger) 12%, transparent)",
+			},
+			".cm-insertedChunk .cm-insertedLine": {
+				backgroundColor: "color-mix(in srgb, var(--netz-success) 12%, transparent)",
+			},
+			".cm-changedText": {
+				backgroundColor: "color-mix(in srgb, var(--netz-warning) 20%, transparent)",
+			},
+			".cm-mergeGutter": {
+				backgroundColor: "var(--netz-surface-alt)",
+			},
+		});
+	}
+
+	async function mountView(mode: "split" | "unified") {
+		if (!mergeHost) return;
+
+		// Destroy previous view if any
+		if (mergeView) {
+			mergeView.destroy();
+			mergeView = undefined;
+		}
+
+		mergeHost.innerHTML = "";
+
+		const [{ EditorState }, { EditorView }, { MergeView, unifiedMergeView }, { json }] =
+			await Promise.all([
+				import("@codemirror/state"),
+				import("@codemirror/view"),
+				import("@codemirror/merge"),
+				import("@codemirror/lang-json"),
+			]);
+
+		const theme = buildMergeTheme(EditorView);
+		const sharedExtensions = [json(), theme, EditorState.readOnly.of(true), EditorView.lineWrapping];
+
+		if (mode === "unified") {
+			const view = new EditorView({
+				doc: afterDoc,
+				extensions: [
+					...sharedExtensions,
+					unifiedMergeView({
+						original: beforeDoc,
+						collapseUnchanged: { margin: 3, minSize: 4 },
+					}),
+				],
+				parent: mergeHost,
+			});
+			mergeView = view;
+		} else {
+			const view = new MergeView({
+				a: {
+					doc: beforeDoc,
+					extensions: [...sharedExtensions],
+				},
+				b: {
+					doc: afterDoc,
+					extensions: [...sharedExtensions],
+				},
+				parent: mergeHost,
+				collapseUnchanged: { margin: 3, minSize: 4 },
+			});
+			mergeView = view;
+		}
+	}
+
+	$effect(() => {
+		if (mergeHost) {
+			void mountView(viewMode);
+		}
+	});
+
+	// Re-mount when diff content changes
+	$effect(() => {
+		// Depend on the actual content to trigger re-mount
+		const _before = beforeDoc;
+		const _after = afterDoc;
+		if (mergeView && mergeHost) {
+			void mountView(viewMode);
+		}
+	});
+
+	onMount(() => {
+		return () => {
+			if (mergeView) {
+				mergeView.destroy();
+				mergeView = undefined;
+			}
+		};
+	});
+</script>
+
+<SectionCard title="Diff — {diff.config_type}" class={className}>
+	<div class="space-y-4">
+		<!-- Summary + toggle row -->
+		<div class="flex items-center justify-between">
+			<div class="space-y-1">
+				<p
+					class="text-sm font-medium {diff.changed_keys.length > 0
+						? 'text-[var(--netz-text-primary)]'
+						: 'text-[var(--netz-text-secondary)]'}"
+				>
+					{summaryText}
+				</p>
+				{#if diff.changed_keys.length > 0}
+					<div class="flex flex-wrap gap-1">
+						{#each diff.changed_keys as key}
+							<span
+								class="rounded-full border border-[var(--netz-border)] bg-[var(--netz-surface-alt)] px-2 py-0.5 font-mono text-xs text-[var(--netz-text-secondary)]"
+							>
+								{key}
+							</span>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<div class="flex shrink-0 gap-1 rounded-md border border-[var(--netz-border)] p-0.5">
+				<button
+					onclick={() => (viewMode = "split")}
+					class="rounded px-3 py-1 text-xs font-medium transition-colors {viewMode === 'split'
+						? 'bg-[var(--netz-brand-primary)] text-white'
+						: 'text-[var(--netz-text-secondary)] hover:bg-[var(--netz-surface-alt)]'}"
+				>
+					Split
+				</button>
+				<button
+					onclick={() => (viewMode = "unified")}
+					class="rounded px-3 py-1 text-xs font-medium transition-colors {viewMode === 'unified'
+						? 'bg-[var(--netz-brand-primary)] text-white'
+						: 'text-[var(--netz-text-secondary)] hover:bg-[var(--netz-surface-alt)]'}"
+				>
+					Unified
+				</button>
+			</div>
+		</div>
+
+		<!-- Column headers for split view -->
+		{#if viewMode === "split"}
+			<div class="grid grid-cols-2 gap-px">
+				<p class="text-xs font-medium uppercase tracking-[0.14em] text-[var(--netz-text-secondary)]">
+					Default
+				</p>
+				<p class="text-xs font-medium uppercase tracking-[0.14em] text-[var(--netz-text-secondary)]">
+					{hasOverride ? "Override" : "No override — showing default"}
+				</p>
+			</div>
+		{/if}
+
+		<!-- Merge view host -->
+		<div
+			bind:this={mergeHost}
+			class="overflow-hidden rounded-xl border border-[var(--netz-border)] bg-[var(--netz-surface)]"
+			style="min-height: 200px;"
+			aria-label="Config diff viewer"
+		></div>
+	</div>
+</SectionCard>

--- a/frontends/admin/src/lib/components/ConfigEditor.svelte
+++ b/frontends/admin/src/lib/components/ConfigEditor.svelte
@@ -1,9 +1,25 @@
 <!--
-  Config Editor — JSON textarea with validation, save (PUT), delete, update default.
+  Config Editor — CodeMirror JSON editor with consequence-aware save,
+  inline diff view, and audit trail panel.
+  Section 3.Admin.1 — consequence-aware config editing.
 -->
 <script lang="ts">
-	import { SectionCard, ActionButton, ConfirmDialog, Button } from "@netz/ui";
+	import {
+		SectionCard,
+		ActionButton,
+		Button,
+		ConsequenceDialog,
+		AuditTrailPanel,
+	} from "@netz/ui";
+	import type {
+		ConsequenceDialogPayload,
+		ConsequenceDialogMetadataItem,
+		AuditTrailEntry,
+	} from "@netz/ui";
 	import { createClientApiClient } from "$lib/api/client";
+	import CodeEditor from "./CodeEditor.svelte";
+	import ConfigDiffView from "./ConfigDiffView.svelte";
+	import type { ConfigDiffOut } from "./ConfigDiffView.svelte";
 
 	let {
 		vertical,
@@ -30,15 +46,61 @@
 	let content = $state("{}");
 	let version = $state(0);
 	let isDefault = $state(true);
-	let jsonError = $state<string | null>(null);
 	let saveError = $state<string | null>(null);
 	let saveMessage = $state<string | null>(null);
 	let saving = $state(false);
 	let loading = $state(true);
+
+	// Diff state
+	let diff = $state<ConfigDiffOut | null>(null);
+	let diffLoading = $state(false);
+	let diffError = $state<string | null>(null);
+
+	// Consequence dialog state
+	let showSaveDialog = $state(false);
+	let showDefaultDialog = $state(false);
 	let showDeleteConfirm = $state(false);
-	let showDefaultConfirm = $state(false);
+
+	// Audit trail state
+	let auditEntries = $state<AuditTrailEntry[]>([]);
 
 	const api = createClientApiClient(() => Promise.resolve(token));
+
+	// ── Derived: diff metadata for ConsequenceDialog ────────────────────────
+
+	const saveMetadata = $derived<ConsequenceDialogMetadataItem[]>([
+		{ label: "Vertical", value: vertical },
+		{ label: "Config type", value: configType },
+		{ label: "Scope", value: scopeLabel, emphasis: true },
+		...(diff
+			? [
+					{
+						label: "Changed keys",
+						value:
+							diff.changed_keys.length > 0
+								? diff.changed_keys.join(", ")
+								: "No keys changed",
+					},
+					{
+						label: "Tenants affected",
+						value: String(diff.tenant_count_affected),
+						emphasis: diff.tenant_count_affected > 1,
+					},
+				]
+			: []),
+	]);
+
+	const defaultMetadata = $derived<ConsequenceDialogMetadataItem[]>([
+		{ label: "Vertical", value: vertical },
+		{ label: "Config type", value: configType },
+		{
+			label: "Scope",
+			value: "ALL tenants without overrides",
+			emphasis: true,
+		},
+	]);
+
+	// ── Loaders ─────────────────────────────────────────────────────────────
 
 	async function loadConfig() {
 		loading = true;
@@ -56,7 +118,6 @@
 			content = JSON.stringify(result.config, null, 2);
 			version = result.version ?? 0;
 			isDefault = result.is_default ?? true;
-			jsonError = null;
 		} catch (e) {
 			saveError = "Failed to load config";
 		} finally {
@@ -64,18 +125,60 @@
 		}
 	}
 
-	function validateJson(value: string) {
+	async function loadDiff() {
+		if (!orgId) return;
+		diffLoading = true;
+		diffError = null;
 		try {
-			JSON.parse(value);
-			jsonError = null;
-		} catch {
-			jsonError = "Invalid JSON";
+			diff = await api.get<ConfigDiffOut>(
+				`/admin/configs/${vertical}/${configType}/diff`,
+				{ org_id: orgId },
+			);
+		} catch (e: unknown) {
+			diffError = e instanceof Error ? e.message : "Failed to load diff";
+		} finally {
+			diffLoading = false;
 		}
-		content = value;
 	}
 
-	async function save() {
-		if (jsonError || !orgId) return;
+	async function loadAuditTrail() {
+		try {
+			const result = await api.get<{ events: Array<{
+				id: string;
+				actor_id: string;
+				actor_roles: string[];
+				action: string;
+				entity_type: string;
+				entity_id: string;
+				created_at: string;
+				before_state: Record<string, unknown> | null;
+				after_state: Record<string, unknown> | null;
+			}> }>(`/admin/audit`, {
+				entity_type: "Config",
+				action: "UPDATE",
+				...(orgId ? { organization_id: orgId } : {}),
+			});
+			auditEntries = result.events.map((ev) => ({
+				id: ev.id,
+				actor: ev.actor_id,
+				actorCapacity: ev.actor_roles.join(", ") || undefined,
+				timestamp: ev.created_at,
+				action: `${ev.action} — ${ev.entity_type}`,
+				scope: `${vertical}/${configType}`,
+				outcome: ev.after_state ? "Applied" : "Reverted",
+				status: "success" as const,
+				immutable: true,
+				sourceSystem: "config-editor",
+			}));
+		} catch {
+			// Audit trail is optional — failing silently is acceptable
+		}
+	}
+
+	// ── Mutations ────────────────────────────────────────────────────────────
+
+	async function save(_payload: ConsequenceDialogPayload) {
+		if (!orgId) return;
 		saving = true;
 		saveError = null;
 		saveMessage = null;
@@ -88,7 +191,7 @@
 			);
 			saveMessage = "Saved successfully";
 			setTimeout(() => (saveMessage = null), 3000);
-			await loadConfig(); // Reload to get new version
+			await Promise.allSettled([loadConfig(), loadDiff(), loadAuditTrail()]);
 		} catch (e: unknown) {
 			if (e instanceof Error) {
 				if (e.message.includes("409") || e.message.includes("modified")) {
@@ -102,6 +205,7 @@
 			} else {
 				saveError = "Save failed";
 			}
+			throw e; // Let ConsequenceDialog stay open on failure
 		} finally {
 			saving = false;
 		}
@@ -113,57 +217,50 @@
 			await api.delete(`/admin/configs/${vertical}/${configType}?org_id=${orgId}`);
 			saveMessage = "Override deleted — reverted to default";
 			setTimeout(() => (saveMessage = null), 3000);
-			await loadConfig();
+			await Promise.allSettled([loadConfig(), loadDiff(), loadAuditTrail()]);
 		} catch (e) {
 			saveError = e instanceof Error ? e.message : "Delete failed";
 		}
 	}
 
-	async function updateDefault() {
-		if (jsonError) return;
+	async function updateDefault(_payload: ConsequenceDialogPayload) {
 		try {
 			const parsed = JSON.parse(content);
 			await api.put(`/admin/configs/defaults/${vertical}/${configType}`, parsed);
 			saveMessage = "Default updated";
 			setTimeout(() => (saveMessage = null), 3000);
+			await Promise.allSettled([loadDiff(), loadAuditTrail()]);
 		} catch (e) {
 			saveError = e instanceof Error ? e.message : "Update default failed";
+			throw e;
 		}
 	}
+
+	// ── Effects ──────────────────────────────────────────────────────────────
 
 	$effect(() => {
 		const _v = vertical;
 		const _c = configType;
 		void loadConfig();
+		void loadDiff();
+		void loadAuditTrail();
 	});
-
-	const jsonValid = $derived(jsonError === null);
 </script>
 
 <SectionCard title="{configType} — {isDefault ? 'Default' : `Override (v${version})`}">
 	{#if loading}
 		<p class="text-sm text-[var(--netz-text-muted)]">Loading...</p>
 	{:else}
-		<div class="space-y-3">
-			<div class="flex items-center gap-2">
-				<span
-					class="h-2 w-2 rounded-full {jsonValid ? 'bg-green-500' : 'bg-red-500'}"
-				></span>
-				<span class="text-xs text-[var(--netz-text-muted)]">
-					{jsonValid ? "Valid JSON" : jsonError}
-				</span>
-			</div>
-
-			<textarea
-				value={content}
-				oninput={(e) => validateJson(e.currentTarget.value)}
-				rows={20}
-				class="w-full rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] p-3 font-mono text-xs text-[var(--netz-text-primary)] focus:border-[var(--netz-brand-primary)] focus:outline-none"
-				spellcheck="false"
-			></textarea>
+		<div class="space-y-4">
+			<!-- CodeMirror JSON editor (replaces textarea) -->
+			<CodeEditor
+				bind:value={content}
+				schema={{}}
+				ariaLabel="{configType} config JSON editor"
+			/>
 
 			{#if saveError}
-				<p class="text-xs text-[var(--netz-danger)]">{saveError}</p>
+				<p role="alert" class="text-xs text-[var(--netz-danger)]">{saveError}</p>
 			{/if}
 			{#if saveMessage}
 				<p class="text-xs text-[var(--netz-brand-primary)]">{saveMessage}</p>
@@ -172,20 +269,32 @@
 			<div class="flex items-center justify-between">
 				<div class="flex gap-2">
 					{#if !isDefault}
-						<Button variant="destructive" size="sm" onclick={() => (showDeleteConfirm = true)}>
+						<Button
+							variant="destructive"
+							size="sm"
+							onclick={() => (showDeleteConfirm = true)}
+						>
 							Revert to Default
 						</Button>
 					{/if}
-					<Button variant="ghost" size="sm" onclick={() => (showDefaultConfirm = true)} disabled={!jsonValid}>
+					<Button
+						variant="ghost"
+						size="sm"
+						onclick={() => (showDefaultDialog = true)}
+					>
 						Update Default for ALL tenants
 					</Button>
 				</div>
 				<div class="flex gap-2">
-					<Button variant="outline" onclick={() => loadConfig()}>
+					<Button variant="outline" onclick={() => void loadConfig()}>
 						Reset
 					</Button>
 					{#if orgId}
-						<ActionButton onclick={save} loading={saving} loadingText="Saving..." disabled={!jsonValid}>
+						<ActionButton
+							onclick={() => (showSaveDialog = true)}
+							loading={saving}
+							loadingText="Saving..."
+						>
 							Save Override for {tenantName ?? "this tenant"}
 						</ActionButton>
 					{/if}
@@ -195,20 +304,97 @@
 	{/if}
 </SectionCard>
 
-<ConfirmDialog
-	bind:open={showDeleteConfirm}
-	title="Revert to Default"
-	message="This will delete the config override for {scopeLabel} and revert to the global default. Continue?"
-	confirmLabel="Revert for {tenantName ?? 'this tenant'}"
-	confirmVariant="destructive"
-	onConfirm={deleteOverride}
+<!-- Inline diff view (shown when orgId is available) -->
+{#if orgId && diff}
+	<ConfigDiffView {diff} />
+{:else if orgId && diffLoading}
+	<SectionCard title="Diff — {configType}">
+		<p class="text-sm text-[var(--netz-text-muted)]">Loading diff...</p>
+	</SectionCard>
+{:else if orgId && diffError}
+	<SectionCard title="Diff — {configType}">
+		<p class="text-sm text-[var(--netz-danger)]">{diffError}</p>
+	</SectionCard>
+{/if}
+
+<!-- Audit trail panel -->
+<AuditTrailPanel
+	title="Config audit trail"
+	description="Record of consequential config changes for {vertical}/{configType}."
+	entries={auditEntries}
 />
 
-<ConfirmDialog
-	bind:open={showDefaultConfirm}
+<!-- Save override consequence dialog -->
+<ConsequenceDialog
+	bind:open={showSaveDialog}
+	title="Save Config Override"
+	impactSummary="You are about to save a config override for {scopeLabel}. Review the changes below before confirming."
+	scopeText="{configType} override for {scopeLabel}"
+	destructive={false}
+	requireRationale={true}
+	rationaleLabel="Reason for change"
+	rationalePlaceholder="Describe the operational or policy basis for this config change."
+	metadata={saveMetadata}
+	onConfirm={save}
+>
+	{#snippet consequenceList()}
+		<ul class="list-disc space-y-1 pl-4 text-sm">
+			<li>The override will take effect immediately for {scopeLabel}</li>
+			{#if diff && diff.changed_keys.length > 0}
+				<li>
+					{diff.changed_keys.length} propert{diff.changed_keys.length === 1 ? "y" : "ies"} will be changed: {diff.changed_keys.join(", ")}
+				</li>
+			{/if}
+			{#if diff && diff.tenant_count_affected > 1}
+				<li class="font-medium text-[var(--netz-warning)]">
+					This will affect {diff.tenant_count_affected} tenants
+				</li>
+			{/if}
+		</ul>
+	{/snippet}
+</ConsequenceDialog>
+
+<!-- Update default consequence dialog -->
+<ConsequenceDialog
+	bind:open={showDefaultDialog}
 	title="Update Global Default — affects ALL tenants"
-	message="This will update the global default {configType} config for ALL tenants without overrides. Every tenant using the default will receive this change immediately."
-	confirmLabel="Update Default for ALL tenants"
-	confirmVariant="destructive"
+	impactSummary="This will update the global default {configType} config. Every tenant using the default will receive this change immediately."
+	scopeText="Global default — applies to all tenants without overrides"
+	destructive={true}
+	requireRationale={true}
+	rationaleLabel="Reason for global default change"
+	rationalePlaceholder="Describe the operational or policy basis for changing the global default."
+	typedConfirmationText="UPDATE DEFAULT"
+	typedConfirmationLabel="Type UPDATE DEFAULT to confirm"
+	metadata={defaultMetadata}
 	onConfirm={updateDefault}
-/>
+>
+	{#snippet consequenceList()}
+		<ul class="list-disc space-y-1 pl-4 text-sm">
+			<li class="font-medium text-[var(--netz-danger)]">
+				ALL tenants without overrides will be affected immediately
+			</li>
+			<li>This change cannot be undone automatically — a new default must be set to revert</li>
+			<li>Tenants with overrides will not be affected</li>
+		</ul>
+	{/snippet}
+</ConsequenceDialog>
+
+<!-- Delete/revert consequence dialog (using ConsequenceDialog for consistency) -->
+<ConsequenceDialog
+	bind:open={showDeleteConfirm}
+	title="Revert to Default"
+	impactSummary="This will delete the config override for {scopeLabel} and revert to the global default."
+	scopeText="{configType} override for {scopeLabel}"
+	destructive={true}
+	requireRationale={false}
+	confirmLabel="Revert for {tenantName ?? 'this tenant'}"
+	onConfirm={deleteOverride}
+>
+	{#snippet consequenceList()}
+		<ul class="list-disc space-y-1 pl-4 text-sm">
+			<li>The override for {scopeLabel} will be permanently deleted</li>
+			<li>The tenant will revert to the global default immediately</li>
+		</ul>
+	{/snippet}
+</ConsequenceDialog>

--- a/frontends/admin/src/routes/(admin)/config/[vertical=vertical]/+page.svelte
+++ b/frontends/admin/src/routes/(admin)/config/[vertical=vertical]/+page.svelte
@@ -1,15 +1,14 @@
 <!--
-  Config Editor — JSON config editor with guardrail validation, diff viewer, and invalid overrides.
+  Config Editor page — JSON config editor with guardrail validation, consequence-aware
+  save, inline diff view, and audit trail. Section 3.Admin.1.
 -->
 <script lang="ts">
 	import { SectionCard, StatusBadge, EmptyState } from "@netz/ui";
 	import type { PageData } from "./$types";
 	import ConfigEditor from "$lib/components/ConfigEditor.svelte";
-	import ConfigDiffViewer from "$lib/components/ConfigDiffViewer.svelte";
 
 	let { data }: { data: PageData } = $props();
 	let selectedConfig = $state<string | null>(null);
-	let showDiff = $state(false);
 </script>
 
 <div class="space-y-6 p-6">
@@ -45,7 +44,6 @@
 					<button
 						onclick={() => {
 							selectedConfig = invalid.config_type;
-							showDiff = false;
 						}}
 						class="flex w-full items-center gap-3 rounded-md border border-[var(--netz-danger)]/30 bg-[var(--netz-danger)]/5 px-4 py-2 text-left hover:bg-[var(--netz-danger)]/10"
 					>
@@ -72,7 +70,6 @@
 					<button
 						onclick={() => {
 							selectedConfig = config.config_type;
-							showDiff = false;
 						}}
 						class="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-[var(--netz-surface-alt)] {selectedConfig === config.config_type ? 'bg-[var(--netz-surface-alt)]' : ''}"
 					>
@@ -97,29 +94,16 @@
 		</SectionCard>
 	{:else}
 		<SectionCard title="Config Types">
-			<EmptyState message="No config types found for {data.vertical}." />
+			<EmptyState title="No config types" message="No config types found for {data.vertical}." />
 		</SectionCard>
 	{/if}
 
-	<!-- Config Editor Panel -->
+	<!-- Config Editor Panel — diff view and audit trail rendered inline by ConfigEditor -->
 	{#if selectedConfig}
-		<ConfigEditor vertical={data.vertical} configType={selectedConfig} token={data.token} />
-
-		<div class="flex justify-start">
-			<button
-				onclick={() => (showDiff = !showDiff)}
-				class="text-sm text-[var(--netz-brand-primary)] hover:underline"
-			>
-				{showDiff ? "Hide Diff" : "Show Diff"}
-			</button>
-		</div>
-
-		{#if showDiff}
-			<ConfigDiffViewer
-				vertical={data.vertical}
-				configType={selectedConfig}
-				token={data.token}
-			/>
-		{/if}
+		<ConfigEditor
+			vertical={data.vertical}
+			configType={selectedConfig}
+			token={data.token}
+		/>
 	{/if}
 </div>

--- a/frontends/credit/src/routes/(team)/funds/[fundId]/documents/reviews/[reviewId]/+page.svelte
+++ b/frontends/credit/src/routes/(team)/funds/[fundId]/documents/reviews/[reviewId]/+page.svelte
@@ -9,7 +9,7 @@
 	import { createOptimisticMutation } from "@netz/ui";
 	import type { AuditTrailEntry } from "@netz/ui";
 	import type { PageData } from "./$types";
-	import type { ReviewDetail, ReviewChecklist } from "$lib/types/api";
+	import type { ReviewChecklist } from "$lib/types/api";
 	import { createClientApiClient } from "$lib/api/client";
 	import { invalidateAll } from "$app/navigation";
 	import { getContext } from "svelte";
@@ -18,12 +18,70 @@
 
 	let { data }: { data: PageData } = $props();
 
-	let review = $derived(data.review as ReviewDetail);
+	// Typed shape from DocumentReviewOut in packages/ui/src/types/api.d.ts
+	interface DocumentReviewOut {
+		document_title?: string | null;
+		title?: string | null;
+		status: string;
+		assignments?: Array<{ reviewer_name?: string | null; decision?: string | null }>;
+		final_decision?: string | null;
+		decided_by?: string | null;
+		decided_at?: string | null;
+		rationale?: string | null;
+		actor_capacity?: string | null;
+		submitted_by?: string;
+		submitted_at?: string;
+	}
+
+	let review = $derived(data.review as DocumentReviewOut);
 	let checklist = $derived((data.checklist as ReviewChecklist)?.items ?? []);
 	let actionError = $state<string | null>(null);
 
-	// ── Audit Trail ──
-	let auditEntries = $state<AuditTrailEntry[]>([]);
+	// ── Audit Trail — initialize from DocumentReviewOut decision fields ──
+	function buildInitialAuditEntries(): AuditTrailEntry[] {
+		const entries: AuditTrailEntry[] = [];
+		const r = data.review as DocumentReviewOut;
+
+		// Submission event
+		if (r?.submitted_at) {
+			entries.push({
+				actor: r.submitted_by ?? "Submitter",
+				timestamp: r.submitted_at,
+				action: "Review Submitted",
+				scope: `Review: ${String(r.title ?? r.document_title ?? data.reviewId)}`,
+				outcome: "Submitted",
+				immutable: true,
+				status: "success",
+			});
+		}
+
+		// Decision event (if already decided)
+		if (r?.final_decision && r.decided_at) {
+			const decisionLabel =
+				r.final_decision === "APPROVED"
+					? "Review Approved"
+					: r.final_decision === "REJECTED"
+						? "Review Rejected"
+						: r.final_decision === "REVISION_REQUESTED"
+							? "Revision Requested"
+							: r.final_decision;
+			entries.push({
+				actor: r.decided_by ?? "Reviewer",
+				actorCapacity: r.actor_capacity ?? undefined,
+				timestamp: r.decided_at,
+				action: decisionLabel,
+				scope: `Review: ${String(r.title ?? r.document_title ?? data.reviewId)}`,
+				rationale: r.rationale ?? undefined,
+				outcome: decisionLabel,
+				immutable: true,
+				status: "success",
+			});
+		}
+
+		return entries;
+	}
+
+	let auditEntries = $state<AuditTrailEntry[]>(buildInitialAuditEntries());
 
 	const auditMutation = createOptimisticMutation<AuditTrailEntry[]>({
 		getState: () => auditEntries,
@@ -76,17 +134,18 @@
 			actorCapacity: decisionActorCapacity || undefined,
 			timestamp: new Date().toISOString(),
 			action: decisionLabel,
-			scope: `Review: ${String(review?.document_title ?? data.reviewId)}`,
+			scope: `Review: ${String(review?.title ?? review?.document_title ?? data.reviewId)}`,
 			rationale,
 			outcome: "Pending",
 		});
 
 		try {
 			const api = createClientApiClient(getToken);
-			// ReviewDecisionPayload: { decision: string; comments?: string | null }
-			// rationale maps to comments — actor_capacity is audit-local only
+			// ReviewDecisionPayload: { decision, rationale, actor_capacity, comments? }
 			await api.post(`/funds/${data.fundId}/document-reviews/${data.reviewId}/decide`, {
 				decision,
+				rationale,
+				actor_capacity: decisionActorCapacity,
 				comments: rationale || null,
 			});
 			showDecisionDialog = false;
@@ -213,7 +272,7 @@
 				actor: "You",
 				timestamp: new Date().toISOString(),
 				action: "Checklist Item Unchecked",
-				scope: `Review: ${String(review?.document_title ?? data.reviewId)}`,
+				scope: `Review: ${String(review?.title ?? review?.document_title ?? data.reviewId)}`,
 				rationale,
 				outcome: "Checklist Reversed",
 				status: "warning",
@@ -255,7 +314,7 @@
 	<div class="mb-4 flex items-center justify-between">
 		<div>
 			<h2 class="text-xl font-semibold text-[var(--netz-text-primary)]">
-				{review.document_title ?? "Review"}
+				{review.title ?? review.document_title ?? "Review"}
 			</h2>
 			<StatusBadge status={status} type="review" />
 		</div>
@@ -393,7 +452,7 @@
 				: "Request Revision"
 	}
 	metadata={[
-		{ label: "Document", value: String(review?.document_title ?? "—"), emphasis: true },
+		{ label: "Document", value: String(review?.title ?? review?.document_title ?? "—"), emphasis: true },
 		{ label: "Decision", value: pendingDecision ?? "—" },
 	]}
 	onConfirm={submitDecision}
@@ -421,7 +480,7 @@
 <ConsequenceDialog
 	bind:open={showUncheckDialog}
 	title="Reverse Checklist Item"
-	impactSummary="Unchecking a completed checklist item will mark it as incomplete. This reversal will be recorded in the audit trail. Provide a rationale for the reversal."
+	impactSummary="Reverter este item exige justificativa. Unchecking a completed checklist item will mark it as incomplete. This reversal will be recorded in the audit trail."
 	destructive={false}
 	requireRationale={true}
 	rationaleLabel="Reversal Rationale"

--- a/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/[dealId]/+page.svelte
+++ b/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/[dealId]/+page.svelte
@@ -4,11 +4,12 @@
   Overview tab shows deal actions (decide, resolve conditions, convert).
 -->
 <script lang="ts">
-	import { PageTabs, Card, StatusBadge, Button, EmptyState } from "@netz/ui";
+	import { PageTabs, Card, StatusBadge, Button, EmptyState, MetricCard } from "@netz/ui";
 	import { ActionButton, FormField } from "@netz/ui";
 	import { ConsequenceDialog, AuditTrailPanel } from "@netz/ui";
 	import { createOptimisticMutation } from "@netz/ui";
 	import type { AuditTrailEntry } from "@netz/ui";
+	import { formatNumber, formatBps, formatRatio } from "@netz/ui";
 	import DealStageTimeline from "$lib/components/DealStageTimeline.svelte";
 	import ICMemoViewer from "$lib/components/ICMemoViewer.svelte";
 	import { goto, invalidateAll } from "$app/navigation";
@@ -341,6 +342,47 @@
 					{/if}
 				</div>
 			</Card>
+
+			<!-- Financial Terms — fields from app__domains__credit__deals__schemas__deals__DealOut -->
+			{#if data.deal.tenor_months != null || data.deal.spread_bps != null || data.deal.ltv_ratio != null || data.deal.covenant_type != null || data.deal.collateral_description != null || data.deal.agreement_language != null}
+				<Card class="mt-4 p-6">
+					<h3 class="mb-4 text-lg font-semibold">Financial Terms</h3>
+					<!-- Numeric KPIs via MetricCard -->
+					<div class="mb-4 grid gap-4 md:grid-cols-3">
+						<MetricCard
+							label="Tenor"
+							value={data.deal.tenor_months != null ? formatNumber(Number(data.deal.tenor_months), 0) + " mo" : "—"}
+						/>
+						<MetricCard
+							label="Spread"
+							value={data.deal.spread_bps != null ? formatBps(Number(data.deal.spread_bps) / 10_000) : "—"}
+						/>
+						<MetricCard
+							label="LTV Ratio"
+							value={data.deal.ltv_ratio != null ? formatRatio(parseFloat(String(data.deal.ltv_ratio))) : "—"}
+						/>
+					</div>
+					<!-- Text fields -->
+					<div class="grid gap-4 md:grid-cols-2">
+						<div>
+							<p class="text-xs text-[var(--netz-text-muted)]">Covenant Type</p>
+							<p class="text-sm font-medium">{data.deal.covenant_type ?? "—"}</p>
+						</div>
+						<div>
+							<p class="text-xs text-[var(--netz-text-muted)]">Covenant Frequency</p>
+							<p class="text-sm font-medium">{data.deal.covenant_frequency ?? "—"}</p>
+						</div>
+						<div class="md:col-span-2">
+							<p class="text-xs text-[var(--netz-text-muted)]">Collateral Description</p>
+							<p class="text-sm font-medium">{data.deal.collateral_description ?? "—"}</p>
+						</div>
+						<div>
+							<p class="text-xs text-[var(--netz-text-muted)]">Agreement Language</p>
+							<p class="text-sm font-medium">{data.deal.agreement_language ?? "—"}</p>
+						</div>
+					</div>
+				</Card>
+			{/if}
 
 		{:else if activeTab === "conditions"}
 			{#if conditions.length === 0}

--- a/frontends/wealth/src/lib/components/DriftHistoryPanel.svelte
+++ b/frontends/wealth/src/lib/components/DriftHistoryPanel.svelte
@@ -16,10 +16,34 @@
 	import { ChartContainer } from "@netz/ui/charts";
 	import { createClientApiClient } from "$lib/api/client";
 	import { getContext } from "svelte";
-	import type { components } from "@netz/ui/types/api";
 
-	type DriftEvent = components["schemas"]["DriftEventOut"];
-	type DriftHistory = components["schemas"]["DriftHistoryOut"];
+	// Inline types from API schema (DriftEventOut / DriftHistoryOut)
+	type DriftEvent = {
+		id: string;
+		instrument_id: string;
+		status: string;
+		severity: string;
+		anomalous_count: number;
+		total_metrics: number;
+		metric_details?: Record<string, unknown>[] | null;
+		is_current: boolean;
+		detected_at: string;
+		created_at?: string | null;
+		snapshot_date?: string | null;
+		drift_magnitude?: string | null;
+		drift_threshold?: string | null;
+		rebalance_triggered?: boolean | null;
+		breached: boolean;
+		asset_class_breakdown?: Record<string, unknown>[] | null;
+	};
+
+	type DriftHistory = {
+		instrument_id: string;
+		instrument_name: string;
+		events: DriftEvent[];
+		total: number;
+		computed_at?: string | null;
+	};
 
 	interface Props {
 		instrumentId: string;
@@ -107,7 +131,8 @@
 				return v === true ? "Yes" : v === false ? "No" : "—";
 			},
 		},
-	] as import("@tanstack/svelte-table").ColumnDef<Record<string, unknown>, unknown>[];
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	] as any[];
 
 	// ── Scatter chart option ────────────────────────────────────
 	let scatterOption = $derived.by(() => {

--- a/frontends/wealth/src/lib/components/DriftHistoryPanel.svelte
+++ b/frontends/wealth/src/lib/components/DriftHistoryPanel.svelte
@@ -1,0 +1,351 @@
+<!--
+  DriftHistoryPanel — lazy-loaded drift event workbench.
+  Fetches GET /analytics/strategy-drift/{instrument_id}/history.
+  Renders a scatter chart (drift_magnitude × detected_at) + DataTable with row expansion.
+  Supports severity filter, date range filter, and client-side CSV export.
+-->
+<script lang="ts">
+	import { onMount } from "svelte";
+	import {
+		DataTable,
+		EmptyState,
+		StatusBadge,
+		formatDateTime,
+		formatNumber,
+	} from "@netz/ui";
+	import { ChartContainer } from "@netz/ui/charts";
+	import { createClientApiClient } from "$lib/api/client";
+	import { getContext } from "svelte";
+	import type { components } from "@netz/ui/types/api";
+
+	type DriftEvent = components["schemas"]["DriftEventOut"];
+	type DriftHistory = components["schemas"]["DriftHistoryOut"];
+
+	interface Props {
+		instrumentId: string;
+		instrumentName?: string;
+	}
+
+	let { instrumentId, instrumentName = "Instrument" }: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+
+	// ── Data ───────────────────────────────────────────────────
+	let events = $state.raw<DriftEvent[]>([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let computedAt = $state<string | null>(null);
+
+	// ── Filters ────────────────────────────────────────────────
+	let filterSeverity = $state<string>("");
+	let filterFrom = $state<string>("");
+	let filterTo = $state<string>("");
+
+	// ── Derived: filtered events ────────────────────────────────
+	let filteredEvents = $derived.by(() => {
+		let result = events;
+		if (filterSeverity) {
+			result = result.filter((e) => e.severity === filterSeverity);
+		}
+		if (filterFrom) {
+			const from = new Date(filterFrom).getTime();
+			result = result.filter((e) => new Date(e.detected_at).getTime() >= from);
+		}
+		if (filterTo) {
+			const to = new Date(filterTo).getTime();
+			result = result.filter((e) => new Date(e.detected_at).getTime() <= to);
+		}
+		return result;
+	});
+
+	// ── Unique severities for filter select ────────────────────
+	let severities = $derived(
+		[...new Set(events.map((e) => e.severity))].filter(Boolean).sort(),
+	);
+
+	// ── Table columns ───────────────────────────────────────────
+	const columns = [
+		{
+			id: "detected_at",
+			accessorKey: "detected_at",
+			header: "Detected At",
+			cell: (info: { getValue: () => unknown }) => formatDateTime(info.getValue() as string),
+		},
+		{
+			id: "severity",
+			accessorKey: "severity",
+			header: "Severity",
+		},
+		{
+			id: "status",
+			accessorKey: "status",
+			header: "Status",
+		},
+		{
+			id: "anomalous_count",
+			accessorKey: "anomalous_count",
+			header: "Anomalous",
+			cell: (info: { getValue: () => unknown }) => String(info.getValue() ?? "—"),
+		},
+		{
+			id: "drift_magnitude",
+			accessorKey: "drift_magnitude",
+			header: "Drift Magnitude",
+			cell: (info: { getValue: () => unknown }) => {
+				const v = info.getValue();
+				if (v == null) return "—";
+				const num = typeof v === "string" ? parseFloat(v) : (v as number);
+				return isNaN(num) ? "—" : formatNumber(num, 4);
+			},
+		},
+		{
+			id: "rebalance_triggered",
+			accessorKey: "rebalance_triggered",
+			header: "Rebalance",
+			cell: (info: { getValue: () => unknown }) => {
+				const v = info.getValue();
+				return v === true ? "Yes" : v === false ? "No" : "—";
+			},
+		},
+	] as import("@tanstack/svelte-table").ColumnDef<Record<string, unknown>, unknown>[];
+
+	// ── Scatter chart option ────────────────────────────────────
+	let scatterOption = $derived.by(() => {
+		const pts = filteredEvents
+			.filter((e) => e.drift_magnitude != null)
+			.map((e) => {
+				const mag = typeof e.drift_magnitude === "string"
+					? parseFloat(e.drift_magnitude)
+					: (e.drift_magnitude as number | null | undefined);
+				return [new Date(e.detected_at).getTime(), mag ?? 0, e.severity] as [number, number, string];
+			});
+
+		if (pts.length === 0) return null;
+
+		return {
+			tooltip: {
+				trigger: "item",
+				formatter: (params: { value: [number, number, string] }) =>
+					`${formatDateTime(new Date(params.value[0]).toISOString())}<br/>Magnitude: ${formatNumber(params.value[1], 4)}<br/>Severity: ${params.value[2]}`,
+			},
+			grid: { left: 70, right: 20, top: 20, bottom: 50, containLabel: true },
+			xAxis: {
+				type: "time",
+				axisLabel: {
+					formatter: (v: number) => {
+						const d = new Date(v);
+						return `${d.getDate().toString().padStart(2, "0")}/${(d.getMonth() + 1).toString().padStart(2, "0")}`;
+					},
+				},
+			},
+			yAxis: {
+				type: "value",
+				name: "Magnitude",
+				nameLocation: "middle" as const,
+				nameGap: 50,
+			},
+			dataZoom: [
+				{ type: "inside", xAxisIndex: 0 },
+				{ type: "slider", xAxisIndex: 0, bottom: 5, height: 20 },
+			],
+			series: [
+				{
+					type: "scatter",
+					large: true,
+					data: pts.map(([x, y]) => [x, y]),
+					symbolSize: 8,
+					itemStyle: { opacity: 0.75 },
+				},
+			],
+		} as Record<string, unknown>;
+	});
+
+	// ── Fetch ───────────────────────────────────────────────────
+	async function fetchHistory() {
+		loading = true;
+		error = null;
+		try {
+			const api = createClientApiClient(getToken);
+			const params = new URLSearchParams();
+			if (filterFrom) params.set("from_date", filterFrom);
+			if (filterTo) params.set("to_date", filterTo);
+			if (filterSeverity) params.set("severity", filterSeverity);
+			params.set("limit", "500");
+			const qs = params.toString() ? `?${params.toString()}` : "";
+			const res = await api.get<DriftHistory>(
+				`/analytics/strategy-drift/${instrumentId}/history${qs}`,
+			);
+			events = Array.isArray(res.events) ? res.events : [];
+			computedAt = res.computed_at ?? null;
+		} catch (e) {
+			error = e instanceof Error ? e.message : "Failed to load drift history";
+			events = [];
+		} finally {
+			loading = false;
+		}
+	}
+
+	// ── CSV export ──────────────────────────────────────────────
+	function exportCSV() {
+		const header = ["detected_at", "severity", "status", "anomalous_count", "drift_magnitude", "rebalance_triggered"].join(",");
+		const rows = filteredEvents.map((e) =>
+			[
+				e.detected_at,
+				e.severity,
+				e.status,
+				e.anomalous_count,
+				e.drift_magnitude ?? "",
+				e.rebalance_triggered ?? "",
+			]
+				.map((v) => `"${String(v).replace(/"/g, '""')}"`)
+				.join(","),
+		);
+		const csv = [header, ...rows].join("\n");
+		const blob = new Blob([csv], { type: "text/csv" });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = `drift-history-${instrumentId}.csv`;
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
+	// Load on mount
+	let mounted = $state(false);
+	onMount(() => {
+		mounted = true;
+		fetchHistory();
+	});
+</script>
+
+{#if mounted}
+	<div class="space-y-4">
+		<!-- Header row with filters + export -->
+		<div class="flex flex-wrap items-end gap-3">
+			<!-- Severity filter -->
+			<div class="flex flex-col gap-1">
+				<label class="text-xs font-medium text-[var(--netz-text-secondary)]" for="drift-severity-filter">
+					Severity
+				</label>
+				<select
+					id="drift-severity-filter"
+					class="h-8 rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] px-2 text-xs text-[var(--netz-text-primary)]"
+					bind:value={filterSeverity}
+				>
+					<option value="">All</option>
+					{#each severities as sev (sev)}
+						<option value={sev}>{sev}</option>
+					{/each}
+				</select>
+			</div>
+
+			<!-- Date from -->
+			<div class="flex flex-col gap-1">
+				<label class="text-xs font-medium text-[var(--netz-text-secondary)]" for="drift-from-filter">
+					From
+				</label>
+				<input
+					id="drift-from-filter"
+					type="date"
+					class="h-8 rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] px-2 text-xs text-[var(--netz-text-primary)]"
+					bind:value={filterFrom}
+				/>
+			</div>
+
+			<!-- Date to -->
+			<div class="flex flex-col gap-1">
+				<label class="text-xs font-medium text-[var(--netz-text-secondary)]" for="drift-to-filter">
+					To
+				</label>
+				<input
+					id="drift-to-filter"
+					type="date"
+					class="h-8 rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] px-2 text-xs text-[var(--netz-text-primary)]"
+					bind:value={filterTo}
+				/>
+			</div>
+
+			<button
+				class="ml-auto inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] px-3 text-xs font-medium text-[var(--netz-text-primary)] hover:bg-[var(--netz-surface-alt)] disabled:opacity-40"
+				onclick={exportCSV}
+				disabled={filteredEvents.length === 0}
+			>
+				Export CSV
+			</button>
+		</div>
+
+		{#if computedAt}
+			<p class="text-xs text-[var(--netz-text-muted)]">
+				Computed: {formatDateTime(computedAt)}
+			</p>
+		{/if}
+
+		{#if loading}
+			<div class="flex h-24 items-center justify-center">
+				<span class="text-sm text-[var(--netz-text-muted)]">Loading drift history…</span>
+			</div>
+		{:else if error}
+			<div class="rounded-md border border-[var(--netz-status-error)] bg-[var(--netz-status-error)]/10 p-3 text-sm text-[var(--netz-status-error)]">
+				{error}
+			</div>
+		{:else if filteredEvents.length === 0}
+			<EmptyState
+				title="No drift events"
+				message="No drift events found for the selected filters."
+			/>
+		{:else}
+			<!-- Scatter chart -->
+			{#if scatterOption}
+				<div class="rounded-lg border border-[var(--netz-border)] bg-[var(--netz-surface-elevated)] p-4">
+					<h3 class="mb-3 text-sm font-semibold text-[var(--netz-text-primary)]">
+						Drift Magnitude Timeline — {instrumentName}
+					</h3>
+					<ChartContainer
+						option={scatterOption}
+						height={260}
+						ariaLabel="Drift magnitude scatter chart"
+					/>
+				</div>
+			{/if}
+
+			<!-- Event table with row expansion for metric_details -->
+			<DataTable
+				data={filteredEvents as unknown as Record<string, unknown>[]}
+				{columns}
+				pageSize={20}
+			>
+				{#snippet expandedRow(row)}
+					{@const typedRow = row as unknown as DriftEvent}
+					<div class="space-y-2 p-2">
+						{#if typedRow.metric_details && typedRow.metric_details.length > 0}
+							<h4 class="text-xs font-semibold uppercase tracking-wider text-[var(--netz-text-secondary)]">
+								Metric Details
+							</h4>
+							<div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+								{#each typedRow.metric_details as detail, i (i)}
+									<div class="rounded border border-[var(--netz-border)] bg-[var(--netz-surface)] p-2 text-xs">
+										{#each Object.entries(detail ?? {}) as [key, val] (key)}
+											<div class="flex justify-between gap-2">
+												<span class="text-[var(--netz-text-muted)]">{key}</span>
+												<span class="font-medium text-[var(--netz-text-primary)]">
+													{String(val ?? "—")}
+												</span>
+											</div>
+										{/each}
+									</div>
+								{/each}
+							</div>
+						{:else}
+							<p class="text-xs text-[var(--netz-text-muted)]">No metric details available.</p>
+						{/if}
+						{#if typedRow.breached}
+							<div class="inline-flex items-center gap-1 rounded-full bg-[var(--netz-status-error)]/15 px-2 py-0.5 text-xs font-medium text-[var(--netz-status-error)]">
+								Threshold Breached
+							</div>
+						{/if}
+					</div>
+				{/snippet}
+			</DataTable>
+		{/if}
+	</div>
+{/if}

--- a/frontends/wealth/src/routes/(team)/allocation/+page.svelte
+++ b/frontends/wealth/src/routes/(team)/allocation/+page.svelte
@@ -1,13 +1,27 @@
 <!--
   Allocation — strategic, tactical, and effective views with profile selector.
+  Governed save flow: simulate → preview CVaR → ConsequenceDialog with rationale.
 -->
 <script lang="ts">
-	import { DataCard, BarChart, PageHeader, EmptyState, Button, formatNumber, formatPercent } from "@netz/ui";
+	import {
+		BarChart,
+		PageHeader,
+		EmptyState,
+		Button,
+		formatNumber,
+		formatPercent,
+		formatBps,
+		MetricCard,
+		ConsequenceDialog,
+	} from "@netz/ui";
 	import { ActionButton } from "@netz/ui";
 	import { createClientApiClient } from "$lib/api/client";
 	import { invalidateAll, goto } from "$app/navigation";
 	import { getContext } from "svelte";
 	import type { PageData } from "./$types";
+	import type { components } from "@netz/ui/types/api";
+
+	type SimulationResult = components["schemas"]["SimulationResult"];
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 
@@ -150,6 +164,92 @@
 			savingTactical = false;
 		}
 	}
+
+	// ── Simulation + Governance ──────────────────────────────────
+	let simulationResult = $state<SimulationResult | null>(null);
+	let simulating = $state(false);
+	let simError = $state<string | null>(null);
+	let showConfirmDialog = $state(false);
+
+	/**
+	 * Runs simulation against the proposed strategic weights.
+	 * Returns false if within_limit is false — callers should block submit.
+	 */
+	async function runSimulation(): Promise<boolean> {
+		if (!editValid) return false;
+		simulating = true;
+		simError = null;
+		simulationResult = null;
+		try {
+			const api = createClientApiClient(getToken);
+			const weights: Record<string, number> = {};
+			for (const [block, w] of Object.entries(editWeights)) {
+				weights[block] = w / 100;
+			}
+			const result = await api.post<SimulationResult>(
+				`/allocation/${activeProfile}/simulate`,
+				{ weights, rationale: "pre-save simulation" },
+			);
+			simulationResult = result;
+			return result.within_limit === true;
+		} catch (e) {
+			simError = e instanceof Error ? e.message : "Simulation failed";
+			return false;
+		} finally {
+			simulating = false;
+		}
+	}
+
+	/**
+	 * Called when user clicks "Save" on strategic tab.
+	 * Runs simulation first; opens ConsequenceDialog only when within_limit.
+	 */
+	async function handleSaveStrategicClick() {
+		const withinLimit = await runSimulation();
+		if (!withinLimit) {
+			// Block — simulationResult.within_limit === false, error shown in UI
+			return;
+		}
+		showConfirmDialog = true;
+	}
+
+	/** Final save — called from ConsequenceDialog onConfirm with rationale. */
+	async function confirmSaveStrategic({ rationale }: { rationale?: string }) {
+		if (!editValid) return;
+		saving = true;
+		editError = null;
+		try {
+			const api = createClientApiClient(getToken);
+			const weights: Record<string, number> = {};
+			for (const [block, w] of Object.entries(editWeights)) {
+				weights[block] = w / 100;
+			}
+			await api.put(`/allocation/${activeProfile}/strategic`, {
+				weights,
+				...(rationale ? { rationale } : {}),
+			});
+			editing = false;
+			simulationResult = null;
+			await invalidateAll();
+		} catch (e) {
+			editError = e instanceof Error ? e.message : "Failed to save allocation";
+		} finally {
+			saving = false;
+		}
+	}
+
+	// Simulation metric helpers
+	function fmtSimBps(v: string | number | null | undefined): string {
+		if (v == null) return "—";
+		const n = typeof v === "string" ? parseFloat(v) : v;
+		return isNaN(n) ? "—" : formatBps(n);
+	}
+
+	function fmtSimPct(v: string | number | null | undefined): string {
+		if (v == null) return "—";
+		const n = typeof v === "string" ? parseFloat(v) : v;
+		return isNaN(n) ? "—" : formatPercent(n, 2, "en-US");
+	}
 </script>
 
 <div class="space-y-6 p-6">
@@ -206,8 +306,14 @@
 									Total: {fmtPercentPoint(editTotal)} {editValid ? "✓" : `(${fmtSignedPercentPoint(editTotal - 100)})`}
 								</span>
 								<Button size="sm" variant="outline" onclick={cancelEditing}>Cancel</Button>
-								<ActionButton size="sm" onclick={saveStrategic} loading={saving} loadingText="Saving..." disabled={!editValid}>
-									Save
+								<ActionButton
+									size="sm"
+									onclick={handleSaveStrategicClick}
+									loading={simulating || saving}
+									loadingText={simulating ? "Simulating…" : "Saving…"}
+									disabled={!editValid}
+								>
+									Review & Save
 								</ActionButton>
 							</div>
 						{/if}
@@ -250,6 +356,83 @@
 			</div>
 		{:else}
 			<EmptyState title="No Strategic Allocation" message="Strategic allocation has not been configured." />
+		{/if}
+
+		<!-- Simulation error -->
+		{#if simError}
+			<div class="rounded-md border border-[var(--netz-status-error)] bg-[var(--netz-status-error)]/10 p-3 text-sm text-[var(--netz-status-error)]">
+				{simError}
+				<button class="ml-2 underline" onclick={() => simError = null}>dismiss</button>
+			</div>
+		{/if}
+
+		<!-- Simulation result panel -->
+		{#if simulationResult}
+			<div class="rounded-lg border {simulationResult.within_limit ? 'border-[var(--netz-border)]' : 'border-[var(--netz-status-error)]'} bg-[var(--netz-surface-elevated)] p-5">
+				<div class="mb-3 flex items-center justify-between">
+					<h3 class="text-sm font-semibold text-[var(--netz-text-primary)]">CVaR Simulation Preview</h3>
+					{#if simulationResult.within_limit}
+						<span class="inline-flex items-center gap-1 rounded-full bg-[var(--netz-success,#22c55e)]/15 px-2 py-0.5 text-xs font-medium text-[var(--netz-success,#22c55e)]">
+							Within Limit
+						</span>
+					{:else}
+						<span class="inline-flex items-center gap-1 rounded-full bg-[var(--netz-status-error)]/15 px-2 py-0.5 text-xs font-medium text-[var(--netz-status-error)]">
+							Exceeds CVaR Limit — Submit Blocked
+						</span>
+					{/if}
+				</div>
+				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+					<MetricCard
+						label="Proposed CVaR 95%"
+						value={fmtSimBps(simulationResult.proposed_cvar_95_3m)}
+						sublabel="3-month horizon"
+						status={simulationResult.within_limit ? undefined : "error"}
+					/>
+					<MetricCard
+						label="CVaR Utilization"
+						value={fmtSimPct(simulationResult.cvar_utilization_pct)}
+						sublabel="of limit"
+						status={
+							simulationResult.cvar_utilization_pct != null &&
+							parseFloat(String(simulationResult.cvar_utilization_pct)) > 1
+								? "error"
+								: simulationResult.cvar_utilization_pct != null &&
+								  parseFloat(String(simulationResult.cvar_utilization_pct)) > 0.8
+								? "warn"
+								: undefined
+						}
+					/>
+					<MetricCard
+						label="CVaR Delta vs Current"
+						value={fmtSimBps(simulationResult.cvar_delta_vs_current)}
+						sublabel="change from current"
+					/>
+					<MetricCard
+						label="CVaR Limit"
+						value={fmtSimBps(simulationResult.cvar_limit)}
+						sublabel="hard limit"
+					/>
+				</div>
+
+				<!-- Warnings from simulation -->
+				{#if simulationResult.warnings.length > 0}
+					<div class="mt-4 rounded-md border border-[var(--netz-status-warning,#f59e0b)] bg-[var(--netz-status-warning,#f59e0b)]/10 p-3">
+						<p class="mb-1 text-xs font-semibold uppercase tracking-wider text-[var(--netz-status-warning,#f59e0b)]">Warnings</p>
+						<ul class="space-y-1">
+							{#each simulationResult.warnings as warning, i (i)}
+								<li class="text-sm text-[var(--netz-text-primary)]">• {warning}</li>
+							{/each}
+						</ul>
+					</div>
+				{/if}
+
+				<!-- Block message when limit exceeded -->
+				{#if !simulationResult.within_limit}
+					<p class="mt-3 text-sm font-medium text-[var(--netz-status-error)]">
+						This allocation exceeds the CVaR limit. Adjust weights before submitting.
+					</p>
+				{/if}
+			</div>
 		{/if}
 	{/if}
 
@@ -346,3 +529,26 @@
 		{/if}
 	{/if}
 </div>
+
+<!-- Governed submit: ConsequenceDialog with mandatory rationale -->
+<ConsequenceDialog
+	bind:open={showConfirmDialog}
+	title="Confirm Strategic Allocation Change"
+	impactSummary="This will update the strategic weights for the {activeProfile} profile. The change will affect effective allocation and CVaR calculations for all portfolios using this profile."
+	scopeText="Profile: {activeProfile} — affects all model portfolios using this allocation profile."
+	requireRationale
+	rationaleLabel="Rationale for allocation change"
+	rationalePlaceholder="State the investment thesis, market conditions, or committee direction behind this strategic change."
+	rationaleMinLength={20}
+	confirmLabel="Submit Allocation Change"
+	metadata={simulationResult
+		? [
+				{ label: "Proposed CVaR 95%", value: fmtSimBps(simulationResult.proposed_cvar_95_3m), emphasis: true },
+				{ label: "CVaR Utilization", value: fmtSimPct(simulationResult.cvar_utilization_pct), emphasis: true },
+				{ label: "CVaR Delta vs Current", value: fmtSimBps(simulationResult.cvar_delta_vs_current) },
+				{ label: "Within Limit", value: simulationResult.within_limit ? "Yes" : "No", emphasis: !simulationResult.within_limit },
+		  ]
+		: []}
+	onConfirm={confirmSaveStrategic}
+	onCancel={() => showConfirmDialog = false}
+/>

--- a/frontends/wealth/src/routes/(team)/allocation/+page.svelte
+++ b/frontends/wealth/src/routes/(team)/allocation/+page.svelte
@@ -19,9 +19,19 @@
 	import { invalidateAll, goto } from "$app/navigation";
 	import { getContext } from "svelte";
 	import type { PageData } from "./$types";
-	import type { components } from "@netz/ui/types/api";
 
-	type SimulationResult = components["schemas"]["SimulationResult"];
+	// Inline SimulationResult type from API schema
+	type SimulationResult = {
+		profile: string;
+		proposed_cvar_95_3m?: string | null;
+		cvar_limit?: string | null;
+		cvar_utilization_pct?: string | null;
+		cvar_delta_vs_current?: string | null;
+		tracking_error_expected?: string | null;
+		within_limit: boolean;
+		warnings: string[];
+		computed_at: string;
+	};
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 
@@ -386,7 +396,7 @@
 						label="Proposed CVaR 95%"
 						value={fmtSimBps(simulationResult.proposed_cvar_95_3m)}
 						sublabel="3-month horizon"
-						status={simulationResult.within_limit ? undefined : "error"}
+						status={simulationResult.within_limit ? undefined : "breach"}
 					/>
 					<MetricCard
 						label="CVaR Utilization"
@@ -395,7 +405,7 @@
 						status={
 							simulationResult.cvar_utilization_pct != null &&
 							parseFloat(String(simulationResult.cvar_utilization_pct)) > 1
-								? "error"
+								? "breach"
 								: simulationResult.cvar_utilization_pct != null &&
 								  parseFloat(String(simulationResult.cvar_utilization_pct)) > 0.8
 								? "warn"

--- a/frontends/wealth/src/routes/(team)/dashboard/+page.svelte
+++ b/frontends/wealth/src/routes/(team)/dashboard/+page.svelte
@@ -5,17 +5,14 @@
 -->
 <script lang="ts">
 	import {
-		StatusBadge, EmptyState, TimeSeriesChart, PageHeader,
-		PeriodSelector, RegimeBanner, SectionCard, AlertFeed,
+		StatusBadge, EmptyState, PageHeader,
+		RegimeBanner, SectionCard,
 		formatDateTime,
-		type WealthAlert,
 	} from "@netz/ui";
 	import PortfolioCard from "$lib/components/PortfolioCard.svelte";
 	import MacroChips from "$lib/components/MacroChips.svelte";
-	import { regimeLabels } from "$lib/constants/regime";
 	import { resolveWealthStatus } from "$lib/utils/status-maps";
 	import type { PageData } from "./$types";
-	import type { RegimeData } from "$lib/types/api";
 	import { getContext } from "svelte";
 	import type { RiskStore } from "$lib/stores/risk-store.svelte";
 
@@ -110,10 +107,6 @@
 		});
 	});
 
-	// Period selector
-	const periods = ["1M", "3M", "YTD", "1Y", "3Y"];
-	let selectedPeriod = $state("YTD");
-
 	// Current regime — from live store, fallback to page data
 	const currentRegime = $derived(
 		liveRegime?.regime ?? portfolios?.[0]?.regime ?? null
@@ -147,7 +140,7 @@
 		{#if cards.length > 0}
 			<div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
 				{#each cards as card (card.profile)}
-					<a href="/model-portfolios?portfolio={card.id}" class="block transition-transform hover:scale-[1.01]">
+					<a href="/portfolios/{card.profile}" class="block transition-transform hover:scale-[1.01]">
 						<PortfolioCard
 							name={card.name}
 							profile={card.profile}
@@ -168,47 +161,119 @@
 		{/if}
 	</section>
 
-	<!-- NAV Chart + Alerts — side by side -->
+	<!-- Decision Surface — Drift Alerts + Recent Activity -->
 	<section class="grid gap-4 lg:grid-cols-5">
-		<!-- NAV Chart (60%) -->
-		<SectionCard title="NAV — Portfólios Consolidados" class="lg:col-span-3">
+		<!-- Drift Alerts (60%) -->
+		<SectionCard title="Drift Alerts" class="lg:col-span-3">
 			{#snippet actions()}
-				<PeriodSelector {periods} selected={selectedPeriod} onSelect={(p) => selectedPeriod = p} />
+				{#if riskStore.computedAt}
+					<span class="text-xs text-[var(--netz-text-muted)]">
+						{formatDateTime(riskStore.computedAt)}
+					</span>
+				{/if}
 			{/snippet}
-			<div class="h-80">
-				<TimeSeriesChart
-					series={[]}
-					yAxisLabel="NAV"
-					empty={true}
-					emptyMessage="Track-record data not yet available"
-					ariaLabel="Consolidated NAV chart"
-				/>
-			</div>
-		</SectionCard>
-
-		<!-- Alertas Ativos (40%) -->
-		<SectionCard title="Alertas Ativos" class="lg:col-span-2">
 			{#if riskStore.driftAlerts.dtw_alerts.length > 0 || riskStore.driftAlerts.behavior_change_alerts.length > 0}
-				<div class="space-y-2 text-sm text-[var(--netz-text-secondary)]">
+				<div class="space-y-2">
 					{#each riskStore.driftAlerts.dtw_alerts as alert (alert.instrument_name)}
-						<div class="rounded border border-[var(--netz-border)] p-2">
-							<span class="font-medium">{alert.instrument_name}</span>
-							<span class="ml-2 text-[var(--netz-text-muted)]">DTW: {alert.dtw_score}</span>
+						<div class="flex items-center justify-between rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface-alt)] p-3">
+							<div class="space-y-0.5">
+								<p class="text-sm font-medium text-[var(--netz-text-primary)]">{alert.instrument_name}</p>
+								<p class="text-xs text-[var(--netz-text-muted)]">DTW score: {alert.dtw_score}</p>
+							</div>
+							<div class="flex items-center gap-2">
+								<span class="inline-flex items-center rounded-full bg-[var(--netz-status-warning,#f59e0b)]/15 px-2 py-0.5 text-xs font-medium text-[var(--netz-status-warning,#f59e0b)]">
+									DTW Drift
+								</span>
+								{#if alert.instrument_id}
+									<a
+										href="/portfolios/{alert.instrument_id}"
+										class="inline-flex h-7 items-center rounded-md border border-[var(--netz-border)] px-2 text-xs font-medium text-[var(--netz-text-primary)] hover:bg-[var(--netz-surface-alt)] transition-colors"
+									>
+										Review
+									</a>
+								{/if}
+							</div>
 						</div>
 					{/each}
 					{#each riskStore.driftAlerts.behavior_change_alerts as alert (alert.instrument_name)}
-						<div class="rounded border border-[var(--netz-border)] p-2">
-							<span class="font-medium">{alert.instrument_name}</span>
-							<span class="ml-2 text-[var(--netz-text-muted)]">{alert.severity}</span>
+						<div class="flex items-center justify-between rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface-alt)] p-3">
+							<div class="space-y-0.5">
+								<p class="text-sm font-medium text-[var(--netz-text-primary)]">{alert.instrument_name}</p>
+								<p class="text-xs text-[var(--netz-text-muted)]">
+									{alert.anomalous_count} / {alert.total_metrics} metrics anomalous
+								</p>
+							</div>
+							<div class="flex items-center gap-2">
+								<span class="inline-flex items-center rounded-full bg-[var(--netz-status-error)]/15 px-2 py-0.5 text-xs font-medium text-[var(--netz-status-error)]">
+									{alert.severity}
+								</span>
+								{#if alert.instrument_id}
+									<a
+										href="/portfolios/{alert.instrument_id}"
+										class="inline-flex h-7 items-center rounded-md border border-[var(--netz-border)] px-2 text-xs font-medium text-[var(--netz-text-primary)] hover:bg-[var(--netz-surface-alt)] transition-colors"
+									>
+										Review
+									</a>
+								{/if}
+							</div>
 						</div>
 					{/each}
 				</div>
 			{:else}
 				<EmptyState
-					title="Sem alertas ativos"
-					message="Alertas de risco aparecerão aqui quando detectados pelo motor de análise."
+					title="No active drift alerts"
+					message="Risk alerts will appear here when detected by the analysis engine."
 				/>
 			{/if}
+		</SectionCard>
+
+		<!-- Recent Activity (40%) -->
+		<SectionCard title="Quick Actions" class="lg:col-span-2">
+			<div class="space-y-2">
+				<!-- Portfolio links -->
+				{#each cards as card (card.profile)}
+					<a
+						href="/portfolios/{card.profile}"
+						class="flex items-center justify-between rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface-alt)] p-3 transition-colors hover:bg-[var(--netz-surface-elevated)]"
+					>
+						<div class="space-y-0.5">
+							<p class="text-sm font-medium text-[var(--netz-text-primary)]">{card.name}</p>
+							<p class="text-xs text-[var(--netz-text-muted)]">
+								{card.triggerStatus
+									? card.triggerStatus === "breach"
+										? "CVaR Breached"
+										: card.triggerStatus === "warning"
+										? "CVaR Warning"
+										: "Normal"
+									: "Normal"}
+							</p>
+						</div>
+						{#if card.triggerStatus === "breach"}
+							<span class="inline-flex items-center rounded-full bg-[var(--netz-status-error)]/15 px-2 py-0.5 text-xs font-medium text-[var(--netz-status-error)]">
+								Action Required
+							</span>
+						{:else if card.triggerStatus === "warning"}
+							<span class="inline-flex items-center rounded-full bg-[var(--netz-status-warning,#f59e0b)]/15 px-2 py-0.5 text-xs font-medium text-[var(--netz-status-warning,#f59e0b)]">
+								Monitor
+							</span>
+						{:else}
+							<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-[var(--netz-text-muted)]"><path d="m9 18 6-6-6-6"/></svg>
+						{/if}
+					</a>
+				{/each}
+
+				<!-- Allocation shortcut -->
+				<a
+					href="/allocation"
+					class="flex items-center justify-between rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface-alt)] p-3 transition-colors hover:bg-[var(--netz-surface-elevated)]"
+				>
+					<div class="space-y-0.5">
+						<p class="text-sm font-medium text-[var(--netz-text-primary)]">Strategic Allocation</p>
+						<p class="text-xs text-[var(--netz-text-muted)]">Review and update allocation weights</p>
+					</div>
+					<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-[var(--netz-text-muted)]"><path d="m9 18 6-6-6-6"/></svg>
+				</a>
+			</div>
 		</SectionCard>
 	</section>
 

--- a/frontends/wealth/src/routes/(team)/portfolios/[profile]/+page.svelte
+++ b/frontends/wealth/src/routes/(team)/portfolios/[profile]/+page.svelte
@@ -244,7 +244,7 @@
 			value={fmtPct(cvarStatus?.cvar_current ?? snapshot?.cvar_current)}
 			sublabel="Limit: {fmtPct(cvarStatus?.cvar_limit ?? snapshot?.cvar_limit)} | Util: {fmtPct(cvarStatus?.cvar_utilized_pct ?? snapshot?.cvar_utilized_pct)}"
 			status={
-				(cvarStatus?.cvar_utilized_pct ?? 0) > 1 ? "error" :
+				(cvarStatus?.cvar_utilized_pct ?? 0) > 1 ? "breach" :
 				(cvarStatus?.cvar_utilized_pct ?? 0) > 0.8 ? "warn" : undefined
 			}
 		/>
@@ -262,7 +262,7 @@
 			label="Regime"
 			value={cvarStatus?.regime ?? snapshot?.regime ?? "—"}
 			sublabel="Breach days: {cvarStatus?.consecutive_breach_days ?? 0}"
-			status={cvarStatus?.trigger_status === "warning" ? "warn" : cvarStatus?.trigger_status === "breach" ? "error" : undefined}
+			status={cvarStatus?.trigger_status === "warning" ? "warn" : cvarStatus?.trigger_status === "breach" ? "breach" : undefined}
 		/>
 	</div>
 

--- a/frontends/wealth/src/routes/(team)/portfolios/[profile]/+page.svelte
+++ b/frontends/wealth/src/routes/(team)/portfolios/[profile]/+page.svelte
@@ -14,6 +14,7 @@
 		globalChartOptions, regimeColors, statusColors,
 	} from "@netz/ui/charts/echarts-setup";
 	import StaleBanner from "$lib/components/StaleBanner.svelte";
+	import DriftHistoryPanel from "$lib/components/DriftHistoryPanel.svelte";
 	import { createClientApiClient } from "$lib/api/client";
 	import { invalidateAll, goto } from "$app/navigation";
 	import { getContext } from "svelte";
@@ -185,6 +186,12 @@
 	// ── Drift history panel ──
 	let showDriftHistory = $state(false);
 
+	// instrument_id for drift history — from portfolio record if available
+	type PortfolioRecord = { id: string; display_name?: string | null };
+	let portfolioRecord = $derived(data.portfolio as PortfolioRecord | null);
+	let driftInstrumentId = $derived(portfolioRecord?.id ?? profile);
+	let driftInstrumentName = $derived(portfolioRecord?.display_name ?? profile);
+
 	// Load rebalance events on mount
 	$effect(() => { loadRebalanceEvents(); });
 
@@ -355,16 +362,12 @@
 		open={showDriftHistory}
 		title="Drift History — {profile}"
 		onClose={() => showDriftHistory = false}
-		width="560px"
+		width="720px"
 	>
 		<div class="p-4">
-			<p class="text-sm text-[var(--netz-text-muted)]">
-				Drift history with full audit trail. Export to CSV coming soon.
-			</p>
-			<!-- Drift timeline chart and table would go here with ECharts -->
-			<EmptyState
-				title="Loading drift history..."
-				message="Drift events with timestamps, block deviations, and rebalance markers."
+			<DriftHistoryPanel
+				instrumentId={driftInstrumentId}
+				instrumentName={driftInstrumentName}
 			/>
 		</div>
 	</ContextPanel>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@codemirror/lint':
         specifier: ^6.9.5
         version: 6.9.5
+      '@codemirror/merge':
+        specifier: ^6.12.1
+        version: 6.12.1
       '@codemirror/state':
         specifier: ^6.6.0
         version: 6.6.0
@@ -266,6 +269,9 @@ packages:
 
   '@codemirror/lint@6.9.5':
     resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/merge@6.12.1':
+    resolution: {integrity: sha512-GA8hBq2T+IFM0sb5fk8CunTrqOulA3zurJmHtzcU15EMnL8aYpVINfJ5bkfd53M4ikwoew4Y1ydtSaAlk6+B1w==}
 
   '@codemirror/state@6.6.0':
     resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
@@ -2145,6 +2151,14 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.40.0
       crelt: 1.0.6
+
+  '@codemirror/merge@6.12.1':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
+      '@lezer/highlight': 1.2.3
+      style-mod: 4.1.3
 
   '@codemirror/state@6.6.0':
     dependencies:


### PR DESCRIPTION
## Summary

- **Credit.2** — Document review decision governance: ConsequenceDialog for approve/reject/revision, rationale + actor_capacity mandatory, checklist uncheck gated, AuditTrailPanel for decision history, optimistic mutation
- **Credit.3** — Deal financial term fields: MetricCard KPIs (tenor, spread_bps, ltv_ratio), text grid for covenants/collateral/language, all optional with `—` fallback
- **Wealth.2** — Drift-history workbench: DriftHistoryPanel with DataTable (row expansion, CSV export), svelte-echarts scatter chart with dataZoom, severity + date range filters, `$state.raw`
- **Wealth.3** — Allocation governance: pre-submit CVaR simulation preview (formatBps/formatPercent), submit blocked when `within_limit === false`, warnings banner, ConsequenceDialog with mandatory rationale
- **Wealth.5** — Dashboard decision surface: drift-alerts module from store, recent activity, card actions link to decision routes, freshness from `computed_at`
- **Admin.1** — Consequence-aware config editing: CodeEditor (json), ConfigDiffView via @codemirror/merge (split/unified toggle), ConsequenceDialog with changed_keys + tenant_count_affected, post-save refetch

## Files changed (11 — all frontend, zero backend)

| Frontend | Files |
|----------|-------|
| credit | reviews/[reviewId]/+page.svelte, pipeline/[dealId]/+page.svelte |
| wealth | DriftHistoryPanel.svelte (new), portfolios/[profile]/+page.svelte, allocation/+page.svelte, dashboard/+page.svelte |
| admin | ConfigDiffView.svelte (new), ConfigEditor.svelte, config/[vertical]/+page.svelte, package.json |

## Test plan

- [ ] Credit: open document review → approve/reject requires rationale ≥20 chars + actor_capacity
- [ ] Credit: uncheck checklist item → ConsequenceDialog with justification prompt
- [ ] Credit: deal page shows Financial Terms section with MetricCard KPIs
- [ ] Wealth: portfolio page → drift history panel with scatter chart + DataTable + CSV export
- [ ] Wealth: allocation submit → simulation preview blocks when `within_limit === false`
- [ ] Wealth: dashboard shows drift alerts + activity cards linking to correct routes
- [ ] Admin: config editor uses CodeEditor + diff view with split/unified toggle
- [ ] Admin: config save shows ConsequenceDialog with changed_keys count

🤖 Generated with [Claude Code](https://claude.com/claude-code)