### PR TITLE
Add retrieval confidence signals + pipeline local OCR fixes

### DIFF
--- a/backend/ai_engine/extraction/document_intelligence.py
+++ b/backend/ai_engine/extraction/document_intelligence.py
@@ -36,7 +36,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from ai_engine.governance.prompt_safety import sanitize_user_input
-
 from ai_engine.model_config import get_model
 from ai_engine.pipeline.models import CANONICAL_DOC_TYPES
 from ai_engine.prompts import prompt_registry

--- a/backend/ai_engine/extraction/local_reranker.py
+++ b/backend/ai_engine/extraction/local_reranker.py
@@ -143,7 +143,7 @@ def rerank(
         _MODEL_NAME,
     )
 
-    for doc, score in zip(documents, scores):
+    for doc, score in zip(documents, scores, strict=False):
         doc[score_key] = float(score)
 
     documents.sort(key=lambda d: d.get(score_key, 0.0), reverse=True)

--- a/backend/ai_engine/extraction/local_vlm_ocr.py
+++ b/backend/ai_engine/extraction/local_vlm_ocr.py
@@ -1,6 +1,6 @@
 """Local VLM OCR — PDF to markdown via LM Studio SDK.
 
-Uses a local LM Studio server with a VLM (qwen2.5-vl-7b) to extract
+Uses a local LM Studio server with a VLM (e.g. Qwen2.5-VL-7B) to extract
 text from PDF pages rendered as JPEG images.
 
 Drop-in replacement for mistral_ocr.async_extract_pdf_with_mistral().
@@ -11,13 +11,25 @@ from __future__ import annotations
 import asyncio
 import io
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
 from ai_engine.extraction.mistral_ocr import PageBlock
 
+
 # ── Defaults ────────────────────────────────────────────────────────
-DEFAULT_HOST = "127.0.0.1:1234"
+def _default_host() -> str:
+    """Resolve LM Studio host from settings (strips http:// and /v1 suffix)."""
+    try:
+        from app.core.config.settings import settings as _settings
+        url = _settings.local_llm_url  # e.g. "http://127.0.0.1:1234/v1"
+        host = url.replace("http://", "").replace("https://", "").rstrip("/")
+        if host.endswith("/v1"):
+            host = host[:-3]
+        return host
+    except Exception:
+        return "127.0.0.1:1234"
 _DPI = 100
 _JPEG_QUALITY = 55
 _MAX_IMAGE_PIXELS = 1200 * 1600
@@ -82,7 +94,20 @@ def _ocr_page_sync(
             client.close()
             return PageBlock(page_start=page_num, page_end=page_num, text="")
 
-        model = models[0]
+        # Select VLM model — prefer LOCAL_VLM_MODEL env var, then vision keywords
+        _preferred = os.environ.get("LOCAL_VLM_MODEL", "").lower()
+        _VISION_KEYWORDS = ("olmocr", "qwen2.5-vl", "qwen2-vl", "gemma-3", "qwen3-vl", "llava", "pixtral")
+        if _preferred:
+            model = next(
+                (m for m in models if _preferred in m.identifier.lower()),
+                models[0],
+            )
+        else:
+            model = next(
+                (m for m in models if any(kw in m.identifier.lower() for kw in _VISION_KEYWORDS)),
+                models[0],
+            )
+        logger.info("VLM OCR using model: %s", model.identifier)
         img_handle = client.prepare_image(jpeg_bytes, name=f"page{page_num}.jpg")
 
         chat = lmstudio.Chat()
@@ -104,13 +129,15 @@ def _ocr_page_sync(
 async def async_extract_pdf_with_local_vlm(
     pdf_bytes: bytes,
     *,
-    host: str = DEFAULT_HOST,
+    host: str | None = None,
 ) -> list[PageBlock]:
     """Extract text from a PDF via local VLM (async).
 
     Drop-in replacement for async_extract_pdf_with_mistral().
     Processes pages sequentially (local GPU can only handle one at a time).
     """
+    if host is None:
+        host = _default_host()
     total = await asyncio.to_thread(_get_page_count, pdf_bytes)
     if total == 0:
         return []

--- a/backend/ai_engine/extraction/pgvector_search_service.py
+++ b/backend/ai_engine/extraction/pgvector_search_service.py
@@ -19,6 +19,8 @@ from typing import Any
 from sqlalchemy import Engine, create_engine, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ai_engine.extraction.retrieval_signal import RetrievalSignal
+
 logger = logging.getLogger(__name__)
 
 # ── Lazy sync engine for callers that don't have an AsyncSession ──────
@@ -80,6 +82,14 @@ class ChunkSearchResult:
     page_end: int | None
     chunk_index: int | None
     score: float
+
+
+@dataclass(frozen=True)
+class RerankedResult:
+    """Typed return from search_and_rerank_* functions."""
+
+    chunks: list[dict[str, Any]]
+    signal: RetrievalSignal
 
 
 # ── ID sanitization (same as Azure Search service) ────────────────────
@@ -601,7 +611,7 @@ async def search_and_rerank_deal(
     top: int = 10,
     candidates: int = 50,
     domain_filter: str | None = None,
-) -> list[dict[str, Any]]:
+) -> RerankedResult:
     """pgvector cosine recall → cross-encoder rerank → top results.
 
     Parameters
@@ -621,11 +631,12 @@ async def search_and_rerank_deal(
         domain_filter=domain_filter,
     )
     if not raw:
-        return raw
+        return RerankedResult(chunks=raw, signal=RetrievalSignal.from_results(raw))
 
     from ai_engine.extraction.local_reranker import rerank
 
-    return rerank(query_text, raw, top_k=top)
+    reranked = rerank(query_text, raw, top_k=top)
+    return RerankedResult(chunks=reranked, signal=RetrievalSignal.from_results(reranked))
 
 
 async def search_and_rerank_fund_policy(
@@ -638,7 +649,7 @@ async def search_and_rerank_fund_policy(
     top: int = 10,
     candidates: int = 50,
     domain_filter: str = "POLICY",
-) -> list[dict[str, Any]]:
+) -> RerankedResult:
     """pgvector cosine recall → cross-encoder rerank for fund policy."""
     raw = await search_fund_policy_chunks(
         db,
@@ -650,11 +661,12 @@ async def search_and_rerank_fund_policy(
         domain_filter=domain_filter,
     )
     if not raw:
-        return raw
+        return RerankedResult(chunks=raw, signal=RetrievalSignal.from_results(raw))
 
     from ai_engine.extraction.local_reranker import rerank
 
-    return rerank(query_text, raw, top_k=top)
+    reranked = rerank(query_text, raw, top_k=top)
+    return RerankedResult(chunks=reranked, signal=RetrievalSignal.from_results(reranked))
 
 
 def search_and_rerank_deal_sync(
@@ -666,7 +678,7 @@ def search_and_rerank_deal_sync(
     top: int = 10,
     candidates: int = 50,
     domain_filter: str | None = None,
-) -> list[dict[str, Any]]:
+) -> RerankedResult:
     """Sync variant: pgvector cosine → cross-encoder rerank for deals."""
     raw = search_deal_chunks_sync(
         deal_id=deal_id,
@@ -677,11 +689,12 @@ def search_and_rerank_deal_sync(
         domain_filter=domain_filter,
     )
     if not raw:
-        return raw
+        return RerankedResult(chunks=raw, signal=RetrievalSignal.from_results(raw))
 
     from ai_engine.extraction.local_reranker import rerank_sync
 
-    return rerank_sync(query_text, raw, top_k=top)
+    reranked = rerank_sync(query_text, raw, top_k=top)
+    return RerankedResult(chunks=reranked, signal=RetrievalSignal.from_results(reranked))
 
 
 def search_fund_chunks_sync(
@@ -751,7 +764,7 @@ def search_and_rerank_fund_sync(
     top: int = 10,
     candidates: int = 50,
     domain_filter: str | None = None,
-) -> list[dict[str, Any]]:
+) -> RerankedResult:
     """Sync variant: pgvector cosine → cross-encoder rerank for fund (all domains)."""
     raw = search_fund_chunks_sync(
         fund_id=fund_id,
@@ -762,11 +775,12 @@ def search_and_rerank_fund_sync(
         domain_filter=domain_filter,
     )
     if not raw:
-        return raw
+        return RerankedResult(chunks=raw, signal=RetrievalSignal.from_results(raw))
 
     from ai_engine.extraction.local_reranker import rerank_sync
 
-    return rerank_sync(query_text, raw, top_k=top)
+    reranked = rerank_sync(query_text, raw, top_k=top)
+    return RerankedResult(chunks=reranked, signal=RetrievalSignal.from_results(reranked))
 
 
 def search_and_rerank_fund_policy_sync(
@@ -778,7 +792,7 @@ def search_and_rerank_fund_policy_sync(
     top: int = 10,
     candidates: int = 50,
     domain_filter: str = "POLICY",
-) -> list[dict[str, Any]]:
+) -> RerankedResult:
     """Sync variant: pgvector cosine → cross-encoder rerank for fund policy."""
     raw = search_fund_policy_chunks_sync(
         fund_id=fund_id,
@@ -789,8 +803,9 @@ def search_and_rerank_fund_policy_sync(
         domain_filter=domain_filter,
     )
     if not raw:
-        return raw
+        return RerankedResult(chunks=raw, signal=RetrievalSignal.from_results(raw))
 
     from ai_engine.extraction.local_reranker import rerank_sync
 
-    return rerank_sync(query_text, raw, top_k=top)
+    reranked = rerank_sync(query_text, raw, top_k=top)
+    return RerankedResult(chunks=reranked, signal=RetrievalSignal.from_results(reranked))

--- a/backend/ai_engine/extraction/retrieval_signal.py
+++ b/backend/ai_engine/extraction/retrieval_signal.py
@@ -1,0 +1,118 @@
+"""Retrieval confidence signal — delta/rank-based decision layer.
+
+Provides a domain-agnostic RetrievalSignal that captures confidence
+metadata for a query's result set.  Based on relative measures (deltas,
+percentiles) rather than fragile absolute score thresholds.
+
+Usage:
+    from ai_engine.extraction.retrieval_signal import RetrievalSignal
+
+    signal = RetrievalSignal.from_results(results, score_key="reranker_score")
+    print(signal.confidence)  # "HIGH" | "MODERATE" | "LOW" | "AMBIGUOUS"
+"""
+from __future__ import annotations
+
+import dataclasses
+import statistics
+from typing import Any
+
+# ── Tunable heuristics (reranker logit scale) ───────────────────────
+RERANKER_DELTA_HIGH: float = 2.0
+RERANKER_DELTA_MODERATE: float = 0.5
+
+# ── Tunable heuristics (cosine similarity scale) ────────────────────
+COSINE_DELTA_HIGH: float = 0.08
+COSINE_DELTA_MODERATE: float = 0.03
+
+# ── Minimum result count for meaningful signal ──────────────────────
+MIN_RESULTS_FOR_AMBIGUOUS: int = 5
+MIN_RESULTS_FOR_HIGH: int = 3
+
+
+@dataclasses.dataclass(frozen=True)
+class RetrievalSignal:
+    """Confidence metadata for a retrieval query's result set."""
+
+    top1_score: float
+    top2_score: float | None
+    delta_top1_top2: float
+    percentile_top1: float
+    result_count: int
+    confidence: str  # "HIGH" | "MODERATE" | "LOW" | "AMBIGUOUS"
+
+    @classmethod
+    def from_results(
+        cls,
+        results: list[dict[str, Any]],
+        score_key: str = "reranker_score",
+    ) -> RetrievalSignal:
+        """Compute signal from a sorted (descending) result list.
+
+        Parameters
+        ----------
+        results : list[dict]
+            Results sorted by descending score.
+        score_key : str
+            Primary score key.  Falls back to ``"score"`` if the key is
+            absent on the first result.
+        """
+        if not results:
+            return cls(
+                top1_score=0.0,
+                top2_score=None,
+                delta_top1_top2=0.0,
+                percentile_top1=0.0,
+                result_count=0,
+                confidence="LOW",
+            )
+
+        # Resolve score key — prefer score_key, fallback to "score"
+        first = results[0]
+        if score_key not in first and "score" in first:
+            score_key = "score"
+
+        scores = [float(r.get(score_key, 0.0)) for r in results]
+        top1 = scores[0]
+        top2 = scores[1] if len(scores) > 1 else None
+        delta = (top1 - top2) if top2 is not None else 0.0
+        result_count = len(scores)
+
+        # Percentile: fraction of results that top1 exceeds
+        if result_count > 1:
+            below = sum(1 for s in scores[1:] if s < top1)
+            percentile = below / (result_count - 1)
+        else:
+            percentile = 1.0
+
+        # Detect score scale — reranker logits can be negative / > 1;
+        # cosine is bounded [0, 1].
+        is_cosine = score_key == "score"
+        delta_high = COSINE_DELTA_HIGH if is_cosine else RERANKER_DELTA_HIGH
+        delta_moderate = COSINE_DELTA_MODERATE if is_cosine else RERANKER_DELTA_MODERATE
+
+        # Classify confidence
+        if result_count < MIN_RESULTS_FOR_HIGH:
+            confidence = "LOW"
+        elif delta > delta_high and result_count >= MIN_RESULTS_FOR_HIGH:
+            confidence = "HIGH"
+        elif delta > delta_moderate:
+            confidence = "MODERATE"
+        elif result_count >= MIN_RESULTS_FOR_AMBIGUOUS:
+            confidence = "AMBIGUOUS"
+        else:
+            confidence = "LOW"
+
+        # Edge case: if top1 is below the median, downgrade to LOW
+        if result_count >= MIN_RESULTS_FOR_HIGH:
+            median = statistics.median(scores)
+            if top1 <= median:
+                confidence = "LOW"
+
+        return cls(
+            top1_score=round(top1, 6),
+            top2_score=round(top2, 6) if top2 is not None else None,
+            delta_top1_top2=round(delta, 6),
+            percentile_top1=round(percentile, 6),
+            result_count=result_count,
+            confidence=confidence,
+        )

--- a/backend/ai_engine/ingestion/pipeline_ingest_runner.py
+++ b/backend/ai_engine/ingestion/pipeline_ingest_runner.py
@@ -576,8 +576,9 @@ async def async_run_full_pipeline_ingest(
         if job is not None:
             finalize_db = _get_db_session()
             try:
-                from app.domains.credit.modules.ai.ingest_job_model import PipelineIngestJob
                 from sqlalchemy import select as sa_select
+
+                from app.domains.credit.modules.ai.ingest_job_model import PipelineIngestJob
 
                 refreshed_job = finalize_db.execute(
                     sa_select(PipelineIngestJob).where(PipelineIngestJob.id == job.id)

--- a/backend/ai_engine/openai_client.py
+++ b/backend/ai_engine/openai_client.py
@@ -56,7 +56,7 @@ def _get_client() -> OpenAI:
     if _client is not None:
         return _client
 
-    api_key = settings.OPENAI_API_KEY
+    api_key = settings.openai_api_key
     if api_key:
         _client = OpenAI(api_key=api_key, timeout=600.0)
         logger.info("AI_PROVIDER=openai (direct API key)")
@@ -112,7 +112,7 @@ def _get_async_client() -> AsyncOpenAI:
     if _async_client is not None:
         return _async_client
 
-    api_key = settings.OPENAI_API_KEY
+    api_key = settings.openai_api_key
     if api_key:
         _async_client = AsyncOpenAI(api_key=api_key, timeout=600.0, max_retries=0)
         logger.info("ASYNC_AI_PROVIDER=openai (direct API key)")

--- a/backend/ai_engine/pipeline/unified_pipeline.py
+++ b/backend/ai_engine/pipeline/unified_pipeline.py
@@ -22,7 +22,6 @@ import asyncio
 import datetime as dt
 import json
 import logging
-import os
 import time
 import uuid
 from pathlib import Path
@@ -573,7 +572,8 @@ async def process(
         page_count = cached_ocr.count("\n\n") + 1  # approximate from cached text
         del pdf_bytes
     else:
-        ocr_provider = os.environ.get("OCR_PROVIDER", "mistral")
+        from app.core.config.settings import settings as _s
+        ocr_provider = _s.local_ocr_provider if _s.use_local_ocr else "mistral"
         if ocr_provider == "local_vlm":
             from ai_engine.extraction.local_vlm_ocr import async_extract_pdf_with_local_vlm
             page_blocks = await async_extract_pdf_with_local_vlm(pdf_bytes)

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -56,6 +56,7 @@ class Settings(BaseSettings):
 
     # ── AI (REQUIRED) ────────────────────────────────────────
     openai_api_key: str = ""
+    OPENAI_MODEL_INTELLIGENCE: str = "gpt-4.1"
     OPENAI_EMBEDDING_MODEL: str = "text-embedding-3-large"
 
     # ── External APIs ────────────────────────────────────────
@@ -112,7 +113,7 @@ class Settings(BaseSettings):
     local_embedding_dimensions: int = 768
     # OCR: routes document extraction through local provider
     use_local_ocr: bool = False
-    local_ocr_provider: str = "pymupdf"  # pymupdf | qwen2vl
+    local_ocr_provider: str = "pymupdf"  # pymupdf | local_vlm
 
     # ── Pipeline cache (reduces API costs during development) ──
     # Caches OCR text and embedding vectors in a local SQLite DB.

--- a/backend/app/core/db/migrations/versions/0003_credit_domain.py
+++ b/backend/app/core/db/migrations/versions/0003_credit_domain.py
@@ -19,7 +19,7 @@ _RLS_TABLES = [
     # From 0001
     "audit_events",
     # From 0002 (wealth)
-    "instruments_universe", "nav_timeseries", "fund_risk_metrics",
+    "funds_universe", "nav_timeseries", "fund_risk_metrics",
     "portfolio_snapshots", "strategic_allocation", "tactical_positions",
     "rebalance_events", "lipper_ratings", "backtest_runs",
     # From 0003 — credit core

--- a/backend/app/domains/credit/modules/ai/copilot.py
+++ b/backend/app/domains/credit/modules/ai/copilot.py
@@ -173,7 +173,7 @@ def retrieve(
         query_vector = None
 
     try:
-        chunks = search_and_rerank_fund_sync(
+        reranked_result = search_and_rerank_fund_sync(
             fund_id=fund_id,
             organization_id=actor.organization_id,
             query_text=payload.query,
@@ -181,6 +181,8 @@ def retrieve(
             top=payload.top_k,
             candidates=payload.top_k * 3,
         )
+        chunks = reranked_result.chunks
+        retrieval_confidence = reranked_result.signal.confidence
     except Exception:
         raise HTTPException(status_code=502, detail="Search backend unavailable")
 
@@ -259,7 +261,7 @@ def retrieve(
     )
     db.commit()
 
-    return AIRetrieveResponse(results=results)
+    return AIRetrieveResponse(results=results, retrieval_confidence=retrieval_confidence)
 
 
 @router.post("/answer", response_model=AIAnswerResponse)
@@ -304,7 +306,7 @@ def answer(
         query_vector = None
 
     try:
-        chunks = search_and_rerank_fund_sync(
+        reranked_result = search_and_rerank_fund_sync(
             fund_id=fund_id,
             organization_id=actor.organization_id,
             query_text=payload.question,
@@ -312,6 +314,8 @@ def answer(
             top=payload.top_k,
             candidates=payload.top_k * 3,
         )
+        chunks = reranked_result.chunks
+        retrieval_confidence = reranked_result.signal.confidence
     except Exception:
         raise HTTPException(status_code=502, detail="Search backend unavailable")
 
@@ -603,4 +607,4 @@ def answer(
     )
     db.commit()
 
-    return AIAnswerResponse(answer=ans, citations=out_citations)
+    return AIAnswerResponse(answer=ans, citations=out_citations, retrieval_confidence=retrieval_confidence)

--- a/backend/app/domains/credit/modules/ai/extraction.py
+++ b/backend/app/domains/credit/modules/ai/extraction.py
@@ -170,7 +170,6 @@ def get_latest_ingest_job(
 ):
     """Return the most recent PipelineIngestJob for the given fund."""
     from app.domains.credit.modules.ai.ingest_job_model import PipelineIngestJob
-
     from app.domains.credit.modules.ai.schemas import IngestJobOut
 
     row = db.execute(
@@ -195,7 +194,6 @@ def get_ingest_job(
 ):
     """Return a specific PipelineIngestJob by ID."""
     from app.domains.credit.modules.ai.ingest_job_model import PipelineIngestJob
-
     from app.domains.credit.modules.ai.schemas import IngestJobOut
 
     row = db.execute(
@@ -303,9 +301,8 @@ def trigger_deal_reanalyze(
         raise HTTPException(status_code=404, detail="Pipeline deal not found.")
 
     def _run_reanalyze():
-        from app.domains.credit.modules.deals.ai_mode import resolve_ai_mode
-
         from app.core.db.session import sync_session_factory
+        from app.domains.credit.modules.deals.ai_mode import resolve_ai_mode
         from vertical_engines.credit.domain_ai import run_deal_ai_analysis
 
         with sync_session_factory() as session:

--- a/backend/app/domains/credit/modules/ai/schemas.py
+++ b/backend/app/domains/credit/modules/ai/schemas.py
@@ -66,6 +66,7 @@ class AIRetrieveResult(BaseModel):
 
 class AIRetrieveResponse(BaseModel):
     results: list[AIRetrieveResult]
+    retrieval_confidence: str | None = None
 
 
 class AIAnswerRequest(BaseModel):
@@ -92,6 +93,7 @@ class AIAnswerCitationOut(BaseModel):
 class AIAnswerResponse(BaseModel):
     answer: str
     citations: list[AIAnswerCitationOut]
+    retrieval_confidence: str | None = None
 
 
 class AIActivityItemOut(BaseModel):

--- a/backend/app/domains/wealth/workers/macro_ingestion.py
+++ b/backend/app/domains/wealth/workers/macro_ingestion.py
@@ -20,7 +20,6 @@ import asyncio
 import logging
 from datetime import date, timedelta
 from decimal import Decimal, InvalidOperation
-from functools import lru_cache
 
 import structlog
 from sqlalchemy import text

--- a/backend/tests/e2e_smoke_test.py
+++ b/backend/tests/e2e_smoke_test.py
@@ -18,7 +18,6 @@ import time
 import traceback
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -296,6 +295,7 @@ async def main() -> None:
         # 2.5 US Treasury Fiscal Data
         try:
             import httpx
+
             from quant_engine.fiscal_data_service import FiscalDataService
 
             async with httpx.AsyncClient() as hc:
@@ -308,6 +308,7 @@ async def main() -> None:
         # 2.6 OFR Hedge Fund
         try:
             import httpx
+
             from quant_engine.ofr_hedge_fund_service import OFRHedgeFundService
 
             async with httpx.AsyncClient() as hc:
@@ -881,7 +882,7 @@ async def main() -> None:
                         if resp.status_code == 200:
                             items = resp.json()
                             if isinstance(items, list) and len(items) == 1:
-                                ok("7.8 Status filter", f"1 approved report returned")
+                                ok("7.8 Status filter", "1 approved report returned")
                             else:
                                 fail("7.8 Status filter", f"expected 1 item, got {len(items) if isinstance(items, list) else type(items)}")
                         else:
@@ -955,7 +956,7 @@ async def main() -> None:
 
         # 7.12 Engine pending_approval verification (unit-level, no DB)
         try:
-            from unittest.mock import AsyncMock, MagicMock, PropertyMock
+            from unittest.mock import MagicMock
 
             from vertical_engines.wealth.dd_report.dd_report_engine import DDReportEngine
             from vertical_engines.wealth.dd_report.models import ChapterResult
@@ -1064,16 +1065,19 @@ Sharpe Ratio: 1.85
         except Exception as e:
             fail("8.2 Semantic Chunker", str(e))
 
-        # 8.3 Mistral OCR
-        if has_key("MISTRAL_API_KEY"):
-            try:
-                from ai_engine.extraction.mistral_ocr import async_extract_pdf_with_mistral
+        # 8.3 OCR (routes via settings: Mistral, local_vlm, or pymupdf)
+        from app.core.config.settings import settings as _ocr_settings
+        _use_local = _ocr_settings.use_local_ocr
+        _ocr_provider = _ocr_settings.local_ocr_provider if _use_local else "mistral"
+        _ocr_can_run = _use_local or has_key("MISTRAL_API_KEY")
 
-                # Create minimal PDF with reportlab if available, else skip
+        if _ocr_can_run:
+            try:
                 try:
+                    import io
+
                     from reportlab.lib.pagesizes import letter
                     from reportlab.pdfgen import canvas
-                    import io
 
                     buf = io.BytesIO()
                     c = canvas.Canvas(buf, pagesize=letter)
@@ -1083,17 +1087,30 @@ Sharpe Ratio: 1.85
                     c.save()
                     pdf_bytes = buf.getvalue()
 
-                    pages = await with_timeout(async_extract_pdf_with_mistral(
-                        pdf_bytes, api_key=os.environ["MISTRAL_API_KEY"],
-                    ), 30)
+                    if _ocr_provider == "local_vlm":
+                        from ai_engine.extraction.local_vlm_ocr import (
+                            async_extract_pdf_with_local_vlm,
+                        )
+                        pages = await with_timeout(async_extract_pdf_with_local_vlm(pdf_bytes), 120)
+                    elif _ocr_provider == "pymupdf":
+                        import asyncio as _aio
+
+                        from ai_engine.pipeline.unified_pipeline import _extract_text_pymupdf
+                        pages = await _aio.to_thread(_extract_text_pymupdf, pdf_bytes)
+                    else:
+                        from ai_engine.extraction.mistral_ocr import async_extract_pdf_with_mistral
+                        pages = await with_timeout(async_extract_pdf_with_mistral(
+                            pdf_bytes, api_key=os.environ["MISTRAL_API_KEY"],
+                        ), 30)
+
                     has_text = any(p.text for p in pages) if pages else False
-                    ok("8.3 Mistral OCR", f"pages={len(pages)}, has_text={has_text}")
+                    ok(f"8.3 OCR ({_ocr_provider})", f"pages={len(pages)}, has_text={has_text}")
                 except ImportError:
-                    skip("8.3 Mistral OCR", "reportlab not installed for PDF generation")
+                    skip(f"8.3 OCR ({_ocr_provider})", "reportlab not installed for PDF generation")
             except Exception as e:
-                fail("8.3 Mistral OCR", str(e))
+                fail(f"8.3 OCR ({_ocr_provider})", str(e))
         else:
-            skip("8.3 Mistral OCR", "MISTRAL_API_KEY not set")
+            skip("8.3 OCR", "No OCR provider available (set USE_LOCAL_OCR=true or MISTRAL_API_KEY)")
 
         # 8.4 Embedding
         if has_key("OPENAI_API_KEY"):
@@ -1159,9 +1176,9 @@ Sharpe Ratio: 1.85
         # 8.6 IC Memo Chapter Generation
         if has_key("OPENAI_API_KEY"):
             try:
-                from vertical_engines.credit.memo.chapters import generate_chapter
-
                 from openai import OpenAI
+
+                from vertical_engines.credit.memo.chapters import generate_chapter
 
                 sync_client = OpenAI()
 
@@ -1215,18 +1232,17 @@ Sharpe Ratio: 1.85
             skip("8.6 Memo Chapter", "OPENAI_API_KEY not set")
 
         # 8.7 Full Pipeline Integration (mini)
-        if has_key("OPENAI_API_KEY") and has_key("MISTRAL_API_KEY"):
+        if has_key("OPENAI_API_KEY") and _ocr_can_run:
             try:
                 from ai_engine.classification.hybrid_classifier import classify
                 from ai_engine.extraction.embedding_service import async_generate_embeddings
                 from ai_engine.extraction.semantic_chunker import chunk_document
 
                 try:
-                    from reportlab.lib.pagesizes import letter
-                    from reportlab.pdfgen import canvas
                     import io
 
-                    from ai_engine.extraction.mistral_ocr import async_extract_pdf_with_mistral
+                    from reportlab.lib.pagesizes import letter
+                    from reportlab.pdfgen import canvas
 
                     # 1. Create PDF
                     buf = io.BytesIO()
@@ -1239,10 +1255,22 @@ Sharpe Ratio: 1.85
                     c.save()
                     pdf_bytes = buf.getvalue()
 
-                    # 2. OCR
-                    pages = await with_timeout(async_extract_pdf_with_mistral(
-                        pdf_bytes, api_key=os.environ["MISTRAL_API_KEY"],
-                    ), 30)
+                    # 2. OCR (routed via settings)
+                    if _ocr_provider == "local_vlm":
+                        from ai_engine.extraction.local_vlm_ocr import (
+                            async_extract_pdf_with_local_vlm,
+                        )
+                        pages = await with_timeout(async_extract_pdf_with_local_vlm(pdf_bytes), 120)
+                    elif _ocr_provider == "pymupdf":
+                        import asyncio as _aio
+
+                        from ai_engine.pipeline.unified_pipeline import _extract_text_pymupdf
+                        pages = await _aio.to_thread(_extract_text_pymupdf, pdf_bytes)
+                    else:
+                        from ai_engine.extraction.mistral_ocr import async_extract_pdf_with_mistral
+                        pages = await with_timeout(async_extract_pdf_with_mistral(
+                            pdf_bytes, api_key=os.environ["MISTRAL_API_KEY"],
+                        ), 30)
                     ocr_text = "\n".join(p.text for p in pages if p.text)
 
                     # 3. Classify
@@ -1256,16 +1284,16 @@ Sharpe Ratio: 1.85
                     if chunk_texts:
                         emb_batch = await with_timeout(async_generate_embeddings(chunk_texts), 30)
                         dims_consistent = all(len(v) == 3072 for v in emb_batch.vectors)
-                        ok("8.7 Full Pipeline", f"ocr={len(ocr_text)}ch, class={cls_result.doc_type}, chunks={len(chunks)}, embs={emb_batch.count}, dim_ok={dims_consistent}")
+                        ok(f"8.7 Full Pipeline ({_ocr_provider})", f"ocr={len(ocr_text)}ch, class={cls_result.doc_type}, chunks={len(chunks)}, embs={emb_batch.count}, dim_ok={dims_consistent}")
                     else:
-                        ok("8.7 Full Pipeline", f"ocr={len(ocr_text)}ch, class={cls_result.doc_type}, chunks=0 (OCR text too short for chunking)")
+                        ok(f"8.7 Full Pipeline ({_ocr_provider})", f"ocr={len(ocr_text)}ch, class={cls_result.doc_type}, chunks=0 (OCR text too short for chunking)")
 
                 except ImportError:
                     skip("8.7 Full Pipeline", "reportlab not installed")
             except Exception as e:
                 fail("8.7 Full Pipeline", f"{e}\n{traceback.format_exc()}")
         else:
-            skip("8.7 Full Pipeline", "OPENAI_API_KEY or MISTRAL_API_KEY not set")
+            skip("8.7 Full Pipeline", "OPENAI_API_KEY or OCR provider not available")
 
         print(f"  [TIME] Group 8: {time.time() - g8:.1f}s")
 
@@ -1355,7 +1383,7 @@ Sharpe Ratio: 1.85
                 )
 
                 search_docs = []
-                for i, (chunk, embedding) in enumerate(zip(corpus, emb_batch.vectors)):
+                for i, (chunk, embedding) in enumerate(zip(corpus, emb_batch.vectors, strict=False)):
                     doc = build_search_document(
                         deal_id=SMOKE_DEAL_ID,
                         fund_id=SMOKE_FUND_ID,

--- a/backend/tests/test_dd_report_approval.py
+++ b/backend/tests/test_dd_report_approval.py
@@ -61,11 +61,29 @@ def _make_dd_report(
 
 
 def _mock_db_with_report(report):
-    """Create a mock AsyncSession that returns the given report from execute()."""
+    """Create a mock AsyncSession that returns the given report from execute().
+
+    Handles both report queries (scalar_one_or_none) and RLS context queries
+    (current_setting → returns ORG_ID via scalar()).
+    """
     mock_db = AsyncMock()
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = report
-    mock_db.execute.return_value = mock_result
+
+    report_result = MagicMock()
+    report_result.scalar_one_or_none.return_value = report
+
+    rls_result = MagicMock()
+    rls_result.scalar.return_value = ORG_ID
+
+    call_count = {"n": 0}
+
+    async def _execute_side_effect(*args, **kwargs):
+        call_count["n"] += 1
+        query_str = str(args[0]) if args else ""
+        if "current_setting" in query_str:
+            return rls_result
+        return report_result
+
+    mock_db.execute = AsyncMock(side_effect=_execute_side_effect)
     mock_db.commit = AsyncMock()
     return mock_db
 

--- a/backend/tests/test_retrieval_signal.py
+++ b/backend/tests/test_retrieval_signal.py
@@ -1,0 +1,143 @@
+"""Tests for RetrievalSignal confidence classification."""
+from __future__ import annotations
+
+import pytest
+
+from ai_engine.extraction.retrieval_signal import RetrievalSignal
+
+
+def _make_results(
+    scores: list[float],
+    score_key: str = "reranker_score",
+) -> list[dict]:
+    """Build a fake result list sorted descending by score_key."""
+    results = [{score_key: s, "content": f"chunk {i}"} for i, s in enumerate(scores)]
+    results.sort(key=lambda r: r[score_key], reverse=True)
+    return results
+
+
+class TestHighConfidence:
+    """One dominant result with a large gap → HIGH."""
+
+    def test_reranker_high(self):
+        # top1=8.0, top2=5.0, delta=3.0 > RERANKER_DELTA_HIGH (2.0)
+        results = _make_results([8.0, 5.0, 4.5, 4.0, 3.0])
+        signal = RetrievalSignal.from_results(results, score_key="reranker_score")
+        assert signal.confidence == "HIGH"
+        assert signal.delta_top1_top2 == pytest.approx(3.0)
+        assert signal.result_count == 5
+
+    def test_cosine_high(self):
+        # top1=0.95, top2=0.85, delta=0.10 > COSINE_DELTA_HIGH (0.08)
+        results = _make_results([0.95, 0.85, 0.80, 0.75, 0.70], score_key="score")
+        signal = RetrievalSignal.from_results(results, score_key="score")
+        assert signal.confidence == "HIGH"
+        assert signal.delta_top1_top2 == pytest.approx(0.10, abs=1e-4)
+
+
+class TestAmbiguous:
+    """Top 5 results within a tight score band → AMBIGUOUS."""
+
+    def test_reranker_ambiguous(self):
+        # All scores within 0.3 — delta < RERANKER_DELTA_MODERATE (0.5)
+        results = _make_results([5.3, 5.2, 5.15, 5.1, 5.05])
+        signal = RetrievalSignal.from_results(results, score_key="reranker_score")
+        assert signal.confidence == "AMBIGUOUS"
+        assert signal.result_count == 5
+
+    def test_cosine_ambiguous(self):
+        # All scores within 0.02 — delta < COSINE_DELTA_MODERATE (0.03)
+        results = _make_results([0.90, 0.89, 0.885, 0.88, 0.879], score_key="score")
+        signal = RetrievalSignal.from_results(results, score_key="score")
+        assert signal.confidence == "AMBIGUOUS"
+
+
+class TestLowResultCount:
+    """Only 1-2 results → LOW."""
+
+    def test_single_result(self):
+        results = _make_results([7.5])
+        signal = RetrievalSignal.from_results(results, score_key="reranker_score")
+        assert signal.confidence == "LOW"
+        assert signal.top2_score is None
+        assert signal.delta_top1_top2 == 0.0
+
+    def test_two_results(self):
+        results = _make_results([7.5, 3.0])
+        signal = RetrievalSignal.from_results(results, score_key="reranker_score")
+        assert signal.confidence == "LOW"
+        assert signal.result_count == 2
+
+
+class TestModerate:
+    """Clear but not dominant gap → MODERATE."""
+
+    def test_reranker_moderate(self):
+        # delta=1.0 — between RERANKER_DELTA_MODERATE (0.5) and RERANKER_DELTA_HIGH (2.0)
+        results = _make_results([6.0, 5.0, 4.8, 4.5, 4.0])
+        signal = RetrievalSignal.from_results(results, score_key="reranker_score")
+        assert signal.confidence == "MODERATE"
+        assert signal.delta_top1_top2 == pytest.approx(1.0)
+
+    def test_cosine_moderate(self):
+        # delta=0.05 — between COSINE_DELTA_MODERATE (0.03) and COSINE_DELTA_HIGH (0.08)
+        results = _make_results([0.90, 0.85, 0.82, 0.80, 0.78], score_key="score")
+        signal = RetrievalSignal.from_results(results, score_key="score")
+        assert signal.confidence == "MODERATE"
+
+
+class TestScoreKeyFallback:
+    """Verifies score_key fallback logic."""
+
+    def test_uses_reranker_score_first(self):
+        results = [
+            {"reranker_score": 8.0, "score": 0.5, "content": "a"},
+            {"reranker_score": 3.0, "score": 0.9, "content": "b"},
+            {"reranker_score": 2.0, "score": 0.8, "content": "c"},
+        ]
+        signal = RetrievalSignal.from_results(results, score_key="reranker_score")
+        assert signal.top1_score == pytest.approx(8.0)
+
+    def test_falls_back_to_score(self):
+        results = [
+            {"score": 0.95, "content": "a"},
+            {"score": 0.90, "content": "b"},
+            {"score": 0.85, "content": "c"},
+        ]
+        # Request reranker_score but it's missing — should fallback to "score"
+        signal = RetrievalSignal.from_results(results, score_key="reranker_score")
+        assert signal.top1_score == pytest.approx(0.95)
+
+
+class TestEmptyResults:
+    """Empty list → LOW with zeros."""
+
+    def test_empty(self):
+        signal = RetrievalSignal.from_results([])
+        assert signal.confidence == "LOW"
+        assert signal.top1_score == 0.0
+        assert signal.top2_score is None
+        assert signal.delta_top1_top2 == 0.0
+        assert signal.percentile_top1 == 0.0
+        assert signal.result_count == 0
+
+
+class TestCosineVsRerankerThresholds:
+    """Verify different threshold scales applied based on score_key."""
+
+    def test_same_delta_different_scale(self):
+        # delta=0.05 — HIGH for cosine (> 0.03), but far below HIGH for reranker (< 2.0)
+        cosine_results = _make_results([0.90, 0.85, 0.80, 0.75, 0.70], score_key="score")
+        reranker_results = _make_results([5.05, 5.0, 4.95, 4.90, 4.85], score_key="reranker_score")
+
+        cosine_signal = RetrievalSignal.from_results(cosine_results, score_key="score")
+        reranker_signal = RetrievalSignal.from_results(reranker_results, score_key="reranker_score")
+
+        # Both have delta=0.05 but different classification
+        assert cosine_signal.delta_top1_top2 == pytest.approx(0.05, abs=1e-4)
+        assert reranker_signal.delta_top1_top2 == pytest.approx(0.05, abs=1e-4)
+
+        # Cosine: 0.05 > COSINE_DELTA_MODERATE (0.03) → MODERATE
+        assert cosine_signal.confidence == "MODERATE"
+        # Reranker: 0.05 < RERANKER_DELTA_MODERATE (0.5) → AMBIGUOUS
+        assert reranker_signal.confidence == "AMBIGUOUS"

--- a/backend/tests/test_rls.py
+++ b/backend/tests/test_rls.py
@@ -20,7 +20,7 @@ _RLS_TABLES: list[str] = _mod._RLS_TABLES  # type: ignore[attr-defined]
 async def test_rls_table_list_includes_wealth_tables():
     """Wealth tables from migration 0002 must be in RLS list."""
     wealth_tables = {
-        "instruments_universe", "nav_timeseries", "fund_risk_metrics",
+        "funds_universe", "nav_timeseries", "fund_risk_metrics",
         "portfolio_snapshots", "strategic_allocation", "tactical_positions",
         "rebalance_events", "lipper_ratings", "backtest_runs",
     }

--- a/backend/vertical_engines/credit/deep_review/corpus.py
+++ b/backend/vertical_engines/credit/deep_review/corpus.py
@@ -472,7 +472,7 @@ def _gather_investment_texts(
 
     try:
         investment_deal_id = investment.deal_id or investment.id
-        chunks = search_deal_chunks(
+        result = search_deal_chunks(
             deal_id=investment_deal_id,
             organization_id=organization_id,
             query_text=query_text,
@@ -480,6 +480,7 @@ def _gather_investment_texts(
             candidates=120,
             top=80,
         )
+        chunks = result.chunks
     except Exception:
         logger.warning(
             "rag_retrieval.failed",

--- a/backend/vertical_engines/credit/domain_ai/service.py
+++ b/backend/vertical_engines/credit/domain_ai/service.py
@@ -15,7 +15,6 @@ import uuid
 from typing import Any
 
 import structlog
-from app.domains.credit.modules.deals.ai_mode import AIMode
 from sqlalchemy.orm import Session
 
 from ai_engine.extraction.embedding_service import generate_embeddings
@@ -23,6 +22,7 @@ from ai_engine.extraction.pgvector_search_service import (
     search_and_rerank_deal_sync as search_deal_chunks,
 )
 from ai_engine.prompts import prompt_registry
+from app.domains.credit.modules.deals.ai_mode import AIMode
 
 logger = structlog.get_logger()
 
@@ -54,7 +54,7 @@ def _retrieve_context(
         query_text = deal_name
 
     try:
-        chunks = search_deal_chunks(
+        result = search_deal_chunks(
             deal_id=deal_id,
             organization_id=organization_id,
             query_text=query_text,
@@ -62,6 +62,8 @@ def _retrieve_context(
             candidates=max_chunks * 3,
             top=max_chunks,
         )
+        chunks = result.chunks
+        retrieval_signal = result.signal
     except Exception as exc:
         logger.warning("domain_ai.retrieve_context.search_failed", deal_id=str(deal_id), error=str(exc), exc_info=True)
         return ""
@@ -69,7 +71,21 @@ def _retrieve_context(
     if not chunks:
         return ""
 
+    logger.info(
+        "domain_ai.retrieval_signal",
+        deal_id=str(deal_id),
+        confidence=retrieval_signal.confidence,
+        delta=retrieval_signal.delta_top1_top2,
+        result_count=retrieval_signal.result_count,
+    )
+
     context_parts: list[str] = []
+
+    if retrieval_signal.confidence == "LOW":
+        context_parts.append(
+            "Note: limited documentary evidence was found for this query."
+        )
+
     for chunk in chunks:
         header = f"[{chunk.get('doc_type', 'unknown')} | pages {chunk.get('page_start', '?')}-{chunk.get('page_end', '?')}]"
         context_parts.append(f"{header}\n{chunk.get('content', '')}")

--- a/backend/vertical_engines/credit/pipeline/screening.py
+++ b/backend/vertical_engines/credit/pipeline/screening.py
@@ -52,7 +52,7 @@ def _retrieve_deal_context(
         query_text = deal_name
 
     try:
-        chunks = search_deal_chunks(
+        result = search_deal_chunks(
             deal_id=deal_id,
             organization_id=organization_id,
             query_text=query_text,
@@ -60,6 +60,8 @@ def _retrieve_deal_context(
             candidates=max_chunks,
             top=max_chunks,
         )
+        chunks = result.chunks
+        retrieval_signal = result.signal
     except Exception:
         logger.warning(
             "search_retrieval_failed",
@@ -67,6 +69,14 @@ def _retrieve_deal_context(
             exc_info=True,
         )
         return "", 0, [], {}
+
+    logger.info(
+        "pipeline_retrieval_signal",
+        deal_id=str(deal_id),
+        confidence=retrieval_signal.confidence,
+        delta=retrieval_signal.delta_top1_top2,
+        result_count=retrieval_signal.result_count,
+    )
 
     if not chunks:
         return "", 0, [], {}

--- a/backend/vertical_engines/credit/retrieval/evidence.py
+++ b/backend/vertical_engines/credit/retrieval/evidence.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import structlog
 
+from ai_engine.extraction.retrieval_signal import RetrievalSignal
 from app.core.config import settings
 from vertical_engines.credit.retrieval.models import (
     CHAPTER_DOC_TYPE_FILTERS,
@@ -379,12 +380,34 @@ def gather_chapter_evidence(
     else:
         coverage_status = COVERAGE_MISSING
 
+    # Compute retrieval confidence signal from chapter results
+    retrieval_signal = RetrievalSignal.from_results(
+        valid_chunks,
+        score_key="reranker_score",
+    )
+
+    # Override to EVIDENCE_CONTESTED when signal is AMBIGUOUS
+    if retrieval_signal.confidence == "AMBIGUOUS" and coverage_status != COVERAGE_MISSING:
+        coverage_status = COVERAGE_CONTESTED
+        logger.warning(
+            "evidence_contested",
+            chapter=chapter_key,
+            signal_confidence=retrieval_signal.confidence,
+            delta=retrieval_signal.delta_top1_top2,
+        )
+
     return {
         "chunks":          valid_chunks,
         "queries":         queries,
         "coverage_status": coverage_status,
         "retrieval_mode":  retrieval_mode,
         "doc_type_filter": active_filter,
+        "retrieval_signal": {
+            "confidence":      retrieval_signal.confidence,
+            "top1_score":      retrieval_signal.top1_score,
+            "delta_top1_top2": retrieval_signal.delta_top1_top2,
+            "result_count":    retrieval_signal.result_count,
+        },
         "stats": {
             "chunk_count":    chunk_count,
             "unique_docs":    unique_docs,

--- a/backend/vertical_engines/credit/retrieval/models.py
+++ b/backend/vertical_engines/credit/retrieval/models.py
@@ -250,9 +250,10 @@ CHAPTER_EVIDENCE_THRESHOLDS: dict[str, ChapterEvidenceThreshold] = {
 
 # ── Coverage-status labels ─────────────────────────────────────────
 
-COVERAGE_SATURATED = "SATURATED"
-COVERAGE_PARTIAL   = "PARTIAL"
-COVERAGE_MISSING   = "MISSING_EVIDENCE"
+COVERAGE_SATURATED  = "SATURATED"
+COVERAGE_PARTIAL    = "PARTIAL"
+COVERAGE_MISSING    = "MISSING_EVIDENCE"
+COVERAGE_CONTESTED  = "EVIDENCE_CONTESTED"
 
 # ── Provenance validation fields ───────────────────────────────────
 

--- a/backend/vertical_engines/credit/retrieval/saturation.py
+++ b/backend/vertical_engines/credit/retrieval/saturation.py
@@ -14,6 +14,7 @@ import structlog
 
 from vertical_engines.credit.retrieval.models import (
     CHAPTER_EVIDENCE_THRESHOLDS,
+    COVERAGE_CONTESTED,
     COVERAGE_MISSING,
     COVERAGE_PARTIAL,
     RETRIEVAL_POLICY_NAME,
@@ -53,6 +54,17 @@ def enforce_evidence_saturation(
                 missing_document_classes.append("MISSING_FINANCIAL_DISCLOSURE")
             elif ch_key in ("ch05_legal", "ch06_terms"):
                 missing_document_classes.append("NO_LPA_FOUND")
+
+        elif status == COVERAGE_CONTESTED:
+            signal_info = ch_data.get("retrieval_signal", {})
+            reason = (
+                f"Chapter {ch_key}: CONTESTED evidence (ambiguous retrieval). "
+                f"chunks={stats.get('chunk_count', 0)} "
+                f"delta={signal_info.get('delta_top1_top2', '?')} "
+                f"mode={ch_data.get('retrieval_mode', '?')}"
+            )
+            gaps.append({"chapter": ch_key, "status": status, "reason": reason})
+            logger.warning("evidence_contested", reason=reason)
 
         elif status == COVERAGE_PARTIAL:
             threshold = CHAPTER_EVIDENCE_THRESHOLDS.get(ch_key)

--- a/docs/reference/dual-mode-pipeline-architecture.md
+++ b/docs/reference/dual-mode-pipeline-architecture.md
@@ -8,9 +8,8 @@
   │  ROG Flow Z13 — Ryzen AI MAX+ 395, 64GB unified            │
   │                                                             │
   │  LM Studio Server (localhost:1234)                          │
-  │  ├── GPT OSS 20B (text LLM)                                │
-  │  │   └── Classification L3, metadata extraction, summary   │
-  │  └── Vision model (VLM OCR) — via Legion GPU link          │
+  │  ├── Qwen2.5-VL-7B (VLM OCR) — via Legion GPU link        │
+  │  └── GPT OSS 20B (Classification L3 only, dry mode)        │
   │                                                             │
   │  Pipeline (unified_pipeline.py)                             │
   │    │                                                        │
@@ -21,21 +20,22 @@
   │    │                                                        │
   │    ├── Classify ─┬── L1 Rules (deterministic, free)        │
   │    │             ├── L2 TF-IDF (deterministic, free)       │
-  │    │             ├── L3 Local LLM (localhost:1234)          │
-  │    │             └── L3 OpenAI (golden mode)               │
+  │    │             └── L3 LLM (local dry / OpenAI standard)  │
   │    │                                                        │
   │    ├── Chunk ────── Deterministic (free)                    │
   │    │                                                        │
-  │    ├── Extract ──┬── Local LLM (localhost:1234)             │
-  │    │             └── OpenAI (golden mode)                   │
+  │    ├── Extract ──── OpenAI API (gpt-4.1, always)           │
+  │    │                                                        │
+  │    ├── Summary ──── OpenAI API (gpt-4.1-mini, always)      │
   │    │                                                        │
   │    ├── Embed ────┬── Cache HIT → SQLite (.data/cache/)     │
   │    │             └── OpenAI API (only cache misses)         │
   │    │                                                        │
-  │    ├── Upsert ───── pgvector (local PostgreSQL, free)      │
-  │    └── Store ────── LocalStorage (.data/lake/, free)       │
+  │    ├── Store ────── R2 (prod) / LocalStorage (dev)         │
+  │    └── Upsert ───── pgvector (Timescale Cloud)             │
   │                                                             │
-  │  Docker: PostgreSQL 16 + TimescaleDB + Redis 7             │
+  │  Prod DB: Timescale Cloud (PostgreSQL 16 + pgvector)       │
+  │  Dev DB:  Docker (PostgreSQL 16 + TimescaleDB + Redis 7)   │
   └─────────────────────────────────────────────────────────────┘
                         │
           ┌─────────────┴──────────────┐
@@ -49,15 +49,17 @@
 
 **Key design:** Z13 runs both pipeline and LM Studio server. Vision models that need NVIDIA CUDA run on Legion's RTX 5070 Ti via dedicated hardware link — this is transparent to the application (appears as localhost to LM Studio). No network URLs or IP addresses in code.
 
+**Metadata extraction + summary always use OpenAI API** (gpt-4.1 / gpt-4.1-mini). These stages require structured JSON output with high accuracy for entity extraction (dates, counterparties, jurisdictions) — local LLMs do not meet the quality bar. The local LLM (GPT OSS 20B) is only used for classification L3 fallback in dry mode.
+
 ---
 
 ## Pipeline Modes
 
-| Mode | OCR | LLM | Embeddings | Cost | Use Case |
-|------|-----|-----|------------|------|----------|
-| **dry** | Cache → PyMuPDF → Local VLM | Local LLM (localhost) | Cache (OpenAI for misses) | ~$0/day | Large-scale dev testing |
-| **golden** | Mistral API | OpenAI API | OpenAI API | ~$5-10/run | Final quality validation |
-| **standard** | Whatever configured | Whatever configured | Whatever configured | Variable | Normal development |
+| Mode | OCR | Classification L3 | Extraction + Summary | Embeddings | Cost | Use Case |
+|------|-----|-------------------|---------------------|------------|------|----------|
+| **dry** | Cache → PyMuPDF → Local VLM | Local LLM (localhost) | OpenAI API (gpt-4.1) | Cache (OpenAI for misses) | ~$1-2/day | Large-scale dev testing |
+| **standard** | Cache → Local VLM | L1/L2 deterministic | OpenAI API (gpt-4.1) | OpenAI API | ~$3-5/day | Normal development + batch ingestion |
+| **golden** | Mistral API | OpenAI API | OpenAI API (gpt-4.1) | OpenAI API | ~$5-10/run | Final quality validation |
 
 ---
 
@@ -73,16 +75,21 @@ PIPELINE_MODE=dry
 ENABLE_PIPELINE_CACHE=true
 PIPELINE_CACHE_DIR=.data/cache
 
-# LLM → LM Studio local server
+# Classification L3 → LM Studio local server (dry mode only)
 USE_LOCAL_LLM=true
 LOCAL_LLM_URL=http://localhost:1234/v1
 
 # OCR → cache first, PyMuPDF fallback (zero cost)
-OCR_PROVIDER=pymupdf
-# OR for scanned PDFs: OCR_PROVIDER=local_vlm (requires Vision model)
+USE_LOCAL_OCR=true
+LOCAL_OCR_PROVIDER=pymupdf
+# OR for scanned PDFs: LOCAL_OCR_PROVIDER=local_vlm (requires Vision model on Legion GPU)
+
+# Metadata extraction + summary → always OpenAI (quality requirement)
+OPENAI_API_KEY=sk-...
+OPENAI_MODEL_INTELLIGENCE=gpt-4.1
 
 # Embeddings → OpenAI API (cached after first run)
-OPENAI_API_KEY=sk-...
+OPENAI_EMBEDDING_MODEL=text-embedding-3-large
 
 # Confidence fallback (optional)
 LOCAL_CONFIDENCE_THRESHOLD=0.0   # 0.0 = never escalate
@@ -282,16 +289,16 @@ Layer 3 (LLM Fallback):
 | Embeddings | OpenAI | $0.02 | $10.00 |
 | **Total** | | | **$55.50/day** |
 
-### After (dry mode with cache)
+### After (standard mode with cache + local OCR)
 
 | Step | Provider | Cost | Daily (50 docs x 10 runs) |
 |------|----------|------|--------------------------|
-| OCR | Cache / PyMuPDF | $0.00 | $0.00 |
-| Classification L3 | Local LLM | $0.00 | $0.00 |
-| Metadata | Local LLM | $0.00 | $0.00 |
-| Summary | Local LLM | $0.00 | $0.00 |
+| OCR | Cache / Local VLM | $0.00 | $0.00 |
+| Classification L3 | L1/L2 deterministic (~90%) | $0.00 | $0.00 |
+| Metadata | OpenAI gpt-4.1 | $0.05 | $2.50 (1st run, cached after) |
+| Summary | OpenAI gpt-4.1-mini | $0.01 | $0.50 (1st run, cached after) |
 | Embeddings | Cache (OpenAI 1st run only) | $0.00 | ~$1.00 first run |
-| **Total** | | | **~$0/day** |
+| **Total** | | | **~$4/day (first run), ~$0 re-runs** |
 
 Golden validation: ~$5.55 per run (once per release cycle).
 

--- a/docs/reference/retrieval-confidence-analysis-2026-03-20.md
+++ b/docs/reference/retrieval-confidence-analysis-2026-03-20.md
@@ -1,0 +1,121 @@
+# Retrieval Confidence Analysis — 2026-03-20
+
+## Origin
+
+Analysis conducted over the Pipeline Quality Validation Report (2026-03-19) to assess retrieval readiness for production use across different confidence tiers. This document records the findings, the identified gaps, and the architectural decisions taken.
+
+---
+
+## Assessment of Current State
+
+### What is working well
+
+**Embedding + pgvector semantic separation is solid.** The synthetic corpus test (5 hand-written chunks, 10 queries) achieved 10/10 rank-1 accuracy with a diagonally dominant similarity matrix and an average gap of 0.273 between top-1 and top-2. This confirms that the vector space is not collapsing representations and that document types are well-separated when the corpus is clean.
+
+**Cross-encoder reranker discrimination is excellent.** On synthetic data, the reranker produced a logit gap of ~15 points between the correct chunk (4.558) and irrelevant candidates (-10 to -11). Inference runs in 99ms for 50 documents on CPU. The two-stage pipeline (broad cosine recall → precise cross-encoder rerank) is architecturally correct and performant.
+
+**Infrastructure is reliable.** 540/540 upserts succeeded, HNSW index with halfvec(3072) is operational, the CAST(:param AS type) fix eliminated asyncpg parse ambiguity, and tenant isolation was confirmed with 0 cross-org results. The retrieval layer is not being undermined by storage, indexing, or multi-tenant bugs.
+
+**Real corpus results are better than the headline number suggests.** The reported 5/8 (62%) accuracy on BridgeInvest PDFs refers to source document match, not semantic relevance. All three "misses" returned semantically correct content from a different document in the same dataroom — a consequence of informational overlap between PPM, LPA, and Investment Memo for the same fund/deal. This is not a retrieval failure; it is a ground truth labeling limitation when documents share content about the same entities.
+
+**Score distribution is healthy.** Real corpus top-1 scores averaged 0.577 (range 0.487–0.681), which is reasonable for long heterogeneous financial documents. Critical queries (deal structure, LTV, conflicts, withdrawals, portfolio performance) consistently surfaced substantive passages, not surface-level keyword matches.
+
+### Where gaps remain
+
+**Reranker is validated only on synthetic data.** The logit gap of 15 points was measured on 5 deliberately distinct chunks. The real corpus (540 chunks, many semantically overlapping) has no reported reranker logit analysis. The claim that the reranker "cleans false positives" is well-founded in principle but not yet evidenced on production-like data.
+
+**Corpus is small and homogeneous.** 5 PDFs from a single fund, single gestora, single vertical. This validates direction but does not prove robustness across gestora styles, document structures (term sheets, side letters, Excel-to-PDF), or corpus sizes (50+ PDFs, 5000+ chunks). Score distributions may shift materially as the corpus diversifies.
+
+**No confidence signal exists for downstream consumers.** The pipeline returns ranked results but provides no metadata about how confident the ranking is. A caller receiving 10 chunks cannot distinguish "one chunk is clearly dominant" from "10 chunks are essentially tied." This matters most for IC evidence assembly, where contested evidence should be flagged differently from clear evidence.
+
+**No BM25 hybrid search.** The pipeline uses pure vector similarity. For keyword-heavy queries — specific clause numbers, defined terms, covenant formulas, exact siglas, threshold values — embedding-based search generalizes where the user wants literalism. This is an accepted limitation, not a defect, but it bounds the system's precision on lexical queries.
+
+---
+
+## Key Insight: Absolute Score Thresholds Are Wrong for This System
+
+Score distributions in retrieval systems are not stable properties. They shift with:
+
+- **Corpus size** — more chunks compress the score range as more near-neighbors appear
+- **Document homogeneity** — a dataroom of 30 credit memos will have tighter score bands than a mixed dataroom
+- **Chunk length** — longer chunks dilute cosine similarity; shorter chunks inflate it
+- **Embedding model** — any model upgrade changes the absolute scale
+
+A threshold like `score > 0.6` calibrated on 540 chunks from 5 PDFs will not transfer to 5000 chunks from 50 PDFs. It will either over-filter (rejecting relevant results in a compressed distribution) or under-filter (accepting noise in an inflated distribution).
+
+The correct approach is **relative confidence**: measuring the relationship between candidates within a single query's result set, not their position on a global scale.
+
+---
+
+## Decision: Relative Confidence Signals
+
+### Three complementary signals
+
+| Signal | Definition | What it captures |
+|---|---|---|
+| **Rank position** | Ordinal position in sorted results | Useful when the consumer just needs "best available" without quality judgment |
+| **Delta top-1 vs top-2** | Score gap between rank-1 and rank-2 | Whether the system has a clear answer or is choosing between tied candidates |
+| **Percentile within query** | Top-1 score relative to the full result distribution | Whether the best result is an outlier (strong signal) or part of the pack (weak signal) |
+
+### How these map to product use cases
+
+| Use case | Current behavior | Decided behavior |
+|---|---|---|
+| **Copilot RAG** (exploratório) | Returns top-K, user judges | Same, but surface confidence level in response so frontend can indicate certainty |
+| **Pipeline screening** | Returns top-80, LLM assesses | Same, but flag ambiguous retrieval so the LLM prompt can hedge |
+| **Portfolio monitoring** | Returns top-20, LLM summarizes | Same, but prepend caveat when evidence is thin |
+| **IC evidence pack** (auditável) | Saturation based on chunk count + doc diversity | Add EVIDENCE_CONTESTED status when retrieval confidence is ambiguous — contested evidence must be flagged to the analyst, not silently treated as confirmed |
+| **IC coverage rerank** | Coverage bonus on top of semantic score | Pass through signal, do not recompute |
+
+### What the signal is NOT
+
+- It is **not a gate**. No downstream flow should block on low confidence. The signal is advisory.
+- It is **not a score**. It is metadata about the score distribution, not a replacement for it.
+- It is **not a quality judgment on the content**. High retrieval confidence means the system found a clearly dominant result, not that the content itself is correct or complete.
+
+---
+
+## Production Readiness Tiers
+
+Based on the analysis, the retrieval system's readiness is tiered by use case:
+
+### Ready for production use
+
+- Semantic content discovery
+- RAG exploratório (copilot, assisted search)
+- Pre-selection of evidence candidates
+- Pipeline screening (with human review downstream)
+- Conceptual queries (theme, risk, structure, performance)
+
+### Ready with caveats (validate further as corpus grows)
+
+- Exact term extraction (covenants, defined terms, thresholds)
+- Auditable evidence assembly (IC memos, compliance)
+- Cross-document comparison within homogeneous datarooms
+- Queries with strong lexical dependence (clause numbers, formulas)
+
+### Not yet ready (requires BM25 hybrid or additional infrastructure)
+
+- Literal search for specific strings, section numbers, or exact phrases
+- Regulatory citation lookup (specific clause of specific regulation)
+- Full-text keyword search as a user-facing feature
+
+---
+
+## Implementation Reference
+
+The architectural decisions above are specified for implementation in `docs/reference/retrieval-confidence-signals-spec.md`. Key components:
+
+- `RetrievalSignal` dataclass in `ai_engine/extraction/` (domain-agnostic, no vertical imports)
+- `RerankedResult` wrapper replacing raw `list[dict]` return from `search_and_rerank_*` functions
+- Per-caller behavioral integration (copilot, screening, domain_ai, evidence, corpus)
+- Confidence thresholds as tunable constants, not hardcoded business rules
+- Detection heuristic for reranker logit scale vs cosine scale (negative scores → logit)
+
+---
+
+## Related Documents
+
+- `docs/reference/pipeline-quality-validation-2026-03-19.md` — validation data this analysis is based on
+- `docs/reference/retrieval-confidence-signals-spec.md` — implementation specification
+- `docs/reference/dual-mode-pipeline-architecture.md` — pipeline architecture context

--- a/docs/reference/retrieval-confidence-signals-spec.md
+++ b/docs/reference/retrieval-confidence-signals-spec.md
@@ -1,0 +1,166 @@
+# Retrieval Confidence Signals — Delta/Rank-Based Decision Layer
+
+## Context
+
+Read these files first:
+
+- `docs/reference/pipeline-quality-validation-2026-03-19.md` (validation report)
+- `backend/ai_engine/extraction/local_reranker.py` (cross-encoder reranker)
+- `backend/ai_engine/extraction/pgvector_search_service.py` (search + rerank wrappers)
+- `backend/vertical_engines/credit/retrieval/corpus.py` (ic_coverage_rerank)
+- `backend/vertical_engines/credit/retrieval/models.py` (constants, ChapterEvidenceThreshold)
+- `backend/vertical_engines/credit/retrieval/evidence.py` (evidence assembly, _best_score)
+- `backend/vertical_engines/credit/retrieval/saturation.py` (confidence levels)
+- `backend/vertical_engines/credit/pipeline/screening.py` (pipeline screening)
+- `backend/vertical_engines/credit/domain_ai/service.py` (portfolio monitoring)
+- `backend/app/domains/credit/modules/ai/copilot.py` (fund copilot RAG)
+
+## Problem
+
+The retrieval pipeline currently returns results sorted by rank (reranker_score or cosine score) but provides NO signal about retrieval confidence to downstream consumers. Callers have no way to distinguish "the system found one clearly dominant result" from "the system is guessing between 5 equally-scored candidates."
+
+Absolute score thresholds (e.g., `score > 0.6`) are fragile — they shift with corpus size, document heterogeneity, and chunk length. The correct approach is relative: rank-based, delta-based, and percentile-based signals that are intrinsic to each query's result distribution.
+
+### Why relative over absolute
+
+| Approach | Failure mode |
+|---|---|
+| `score > 0.6` threshold | Breaks when corpus grows (score distribution shifts), when chunk length changes (longer chunks dilute similarity), or when document homogeneity increases (all scores compress into a narrow band) |
+| `delta top-1 vs top-2` | Stable across corpus size because it measures separation within the query, not absolute position on a global scale |
+| `percentile within query` | Self-calibrating — adapts to whatever score distribution the query produces |
+
+In financial/legal document retrieval, the question is never "is this score high enough?" but rather "does this result clearly separate from the alternatives?"
+
+## Design
+
+### 1. RetrievalSignal dataclass
+
+New file: `backend/ai_engine/extraction/retrieval_signal.py`
+
+Create a frozen dataclass that captures confidence metadata for a query's result set:
+
+```python
+@dataclasses.dataclass(frozen=True)
+class RetrievalSignal:
+    top1_score: float           # best score (reranker_score preferred, else cosine)
+    top2_score: float | None    # second-best score (None if only 1 result)
+    delta_top1_top2: float      # gap between rank-1 and rank-2 (0.0 if <=1 result)
+    percentile_top1: float      # top1 score as percentile within result set (0-1)
+    result_count: int           # total results returned
+    confidence: str             # "HIGH" | "MODERATE" | "LOW" | "AMBIGUOUS"
+```
+
+Confidence classification (starting heuristics, tunable — constants at top of file):
+
+| Level | Reranker logits condition | Cosine condition | Additional |
+|---|---|---|---|
+| HIGH | `delta > 2.0` | `delta > 0.08` | AND `result_count >= 3` |
+| MODERATE | `delta > 0.5` | `delta > 0.03` | — |
+| AMBIGUOUS | `delta <= 0.5` | `delta <= 0.03` | AND `result_count >= 5` |
+| LOW | — | — | `result_count < 3` OR `top1 < median(all scores)` |
+
+Add a `from_results()` classmethod:
+
+```python
+@classmethod
+def from_results(
+    cls,
+    results: list[dict[str, Any]],
+    score_key: str = "reranker_score",
+    fallback_key: str = "score",
+) -> "RetrievalSignal":
+    ...
+```
+
+This method extracts scores from the result dicts (trying `score_key` first, then `fallback_key`, then `0.0`), computes all fields, and classifies confidence. It must detect whether scores are reranker logits (can be negative, typical range -12 to +6) or cosine similarity (0-1 range) and apply the corresponding threshold scale.
+
+**Detection heuristic:** if any score in the result set is negative, assume reranker logit scale; otherwise assume cosine scale.
+
+### 2. RerankedResult wrapper
+
+Enrich the return type of the `search_and_rerank_*` functions in `pgvector_search_service.py`:
+
+```python
+@dataclasses.dataclass
+class RerankedResult:
+    chunks: list[dict[str, Any]]
+    signal: RetrievalSignal
+```
+
+The 5 `search_and_rerank_*` functions currently return `list[dict]`. Change them to return `RerankedResult`. This is a breaking interface change — update all callers.
+
+### 3. Caller integration
+
+For each caller, integrate the signal appropriately to its use case:
+
+#### a) copilot.py — RAG exploratório
+
+Pass signal through to API response. Add `retrieval_confidence: str` field to the copilot response schema so the frontend can show confidence indicators. No filtering — copilot always returns results, user judges.
+
+#### b) screening.py — pipeline screening
+
+Log signal. If confidence is `AMBIGUOUS`, add a `_retrieval_ambiguous: true` flag to the screening context so the LLM prompt can hedge its assessment. Do NOT block screening on low confidence.
+
+#### c) domain_ai/service.py — portfolio monitoring
+
+Log signal. If confidence is `LOW`, prepend a caveat to the LLM context: `"Note: limited documentary evidence was found for this query."` No blocking.
+
+#### d) evidence.py — IC evidence pack (most critical consumer)
+
+Add signal to the evidence audit metadata (the saturation dict). When confidence is `AMBIGUOUS` for a chapter query, mark the chapter coverage as `EVIDENCE_CONTESTED` (new status alongside `SATURATED`/`PARTIAL`/`MISSING`). The IC memo generator can then flag contested evidence to the analyst.
+
+#### e) corpus.py — ic_coverage_rerank
+
+Pass through signal. `ic_coverage_rerank` receives already-reranked chunks, so it should accept and forward the `RetrievalSignal`, not recompute it.
+
+### 4. Tests
+
+New file: `backend/tests/test_retrieval_signal.py`
+
+| Test | Assertion |
+|---|---|
+| `test_high_confidence` | One dominant result with large gap -> HIGH |
+| `test_ambiguous` | Top 5 results within tight score band -> AMBIGUOUS |
+| `test_low_result_count` | Only 1-2 results -> LOW |
+| `test_moderate` | Clear but not dominant gap -> MODERATE |
+| `test_from_results_uses_reranker_score_first` | Verifies score_key fallback chain |
+| `test_from_results_empty` | Empty list -> LOW with zeros |
+| `test_cosine_vs_reranker_thresholds` | Different threshold scales applied based on detected score range |
+
+### 5. NOT in scope
+
+- No BM25 hybrid search (separate initiative)
+- No changes to embedding model or pgvector index
+- No changes to chunking or classification
+- No absolute score thresholds anywhere
+- No blocking of results based on signal (signal is advisory, never gate)
+- Do not modify the reranker model or its parameters
+
+## Constraints
+
+- `RetrievalSignal` lives in `ai_engine/` (domain-agnostic). It must NOT import from `vertical_engines/` or `app/domains/`.
+- The confidence thresholds must be constants at the top of `retrieval_signal.py`, clearly labeled as tunable heuristics.
+- All existing tests must continue passing. Run `make check` before committing.
+- Branch: `feat/retrieval-confidence-signals`
+- Single PR with clear commit message.
+
+## Architecture summary
+
+```
+pgvector cosine search (candidates=50-120)
+    |
+    v
+cross-encoder rerank (top_k=10-80)
+    |
+    v
+RetrievalSignal.from_results(chunks)  <-- NEW
+    |
+    v
+RerankedResult { chunks, signal }     <-- NEW return type
+    |
+    +---> copilot:     signal.confidence in API response
+    +---> screening:   _retrieval_ambiguous flag if AMBIGUOUS
+    +---> domain_ai:   caveat prefix if LOW
+    +---> evidence:    EVIDENCE_CONTESTED status if AMBIGUOUS
+    +---> corpus:      pass-through signal
+```


### PR DESCRIPTION
## Summary

- **RetrievalSignal** — relative confidence classification (HIGH/MODERATE/LOW/AMBIGUOUS) based on delta top-1 vs top-2 and percentile. Separate thresholds for reranker logits vs cosine scores
- **RerankedResult** wrapper replaces raw `list[dict]` in all 5 `search_and_rerank_*` functions
- **EVIDENCE_CONTESTED** status in IC evidence assembly when retrieval is ambiguous
- All callers updated: copilot, screening, domain_ai, deep_review/corpus, saturation
- Pipeline fixes for local VLM OCR (olmocr-2-7b), settings case mismatch, migration fix
- Dual-mode architecture doc updated (OpenAI for extraction, not local LLM)

## Test plan

- [ ] 1530/1530 unit tests passing
- [ ] 12 retrieval signal tests covering all confidence tiers
- [ ] Run `compare_retrieval_quality.py` against prod vectors to validate cosine vs cosine+reranker
- [ ] Verify EVIDENCE_CONTESTED surfaces in IC evidence for ambiguous queries
- [ ] E2E smoke test with local VLM OCR (olmocr-2-7b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)