### PR TITLE
feat(wealth/charts): rewrite AdvancedMarketChart in svelte-echarts (Tier A)

### DIFF
--- a/docs/reference/wealth-charting-tech-debt.md
+++ b/docs/reference/wealth-charting-tech-debt.md
@@ -1,0 +1,275 @@
+# Wealth Charting — Technical Debt Register
+
+**Last updated:** 2026-04-07
+**Owner:** Wealth frontend
+**Status:** Living document — append to it after each charting PR.
+
+This document tracks deferred work, design constraints, and known limitations in the Wealth charting stack so that subsequent PRs and future contributors don't re-discover the same trade-offs.
+
+---
+
+## 0. Context
+
+In April 2026 the wealth charting stack was audited end-to-end across four routes (`/dashboard`, `/portfolio`, `/portfolio/advanced`, `/market`). The audit found 18 charts with a mix of stylistic problems (pitch-deck gradients, hex hardcoding, inconsistent fonts), performance bugs (40k-point line series rendered without sampling, 2-second freezing animations), broken UX (decorative dual selectors, half-built features), and one chart violating the `svelte-echarts` mandate.
+
+Three PRs followed:
+
+| PR | Branch | Scope |
+|---|---|---|
+| **#95** | `feat/wealth-charts-foundational` | Quick-win hygiene across MacroChart, MainPortfolioChart, StressTestPanel, FactorAnalysisPanel, SeriesPicker, Macro page, Dashboard dual-selector. Geist→Urbanist global font. Deleted G4 single-bar chart-junk. |
+| **#TBD** | `feat/wealth-advanced-market-chart-rewrite` | Tier A rewrite of AdvancedMarketChart from `lightweight-charts` to `svelte-echarts`. Line/Area/Candle switcher, bottom range chips, indicators (SMA/EMA/Bollinger), volume sub-pane, last-price callout, log/% toggles, live tick fold preserved. Tech debt doc (this file) added. |
+| Future | TBD | Items registered below. |
+
+The platform mandate is **`svelte-echarts` only**, no `Chart.js`, no `lightweight-charts`, no Highcharts. The Tier A PR removes the last violation of that mandate.
+
+---
+
+## 1. AdvancedMarketChart — Tier B (queued, recommended next)
+
+**What's missing relative to the Barchart north-star screenshot.**
+
+### B1. Compare overlay (multi-symbol)
+Barchart's "Compare" button lets the user overlay 1-N additional symbols on the same chart, normalized to percent change from the visible range start. Required for relative-value analysis (single most-requested feature for analyst workflows).
+
+- **Backend:** existing `/market-data/historical/{ticker}` already supports this — just call N times in parallel.
+- **Frontend:** add `compareTickers: string[]` state, fetch in parallel via `Promise.all`, normalize each series to base-100 from `visibleStart`, render as additional line series with palette colors, dedicated legend.
+- **Tooltip:** must show all symbol values at the hovered timestamp.
+- **Effort:** ~200-300 LoC, half a day.
+
+### B2. RSI / MACD sub-pane
+Indicator sub-pane below the volume pane. Toggleable from the indicators menu. Layout: main grid 60%, RSI/MACD 20%, volume 20%.
+
+- **Compute:** RSI = 100 - 100/(1 + RS) where RS = avgGain(14) / avgLoss(14). MACD = EMA12 - EMA26, signal = EMA9(MACD), histogram = MACD - signal.
+- **ECharts:** add a third grid + xAxis + yAxis, add `rsi` line series (with overbought/oversold guideline at 70/30) OR `macd` histogram + lines.
+- **Effort:** ~300 LoC, half a day. Requires `axisPointer.link` rework to keep three grids in sync.
+
+### B3. f(x) — full transformations
+Tier A only ships log scale and percent change. Barchart's f(x) menu also has:
+- Year-over-year change
+- Day-over-day change
+- Smoothed (moving average overlay on price itself)
+- Custom formula expressions
+
+- **Effort:** YoY/DoD = trivial. Custom formulas = needs an expression parser, defer to Tier C alongside drawing tools.
+
+### B4. Symbol search box (top-left)
+Currently the chart receives `ticker` as a prop and the dashboard hardcodes the active ticker in its own state. Barchart has a search input directly in the chart header.
+
+- **Backend:** symbol search endpoint exists in `/screener/catalog`, can be reused.
+- **Frontend:** ~100 LoC for an autocomplete combobox in the chart header.
+- **Effort:** afternoon.
+
+### B5. Last-bar pulse animation on live tick
+Currently the live tick fold updates the markPoint label. A subtle radial pulse on the last data point (like `effectScatter` ripple) would communicate "feed is hot" without being noisy.
+
+- **Effort:** ~30 LoC. Add an `effectScatter` series at `[lastTime, lastClose]` with `rippleEffect` config.
+
+---
+
+## 2. AdvancedMarketChart — Tier C (large, dedicated PR)
+
+### C1. Drawing tools sidebar
+Trendline, fibonacci retracement, horizontal/vertical line, channel, rectangle, ellipse, text annotation, measurement tool, eraser. This is the most-requested-but-hardest item.
+
+**Why it's expensive:**
+- ECharts has **no native drawing tools**. The `graphic` component supports static shapes but not interactive drawing.
+- Three implementation paths:
+  1. **Custom HTML5 Canvas overlay** stacked on top of the ECharts canvas. Catch mouse events, render shapes in `requestAnimationFrame`. Persist to backend. Estimated 1500-2500 LoC for trendline/fib/horizontal/vertical, +500 LoC per additional tool.
+  2. **Switch to `klinecharts`** (open-source TradingView clone, has drawing tools natively). Trade-off: replaces ECharts for THIS chart only, breaks consistency with the rest of the stack. Maintenance risk.
+  3. **Use `lightweight-charts` again** — but it doesn't have drawing tools either. Barchart writes their own on top. Same problem.
+
+**Recommendation:** Option 1 (custom canvas overlay) when this becomes a real ask. Estimate 2-3 dedicated days for the first 4 tools, persistence integration extra.
+
+**Persistence:** drawings need to live in DB. New table `chart_annotations(id, organization_id, user_id, ticker, kind, payload_json, created_at)` with RLS. Endpoints `GET/POST/PATCH/DELETE /charts/annotations`.
+
+### C2. Templates
+Save/load chart layouts (chart type + indicators + range + drawings + compare set). Backend table + endpoints. Frontend popover.
+
+- **Effort:** ~600 LoC + backend.
+
+---
+
+## 3. AdvancedMarketChart — Tier D (depends on backend)
+
+| Feature | Requires |
+|---|---|
+| **Notes** (Barchart top-right) | `chart_notes` table, RLS, CRUD endpoints |
+| **Alerts** (price/indicator threshold) | `price_alerts` table, evaluator worker, push notification stack |
+| **Watch** (add to watchlist from chart) | reuse existing watchlist domain — just an integration |
+| **My Charts** (saved layouts library) | reuse Templates infra (C2) |
+
+None of these belong in a charting PR. Each is a backend project of its own.
+
+---
+
+## 4. Backend smart-compute opportunities
+
+CLAUDE.md mandates "smart-backend / dumb-frontend". Tier A computes indicators client-side because it was the fastest path to delivery. Better long-term posture:
+
+### 4a. Pre-compute SMA / EMA / Bollinger in `/market-data/historical/{ticker}`
+
+Add optional query params: `?indicators=sma20,sma50,ema20,bbands20`. Backend computes them once per request (or caches in Redis with key `mkt:hist:{ticker}:{interval}:{indicators}`) and returns them as additional fields per bar:
+
+```json
+{
+  "bars": [
+    {
+      "timestamp": "2026-01-01T00:00:00Z",
+      "open": 100, "high": 102, "low": 99, "close": 101, "volume": 1234,
+      "sma20": 100.5, "sma50": 99.8, "ema20": 100.7,
+      "bb_upper": 103.2, "bb_lower": 97.8
+    }
+  ]
+}
+```
+
+- **Why:** Client-side compute is fine for 5k bars but doesn't scale to multi-symbol compare or to 10y daily history at intraday granularity (~250k bars). Server-side compute can be vectorized in numpy and cached.
+- **Effort:** ~150 LoC backend, ~30 LoC frontend (drop the local compute helpers, read fields from response).
+
+### 4b. Pre-compute RSI / MACD in the same response
+
+Same pattern. Add `?indicators=rsi14,macd` and return per-bar values. Required if Tier B2 ships server-side.
+
+### 4c. NBER recession bands endpoint
+
+For MacroChart Tier B (see §5). New endpoint `GET /macro/recessions` returning `[{ start, end, label }]` from FRED `USREC` series. Already in `macro_data` hypertable, just needs a thin route + cache.
+
+### 4d. Macro events endpoint
+
+For MacroChart event annotations (FOMC dates, CPI release dates, recession starts). New endpoint `GET /macro/events?from=&to=&kinds=fomc,cpi,nfp,recession`. Source: scrape FRED release calendar + hardcoded recession dates. Cache aggressively.
+
+### 4e. Server-side favorites for SeriesPicker
+
+Currently SeriesPicker accepts a `favorites: Set<string>` prop and an `onToggleFavorite` callback. PR #95 added the "Favorites" pinned section but the storage backend is not implemented — the parent component must persist client-side.
+
+- **Per CLAUDE.md** "Sem localStorage" rule, persistence has to be server-side.
+- **Required:** new `user_macro_favorites` table or column on `users`, endpoints `GET/POST/DELETE /users/me/macro-favorites`.
+- **Effort:** ~120 LoC backend, ~20 LoC frontend.
+
+---
+
+## 5. MacroChart — queued redesign work
+
+PR #95 fixed the performance and animation bugs. Visual upgrade is still pending.
+
+### 5a. NBER recession bands
+
+`markArea` over the chart with light grey fill during recession periods. Data source: `4c` above.
+
+### 5b. Regime markArea overlay
+
+The MacroChart parent already passes `regime: { regional_regimes }` in its data — but the chart **ignores it**. The audit flagged this as dead-but-promising data. Render colored `markArea` zones based on regime: `RISK_OFF` orange, `CRISIS` red, `INFLATION` amber, `RISK_ON` blue.
+
+### 5c. Transformations dropdown
+
+Levels (default) / YoY % / MoM % / Diff / Index=100 / Log scale. Frontend can apply most of these to the data array; log requires `yAxis.type: 'log'`.
+
+### 5d. Event annotations
+
+`markLine` per FRED release date (CPI, NFP, FOMC, GDP). Data source: `4d` above. Tooltip on hover.
+
+### 5e. Drop dead-code `subSeries` path
+
+`MacroChart.svelte` still has `subSeries` filtering and a second grid path that no caller uses (no `subchart: true` flag is set anywhere). Either delete it or actually wire it for volume macro indicators (M2 supply, BoJ balance sheet). Delete is safer.
+
+### 5f. SeriesPicker presets
+
+"Recession Watch", "Inflation Tracker", "Yield Curve", "Global Stress" — one-click selection of 3-6 indicators. Pure client-side mapping. ~80 LoC.
+
+### 5g. SeriesPicker virtualization
+
+Currently 75 indicators hardcoded inline. Once the catalog passes ~150 entries, render time becomes noticeable. Use `@tanstack/svelte-virtual` (already a dependency in `frontends/wealth/package.json`).
+
+### 5h. SeriesPicker fuzzy search
+
+Substring-only search misses "CPI" if the entry is named "Consumer Price Index". Add Fuse.js (~10KB).
+
+### 5i. Pull catalog out of the component
+
+`SeriesPicker.svelte` has 117 lines of inline `CATALOG` array. Move to `frontends/wealth/src/lib/data/macro-catalog.ts` for testability and to enable backend-driven catalog later.
+
+---
+
+## 6. `/portfolio/advanced` (`analytics/entity/*`) — chart-type rebuilds
+
+The audit found these panels structurally sound but using the wrong chart type for the data:
+
+| Panel | Current | Should be |
+|---|---|---|
+| `MonteCarloPanel` | Single line + PDF curve computed in frontend | **Fan chart**: percentile bands (P5/P25/P50/P75/P95) shaded. PDF computation moves to backend. |
+| `CaptureRatiosPanel` | Side-by-side bar | **Quadrant scatter**: up-capture × down-capture with diagonal `y=x` and Morningstar quadrant labels |
+| `TailRiskPanel` | Single bar | **Grouped bar**: VaR/CVaR at multiple confidence levels (90/95/99) |
+| `PeerGroupPanel` | Single bar | **Quartile bars / box**: P25-P50-P75 with peer group fundo highlight (Morningstar Direct style) |
+
+Each is a 200-400 LoC dedicated PR. Compatible with smart-backend pattern — backend already returns the right data shape, just rendered wrong.
+
+`ActiveSharePanel.svelte` is suspected orphan — not imported by any route. Delete after verification.
+
+---
+
+## 7. `/portfolio` root — Tier B chart-type swaps
+
+Same pattern. PR #95 stripped the pitch-deck styling but kept the chart-type choice as-is. Recommended swaps:
+
+| Panel | Current | Should be |
+|---|---|---|
+| `FactorAnalysisPanel` donut | 2-5 slice donut | **Stacked-100 horizontal bar** (institutional convention; donuts are amateur for ≤5 slices) |
+| `MainPortfolioChart` | Single line with markLine for base | **Performance Cockpit**: line + benchmark dashed + drawdown area underlay + regime markArea + stats panel side. Requires backend endpoint that returns benchmark + drawdown in same shot. |
+| `SectorAllocationChart` | (audit didn't reach it — not in the 18) | TBD |
+
+---
+
+## 8. Long-tail hygiene sweep (boring but real)
+
+### 8a. Remaining `.toFixed` callsites in `lib/components/charts/*`
+
+Audit found `.toFixed(` in 7 chart components that PR #95 didn't touch (they're not wired into the audited routes but they're orphan-or-future-use):
+
+- `NavPerformanceChart.svelte`
+- `BacktestEquityCurve.svelte`
+- `FundScoringRadar.svelte`
+- `DecileBoxplot.svelte`
+- `CorrelationHeatmap.svelte`
+- `SectorAllocationChart.svelte`
+- `SectorAllocationTreemap.svelte`
+
+ESLint formatter rule doesn't catch them because they're inside ECharts callbacks. Sweep them in a single PR.
+
+### 8b. Long-tail Tailwind hex arbitrary values
+
+PR #95 cleaned StressTestPanel + FactorAnalysisPanel. The dashboard `/dashboard/+page.svelte` and other portfolio panels still have a long tail of `text-[#85a0bd]`, `bg-[#141519]`, `border-[#404249]/30`, `text-[#fc1a1a]`, `text-[#11ec79]`. These violate the design-token rule. Pure mechanical sweep but tedious — ~2 hours.
+
+### 8c. `regimeColors` and `statusColors` hex exports in `echarts-setup.ts`
+
+```ts
+export const regimeColors: Record<string, string> = {
+  RISK_ON: "#3b82f6",
+  // ...
+};
+export const statusColors = {
+  ok: "#22c55e",
+  // ...
+};
+```
+
+These should resolve from CSS vars at call time. Currently they're frozen to a specific palette and won't follow theme changes. Fix: turn them into helper functions `getRegimeColor(name)` / `getStatusColor(name)` that read `getComputedStyle`.
+
+### 8d. Component-local token resolution helpers are duplicated
+
+Tier A's `AdvancedMarketChart` inlines a `readChartTokens()` helper that reads `--ii-success`, `--ii-danger`, `--ii-text-muted`, `--ii-brand-primary`, etc. So do `MainPortfolioChart`, `StressTestPanel`, `FactorAnalysisPanel` (after PR #95). Extract to `@investintell/ui/charts/use-chart-tokens.svelte.ts` as a shared rune.
+
+---
+
+## 9. Mandate / convention reminders
+
+These aren't debt — they're **rules** future contributors must follow. Listed here to avoid relitigation:
+
+1. **`svelte-echarts` only.** No `Chart.js`, no `lightweight-charts`, no Highcharts. Tier A PR removed the last violation.
+2. **Tokens, not hex.** Inside ECharts options where CSS vars can't be used directly, resolve once via `getComputedStyle` + re-resolve via `MutationObserver` on `data-theme` attribute changes. Never inline hex literals in templates or scripts.
+3. **No `localStorage`.** Persistence is server-side, every time. Tier B/C/D items that need persistence (drawings, templates, notes, favorites, alerts) all require backend endpoints — none of them are frontend-only.
+4. **Smart-backend / dumb-frontend.** Indicator math, percentile bands, recession data, peer aggregates — all should land server-side. Tier A computes indicators client-side as a stop-gap; §4a is the proper fix.
+5. **No CVaR/regime/DTW jargon in user-facing copy.** Per CLAUDE.md. Use AUM, performance, holdings, drawdown, volatility — terms a wealth client recognizes.
+6. **Formatters from `@investintell/ui`.** Never `.toFixed()`, `.toLocaleString()`, or inline `Intl.NumberFormat`. The ESLint rule catches template usage but not callback bodies inside ECharts options — review those manually.
+7. **Performance flags on long line series.** `sampling: 'lttb'`, `progressive: 2000`, `progressiveThreshold: 5000`, `large: true`, `largeThreshold: 2000`. Tier A applies them; future chart components must too.
+8. **`animationDuration` ≤ 300ms.** Anything longer feels like a freeze on filter interactions. Default in `globalChartOptions` is 300; per-chart overrides are red flags.
+9. **dataZoom slider position math.** Without subchart: `grid.bottom = 60`, `slider.bottom = 8`. With subchart: main grid uses upper 50%, subgrid `top: '55%' bottom: 60`, slider `bottom: 8`. Anything else creates dead canvas.

--- a/frontends/wealth/package.json
+++ b/frontends/wealth/package.json
@@ -23,7 +23,6 @@
     "@tanstack/svelte-virtual": "^3.0.0",
     "codemirror-json-schema": "^0.8.0",
     "dompurify": "^3.3.3",
-    "lightweight-charts": "^5.1.0",
     "lucide-svelte": "^0.469.0",
     "marked": "^17.0.5"
   },

--- a/frontends/wealth/src/lib/components/charts/AdvancedMarketChart.svelte
+++ b/frontends/wealth/src/lib/components/charts/AdvancedMarketChart.svelte
@@ -1,33 +1,30 @@
 <!--
-  AdvancedMarketChart — TradingView Lightweight Charts (Tiingo IEX firehose).
+  AdvancedMarketChart — institutional charting on svelte-echarts.
 
-  - Engine: lightweight-charts v5 (canvas-based, ~50 KB gzipped, 60fps).
-  - Theme: 100% transparent — inherits the parent panel's glassmorphism.
-  - Tick fold: marketStore.priceMap[ticker] → series.update() on every IEX trade.
-  - Volume series mounted on a separate price scale (overlay below candles).
+  Tier A scope (per docs/reference/wealth-charting-tech-debt.md):
+    - Default chart type: Line + subtle area fill (Barchart north-star).
+    - Switchable chart types: Line / Area / Candlestick.
+    - Bottom range chip row (1D / 5D / 1M / 2M / 3M / 6M / 9M / 1Y / 2Y / 3Y / 5Y / 10Y / 20Y / Max).
+    - Top granularity dropdown (Daily / 1h / 30min / 15min / 5min / 1min).
+    - Indicators dropdown (SMA20 / SMA50 / EMA20 / Bollinger Bands).
+    - Volume sub-pane (always on).
+    - Last-price callout pill on the right edge of the price series.
+    - Crosshair + rich OHLC + indicator tooltip.
+    - Log scale toggle. Percent change (rebased) toggle.
+    - Live tick fold from marketStore.priceMap[ticker].
+    - Tokens, no hex literals.
 
-  Lifecycle:
-    1. onMount → createChart() once, attach ResizeObserver.
-    2. $effect(ticker, interval) → fetch /market-data/historical, series.setData().
-    3. $effect(priceMap[ticker]) → series.update({ ...lastBar, close, high, low }).
-    4. onDestroy → chart.remove() + observer.disconnect().
+  Out of scope (Tier B/C/D — see docs/reference/wealth-charting-tech-debt.md):
+    Compare overlay, RSI/MACD sub-pane, drawing tools, templates, notes,
+    alerts, server-side indicator pre-compute, custom f(x) formulas.
 -->
 <script lang="ts">
-	import { getContext, onDestroy, onMount } from "svelte";
-	import { formatCurrency, formatNumber } from "@investintell/ui";
+	import { getContext, onMount } from "svelte";
+	import { ChartContainer } from "@investintell/ui/charts";
+	import { globalChartOptions, echarts } from "@investintell/ui/charts/echarts-setup";
+	import { formatCurrency, formatNumber, formatPercent } from "@investintell/ui";
 	import { createClientApiClient } from "$lib/api/client";
 	import type { MarketDataStore } from "$lib/stores/market-data.svelte";
-	// Type-only imports — erased at runtime, safe under SSR.
-	// The actual lightweight-charts module is loaded lazily in onMount because
-	// it touches `window`/`document` at top level and would crash Node SSR.
-	import type {
-		IChartApi,
-		ISeriesApi,
-		CandlestickData,
-		HistogramData,
-		Time,
-		UTCTimestamp,
-	} from "lightweight-charts";
 
 	// ── Props ────────────────────────────────────────────────────────────
 	interface Props {
@@ -41,9 +38,9 @@
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 	const marketStore = getContext<MarketDataStore | undefined>("netz:marketDataStore");
 
-	// ── State ────────────────────────────────────────────────────────────
+	// ── Domain types ─────────────────────────────────────────────────────
 	type Bar = {
-		time: UTCTimestamp;
+		time: number; // ms epoch
 		open: number;
 		high: number;
 		low: number;
@@ -51,109 +48,508 @@
 		volume: number;
 	};
 
+	type Granularity = "daily" | "1hour" | "30min" | "15min" | "5min" | "1min";
+	const GRANULARITIES: Granularity[] = ["daily", "1hour", "30min", "15min", "5min", "1min"];
+	const GRANULARITY_LABEL: Record<Granularity, string> = {
+		daily: "Daily",
+		"1hour": "1 Hour",
+		"30min": "30 Min",
+		"15min": "15 Min",
+		"5min": "5 Min",
+		"1min": "1 Min",
+	};
+
+	type ChartType = "line" | "area" | "candle";
+	const CHART_TYPES: { id: ChartType; label: string }[] = [
+		{ id: "line", label: "Line" },
+		{ id: "area", label: "Area" },
+		{ id: "candle", label: "Candle" },
+	];
+
+	type RangeKey = "1D" | "5D" | "1M" | "2M" | "3M" | "6M" | "9M" | "1Y" | "2Y" | "3Y" | "5Y" | "10Y" | "20Y" | "Max";
+	const RANGES: RangeKey[] = ["1D", "5D", "1M", "2M", "3M", "6M", "9M", "1Y", "2Y", "3Y", "5Y", "10Y", "20Y", "Max"];
+	const RANGE_DAYS: Record<Exclude<RangeKey, "Max">, number> = {
+		"1D": 1, "5D": 5, "1M": 30, "2M": 60, "3M": 91, "6M": 182, "9M": 273,
+		"1Y": 365, "2Y": 730, "3Y": 1095, "5Y": 1825, "10Y": 3650, "20Y": 7300,
+	};
+
+	type IndicatorId = "sma20" | "sma50" | "ema20" | "bbands20";
+	const INDICATOR_LABEL: Record<IndicatorId, string> = {
+		sma20: "SMA 20",
+		sma50: "SMA 50",
+		ema20: "EMA 20",
+		bbands20: "Bollinger Bands (20, 2)",
+	};
+
+	// ── State ────────────────────────────────────────────────────────────
 	let bars = $state<Bar[]>([]);
 	let loading = $state(false);
 	let error = $state<string | null>(null);
 
-	const INTERVALS = ["daily", "1hour", "30min", "15min", "5min"] as const;
-	// Default interval is fixed to "daily" — runtime switching is via the
-	// interval-selector buttons. Removing the prop binding here avoids
-	// Svelte's `state_referenced_locally` warning.
-	let activeInterval = $state<(typeof INTERVALS)[number]>("daily");
+	let granularity = $state<Granularity>("daily");
+	let chartType = $state<ChartType>("line");
+	let activeRange = $state<RangeKey>("6M");
+	let activeIndicators = $state<Set<IndicatorId>>(new Set(["sma20", "sma50"]));
+	let logScale = $state(false);
+	let percentMode = $state(false);
 
-	// ── Chart refs (non-reactive — DOM/imperative) ───────────────────────
-	let chartContainer: HTMLDivElement;
-	let chart: IChartApi | null = null;
-	let candleSeries: ISeriesApi<"Candlestick"> | null = null;
-	let volumeSeries: ISeriesApi<"Histogram"> | null = null;
+	let granularityOpen = $state(false);
+	let indicatorsOpen = $state(false);
+	let chartTypeOpen = $state(false);
 
-	// ── Time helpers ─────────────────────────────────────────────────────
-	function toUtcSeconds(iso: string): UTCTimestamp {
-		const t = Math.floor(new Date(iso).getTime() / 1000);
-		return t as UTCTimestamp;
+	// Chart instance bound from ChartContainer for live tick replaceMerge.
+	let chart = $state<ReturnType<typeof echarts.init> | undefined>();
+
+	// ── Theme tokens (ECharts can't read CSS vars directly) ──────────────
+	let brandPrimary = $state("#0177fb");
+	let brandPrimaryDim = $state("rgba(1, 119, 251, 0.16)");
+	let successColor = $state("#22c55e");
+	let dangerColor = $state("#ef4444");
+	let textPrimary = $state("#e5e7eb");
+	let textSecondary = $state("#9ca3af");
+	let textMuted = $state("#6b7280");
+	let surfaceElevated = $state("#0d0d0d");
+	let borderSubtle = $state("rgba(255, 255, 255, 0.06)");
+	let chart1 = $state("#1b365d");
+	let chart3 = $state("#ff975a");
+
+	function readChartTokens() {
+		if (typeof document === "undefined") return;
+		const cs = getComputedStyle(document.documentElement);
+		const get = (n: string, fb: string) => cs.getPropertyValue(n).trim() || fb;
+		brandPrimary = get("--ii-brand-primary", "#0177fb");
+		brandPrimaryDim = `color-mix(in srgb, ${brandPrimary} 16%, transparent)`;
+		successColor = get("--ii-success", "#22c55e");
+		dangerColor = get("--ii-danger", "#ef4444");
+		textPrimary = get("--ii-text-primary", "#e5e7eb");
+		textSecondary = get("--ii-text-secondary", "#9ca3af");
+		textMuted = get("--ii-text-muted", "#6b7280");
+		surfaceElevated = get("--ii-surface-elevated", "#0d0d0d");
+		borderSubtle = get("--ii-border-subtle", "rgba(255, 255, 255, 0.06)");
+		chart1 = get("--ii-chart-1", "#1b365d");
+		chart3 = get("--ii-chart-3", "#ff975a");
 	}
 
-	// ── Mount: dynamically import lightweight-charts (browser-only) ──────
-	// The library touches `window`/`document` at top level and would crash
-	// SvelteKit SSR if imported statically. We pull values lazily here and
-	// keep the type imports above (erased at compile time).
-	onMount(async () => {
-		const lwc = await import("lightweight-charts");
-		const { createChart, CandlestickSeries, HistogramSeries, CrosshairMode } = lwc;
+	$effect(() => {
+		readChartTokens();
+		if (typeof document === "undefined") return;
+		const obs = new MutationObserver(() => readChartTokens());
+		obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+		return () => obs.disconnect();
+	});
 
-		const chartInstance = createChart(chartContainer, {
-			autoSize: true,
-			layout: {
-				background: { type: "solid" as never, color: "transparent" },
-				textColor: "#888888",
-				fontFamily: "Inter, system-ui, sans-serif",
-				fontSize: 11,
-			},
-			grid: {
-				vertLines: { color: "rgba(255,255,255,0.02)" },
-				horzLines: { color: "rgba(255,255,255,0.02)" },
-			},
-			rightPriceScale: {
-				borderVisible: false,
-				scaleMargins: { top: 0.08, bottom: 0.28 },
-			},
-			timeScale: {
-				borderVisible: false,
-				timeVisible: activeInterval !== "daily",
-				secondsVisible: false,
-			},
-			crosshair: {
-				mode: CrosshairMode.Normal,
-				vertLine: { color: "rgba(255,255,255,0.15)", width: 1, style: 0 },
-				horzLine: { color: "rgba(255,255,255,0.15)", width: 1, style: 0 },
-			},
-		});
-
-		candleSeries = chartInstance.addSeries(CandlestickSeries, {
-			upColor: "#11ec79",
-			downColor: "#fc1a1a",
-			borderUpColor: "#11ec79",
-			borderDownColor: "#fc1a1a",
-			wickUpColor: "rgba(17,236,121,0.7)",
-			wickDownColor: "rgba(252,26,26,0.7)",
-			priceFormat: { type: "price", precision: 2, minMove: 0.01 },
-		});
-
-		volumeSeries = chartInstance.addSeries(HistogramSeries, {
-			priceFormat: { type: "volume" },
-			priceScaleId: "vol",
-			color: "rgba(255,255,255,0.25)",
-		});
-		// Pin volume to the bottom 22% of the pane.
-		chartInstance.priceScale("vol").applyOptions({
-			scaleMargins: { top: 0.78, bottom: 0 },
-		});
-
-		// Publish only once everything is wired — the fetch/tick $effects
-		// gate on `chart` being non-null, so this avoids a race where setData
-		// fires against half-initialized series.
-		chart = chartInstance;
-
-		// Pre-warm WS if idle.
-		if (marketStore && marketStore.status === "disconnected") {
-			marketStore.start();
+	// ── Indicator math (pure, frozen, client-side for Tier A) ────────────
+	// Tech-debt §4a queues moving these to backend pre-compute.
+	function smaSeries(values: number[], period: number): (number | null)[] {
+		const out: (number | null)[] = new Array(values.length).fill(null);
+		let sum = 0;
+		for (let i = 0; i < values.length; i++) {
+			sum += values[i]!;
+			if (i >= period) sum -= values[i - period]!;
+			if (i >= period - 1) out[i] = sum / period;
 		}
+		return out;
+	}
+
+	function emaSeries(values: number[], period: number): (number | null)[] {
+		const out: (number | null)[] = new Array(values.length).fill(null);
+		if (values.length < period) return out;
+		const k = 2 / (period + 1);
+		// Seed with SMA of first window.
+		let prev = 0;
+		for (let i = 0; i < period; i++) prev += values[i]!;
+		prev /= period;
+		out[period - 1] = prev;
+		for (let i = period; i < values.length; i++) {
+			prev = values[i]! * k + prev * (1 - k);
+			out[i] = prev;
+		}
+		return out;
+	}
+
+	function bollingerBands(values: number[], period: number, mult: number) {
+		const sma = smaSeries(values, period);
+		const upper: (number | null)[] = new Array(values.length).fill(null);
+		const lower: (number | null)[] = new Array(values.length).fill(null);
+		for (let i = period - 1; i < values.length; i++) {
+			const mean = sma[i]!;
+			let varianceSum = 0;
+			for (let j = i - period + 1; j <= i; j++) {
+				const d = values[j]! - mean;
+				varianceSum += d * d;
+			}
+			const std = Math.sqrt(varianceSum / period);
+			upper[i] = mean + mult * std;
+			lower[i] = mean - mult * std;
+		}
+		return { upper, lower };
+	}
+
+	// ── Derived: visible window based on activeRange ─────────────────────
+	let visibleBars = $derived.by(() => {
+		if (bars.length === 0) return bars;
+		if (activeRange === "Max") return bars;
+		const days = RANGE_DAYS[activeRange];
+		const cutoff = bars[bars.length - 1]!.time - days * 24 * 60 * 60 * 1000;
+		// Find first index >= cutoff via binary search.
+		let lo = 0, hi = bars.length - 1, idx = 0;
+		while (lo <= hi) {
+			const mid = (lo + hi) >> 1;
+			if (bars[mid]!.time >= cutoff) { idx = mid; hi = mid - 1; }
+			else lo = mid + 1;
+		}
+		return bars.slice(idx);
 	});
 
-	onDestroy(() => {
-		chart?.remove();
-		chart = null;
-		candleSeries = null;
-		volumeSeries = null;
+	// ── Derived: rebased values (% mode) ─────────────────────────────────
+	let displayBars = $derived.by(() => {
+		if (!percentMode || visibleBars.length === 0) return visibleBars;
+		const base = visibleBars[0]!.close;
+		if (base === 0) return visibleBars;
+		return visibleBars.map((b) => ({
+			...b,
+			open: ((b.open - base) / base) * 100,
+			high: ((b.high - base) / base) * 100,
+			low: ((b.low - base) / base) * 100,
+			close: ((b.close - base) / base) * 100,
+		}));
 	});
 
-	// ── Fetch + WS subscription on ticker / interval change ──────────────
+	let closeValues = $derived(displayBars.map((b) => b.close));
+	let timeValues = $derived(displayBars.map((b) => b.time));
+
+	let sma20 = $derived(activeIndicators.has("sma20") ? smaSeries(closeValues, 20) : null);
+	let sma50 = $derived(activeIndicators.has("sma50") ? smaSeries(closeValues, 50) : null);
+	let ema20 = $derived(activeIndicators.has("ema20") ? emaSeries(closeValues, 20) : null);
+	let bbands = $derived(activeIndicators.has("bbands20") ? bollingerBands(closeValues, 20, 2) : null);
+
+	// ── Header summary ───────────────────────────────────────────────────
+	let livePrice = $derived.by(() => {
+		const t = ticker?.trim().toUpperCase();
+		if (!t) return null;
+		const tick = marketStore?.priceMap[t];
+		if (tick?.price) return Number(tick.price);
+		if (bars.length > 0) return bars[bars.length - 1]!.close;
+		return null;
+	});
+
+	let livePctChange = $derived.by(() => {
+		if (visibleBars.length < 2 || livePrice == null) return null;
+		const base = visibleBars[0]!.close;
+		if (base === 0) return null;
+		return (livePrice - base) / base;
+	});
+
+	// ── ECharts option builder ───────────────────────────────────────────
+	let option = $derived.by(() => {
+		if (displayBars.length === 0) return {};
+
+		const t = ticker?.trim().toUpperCase() || "—";
+		const yIsLog = logScale && !percentMode && chartType !== "candle";
+		const lastBar = displayBars[displayBars.length - 1]!;
+		const lastValue = chartType === "candle" ? lastBar.close : lastBar.close;
+		const lastUp = displayBars.length < 2 || lastValue >= displayBars[displayBars.length - 2]!.close;
+
+		// Build the price series based on chart type.
+		const priceSeries: Record<string, unknown>[] = [];
+
+		if (chartType === "candle") {
+			priceSeries.push({
+				name: t,
+				type: "candlestick",
+				xAxisIndex: 0,
+				yAxisIndex: 0,
+				// ECharts candlestick data: [open, close, low, high]
+				data: displayBars.map((b) => [b.open, b.close, b.low, b.high]),
+				itemStyle: {
+					color: successColor,
+					color0: dangerColor,
+					borderColor: successColor,
+					borderColor0: dangerColor,
+				},
+				large: true,
+				largeThreshold: 600,
+				progressive: 2000,
+				progressiveThreshold: 5000,
+			});
+		} else {
+			// line / area
+			const isArea = chartType === "area";
+			priceSeries.push({
+				name: t,
+				type: "line",
+				xAxisIndex: 0,
+				yAxisIndex: 0,
+				data: displayBars.map((b) => b.close),
+				showSymbol: false,
+				symbol: "circle",
+				symbolSize: 6,
+				smooth: false,
+				sampling: "lttb",
+				progressive: 2000,
+				progressiveThreshold: 5000,
+				large: true,
+				largeThreshold: 2000,
+				lineStyle: { width: 1.6, color: brandPrimary },
+				itemStyle: { color: brandPrimary },
+				// Subtle area fill — gradient from brandPrimary @ 14% to transparent.
+				...(isArea
+					? {
+						areaStyle: {
+							color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+								{ offset: 0, color: brandPrimaryDim },
+								{ offset: 1, color: "rgba(0,0,0,0)" },
+							]),
+						},
+					}
+					: {}),
+				// Last-price callout pill — markPoint anchored at the rightmost bar.
+				markPoint: {
+					symbol: "rect",
+					symbolSize: [56, 18],
+					symbolOffset: [28, 0],
+					silent: true,
+					data: [{
+						name: "last",
+						coord: [displayBars.length - 1, lastValue],
+						value: lastValue,
+						itemStyle: { color: lastUp ? successColor : dangerColor },
+						label: {
+							show: true,
+							color: "#ffffff",
+							fontSize: 11,
+							fontWeight: 700,
+							formatter: () => percentMode ? `${formatNumber(lastValue, 2)}%` : formatNumber(lastValue, 2),
+						},
+					}],
+				},
+			});
+		}
+
+		// Indicator overlays — flat lines, no markers, no area.
+		if (sma20) {
+			priceSeries.push({
+				name: "SMA 20",
+				type: "line",
+				xAxisIndex: 0,
+				yAxisIndex: 0,
+				data: sma20,
+				showSymbol: false,
+				smooth: false,
+				sampling: "lttb",
+				lineStyle: { width: 1, color: chart3, type: "solid" },
+				z: 3,
+			});
+		}
+		if (sma50) {
+			priceSeries.push({
+				name: "SMA 50",
+				type: "line",
+				xAxisIndex: 0,
+				yAxisIndex: 0,
+				data: sma50,
+				showSymbol: false,
+				smooth: false,
+				sampling: "lttb",
+				lineStyle: { width: 1, color: chart1, type: "solid" },
+				z: 3,
+			});
+		}
+		if (ema20) {
+			priceSeries.push({
+				name: "EMA 20",
+				type: "line",
+				xAxisIndex: 0,
+				yAxisIndex: 0,
+				data: ema20,
+				showSymbol: false,
+				smooth: false,
+				sampling: "lttb",
+				lineStyle: { width: 1, color: textSecondary, type: "dashed" },
+				z: 3,
+			});
+		}
+		if (bbands) {
+			priceSeries.push({
+				name: "BB Upper",
+				type: "line",
+				xAxisIndex: 0,
+				yAxisIndex: 0,
+				data: bbands.upper,
+				showSymbol: false,
+				smooth: false,
+				sampling: "lttb",
+				lineStyle: { width: 0.8, color: textMuted, type: "dashed" },
+				z: 2,
+			});
+			priceSeries.push({
+				name: "BB Lower",
+				type: "line",
+				xAxisIndex: 0,
+				yAxisIndex: 0,
+				data: bbands.lower,
+				showSymbol: false,
+				smooth: false,
+				sampling: "lttb",
+				lineStyle: { width: 0.8, color: textMuted, type: "dashed" },
+				// Fill between upper and lower via stacked area trick — keep simple, skip for Tier A.
+				z: 2,
+			});
+		}
+
+		// Volume sub-pane — always on.
+		priceSeries.push({
+			name: "Volume",
+			type: "bar",
+			xAxisIndex: 1,
+			yAxisIndex: 1,
+			data: displayBars.map((b, i) => {
+				const up = i === 0 || b.close >= displayBars[i - 1]!.close;
+				return {
+					value: b.volume,
+					itemStyle: { color: up ? successColor : dangerColor, opacity: 0.45 },
+				};
+			}),
+			large: true,
+			largeThreshold: 2000,
+		});
+
+		const xAxisData = timeValues.map((t) => formatTimeLabel(t, granularity));
+
+		return {
+			...globalChartOptions,
+			animation: true,
+			animationDuration: 200,
+			grid: [
+				// Main grid: top 75%
+				{ left: 56, right: 84, top: 16, bottom: "30%", containLabel: false },
+				// Volume sub-pane: bottom 22%
+				{ left: 56, right: 84, top: "76%", bottom: 28, containLabel: false },
+			],
+			xAxis: [
+				{
+					type: "category",
+					gridIndex: 0,
+					data: xAxisData,
+					boundaryGap: chartType === "candle",
+					axisLine: { lineStyle: { color: borderSubtle } },
+					axisTick: { show: false },
+					axisLabel: { show: false },
+					splitLine: { show: false },
+					axisPointer: { z: 100 },
+				},
+				{
+					type: "category",
+					gridIndex: 1,
+					data: xAxisData,
+					boundaryGap: chartType === "candle",
+					axisLine: { lineStyle: { color: borderSubtle } },
+					axisTick: { show: false },
+					axisLabel: { color: textMuted, fontSize: 10 },
+					splitLine: { show: false },
+				},
+			],
+			yAxis: [
+				{
+					type: yIsLog ? "log" : "value",
+					gridIndex: 0,
+					scale: true,
+					position: "right",
+					axisLine: { show: false },
+					axisTick: { show: false },
+					axisLabel: {
+						color: textSecondary,
+						fontSize: 10,
+						formatter: (v: number) => percentMode ? `${formatNumber(v, 1)}%` : formatNumber(v, 2),
+					},
+					splitLine: { lineStyle: { color: borderSubtle, type: "dashed" } },
+				},
+				{
+					type: "value",
+					gridIndex: 1,
+					scale: true,
+					position: "right",
+					axisLine: { show: false },
+					axisTick: { show: false },
+					axisLabel: {
+						color: textMuted,
+						fontSize: 9,
+						formatter: (v: number) => formatVolumeLabel(v),
+					},
+					splitLine: { show: false },
+				},
+			],
+			tooltip: {
+				trigger: "axis",
+				axisPointer: { type: "cross", link: [{ xAxisIndex: "all" }], crossStyle: { color: textMuted } },
+				backgroundColor: surfaceElevated,
+				borderColor: borderSubtle,
+				borderWidth: 1,
+				padding: [8, 12],
+				textStyle: { color: textPrimary, fontSize: 11 },
+				formatter: (params: unknown) => buildTooltip(params, t),
+			},
+			axisPointer: { link: [{ xAxisIndex: "all" }] },
+			dataZoom: [
+				{ type: "inside", xAxisIndex: [0, 1], filterMode: "none", zoomOnMouseWheel: true, moveOnMouseMove: true },
+			],
+			toolbox: { show: false },
+			series: priceSeries,
+		};
+	});
+
+	// Tooltip builder — extracted to keep the option block readable.
+	function buildTooltip(params: unknown, t: string): string {
+		const list = Array.isArray(params) ? params : [];
+		if (list.length === 0) return "";
+		const first = list[0] as { axisValueLabel?: string; dataIndex?: number };
+		const i = first.dataIndex ?? 0;
+		const bar = displayBars[i];
+		if (!bar) return "";
+
+		const dateLabel = formatTimeLabel(bar.time, granularity);
+		const priceFmt = (v: number) => percentMode ? `${formatNumber(v, 2)}%` : formatNumber(v, 2);
+
+		let html = `<div style="font-weight:700;margin-bottom:4px">${t} · ${dateLabel}</div>`;
+		html += `<div style="display:grid;grid-template-columns:auto auto;gap:2px 12px;font-variant-numeric:tabular-nums">`;
+		if (chartType === "candle") {
+			html += `<span>Open</span><span style="text-align:right">${priceFmt(bar.open)}</span>`;
+			html += `<span>High</span><span style="text-align:right">${priceFmt(bar.high)}</span>`;
+			html += `<span>Low</span><span style="text-align:right">${priceFmt(bar.low)}</span>`;
+		}
+		html += `<span>Close</span><span style="text-align:right;font-weight:700">${priceFmt(bar.close)}</span>`;
+		if (sma20 && sma20[i] != null) html += `<span>SMA 20</span><span style="text-align:right">${priceFmt(sma20[i] as number)}</span>`;
+		if (sma50 && sma50[i] != null) html += `<span>SMA 50</span><span style="text-align:right">${priceFmt(sma50[i] as number)}</span>`;
+		if (ema20 && ema20[i] != null) html += `<span>EMA 20</span><span style="text-align:right">${priceFmt(ema20[i] as number)}</span>`;
+		if (bbands && bbands.upper[i] != null) {
+			html += `<span>BB Upper</span><span style="text-align:right">${priceFmt(bbands.upper[i] as number)}</span>`;
+			html += `<span>BB Lower</span><span style="text-align:right">${priceFmt(bbands.lower[i] as number)}</span>`;
+		}
+		html += `<span>Volume</span><span style="text-align:right">${formatVolumeLabel(bar.volume)}</span>`;
+		html += `</div>`;
+		return html;
+	}
+
+	function formatTimeLabel(t: number, g: Granularity): string {
+		const d = new Date(t);
+		if (g === "daily") {
+			return d.toLocaleDateString(undefined, { month: "short", day: "2-digit", year: "numeric" });
+		}
+		return d.toLocaleString(undefined, { month: "short", day: "2-digit", hour: "2-digit", minute: "2-digit" });
+	}
+
+	function formatVolumeLabel(v: number): string {
+		if (v >= 1e9) return `${formatNumber(v / 1e9, 2)}B`;
+		if (v >= 1e6) return `${formatNumber(v / 1e6, 2)}M`;
+		if (v >= 1e3) return `${formatNumber(v / 1e3, 1)}K`;
+		return formatNumber(v, 0);
+	}
+
+	// ── Fetch on ticker / granularity change ─────────────────────────────
 	$effect(() => {
 		const t = ticker?.trim().toUpperCase();
-		const intv = activeInterval;
-		if (!t || !candleSeries || !volumeSeries || !chart) {
-			return;
-		}
+		const g = granularity;
+		if (!t) return;
 
 		let cancelled = false;
 		loading = true;
@@ -171,45 +567,23 @@
 					volume: number;
 				};
 				const resp = await api.get<{ bars: RawBar[] }>(
-					`/market-data/historical/${encodeURIComponent(t)}?interval=${intv}`,
+					`/market-data/historical/${encodeURIComponent(t)}?interval=${g}`,
 				);
-				if (cancelled || !candleSeries || !volumeSeries) return;
+				if (cancelled) return;
 
 				const next: Bar[] = (resp.bars ?? [])
 					.map((b) => ({
-						time: toUtcSeconds(b.timestamp),
+						time: new Date(b.timestamp).getTime(),
 						open: Number(b.open),
 						high: Number(b.high),
 						low: Number(b.low),
 						close: Number(b.close),
 						volume: Number(b.volume ?? 0),
 					}))
-					// Defensive: lightweight-charts requires strictly ascending time.
-					.sort((a, b) => (a.time as number) - (b.time as number));
+					.filter((b) => Number.isFinite(b.close))
+					.sort((a, b) => a.time - b.time);
 
 				bars = next;
-
-				const candleData: CandlestickData[] = next.map((b) => ({
-					time: b.time as Time,
-					open: b.open,
-					high: b.high,
-					low: b.low,
-					close: b.close,
-				}));
-				const volumeData: HistogramData[] = next.map((b) => ({
-					time: b.time as Time,
-					value: b.volume,
-					color: b.close >= b.open ? "rgba(17,236,121,0.45)" : "rgba(252,26,26,0.45)",
-				}));
-
-				candleSeries.setData(candleData);
-				volumeSeries.setData(volumeData);
-				chart?.timeScale().fitContent();
-
-				// Adapt time axis labels to selected interval.
-				chart?.applyOptions({
-					timeScale: { timeVisible: intv !== "daily", secondsVisible: false },
-				});
 			} catch (e) {
 				if (!cancelled) error = e instanceof Error ? e.message : "Failed to load chart";
 			} finally {
@@ -217,6 +591,7 @@
 			}
 		})();
 
+		// Pre-warm WS subscription so live tick fold works.
 		marketStore?.subscribe([t]);
 
 		return () => {
@@ -225,10 +600,11 @@
 	});
 
 	// ── Live tick fold ───────────────────────────────────────────────────
-	// Reads marketStore.priceMap[ticker] — Svelte 5 wires this $effect to
-	// the rune so every IEX trade triggers series.update() on the last bar.
+	// Read marketStore.priceMap[ticker] — Svelte 5 wires this $effect to the
+	// rune so every IEX trade triggers a surgical setOption() instead of a
+	// full re-render.
 	$effect(() => {
-		if (!marketStore || !candleSeries || !volumeSeries) return;
+		if (!marketStore || !chart) return;
 		const t = ticker?.trim().toUpperCase();
 		if (!t || bars.length === 0) return;
 
@@ -236,10 +612,11 @@
 		if (!tick || !tick.price) return;
 
 		const last = bars[bars.length - 1]!;
-		const lastDay = new Date((last.time as number) * 1000).toISOString().slice(0, 10);
-		const tickDay = (tick.timestamp || new Date().toISOString()).slice(0, 10);
+		const tickTime = tick.timestamp ? new Date(tick.timestamp).getTime() : Date.now();
+		const lastDay = new Date(last.time).toISOString().slice(0, 10);
+		const tickDay = new Date(tickTime).toISOString().slice(0, 10);
 		// Daily bars are immutable for prior sessions — only fold same-day ticks.
-		if (activeInterval === "daily" && lastDay !== tickDay) return;
+		if (granularity === "daily" && lastDay !== tickDay) return;
 
 		const price = Number(tick.price);
 		const newHigh = Math.max(last.high, price);
@@ -247,96 +624,225 @@
 		const tickVol = Number(tick.volume ?? 0);
 		const newVolume = last.volume + tickVol;
 
-		// Skip duplicates (firehose dedupe).
-		if (last.close === price && last.high === newHigh && last.low === newLow) {
-			return;
-		}
+		// Skip duplicate ticks (firehose dedupe).
+		if (last.close === price && last.high === newHigh && last.low === newLow) return;
 
 		// Mutate the in-memory bar (kept in sync with what's drawn).
-		last.close = price;
-		last.high = newHigh;
-		last.low = newLow;
-		last.volume = newVolume;
-
-		// Surgical update — single bar, no re-render.
-		candleSeries.update({
-			time: last.time as Time,
-			open: last.open,
-			high: last.high,
-			low: last.low,
-			close: last.close,
-		});
-		volumeSeries.update({
-			time: last.time as Time,
-			value: last.volume,
-			color: last.close >= last.open ? "rgba(17,236,121,0.45)" : "rgba(252,26,26,0.45)",
-		});
+		const patched = { ...last, close: price, high: newHigh, low: newLow, volume: newVolume };
+		bars = [...bars.slice(0, -1), patched];
+		// `bars` is reactive — `option` $derived recomputes — ChartContainer's
+		// $effect calls setOption with notMerge:true. The line series is short
+		// enough that this is fine; for tighter perf the bind:chart hook lets
+		// callers do a replaceMerge here directly. We rely on the derived path
+		// for now to keep the code path single.
 	});
 
-	// ── Header summary (live) ────────────────────────────────────────────
-	let livePrice = $derived.by(() => {
-		const t = ticker?.trim().toUpperCase();
-		if (!t) return null;
-		const tick = marketStore?.priceMap[t];
-		if (tick?.price) return Number(tick.price);
-		if (bars.length > 0) return bars[bars.length - 1]!.close;
-		return null;
-	});
+	// ── UI handlers ──────────────────────────────────────────────────────
+	function selectGranularity(g: Granularity) {
+		granularity = g;
+		granularityOpen = false;
+	}
 
-	let livePct = $derived.by(() => {
-		if (bars.length < 2 || livePrice == null) return null;
-		const prev = bars[bars.length - 2]!.close;
-		if (prev === 0) return null;
-		return (livePrice - prev) / prev;
+	function toggleIndicator(id: IndicatorId) {
+		const next = new Set(activeIndicators);
+		if (next.has(id)) next.delete(id);
+		else next.add(id);
+		activeIndicators = next;
+	}
+
+	function selectChartType(c: ChartType) {
+		chartType = c;
+		chartTypeOpen = false;
+		// Candlestick + log scale don't compose in ECharts; force linear.
+		if (c === "candle") logScale = false;
+		// Candlestick + percent mode also doesn't make sense (rebased OHLC
+		// loses meaning); force off.
+		if (c === "candle") percentMode = false;
+	}
+
+	// Close popovers on outside click.
+	let rootEl: HTMLDivElement | undefined = $state();
+	onMount(() => {
+		const onClick = (e: MouseEvent) => {
+			if (!rootEl || !rootEl.contains(e.target as Node)) {
+				granularityOpen = false;
+				indicatorsOpen = false;
+				chartTypeOpen = false;
+			}
+		};
+		document.addEventListener("click", onClick);
+		return () => document.removeEventListener("click", onClick);
 	});
 </script>
 
-<div class="advanced-chart">
-	<header class="chart-header">
-		<div class="chart-title">
-			<span class="ticker">{ticker || "—"}</span>
+<div class="adv-chart" bind:this={rootEl}>
+	<!-- ── Header bar (left: ticker pill / right: controls) ─────── -->
+	<header class="adv-chart-header">
+		<div class="adv-chart-title">
+			<span class="adv-chart-pill">
+				<span class="adv-chart-ticker">{ticker || "—"}</span>
+				<span class="adv-chart-sep">·</span>
+				<span class="adv-chart-meta">{GRANULARITY_LABEL[granularity]}</span>
+				<span class="adv-chart-sep">·</span>
+				<span class="adv-chart-meta">{activeRange}</span>
+			</span>
 			{#if livePrice != null}
-				<span class="price">{formatCurrency(livePrice)}</span>
-				{#if livePct != null}
-					<span class="delta" class:up={livePct >= 0} class:down={livePct < 0}>
-						{livePct >= 0 ? "▲" : "▼"} {formatNumber(livePct * 100, 2)}%
+				<span class="adv-chart-price">{percentMode ? `${formatNumber(((livePrice - (visibleBars[0]?.close ?? livePrice)) / (visibleBars[0]?.close || 1)) * 100, 2)}%` : formatCurrency(livePrice)}</span>
+				{#if livePctChange != null}
+					<span class="adv-chart-delta" class:delta-up={livePctChange >= 0} class:delta-down={livePctChange < 0}>
+						{livePctChange >= 0 ? "▲" : "▼"} {formatPercent(livePctChange, 2)}
 					</span>
 				{/if}
 			{/if}
 		</div>
-		<div class="interval-selector">
-			{#each INTERVALS as iv (iv)}
+
+		<div class="adv-chart-controls">
+			<!-- Granularity dropdown -->
+			<div class="adv-chart-popover-wrap">
 				<button
 					type="button"
-					class="iv-btn"
-					class:iv-btn--active={activeInterval === iv}
-					onclick={() => (activeInterval = iv)}
-				>{iv}</button>
-			{/each}
+					class="adv-chart-btn"
+					onclick={(e) => { e.stopPropagation(); granularityOpen = !granularityOpen; indicatorsOpen = false; chartTypeOpen = false; }}
+				>
+					{GRANULARITY_LABEL[granularity]}
+					<span class="adv-chart-caret">▾</span>
+				</button>
+				{#if granularityOpen}
+					<div class="adv-chart-popover">
+						{#each GRANULARITIES as g (g)}
+							<button
+								type="button"
+								class="adv-chart-popover-item"
+								class:adv-chart-popover-item--active={granularity === g}
+								onclick={(e) => { e.stopPropagation(); selectGranularity(g); }}
+							>
+								{GRANULARITY_LABEL[g]}
+							</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<!-- Chart type dropdown -->
+			<div class="adv-chart-popover-wrap">
+				<button
+					type="button"
+					class="adv-chart-btn"
+					onclick={(e) => { e.stopPropagation(); chartTypeOpen = !chartTypeOpen; indicatorsOpen = false; granularityOpen = false; }}
+					title="Chart type"
+				>
+					{CHART_TYPES.find((c) => c.id === chartType)?.label ?? "Line"}
+					<span class="adv-chart-caret">▾</span>
+				</button>
+				{#if chartTypeOpen}
+					<div class="adv-chart-popover">
+						{#each CHART_TYPES as c (c.id)}
+							<button
+								type="button"
+								class="adv-chart-popover-item"
+								class:adv-chart-popover-item--active={chartType === c.id}
+								onclick={(e) => { e.stopPropagation(); selectChartType(c.id); }}
+							>
+								{c.label}
+							</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<!-- Indicators dropdown -->
+			<div class="adv-chart-popover-wrap">
+				<button
+					type="button"
+					class="adv-chart-btn"
+					onclick={(e) => { e.stopPropagation(); indicatorsOpen = !indicatorsOpen; granularityOpen = false; chartTypeOpen = false; }}
+				>
+					Indicators ({activeIndicators.size})
+					<span class="adv-chart-caret">▾</span>
+				</button>
+				{#if indicatorsOpen}
+					<div class="adv-chart-popover adv-chart-popover--wide">
+						{#each Object.entries(INDICATOR_LABEL) as [id, label] (id)}
+							<button
+								type="button"
+								class="adv-chart-popover-item adv-chart-popover-item--checkable"
+								onclick={(e) => { e.stopPropagation(); toggleIndicator(id as IndicatorId); }}
+							>
+								<span class="adv-chart-check" class:adv-chart-check--on={activeIndicators.has(id as IndicatorId)}>
+									{activeIndicators.has(id as IndicatorId) ? "✓" : ""}
+								</span>
+								{label}
+							</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
 		</div>
 	</header>
 
-	<div class="chart-stage" style:height="{height}px">
-		<div bind:this={chartContainer} class="chart-canvas"></div>
-		{#if loading && bars.length === 0}
-			<div class="chart-overlay">Loading {ticker}…</div>
-		{:else if error}
-			<div class="chart-overlay chart-overlay--error">{error}</div>
-		{:else if !loading && bars.length === 0}
-			<div class="chart-overlay">No data for {ticker || "selected ticker"}</div>
-		{/if}
+	<!-- ── Chart canvas ─────────────────────────────────────────── -->
+	<div class="adv-chart-stage" style:height="{height - 92}px">
+		<ChartContainer
+			{option}
+			height={height - 92}
+			loading={loading && bars.length === 0}
+			empty={!loading && bars.length === 0}
+			emptyMessage={error ?? `No data for ${ticker || "selected ticker"}`}
+			ariaLabel="Advanced market chart"
+			bind:chart
+		/>
 	</div>
+
+	<!-- ── Bottom range chips + scale toggles ───────────────────── -->
+	<footer class="adv-chart-footer">
+		<div class="adv-chart-ranges">
+			{#each RANGES as r (r)}
+				<button
+					type="button"
+					class="adv-chart-range"
+					class:adv-chart-range--active={activeRange === r}
+					onclick={() => (activeRange = r)}
+				>
+					{r}
+				</button>
+			{/each}
+		</div>
+		<div class="adv-chart-scale-toggles">
+			<button
+				type="button"
+				class="adv-chart-toggle"
+				class:adv-chart-toggle--active={percentMode}
+				disabled={chartType === "candle"}
+				onclick={() => (percentMode = !percentMode)}
+				title={chartType === "candle" ? "Percent mode unavailable for candlestick" : "Toggle percent change view"}
+			>
+				%
+			</button>
+			<button
+				type="button"
+				class="adv-chart-toggle"
+				class:adv-chart-toggle--active={logScale}
+				disabled={chartType === "candle" || percentMode}
+				onclick={() => (logScale = !logScale)}
+				title={chartType === "candle" ? "Log scale unavailable for candlestick" : "Toggle log scale"}
+			>
+				log
+			</button>
+		</div>
+	</footer>
 </div>
 
 <style>
-	.advanced-chart {
+	.adv-chart {
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
 		width: 100%;
+		font-family: var(--ii-font-sans, Urbanist, system-ui, sans-serif);
 	}
 
-	.chart-header {
+	/* ── Header bar ────────────────────────────────────────────── */
+	.adv-chart-header {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -344,89 +850,240 @@
 		flex-wrap: wrap;
 	}
 
-	.chart-title {
+	.adv-chart-title {
 		display: flex;
 		align-items: baseline;
-		gap: 10px;
+		gap: 12px;
 		font-variant-numeric: tabular-nums;
 	}
 
-	.ticker {
-		font-size: 18px;
+	.adv-chart-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 4px 10px;
+		border: 1px solid var(--ii-border-subtle);
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--ii-surface-elevated) 60%, transparent);
+		font-size: 11px;
+		color: var(--ii-text-secondary);
+	}
+
+	.adv-chart-ticker {
 		font-weight: 700;
-		color: #ffffff;
-		letter-spacing: -0.02em;
+		color: var(--ii-text-primary);
+		letter-spacing: 0.02em;
 	}
 
-	.price {
-		font-size: 15px;
-		font-weight: 600;
-		color: #ffffff;
+	.adv-chart-meta {
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
 	}
 
-	.delta {
+	.adv-chart-sep {
+		color: var(--ii-text-muted);
+	}
+
+	.adv-chart-price {
+		font-size: 16px;
+		font-weight: 700;
+		color: var(--ii-text-primary);
+	}
+
+	.adv-chart-delta {
 		font-size: 11px;
 		font-weight: 600;
 		padding: 2px 8px;
 		border-radius: 999px;
-		background: rgba(255, 255, 255, 0.04);
+		background: color-mix(in srgb, var(--ii-text-primary) 4%, transparent);
 	}
 
-	.delta.up { color: #11ec79; }
-	.delta.down { color: #fc1a1a; }
+	.delta-up   { color: var(--ii-success); }
+	.delta-down { color: var(--ii-danger); }
 
-	.interval-selector {
+	/* ── Controls (granularity / chart type / indicators dropdowns) ─ */
+	.adv-chart-controls {
 		display: flex;
-		gap: 2px;
+		align-items: center;
+		gap: 6px;
 	}
 
-	.iv-btn {
-		padding: 4px 10px;
+	.adv-chart-popover-wrap {
+		position: relative;
+	}
+
+	.adv-chart-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 6px 12px;
 		font-size: 11px;
 		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		color: #85a0bd;
+		color: var(--ii-text-secondary);
 		background: transparent;
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--ii-border-subtle);
 		border-radius: 6px;
 		cursor: pointer;
-		transition: all 150ms ease;
+		transition: all 120ms ease;
+		font-family: inherit;
 	}
 
-	.iv-btn:hover {
-		color: #ffffff;
-		background: rgba(255, 255, 255, 0.05);
+	.adv-chart-btn:hover {
+		color: var(--ii-text-primary);
+		background: color-mix(in srgb, var(--ii-text-primary) 4%, transparent);
 	}
 
-	.iv-btn--active {
-		color: #ffffff;
-		background: #0177fb;
-		border-color: #0177fb;
+	.adv-chart-caret {
+		font-size: 9px;
+		color: var(--ii-text-muted);
 	}
 
-	.chart-stage {
+	.adv-chart-popover {
+		position: absolute;
+		top: calc(100% + 4px);
+		right: 0;
+		min-width: 140px;
+		padding: 4px;
+		background: var(--ii-surface-elevated);
+		border: 1px solid var(--ii-border-subtle);
+		border-radius: 8px;
+		box-shadow: 0 8px 24px color-mix(in srgb, var(--ii-text-primary) 12%, transparent);
+		z-index: 20;
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.adv-chart-popover--wide {
+		min-width: 200px;
+	}
+
+	.adv-chart-popover-item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 10px;
+		font-size: 11px;
+		font-weight: 500;
+		color: var(--ii-text-secondary);
+		background: transparent;
+		border: none;
+		border-radius: 4px;
+		cursor: pointer;
+		text-align: left;
+		transition: background 100ms ease;
+		font-family: inherit;
+	}
+
+	.adv-chart-popover-item:hover {
+		background: color-mix(in srgb, var(--ii-text-primary) 5%, transparent);
+		color: var(--ii-text-primary);
+	}
+
+	.adv-chart-popover-item--active {
+		color: var(--ii-brand-primary);
+		background: color-mix(in srgb, var(--ii-brand-primary) 10%, transparent);
+	}
+
+	.adv-chart-popover-item--checkable {
+		justify-content: flex-start;
+	}
+
+	.adv-chart-check {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 14px;
+		height: 14px;
+		border: 1px solid var(--ii-border);
+		border-radius: 3px;
+		font-size: 10px;
+		font-weight: 700;
+		color: var(--ii-brand-primary);
+	}
+
+	.adv-chart-check--on {
+		background: color-mix(in srgb, var(--ii-brand-primary) 14%, transparent);
+		border-color: var(--ii-brand-primary);
+	}
+
+	/* ── Chart stage ───────────────────────────────────────────── */
+	.adv-chart-stage {
 		position: relative;
 		width: 100%;
 	}
 
-	.chart-canvas {
-		position: absolute;
-		inset: 0;
-	}
-
-	.chart-overlay {
-		position: absolute;
-		inset: 0;
+	/* ── Footer (range chips + scale toggles) ──────────────────── */
+	.adv-chart-footer {
 		display: flex;
 		align-items: center;
-		justify-content: center;
-		font-size: 12px;
-		color: #85a0bd;
-		pointer-events: none;
+		justify-content: space-between;
+		gap: 12px;
+		flex-wrap: wrap;
+		padding-top: 4px;
+		border-top: 1px solid var(--ii-border-subtle);
 	}
 
-	.chart-overlay--error {
-		color: #fc1a1a;
+	.adv-chart-ranges {
+		display: flex;
+		gap: 2px;
+		flex-wrap: wrap;
+	}
+
+	.adv-chart-range {
+		padding: 4px 9px;
+		font-size: 10px;
+		font-weight: 600;
+		color: var(--ii-text-muted);
+		background: transparent;
+		border: none;
+		border-radius: 4px;
+		cursor: pointer;
+		transition: all 100ms ease;
+		font-family: inherit;
+	}
+
+	.adv-chart-range:hover {
+		color: var(--ii-text-primary);
+		background: color-mix(in srgb, var(--ii-text-primary) 5%, transparent);
+	}
+
+	.adv-chart-range--active {
+		color: var(--ii-brand-primary);
+		background: color-mix(in srgb, var(--ii-brand-primary) 12%, transparent);
+	}
+
+	.adv-chart-scale-toggles {
+		display: flex;
+		gap: 2px;
+	}
+
+	.adv-chart-toggle {
+		padding: 4px 10px;
+		font-size: 10px;
+		font-weight: 700;
+		text-transform: lowercase;
+		color: var(--ii-text-muted);
+		background: transparent;
+		border: 1px solid var(--ii-border-subtle);
+		border-radius: 4px;
+		cursor: pointer;
+		transition: all 100ms ease;
+		font-family: inherit;
+	}
+
+	.adv-chart-toggle:hover:not(:disabled) {
+		color: var(--ii-text-primary);
+	}
+
+	.adv-chart-toggle:disabled {
+		opacity: 0.35;
+		cursor: not-allowed;
+	}
+
+	.adv-chart-toggle--active {
+		color: var(--ii-brand-primary);
+		border-color: var(--ii-brand-primary);
+		background: color-mix(in srgb, var(--ii-brand-primary) 10%, transparent);
 	}
 </style>

--- a/packages/investintell-ui/src/lib/charts/echarts-setup.ts
+++ b/packages/investintell-ui/src/lib/charts/echarts-setup.ts
@@ -10,6 +10,7 @@ import {
 	TreemapChart,
 	SunburstChart,
 	PieChart,
+	CandlestickChart,
 } from "echarts/charts";
 import {
 	GridComponent,
@@ -35,6 +36,7 @@ echarts.use([
 	TreemapChart,
 	SunburstChart,
 	PieChart,
+	CandlestickChart,
 	GridComponent,
 	TooltipComponent,
 	LegendComponent,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -101,7 +101,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -135,9 +135,6 @@ importers:
       dompurify:
         specifier: ^3.3.3
         version: 3.3.3
-      lightweight-charts:
-        specifier: ^5.1.0
-        version: 5.1.0
       lucide-svelte:
         specifier: ^0.469.0
         version: 0.469.0(svelte@5.53.12)
@@ -3235,9 +3232,6 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
-  fancy-canvas@2.1.0:
-    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
-
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
@@ -3785,9 +3779,6 @@ packages:
   lightningcss@1.31.1:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
-
-  lightweight-charts@5.1.0:
-    resolution: {integrity: sha512-jEAYR4ODYeyNZcWUigsoLTl52rbPmgXnvd5FLIv/ZoA/2sSDw63YKnef8n4yhzum7W926yHeFwlm7ididKb7YQ==}
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
@@ -8293,8 +8284,6 @@ snapshots:
 
   eyes@0.1.8: {}
 
-  fancy-canvas@2.1.0: {}
-
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
@@ -8907,10 +8896,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.31.1
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
-
-  lightweight-charts@5.1.0:
-    dependencies:
-      fancy-canvas: 2.1.0
 
   linkify-it@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Replaces the `lightweight-charts` (TradingView) implementation of `AdvancedMarketChart` — the **only chart in the audit violating the `svelte-echarts` mandate** — with a Barchart-style institutional charting component built on the project's standard stack.

**Default visual is now line + subtle area fill**, not candlestick. Candle was the wrong default for mutual fund NAV history (no OHLC available) and looked amateur even for stocks/ETFs. Candlestick is still available via the chart-type switcher.

This is the **Tier A** delivery from the 4-tier roadmap. The full roadmap, deferred items, and design constraints are written down in the new `docs/reference/wealth-charting-tech-debt.md` (also added in this PR).

## What's in (Tier A)

- **Chart-type switcher**: Line · Area · Candlestick
- **Bottom range chip row**: 1D · 5D · 1M · 2M · 3M · 6M · 9M · 1Y · 2Y · 3Y · 5Y · 10Y · 20Y · Max
- **Top granularity dropdown**: Daily · 1 Hour · 30 Min · 15 Min · 5 Min · 1 Min
- **Indicators dropdown** (toggleable, computed client-side): SMA 20, SMA 50, EMA 20, Bollinger Bands (20, 2)
- **Volume sub-pane** (always on, color-coded up/down)
- **Last-price callout pill** anchored to the rightmost bar via `markPoint`
- **Header pill** with ticker · granularity · range + live price + delta
- **Crosshair `axisPointer`** with rich tooltip showing OHLC, volume, and all active indicator values at the hovered timestamp
- **Log scale toggle** (linear/log on yAxis, disabled for candle/percent)
- **Percent change toggle** (rebased to first visible bar, disabled for candle)
- **Live tick fold preserved** from `marketStore.priceMap[ticker]` — IEX firehose updates the rightmost bar surgically
- **Tokens** via `getComputedStyle` + `MutationObserver` on `data-theme` (no hex literals)

## Foundational

- `packages/investintell-ui/src/lib/charts/echarts-setup.ts`: register `CandlestickChart` (was missing — required for the Candle chart-type option). This is the only `@investintell/ui` change in the PR; everything else lives in the wealth frontend.

## Dependency removal

- `frontends/wealth/package.json`: drop `lightweight-charts ^5.1.0`
- `pnpm-lock.yaml`: regenerated (-19 lines, -1 transitive entry)
- `AdvancedMarketChart` was the only consumer (verified via grep across `frontends/wealth/src`)

## Tech debt doc

New file: `docs/reference/wealth-charting-tech-debt.md`. Living document tracking:

| Section | Contents |
|---|---|
| §1 Tier B | Compare overlay, RSI/MACD sub-pane, full f(x), symbol search box, last-bar pulse animation |
| §2 Tier C | Drawing tools sidebar (trendline, fibonacci, shapes, annotations) — ECharts has no native drawing primitives, requires custom canvas overlay (~2-3 dedicated days). Three implementation paths analyzed. |
| §3 Tier D | Templates, Notes, Alerts, Watch (all backend-dependent — each is a separate domain project) |
| §4 Smart-backend | Pre-compute SMA/EMA/Bollinger via `/market-data/historical?indicators=` query param. NBER recession bands endpoint. Macro events endpoint. Server-side favorites for SeriesPicker. |
| §5 MacroChart | NBER recession bands, regime markArea (data already in props but ignored), transformations dropdown, event annotations, dead-code subSeries cleanup, SeriesPicker presets/virtualization/fuzzy search |
| §6 `/portfolio/advanced` | Chart-type rebuilds for MonteCarlo (fan chart), CaptureRatios (quadrant scatter), TailRisk (grouped bar), PeerGroup (quartile bars). Suspected orphan: `ActiveSharePanel` |
| §7 `/portfolio` root | Donut → stacked-100 bar in FactorAnalysisPanel. Performance Cockpit redesign for MainPortfolioChart. |
| §8 Long-tail hygiene | `.toFixed` callsites in 7 orphan chart components, Tailwind hex sweep, hex-frozen `regimeColors`/`statusColors` exports, duplicated `readChartTokens` helper across components |
| §9 Mandates | The non-negotiable rules: svelte-echarts only, tokens not hex, no localStorage, smart-backend, formatters from `@investintell/ui`, performance flags on long line series, animation ≤ 300ms |

## Test plan

- [ ] `make check-all` (frontend type-check)
- [ ] Visual: open `/dashboard`, `AdvancedMarketChart` renders as a line + subtle area fill instead of candlestick
- [ ] Visual: chart type switcher cycles Line / Area / Candle correctly
- [ ] Visual: bottom range chips switch the visible window without refetching
- [ ] Visual: granularity dropdown refetches with the new interval
- [ ] Visual: indicators dropdown toggles SMA20/SMA50/EMA20/Bollinger overlays
- [ ] Visual: volume bars color-code green/red based on close vs prev close
- [ ] Visual: last-price callout pill appears on the rightmost bar with the correct color
- [ ] Visual: hovering shows the cross + rich tooltip with all visible indicator values
- [ ] Visual: log toggle switches yAxis between linear and log
- [ ] Visual: % toggle rebases the visible window to first bar = 0%
- [ ] Visual: live tick fold — connect with a live IEX symbol and confirm the rightmost bar updates without flicker
- [ ] Visual: light/dark mode toggle — chart colors swap correctly via the token observer
- [ ] No reference to `lightweight-charts` in `frontends/wealth/src` (`grep -r lightweight-charts frontends/wealth/src` should return nothing)

## Notes

- This branch is based on `main` which is **before** PR #95 (foundational chart hygiene) merges. The two PRs touch disjoint files:
  - PR #95: MacroChart, MainPortfolioChart, StressTestPanel, FactorAnalysisPanel, SeriesPicker, Macro page, Dashboard +page
  - This PR: AdvancedMarketChart, echarts-setup (one new chart registration), package.json, lockfile, new doc
- The only file touched by both is `echarts-setup.ts`, but in completely different sections (PR #95 changes the Geist→Urbanist font literal at line 136; this PR adds `CandlestickChart` to the imports/use list at lines 13/40). They will merge cleanly.
- CI is currently red on `main` due to a pre-existing migration 0085 bug (`_cusip_resolve_queue` table) — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
