### PR TITLE
fix(wealth): Fund→Instrument migration + formatter cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ frontends/
 
 **Classification:** Three-layer hybrid classifier (no external ML APIs). Layer 1: filename + keyword rules (~60% of docs). Layer 2: TF-IDF + cosine similarity (~30%). Layer 3: LLM fallback (~10%). Cross-encoder local reranker for IC memo evidence (replaced Cohere).
 
-**324 tests.** All passing. Enforced by `make check` (lint + typecheck + test).
+**1405 tests.** All passing. Enforced by `make check` (lint + typecheck + test). CI: GitHub Actions (`pip install -e ".[dev,ai,quant]"`).
 
 ## Product Scope — Analytical Core Only
 
@@ -285,3 +285,19 @@ npx @sveltejs/mcp svelte-autofixer ./src/lib/Component.svelte
 - ALWAYS run `svelte-autofixer` before finalizing any `.svelte` component
 - Use `fetch()` + `ReadableStream` for SSE — NEVER `EventSource` (cannot send auth headers)
 - Svelte 5 runes syntax (`$state`, `$derived`, `$effect`) — escape `$` as `\$` in terminal
+
+## UX Sprint 7 — Scope Decisions (2026-03-19)
+
+### C.3 — Portfolio deal-level contract fields: NOT IMPLEMENTED (architecture decision)
+
+The portfolio view (`frontends/credit/src/routes/(team)/funds/[fundId]/portfolio/+page.svelte`) is asset-centric post-conversion. Assets are identified by name, type, and strategy with tabs for obligations, alerts, and actions. Fields like tenor, basis, and covenant are deal-level contract fields that live in `deal_context.json` on the deal entity — NOT on portfolio assets. Displaying them per asset row would cross the deal/asset boundary and create misleading attribution (one deal can map to one asset, but deal terms do not become asset attributes post-conversion). Do not add tenor/basis/covenant to the portfolio asset view. If deal-level contract terms need to be visible post-conversion, add a "Source Deal" link from the asset to the originating deal's detail page.
+
+### C.4 — Kanban pipeline board: BLOCKED on `svelte-dnd-action` dependency
+
+Backend endpoint exists: `PATCH /pipeline/deals/{deal_id}/stage` with payload `{ to_stage: string, rationale?: string }` (defined in `backend/app/domains/credit/modules/deals/routes.py:332` and schemas `DealStagePatch`). Implementation is unblocked from a backend contract standpoint.
+
+However, `svelte-dnd-action` is NOT in `frontends/credit/package.json`. The Kanban board requires this package for drag-and-drop column interaction. Do NOT implement the Kanban board with a different DnD mechanism or inline implementation — this would diverge from the plan spec. To unblock: add `svelte-dnd-action` to the credit frontend dependencies (`pnpm add svelte-dnd-action` in `frontends/credit/`), then implement:
+1. Columns per `DealStage` enum value
+2. Deal cards draggable between columns
+3. On drop: open `ConsequenceDialog` with rationale field, PATCH on confirm
+4. `invalidateAll()` on success

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ frontends/
 
 **Classification:** Three-layer hybrid classifier (no external ML APIs). Layer 1: filename + keyword rules (~60% of docs). Layer 2: TF-IDF + cosine similarity (~30%). Layer 3: LLM fallback (~10%). Cross-encoder local reranker for IC memo evidence (replaced Cohere).
 
-**1405 tests.** All passing. Enforced by `make check` (lint + typecheck + test). CI: GitHub Actions (`pip install -e ".[dev,ai,quant]"`).
+**324 tests.** All passing. Enforced by `make check` (lint + typecheck + test).
 
 ## Product Scope — Analytical Core Only
 
@@ -285,19 +285,3 @@ npx @sveltejs/mcp svelte-autofixer ./src/lib/Component.svelte
 - ALWAYS run `svelte-autofixer` before finalizing any `.svelte` component
 - Use `fetch()` + `ReadableStream` for SSE — NEVER `EventSource` (cannot send auth headers)
 - Svelte 5 runes syntax (`$state`, `$derived`, `$effect`) — escape `$` as `\$` in terminal
-
-## UX Sprint 7 — Scope Decisions (2026-03-19)
-
-### C.3 — Portfolio deal-level contract fields: NOT IMPLEMENTED (architecture decision)
-
-The portfolio view (`frontends/credit/src/routes/(team)/funds/[fundId]/portfolio/+page.svelte`) is asset-centric post-conversion. Assets are identified by name, type, and strategy with tabs for obligations, alerts, and actions. Fields like tenor, basis, and covenant are deal-level contract fields that live in `deal_context.json` on the deal entity — NOT on portfolio assets. Displaying them per asset row would cross the deal/asset boundary and create misleading attribution (one deal can map to one asset, but deal terms do not become asset attributes post-conversion). Do not add tenor/basis/covenant to the portfolio asset view. If deal-level contract terms need to be visible post-conversion, add a "Source Deal" link from the asset to the originating deal's detail page.
-
-### C.4 — Kanban pipeline board: BLOCKED on `svelte-dnd-action` dependency
-
-Backend endpoint exists: `PATCH /pipeline/deals/{deal_id}/stage` with payload `{ to_stage: string, rationale?: string }` (defined in `backend/app/domains/credit/modules/deals/routes.py:332` and schemas `DealStagePatch`). Implementation is unblocked from a backend contract standpoint.
-
-However, `svelte-dnd-action` is NOT in `frontends/credit/package.json`. The Kanban board requires this package for drag-and-drop column interaction. Do NOT implement the Kanban board with a different DnD mechanism or inline implementation — this would diverge from the plan spec. To unblock: add `svelte-dnd-action` to the credit frontend dependencies (`pnpm add svelte-dnd-action` in `frontends/credit/`), then implement:
-1. Columns per `DealStage` enum value
-2. Deal cards draggable between columns
-3. On drop: open `ConsequenceDialog` with rationale field, PATCH on confirm
-4. `invalidateAll()` on success

--- a/frontends/credit/src/lib/components/ICMemoViewer.svelte
+++ b/frontends/credit/src/lib/components/ICMemoViewer.svelte
@@ -13,6 +13,7 @@
 	import { createClientApiClient } from "$lib/api/client";
 	import { getContext } from "svelte";
 	import { formatDateTime } from "@netz/ui";
+	import { resolveCreditStatus } from "$lib/utils/status-maps";
 
 	import type { ICMemo, VotingStatus, CommitteeVoteOut } from "$lib/types/api";
 
@@ -146,7 +147,7 @@
 			<Card class="p-4">
 				<div class="mb-3 flex items-center justify-between">
 					<p class="text-sm font-semibold text-[var(--netz-text-primary)]">IC Committee Voting</p>
-					<StatusBadge status={String(votingStatus.status ?? "pending")} type="review" />
+					<StatusBadge status={String(votingStatus.status ?? "pending")} type="review" resolve={resolveCreditStatus} />
 				</div>
 				<p class="mb-4 text-xs text-[var(--netz-text-muted)]">
 					{votingStatus.votes_cast ?? 0} / {votingStatus.quorum ?? 0} votes cast
@@ -235,7 +236,7 @@
 							</span>
 							<span class="text-sm font-medium">{chapter.title}</span>
 						</div>
-						<StatusBadge status={chapter.status} type="review" />
+						<StatusBadge status={chapter.status} type="review" resolve={resolveCreditStatus} />
 					</button>
 					{#if chapter.content}
 						<div class="mt-3 border-t border-[var(--netz-border)] pt-3 text-sm leading-relaxed whitespace-pre-wrap text-[var(--netz-text-secondary)]">

--- a/frontends/credit/src/lib/components/IngestionProgress.svelte
+++ b/frontends/credit/src/lib/components/IngestionProgress.svelte
@@ -6,6 +6,7 @@
 	import { Card, StatusBadge } from "@netz/ui";
 	import { createSSEStream } from "@netz/ui/utils";
 	import { onMount, getContext } from "svelte";
+	import { resolveCreditStatus } from "$lib/utils/status-maps";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 
@@ -55,7 +56,7 @@
 		{#each STAGES as stage (stage)}
 			<div class="flex items-center justify-between">
 				<span class="text-sm capitalize text-[var(--netz-text-secondary)]">{stage}</span>
-				<StatusBadge status={stageStatus(stage)} type="review" />
+				<StatusBadge status={stageStatus(stage)} type="review" resolve={resolveCreditStatus} />
 			</div>
 		{/each}
 	</div>

--- a/frontends/credit/src/lib/components/TaskInbox.svelte
+++ b/frontends/credit/src/lib/components/TaskInbox.svelte
@@ -4,6 +4,7 @@
 -->
 <script lang="ts">
 	import { StatusBadge, Card } from "@netz/ui";
+	import { resolveCreditStatus } from "$lib/utils/status-maps";
 
 	interface Task {
 		id: string;
@@ -31,7 +32,7 @@
 				class="flex items-center justify-between px-4 py-3 transition-colors hover:bg-[var(--netz-surface-alt)]"
 			>
 				<div class="flex items-center gap-3">
-					<StatusBadge status={task.priority} type="risk" />
+					<StatusBadge status={task.priority} type="risk" resolve={resolveCreditStatus} />
 					<div>
 						<p class="text-sm font-medium text-[var(--netz-text-primary)]">{task.title}</p>
 						<p class="text-xs text-[var(--netz-text-muted)]">{task.type}</p>

--- a/frontends/credit/src/routes/(investor)/documents/+page.svelte
+++ b/frontends/credit/src/routes/(investor)/documents/+page.svelte
@@ -2,7 +2,7 @@
   Investor — Approved-for-distribution documents.
 -->
 <script lang="ts">
-	import { PageHeader, EmptyState, StatusBadge } from "@netz/ui";
+	import { PageHeader, EmptyState, StatusBadge, formatDate } from "@netz/ui";
 	import type { PageData } from "./$types";
 
 	let { data }: { data: PageData } = $props();
@@ -44,7 +44,7 @@
 						<p class="mt-1 text-sm text-[var(--netz-text-muted)]">
 							{doc.document_type}
 							{#if doc.created_at}
-								&middot; {new Date(doc.created_at as string).toLocaleDateString()}
+								&middot; {formatDate(doc.created_at as string)}
 							{/if}
 						</p>
 					</div>

--- a/frontends/credit/src/routes/(investor)/documents/+page.svelte
+++ b/frontends/credit/src/routes/(investor)/documents/+page.svelte
@@ -3,6 +3,7 @@
 -->
 <script lang="ts">
 	import { PageHeader, EmptyState, StatusBadge, formatDate } from "@netz/ui";
+	import { resolveCreditStatus } from "$lib/utils/status-maps";
 	import type { PageData } from "./$types";
 
 	let { data }: { data: PageData } = $props();
@@ -39,7 +40,7 @@
 							<p class="font-medium text-[var(--netz-text-primary)]">
 								{doc.title}
 							</p>
-							<StatusBadge status={doc.status as string} />
+							<StatusBadge status={doc.status as string} resolve={resolveCreditStatus} />
 						</div>
 						<p class="mt-1 text-sm text-[var(--netz-text-muted)]">
 							{doc.document_type}

--- a/frontends/credit/src/routes/(investor)/report-packs/+page.svelte
+++ b/frontends/credit/src/routes/(investor)/report-packs/+page.svelte
@@ -2,7 +2,7 @@
   Investor — Published report packs with PDF download.
 -->
 <script lang="ts">
-	import { PageHeader, DataTable, EmptyState, PDFDownload } from "@netz/ui";
+	import { PageHeader, DataTable, EmptyState, PDFDownload, formatDate } from "@netz/ui";
 	import type { PageData } from "./$types";
 
 	let { data }: { data: PageData } = $props();
@@ -40,7 +40,7 @@
 						</p>
 						{#if pack.published_at}
 							<p class="text-sm text-[var(--netz-text-muted)]">
-								Published: {new Date(pack.published_at).toLocaleDateString()}
+								Published: {formatDate(pack.published_at)}
 							</p>
 						{/if}
 					</div>

--- a/frontends/credit/src/routes/(investor)/statements/+page.svelte
+++ b/frontends/credit/src/routes/(investor)/statements/+page.svelte
@@ -2,7 +2,7 @@
   Investor — Published statements with download.
 -->
 <script lang="ts">
-	import { PageHeader, EmptyState, PDFDownload } from "@netz/ui";
+	import { PageHeader, EmptyState, PDFDownload, formatDate } from "@netz/ui";
 	import type { PageData } from "./$types";
 
 	let { data }: { data: PageData } = $props();
@@ -34,7 +34,7 @@
 						</p>
 						{#if stmt.created_at}
 							<p class="text-sm text-[var(--netz-text-muted)]">
-								Created: {new Date(stmt.created_at as string).toLocaleDateString()}
+								Created: {formatDate(stmt.created_at as string)}
 							</p>
 						{/if}
 					</div>

--- a/frontends/credit/src/routes/(team)/copilot/+page.svelte
+++ b/frontends/credit/src/routes/(team)/copilot/+page.svelte
@@ -3,7 +3,7 @@
   Enhanced: History sidebar, Activity log, Document retrieval.
 -->
 <script lang="ts">
-	import { Card, Button, PageTabs, EmptyState, DataTable } from "@netz/ui";
+	import { Card, Button, PageTabs, EmptyState, DataTable, formatPercent } from "@netz/ui";
 	import { ActionButton } from "@netz/ui";
 	import CopilotChat from "$lib/components/CopilotChat.svelte";
 	import { createClientApiClient } from "$lib/api/client";
@@ -235,7 +235,7 @@
 								<div class="flex items-start justify-between">
 									<p class="text-sm font-medium text-[var(--netz-text-primary)]">{doc.title}</p>
 									<span class="ml-2 shrink-0 rounded-full bg-[var(--netz-brand-primary)]/10 px-2 py-0.5 text-xs text-[var(--netz-brand-primary)]">
-										{(doc.score * 100).toFixed(0)}%
+										{formatPercent(doc.score)}
 									</span>
 								</div>
 								<p class="mt-1 line-clamp-3 text-xs text-[var(--netz-text-muted)]">{doc.snippet}</p>

--- a/frontends/credit/src/routes/(team)/funds/[fundId]/documents/reviews/[reviewId]/+page.svelte
+++ b/frontends/credit/src/routes/(team)/funds/[fundId]/documents/reviews/[reviewId]/+page.svelte
@@ -4,6 +4,7 @@
 -->
 <script lang="ts">
 	import { Card, StatusBadge, Button, Dialog } from "@netz/ui";
+	import { resolveCreditStatus } from "$lib/utils/status-maps";
 	import { ActionButton, ConfirmDialog, FormField } from "@netz/ui";
 	import { ConsequenceDialog, AuditTrailPanel } from "@netz/ui";
 	import { createOptimisticMutation } from "@netz/ui";
@@ -319,7 +320,7 @@
 			<h2 class="text-xl font-semibold text-[var(--netz-text-primary)]">
 				{review.title ?? review.document_title ?? "Review"}
 			</h2>
-			<StatusBadge status={status} type="review" />
+			<StatusBadge status={status} type="review" resolve={resolveCreditStatus} />
 		</div>
 		<div class="flex gap-2">
 			{#if canAssign}
@@ -368,7 +369,7 @@
 			{#each review.assignments as assignment}
 				<div class="flex items-center justify-between py-2">
 					<span class="text-sm">{assignment.reviewer_name ?? "Unknown"}</span>
-					<StatusBadge status={String(assignment.decision ?? "pending")} type="review" />
+					<StatusBadge status={String(assignment.decision ?? "pending")} type="review" resolve={resolveCreditStatus} />
 				</div>
 			{/each}
 		{:else}

--- a/frontends/credit/src/routes/(team)/funds/[fundId]/documents/upload/+page.svelte
+++ b/frontends/credit/src/routes/(team)/funds/[fundId]/documents/upload/+page.svelte
@@ -7,7 +7,7 @@
   5. SSE stream showing pipeline stages
 -->
 <script lang="ts">
-	import { Card, Button, EmptyState } from "@netz/ui";
+	import { Card, Button, EmptyState, formatNumber } from "@netz/ui";
 	import { createSSEStream } from "@netz/ui/utils";
 	import IngestionProgress from "$lib/components/IngestionProgress.svelte";
 	import { createClientApiClient } from "$lib/api/client";
@@ -44,7 +44,7 @@
 	/** Validate file size and magic bytes. Sets uploadError and returns false on failure. */
 	async function validateFile(f: File): Promise<boolean> {
 		if (f.size > MAX_FILE_SIZE) {
-			uploadError = `File "${f.name}" exceeds 50 MB limit (${(f.size / 1024 / 1024).toFixed(1)} MB)`;
+			uploadError = `File "${f.name}" exceeds 50 MB limit (${formatNumber(f.size / 1024 / 1024, 1)} MB)`;
 			return false;
 		}
 		if (!(await validateMagicBytes(f))) {
@@ -132,7 +132,7 @@
 				{#if file}
 					<p class="text-sm font-medium text-[var(--netz-text-primary)]">{file.name}</p>
 					<p class="text-xs text-[var(--netz-text-muted)]">
-						{(file.size / 1024 / 1024).toFixed(2)} MB
+						{formatNumber(file.size / 1024 / 1024, 2)} MB
 					</p>
 				{:else}
 					<p class="mb-2 text-sm text-[var(--netz-text-secondary)]">

--- a/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/+page.svelte
+++ b/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/+page.svelte
@@ -10,6 +10,7 @@
 	import { createClientApiClient } from "$lib/api/client";
 	import type { PageData } from "./$types";
 	import type { DealStage, DealType } from "$lib/types/api";
+	import { resolveCreditStatus } from "$lib/utils/status-maps";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 
@@ -137,7 +138,7 @@
 			<div class="space-y-4 p-4">
 				<div>
 					<p class="text-xs text-[var(--netz-text-muted)]">Stage</p>
-					<StatusBadge status={String(selectedDeal.stage)} type="deal" />
+					<StatusBadge status={String(selectedDeal.stage)} type="deal" resolve={resolveCreditStatus} />
 				</div>
 				<div>
 					<p class="text-xs text-[var(--netz-text-muted)]">Type</p>

--- a/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/[dealId]/+page.svelte
+++ b/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/[dealId]/+page.svelte
@@ -19,6 +19,7 @@
 	import { createClientApiClient } from "$lib/api/client";
 	import type { PageData } from "./$types";
 	import type { DealStage, RejectionCode, ICCondition, StageTimeline, VotingStatusDetail } from "$lib/types/api";
+	import { resolveCreditStatus } from "$lib/utils/status-maps";
 
 	/** Matches components["schemas"]["DealDecision"] from packages/ui/src/types/api.d.ts */
 	interface DealDecisionPayload {
@@ -280,7 +281,7 @@
 				{data.deal.name ?? "Deal"}
 			</h2>
 			<div class="mt-1 flex items-center gap-2">
-				<StatusBadge status={String(data.deal.stage)} type="deal" />
+				<StatusBadge status={String(data.deal.stage)} type="deal" resolve={resolveCreditStatus} />
 				{#if data.deal.deal_type}
 					<span class="text-sm text-[var(--netz-text-muted)]">{data.deal.deal_type}</span>
 				{/if}
@@ -440,7 +441,7 @@
 										{condition.title}
 									</p>
 									<p class="mt-1 text-xs text-[var(--netz-text-muted)]">
-										Status: <StatusBadge status={condition.status} type="default" />
+										Status: <StatusBadge status={condition.status} type="default" resolve={resolveCreditStatus} />
 									</p>
 									{#if condition.notes}
 										<p class="mt-1 text-xs text-[var(--netz-text-muted)]">{condition.notes}</p>

--- a/frontends/wealth/src/lib/components/FundDetailPanel.svelte
+++ b/frontends/wealth/src/lib/components/FundDetailPanel.svelte
@@ -4,7 +4,7 @@
   DD report progress subscribes via SSE when an active report ID is available.
 -->
 <script lang="ts">
-	import { ContextPanel, EmptyState, SectionCard, MetricCard } from "@netz/ui";
+	import { ContextPanel, EmptyState, SectionCard, MetricCard, formatAUM, formatNumber, formatPercent, formatDate } from "@netz/ui";
 	import { getContext } from "svelte";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
@@ -158,21 +158,11 @@
 	// ── Format helpers ─────────────────────────────────────────────────────
 
 	function formatAum(value: number | null): string {
-		if (value === null) return "—";
-		if (value >= 1_000_000_000) return `R$ ${(value / 1_000_000_000).toFixed(1)}B`;
-		if (value >= 1_000_000) return `R$ ${(value / 1_000_000).toFixed(0)}M`;
-		return `R$ ${value.toLocaleString("pt-BR")}`;
+		return formatAUM(value, "BRL", "pt-BR");
 	}
 
 	function formatPct(value: number | null): string {
-		if (value === null) return "—";
-		const sign = value >= 0 ? "+" : "";
-		return `${sign}${(value * 100).toFixed(2)}%`;
-	}
-
-	function formatDate(value: string | null): string {
-		if (!value) return "—";
-		return new Date(value).toLocaleDateString("pt-BR");
+		return formatPercent(value, 2, "pt-BR", true);
 	}
 </script>
 
@@ -189,7 +179,7 @@
 			<div class="flex shrink-0 flex-col items-end gap-1">
 				{#if fund.score !== null}
 					<span class="text-lg font-bold text-[var(--netz-text-primary)]">
-						{fund.score.toFixed(1)}
+						{formatNumber(fund.score, 1, "pt-BR")}
 					</span>
 					<span class="text-xs text-[var(--netz-text-muted)]">Score</span>
 				{/if}
@@ -221,7 +211,7 @@
 					<MetricCard label="AUM" value={formatAum(fund.aum)} />
 					<MetricCard
 						label="Score Geral"
-						value={fund.score !== null ? fund.score.toFixed(1) : "—"}
+						value={formatNumber(fund.score, 1, "pt-BR")}
 					/>
 					{#if fund.annual_return !== undefined}
 						<MetricCard
@@ -232,7 +222,7 @@
 					{#if fund.sharpe_ratio !== undefined}
 						<MetricCard
 							label="Sharpe"
-							value={fund.sharpe_ratio !== null ? fund.sharpe_ratio.toFixed(2) : "—"}
+							value={formatNumber(fund.sharpe_ratio, 2, "pt-BR")}
 						/>
 					{/if}
 					{#if fund.max_drawdown !== undefined}
@@ -275,12 +265,12 @@
 							</div>
 							<div class="flex justify-between">
 								<dt class="text-[var(--netz-text-muted)]">Atualizado</dt>
-								<dd class="text-[var(--netz-text-primary)]">{formatDate(fund.updated_at)}</dd>
+								<dd class="text-[var(--netz-text-primary)]">{formatDate(fund.updated_at, "short", "pt-BR")}</dd>
 							</div>
 							{#if fund.inception_date}
 								<div class="flex justify-between">
 									<dt class="text-[var(--netz-text-muted)]">Início</dt>
-									<dd class="text-[var(--netz-text-primary)]">{formatDate(fund.inception_date)}</dd>
+									<dd class="text-[var(--netz-text-primary)]">{formatDate(fund.inception_date, "short", "pt-BR")}</dd>
 								</div>
 							{/if}
 						</dl>

--- a/frontends/wealth/src/lib/components/MacroChips.svelte
+++ b/frontends/wealth/src/lib/components/MacroChips.svelte
@@ -6,7 +6,7 @@
   CPI YoY / Fed Funds: primary text, no conditional colour.
 -->
 <script lang="ts">
-	import { cn } from "@netz/ui";
+	import { cn, formatNumber, formatPercent } from "@netz/ui";
 
 	interface Props {
 		macro: {
@@ -30,7 +30,7 @@
 			style:color={macro.vix !== null && macro.vix > 25
 				? "var(--netz-danger)"
 				: "var(--netz-success)"}
-		>{macro.vix?.toFixed(1) ?? "—"}</p>
+		>{formatNumber(macro.vix, 1, "en-US")}</p>
 	</div>
 
 	<!-- Yield Curve -->
@@ -41,14 +41,14 @@
 			style:color={macro.yield_curve_10y2y !== null && macro.yield_curve_10y2y < 0
 				? "var(--netz-danger)"
 				: "var(--netz-text-primary)"}
-		>{macro.yield_curve_10y2y !== null ? `${macro.yield_curve_10y2y.toFixed(2)}%` : "—"}</p>
+		>{macro.yield_curve_10y2y !== null ? `${formatNumber(macro.yield_curve_10y2y, 2, "en-US")}%` : "—"}</p>
 	</div>
 
 	<!-- CPI YoY -->
 	<div class="rounded-lg border border-[var(--netz-border)] bg-[var(--netz-surface-inset)] px-4 py-3">
 		<p class="text-xs text-[var(--netz-text-muted)]">CPI YoY</p>
 		<p class="text-lg font-semibold text-[var(--netz-text-primary)]">
-			{macro.cpi_yoy !== null ? `${macro.cpi_yoy.toFixed(1)}%` : "—"}
+			{macro.cpi_yoy !== null ? formatPercent(macro.cpi_yoy / 100, 1, "en-US") : "—"}
 		</p>
 	</div>
 
@@ -56,7 +56,7 @@
 	<div class="rounded-lg border border-[var(--netz-border)] bg-[var(--netz-surface-inset)] px-4 py-3">
 		<p class="text-xs text-[var(--netz-text-muted)]">Fed Funds</p>
 		<p class="text-lg font-semibold text-[var(--netz-text-primary)]">
-			{macro.fed_funds_rate !== null ? `${macro.fed_funds_rate.toFixed(2)}%` : "—"}
+			{macro.fed_funds_rate !== null ? formatPercent(macro.fed_funds_rate / 100, 2, "en-US") : "—"}
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- Migrate `FundDetailPanel` and `MacroChips` to `@netz/ui` formatters (Section W.7)
- Migrate 6 credit formatter violations to `@netz/ui` (Section C.6)
- Wire `resolveCreditStatus` into all `StatusBadge` usages (Section S.3)

## Test plan
- [ ] `make check` passes (1405 tests)
- [ ] Verify FundDetailPanel renders formatted numbers correctly
- [ ] Verify MacroChips date/number formatting via @netz/ui

🤖 Generated with [Claude Code](https://claude.com/claude-code)