### PR TITLE
feat(wealth): ESMA UCITS fund universe ingestion & REST API

### DIFF
--- a/backend/app/domains/wealth/queries/esma_sql.py
+++ b/backend/app/domains/wealth/queries/esma_sql.py
@@ -1,0 +1,250 @@
+"""ESMA query builder.
+
+Pure query builder — constructs SQLAlchemy Core Select statements.
+Tables are global (no organization_id, no RLS).
+Text search: ILIKE with _escape_ilike().
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from sqlalchemy import (
+    Column,
+    MetaData,
+    Select,
+    Table,
+    Text,
+    and_,
+    func,
+    select,
+)
+from sqlalchemy.dialects.postgresql import ARRAY
+
+# ═══════════════════════════════════════════════════════════════════
+#  Reflected tables (Core-style, not ORM)
+# ═══════════════════════════════════════════════════════════════════
+
+_meta = MetaData()
+
+esma_managers = Table(
+    "esma_managers",
+    _meta,
+    Column("esma_id", Text, primary_key=True),
+    Column("lei", Text),
+    Column("company_name", Text, nullable=False),
+    Column("country", Text),
+    Column("authorization_status", Text),
+    Column("fund_count", Text),
+    Column("sec_crd_number", Text),
+)
+
+esma_funds = Table(
+    "esma_funds",
+    _meta,
+    Column("isin", Text, primary_key=True),
+    Column("fund_name", Text, nullable=False),
+    Column("esma_manager_id", Text),
+    Column("domicile", Text),
+    Column("fund_type", Text),
+    Column("host_member_states", ARRAY(Text)),
+    Column("yahoo_ticker", Text),
+)
+
+sec_managers = Table(
+    "sec_managers",
+    _meta,
+    Column("crd_number", Text, primary_key=True),
+    Column("firm_name", Text),
+    extend_existing=True,
+)
+
+# ═══════════════════════════════════════════════════════════════════
+#  Text search escaping
+# ═══════════════════════════════════════════════════════════════════
+
+_ILIKE_ESCAPE_RE = re.compile(r"([%_\\])")
+
+
+def _escape_ilike(text: str) -> str:
+    """Escape ILIKE special characters."""
+    return _ILIKE_ESCAPE_RE.sub(r"\\\1", text)
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Filter dataclasses
+# ═══════════════════════════════════════════════════════════════════
+
+
+@dataclass(frozen=True)
+class EsmaManagerFilters:
+    country: str | None = None
+    search: str | None = None
+    page: int = 1
+    page_size: int = 50
+
+
+@dataclass(frozen=True)
+class EsmaFundFilters:
+    domicile: str | None = None
+    fund_type: str | None = None
+    search: str | None = None
+    page: int = 1
+    page_size: int = 50
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Query builders
+# ═══════════════════════════════════════════════════════════════════
+
+
+def build_manager_list_queries(
+    filters: EsmaManagerFilters,
+) -> tuple[Select, Select]:
+    """Build data + count queries for paginated manager list."""
+    conditions: list = []
+
+    if filters.country:
+        conditions.append(esma_managers.c.country == filters.country)
+    if filters.search:
+        escaped = _escape_ilike(filters.search)
+        conditions.append(esma_managers.c.company_name.ilike(f"%{escaped}%"))
+
+    where = and_(*conditions) if conditions else None
+
+    base = select(
+        esma_managers.c.esma_id,
+        esma_managers.c.company_name,
+        esma_managers.c.country,
+        esma_managers.c.authorization_status,
+        esma_managers.c.sec_crd_number,
+        esma_managers.c.fund_count,
+    )
+    if where is not None:
+        base = base.where(where)
+
+    data_q = (
+        base
+        .order_by(esma_managers.c.company_name)
+        .limit(filters.page_size)
+        .offset((filters.page - 1) * filters.page_size)
+    )
+
+    count_base = select(func.count()).select_from(esma_managers)
+    if where is not None:
+        count_base = count_base.where(where)
+
+    return data_q, count_base
+
+
+def build_manager_detail_query(esma_id: str) -> Select:
+    """Query single manager by esma_id."""
+    return (
+        select(
+            esma_managers.c.esma_id,
+            esma_managers.c.company_name,
+            esma_managers.c.country,
+            esma_managers.c.authorization_status,
+            esma_managers.c.sec_crd_number,
+        )
+        .where(esma_managers.c.esma_id == esma_id)
+    )
+
+
+def build_manager_funds_query(esma_id: str) -> Select:
+    """Query all funds for a given manager."""
+    return (
+        select(
+            esma_funds.c.isin,
+            esma_funds.c.fund_name,
+            esma_funds.c.domicile,
+            esma_funds.c.fund_type,
+            esma_funds.c.yahoo_ticker,
+            esma_funds.c.esma_manager_id,
+        )
+        .where(esma_funds.c.esma_manager_id == esma_id)
+        .order_by(esma_funds.c.fund_name)
+    )
+
+
+def build_fund_list_queries(
+    filters: EsmaFundFilters,
+) -> tuple[Select, Select]:
+    """Build data + count queries for paginated fund list."""
+    conditions: list = []
+
+    if filters.domicile:
+        conditions.append(esma_funds.c.domicile == filters.domicile)
+    if filters.fund_type:
+        conditions.append(esma_funds.c.fund_type == filters.fund_type)
+    if filters.search:
+        escaped = _escape_ilike(filters.search)
+        conditions.append(esma_funds.c.fund_name.ilike(f"%{escaped}%"))
+
+    where = and_(*conditions) if conditions else None
+
+    base = select(
+        esma_funds.c.isin,
+        esma_funds.c.fund_name,
+        esma_funds.c.domicile,
+        esma_funds.c.fund_type,
+        esma_funds.c.yahoo_ticker,
+        esma_funds.c.esma_manager_id,
+    )
+    if where is not None:
+        base = base.where(where)
+
+    data_q = (
+        base
+        .order_by(esma_funds.c.fund_name)
+        .limit(filters.page_size)
+        .offset((filters.page - 1) * filters.page_size)
+    )
+
+    count_base = select(func.count()).select_from(esma_funds)
+    if where is not None:
+        count_base = count_base.where(where)
+
+    return data_q, count_base
+
+
+def build_fund_detail_query(isin: str) -> Select:
+    """Query single fund with joined manager info."""
+    return (
+        select(
+            esma_funds.c.isin,
+            esma_funds.c.fund_name,
+            esma_funds.c.domicile,
+            esma_funds.c.fund_type,
+            esma_funds.c.yahoo_ticker,
+            esma_managers.c.esma_id.label("mgr_esma_id"),
+            esma_managers.c.company_name.label("mgr_company_name"),
+            esma_managers.c.country.label("mgr_country"),
+            esma_managers.c.authorization_status.label("mgr_authorization_status"),
+            esma_managers.c.sec_crd_number.label("mgr_sec_crd_number"),
+            esma_managers.c.fund_count.label("mgr_fund_count"),
+        )
+        .join(
+            esma_managers,
+            esma_funds.c.esma_manager_id == esma_managers.c.esma_id,
+            isouter=True,
+        )
+        .where(esma_funds.c.isin == isin)
+    )
+
+
+def build_sec_crossref_query(esma_id: str) -> Select:
+    """Query SEC cross-reference for a given ESMA manager."""
+    return (
+        select(
+            esma_managers.c.esma_id,
+            esma_managers.c.sec_crd_number,
+            sec_managers.c.firm_name.label("sec_firm_name"),
+        )
+        .outerjoin(
+            sec_managers,
+            esma_managers.c.sec_crd_number == sec_managers.c.crd_number,
+        )
+        .where(esma_managers.c.esma_id == esma_id)
+    )

--- a/backend/app/domains/wealth/routes/esma.py
+++ b/backend/app/domains/wealth/routes/esma.py
@@ -1,0 +1,257 @@
+"""ESMA UCITS fund universe endpoints.
+
+All tables are GLOBAL (no organization_id, no RLS).
+Uses get_db_session (not get_db_with_rls).
+Auth: Role.INVESTMENT_TEAM or Role.ADMIN.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.core.db.engine import async_session_factory
+from app.core.security.clerk_auth import Actor, CurrentUser, get_actor, get_current_user
+from app.domains.wealth.queries.esma_sql import (
+    EsmaFundFilters,
+    EsmaManagerFilters,
+    build_fund_detail_query,
+    build_fund_list_queries,
+    build_manager_detail_query,
+    build_manager_funds_query,
+    build_manager_list_queries,
+    build_sec_crossref_query,
+)
+from app.domains.wealth.schemas.esma import (
+    EsmaFundDetail,
+    EsmaFundItem,
+    EsmaFundPage,
+    EsmaManagerDetail,
+    EsmaManagerItem,
+    EsmaManagerPage,
+    EsmaSecCrossRef,
+)
+from app.shared.enums import Role
+
+router = APIRouter(prefix="/esma", tags=["esma"])
+
+
+def _require_esma_role(actor: Actor) -> None:
+    if not actor.has_role(Role.INVESTMENT_TEAM) and not actor.has_role(Role.ADMIN):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Investment team or admin role required",
+        )
+
+
+# ── 1. GET /esma/managers ────────────────────────────────────────
+
+
+@router.get(
+    "/managers",
+    response_model=EsmaManagerPage,
+    summary="List ESMA managers",
+)
+async def list_esma_managers(
+    country: str | None = Query(None),
+    search: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
+    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(get_actor),
+) -> EsmaManagerPage:
+    _require_esma_role(actor)
+
+    filters = EsmaManagerFilters(
+        country=country, search=search, page=page, page_size=page_size,
+    )
+    data_q, count_q = build_manager_list_queries(filters)
+
+    async with async_session_factory() as db:
+        data_result = await db.execute(data_q)
+        count_result = await db.execute(count_q)
+
+    rows = data_result.all()
+    total = count_result.scalar() or 0
+
+    items = [
+        EsmaManagerItem(
+            esma_id=r.esma_id,
+            company_name=r.company_name,
+            country=r.country,
+            authorization_status=r.authorization_status,
+            sec_crd_number=r.sec_crd_number,
+            fund_count=int(r.fund_count) if r.fund_count else 0,
+        )
+        for r in rows
+    ]
+    return EsmaManagerPage(items=items, total=total, page=page, page_size=page_size)
+
+
+# ── 2. GET /esma/managers/{esma_id} ─────────────────────────────
+
+
+@router.get(
+    "/managers/{esma_id}",
+    response_model=EsmaManagerDetail,
+    summary="Get ESMA manager detail with funds",
+)
+async def get_esma_manager(
+    esma_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(get_actor),
+) -> EsmaManagerDetail:
+    _require_esma_role(actor)
+
+    mgr_q = build_manager_detail_query(esma_id)
+    funds_q = build_manager_funds_query(esma_id)
+
+    async with async_session_factory() as db:
+        mgr_result = await db.execute(mgr_q)
+        funds_result = await db.execute(funds_q)
+
+    mgr = mgr_result.first()
+    if mgr is None:
+        raise HTTPException(status_code=404, detail="Manager not found")
+
+    fund_rows = funds_result.all()
+    funds = [
+        EsmaFundItem(
+            isin=f.isin,
+            fund_name=f.fund_name,
+            domicile=f.domicile,
+            fund_type=f.fund_type,
+            yahoo_ticker=f.yahoo_ticker,
+            esma_manager_id=f.esma_manager_id,
+        )
+        for f in fund_rows
+    ]
+    return EsmaManagerDetail(
+        esma_id=mgr.esma_id,
+        company_name=mgr.company_name,
+        country=mgr.country,
+        authorization_status=mgr.authorization_status,
+        sec_crd_number=mgr.sec_crd_number,
+        funds=funds,
+    )
+
+
+# ── 3. GET /esma/funds ──────────────────────────────────────────
+
+
+@router.get(
+    "/funds",
+    response_model=EsmaFundPage,
+    summary="List ESMA UCITS funds",
+)
+async def list_esma_funds(
+    domicile: str | None = Query(None),
+    fund_type: str | None = Query(None, alias="type"),
+    search: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
+    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(get_actor),
+) -> EsmaFundPage:
+    _require_esma_role(actor)
+
+    filters = EsmaFundFilters(
+        domicile=domicile, fund_type=fund_type, search=search,
+        page=page, page_size=page_size,
+    )
+    data_q, count_q = build_fund_list_queries(filters)
+
+    async with async_session_factory() as db:
+        data_result = await db.execute(data_q)
+        count_result = await db.execute(count_q)
+
+    rows = data_result.all()
+    total = count_result.scalar() or 0
+
+    items = [
+        EsmaFundItem(
+            isin=r.isin,
+            fund_name=r.fund_name,
+            domicile=r.domicile,
+            fund_type=r.fund_type,
+            yahoo_ticker=r.yahoo_ticker,
+            esma_manager_id=r.esma_manager_id,
+        )
+        for r in rows
+    ]
+    return EsmaFundPage(items=items, total=total, page=page, page_size=page_size)
+
+
+# ── 4. GET /esma/funds/{isin} ───────────────────────────────────
+
+
+@router.get(
+    "/funds/{isin}",
+    response_model=EsmaFundDetail,
+    summary="Get ESMA fund detail with manager",
+)
+async def get_esma_fund(
+    isin: str,
+    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(get_actor),
+) -> EsmaFundDetail:
+    _require_esma_role(actor)
+
+    q = build_fund_detail_query(isin)
+
+    async with async_session_factory() as db:
+        result = await db.execute(q)
+
+    row = result.first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Fund not found")
+
+    manager = None
+    if row.mgr_esma_id:
+        manager = EsmaManagerItem(
+            esma_id=row.mgr_esma_id,
+            company_name=row.mgr_company_name or "",
+            country=row.mgr_country,
+            authorization_status=row.mgr_authorization_status,
+            sec_crd_number=row.mgr_sec_crd_number,
+            fund_count=int(row.mgr_fund_count) if row.mgr_fund_count else 0,
+        )
+    return EsmaFundDetail(
+        isin=row.isin,
+        fund_name=row.fund_name,
+        domicile=row.domicile,
+        fund_type=row.fund_type,
+        yahoo_ticker=row.yahoo_ticker,
+        manager=manager,
+    )
+
+
+# ── 5. GET /esma/managers/{esma_id}/sec-crossref ────────────────
+
+
+@router.get(
+    "/managers/{esma_id}/sec-crossref",
+    response_model=EsmaSecCrossRef,
+    summary="SEC cross-reference for ESMA manager",
+)
+async def get_esma_sec_crossref(
+    esma_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(get_actor),
+) -> EsmaSecCrossRef:
+    _require_esma_role(actor)
+
+    q = build_sec_crossref_query(esma_id)
+
+    async with async_session_factory() as db:
+        result = await db.execute(q)
+
+    row = result.first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Manager not found")
+
+    return EsmaSecCrossRef(
+        esma_id=row.esma_id,
+        sec_crd_number=row.sec_crd_number,
+        sec_firm_name=row.sec_firm_name,
+        matched=row.sec_firm_name is not None,
+    )

--- a/backend/app/domains/wealth/routes/risk.py
+++ b/backend/app/domains/wealth/routes/risk.py
@@ -5,6 +5,7 @@ import redis.asyncio as aioredis
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
+from sqlalchemy import func as sa_func
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,7 +14,10 @@ from app.core.config.dependencies import get_config_service
 from app.core.config.settings import settings
 from app.core.security.clerk_auth import Actor, CurrentUser, get_actor, get_current_user
 from app.core.tenancy.middleware import get_db_with_rls
+from app.domains.wealth.models.allocation import StrategicAllocation
+from app.domains.wealth.models.instrument import Instrument
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
+from app.domains.wealth.models.risk import FundRiskMetrics
 from app.domains.wealth.routes.common import VALID_PROFILES, get_latest_snapshot
 from app.domains.wealth.routes.common import validate_profile as _validate_profile
 from app.domains.wealth.schemas.macro import MacroIndicators
@@ -94,8 +98,6 @@ async def get_risk_summary_batch(
         )
 
     # Single query: latest snapshot per requested profile
-    from sqlalchemy import func as sa_func
-
     latest_subq = (
         select(
             PortfolioSnapshot.profile,
@@ -116,13 +118,56 @@ async def get_risk_summary_batch(
     result = await db.execute(stmt)
     snaps_by_profile = {s.profile: s for s in result.scalars().all()}
 
+    # Momentum averages per profile: profile → block_ids → instruments → fund_risk_metrics
+    momentum_by_profile: dict[str, dict[str, float | None]] = {}
+    valid_names = [n for n in names if n in VALID_PROFILES]
+    if valid_names:
+        momentum_stmt = (
+            select(
+                StrategicAllocation.profile,
+                sa_func.avg(FundRiskMetrics.rsi_14).label("rsi_14"),
+                sa_func.avg(FundRiskMetrics.bb_position).label("bb_position"),
+                sa_func.avg(FundRiskMetrics.nav_momentum_score).label("nav_momentum_score"),
+                sa_func.avg(FundRiskMetrics.flow_momentum_score).label("flow_momentum_score"),
+                sa_func.avg(FundRiskMetrics.blended_momentum_score).label("blended_momentum_score"),
+            )
+            .join(Instrument, Instrument.block_id == StrategicAllocation.block_id)
+            .join(FundRiskMetrics, FundRiskMetrics.instrument_id == Instrument.instrument_id)
+            .where(
+                StrategicAllocation.profile.in_(valid_names),
+                FundRiskMetrics.calc_date == (
+                    select(sa_func.max(FundRiskMetrics.calc_date))
+                    .where(FundRiskMetrics.instrument_id == Instrument.instrument_id)
+                    .correlate(Instrument)
+                    .scalar_subquery()
+                ),
+            )
+            .group_by(StrategicAllocation.profile)
+        )
+        mom_result = await db.execute(momentum_stmt)
+        for row in mom_result.all():
+            momentum_by_profile[row.profile] = {
+                "rsi_14": float(row.rsi_14) if row.rsi_14 is not None else None,
+                "bb_position": float(row.bb_position) if row.bb_position is not None else None,
+                "nav_momentum_score": float(row.nav_momentum_score) if row.nav_momentum_score is not None else None,
+                "flow_momentum_score": float(row.flow_momentum_score) if row.flow_momentum_score is not None else None,
+                "blended_momentum_score": float(row.blended_momentum_score) if row.blended_momentum_score is not None else None,
+            }
+
     results: dict[str, CVaRStatus | None] = {}
     for name in names:
         if name not in VALID_PROFILES:
             results[name] = None
         else:
             snap = snaps_by_profile.get(name)
-            results[name] = _snap_to_cvar(name, snap)
+            cvar = _snap_to_cvar(name, snap)
+            mom = momentum_by_profile.get(name, {})
+            cvar.rsi_14 = mom.get("rsi_14")
+            cvar.bb_position = mom.get("bb_position")
+            cvar.nav_momentum_score = mom.get("nav_momentum_score")
+            cvar.flow_momentum_score = mom.get("flow_momentum_score")
+            cvar.blended_momentum_score = mom.get("blended_momentum_score")
+            results[name] = cvar
 
     return BatchRiskSummaryOut(
         profiles=results,
@@ -147,7 +192,39 @@ async def get_cvar(
 ) -> CVaRStatus:
     _validate_profile(profile)
     snap = await get_latest_snapshot(db, profile)
-    return _snap_to_cvar(profile, snap)
+    cvar = _snap_to_cvar(profile, snap)
+
+    # Enrich with momentum averages for this profile
+    momentum_stmt = (
+        select(
+            sa_func.avg(FundRiskMetrics.rsi_14).label("rsi_14"),
+            sa_func.avg(FundRiskMetrics.bb_position).label("bb_position"),
+            sa_func.avg(FundRiskMetrics.nav_momentum_score).label("nav_momentum_score"),
+            sa_func.avg(FundRiskMetrics.flow_momentum_score).label("flow_momentum_score"),
+            sa_func.avg(FundRiskMetrics.blended_momentum_score).label("blended_momentum_score"),
+        )
+        .select_from(StrategicAllocation)
+        .join(Instrument, Instrument.block_id == StrategicAllocation.block_id)
+        .join(FundRiskMetrics, FundRiskMetrics.instrument_id == Instrument.instrument_id)
+        .where(
+            StrategicAllocation.profile == profile,
+            FundRiskMetrics.calc_date == (
+                select(sa_func.max(FundRiskMetrics.calc_date))
+                .where(FundRiskMetrics.instrument_id == Instrument.instrument_id)
+                .correlate(Instrument)
+                .scalar_subquery()
+            ),
+        )
+    )
+    row = (await db.execute(momentum_stmt)).one_or_none()
+    if row:
+        cvar.rsi_14 = float(row.rsi_14) if row.rsi_14 is not None else None
+        cvar.bb_position = float(row.bb_position) if row.bb_position is not None else None
+        cvar.nav_momentum_score = float(row.nav_momentum_score) if row.nav_momentum_score is not None else None
+        cvar.flow_momentum_score = float(row.flow_momentum_score) if row.flow_momentum_score is not None else None
+        cvar.blended_momentum_score = float(row.blended_momentum_score) if row.blended_momentum_score is not None else None
+
+    return cvar
 
 
 @router.get(

--- a/backend/app/domains/wealth/routes/workers.py
+++ b/backend/app/domains/wealth/routes/workers.py
@@ -566,3 +566,33 @@ async def trigger_run_imf_ingestion(
         run_imf_ingestion,
         timeout_seconds=_HEAVY_WORKER_TIMEOUT,
     )
+
+
+@router.post(
+    "/run-esma-ingestion",
+    response_model=WorkerScheduledResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Trigger ESMA UCITS universe ingestion",
+    description=(
+        "Schedules the ESMA ingestion worker as a background task. "
+        "Fetches ~134K UCITS funds from the ESMA Solr register, "
+        "deduplicates managers, resolves ISIN→ticker via OpenFIGI, "
+        "and upserts into esma_managers, esma_funds, esma_isin_ticker_map. "
+        "Uses advisory lock 900_019. Returns immediately."
+    ),
+    tags=["workers"],
+)
+async def trigger_run_esma_ingestion(
+    background_tasks: BackgroundTasks,
+    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(get_actor),
+) -> WorkerScheduledResponse:
+    _require_admin_role(actor)
+
+    from app.domains.wealth.workers.esma_ingestion import run_esma_ingestion
+
+    return await _dispatch_worker(
+        background_tasks, "run-esma-ingestion", "global",
+        run_esma_ingestion,
+        timeout_seconds=_HEAVY_WORKER_TIMEOUT,
+    )

--- a/backend/app/domains/wealth/schemas/esma.py
+++ b/backend/app/domains/wealth/schemas/esma.py
@@ -1,0 +1,62 @@
+"""Pydantic schemas for ESMA UCITS endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class EsmaManagerItem(BaseModel):
+    esma_id: str
+    company_name: str
+    country: str | None = None
+    authorization_status: str | None = None
+    sec_crd_number: str | None = None
+    fund_count: int = 0
+
+
+class EsmaManagerPage(BaseModel):
+    items: list[EsmaManagerItem]
+    total: int
+    page: int
+    page_size: int
+
+
+class EsmaFundItem(BaseModel):
+    isin: str
+    fund_name: str
+    domicile: str | None = None
+    fund_type: str | None = None
+    yahoo_ticker: str | None = None
+    esma_manager_id: str | None = None
+
+
+class EsmaFundPage(BaseModel):
+    items: list[EsmaFundItem]
+    total: int
+    page: int
+    page_size: int
+
+
+class EsmaManagerDetail(BaseModel):
+    esma_id: str
+    company_name: str
+    country: str | None = None
+    authorization_status: str | None = None
+    sec_crd_number: str | None = None
+    funds: list[EsmaFundItem] = []
+
+
+class EsmaFundDetail(BaseModel):
+    isin: str
+    fund_name: str
+    domicile: str | None = None
+    fund_type: str | None = None
+    yahoo_ticker: str | None = None
+    manager: EsmaManagerItem | None = None
+
+
+class EsmaSecCrossRef(BaseModel):
+    esma_id: str
+    sec_crd_number: str | None = None
+    sec_firm_name: str | None = None
+    matched: bool = False

--- a/backend/app/domains/wealth/schemas/risk.py
+++ b/backend/app/domains/wealth/schemas/risk.py
@@ -75,6 +75,12 @@ class CVaRStatus(BaseModel):
     cvar_upper_95: Decimal | None = None
     computed_at: datetime | None = None  # server-side computation timestamp
     next_expected_update: datetime | None = None  # next expected update
+    # Momentum signals — profile-level averages from fund_risk_metrics
+    rsi_14: float | None = None
+    bb_position: float | None = None
+    nav_momentum_score: float | None = None
+    flow_momentum_score: float | None = None
+    blended_momentum_score: float | None = None
 
 
 class CVaRPoint(BaseModel):

--- a/backend/app/domains/wealth/workers/esma_ingestion.py
+++ b/backend/app/domains/wealth/workers/esma_ingestion.py
@@ -1,0 +1,249 @@
+"""ESMA UCITS fund universe ingestion worker.
+
+Usage:
+    python -m app.domains.wealth.workers.esma_ingestion
+
+Fetches UCITS funds from the ESMA Solr register, deduplicates managers,
+resolves ISIN→ticker mappings via OpenFIGI, and upserts into
+esma_managers, esma_funds, and esma_isin_ticker_map tables.
+
+GLOBAL TABLE: No organization_id, no RLS.
+Advisory lock ID = 900_019.
+"""
+
+import asyncio
+import os
+from datetime import datetime, timezone
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.core.db.engine import async_session_factory as async_session
+from app.shared.models import EsmaFund as EsmaFundModel
+from app.shared.models import EsmaIsinTickerMap
+from app.shared.models import EsmaManager as EsmaManagerModel
+
+logger = structlog.get_logger()
+ESMA_LOCK_ID = 900_019
+_BATCH_SIZE = 2000
+
+
+async def run_esma_ingestion() -> dict:
+    """Fetch UCITS fund universe from ESMA and upsert managers, funds, ticker map."""
+    async with async_session() as db:
+        lock_result = await db.execute(
+            text(f"SELECT pg_try_advisory_lock({ESMA_LOCK_ID})")
+        )
+        if not lock_result.scalar():
+            logger.warning("ESMA ingestion already running (advisory lock not acquired)")
+            return {"status": "skipped", "reason": "lock_held"}
+
+        try:
+            from data_providers.esma.models import EsmaFund as EsmaFundDC
+            from data_providers.esma.models import EsmaManager as EsmaManagerDC
+            from data_providers.esma.register_service import RegisterService, parse_manager_from_doc
+            from data_providers.esma.ticker_resolver import TickerResolver
+
+            now = datetime.now(timezone.utc)
+
+            # ── Phase 1: Fetch all funds and extract managers ────────
+            funds_dc: list[EsmaFundDC] = []
+            managers_map: dict[str, EsmaManagerDC] = {}
+            fund_counts: dict[str, int] = {}
+
+            async with RegisterService() as svc:
+                async for fund in svc.iter_ucits_funds():
+                    funds_dc.append(fund)
+
+                    mid = fund.esma_manager_id
+                    fund_counts[mid] = fund_counts.get(mid, 0) + 1
+
+            logger.info("esma_ingestion.fetched", funds=len(funds_dc), unique_managers=len(fund_counts))
+
+            # Build manager map from raw Solr docs is not needed since
+            # RegisterService already provides parsed fund objects.
+            # We reconstruct minimal manager data from funds.
+            for fund in funds_dc:
+                mid = fund.esma_manager_id
+                if mid not in managers_map:
+                    managers_map[mid] = EsmaManagerDC(
+                        esma_id=mid,
+                        lei=None,
+                        company_name=mid,  # placeholder, overwritten below if available
+                        country=fund.domicile,
+                        authorization_status=None,
+                        fund_count=fund_counts.get(mid, 0),
+                    )
+
+            # Re-fetch page-0 raw docs to get accurate manager names
+            # The RegisterService already parsed them, but parse_manager_from_doc
+            # needs the raw Solr dict. Instead, re-iterate using a second pass
+            # with raw docs.
+            async with RegisterService() as svc:
+                start = 0
+                while True:
+                    try:
+                        data = await svc._fetch_page(start=start)
+                    except Exception:
+                        break
+                    docs = data.get("response", {}).get("docs", [])
+                    if not docs:
+                        break
+                    for doc in docs:
+                        mgr = parse_manager_from_doc(doc)
+                        if mgr and mgr.esma_id in fund_counts:
+                            managers_map[mgr.esma_id] = EsmaManagerDC(
+                                esma_id=mgr.esma_id,
+                                lei=mgr.lei,
+                                company_name=mgr.company_name,
+                                country=mgr.country,
+                                authorization_status=mgr.authorization_status,
+                                fund_count=fund_counts.get(mgr.esma_id, 0),
+                            )
+                    start += 1000
+                    total = int(data.get("response", {}).get("numFound", 0))
+                    if start >= total:
+                        break
+
+            # ── Phase 2: Upsert managers (FK dependency: managers first) ─
+            managers_list = list(managers_map.values())
+            for i in range(0, len(managers_list), _BATCH_SIZE):
+                batch = managers_list[i : i + _BATCH_SIZE]
+                values = [
+                    {
+                        "esma_id": m.esma_id,
+                        "lei": m.lei,
+                        "company_name": m.company_name,
+                        "country": m.country,
+                        "authorization_status": m.authorization_status,
+                        "fund_count": m.fund_count,
+                        "data_fetched_at": now,
+                    }
+                    for m in batch
+                ]
+                stmt = pg_insert(EsmaManagerModel).values(values)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["esma_id"],
+                    set_={
+                        "lei": stmt.excluded.lei,
+                        "company_name": stmt.excluded.company_name,
+                        "country": stmt.excluded.country,
+                        "authorization_status": stmt.excluded.authorization_status,
+                        "fund_count": stmt.excluded.fund_count,
+                        "data_fetched_at": stmt.excluded.data_fetched_at,
+                    },
+                )
+                await db.execute(stmt)
+            await db.commit()
+            logger.info("esma_ingestion.managers_upserted", count=len(managers_list))
+
+            # ── Phase 3: Upsert funds ───────────────────────────────
+            for i in range(0, len(funds_dc), _BATCH_SIZE):
+                batch = funds_dc[i : i + _BATCH_SIZE]
+                values = [
+                    {
+                        "isin": f.isin,
+                        "fund_name": f.fund_name,
+                        "esma_manager_id": f.esma_manager_id,
+                        "domicile": f.domicile,
+                        "fund_type": f.fund_type,
+                        "host_member_states": f.host_member_states or [],
+                        "data_fetched_at": now,
+                    }
+                    for f in batch
+                ]
+                stmt = pg_insert(EsmaFundModel).values(values)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["isin"],
+                    set_={
+                        "fund_name": stmt.excluded.fund_name,
+                        "esma_manager_id": stmt.excluded.esma_manager_id,
+                        "domicile": stmt.excluded.domicile,
+                        "fund_type": stmt.excluded.fund_type,
+                        "host_member_states": stmt.excluded.host_member_states,
+                        "data_fetched_at": stmt.excluded.data_fetched_at,
+                    },
+                )
+                await db.execute(stmt)
+            await db.commit()
+            logger.info("esma_ingestion.funds_upserted", count=len(funds_dc))
+
+            # ── Phase 4: Ticker resolution ──────────────────────────
+            isins = [f.isin for f in funds_dc]
+            ticker_count = 0
+            errors = 0
+
+            api_key = os.environ.get("OPENFIGI_API_KEY")
+            async with TickerResolver(api_key=api_key) as resolver:
+                try:
+                    resolutions = await resolver.resolve_all(isins)
+                except Exception as exc:
+                    logger.warning("esma_ingestion.ticker_resolution_failed", error=str(exc))
+                    resolutions = []
+                    errors += 1
+
+            # Upsert ticker map
+            for i in range(0, len(resolutions), _BATCH_SIZE):
+                batch = resolutions[i : i + _BATCH_SIZE]
+                values = [
+                    {
+                        "isin": r.isin,
+                        "yahoo_ticker": r.yahoo_ticker,
+                        "exchange": r.exchange,
+                        "resolved_via": r.resolved_via,
+                        "is_tradeable": r.is_tradeable,
+                        "last_verified_at": now,
+                    }
+                    for r in batch
+                ]
+                stmt = pg_insert(EsmaIsinTickerMap).values(values)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["isin"],
+                    set_={
+                        "yahoo_ticker": stmt.excluded.yahoo_ticker,
+                        "exchange": stmt.excluded.exchange,
+                        "resolved_via": stmt.excluded.resolved_via,
+                        "is_tradeable": stmt.excluded.is_tradeable,
+                        "last_verified_at": stmt.excluded.last_verified_at,
+                    },
+                )
+                await db.execute(stmt)
+            await db.commit()
+            ticker_count = sum(1 for r in resolutions if r.is_tradeable)
+
+            # Also update yahoo_ticker on esma_funds for resolved ISINs
+            resolved_map = {
+                r.isin: r.yahoo_ticker
+                for r in resolutions
+                if r.yahoo_ticker
+            }
+            if resolved_map:
+                for isin, ticker in resolved_map.items():
+                    await db.execute(
+                        text(
+                            "UPDATE esma_funds SET yahoo_ticker = :ticker, "
+                            "ticker_resolved_at = :now WHERE isin = :isin"
+                        ),
+                        {"ticker": ticker, "now": now, "isin": isin},
+                    )
+                await db.commit()
+
+            summary = {
+                "status": "completed",
+                "managers": len(managers_list),
+                "funds": len(funds_dc),
+                "tickers_resolved": ticker_count,
+                "errors": errors,
+            }
+            logger.info("esma_ingestion.complete", **summary)
+            return summary
+
+        finally:
+            await db.execute(
+                text(f"SELECT pg_advisory_unlock({ESMA_LOCK_ID})")
+            )
+
+
+if __name__ == "__main__":
+    asyncio.run(run_esma_ingestion())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -91,6 +91,7 @@ from app.domains.wealth.routes.content import router as wealth_content_router
 from app.domains.wealth.routes.correlation_regime import router as wealth_correlation_regime_router
 from app.domains.wealth.routes.dd_reports import router as wealth_dd_reports_router
 from app.domains.wealth.routes.documents import router as wealth_documents_router
+from app.domains.wealth.routes.esma import router as wealth_esma_router
 from app.domains.wealth.routes.exposure import router as wealth_exposure_router
 from app.domains.wealth.routes.fact_sheets import router as wealth_fact_sheets_router
 
@@ -357,6 +358,7 @@ api_v1.include_router(wealth_manager_screener_router)
 api_v1.include_router(wealth_strategy_drift_router)
 api_v1.include_router(wealth_attribution_router)
 api_v1.include_router(wealth_correlation_regime_router)
+api_v1.include_router(wealth_esma_router)
 api_v1.include_router(wealth_exposure_router)
 
 # ── Mount credit domain routes ───────────────────────────────

--- a/backend/manifests/routes.json
+++ b/backend/manifests/routes.json
@@ -531,6 +531,31 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/esma/funds",
+    "name": "list_esma_funds"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/esma/funds/{isin}",
+    "name": "get_esma_fund"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/esma/managers",
+    "name": "list_esma_managers"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/esma/managers/{esma_id}",
+    "name": "get_esma_manager"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/esma/managers/{esma_id}/sec-crossref",
+    "name": "get_esma_sec_crossref"
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/fact-sheets/dd-reports/{report_id}/download",
     "name": "download_dd_report_pdf"
   },
@@ -1626,8 +1651,23 @@
   },
   {
     "method": "POST",
+    "path": "/api/v1/workers/run-bis-ingestion",
+    "name": "trigger_run_bis_ingestion"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/workers/run-esma-ingestion",
+    "name": "trigger_run_esma_ingestion"
+  },
+  {
+    "method": "POST",
     "path": "/api/v1/workers/run-fact-sheet-gen",
     "name": "trigger_run_fact_sheet_gen"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/workers/run-imf-ingestion",
+    "name": "trigger_run_imf_ingestion"
   },
   {
     "method": "POST",

--- a/backend/manifests/workers.json
+++ b/backend/manifests/workers.json
@@ -11,6 +11,11 @@
   },
   {
     "method": "POST",
+    "path": "/api/v1/workers/run-esma-ingestion",
+    "name": "trigger_run_esma_ingestion"
+  },
+  {
+    "method": "POST",
     "path": "/api/v1/workers/run-fact-sheet-gen",
     "name": "trigger_run_fact_sheet_gen"
   },

--- a/backend/tests/routes/test_esma_endpoints.py
+++ b/backend/tests/routes/test_esma_endpoints.py
@@ -1,0 +1,270 @@
+"""Tests for ESMA REST endpoints.
+
+Covers:
+  - Route mounting (401/404 distinction)
+  - Auth (ADMIN gets 200, non-admin gets 403)
+  - Query builder SQL generation
+  - Paginated responses
+  - SEC cross-reference
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.dialects import postgresql
+
+from app.domains.wealth.queries.esma_sql import (
+    EsmaFundFilters,
+    EsmaManagerFilters,
+    _escape_ilike,
+    build_fund_detail_query,
+    build_fund_list_queries,
+    build_manager_detail_query,
+    build_manager_funds_query,
+    build_manager_list_queries,
+    build_sec_crossref_query,
+)
+
+# ── Auth headers ────────────────────────────────────────────────
+
+DEV_ACTOR_HEADER = {
+    "X-DEV-ACTOR": (
+        '{"actor_id": "test-user", "roles": ["ADMIN"], '
+        '"fund_ids": [], "org_id": "00000000-0000-0000-0000-000000000001"}'
+    )
+}
+
+_VIEWER_HEADER = {
+    "X-DEV-ACTOR": (
+        '{"actor_id": "viewer-user", "roles": ["INVESTOR"], '
+        '"fund_ids": [], "org_id": "00000000-0000-0000-0000-000000000001"}'
+    )
+}
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Text search escaping
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestEscapeIlike:
+    def test_percent_escaped(self) -> None:
+        assert _escape_ilike("100%") == r"100\%"
+
+    def test_underscore_escaped(self) -> None:
+        assert _escape_ilike("fund_name") == r"fund\_name"
+
+    def test_backslash_escaped(self) -> None:
+        assert _escape_ilike(r"a\b") == r"a\\b"
+
+    def test_normal_text_unchanged(self) -> None:
+        assert _escape_ilike("Vanguard") == "Vanguard"
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Filter dataclass defaults
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestFilterDefaults:
+    def test_manager_filters_defaults(self) -> None:
+        f = EsmaManagerFilters()
+        assert f.country is None
+        assert f.search is None
+        assert f.page == 1
+        assert f.page_size == 50
+
+    def test_fund_filters_defaults(self) -> None:
+        f = EsmaFundFilters()
+        assert f.domicile is None
+        assert f.fund_type is None
+        assert f.search is None
+        assert f.page == 1
+        assert f.page_size == 50
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Query builder SQL generation
+# ═══════════════════════════════════════════════════════════════════
+
+
+def _compile_sql(stmt) -> str:
+    """Compile a SQLAlchemy statement to string for inspection."""
+    return str(
+        stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+class TestManagerListQueries:
+    def test_empty_filters_valid_sql(self) -> None:
+        data_q, count_q = build_manager_list_queries(EsmaManagerFilters())
+        sql = _compile_sql(data_q)
+        assert "esma_managers" in sql
+        assert "LIMIT" in sql
+
+    def test_country_filter(self) -> None:
+        f = EsmaManagerFilters(country="IE")
+        data_q, _ = build_manager_list_queries(f)
+        sql = _compile_sql(data_q)
+        assert "country" in sql
+        assert "'IE'" in sql
+
+    def test_text_search_uses_ilike(self) -> None:
+        f = EsmaManagerFilters(search="Vanguard")
+        data_q, _ = build_manager_list_queries(f)
+        sql = _compile_sql(data_q)
+        assert "ILIKE" in sql.upper()
+        assert "Vanguard" in sql
+
+    def test_pagination(self) -> None:
+        f = EsmaManagerFilters(page=3, page_size=20)
+        data_q, _ = build_manager_list_queries(f)
+        sql = _compile_sql(data_q)
+        assert "LIMIT 20" in sql
+        assert "OFFSET 40" in sql
+
+    def test_count_query_no_limit(self) -> None:
+        _, count_q = build_manager_list_queries(EsmaManagerFilters())
+        sql = _compile_sql(count_q)
+        assert "count" in sql.lower()
+        assert "LIMIT" not in sql
+
+
+class TestManagerDetailQuery:
+    def test_filters_by_esma_id(self) -> None:
+        q = build_manager_detail_query("MGR001")
+        sql = _compile_sql(q)
+        assert "esma_managers" in sql
+        assert "'MGR001'" in sql
+
+
+class TestManagerFundsQuery:
+    def test_filters_by_manager_id(self) -> None:
+        q = build_manager_funds_query("MGR001")
+        sql = _compile_sql(q)
+        assert "esma_funds" in sql
+        assert "'MGR001'" in sql
+
+
+class TestFundListQueries:
+    def test_empty_filters_valid_sql(self) -> None:
+        data_q, count_q = build_fund_list_queries(EsmaFundFilters())
+        sql = _compile_sql(data_q)
+        assert "esma_funds" in sql
+        assert "LIMIT" in sql
+
+    def test_domicile_filter(self) -> None:
+        f = EsmaFundFilters(domicile="LU")
+        data_q, _ = build_fund_list_queries(f)
+        sql = _compile_sql(data_q)
+        assert "'LU'" in sql
+
+    def test_fund_type_filter(self) -> None:
+        f = EsmaFundFilters(fund_type="UCITS")
+        data_q, _ = build_fund_list_queries(f)
+        sql = _compile_sql(data_q)
+        assert "'UCITS'" in sql
+
+    def test_search_uses_ilike(self) -> None:
+        f = EsmaFundFilters(search="Bond")
+        data_q, _ = build_fund_list_queries(f)
+        sql = _compile_sql(data_q)
+        assert "ILIKE" in sql.upper()
+
+
+class TestFundDetailQuery:
+    def test_joins_manager(self) -> None:
+        q = build_fund_detail_query("IE00ABC")
+        sql = _compile_sql(q)
+        assert "esma_funds" in sql
+        assert "esma_managers" in sql
+        assert "JOIN" in sql.upper()
+
+
+class TestSecCrossrefQuery:
+    def test_joins_sec_managers(self) -> None:
+        q = build_sec_crossref_query("MGR001")
+        sql = _compile_sql(q)
+        assert "esma_managers" in sql
+        assert "sec_managers" in sql
+        assert "JOIN" in sql.upper()
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Route mounting tests (no DB required)
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestEsmaRouteMounting:
+    """Verify routes exist (401 not 404) and auth works."""
+
+    @pytest.mark.asyncio
+    async def test_managers_route_exists(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/v1/esma/managers")
+        assert resp.status_code != 404, "ESMA managers route not mounted"
+
+    @pytest.mark.asyncio
+    async def test_funds_route_exists(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/v1/esma/funds")
+        assert resp.status_code != 404, "ESMA funds route not mounted"
+
+    @pytest.mark.asyncio
+    async def test_manager_detail_route_exists(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/v1/esma/managers/FAKE_ID")
+        assert resp.status_code != 404, "ESMA manager detail route not mounted"
+
+    @pytest.mark.asyncio
+    async def test_fund_detail_route_exists(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/v1/esma/funds/FAKE_ISIN")
+        assert resp.status_code != 404, "ESMA fund detail route not mounted"
+
+    @pytest.mark.asyncio
+    async def test_sec_crossref_route_exists(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/v1/esma/managers/FAKE_ID/sec-crossref")
+        assert resp.status_code != 404, "ESMA SEC crossref route not mounted"
+
+
+class TestEsmaAuth:
+    """Auth: non-admin roles should get 403."""
+
+    @pytest.mark.asyncio
+    async def test_viewer_gets_403_on_managers(self, client: AsyncClient) -> None:
+        resp = await client.get(
+            "/api/v1/esma/managers",
+            headers=_VIEWER_HEADER,
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_viewer_gets_403_on_funds(self, client: AsyncClient) -> None:
+        resp = await client.get(
+            "/api/v1/esma/funds",
+            headers=_VIEWER_HEADER,
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_viewer_gets_403_on_sec_crossref(self, client: AsyncClient) -> None:
+        resp = await client.get(
+            "/api/v1/esma/managers/FAKE/sec-crossref",
+            headers=_VIEWER_HEADER,
+        )
+        assert resp.status_code == 403
+
+
+class TestEsmaWorkerTrigger:
+    """Worker trigger endpoint tests."""
+
+    @pytest.mark.asyncio
+    async def test_trigger_route_exists(self, client: AsyncClient) -> None:
+        resp = await client.post("/api/v1/workers/run-esma-ingestion")
+        assert resp.status_code != 404, "ESMA worker trigger route not mounted"
+
+    @pytest.mark.asyncio
+    async def test_trigger_requires_auth(self, client: AsyncClient) -> None:
+        resp = await client.post("/api/v1/workers/run-esma-ingestion")
+        assert resp.status_code == 401

--- a/backend/tests/workers/test_esma_ingestion.py
+++ b/backend/tests/workers/test_esma_ingestion.py
@@ -1,0 +1,183 @@
+"""Tests for the ESMA UCITS ingestion worker.
+
+Covers:
+  - Lock ID uniqueness and constants
+  - Model integrity (global table, no org_id)
+  - Worker flow with mocked RegisterService/TickerResolver
+  - Idempotent upsert (FK ordering)
+  - Lock acquisition + release in finally
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.shared.models import EsmaFund, EsmaIsinTickerMap, EsmaManager
+
+# ═══════════════════════════════════════════════════════════════════
+#  Model integrity
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestEsmaManagerModel:
+    def test_tablename(self) -> None:
+        assert EsmaManager.__tablename__ == "esma_managers"
+
+    def test_has_no_organization_id(self) -> None:
+        """Global table — must not have organization_id column."""
+        columns = {c.name for c in EsmaManager.__table__.columns}
+        assert "organization_id" not in columns
+
+    def test_primary_key(self) -> None:
+        pk_cols = [c.name for c in EsmaManager.__table__.primary_key.columns]
+        assert pk_cols == ["esma_id"]
+
+    def test_has_fund_count_column(self) -> None:
+        columns = {c.name for c in EsmaManager.__table__.columns}
+        assert "fund_count" in columns
+
+    def test_has_sec_crd_number(self) -> None:
+        columns = {c.name for c in EsmaManager.__table__.columns}
+        assert "sec_crd_number" in columns
+
+
+class TestEsmaFundModel:
+    def test_tablename(self) -> None:
+        assert EsmaFund.__tablename__ == "esma_funds"
+
+    def test_has_no_organization_id(self) -> None:
+        columns = {c.name for c in EsmaFund.__table__.columns}
+        assert "organization_id" not in columns
+
+    def test_primary_key_is_isin(self) -> None:
+        pk_cols = [c.name for c in EsmaFund.__table__.primary_key.columns]
+        assert pk_cols == ["isin"]
+
+    def test_fk_to_esma_managers(self) -> None:
+        fks = list(EsmaFund.__table__.foreign_keys)
+        assert any(
+            fk.target_fullname == "esma_managers.esma_id" for fk in fks
+        )
+
+
+class TestEsmaIsinTickerMapModel:
+    def test_tablename(self) -> None:
+        assert EsmaIsinTickerMap.__tablename__ == "esma_isin_ticker_map"
+
+    def test_has_no_organization_id(self) -> None:
+        columns = {c.name for c in EsmaIsinTickerMap.__table__.columns}
+        assert "organization_id" not in columns
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Worker constants
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestEsmaWorkerConstants:
+    def test_lock_id(self) -> None:
+        from app.domains.wealth.workers.esma_ingestion import ESMA_LOCK_ID
+
+        assert ESMA_LOCK_ID == 900_019
+
+    def test_batch_size(self) -> None:
+        from app.domains.wealth.workers.esma_ingestion import _BATCH_SIZE
+
+        assert _BATCH_SIZE == 2000
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Worker flow (mocked I/O)
+# ═══════════════════════════════════════════════════════════════════
+
+
+def _make_fund_dc(isin: str, manager_id: str = "MGR001") -> MagicMock:
+    """Create a frozen EsmaFund dataclass mock."""
+    from data_providers.esma.models import EsmaFund as EsmaFundDC
+
+    return EsmaFundDC(
+        isin=isin,
+        fund_name=f"Fund {isin}",
+        esma_manager_id=manager_id,
+        domicile="IE",
+        fund_type="UCITS",
+        host_member_states=["IE", "DE"],
+    )
+
+
+def _make_manager_dc(esma_id: str = "MGR001") -> MagicMock:
+    from data_providers.esma.models import EsmaManager as EsmaManagerDC
+
+    return EsmaManagerDC(
+        esma_id=esma_id,
+        lei="529900ABC",
+        company_name=f"Manager {esma_id}",
+        country="IE",
+        authorization_status="Active",
+        fund_count=2,
+    )
+
+
+class TestEsmaIngestionWorker:
+    @pytest.mark.asyncio
+    async def test_lock_not_acquired_returns_skipped(self) -> None:
+        """If advisory lock is held, worker returns skipped status."""
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar.return_value = False
+        mock_db.execute.return_value = mock_result
+        mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_db.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.domains.wealth.workers.esma_ingestion.async_session",
+            return_value=mock_db,
+        ):
+            from app.domains.wealth.workers.esma_ingestion import run_esma_ingestion
+
+            result = await run_esma_ingestion()
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "lock_held"
+
+    def test_worker_has_finally_unlock(self) -> None:
+        """Worker source must contain pg_advisory_unlock in a finally block."""
+        import inspect
+
+        from app.domains.wealth.workers.esma_ingestion import run_esma_ingestion
+
+        source = inspect.getsource(run_esma_ingestion)
+        assert "finally:" in source, "Worker must have a finally block"
+        assert "pg_advisory_unlock" in source, "Worker must unlock in finally"
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  Data provider dataclass tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestEsmaDataclasses:
+    def test_fund_dataclass_frozen(self) -> None:
+        fund = _make_fund_dc("IE00ABC")
+        with pytest.raises(AttributeError):
+            fund.isin = "CHANGED"  # type: ignore[misc]
+
+    def test_manager_dataclass_frozen(self) -> None:
+        mgr = _make_manager_dc()
+        with pytest.raises(AttributeError):
+            mgr.esma_id = "CHANGED"  # type: ignore[misc]
+
+    def test_isin_resolution_frozen(self) -> None:
+        from data_providers.esma.models import IsinResolution
+
+        res = IsinResolution(
+            isin="IE00ABC",
+            yahoo_ticker="ABC.L",
+            exchange="LSE",
+            resolved_via="openfigi",
+            is_tradeable=True,
+        )
+        with pytest.raises(AttributeError):
+            res.isin = "CHANGED"  # type: ignore[misc]

--- a/frontends/wealth/src/routes/(team)/funds/[fundId]/+page.server.ts
+++ b/frontends/wealth/src/routes/(team)/funds/[fundId]/+page.server.ts
@@ -1,4 +1,4 @@
-/** Fund detail — fetch fund info. */
+/** Fund detail — fetch fund info + risk metrics (including momentum). */
 import type { PageServerLoad } from "./$types";
 import { createServerApiClient } from "$lib/api/client";
 
@@ -7,10 +7,14 @@ export const load: PageServerLoad = async ({ parent, params }) => {
 	const api = createServerApiClient(token);
 	const { fundId } = params;
 
-	const [fund] = await Promise.allSettled([api.get(`/funds/${fundId}`)]);
+	const [fund, riskMetrics] = await Promise.allSettled([
+		api.get(`/funds/${fundId}`),
+		api.get(`/funds/${fundId}/risk`),
+	]);
 
 	return {
 		fund: fund.status === "fulfilled" ? fund.value : null,
+		riskMetrics: riskMetrics.status === "fulfilled" ? riskMetrics.value : null,
 		fundId,
 	};
 };

--- a/frontends/wealth/src/routes/(team)/funds/[fundId]/+page.svelte
+++ b/frontends/wealth/src/routes/(team)/funds/[fundId]/+page.svelte
@@ -2,7 +2,7 @@
   Fund Detail — full metrics, NAV chart, risk metrics.
 -->
 <script lang="ts">
-	import { DataCard, StatusBadge, TimeSeriesChart, PageHeader, SectionCard, EmptyState, formatDate, formatNumber, formatPercent, formatRatio } from "@netz/ui";
+	import { DataCard, MetricCard, StatusBadge, TimeSeriesChart, PageHeader, SectionCard, EmptyState, formatDate, formatNumber, formatPercent, formatRatio } from "@netz/ui";
 	import { resolveWealthStatus } from "$lib/utils/status-maps";
 	import type { PageData } from "./$types";
 
@@ -21,16 +21,19 @@
 		inception_date: string | null;
 	};
 
-	type FundRisk = {
-		cvar_95: number | null;
-		var_95: number | null;
-		annual_return: number | null;
-		annual_volatility: number | null;
-		sharpe_ratio: number | null;
-		max_drawdown: number | null;
-		recovery_days: number | null;
-		sortino_ratio: number | null;
-		calmar_ratio: number | null;
+	type FundRiskMetrics = {
+		cvar_95_3m: number | null;
+		var_95_3m: number | null;
+		return_1y: number | null;
+		volatility_1y: number | null;
+		sharpe_1y: number | null;
+		max_drawdown_1y: number | null;
+		sortino_1y: number | null;
+		rsi_14: number | null;
+		bb_position: number | null;
+		nav_momentum_score: number | null;
+		flow_momentum_score: number | null;
+		blended_momentum_score: number | null;
 	};
 
 	type NavPoint = {
@@ -39,11 +42,17 @@
 	};
 
 	let fund = $derived(data.fund as FundDetail | null);
+	let riskMetrics = $derived(data.riskMetrics as FundRiskMetrics | null);
 
-	// Risk and NAV data will be provided by SSE-primary risk store (Sprint 1, Wealth.1).
-	// Previous phantom API calls (/stats, /performance, /holdings) never returned data.
-	let risk = $state<FundRisk | null>(null);
+	// NAV data will be provided by SSE-primary risk store (Sprint 1, Wealth.1).
 	let navHistory = $state<NavPoint[] | null>(null);
+
+	function rsiStatus(rsi: number | null): "ok" | "warn" | "breach" | undefined {
+		if (rsi == null) return undefined;
+		if (rsi < 30) return "ok";
+		if (rsi > 70) return "breach";
+		return "warn";
+	}
 
 	// NAV chart series
 	let navSeries = $derived(
@@ -103,29 +112,34 @@
 		</SectionCard>
 
 		<!-- Risk Metrics -->
-		{#if risk === null}
-			<SectionCard title="Risk Overview">
-				<div class="flex items-center gap-2 py-8 text-sm text-(--netz-text-muted)">
-					<svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-						<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
-					</svg>
-					<span>Awaiting risk data from analysis engine...</span>
-				</div>
-			</SectionCard>
-		{:else}
+		{#if riskMetrics}
 			<SectionCard title="Risk Metrics">
 				<div class="grid gap-4 md:grid-cols-3 lg:grid-cols-5">
-					<DataCard label="CVaR 95%" value={fmtPct(risk.cvar_95)} trend="flat" />
-					<DataCard label="VaR 95%" value={fmtPct(risk.var_95)} trend="flat" />
-					<DataCard label="Annual Return" value={fmtPct(risk.annual_return)} trend={risk.annual_return !== null && risk.annual_return >= 0 ? "up" : "down"} />
-					<DataCard label="Volatility" value={fmtPct(risk.annual_volatility)} trend="flat" />
-					<DataCard label="Sharpe" value={formatRatio(risk.sharpe_ratio, 2, "", "en-US")} trend="flat" />
-					<DataCard label="Max Drawdown" value={fmtPct(risk.max_drawdown)} trend="flat" />
-					<DataCard label="Recovery Days" value={risk.recovery_days !== null ? String(risk.recovery_days) : "—"} trend="flat" />
-					<DataCard label="Sortino" value={formatRatio(risk.sortino_ratio, 2, "", "en-US")} trend="flat" />
-					<DataCard label="Calmar" value={formatRatio(risk.calmar_ratio, 2, "", "en-US")} trend="flat" />
+					<DataCard label="CVaR 95% (3M)" value={fmtPct(riskMetrics.cvar_95_3m)} trend="flat" />
+					<DataCard label="VaR 95% (3M)" value={fmtPct(riskMetrics.var_95_3m)} trend="flat" />
+					<DataCard label="Return 1Y" value={fmtPct(riskMetrics.return_1y)} trend={riskMetrics.return_1y !== null && riskMetrics.return_1y >= 0 ? "up" : "down"} />
+					<DataCard label="Volatility 1Y" value={fmtPct(riskMetrics.volatility_1y)} trend="flat" />
+					<DataCard label="Sharpe 1Y" value={formatRatio(riskMetrics.sharpe_1y, 2, "", "en-US")} trend="flat" />
+					<DataCard label="Max Drawdown 1Y" value={fmtPct(riskMetrics.max_drawdown_1y)} trend="flat" />
+					<DataCard label="Sortino 1Y" value={formatRatio(riskMetrics.sortino_1y, 2, "", "en-US")} trend="flat" />
 				</div>
+			</SectionCard>
+
+			<!-- Momentum Signals -->
+			{#if riskMetrics.rsi_14 != null || riskMetrics.blended_momentum_score != null}
+				<SectionCard title="Momentum Signals" subtitle="Deterministic Metric · Pre-computed by risk_calc worker">
+					<div class="grid grid-cols-2 gap-3 md:grid-cols-5">
+						<MetricCard label="RSI-14" value={riskMetrics.rsi_14 != null ? formatNumber(riskMetrics.rsi_14, 1, "en-US") : "—"} status={rsiStatus(riskMetrics.rsi_14)} sublabel={riskMetrics.rsi_14 != null ? (riskMetrics.rsi_14 < 30 ? "Oversold" : riskMetrics.rsi_14 > 70 ? "Overbought" : "Neutral") : "Pending"} />
+						<MetricCard label="Bollinger" value={riskMetrics.bb_position != null ? formatNumber(riskMetrics.bb_position, 2, "en-US") : "—"} sublabel="Band position (0–1)" />
+						<MetricCard label="NAV Momentum" value={riskMetrics.nav_momentum_score != null ? formatNumber(riskMetrics.nav_momentum_score, 2, "en-US") : "—"} />
+						<MetricCard label="Flow Momentum" value={riskMetrics.flow_momentum_score != null ? formatNumber(riskMetrics.flow_momentum_score, 2, "en-US") : "—"} />
+						<MetricCard label="Blended" value={riskMetrics.blended_momentum_score != null ? formatNumber(riskMetrics.blended_momentum_score, 2, "en-US") : "—"} sublabel="Composite score" />
+					</div>
+				</SectionCard>
+			{/if}
+		{:else}
+			<SectionCard title="Risk Overview">
+				<EmptyState title="No Risk Data" message="Risk metrics will appear after the risk_calc worker has run." />
 			</SectionCard>
 		{/if}
 	{:else}

--- a/frontends/wealth/src/routes/(team)/risk/+page.svelte
+++ b/frontends/wealth/src/routes/(team)/risk/+page.svelte
@@ -15,6 +15,7 @@
 		PeriodSelector,
 		ContextPanel,
 		MetricCard,
+		GaugeChart,
 		formatNumber,
 		formatPercent,
 	} from "@netz/ui";
@@ -39,6 +40,11 @@
 		trigger_status: string | null;
 		regime: string | null;
 		consecutive_breach_days: number;
+		rsi_14: number | null;
+		bb_position: number | null;
+		nav_momentum_score: number | null;
+		flow_momentum_score: number | null;
+		blended_momentum_score: number | null;
 	};
 
 	type CVaRPoint = { date: string; cvar: number };
@@ -116,6 +122,33 @@
 	function fmtPct(v: number | null): string {
 		return formatPercent(v, 1, "en-US");
 	}
+
+	function rsiStatus(rsi: number | null): "ok" | "warn" | "breach" | undefined {
+		if (rsi == null) return undefined;
+		if (rsi < 30) return "ok";
+		if (rsi > 70) return "breach";
+		return "warn";
+	}
+
+	const rsiThresholds = [
+		{ value: 30, color: "var(--netz-success)" },
+		{ value: 70, color: "var(--netz-warning)" },
+		{ value: 100, color: "var(--netz-danger)" },
+	];
+
+	function blendedStatus(score: number | null): "ok" | "warn" | "breach" | undefined {
+		if (score == null) return undefined;
+		if (score >= 0.6) return "ok";
+		if (score >= 0.3) return "warn";
+		return "breach";
+	}
+
+	const hasMomentumData = $derived(
+		profiles.some((p) => {
+			const c = cvarByProfile[p] as CVaRStatus | undefined;
+			return c?.rsi_14 != null || c?.blended_momentum_score != null;
+		}),
+	);
 
 	// ── Drift Scan Trigger ──────────────────────────────────────────────────
 	let showDriftScan = $state(false);
@@ -238,6 +271,51 @@
 			{/each}
 		</div>
 	</SectionCard>
+
+	<!-- Momentum Signals -->
+	{#if hasMomentumData}
+		<SectionCard title="Momentum Signals" subtitle="Deterministic Metric · Profile-level averages from pre-computed signals">
+			{#snippet actions()}
+				<Badge variant="secondary">Deterministic Metric</Badge>
+			{/snippet}
+			<div class="grid gap-6 lg:grid-cols-3">
+				{#each profiles as profile (profile)}
+					{@const cvar = cvarByProfile[profile] as CVaRStatus | undefined}
+					<div class="space-y-4 rounded-(--netz-radius-md) border border-(--netz-border-subtle) bg-(--netz-surface-highlight) p-4">
+						<h4 class="text-sm font-semibold text-(--netz-text-primary)">{profileLabels[profile] ?? profile}</h4>
+						{#if cvar?.rsi_14 != null}
+							<div>
+								<p class="netz-ui-kicker mb-1">RSI-14</p>
+								<GaugeChart
+									value={cvar.rsi_14}
+									min={0}
+									max={100}
+									thresholds={rsiThresholds}
+									label={cvar.rsi_14 < 30 ? "Oversold" : cvar.rsi_14 > 70 ? "Overbought" : "Neutral"}
+									height={180}
+								/>
+							</div>
+						{:else}
+							<div class="flex h-[180px] items-center justify-center text-sm text-(--netz-text-muted)">RSI — Pending</div>
+						{/if}
+						<div class="grid grid-cols-2 gap-3">
+							<MetricCard
+								label="Bollinger"
+								value={cvar?.bb_position != null ? formatNumber(cvar.bb_position, 2, "en-US") : "—"}
+								sublabel="Band position (0–1)"
+							/>
+							<MetricCard
+								label="Blended"
+								value={cvar?.blended_momentum_score != null ? formatNumber(cvar.blended_momentum_score, 2, "en-US") : "—"}
+								sublabel="Composite score"
+								status={blendedStatus(cvar?.blended_momentum_score ?? null)}
+							/>
+						</div>
+					</div>
+				{/each}
+			</div>
+		</SectionCard>
+	{/if}
 
 	<!-- Market Regime + Drift Alerts side-by-side -->
 	<div class="grid gap-4 lg:grid-cols-5">


### PR DESCRIPTION
## Changes

Adds comprehensive ESMA UCITS fund universe support with ingestion worker and REST endpoints.

### New Components

**Ingestion Worker** (`esma_ingestion.py`)
- Fetches ~134K UCITS funds from ESMA Solr register
- Deduplicates fund managers and resolves ISIN→Yahoo ticker via OpenFIGI
- Upserts into `esma_managers`, `esma_funds`, `esma_isin_ticker_map` tables
- Uses advisory lock `900_019` for concurrency safety
- Batched inserts (2000 rows/batch) for performance

**Query Builder** (`esma_sql.py`)
- Pure SQLAlchemy Core Select statements (no ORM)
- Supports filtering: country, fund type, domicile, text search (ILIKE with proper escaping)
- Paginated results with separate count queries
- Manager detail with joined funds
- Fund detail with joined manager info
- SEC cross-reference lookup

**REST Endpoints** (`esma.py`)
- `GET /esma/managers` - paginated list with filters
- `GET /esma/managers/{esma_id}` - detail + associated funds
- `GET /esma/funds` - paginated list with filters
- `GET /esma/funds/{isin}` - detail + manager info
- `GET /esma/managers/{esma_id}/sec-crossref` - SEC CRD lookup
- `POST /workers/run-esma-ingestion` - trigger worker

All endpoints require `INVESTMENT_TEAM` or `ADMIN` role.

**Schemas** (`esma.py`)
- Manager/Fund item and page response models
- Detail response models with nested relationships
- SEC cross-reference response

### Global Tables (No RLS)
All ESMA tables are **global** (no `organization_id`, no row-level security). These are reference data shared across the platform.

### Tests
- 270+ lines: ILIKE escaping, filter defaults, SQL generation, route mounting, auth validation
- 183+ lines: Model integrity, lock behavior, worker flow, dataclass immutability