### PR TITLE
feat: wealth backend contracts — computed_at + drift export

### DIFF
--- a/backend/app/domains/wealth/routes/allocation.py
+++ b/backend/app/domains/wealth/routes/allocation.py
@@ -18,7 +18,7 @@ from app.domains.wealth.schemas.allocation import (
     TacticalPositionRead,
     TacticalPositionUpdate,
 )
-from app.routers.common import get_latest_snapshot, validate_profile as _validate_profile
+from app.domains.wealth.routes.common import get_latest_snapshot, validate_profile as _validate_profile
 
 router = APIRouter(prefix="/allocation")
 

--- a/backend/app/domains/wealth/routes/analytics.py
+++ b/backend/app/domains/wealth/routes/analytics.py
@@ -22,7 +22,7 @@ from app.domains.wealth.schemas.analytics import (
     ParetoOptimizeResult,
 )
 from app.domains.wealth.services.quant_queries import compute_inputs_from_nav, fetch_returns_matrix
-from app.routers.common import validate_profile as _validate_profile
+from app.domains.wealth.routes.common import validate_profile as _validate_profile
 from quant_engine.backtest_service import walk_forward_backtest
 from quant_engine.optimizer_service import (
     BlockConstraint,

--- a/backend/app/domains/wealth/routes/portfolios.py
+++ b/backend/app/domains/wealth/routes/portfolios.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date
+from datetime import UTC, date, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
@@ -16,8 +16,8 @@ from app.domains.wealth.schemas.portfolio import (
     RebalanceEventRead,
     RebalanceRequest,
 )
-from app.routers.common import VALID_PROFILES, get_latest_snapshot
-from app.routers.common import validate_profile as _validate_profile
+from app.domains.wealth.routes.common import VALID_PROFILES, get_latest_snapshot
+from app.domains.wealth.routes.common import validate_profile as _validate_profile
 
 router = APIRouter(prefix="/portfolios")
 
@@ -33,6 +33,7 @@ def _snapshot_to_summary(profile: str, snap: PortfolioSnapshot | None) -> Portfo
         regime=snap.regime if snap else None,
         core_weight=snap.core_weight if snap else None,
         satellite_weight=snap.satellite_weight if snap else None,
+        computed_at=datetime.combine(snap.snapshot_date, datetime.min.time(), tzinfo=UTC) if snap else None,
     )
 
 
@@ -84,7 +85,9 @@ async def get_snapshot(
     snap = await get_latest_snapshot(db, profile)
     if snap is None:
         return None
-    return PortfolioSnapshotRead.model_validate(snap)
+    result = PortfolioSnapshotRead.model_validate(snap)
+    result.computed_at = datetime.combine(snap.snapshot_date, datetime.min.time(), tzinfo=UTC)
+    return result
 
 
 @router.get(
@@ -110,7 +113,12 @@ async def get_history(
         stmt = stmt.where(PortfolioSnapshot.snapshot_date <= to_date)
     stmt = stmt.order_by(PortfolioSnapshot.snapshot_date).offset(offset).limit(limit)
     result = await db.execute(stmt)
-    return [PortfolioSnapshotRead.model_validate(row) for row in result.scalars().all()]
+    snapshots = []
+    for row in result.scalars().all():
+        out = PortfolioSnapshotRead.model_validate(row)
+        out.computed_at = datetime.combine(row.snapshot_date, datetime.min.time(), tzinfo=UTC)
+        snapshots.append(out)
+    return snapshots
 
 
 @router.post(

--- a/backend/app/domains/wealth/routes/risk.py
+++ b/backend/app/domains/wealth/routes/risk.py
@@ -16,8 +16,8 @@ from app.core.tenancy.middleware import get_db_with_rls
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 from app.domains.wealth.schemas.macro import MacroIndicators
 from app.domains.wealth.schemas.risk import CVaRPoint, CVaRStatus, RegimeHistoryPoint
-from app.routers.common import VALID_PROFILES, get_latest_snapshot
-from app.routers.common import validate_profile as _validate_profile
+from app.domains.wealth.routes.common import VALID_PROFILES, get_latest_snapshot
+from app.domains.wealth.routes.common import validate_profile as _validate_profile
 from app.shared.schemas import RegimeRead
 from quant_engine.regime_service import get_current_regime, get_latest_macro_values
 

--- a/backend/app/domains/wealth/routes/strategy_drift.py
+++ b/backend/app/domains/wealth/routes/strategy_drift.py
@@ -8,11 +8,16 @@ GET  /analytics/strategy-drift/{instrument_id} — single instrument drift check
 from __future__ import annotations
 
 import asyncio
+import csv
+import io
+import json
 import uuid
 from datetime import datetime, timezone
+from typing import Literal
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import Response
 from sqlalchemy import select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -284,6 +289,61 @@ async def list_drift_alerts(
     ]
 
 
+async def _query_drift_history(
+    db: AsyncSession,
+    instrument_id: uuid.UUID,
+    from_date: datetime | None,
+    to_date: datetime | None,
+    severity: str | None,
+    limit: int,
+) -> tuple[str, list[StrategyDriftAlert]]:
+    """Shared query logic for drift history and export.
+
+    Returns (instrument_name, alerts). Raises 404 if instrument not found.
+    """
+    inst_result = await db.execute(
+        select(Instrument.name).where(Instrument.instrument_id == instrument_id)
+    )
+    inst_name = inst_result.scalar()
+    if inst_name is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Instrument not found"
+        )
+
+    stmt = select(StrategyDriftAlert).where(
+        StrategyDriftAlert.instrument_id == instrument_id,
+    )
+    if from_date is not None:
+        stmt = stmt.where(StrategyDriftAlert.detected_at >= from_date)
+    if to_date is not None:
+        stmt = stmt.where(StrategyDriftAlert.detected_at <= to_date)
+    if severity is not None:
+        stmt = stmt.where(StrategyDriftAlert.severity == severity)
+
+    stmt = stmt.order_by(StrategyDriftAlert.detected_at.desc()).limit(limit)
+
+    result = await db.execute(stmt)
+    return inst_name, list(result.scalars().all())
+
+
+def _alerts_to_events(alerts: list[StrategyDriftAlert]) -> list[DriftEventOut]:
+    return [
+        DriftEventOut(
+            id=a.id,
+            instrument_id=a.instrument_id,
+            status=a.status,
+            severity=a.severity,
+            anomalous_count=a.anomalous_count,
+            total_metrics=a.total_metrics,
+            metric_details=a.metric_details,
+            is_current=a.is_current,
+            detected_at=a.detected_at,
+            created_at=a.created_at,
+        )
+        for a in alerts
+    ]
+
+
 @router.get(
     "/{instrument_id}/history",
     response_model=DriftHistoryOut,
@@ -302,47 +362,10 @@ async def get_drift_history(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> DriftHistoryOut:
-    # Verify instrument exists
-    inst_result = await db.execute(
-        select(Instrument.name).where(Instrument.instrument_id == instrument_id)
+    inst_name, alerts = await _query_drift_history(
+        db, instrument_id, from_date, to_date, severity, limit,
     )
-    inst_name = inst_result.scalar()
-    if inst_name is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Instrument not found"
-        )
-
-    # Build query with filters
-    stmt = select(StrategyDriftAlert).where(
-        StrategyDriftAlert.instrument_id == instrument_id,
-    )
-    if from_date is not None:
-        stmt = stmt.where(StrategyDriftAlert.detected_at >= from_date)
-    if to_date is not None:
-        stmt = stmt.where(StrategyDriftAlert.detected_at <= to_date)
-    if severity is not None:
-        stmt = stmt.where(StrategyDriftAlert.severity == severity)
-
-    stmt = stmt.order_by(StrategyDriftAlert.detected_at.desc()).limit(limit)
-
-    result = await db.execute(stmt)
-    alerts = result.scalars().all()
-
-    events = [
-        DriftEventOut(
-            id=a.id,
-            instrument_id=a.instrument_id,
-            status=a.status,
-            severity=a.severity,
-            anomalous_count=a.anomalous_count,
-            total_metrics=a.total_metrics,
-            metric_details=a.metric_details,
-            is_current=a.is_current,
-            detected_at=a.detected_at,
-            created_at=a.created_at,
-        )
-        for a in alerts
-    ]
+    events = _alerts_to_events(alerts)
 
     return DriftHistoryOut(
         instrument_id=instrument_id,
@@ -350,6 +373,58 @@ async def get_drift_history(
         events=events,
         total=len(events),
         computed_at=datetime.now(timezone.utc),
+    )
+
+
+@router.get(
+    "/{instrument_id}/export",
+    summary="Export drift history as CSV or JSON",
+)
+async def export_drift_history(
+    instrument_id: uuid.UUID,
+    format: Literal["csv", "json"] = Query("csv"),
+    from_date: datetime | None = Query(None, description="Start date filter (inclusive)"),
+    to_date: datetime | None = Query(None, description="End date filter (inclusive)"),
+    severity: str | None = Query(None, pattern="^(none|moderate|severe)$"),
+    limit: int = Query(500, ge=1, le=5000),
+    db: AsyncSession = Depends(get_db_with_rls),
+    user: CurrentUser = Depends(get_current_user),
+) -> Response:
+    inst_name, alerts = await _query_drift_history(
+        db, instrument_id, from_date, to_date, severity, limit,
+    )
+
+    rows = [
+        {
+            "detected_at": a.detected_at.isoformat() if a.detected_at else "",
+            "status": a.status,
+            "severity": a.severity,
+            "anomalous_count": a.anomalous_count,
+            "metric_details": json.dumps(a.metric_details) if a.metric_details else "",
+        }
+        for a in alerts
+    ]
+
+    filename = f"drift-history-{instrument_id}"
+
+    if format == "json":
+        return Response(
+            content=json.dumps(rows, ensure_ascii=False),
+            media_type="application/json",
+            headers={"Content-Disposition": f'attachment; filename="{filename}.json"'},
+        )
+
+    # CSV
+    fieldnames = ["detected_at", "status", "severity", "anomalous_count", "metric_details"]
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(rows)
+
+    return Response(
+        content=buf.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}.csv"'},
     )
 
 

--- a/backend/app/domains/wealth/schemas/portfolio.py
+++ b/backend/app/domains/wealth/schemas/portfolio.py
@@ -16,6 +16,7 @@ class PortfolioSummary(BaseModel):
     regime: str | None = None
     core_weight: Decimal | None = None
     satellite_weight: Decimal | None = None
+    computed_at: datetime | None = None
 
 
 class PortfolioSnapshotRead(BaseModel):
@@ -41,6 +42,7 @@ class PortfolioSnapshotRead(BaseModel):
     # Both are None until the Bayesian CVaR worker has run for the snapshot date.
     cvar_lower_5: Decimal | None = None
     cvar_upper_95: Decimal | None = None
+    computed_at: datetime | None = None
 
 
 class RebalanceRequest(BaseModel):

--- a/backend/app/utils/hashing.py
+++ b/backend/app/utils/hashing.py
@@ -1,0 +1,18 @@
+"""Deterministic hashing utilities for quant reproducibility."""
+from __future__ import annotations
+
+import hashlib
+from datetime import date
+
+
+def compute_input_hash(values: list[float]) -> str:
+    """SHA-256 hex digest of a list of floats, for cache-key / audit trail."""
+    payload = ",".join(f"{v:.10f}" for v in values)
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def derive_seed(profile: str, calc_date: date) -> int:
+    """Deterministic seed from profile + date for reproducible optimization."""
+    payload = f"{profile}:{calc_date.isoformat()}"
+    digest = hashlib.sha256(payload.encode()).digest()
+    return int.from_bytes(digest[:4], "big")

--- a/backend/manifests/routes.json
+++ b/backend/manifests/routes.json
@@ -281,6 +281,11 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/analytics/strategy-drift/{instrument_id}/export",
+    "name": "export_drift_history"
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/analytics/strategy-drift/{instrument_id}/history",
     "name": "get_drift_history"
   },

--- a/backend/tests/test_wealth_backend_contracts.py
+++ b/backend/tests/test_wealth_backend_contracts.py
@@ -1,0 +1,267 @@
+"""Tests for wealth backend contract gaps — computed_at + drift export."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import uuid
+from datetime import UTC, date, datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+DEV_ACTOR_HEADER = {
+    "X-DEV-ACTOR": json.dumps(
+        {
+            "actor_id": "test-user",
+            "roles": ["ADMIN"],
+            "fund_ids": [],
+            "org_id": "00000000-0000-0000-0000-000000000001",
+        }
+    )
+}
+
+ORG_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+
+def _fake_snapshot(profile: str = "conservative", snap_date: date | None = None):
+    """Build a mock PortfolioSnapshot with the fields routes access."""
+    snap = MagicMock()
+    snap.snapshot_id = uuid.uuid4()
+    snap.profile = profile
+    snap.snapshot_date = snap_date or date(2026, 3, 15)
+    snap.weights = {"core": 0.6, "satellite": 0.4}
+    snap.fund_selection = None
+    snap.cvar_current = Decimal("0.045")
+    snap.cvar_limit = Decimal("0.10")
+    snap.cvar_utilized_pct = Decimal("45.0")
+    snap.trigger_status = "ok"
+    snap.consecutive_breach_days = 0
+    snap.regime = "normal"
+    snap.core_weight = Decimal("0.6")
+    snap.satellite_weight = Decimal("0.4")
+    snap.regime_probs = None
+    snap.cvar_lower_5 = None
+    snap.cvar_upper_95 = None
+    return snap
+
+
+def _fake_drift_alert(
+    instrument_id: uuid.UUID,
+    severity: str = "moderate",
+    detected_at: datetime | None = None,
+):
+    alert = MagicMock()
+    alert.id = uuid.uuid4()
+    alert.instrument_id = instrument_id
+    alert.status = "drift_detected"
+    alert.severity = severity
+    alert.anomalous_count = 3
+    alert.total_metrics = 7
+    alert.metric_details = [
+        {"metric_name": "volatility_1y", "z_score": 3.5, "is_anomalous": True}
+    ]
+    alert.is_current = True
+    alert.detected_at = detected_at or datetime(2026, 3, 15, 12, 0, 0, tzinfo=timezone.utc)
+    alert.created_at = datetime(2026, 3, 15, 12, 0, 0, tzinfo=timezone.utc)
+    return alert
+
+
+# ── Gap 1: computed_at on Portfolio schemas ───────────────────────
+
+
+@pytest.mark.asyncio
+class TestPortfolioComputedAt:
+    async def test_computed_at_in_summary(self, client: AsyncClient):
+        snap = _fake_snapshot("conservative")
+
+        async def _mock_get_latest(db, profile):
+            return snap if profile == "conservative" else None
+
+        with patch(
+            "app.domains.wealth.routes.portfolios.get_latest_snapshot",
+            side_effect=_mock_get_latest,
+        ):
+            resp = await client.get(
+                "/api/v1/portfolios/conservative", headers=DEV_ACTOR_HEADER
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "computed_at" in data
+        assert data["computed_at"] is not None
+        # Should be derived from snapshot_date
+        parsed = datetime.fromisoformat(data["computed_at"])
+        assert parsed.date() == date(2026, 3, 15)
+
+    async def test_computed_at_in_snapshot(self, client: AsyncClient):
+        snap = _fake_snapshot("conservative")
+
+        async def _mock_get_latest(db, profile):
+            return snap
+
+        with patch(
+            "app.domains.wealth.routes.portfolios.get_latest_snapshot",
+            side_effect=_mock_get_latest,
+        ):
+            resp = await client.get(
+                "/api/v1/portfolios/conservative/snapshot",
+                headers=DEV_ACTOR_HEADER,
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "computed_at" in data
+        assert data["computed_at"] is not None
+
+    async def test_computed_at_none_when_no_snapshot(self, client: AsyncClient):
+        async def _mock_get_latest(db, profile):
+            return None
+
+        with patch(
+            "app.domains.wealth.routes.portfolios.get_latest_snapshot",
+            side_effect=_mock_get_latest,
+        ):
+            resp = await client.get(
+                "/api/v1/portfolios/conservative", headers=DEV_ACTOR_HEADER
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["computed_at"] is None
+
+
+# ── Gap 2: Drift export ──────────────────────────────────────────
+
+
+INST_ID = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+EXPORT_BASE = f"/api/v1/analytics/strategy-drift/{INST_ID}/export"
+
+
+def _mock_db_with_instrument_and_alerts(alerts: list):
+    """Create a mock AsyncSession that returns instrument name + alerts."""
+    mock_db = AsyncMock()
+
+    # First execute call: instrument name lookup
+    inst_result = MagicMock()
+    inst_result.scalar.return_value = "Test Fund"
+
+    # Second execute call: alerts query
+    alerts_result = MagicMock()
+    alerts_scalars = MagicMock()
+    alerts_scalars.all.return_value = alerts
+    alerts_result.scalars.return_value = alerts_scalars
+
+    mock_db.execute = AsyncMock(side_effect=[inst_result, alerts_result])
+    return mock_db
+
+
+@pytest.mark.asyncio
+class TestDriftExportCSV:
+    async def test_csv_returns_valid_headers(self, client: AsyncClient):
+        alert = _fake_drift_alert(INST_ID)
+        mock_db = _mock_db_with_instrument_and_alerts([alert])
+
+        with patch("app.domains.wealth.routes.strategy_drift.get_db_with_rls") as mock_dep:
+            app.dependency_overrides[
+                __import__(
+                    "app.core.tenancy.middleware", fromlist=["get_db_with_rls"]
+                ).get_db_with_rls
+            ] = lambda: mock_db
+            try:
+                resp = await client.get(
+                    f"{EXPORT_BASE}?format=csv", headers=DEV_ACTOR_HEADER
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "attachment" in resp.headers["content-disposition"]
+
+        reader = csv.DictReader(io.StringIO(resp.text))
+        rows = list(reader)
+        assert len(rows) == 1
+        assert set(reader.fieldnames or []) == {
+            "detected_at",
+            "status",
+            "severity",
+            "anomalous_count",
+            "metric_details",
+        }
+
+    async def test_json_returns_valid_array(self, client: AsyncClient):
+        alert = _fake_drift_alert(INST_ID)
+        mock_db = _mock_db_with_instrument_and_alerts([alert])
+
+        from app.core.tenancy.middleware import get_db_with_rls
+
+        app.dependency_overrides[get_db_with_rls] = lambda: mock_db
+        try:
+            resp = await client.get(
+                f"{EXPORT_BASE}?format=json", headers=DEV_ACTOR_HEADER
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        assert "application/json" in resp.headers["content-type"]
+        data = json.loads(resp.text)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["severity"] == "moderate"
+
+
+@pytest.mark.asyncio
+class TestDriftExportFilters:
+    async def test_date_filter_passed_to_query(self, client: AsyncClient):
+        """Verify from_date/to_date are passed through to the query."""
+        mock_db = _mock_db_with_instrument_and_alerts([])
+
+        from app.core.tenancy.middleware import get_db_with_rls
+
+        app.dependency_overrides[get_db_with_rls] = lambda: mock_db
+        try:
+            resp = await client.get(
+                f"{EXPORT_BASE}?format=csv&from_date=2026-01-01T00:00:00Z&to_date=2026-03-01T00:00:00Z",
+                headers=DEV_ACTOR_HEADER,
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        # Empty CSV (header only)
+        lines = resp.text.strip().split("\n")
+        assert len(lines) == 1  # header only
+
+    async def test_404_for_missing_instrument(self, client: AsyncClient):
+        """RLS: instrument not found returns 404."""
+        mock_db = AsyncMock()
+        inst_result = MagicMock()
+        inst_result.scalar.return_value = None  # instrument not found
+        mock_db.execute = AsyncMock(return_value=inst_result)
+
+        from app.core.tenancy.middleware import get_db_with_rls
+
+        app.dependency_overrides[get_db_with_rls] = lambda: mock_db
+        try:
+            resp = await client.get(EXPORT_BASE, headers=DEV_ACTOR_HEADER)
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Add `computed_at` field to `PortfolioSummary` and `PortfolioSnapshotRead` schemas (derived from `snapshot_date`)
- Add `GET /analytics/strategy-drift/{id}/export` endpoint with CSV/JSON format, date range and severity filters
- Fix stale `app.routers.common` imports across 4 wealth route files (broken on main)
- Add missing `app.utils.hashing` module required by `quant_engine.optimizer_service`

## Test plan
- [x] 7 new tests covering computed_at presence, CSV/JSON export format, date filters, and 404 on missing instrument
- [x] Full suite: 1347 passed
- [x] Route manifest regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)