### PR TITLE
fix(dx): Makefile dash targets + RLS instruments_universe fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,12 @@ make up                 # docker-compose up -d (PG 16 + TimescaleDB + Redis 7)
 make down               # docker-compose down
 
 # Frontend (pnpm + Turborepo)
-make dev:credit         # Credit frontend dev server
-make dev:wealth         # Wealth frontend dev server
-make dev:admin          # Admin frontend dev server
-make dev:all            # All packages in parallel (Turborepo)
-make build:all          # Build all packages (topological order)
-make check:all          # Check all frontend packages
+make dev-credit         # Credit frontend dev server
+make dev-wealth         # Wealth frontend dev server
+make dev-admin          # Admin frontend dev server
+make dev-all            # All packages in parallel (Turborepo)
+make build-all          # Build all packages (topological order)
+make check-all          # Check all frontend packages
 make types              # Generate TS types from OpenAPI schema (requires running backend)
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check test lint typecheck architecture serve migrate migration help pipeline \
-       dev:ui build:ui dev:credit build:credit dev:wealth build:wealth dev:admin build:admin \
-       dev:all build:all check:all types
+       dev-ui build-ui dev-credit build-credit dev-wealth build-wealth dev-admin build-admin \
+       dev-all build-all check-all types
 
 # ── Unified gate ──────────────────────────────────────────
 check: lint architecture typecheck test
@@ -38,37 +38,37 @@ down:
 	docker-compose down
 
 # ── Frontend (pnpm + Turborepo) ──────────────────────────
-dev\:ui:
+dev-ui:
 	pnpm --filter @netz/ui dev
 
-build\:ui:
+build-ui:
 	pnpm --filter @netz/ui build
 
-dev\:credit:
+dev-credit:
 	pnpm --filter netz-credit-intelligence dev
 
-build\:credit:
+build-credit:
 	pnpm --filter netz-credit-intelligence build
 
-dev\:wealth:
+dev-wealth:
 	pnpm --filter netz-wealth-os dev
 
-build\:wealth:
+build-wealth:
 	pnpm --filter netz-wealth-os build
 
-dev\:admin:
+dev-admin:
 	pnpm --filter netz-admin dev
 
-build\:admin:
+build-admin:
 	pnpm --filter netz-admin build
 
-dev\:all:
+dev-all:
 	pnpm exec turbo run dev
 
-build\:all:
+build-all:
 	pnpm exec turbo run build
 
-check\:all:
+check-all:
 	pnpm exec turbo run check
 
 types:
@@ -88,12 +88,12 @@ help:
 	@echo "make down        - docker-compose down"
 	@echo ""
 	@echo "── Frontend ────────────────────────────────────────"
-	@echo "make dev:ui      - @netz/ui watch mode"
-	@echo "make build:ui    - Build @netz/ui package"
-	@echo "make dev:credit  - Credit frontend dev server"
-	@echo "make dev:wealth  - Wealth frontend dev server"
-	@echo "make dev:admin   - Admin frontend dev server"
-	@echo "make dev:all     - All packages in parallel (Turborepo)"
-	@echo "make build:all   - Build all packages (topological order)"
-	@echo "make check:all   - Check all frontend packages"
+	@echo "make dev-ui      - @netz/ui watch mode"
+	@echo "make build-ui    - Build @netz/ui package"
+	@echo "make dev-credit  - Credit frontend dev server"
+	@echo "make dev-wealth  - Wealth frontend dev server"
+	@echo "make dev-admin   - Admin frontend dev server"
+	@echo "make dev-all     - All packages in parallel (Turborepo)"
+	@echo "make build-all   - Build all packages (topological order)"
+	@echo "make check-all   - Check all frontend packages"
 	@echo "make types       - Generate TS types from OpenAPI schema"

--- a/backend/app/core/db/migrations/versions/0003_credit_domain.py
+++ b/backend/app/core/db/migrations/versions/0003_credit_domain.py
@@ -19,7 +19,7 @@ _RLS_TABLES = [
     # From 0001
     "audit_events",
     # From 0002 (wealth)
-    "funds_universe", "nav_timeseries", "fund_risk_metrics",
+    "instruments_universe", "nav_timeseries", "fund_risk_metrics",
     "portfolio_snapshots", "strategic_allocation", "tactical_positions",
     "rebalance_events", "lipper_ratings", "backtest_runs",
     # From 0003 — credit core

--- a/backend/tests/test_rls.py
+++ b/backend/tests/test_rls.py
@@ -20,7 +20,7 @@ _RLS_TABLES: list[str] = _mod._RLS_TABLES  # type: ignore[attr-defined]
 async def test_rls_table_list_includes_wealth_tables():
     """Wealth tables from migration 0002 must be in RLS list."""
     wealth_tables = {
-        "funds_universe", "nav_timeseries", "fund_risk_metrics",
+        "instruments_universe", "nav_timeseries", "fund_risk_metrics",
         "portfolio_snapshots", "strategic_allocation", "tactical_positions",
         "rebalance_events", "lipper_ratings", "backtest_runs",
     }

--- a/docs/audit/frontend-system-map-v1.md
+++ b/docs/audit/frontend-system-map-v1.md
@@ -290,7 +290,7 @@ All tokens mapped via `@theme` block in each frontend's `app.css`:
 
 ```
 build    → depends on ^build (topological: @netz/ui first)
-dev      → persistent, uncached (parallel via make dev:all)
+dev      → persistent, uncached (parallel via make dev-all)
 check    → depends on ^build
 types    → openapi-typescript from running backend
 ```

--- a/docs/plans/2026-03-16-feat-frontend-admin-platform-plan.md
+++ b/docs/plans/2026-03-16-feat-frontend-admin-platform-plan.md
@@ -1826,7 +1826,7 @@ All three frontends consume the same `@netz/ui` components and utilities. The in
 - [ ] Integration tests pass per frontend (vitest + MSW)
 - [ ] E2E tests pass per frontend (Playwright against docker-compose)
 - [ ] `make check` passes (backend lint + typecheck + test)
-- [ ] `make check:frontends` passes (svelte-check + vitest per frontend)
+- [ ] `make check-all` passes (svelte-check + vitest per frontend)
 - [ ] No TypeScript `any` types in production code
 
 ## Dependencies & Prerequisites

--- a/docs/plans/2026-03-17-feat-endpoint-coverage-full-frontend-wiring-plan.md
+++ b/docs/plans/2026-03-17-feat-endpoint-coverage-full-frontend-wiring-plan.md
@@ -379,7 +379,7 @@ New server load: `GET /admin/configs/invalid`. Display as warning list with link
 - [x] Invalid configs list shown with links to editor
 - [x] Prompt version history loaded lazily on tab click
 - [x] Prompt revert works with confirmation
-- [ ] `make check:all` passes
+- [ ] `make check-all` passes
 
 ---
 
@@ -470,7 +470,7 @@ Per report pack row:
 - [ ] Update obligation inline
 - [ ] Update action status
 - [ ] Report pack generate/publish buttons with role guard
-- [ ] `make check:all` passes
+- [ ] `make check-all` passes
 
 ---
 
@@ -578,7 +578,7 @@ AI Analysis: ActionButton "Run AI Analysis" → `POST /ai-analyze`. Returns job_
 - [ ] Resubmit for review
 - [ ] AI analysis trigger with SSE progress
 - [ ] Interactive checklist toggles with optimistic UI
-- [ ] `make check:all` passes
+- [ ] `make check-all` passes
 
 ---
 
@@ -637,7 +637,7 @@ Or add as a tab/section within the existing dashboard. Components:
 - [ ] AI query history sidebar (lazy-loaded on tab click)
 - [ ] AI activity log
 - [ ] Document retrieval interface
-- [ ] `make check:all` passes
+- [ ] `make check-all` passes
 
 ---
 
@@ -727,7 +727,7 @@ Per model portfolio:
 - [ ] Fact sheet generation with "server busy" handling
 - [ ] Fact sheet PDF download
 - [ ] All Markdown rendered via sanitizing renderer (no `{@html}` with raw content)
-- [ ] `make check:all` passes
+- [ ] `make check-all` passes
 
 ---
 
@@ -828,7 +828,7 @@ Add to parallel fetch: `GET /funds/{fund_id}/stats`, `GET /funds/{fund_id}/perfo
 - [ ] Model portfolio backtest display
 - [ ] Model portfolio allocate/rebalance
 - [ ] Fund detail with stats, performance, holdings (non-critical, graceful fallback)
-- [ ] `make check:all` passes
+- [ ] `make check-all` passes
 
 ---
 
@@ -973,7 +973,7 @@ Handle 429 (max connections) with fallback message. (see todo: `todos/138-pendin
 - [ ] Risk SSE in `(team)/+layout.svelte` via `setContext`, consumed by dashboard + risk via `getContext`
 - [ ] Screener run detail in ContextPanel
 - [ ] Instrument screening history
-- [ ] `make check:all` passes
+- [ ] `make check-all` passes
 
 ---
 
@@ -1023,7 +1023,7 @@ Loads: `GET /instruments?limit=500`
 - [ ] Bulk sync with confirmation + loading state
 - [ ] External search with results table + per-row "Import" button
 - [ ] Instrument detail in ContextPanel
-- [ ] `make check:all` passes
+- [ ] `make check-all` passes
 
 ---
 

--- a/docs/prompts/phase-2.5-execution-prompts.md
+++ b/docs/prompts/phase-2.5-execution-prompts.md
@@ -476,7 +476,7 @@ No frontend consumers exist. Do not build new integrations against these.
 If there are two separate files (`/api/dataroom/` and `/api/data-room/`), deprecate both.
 
 ### Verification
-- Run `make check:all` (backend + all frontends)
+- Run `make check-all` (backend + all frontends)
 - Verify the wealth fund detail page still renders (it should — the removed data was always null)
 - Verify the analytics correlation-regime section now loads data (path was wrong before)
 - Verify deprecated endpoints still respond (deprecated ≠ removed)

--- a/todos/179-complete-p3-dead-confirm-dialog-imports.md
+++ b/todos/179-complete-p3-dead-confirm-dialog-imports.md
@@ -23,7 +23,7 @@ Multiple page components import `ConfirmDialog` but never render it in their tem
 
 1. Remove the unused `ConfirmDialog` import from each affected file
 2. Verify no associated state variables (e.g., `showConfirm`, `confirmOpen`) are also dead code and remove those too
-3. Run `make check:all` to confirm no build errors
+3. Run `make check-all` to confirm no build errors
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary
- Rename all Makefile colon targets (`dev:credit`, `build:all`, `check:all`) to dash convention (`dev-credit`, `build-all`, `check-all`) — fixes `multiple target patterns` error on GNU Make Windows32
- Fix `funds_universe` → `instruments_universe` in migration 0003 `_RLS_TABLES` and test assertion
- Update all doc references (CLAUDE.md, 5 docs files, 1 todo)

## Test plan
- [x] `make check` passes on Windows (1405 tests)
- [x] `make help` shows dash-based target names
- [x] Zero remaining colon-based target references (`grep 'make (dev|build|check):' **/*.md` = 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)