### PR TITLE
feat: batched risk summary endpoint

### DIFF
--- a/backend/app/domains/wealth/routes/risk.py
+++ b/backend/app/domains/wealth/routes/risk.py
@@ -1,9 +1,9 @@
 import asyncio
-from datetime import date
+from datetime import date, datetime, timezone
 
 import redis.asyncio as aioredis
 import structlog
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,10 +14,15 @@ from app.core.config.settings import settings
 from app.core.security.clerk_auth import Actor, CurrentUser, get_actor, get_current_user
 from app.core.tenancy.middleware import get_db_with_rls
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
-from app.domains.wealth.schemas.macro import MacroIndicators
-from app.domains.wealth.schemas.risk import CVaRPoint, CVaRStatus, RegimeHistoryPoint
 from app.domains.wealth.routes.common import VALID_PROFILES, get_latest_snapshot
 from app.domains.wealth.routes.common import validate_profile as _validate_profile
+from app.domains.wealth.schemas.macro import MacroIndicators
+from app.domains.wealth.schemas.risk import (
+    BatchRiskSummaryOut,
+    CVaRPoint,
+    CVaRStatus,
+    RegimeHistoryPoint,
+)
 from app.shared.schemas import RegimeRead
 from quant_engine.regime_service import get_current_regime, get_latest_macro_values
 
@@ -48,6 +53,86 @@ async def close_sse_redis() -> None:
 
 router = APIRouter(prefix="/risk")
 
+_MAX_BATCH_PROFILES = 20
+
+
+def _snap_to_cvar(profile: str, snap: PortfolioSnapshot | None) -> CVaRStatus:
+    return CVaRStatus(
+        profile=profile,
+        calc_date=snap.snapshot_date if snap else None,
+        cvar_current=snap.cvar_current if snap else None,
+        cvar_limit=snap.cvar_limit if snap else None,
+        cvar_utilized_pct=snap.cvar_utilized_pct if snap else None,
+        trigger_status=snap.trigger_status if snap else None,
+        consecutive_breach_days=snap.consecutive_breach_days if snap else 0,
+        regime=snap.regime if snap else None,
+        cvar_lower_5=float(snap.cvar_lower_5) if snap and snap.cvar_lower_5 is not None else None,
+        cvar_upper_95=float(snap.cvar_upper_95) if snap and snap.cvar_upper_95 is not None else None,
+    )
+
+
+# ── Batched summary (MUST come before /{profile}/* to avoid path capture) ──
+
+
+@router.get(
+    "/summary",
+    response_model=BatchRiskSummaryOut,
+    summary="Batched risk summary for multiple profiles",
+)
+async def get_risk_summary_batch(
+    profiles: str = Query(..., description="Comma-separated profile names"),
+    db: AsyncSession = Depends(get_db_with_rls),
+    user: CurrentUser = Depends(get_current_user),
+) -> BatchRiskSummaryOut:
+    names = [p.strip() for p in profiles.split(",") if p.strip()]
+    if not names:
+        raise HTTPException(status_code=422, detail="profiles parameter must not be empty")
+    if len(names) > _MAX_BATCH_PROFILES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Too many profiles (max {_MAX_BATCH_PROFILES})",
+        )
+
+    # Single query: latest snapshot per requested profile
+    from sqlalchemy import func as sa_func
+
+    latest_subq = (
+        select(
+            PortfolioSnapshot.profile,
+            sa_func.max(PortfolioSnapshot.snapshot_date).label("max_date"),
+        )
+        .where(PortfolioSnapshot.profile.in_(names))
+        .group_by(PortfolioSnapshot.profile)
+        .subquery()
+    )
+    stmt = (
+        select(PortfolioSnapshot)
+        .join(
+            latest_subq,
+            (PortfolioSnapshot.profile == latest_subq.c.profile)
+            & (PortfolioSnapshot.snapshot_date == latest_subq.c.max_date),
+        )
+    )
+    result = await db.execute(stmt)
+    snaps_by_profile = {s.profile: s for s in result.scalars().all()}
+
+    results: dict[str, CVaRStatus | None] = {}
+    for name in names:
+        if name not in VALID_PROFILES:
+            results[name] = None
+        else:
+            snap = snaps_by_profile.get(name)
+            results[name] = _snap_to_cvar(name, snap)
+
+    return BatchRiskSummaryOut(
+        profiles=results,
+        computed_at=datetime.now(timezone.utc),
+        profile_count=len(results),
+    )
+
+
+# ── Single-profile endpoints ──────────────────────────────────────
+
 
 @router.get(
     "/{profile}/cvar",
@@ -62,18 +147,7 @@ async def get_cvar(
 ) -> CVaRStatus:
     _validate_profile(profile)
     snap = await get_latest_snapshot(db, profile)
-    return CVaRStatus(
-        profile=profile,
-        calc_date=snap.snapshot_date if snap else None,
-        cvar_current=snap.cvar_current if snap else None,
-        cvar_limit=snap.cvar_limit if snap else None,
-        cvar_utilized_pct=snap.cvar_utilized_pct if snap else None,
-        trigger_status=snap.trigger_status if snap else None,
-        consecutive_breach_days=snap.consecutive_breach_days if snap else 0,
-        regime=snap.regime if snap else None,
-        cvar_lower_5=float(snap.cvar_lower_5) if snap and snap.cvar_lower_5 is not None else None,
-        cvar_upper_95=float(snap.cvar_upper_95) if snap and snap.cvar_upper_95 is not None else None,
-    )
+    return _snap_to_cvar(profile, snap)
 
 
 @router.get(

--- a/backend/app/domains/wealth/schemas/risk.py
+++ b/backend/app/domains/wealth/schemas/risk.py
@@ -94,6 +94,14 @@ class RiskSummaryBatch(BaseModel):
     computed_at: datetime | None = None
 
 
+class BatchRiskSummaryOut(BaseModel):
+    """Aggregated risk summary for multiple profiles in a single request."""
+
+    profiles: dict[str, CVaRStatus | None]
+    computed_at: datetime
+    profile_count: int
+
+
 class RegimeHistoryPoint(BaseModel):
     snapshot_date: date
     profile: str

--- a/backend/manifests/routes.json
+++ b/backend/manifests/routes.json
@@ -741,6 +741,11 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/risk/summary",
+    "name": "get_risk_summary_batch"
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/risk/{profile}/cvar",
     "name": "get_cvar"
   },

--- a/backend/tests/test_batched_risk.py
+++ b/backend/tests/test_batched_risk.py
@@ -1,0 +1,147 @@
+"""Tests for batched risk summary endpoint."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+DEV_ACTOR_HEADER = {
+    "X-DEV-ACTOR": json.dumps(
+        {
+            "actor_id": "test-user",
+            "roles": ["ADMIN"],
+            "fund_ids": [],
+            "org_id": "00000000-0000-0000-0000-000000000001",
+        }
+    )
+}
+
+SUMMARY_URL = "/api/v1/risk/summary"
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _fake_snapshot(profile: str, snap_date: date | None = None):
+    snap = MagicMock()
+    snap.profile = profile
+    snap.snapshot_date = snap_date or date(2026, 3, 15)
+    snap.cvar_current = Decimal("0.045")
+    snap.cvar_limit = Decimal("0.10")
+    snap.cvar_utilized_pct = Decimal("45.0")
+    snap.trigger_status = "ok"
+    snap.consecutive_breach_days = 0
+    snap.regime = "normal"
+    snap.cvar_lower_5 = Decimal("0.035")
+    snap.cvar_upper_95 = Decimal("0.055")
+    return snap
+
+
+def _mock_db_with_snapshots(snapshots: list):
+    """Mock db that returns snapshots from the batch query."""
+    mock_db = AsyncMock()
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = snapshots
+    result.scalars.return_value = scalars
+    mock_db.execute = AsyncMock(return_value=result)
+    return mock_db
+
+
+@pytest.mark.asyncio
+class TestBatchRiskSummary:
+    async def test_single_profile(self, client: AsyncClient):
+        snap = _fake_snapshot("conservative")
+        mock_db = _mock_db_with_snapshots([snap])
+
+        from app.core.tenancy.middleware import get_db_with_rls
+        app.dependency_overrides[get_db_with_rls] = lambda: mock_db
+        try:
+            resp = await client.get(
+                f"{SUMMARY_URL}?profiles=conservative", headers=DEV_ACTOR_HEADER
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["profile_count"] == 1
+        assert "conservative" in data["profiles"]
+        cvar = data["profiles"]["conservative"]
+        assert cvar["profile"] == "conservative"
+        assert float(cvar["cvar_current"]) == pytest.approx(0.045)
+        assert data["computed_at"] is not None
+
+    async def test_multiple_profiles(self, client: AsyncClient):
+        snaps = [
+            _fake_snapshot("conservative"),
+            _fake_snapshot("moderate"),
+            _fake_snapshot("growth"),
+        ]
+        mock_db = _mock_db_with_snapshots(snaps)
+
+        from app.core.tenancy.middleware import get_db_with_rls
+        app.dependency_overrides[get_db_with_rls] = lambda: mock_db
+        try:
+            resp = await client.get(
+                f"{SUMMARY_URL}?profiles=conservative,moderate,growth",
+                headers=DEV_ACTOR_HEADER,
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["profile_count"] == 3
+        for name in ("conservative", "moderate", "growth"):
+            assert name in data["profiles"]
+            assert data["profiles"][name] is not None
+
+    async def test_unknown_profile_returns_none(self, client: AsyncClient):
+        snap = _fake_snapshot("conservative")
+        mock_db = _mock_db_with_snapshots([snap])
+
+        from app.core.tenancy.middleware import get_db_with_rls
+        app.dependency_overrides[get_db_with_rls] = lambda: mock_db
+        try:
+            resp = await client.get(
+                f"{SUMMARY_URL}?profiles=conservative,nonexistent",
+                headers=DEV_ACTOR_HEADER,
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["profiles"]["nonexistent"] is None
+        assert data["profiles"]["conservative"] is not None
+
+    async def test_empty_profiles_returns_422(self, client: AsyncClient):
+        resp = await client.get(
+            f"{SUMMARY_URL}?profiles=", headers=DEV_ACTOR_HEADER
+        )
+        assert resp.status_code == 422
+
+    async def test_too_many_profiles_returns_422(self, client: AsyncClient):
+        many = ",".join(f"profile{i}" for i in range(21))
+        resp = await client.get(
+            f"{SUMMARY_URL}?profiles={many}", headers=DEV_ACTOR_HEADER
+        )
+        assert resp.status_code == 422
+        assert "Too many profiles" in resp.json()["detail"]
+
+    async def test_requires_auth(self, client: AsyncClient):
+        resp = await client.get(f"{SUMMARY_URL}?profiles=conservative")
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- Add `GET /risk/summary?profiles=conservative,moderate,growth` — returns CVaR status for multiple profiles in a single request
- Single DB query via `WHERE profile IN (...)` subquery (no N+1)
- Capped at 20 profiles per request (422 if exceeded)
- Unknown profiles return `null` (no error) for graceful degradation
- Extracted `_snap_to_cvar()` helper to DRY up single-profile endpoint

## Test plan
- [x] 6 new tests: single profile, multiple, unknown→null, empty→422, >20→422, auth required
- [x] Full suite: 1361 passed
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)