### PR TITLE
feat(credit): Kanban pipeline board with stage drag — C.4

### DIFF
--- a/frontends/credit/package.json
+++ b/frontends/credit/package.json
@@ -10,7 +10,8 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "@netz/ui": "workspace:*"
+    "@netz/ui": "workspace:*",
+    "svelte-dnd-action": "^0.9.0"
   },
   "devDependencies": {
     "@fontsource-variable/inter": "^5.0.0",

--- a/frontends/credit/src/lib/components/PipelineKanban.svelte
+++ b/frontends/credit/src/lib/components/PipelineKanban.svelte
@@ -1,0 +1,224 @@
+<!--
+  Kanban board for deal pipeline — drag cards between stage columns.
+  Uses svelte-dnd-action for drag-and-drop, ConsequenceDialog for stage mutation.
+-->
+<script lang="ts">
+	import { dndzone, TRIGGERS, SHADOW_ITEM_MARKER_PROPERTY_NAME } from "svelte-dnd-action";
+	import { StatusBadge, ConsequenceDialog } from "@netz/ui";
+	import { invalidateAll } from "$app/navigation";
+	import { createClientApiClient } from "$lib/api/client";
+	import { resolveCreditStatus } from "$lib/utils/status-maps";
+	import type { DealStage } from "$lib/types/api";
+
+	interface DealItem {
+		id: string;
+		name: string;
+		stage: DealStage;
+		deal_type: string;
+		sponsor_name: string | null;
+	}
+
+	interface Props {
+		deals: DealItem[];
+		fundId: string;
+		getToken: () => Promise<string>;
+	}
+
+	let { deals, fundId, getToken }: Props = $props();
+
+	const stages: Array<{ value: DealStage; label: string }> = [
+		{ value: "INTAKE", label: "Intake" },
+		{ value: "QUALIFIED", label: "Qualified" },
+		{ value: "IC_REVIEW", label: "IC Review" },
+		{ value: "CONDITIONAL", label: "Conditional" },
+		{ value: "APPROVED", label: "Approved" },
+		{ value: "CONVERTED_TO_ASSET", label: "Converted" },
+		{ value: "REJECTED", label: "Rejected" },
+		{ value: "CLOSED", label: "Closed" },
+	];
+
+	const stageLabels: Record<DealStage, string> = Object.fromEntries(
+		stages.map((s) => [s.value, s.label]),
+	) as Record<DealStage, string>;
+
+	interface KanbanCard {
+		id: string;
+		name: string;
+		stage: DealStage;
+		deal_type: string;
+		sponsor_name: string | null;
+		[SHADOW_ITEM_MARKER_PROPERTY_NAME]?: boolean;
+	}
+
+	interface ColumnData {
+		stage: DealStage;
+		label: string;
+		items: KanbanCard[];
+	}
+
+	function buildColumns(dealList: DealItem[]): ColumnData[] {
+		return stages.map((s) => ({
+			stage: s.value,
+			label: s.label,
+			items: dealList
+				.filter((d) => d.stage === s.value)
+				.map((d) => ({ ...d })),
+		}));
+	}
+
+	let columns = $state<ColumnData[]>(buildColumns(deals));
+
+	// Sync when deals prop changes
+	$effect(() => {
+		columns = buildColumns(deals);
+	});
+
+	// ── Confirmation dialog state ──
+	let confirmOpen = $state(false);
+	let pendingMove = $state<{
+		dealId: string;
+		dealName: string;
+		fromStage: DealStage;
+		toStage: DealStage;
+		rollback: ColumnData[];
+	} | null>(null);
+	let moveError = $state<string | null>(null);
+
+	function handleConsider(stageIdx: number, e: CustomEvent<{ items: KanbanCard[]; info: { trigger: string } }>) {
+		columns[stageIdx].items = e.detail.items;
+	}
+
+	function handleFinalize(stageIdx: number, e: CustomEvent<{ items: KanbanCard[]; info: { trigger: string; id: string } }>) {
+		const targetStage = columns[stageIdx].stage;
+		const movedCard = e.detail.items.find(
+			(item) => item.stage !== targetStage && !item[SHADOW_ITEM_MARKER_PROPERTY_NAME],
+		);
+
+		columns[stageIdx].items = e.detail.items;
+
+		if (movedCard && movedCard.stage !== targetStage) {
+			const snapshot = buildColumns(deals);
+			pendingMove = {
+				dealId: movedCard.id,
+				dealName: movedCard.name,
+				fromStage: movedCard.stage,
+				toStage: targetStage,
+				rollback: snapshot,
+			};
+			confirmOpen = true;
+		}
+	}
+
+	async function confirmStageMove() {
+		if (!pendingMove) return;
+		moveError = null;
+
+		const { dealId, toStage, rollback } = pendingMove;
+
+		try {
+			const api = createClientApiClient(getToken);
+			await api.patch(`/pipeline/deals/${dealId}/stage?fund_id=${fundId}`, {
+				to_stage: toStage,
+			});
+			// Update the card's stage in our local state
+			for (const col of columns) {
+				for (const card of col.items) {
+					if (card.id === dealId) {
+						card.stage = toStage;
+					}
+				}
+			}
+			pendingMove = null;
+			await invalidateAll();
+		} catch (err) {
+			columns = rollback;
+			pendingMove = null;
+			moveError = err instanceof Error ? err.message : "Failed to move deal";
+			setTimeout(() => (moveError = null), 5000);
+		}
+	}
+
+	function cancelStageMove() {
+		if (pendingMove) {
+			columns = pendingMove.rollback;
+			pendingMove = null;
+		}
+	}
+</script>
+
+<div class="flex gap-3 overflow-x-auto pb-4" role="list" aria-label="Pipeline Kanban board">
+	{#each columns as column, idx}
+		<div
+			class="flex w-64 min-w-[16rem] shrink-0 flex-col rounded-lg border border-[var(--netz-border)] bg-[var(--netz-surface-alt)]"
+			role="listitem"
+			aria-label="{column.label} column, {column.items.length} deals"
+		>
+			<!-- Column header -->
+			<div class="flex items-center justify-between border-b border-[var(--netz-border)] px-3 py-2">
+				<h3 class="text-xs font-semibold uppercase tracking-wider text-[var(--netz-text-secondary)]">
+					{column.label}
+				</h3>
+				<span class="flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-[var(--netz-surface)] px-1.5 text-xs font-medium text-[var(--netz-text-secondary)]">
+					{column.items.length}
+				</span>
+			</div>
+
+			<!-- Drop zone -->
+			<div
+				class="flex min-h-[8rem] flex-1 flex-col gap-2 p-2"
+				use:dndzone={{ items: column.items, flipDurationMs: 200, dropTargetStyle: {} }}
+				onconsider={(e) => handleConsider(idx, e)}
+				onfinalize={(e) => handleFinalize(idx, e)}
+				role="list"
+				aria-label="{column.label} deals"
+			>
+				{#each column.items as card (card.id)}
+					<a
+						href="/funds/{fundId}/pipeline/{card.id}"
+						class="block rounded-md border border-[var(--netz-border)] bg-[var(--netz-surface)] p-3 shadow-sm transition-shadow hover:shadow-md"
+						class:opacity-50={card[SHADOW_ITEM_MARKER_PROPERTY_NAME]}
+						role="listitem"
+						aria-label="Deal: {card.name}"
+					>
+						<p class="text-sm font-medium text-[var(--netz-text-primary)] line-clamp-2">
+							{card.name}
+						</p>
+						<div class="mt-2 flex items-center gap-2">
+							<StatusBadge status={card.stage} type="deal" resolve={resolveCreditStatus} />
+						</div>
+						{#if card.deal_type || card.sponsor_name}
+							<p class="mt-1.5 text-xs text-[var(--netz-text-muted)] line-clamp-1">
+								{[card.deal_type, card.sponsor_name].filter(Boolean).join(" · ")}
+							</p>
+						{/if}
+					</a>
+				{/each}
+			</div>
+		</div>
+	{/each}
+</div>
+
+<!-- Error toast -->
+{#if moveError}
+	<div class="fixed bottom-4 right-4 z-50 rounded-lg border border-[var(--netz-danger)] bg-[var(--netz-surface)] px-4 py-3 shadow-lg">
+		<p class="text-sm text-[var(--netz-danger)]">{moveError}</p>
+	</div>
+{/if}
+
+<!-- Consequence dialog for stage move -->
+<ConsequenceDialog
+	bind:open={confirmOpen}
+	title="Move deal to {pendingMove ? stageLabels[pendingMove.toStage] : ''}"
+	impactSummary="This will change the deal's pipeline stage. The move will be recorded in the deal audit trail."
+	confirmLabel="Move deal"
+	cancelLabel="Cancel"
+	metadata={pendingMove
+		? [
+				{ label: "Deal", value: pendingMove.dealName, emphasis: true },
+				{ label: "From", value: stageLabels[pendingMove.fromStage] },
+				{ label: "To", value: stageLabels[pendingMove.toStage], emphasis: true },
+			]
+		: []}
+	onConfirm={confirmStageMove}
+	onCancel={cancelStageMove}
+/>

--- a/frontends/credit/src/lib/utils/status-maps.ts
+++ b/frontends/credit/src/lib/utils/status-maps.ts
@@ -2,9 +2,13 @@ import type { StatusConfig } from "@netz/ui";
 
 export const creditStatusMap: Record<string, StatusConfig> = {
 	screening: { label: "Screening", severity: "neutral", color: "var(--netz-text-secondary)" },
+	intake: { label: "Intake", severity: "neutral", color: "var(--netz-text-secondary)" },
 	qualified: { label: "Qualified", severity: "info", color: "var(--netz-info)" },
 	ic_review: { label: "IC Review", severity: "warning", color: "var(--netz-warning)" },
+	conditional: { label: "Conditional", severity: "warning", color: "var(--netz-warning)" },
 	approved: { label: "Approved", severity: "success", color: "var(--netz-success)" },
+	converted_to_asset: { label: "Converted", severity: "success", color: "var(--netz-success)" },
+	closed: { label: "Closed", severity: "neutral", color: "var(--netz-text-secondary)" },
 	declined: { label: "Declined", severity: "danger", color: "var(--netz-danger)" },
 	pending: { label: "Pending", severity: "warning", color: "var(--netz-warning)" },
 	in_progress: { label: "In Progress", severity: "info", color: "var(--netz-info)" },

--- a/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/+page.svelte
+++ b/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/+page.svelte
@@ -8,6 +8,7 @@
 	import { goto, invalidateAll } from "$app/navigation";
 	import { getContext } from "svelte";
 	import { createClientApiClient } from "$lib/api/client";
+	import PipelineKanban from "$lib/components/PipelineKanban.svelte";
 	import type { PageData } from "./$types";
 	import type { DealStage, DealType } from "$lib/types/api";
 
@@ -15,6 +16,7 @@
 
 	let { data }: { data: PageData } = $props();
 
+	let viewMode = $state<"list" | "kanban">("list");
 	let selectedDeal = $state<Record<string, unknown> | null>(null);
 	let panelOpen = $derived(selectedDeal !== null);
 	const stageFilters: Array<{ value: DealStage | "ALL"; label: string }> = [
@@ -97,18 +99,40 @@
 	<div class="flex-1 p-6">
 		<div class="mb-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
 			<div class="space-y-3">
-				<h2 class="text-xl font-semibold text-[var(--netz-text-primary)]">Deal Pipeline</h2>
-				<div class="flex flex-wrap gap-2">
-					{#each stageFilters as stage}
-						<Button
-							onclick={() => selectStageFilter(stage.value)}
-							size="sm"
-							variant="outline"
+				<div class="flex items-center gap-4">
+					<h2 class="text-xl font-semibold text-[var(--netz-text-primary)]">Deal Pipeline</h2>
+					<div class="flex rounded-md border border-[var(--netz-border)]">
+						<button
+							class="px-3 py-1 text-xs font-medium transition-colors {viewMode === 'list'
+								? 'bg-[var(--netz-brand-primary)] text-white'
+								: 'bg-[var(--netz-surface)] text-[var(--netz-text-secondary)] hover:bg-[var(--netz-surface-alt)]'} rounded-l-md"
+							onclick={() => (viewMode = "list")}
 						>
-							{stage.label}
-						</Button>
-					{/each}
+							List
+						</button>
+						<button
+							class="px-3 py-1 text-xs font-medium transition-colors {viewMode === 'kanban'
+								? 'bg-[var(--netz-brand-primary)] text-white'
+								: 'bg-[var(--netz-surface)] text-[var(--netz-text-secondary)] hover:bg-[var(--netz-surface-alt)]'} rounded-r-md"
+							onclick={() => (viewMode = "kanban")}
+						>
+							Kanban
+						</button>
+					</div>
 				</div>
+				{#if viewMode === "list"}
+					<div class="flex flex-wrap gap-2">
+						{#each stageFilters as stage}
+							<Button
+								onclick={() => selectStageFilter(stage.value)}
+								size="sm"
+								variant="outline"
+							>
+								{stage.label}
+							</Button>
+						{/each}
+					</div>
+				{/if}
 			</div>
 			<Button onclick={() => { resetForm(); showCreate = true; }}>New Deal</Button>
 		</div>
@@ -118,12 +142,14 @@
 				title="No Deals"
 				description="Create your first deal to get started with the pipeline."
 			/>
-		{:else}
+		{:else if viewMode === "list"}
 			<DataTable
 				data={data.deals.items}
 				{columns}
 				onRowClick={handleRowClick}
 			/>
+		{:else}
+			<PipelineKanban deals={data.deals.items} fundId={data.fundId} {getToken} />
 		{/if}
 	</div>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@netz/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      svelte-dnd-action:
+        specifier: ^0.9.0
+        version: 0.9.69(svelte@5.53.12)
     devDependencies:
       '@fontsource-variable/inter':
         specifier: ^5.0.0
@@ -1771,6 +1774,11 @@ packages:
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
+
+  svelte-dnd-action@0.9.69:
+    resolution: {integrity: sha512-NAmSOH7htJoYraTQvr+q5whlIuVoq88vEuHr4NcFgscDRUxfWPPxgie2OoxepBCQCikrXZV4pqV86aun60wVyw==}
+    peerDependencies:
+      svelte: '>=3.23.0 || ^5.0.0-next.0'
 
   svelte-toolbelt@0.7.1:
     resolution: {integrity: sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==}
@@ -3601,6 +3609,10 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
+
+  svelte-dnd-action@0.9.69(svelte@5.53.12):
+    dependencies:
+      svelte: 5.53.12
 
   svelte-toolbelt@0.7.1(svelte@5.53.12):
     dependencies:


### PR DESCRIPTION
## Summary
- Add `PipelineKanban.svelte` component with `svelte-dnd-action` for drag-and-drop deal stage transitions across 8 pipeline columns
- `ConsequenceDialog` confirms each stage move showing deal name, from/to stage metadata — optimistic update with rollback on PATCH failure
- List/Kanban toggle on pipeline page header; stage filter buttons hidden in Kanban mode
- Add 4 missing DealStage entries (`intake`, `conditional`, `converted_to_asset`, `closed`) to `creditStatusMap`

## Section
UX Remediation Plan — Section C.4 (last open item)

## Test plan
- [ ] Toggle between List and Kanban views on pipeline page
- [ ] Drag a deal card from one stage column to another
- [ ] Verify ConsequenceDialog appears with correct deal name + from/to stage
- [ ] Confirm move — verify PATCH `/pipeline/deals/{id}/stage` fires and page refreshes
- [ ] Cancel move — verify card snaps back to original column
- [ ] Simulate PATCH failure — verify rollback + error toast
- [ ] Verify stage filter buttons visible only in List mode
- [ ] Verify ContextPanel still works in List mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)