### PR TITLE
fix(wealth/charts): foundational hygiene quick wins (audit pass)

### DIFF
--- a/frontends/wealth/src/lib/components/macro/MacroChart.svelte
+++ b/frontends/wealth/src/lib/components/macro/MacroChart.svelte
@@ -51,11 +51,21 @@
 	let option = $derived.by(() => {
 		const mainSeries = series.filter((s) => !s.subchart);
 		const subSeries = series.filter((s) => s.subchart);
-		const mainGridBottom = hasSubchart ? "25%" : "15%";
-		const subGridTop = "80%";
 
+		// Layout cage — fixed pixel offsets so the dataZoom slider sits flush
+		// against the bottom of the chart instead of floating in dead space.
+		// Without subchart: 60px bottom on main grid leaves room for the
+		// slider (height 20 + 8px gap from edge + label).
+		// With subchart: main grid uses upper 50%, subgrid uses 55-60px from
+		// bottom, slider sits flush at 8px.
 		const grids: Record<string, unknown>[] = [
-			{ left: 60, right: 140, top: 40, bottom: mainGridBottom, containLabel: false },
+			{
+				left: 60,
+				right: 140,
+				top: 40,
+				bottom: hasSubchart ? "50%" : 60,
+				containLabel: false,
+			},
 		];
 		const xAxes: Record<string, unknown>[] = [
 			{ type: "time", gridIndex: 0, axisLabel: { fontSize: 10 }, axisTick: { show: false } },
@@ -66,7 +76,7 @@
 		];
 
 		if (hasSubchart) {
-			grids.push({ left: 60, right: 60, top: subGridTop, bottom: "5%", containLabel: false });
+			grids.push({ left: 60, right: 60, top: "55%", bottom: 60, containLabel: false });
 			xAxes.push({ type: "time", gridIndex: 1, axisLabel: { fontSize: 9 }, axisTick: { show: false } });
 			yAxes.push({ type: "value", gridIndex: 1, scale: true, axisLabel: { fontSize: 9 }, splitLine: { lineStyle: { type: "dashed" } } });
 		}
@@ -84,6 +94,13 @@
 				connectNulls: false,
 				showSymbol: false,
 				smooth: false,
+				// Performance: LTTB downsampling + progressive rendering keeps
+				// 8 series × ~5k points (~40k total) responsive.
+				sampling: "lttb",
+				progressive: 2000,
+				progressiveThreshold: 5000,
+				large: true,
+				largeThreshold: 2000,
 				lineStyle: {
 					width: 2.5,
 					type: s.lineStyle ?? "solid",
@@ -97,8 +114,6 @@
 				},
 				labelLayout: { moveOverlap: "shiftY" },
 				emphasis: { focus: "series" },
-				animationDuration: 2000,
-				animationEasing: "cubicInOut",
 				...(s.color ? { itemStyle: { color: s.color }, lineStyle: { color: s.color, width: 2.5, type: s.lineStyle ?? "solid" } } : {}),
 			});
 		}
@@ -111,6 +126,8 @@
 				yAxisIndex: 2,
 				data: s.data,
 				barMaxWidth: 8,
+				large: true,
+				largeThreshold: 2000,
 				...(s.color ? { itemStyle: { color: s.color } } : {}),
 			});
 		}
@@ -118,16 +135,17 @@
 		const axisPointerLink = hasSubchart ? [{ xAxisIndex: "all" }] : [{ xAxisIndex: [0] }];
 
 		const dataZoomEntries: Record<string, unknown>[] = [
-			{ type: "slider", xAxisIndex: hasSubchart ? [0, 1] : [0], bottom: hasSubchart ? "18%" : "3%", height: 20, filterMode: "weakFilter", borderColor: "transparent", fillerColor: "rgba(59,130,246,0.12)", start: zoomStart, end: zoomEnd },
+			{ type: "slider", xAxisIndex: hasSubchart ? [0, 1] : [0], bottom: 8, height: 20, filterMode: "weakFilter", borderColor: "transparent", fillerColor: "rgba(59,130,246,0.12)", start: zoomStart, end: zoomEnd },
 			{ type: "inside", xAxisIndex: hasSubchart ? [0, 1] : [0], filterMode: "weakFilter", start: zoomStart, end: zoomEnd },
 		];
 
 		return {
+			// Animation kept short — long animations turn every filter
+			// interaction into a perceived freeze. Global theme provides
+			// the Urbanist font; no per-chart override needed.
 			animation: true,
-			animationDuration: 2000,
-			animationEasing: "cubicInOut" as const,
+			animationDuration: 200,
 			backgroundColor: "transparent",
-			textStyle: { fontFamily: "Inter, system-ui, sans-serif", fontSize: 12 },
 			grid: grids,
 			xAxis: xAxes,
 			yAxis: yAxes,
@@ -177,11 +195,19 @@
 
 	function applyTimeRange(range: typeof TIME_RANGES[number]) {
 		onTimeRangeChange?.(range);
-		// Compute zoom window as percentage of all data
-		const allDates = series.flatMap((s) => s.data.map(([d]) => new Date(d).getTime()));
-		if (allDates.length === 0) { zoomStart = 0; zoomEnd = 100; return; }
-		const minTs = Math.min(...allDates);
-		const maxTs = Math.max(...allDates);
+		// Compute zoom window as percentage of all data.
+		// Use a single-pass reduce instead of Math.min(...arr) — the spread
+		// pattern blows the stack on 40k+ entries (8 series × ~5k points).
+		let minTs = Infinity;
+		let maxTs = -Infinity;
+		for (const s of series) {
+			for (const [d] of s.data) {
+				const t = new Date(d).getTime();
+				if (t < minTs) minTs = t;
+				if (t > maxTs) maxTs = t;
+			}
+		}
+		if (!isFinite(minTs) || !isFinite(maxTs)) { zoomStart = 0; zoomEnd = 100; return; }
 		const span = maxTs - minTs;
 		if (span <= 0) { zoomStart = 0; zoomEnd = 100; return; }
 

--- a/frontends/wealth/src/lib/components/macro/SeriesPicker.svelte
+++ b/frontends/wealth/src/lib/components/macro/SeriesPicker.svelte
@@ -34,12 +34,26 @@
 	const searchState = createDebouncedState("", 250);
 	let regionFilter = $state("All");
 	let frequencyFilter = $state("All");
+	let sourceFilter = $state<"All" | "fred" | "treasury" | "ofr" | "bis" | "imf">("All");
+	// All groups expanded by default — collapsing-everything-on-mount made
+	// the picker look empty on first render, which audit flagged as broken UX.
+	// Initial set is computed lazily once the CATALOG is in scope below.
 	let expandedGroups = $state<Set<string>>(new Set());
 
 	const REGIONS = ["All", "US", "Europe", "Asia", "EM", "Global"] as const;
 	const FREQUENCIES = ["All", "D", "M", "Q", "A"] as const;
+	const SOURCES = ["All", "fred", "treasury", "ofr", "bis", "imf"] as const;
+	const SOURCE_LABELS: Record<string, string> = {
+		All: "All",
+		fred: "FRED",
+		treasury: "Treasury",
+		ofr: "OFR",
+		bis: "BIS",
+		imf: "IMF",
+	};
 	const MAX_SERIES = 8;
 	const WARN_THRESHOLD = 6;
+	const FAVORITES_GROUP = "★ Favorites";
 
 	const FREQ_LABELS: Record<string, string> = { D: "Daily", M: "Monthly", Q: "Quarterly", A: "Annual" };
 
@@ -170,8 +184,21 @@
 		return CATALOG.find((e) => e.id === id);
 	}
 
+	// Seed expandedGroups once CATALOG is in scope. Default = all groups +
+	// Favorites pseudo-group expanded so the picker is never empty on load.
+	$effect(() => {
+		if (expandedGroups.size === 0) {
+			const allGroups = new Set<string>([FAVORITES_GROUP]);
+			for (const e of CATALOG) allGroups.add(e.group);
+			expandedGroups = allGroups;
+		}
+	});
+
 	let filtered = $derived.by(() => {
 		let items = CATALOG;
+		if (sourceFilter !== "All") {
+			items = items.filter((e) => e.source === sourceFilter);
+		}
 		if (regionFilter !== "All") {
 			items = items.filter((e) => e.region === regionFilter);
 		}
@@ -192,6 +219,15 @@
 
 	let groupedFiltered = $derived.by(() => {
 		const groups = new Map<string, IndicatorEntry[]>();
+		// Pin a virtual "Favorites" group at the top whenever the user has
+		// any favorites that pass the active filters. Favourites used to be
+		// decorative — the ★ button toggled state but no UI surfaced it.
+		if (favorites.size > 0) {
+			const favItems = filtered.filter((e) => favorites.has(e.id));
+			if (favItems.length > 0) {
+				groups.set(FAVORITES_GROUP, favItems);
+			}
+		}
 		for (const item of filtered) {
 			const list = groups.get(item.group) ?? [];
 			list.push(item);
@@ -247,6 +283,18 @@
 				onclick={() => (frequencyFilter = f)}
 			>
 				{f === "All" ? "All" : FREQ_LABELS[f]}
+			</button>
+		{/each}
+	</div>
+
+	<div class="chip-row">
+		{#each SOURCES as s (s)}
+			<button
+				class="chip"
+				class:chip--active={sourceFilter === s}
+				onclick={() => (sourceFilter = s)}
+			>
+				{SOURCE_LABELS[s]}
 			</button>
 		{/each}
 	</div>

--- a/frontends/wealth/src/lib/components/portfolio/FactorAnalysisPanel.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/FactorAnalysisPanel.svelte
@@ -6,7 +6,7 @@
 <script lang="ts">
 	import { ChartContainer } from "@investintell/ui/charts";
 	import { globalChartOptions } from "@investintell/ui/charts/echarts-setup";
-	import { EmptyState } from "@investintell/ui";
+	import { EmptyState, formatNumber } from "@investintell/ui";
 	import { workspace, type FactorContribution } from "$lib/state/portfolio-workspace.svelte";
 
 	// ── Real API Data Integration ───────────────────────────────────────
@@ -14,41 +14,79 @@
 	let isLoading = $derived(workspace.isLoadingFactorAnalysis);
 	let hasData = $derived(data != null);
 
+	// Theme tokens for ECharts (CSS vars don't work inside option objects).
+	let chartPalette = $state<string[]>(["#3a7bd5", "#ff975a", "#1b365d", "#8b9daf", "#d4e4f7"]);
+	let successColor = $state("#22c55e");
+	let dangerColor = $state("#ef4444");
+	let textMuted = $state("#94a3b8");
+	let textSecondary = $state("#cbccd1");
+	let surfaceColor = $state("#141519");
+	let borderSubtle = $state("rgba(64,66,73,0.3)");
+
+	function readChartTokens() {
+		if (typeof document === "undefined") return;
+		const cs = getComputedStyle(document.documentElement);
+		const get = (n: string, fallback: string) => cs.getPropertyValue(n).trim() || fallback;
+		successColor = get("--ii-success", "#22c55e");
+		dangerColor = get("--ii-danger", "#ef4444");
+		textMuted = get("--ii-text-muted", "#94a3b8");
+		textSecondary = get("--ii-text-secondary", "#cbccd1");
+		surfaceColor = get("--ii-surface", "#141519");
+		borderSubtle = get("--ii-border", "rgba(64,66,73,0.3)");
+		chartPalette = [
+			get("--ii-chart-2", "#3a7bd5"),
+			get("--ii-chart-3", "#ff975a"),
+			get("--ii-chart-1", "#1b365d"),
+			get("--ii-chart-4", "#8b9daf"),
+			get("--ii-chart-5", "#d4e4f7"),
+		];
+	}
+
+	$effect(() => {
+		readChartTokens();
+		if (typeof document === "undefined") return;
+		const obs = new MutationObserver(() => readChartTokens());
+		obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+		return () => obs.disconnect();
+	});
+
 	// ── Risk Decomposition (Donut) ──────────────────────────────────────
+	// Note: donut for 2-5 slices is sub-institutional (FactSet/Bloomberg
+	// would use a stacked-100 horizontal bar). Kept as a donut for now;
+	// chart-type change is queued for the redesign PR. This pass strips
+	// the gradients / drop shadows / border-radius pitch-deck styling.
 	let donutOption = $derived.by(() => {
 		if (!data) return {};
 
 		const systematic = data.systematic_risk_pct * 100;
 		const idiosyncratic = data.specific_risk_pct * 100;
-		// Typically style factors are grouped into systematic in the API response, 
-		// but let's see if we have specific risk vs systematic:
-		const style = 0; // If you want to show it based on `data.factor_contributions` or just use 2 slices.
-		
-		// For the breakdown, let's look at `factor_contributions`:
+
 		const factorSlices = (data.factor_contributions || []).map((fc: FactorContribution) => ({
 			value: fc.pct_contribution * 100,
-			name: fc.factor_label
+			name: fc.factor_label,
 		}));
-		// If the sum is < 100, we might add idiosyncratic or just show the slices.
-		const slices = factorSlices.length > 0 ? factorSlices : [
-			{ value: systematic, name: "Systematic (Market)", itemStyle: { color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1, colorStops: [{offset: 0, color: '#0194ff'}, {offset: 1, color: '#0054c2'}] } } },
-			{ value: idiosyncratic, name: "Idiosyncratic", itemStyle: { color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1, colorStops: [{offset: 0, color: '#ebb94d'}, {offset: 1, color: '#9d6d13'}] } } },
-		];
+		const slices = factorSlices.length > 0
+			? factorSlices
+			: [
+				{ value: systematic, name: "Systematic (Market)" },
+				{ value: idiosyncratic, name: "Idiosyncratic" },
+			];
 
 		return {
 			...globalChartOptions,
+			color: chartPalette,
 			toolbox: { show: false },
 			tooltip: {
 				...globalChartOptions.tooltip,
 				trigger: "item" as const,
 				formatter: (p: { name?: string; value?: number; percent?: number; marker?: string }) =>
-					`${p.marker ?? ""} ${p.name}<br/><strong>${p.percent?.toFixed(1)}%</strong> of total risk`,
+					`${p.marker ?? ""} ${p.name}<br/><strong>${formatNumber(p.percent ?? 0, 1)}%</strong> of total risk`,
 			},
 			legend: {
 				bottom: 0,
 				itemWidth: 10,
 				itemHeight: 10,
-				textStyle: { fontSize: 11, color: '#85a0bd' },
+				textStyle: { fontSize: 11, color: textMuted },
 			},
 			series: [
 				{
@@ -59,31 +97,16 @@
 					avoidLabelOverlap: true,
 					label: { show: false },
 					labelLine: { show: false },
+					// Flat slices: 1px separator border using surface color,
+					// no shadow, no border-radius. Institutional convention.
 					itemStyle: {
-						borderColor: '#141519',
-						borderWidth: 2,
-						borderRadius: 4,
-						shadowBlur: 10,
-						shadowColor: 'rgba(0, 0, 0, 0.5)'
+						borderColor: surfaceColor,
+						borderWidth: 1,
 					},
 					emphasis: {
-						label: { show: true, fontSize: 13, fontWeight: 700, color: '#ffffff' },
+						label: { show: true, fontSize: 13, fontWeight: 700, color: textSecondary },
 					},
-					data: slices.map((slice: { value: number; name: string; itemStyle?: any }, i: number) => {
-						if (slice.itemStyle) return slice; // Keep defined ones
-						const colors = [
-							[{offset: 0, color: '#0194ff'}, {offset: 1, color: '#0054c2'}],
-							[{offset: 0, color: '#1ceba7'}, {offset: 1, color: '#0a8844'}],
-							[{offset: 0, color: '#ebb94d'}, {offset: 1, color: '#9d6d13'}],
-							[{offset: 0, color: '#c418e6'}, {offset: 1, color: '#7a0a91'}],
-							[{offset: 0, color: '#ff4d4d'}, {offset: 1, color: '#cc0000'}],
-						];
-						const color = colors[i % colors.length];
-						return {
-							...slice,
-							itemStyle: { color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1, colorStops: color } }
-						}
-					}),
+					data: slices,
 				},
 			],
 		};
@@ -104,26 +127,27 @@
 			tooltip: {
 				...globalChartOptions.tooltip,
 				trigger: "axis" as const,
-				axisPointer: { type: 'shadow' },
+				axisPointer: { type: "shadow" },
 				formatter(params: unknown) {
 					const list = Array.isArray(params) ? params : [params];
 					const p = list[0] as { name?: string; value?: number; marker?: string };
 					if (p.value == null) return "";
-					return `<strong>${p.name}</strong><br/>${p.marker ?? ""} Exposure: ${p.value > 0 ? "+" : ""}${p.value.toFixed(3)}`;
+					const sign = p.value > 0 ? "+" : "";
+					return `<strong>${p.name}</strong><br/>${p.marker ?? ""} Exposure: ${sign}${formatNumber(p.value, 3)}`;
 				},
 			},
 			xAxis: {
 				type: "value" as const,
 				min: -1,
 				max: 1,
-				axisLabel: { formatter: "{value}", fontSize: 10, color: '#85a0bd' },
-				splitLine: { lineStyle: { type: "dashed" as const, color: 'rgba(64,66,73,0.3)' } },
+				axisLabel: { formatter: "{value}", fontSize: 10, color: textMuted },
+				splitLine: { lineStyle: { type: "dashed" as const, color: borderSubtle } },
 			},
 			yAxis: {
 				type: "category" as const,
 				data: categories,
 				inverse: true,
-				axisLabel: { fontSize: 11, fontWeight: 600, color: '#cbccd1' },
+				axisLabel: { fontSize: 11, fontWeight: 600, color: textSecondary },
 				axisTick: { show: false },
 				axisLine: { show: false },
 			},
@@ -133,14 +157,8 @@
 					type: "bar" as const,
 					data: values.map((v) => ({
 						value: v,
-						itemStyle: {
-							color: v >= 0
-									? { type: 'linear', x: 0, y: 0, x2: 1, y2: 0, colorStops: [{offset: 0, color: '#09a552'}, {offset: 1, color: '#11ec79'}] }
-									: { type: 'linear', x: 0, y: 0, x2: 1, y2: 0, colorStops: [{offset: 0, color: '#fc1a1a'}, {offset: 1, color: '#a30c0c'}] },
-							borderRadius: v >= 0 ? [0, 4, 4, 0] : [4, 0, 0, 4],
-							shadowBlur: 8,
-							shadowColor: v >= 0 ? 'rgba(17,236,121,0.2)' : 'rgba(252,26,26,0.2)'
-						},
+						// Flat fill — no gradient, shadow, or border-radius.
+						itemStyle: { color: v >= 0 ? successColor : dangerColor },
 					})),
 					barWidth: "40%",
 					label: {
@@ -148,14 +166,17 @@
 						position: "right" as const,
 						fontSize: 10,
 						fontWeight: 600,
-						color: '#ffffff',
-						formatter: (p: { value: number }) => `${p.value > 0 ? "+" : ""}${p.value.toFixed(2)}`,
+						color: textSecondary,
+						formatter: (p: { value: number }) => {
+							const sign = p.value > 0 ? "+" : "";
+							return `${sign}${formatNumber(p.value, 2)}`;
+						},
 					},
 					markLine: {
 						silent: true,
 						symbol: "none" as const,
 						data: [{ xAxis: 0 }],
-						lineStyle: { color: "var(--ii-text-muted)", type: "solid" as const, width: 1 },
+						lineStyle: { color: textMuted, type: "solid" as const, width: 1 },
 						label: { show: false },
 					},
 				},
@@ -174,9 +195,9 @@
 		/>
 	</div>
 {:else if isLoading}
-	<div class="flex flex-col items-center justify-center p-12 text-[#85a0bd]">
-		<div class="h-8 w-8 animate-spin rounded-full border-2 border-[#0177fb] border-t-transparent mb-4"></div>
-		<p class="text-[13px] font-medium animate-pulse">Running Factor Analysis...</p>
+	<div class="factor-loading">
+		<div class="factor-spinner"></div>
+		<p>Running Factor Analysis…</p>
 	</div>
 {:else if !hasData}
 	<div class="p-6">
@@ -186,17 +207,15 @@
 		/>
 	</div>
 {:else}
-	<div class="flex flex-col gap-6 p-6 h-full">
-		<!-- Header -->
-		<div class="flex items-center gap-3">
-			<span class="text-[16px] font-bold text-white tracking-tight">Factor Analysis</span>
-			<span class="text-[12px] text-[#85a0bd] bg-white/5 border border-white/10 px-2 py-0.5 rounded-full ml-auto">{fundCount} fund{fundCount !== 1 ? "s" : ""}</span>
+	<div class="factor-panel">
+		<div class="factor-header">
+			<span class="factor-title">Factor Analysis</span>
+			<span class="factor-pill">{fundCount} fund{fundCount !== 1 ? "s" : ""}</span>
 		</div>
 
-		<!-- Charts grid -->
-		<div class="grid grid-cols-2 gap-8 flex-1 min-h-0 bg-white/[0.015] rounded-[20px] border border-[#404249]/30 p-5">
-			<div class="flex flex-col gap-3">
-				<span class="text-[11px] font-semibold text-[#85a0bd] uppercase tracking-[0.06em]">Risk Decomposition</span>
+		<div class="factor-grid">
+			<div class="factor-block">
+				<span class="factor-label">Risk Decomposition</span>
 				<ChartContainer
 					option={donutOption}
 					height={240}
@@ -205,8 +224,8 @@
 				/>
 			</div>
 
-			<div class="flex flex-col gap-3">
-				<span class="text-[11px] font-semibold text-[#85a0bd] uppercase tracking-[0.06em]">Style Factor Exposures</span>
+			<div class="factor-block">
+				<span class="factor-label">Style Factor Exposures</span>
 				<ChartContainer
 					option={barOption}
 					height={240}
@@ -217,3 +236,90 @@
 		</div>
 	</div>
 {/if}
+
+<style>
+	.factor-loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 48px;
+		color: var(--ii-text-muted);
+		gap: 16px;
+	}
+
+	.factor-loading p {
+		font-size: 13px;
+		font-weight: 500;
+		animation: pulse 1.5s ease-in-out infinite;
+	}
+
+	.factor-spinner {
+		width: 32px;
+		height: 32px;
+		border: 2px solid var(--ii-brand-primary);
+		border-top-color: transparent;
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	@keyframes spin { to { transform: rotate(360deg); } }
+	@keyframes pulse { 50% { opacity: 0.5; } }
+
+	.factor-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
+		padding: 24px;
+		height: 100%;
+	}
+
+	.factor-header {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+	}
+
+	.factor-title {
+		font-size: 16px;
+		font-weight: 700;
+		color: var(--ii-text-primary);
+		letter-spacing: -0.02em;
+	}
+
+	.factor-pill {
+		font-size: 12px;
+		color: var(--ii-text-muted);
+		background: color-mix(in srgb, var(--ii-text-primary) 5%, transparent);
+		border: 1px solid color-mix(in srgb, var(--ii-text-primary) 10%, transparent);
+		padding: 2px 8px;
+		border-radius: 999px;
+		margin-left: auto;
+	}
+
+	.factor-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 32px;
+		flex: 1;
+		min-height: 0;
+		background: color-mix(in srgb, var(--ii-text-primary) 1.5%, transparent);
+		border: 1px solid var(--ii-border-subtle);
+		border-radius: 20px;
+		padding: 20px;
+	}
+
+	.factor-block {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.factor-label {
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--ii-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/portfolio/MainPortfolioChart.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/MainPortfolioChart.svelte
@@ -5,21 +5,38 @@
 <script lang="ts">
 	import { onMount } from "svelte";
 	import { ChartContainer } from "@investintell/ui/charts";
-	import { globalChartOptions, echarts } from "@investintell/ui/charts/echarts-setup";
+	import { globalChartOptions } from "@investintell/ui/charts/echarts-setup";
+	import { formatNumber, formatPercent } from "@investintell/ui";
 	import { workspace } from "$lib/state/portfolio-workspace.svelte";
 
 	let wrapEl: HTMLDivElement | undefined = $state();
 	let chartHeight = $state(0);
 
+	// ECharts series colors must be resolved hex/rgba (CSS vars don't work
+	// inside ECharts option). Read the brand-primary token from the live
+	// computed style at mount and re-read on theme changes.
+	let brandPrimary = $state("#0177fb"); // fallback if document is unavailable
+	let brandPrimaryFill = $derived(`color-mix(in srgb, ${brandPrimary} 12%, transparent)`);
+
+	function readBrandPrimary(): string {
+		if (typeof document === "undefined") return "#0177fb";
+		return getComputedStyle(document.documentElement)
+			.getPropertyValue("--ii-brand-primary").trim() || "#0177fb";
+	}
+
 	onMount(() => {
 		if (!wrapEl) return;
+		brandPrimary = readBrandPrimary();
 		const ro = new ResizeObserver(([entry]) => {
 			chartHeight = Math.floor(entry!.contentRect.height);
 		});
 		ro.observe(wrapEl);
 		// Initial measurement
 		chartHeight = wrapEl.clientHeight;
-		return () => ro.disconnect();
+		// Re-resolve token on theme change
+		const themeObserver = new MutationObserver(() => { brandPrimary = readBrandPrimary(); });
+		themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+		return () => { ro.disconnect(); themeObserver.disconnect(); };
 	});
 
 	let navData = $derived(workspace.navSeries);
@@ -32,7 +49,7 @@
 		const seriesData = navData.map((d) => [d.date, d.nav]);
 		const firstNav = navData[0]?.nav ?? 1000;
 		const lastNav = navData[navData.length - 1]?.nav ?? 1000;
-		const totalReturn = ((lastNav - firstNav) / firstNav) * 100;
+		const totalReturn = (lastNav - firstNav) / firstNav;
 
 		return {
 			...globalChartOptions,
@@ -44,7 +61,7 @@
 					const { axisValueLabel, value } = p as { axisValueLabel?: string; value?: unknown[] };
 					const nav = Array.isArray(value) ? value[1] : null;
 					if (nav == null) return "";
-					return `<strong>${axisValueLabel ?? ""}</strong><br/>NAV: ${Number(nav).toFixed(2)}`;
+					return `<strong>${axisValueLabel ?? ""}</strong><br/>NAV: ${formatNumber(Number(nav), 2)}`;
 				},
 			},
 			xAxis: {
@@ -64,7 +81,7 @@
 					type: "slider" as const, xAxisIndex: 0, height: 20, bottom: 6,
 					filterMode: "weakFilter" as const,
 					borderColor: "transparent",
-					fillerColor: "rgba(1, 119, 251, 0.12)",
+					fillerColor: brandPrimaryFill,
 				},
 			],
 			series: [
@@ -75,15 +92,9 @@
 					smooth: true,
 					symbol: "none",
 					sampling: "lttb",
-					lineStyle: { width: 2, color: "#0177fb" },
-					itemStyle: { color: "#0177fb" },
-					areaStyle: {
-						color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-							{ offset: 0, color: "rgba(1, 119, 251, 0.18)" },
-							{ offset: 0.6, color: "rgba(1, 119, 251, 0.04)" },
-							{ offset: 1, color: "rgba(1, 119, 251, 0)" },
-						]),
-					},
+					// Institutional line chart — no area fill / gradient.
+					lineStyle: { width: 2, color: brandPrimary },
+					itemStyle: { color: brandPrimary },
 					markLine: {
 						silent: true,
 						symbol: "none" as const,
@@ -91,7 +102,7 @@
 						lineStyle: { color: "var(--ii-text-muted)", type: "dashed" as const, width: 1 },
 						label: {
 							position: "insideEndTop" as const,
-							formatter: `Base ${firstNav.toFixed(0)}`,
+							formatter: `Base ${formatNumber(firstNav, 0)}`,
 							fontSize: 10,
 						},
 					},
@@ -103,11 +114,10 @@
 					right: 16,
 					top: 6,
 					style: {
-						text: `${totalReturn >= 0 ? "+" : ""}${totalReturn.toFixed(2)}%`,
+						text: `${totalReturn >= 0 ? "+" : ""}${formatPercent(totalReturn, 2)}`,
 						fontSize: 13,
 						fontWeight: 700 as const,
 						fill: totalReturn >= 0 ? "var(--ii-success)" : "var(--ii-danger)",
-						fontFamily: "Urbanist, system-ui, sans-serif",
 					},
 				},
 			],
@@ -157,22 +167,21 @@
 		gap: 6px;
 		flex: 1;
 		height: 100%;
-		color: #85a0bd;
-		font-size: 13px;
-		font-family: "Urbanist", sans-serif;
+		color: var(--ii-text-muted);
+		font-size: var(--ii-text-small, 0.8125rem);
 	}
 
 	.main-chart-placeholder-title {
-		font-size: 14px;
+		font-size: var(--ii-text-body, 0.875rem);
 		font-weight: 600;
-		color: #cbccd1;
+		color: var(--ii-text-secondary);
 	}
 
 	.main-chart-spinner {
 		width: 24px;
 		height: 24px;
-		border: 3px solid rgba(1, 119, 251, 0.2);
-		border-top-color: #0177fb;
+		border: 3px solid color-mix(in srgb, var(--ii-brand-primary) 20%, transparent);
+		border-top-color: var(--ii-brand-primary);
 		border-radius: 50%;
 		animation: spin 0.8s linear infinite;
 	}

--- a/frontends/wealth/src/lib/components/portfolio/StressTestPanel.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/StressTestPanel.svelte
@@ -27,80 +27,37 @@
 		});
 	}
 
-	// ── Portfolio impact chart ────────────────────────────────────────────
-	let chartOption = $derived.by(() => {
-		const stress = workspace.localStress;
-		if (!stress) return {};
+	// ECharts series colors must be resolved hex (CSS vars don't work
+	// inside the option object). Read from CSS at mount + on theme change.
+	let successColor = $state("#22c55e");
+	let dangerColor = $state("#ef4444");
+	let textMuted = $state("#94a3b8");
+	let textSecondary = $state("#cbccd1");
+	let borderColor = $state("rgba(64,66,73,0.3)");
 
-		const value = stress.portfolioDrop;
+	function readChartTokens() {
+		if (typeof document === "undefined") return;
+		const cs = getComputedStyle(document.documentElement);
+		const get = (n: string, fallback: string) => cs.getPropertyValue(n).trim() || fallback;
+		successColor = get("--ii-success", "#22c55e");
+		dangerColor = get("--ii-danger", "#ef4444");
+		textMuted = get("--ii-text-muted", "#94a3b8");
+		textSecondary = get("--ii-text-secondary", "#cbccd1");
+		borderColor = get("--ii-border", "rgba(64,66,73,0.3)");
+	}
 
-		return {
-			...globalChartOptions,
-			toolbox: { show: false },
-			grid: { left: 100, right: 40, top: 24, bottom: 24, containLabel: false },
-			tooltip: {
-				...globalChartOptions.tooltip,
-				trigger: "axis" as const,
-				axisPointer: { type: 'shadow' },
-				formatter(params: unknown) {
-					const list = Array.isArray(params) ? params : [params];
-					const p = list[0] as { name?: string; value?: number; marker?: string };
-					if (p.value == null) return "";
-					return `<strong>${p.name}</strong><br/>${p.marker ?? ""} Impact: ${p.value > 0 ? "+" : ""}${p.value.toFixed(2)}%`;
-				},
-			},
-			xAxis: {
-				type: "value" as const,
-				axisLabel: { formatter: "{value}%", fontSize: 10, color: '#85a0bd' },
-				splitLine: { lineStyle: { type: "dashed" as const, color: 'rgba(64,66,73,0.3)' } },
-			},
-			yAxis: {
-				type: "category" as const,
-				data: ["Portfolio NAV"],
-				inverse: true,
-				axisLabel: { fontSize: 11, fontWeight: 600, color: '#cbccd1' },
-				axisTick: { show: false },
-				axisLine: { show: false },
-			},
-			series: [
-				{
-					name: "Impact",
-					type: "bar" as const,
-					data: [
-						{
-							value,
-							itemStyle: {
-								color: value >= 0
-									? { type: 'linear', x: 0, y: 0, x2: 1, y2: 0, colorStops: [{offset: 0, color: '#09a552'}, {offset: 1, color: '#11ec79'}] }
-									: { type: 'linear', x: 0, y: 0, x2: 1, y2: 0, colorStops: [{offset: 0, color: '#fc1a1a'}, {offset: 1, color: '#a30c0c'}] },
-								borderRadius: value >= 0 ? [0, 6, 6, 0] : [6, 0, 0, 6],
-								shadowBlur: 8,
-								shadowColor: value >= 0 ? 'rgba(17,236,121,0.2)' : 'rgba(252,26,26,0.2)'
-							},
-						},
-					],
-					barWidth: "40%",
-					label: {
-						show: true,
-						position: "right" as const,
-						fontSize: 10,
-						fontWeight: 600,
-						color: '#ffffff',
-						formatter: (p: { value: number }) => `${p.value > 0 ? "+" : ""}${p.value.toFixed(2)}%`,
-					},
-					markLine: {
-						silent: true,
-						symbol: "none" as const,
-						data: [{ xAxis: 0 }],
-						lineStyle: { color: "var(--ii-text-muted)", type: "solid" as const, width: 1 },
-						label: { show: false },
-					},
-				},
-			],
-		};
+	$effect(() => {
+		readChartTokens();
+		if (typeof document === "undefined") return;
+		const obs = new MutationObserver(() => readChartTokens());
+		obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+		return () => obs.disconnect();
 	});
 
 	// ── Block impacts chart ───────────────────────────────────────────────
+	// Note: a single-bar "Portfolio NAV Impact" chart used to live above
+	// this one. It was deleted as chart-junk — the same value is shown in
+	// the KPI strip below, so the chart added zero information.
 	let blockChartOption = $derived.by(() => {
 		const stress = workspace.localStress;
 		if (!stress || !stress.blockImpacts) return {};
@@ -116,24 +73,25 @@
 			tooltip: {
 				...globalChartOptions.tooltip,
 				trigger: "axis" as const,
-				axisPointer: { type: 'shadow' },
+				axisPointer: { type: "shadow" },
 				formatter(params: unknown) {
 					const list = Array.isArray(params) ? params : [params];
 					const p = list[0] as { name?: string; value?: number };
 					if (p.value == null) return "";
-					return `<strong>${p.name}</strong><br/>Impact: ${p.value > 0 ? "+" : ""}${p.value.toFixed(2)}%`;
+					const sign = p.value > 0 ? "+" : "";
+					return `<strong>${p.name}</strong><br/>Impact: ${sign}${formatPercent(p.value / 100, 2)}`;
 				},
 			},
 			xAxis: {
 				type: "value" as const,
-				axisLabel: { formatter: "{value}%", fontSize: 10, color: '#85a0bd' },
-				splitLine: { lineStyle: { type: "dashed" as const, color: 'rgba(64,66,73,0.3)' } },
+				axisLabel: { formatter: "{value}%", fontSize: 10, color: textMuted },
+				splitLine: { lineStyle: { type: "dashed" as const, color: borderColor } },
 			},
 			yAxis: {
 				type: "category" as const,
 				data: categories,
 				inverse: true,
-				axisLabel: { fontSize: 11, fontWeight: 500, color: '#cbccd1' },
+				axisLabel: { fontSize: 11, fontWeight: 500, color: textSecondary },
 				axisTick: { show: false },
 				axisLine: { show: false },
 			},
@@ -141,16 +99,11 @@
 				{
 					name: "Block Impact",
 					type: "bar" as const,
+					// Flat fills, no gradient, no shadow, no borderRadius —
+					// institutional bar charts don't decorate.
 					data: values.map((v) => ({
 						value: Math.round(v * 100) / 100,
-						itemStyle: {
-							color: v >= 0
-									? { type: 'linear', x: 0, y: 0, x2: 1, y2: 0, colorStops: [{offset: 0, color: '#09a552'}, {offset: 1, color: '#11ec79'}] }
-									: { type: 'linear', x: 0, y: 0, x2: 1, y2: 0, colorStops: [{offset: 0, color: '#fc1a1a'}, {offset: 1, color: '#a30c0c'}] },
-							borderRadius: v >= 0 ? [0, 4, 4, 0] : [4, 0, 0, 4],
-							shadowBlur: 8,
-							shadowColor: v >= 0 ? 'rgba(17,236,121,0.2)' : 'rgba(252,26,26,0.2)'
-						},
+						itemStyle: { color: v >= 0 ? successColor : dangerColor },
 					})),
 					barWidth: "45%",
 					label: {
@@ -158,14 +111,17 @@
 						position: "right" as const,
 						fontSize: 10,
 						fontWeight: 600,
-						color: '#ffffff',
-						formatter: (p: { value: number }) => `${p.value > 0 ? "+" : ""}${p.value.toFixed(1)}%`,
+						color: textSecondary,
+						formatter: (p: { value: number }) => {
+							const sign = p.value > 0 ? "+" : "";
+							return `${sign}${formatPercent(p.value / 100, 1)}`;
+						},
 					},
 					markLine: {
 						silent: true,
 						symbol: "none" as const,
 						data: [{ xAxis: 0 }],
-						lineStyle: { color: "var(--ii-text-muted)", type: "solid" as const, width: 1 },
+						lineStyle: { color: textMuted, type: "solid" as const, width: 1 },
 						label: { show: false },
 					},
 				},
@@ -193,24 +149,23 @@
 {:else}
 	<div class="flex flex-col h-full">
 		<!-- Input section -->
-		<div class="px-6 py-5 border-b border-[#404249]/30">
-			<!-- Header -->
-			<div class="flex items-center gap-3 mb-5">
-				<span class="text-[16px] font-bold text-white tracking-tight">Parametric Stress Scenario</span>
+		<div class="stress-input-section">
+			<div class="stress-header">
+				<span class="stress-title">Parametric Stress Scenario</span>
 			</div>
 
-			<div class="grid grid-cols-3 gap-6 mb-5">
-				<div class="flex flex-col gap-2">
-					<label class="text-[11px] font-semibold text-[#85a0bd] uppercase tracking-wide" for="equity-shock">Equity Shock (%)</label>
-					<Input id="equity-shock" type="number" step={5} bind:value={equityShock} class="bg-[#141519] border-[#404249]" />
+			<div class="stress-input-grid">
+				<div class="stress-input-col">
+					<label class="stress-label" for="equity-shock">Equity Shock (%)</label>
+					<Input id="equity-shock" type="number" step={5} bind:value={equityShock} />
 				</div>
-				<div class="flex flex-col gap-2">
-					<label class="text-[11px] font-semibold text-[#85a0bd] uppercase tracking-wide" for="rates-shock">Rates Shock (bps)</label>
-					<Input id="rates-shock" type="number" step={25} bind:value={ratesShock} class="bg-[#141519] border-[#404249]" />
+				<div class="stress-input-col">
+					<label class="stress-label" for="rates-shock">Rates Shock (bps)</label>
+					<Input id="rates-shock" type="number" step={25} bind:value={ratesShock} />
 				</div>
-				<div class="flex flex-col gap-2">
-					<label class="text-[11px] font-semibold text-[#85a0bd] uppercase tracking-wide" for="credit-shock">Credit Spread (bps)</label>
-					<Input id="credit-shock" type="number" step={25} bind:value={creditShock} class="bg-[#141519] border-[#404249]" />
+				<div class="stress-input-col">
+					<label class="stress-label" for="credit-shock">Credit Spread (bps)</label>
+					<Input id="credit-shock" type="number" step={25} bind:value={creditShock} />
 				</div>
 			</div>
 
@@ -219,26 +174,16 @@
 					<Loader2 class="mr-1.5 h-4 w-4 animate-spin" />
 					Running…
 				{:else}
-						Run Scenario
+					Run Scenario
 				{/if}
 			</Button>
 		</div>
 
 		<!-- Results section -->
 		{#if hasResult}
-			<div class="flex flex-col gap-5 p-5 flex-1 overflow-y-auto">
-				<div class="flex flex-col gap-1">
-					<span class="text-[11px] font-semibold text-[#85a0bd] uppercase tracking-[0.04em]">Portfolio NAV Impact</span>
-					<ChartContainer
-						option={chartOption}
-						height={80}
-						empty={!hasResult}
-						ariaLabel="Stress test portfolio NAV impact"
-					/>
-				</div>
-
-				<div class="flex flex-col gap-1">
-					<span class="text-[11px] font-semibold text-[#85a0bd] uppercase tracking-[0.04em]">Impact by Allocation Block</span>
+			<div class="stress-results">
+				<div class="stress-chart-block">
+					<span class="stress-label">Impact by Allocation Block</span>
 					<ChartContainer
 						option={blockChartOption}
 						height={Math.max(120, Object.keys(workspace.localStress!.blockImpacts).length * 28)}
@@ -248,33 +193,33 @@
 				</div>
 
 				<!-- KPI summary strip -->
-				<div class="flex gap-6 px-5 py-3 bg-white/[0.03] rounded-[12px]">
-					<div class="flex flex-col gap-0.5">
-						<span class="text-[11px] text-[#85a0bd] font-medium">NAV Impact</span>
-						<span class="text-[15px] font-bold tabular-nums {workspace.localStress!.portfolioDrop <= 0 ? 'text-[#fc1a1a]' : 'text-[#11ec79]'}">
+				<div class="stress-kpi-strip">
+					<div class="stress-kpi">
+						<span class="stress-kpi-label">NAV Impact</span>
+						<span class="stress-kpi-value tabular-nums" class:stress-kpi-value--bad={workspace.localStress!.portfolioDrop <= 0} class:stress-kpi-value--good={workspace.localStress!.portfolioDrop > 0}>
 							{workspace.localStress!.portfolioDrop > 0 ? "+" : ""}{formatPercent(workspace.localStress!.portfolioDrop / 100)}
 						</span>
 					</div>
 					{#if workspace.localStress!.cvarStressed != null}
-						<div class="flex flex-col gap-0.5">
-							<span class="text-[11px] text-[#85a0bd] font-medium">CVaR Stressed</span>
-							<span class="text-[15px] font-bold tabular-nums text-[#fc1a1a]">
+						<div class="stress-kpi">
+							<span class="stress-kpi-label">CVaR Stressed</span>
+							<span class="stress-kpi-value stress-kpi-value--bad tabular-nums">
 								{formatPercent(workspace.localStress!.cvarStressed)}
 							</span>
 						</div>
 					{/if}
 					{#if workspace.localStress!.worstBlock}
-						<div class="flex flex-col gap-0.5">
-							<span class="text-[11px] text-[#85a0bd] font-medium">Worst Block</span>
-							<span class="text-[15px] font-bold text-[#fc1a1a]">
+						<div class="stress-kpi">
+							<span class="stress-kpi-label">Worst Block</span>
+							<span class="stress-kpi-value stress-kpi-value--bad">
 								{blockLabel(workspace.localStress!.worstBlock)}
 							</span>
 						</div>
 					{/if}
 					{#if workspace.localStress!.bestBlock}
-						<div class="flex flex-col gap-0.5">
-							<span class="text-[11px] text-[#85a0bd] font-medium">Best Block</span>
-							<span class="text-[15px] font-bold text-[#11ec79]">
+						<div class="stress-kpi">
+							<span class="stress-kpi-label">Best Block</span>
+							<span class="stress-kpi-value stress-kpi-value--good">
 								{blockLabel(workspace.localStress!.bestBlock)}
 							</span>
 						</div>
@@ -282,9 +227,111 @@
 				</div>
 			</div>
 		{:else if !workspace.isStressing}
-			<div class="flex flex-col items-center justify-center gap-3 flex-1 py-12 text-center">
-				<p class="text-[13px] text-[#85a0bd]">Configure shocks above and click <strong class="text-[#cbccd1]">Run Scenario</strong> to see projected impacts.</p>
+			<div class="stress-empty">
+				<p>Configure shocks above and click <strong>Run Scenario</strong> to see projected impacts.</p>
 			</div>
 		{/if}
 	</div>
+
+<style>
+	.stress-input-section {
+		padding: 20px 24px;
+		border-bottom: 1px solid var(--ii-border-subtle);
+	}
+
+	.stress-header {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		margin-bottom: 20px;
+	}
+
+	.stress-title {
+		font-size: 16px;
+		font-weight: 700;
+		color: var(--ii-text-primary);
+		letter-spacing: -0.02em;
+	}
+
+	.stress-input-grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 24px;
+		margin-bottom: 20px;
+	}
+
+	.stress-input-col {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.stress-label {
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--ii-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.stress-results {
+		display: flex;
+		flex-direction: column;
+		gap: 20px;
+		padding: 20px;
+		flex: 1;
+		overflow-y: auto;
+	}
+
+	.stress-chart-block {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.stress-kpi-strip {
+		display: flex;
+		gap: 24px;
+		padding: 12px 20px;
+		background: color-mix(in srgb, var(--ii-text-primary) 3%, transparent);
+		border-radius: 12px;
+	}
+
+	.stress-kpi {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.stress-kpi-label {
+		font-size: 11px;
+		color: var(--ii-text-muted);
+		font-weight: 500;
+	}
+
+	.stress-kpi-value {
+		font-size: 15px;
+		font-weight: 700;
+	}
+
+	.stress-kpi-value--bad  { color: var(--ii-danger); }
+	.stress-kpi-value--good { color: var(--ii-success); }
+
+	.stress-empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 12px;
+		flex: 1;
+		padding: 48px 0;
+		text-align: center;
+		color: var(--ii-text-muted);
+		font-size: 13px;
+	}
+
+	.stress-empty strong {
+		color: var(--ii-text-secondary);
+	}
+</style>
 {/if}

--- a/frontends/wealth/src/routes/(app)/dashboard/+page.svelte
+++ b/frontends/wealth/src/routes/(app)/dashboard/+page.svelte
@@ -9,7 +9,7 @@
 	import type { RiskStore, RegimeData, DriftAlert, BehaviorAlert } from "$lib/stores/risk-store.svelte";
 	import type { MarketDataStore, DashboardSnapshot } from "$lib/stores/market-data.svelte";
 	import type { PortfolioAnalyticsStore } from "$lib/stores/portfolio-analytics.svelte";
-	import { ArrowUpRight, ChevronDown, TrendingUp, TrendingDown } from "lucide-svelte";
+	import { ArrowUpRight, TrendingUp, TrendingDown } from "lucide-svelte";
 	import AdvancedMarketChart from "$lib/components/charts/AdvancedMarketChart.svelte";
 	import LiveNewsFeed from "$lib/components/dashboard/LiveNewsFeed.svelte";
 
@@ -65,8 +65,11 @@
 
 	let totalPnl = $derived(analytics.totalPnl);
 
-	let selectedRange = $state("6M");
-	const timeRanges = ["1D", "1W", "1M", "6M", "1Y"];
+	// Note: a parent-level "1D / 1W / 1M / 6M / 1Y" selector used to live
+	// here but it was decorative — only updated a label in the AUM card and
+	// never propagated to AdvancedMarketChart. The audit flagged it as a
+	// confusing dual-selector against the chart's own granularity controls.
+	// Removed entirely; the chart manages its own range.
 
 	let selectedProfile = $state("All");
 	const profileFilters = ["Conservative", "Balanced", "Growth", "All"];
@@ -166,12 +169,6 @@
 		<div class="relative flex flex-col justify-between h-full px-5 py-4 gap-2">
 			<div class="flex items-center justify-between">
 				<span class="text-xs font-semibold uppercase tracking-[0.08em] text-[#85a0bd]">Total AUM</span>
-				<div class="flex items-center gap-1">
-					<span class="border border-white/20 rounded-full px-3 py-1 text-[11px] text-white leading-none">{selectedRange}</span>
-					<span class="border border-white/20 rounded-full p-1.5 leading-none">
-						<ChevronDown size={14} class="text-white" />
-					</span>
-				</div>
 			</div>
 
 			{#if isLoading}
@@ -277,18 +274,6 @@
 				</div>
 			</div>
 
-			<div class="flex flex-wrap items-center gap-1">
-				{#each timeRanges as tr}
-					<button
-						type="button"
-						class="h-7 px-3 rounded-full text-[11px] font-medium text-white transition-colors leading-none
-							{selectedRange === tr
-								? 'bg-[#0177fb]'
-								: 'border border-white/20 hover:bg-white/10'}"
-						onclick={() => selectedRange = tr}
-					>{tr}</button>
-				{/each}
-			</div>
 		</div>
 
 		<!-- Chart cola nas bordas internas — sem padding extra -->

--- a/frontends/wealth/src/routes/(app)/market/+page.svelte
+++ b/frontends/wealth/src/routes/(app)/market/+page.svelte
@@ -198,16 +198,16 @@
 		return REGION_DISPLAY[key] ?? key;
 	}
 
-	function scoreColor(score: number): string {
-		if (score >= 70) return "#3fb950";   /* --ii-success */
-		if (score >= 40) return "#e3b341";   /* --ii-warning */
-		return "#f85149";                     /* --ii-danger */
+	function scoreClass(score: number): string {
+		if (score >= 70) return "score-good";
+		if (score >= 40) return "score-warn";
+		return "score-bad";
 	}
 
-	function stressBarColor(value: number): string {
-		if (value > 80) return "#f85149";    /* --ii-danger */
-		if (value >= 40) return "#e3b341";   /* --ii-warning */
-		return "#94a3b8";                    /* --ii-brand-secondary (slate-400) */
+	function stressBarClass(value: number): string {
+		if (value > 80) return "stress-bar-bad";
+		if (value >= 40) return "stress-bar-warn";
+		return "stress-bar-neutral";
 	}
 
 	// ── Snapshot regime badge ────────────────────────────────────────────
@@ -301,11 +301,11 @@
 					<div class="ind-col stress-col" class:ind-col--last={i === 3}>
 						<span class="stress-label">{item.label}</span>
 						<div class="stress-value-row">
-							<span class="stress-value">{item.value != null ? item.value.toFixed(0) : "—"}</span>
+							<span class="stress-value">{item.value != null ? formatNumber(item.value, 0) : "—"}</span>
 							<span class="stress-max">/ 100</span>
 						</div>
 						<div class="stress-bar-track">
-							<div class="stress-bar-fill" style:width="{item.value ?? 0}%" style:background={stressBarColor(item.value ?? 0)}></div>
+							<div class="stress-bar-fill {stressBarClass(item.value ?? 0)}" style:width="{item.value ?? 0}%"></div>
 						</div>
 					</div>
 				{/each}
@@ -331,13 +331,13 @@
 						{#if regime?.regional_regimes[regionName]}
 							<span class="region-regime-badge">{regime.regional_regimes[regionName].replace(/_/g, " ").toUpperCase()}</span>
 						{/if}
-						<span class="region-coverage">COVERAGE {regionData.coverage != null ? (regionData.coverage * 100).toFixed(0) : "—"}%</span>
+						<span class="region-coverage">COVERAGE {regionData.coverage != null ? formatNumber(regionData.coverage * 100, 0) : "—"}%</span>
 					</div>
 					<div class="region-header-right">
 						<div class="region-score-group">
 							<span class="region-score-label">MACRO SCORE</span>
-							<span class="region-score-value" style:color={scoreColor(regionData.composite_score)}>
-								{regionData.composite_score != null ? regionData.composite_score.toFixed(0) : "—"}
+							<span class="region-score-value {scoreClass(regionData.composite_score ?? 0)}">
+								{regionData.composite_score != null ? formatNumber(regionData.composite_score, 0) : "—"}
 							</span>
 						</div>
 						<div class="region-chevron" class:region-chevron--open={isExpanded}>
@@ -369,7 +369,7 @@
 										<div class="breakdown-item">
 											<div class="breakdown-item-header">
 												<span class="breakdown-dim-name">{formatLabel(dimName)}</span>
-												<span class="breakdown-dim-score" style:color={scoreColor(dim.score ?? 0)}>{dim.score != null ? dim.score.toFixed(0) : "—"}</span>
+												<span class="breakdown-dim-score {scoreClass(dim.score ?? 0)}">{dim.score != null ? formatNumber(dim.score, 0) : "—"}</span>
 											</div>
 											<div class="breakdown-bar-track">
 												<div class="breakdown-bar-fill" style:width="{dim.score ?? 0}%"></div>
@@ -957,4 +957,15 @@
 			font-size: 16px;
 		}
 	}
+
+	/* Score / stress color tokens — replaces inline hex from scoreColor()
+	   and stressBarColor() helpers. Using semantic vars so light/dark mode
+	   and theme overrides work without touching the script. */
+	.score-good { color: var(--ii-success); }
+	.score-warn { color: var(--ii-warning); }
+	.score-bad  { color: var(--ii-danger); }
+
+	.stress-bar-bad     { background: var(--ii-danger); }
+	.stress-bar-warn    { background: var(--ii-warning); }
+	.stress-bar-neutral { background: var(--ii-text-muted); }
 </style>

--- a/packages/investintell-ui/src/lib/charts/echarts-setup.ts
+++ b/packages/investintell-ui/src/lib/charts/echarts-setup.ts
@@ -133,7 +133,7 @@ export const globalChartOptions = {
 	animation: true,
 	animationDuration: 300,
 	backgroundColor: "transparent",
-	textStyle: { fontFamily: "Geist, system-ui, sans-serif", fontSize: 12 },
+	textStyle: { fontFamily: "Urbanist, system-ui, sans-serif", fontSize: 12 },
 	grid: { containLabel: true, left: 8, right: 8, top: 8, bottom: 8 },
 	tooltip: {
 		trigger: "axis" as const,


### PR DESCRIPTION
## Summary

First foundational PR addressing the chart audit findings across **all 4 audited frontends** (Portfolio root, Portfolio/advanced, Dashboard, Macro). Quick wins only — chart-type redesigns (Monte Carlo fan, Capture quadrant, AdvancedMarketChart rewrite to svelte-echarts, MacroChart Barchart-grade) are queued for follow-up dedicated PRs.

## What is in (4 commits)

### 1. `fix(wealth/charts): foundational hygiene + MacroChart performance` (`6d6157e`)

**Foundational:**
- `packages/investintell-ui/src/lib/charts/echarts-setup.ts`: switch global `textStyle.fontFamily` from Geist to Urbanist. Every chart consuming the global theme now picks up the institutional font without per-chart overrides.

**MacroChart performance** (highest user-facing impact — explained the "indescritivelmente lento" complaint):
- Drop the per-series and top-level `animationDuration: 2000` + `cubicInOut`. The 2s animation on every filter click was perceived as a freeze. Now 200ms.
- Add `sampling: 'lttb'`, `progressive: 2000`, `progressiveThreshold: 5000`, `large: true`, `largeThreshold: 2000` to all line series. 8 series × ~5k points = ~40k raw was rendered without any downsampling. Bar series get `large` mode too.
- Replace `Math.min(...allDates)` / `Math.max(...allDates)` with a single-pass for-loop. The spread pattern blows the stack on 40k+ entries.
- Fix dataZoom slider position math — was floating in 12% of dead canvas. Now flush at `bottom: 8px` with proper grid offsets for both subchart-on and subchart-off layouts.
- Delete the `Inter` font override on top-level option (lets the global Urbanist theme apply).

**MainPortfolioChart** (regression from #94 + audit):
- Replace hex literals (`#85a0bd`, `#cbccd1`, `#0177fb`, `rgba(1,119,251,0.2)`) introduced in #94 with `var(--ii-text-muted)`, `var(--ii-text-secondary)`, `var(--ii-brand-primary)`, `color-mix`.
- Delete the `"Urbanist"` literal in CSS (global font handles it).
- Remove the area-under-line gradient (4 hex literals at once) — institutional decks do not decorate line charts with area fills.
- Replace `.toFixed()` calls inside ECharts callbacks with `formatNumber` / `formatPercent` from `@investintell/ui`. The formatter rule is enforced by ESLint elsewhere but does not catch ECharts callback bodies.
- ECharts series colors must be resolved hex — read `--ii-brand-primary` via `getComputedStyle` on mount and re-resolve via `MutationObserver` on `data-theme` attribute changes.

### 2. `fix(wealth/macro): page hygiene + SeriesPicker UX fixes` (`4bb3506`)

**Macro page (`/market`):**
- Replace 4 `.toFixed(0)` calls in HTML template with `formatNumber(x, 0)`.
- Delete `scoreColor()` and `stressBarColor()` helpers that returned hardcoded hex (`#3fb950`, `#e3b341`, `#f85149`, `#94a3b8`). Comments claimed they matched tokens but the code was hardcoded — light mode was broken. Replaced with semantic CSS classes that read `var(--ii-success/warning/danger/text-muted)`.

**SeriesPicker** (audit's worst UX bug in the picker):
- Default `expandedGroups` = all groups expanded on first mount. Previously the picker opened with every group collapsed and looked completely empty.
- Pin a virtual "★ Favorites" group at the top whenever the user has favorites that pass active filters. Favorites used to be decorative — the ★ toggle worked but nothing in the UI ever surfaced them.
- Add a Source filter chip row (FRED / Treasury / OFR / BIS / IMF / All).

### 3. `fix(wealth/portfolio): G2-G5 chart hygiene + delete G4 chart-junk` (`a158c54`)

**StressTestPanel:**
- **DELETE the "Portfolio NAV Impact" single-bar chart (G4 in audit).** Same value is shown in the KPI strip below — chart added zero information.
- Block impacts chart (G5) keeps the data but loses every piece of pitch-deck decoration: gradient `colorStops`, `shadowBlur`, `shadowColor`, `borderRadius`. Flat fills only.
- Replace tooltip and label `.toFixed()` calls with `formatPercent`.
- Read `--ii-success` / `--ii-danger` / `--ii-text-muted` / `--ii-text-secondary` / `--ii-border` via `getComputedStyle` + theme observer.
- Replace every Tailwind hex arbitrary value (`text-[#85a0bd]`, `bg-[#141519]`, `border-[#404249]`, `text-[#fc1a1a]`, `text-[#11ec79]`, `text-[#cbccd1]`) with semantic CSS classes that read `--ii-*` tokens. Light/dark mode now actually works.

**FactorAnalysisPanel:**
- Donut: drop gradient colorStops, drop `borderColor: '#141519'`, drop `shadowBlur`/`shadowColor`, drop `borderRadius`. Flat slices, 1px separator using `--ii-surface`. Palette comes from `chartPalette` reading `--ii-chart-*` tokens. *(Note: donut for 2-5 values is sub-institutional; chart-type change to stacked-100 horizontal bar is queued for the redesign PR.)*
- Bar: same flat-fill cleanup as StressTestPanel.
- Replace `.toFixed()` in tooltip + label formatters with `formatNumber`.
- Replace every Tailwind hex arbitrary value with semantic classes.

### 4. `fix(wealth/dashboard): remove decorative dual time-range selector` (`fb2cf7a`)

A parent-level "1D / 1W / 1M / 6M / 1Y" selector lived above the AdvancedMarketChart and only updated a small label inside the AUM card. It never propagated to the chart and never affected the AUM calculation either — pure decoration. Combined with the chart's own granularity selector (daily / 1h / 30min / 15min / 5min), the audit flagged 10 controls in roughly the same area with two distinct "time" semantics, no labels distinguishing them.

Removed: `selectedRange` state, `timeRanges` constant, the AUM-card pill, the chevron-down decoration, the parent button row, and the now-unused `ChevronDown` lucide import.

## Test plan

- [ ] `make check-all` (frontend type-check) for the wealth package
- [ ] Visual: open `/market`, click filters, confirm interaction is no longer perceived as frozen
- [ ] Visual: `/market` SeriesPicker — opens with all groups expanded, source filter row visible
- [ ] Visual: `/market` SeriesPicker — favoriting an item pins a "★ Favorites" section at the top
- [ ] Visual: `/portfolio/model` — MainPortfolioChart no longer has area gradient under the line
- [ ] Visual: `/portfolio/model` Stress tab — single-bar Portfolio NAV Impact chart is gone, only the per-block bar remains, KPI strip retains all metrics
- [ ] Visual: `/portfolio/model` Factor tab — donut slices have no shadow/border-radius, bar uses flat fills
- [ ] Visual: `/dashboard` — only one set of time controls visible (the chart's own granularity); AUM card no longer shows the decorative pill
- [ ] Light mode toggle: stress/factor panels and macro page now actually swap colors (was broken before due to hardcoded hex)

## Out of scope (queued for follow-up PRs)

- **AdvancedMarketChart rewrite** — currently uses `lightweight-charts`, the only chart in the audit violating the svelte-echarts mandate. Needs full reimplementation as candlestick + volume + indicators (SMA, Bollinger) with backend-computed series. Dedicated PR.
- **MacroChart Barchart-grade redesign** — NBER recession bands, regime markArea consuming `regime.regional_regimes` (already in props but ignored), transformations dropdown (Levels / YoY % / Index=100 / Log), event annotations. Backend endpoints `/macro/recessions`, `/macro/events` needed.
- **SeriesPicker presets + persistence** — "Recession Watch", "Inflation Tracker" presets; server-side favorites via `/users/me/macro-favorites` (no localStorage); virtualization once catalog grows past 150.
- **Donut → stacked-100 horizontal bar** in FactorAnalysisPanel.
- **Monte Carlo fan chart**, **Capture quadrant scatter**, **Tail grouped bar**, **Peer quartile bars** in `analytics/entity/*` panels (`/portfolio/advanced`).
- **Remaining `.toFixed` callsites** in `lib/components/charts/` (NavPerformanceChart, BacktestEquityCurve, FundScoringRadar, DecileBoxplot, CorrelationHeatmap, SectorAllocationChart, SectorAllocationTreemap) — not all are wired into Portfolio routes; the audit identified them as orphans for the main routes audited.
- **Remaining inline-tailwind-hex sweep** in dashboard, portfolio panels — there is a long tail of `text-[#85a0bd]` etc that this PR did not touch.

## Notes

- This branch is based on `main` after PR #94 merged. CI is currently red on `main` due to a pre-existing migration 0085 bug (`_cusip_resolve_queue` table), unrelated to anything in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
