### PR TITLE
fix(wealth): resolve svelte-check errors blocking CI

### DIFF
--- a/frontends/wealth/src/lib/components/AllocationView.svelte
+++ b/frontends/wealth/src/lib/components/AllocationView.svelte
@@ -89,9 +89,16 @@
 		effective_weight: number;
 	};
 
+	// Local mutable copies seeded from SSR props. The $effect below re-syncs
+	// whenever props change (profile switch via goto). Initial capture is
+	// intentional — local edits must not be immediately overwritten by props.
+	// svelte-ignore state_referenced_locally
 	let blocks = $state<BlockMeta[]>(ssrBlocks as BlockMeta[]);
+	// svelte-ignore state_referenced_locally
 	let strategic = $state<StrategicRow[]>(ssrStrategic as StrategicRow[]);
+	// svelte-ignore state_referenced_locally
 	let tactical = $state<TacticalRow[]>(ssrTactical as TacticalRow[]);
+	// svelte-ignore state_referenced_locally
 	let effective = $state<EffectiveRow[]>(ssrEffective as EffectiveRow[]);
 
 	// Keep local state in sync when SSR props change (profile switch via goto)

--- a/frontends/wealth/src/lib/components/BlendedBenchmarkEditor.svelte
+++ b/frontends/wealth/src/lib/components/BlendedBenchmarkEditor.svelte
@@ -279,8 +279,9 @@
 		<!-- Benchmark Name -->
 		<div class="flex items-end gap-3">
 			<div class="flex-1">
-				<label class="mb-1 block text-xs font-medium text-(--ii-text-muted)">Benchmark Name</label>
+				<label class="mb-1 block text-xs font-medium text-(--ii-text-muted)" for="benchmark-name-input">Benchmark Name</label>
 				<Input
+					id="benchmark-name-input"
 					bind:value={benchmarkName}
 					placeholder="e.g. 60/40 Blend, Moderate Custom"
 				/>

--- a/frontends/wealth/src/routes/(app)/portfolio/model/+page.server.ts
+++ b/frontends/wealth/src/routes/(app)/portfolio/model/+page.server.ts
@@ -14,8 +14,8 @@ export const load: PageServerLoad = async ({ parent }) => {
 
 	// Pre-fetch reports for the first portfolio (if any) to avoid waterfall
 	const initialReports: Record<string, ReportHistoryResponse> = {};
-	if (portfolios.length > 0) {
-		const first = portfolios[0];
+	const first = portfolios[0];
+	if (first) {
 		const reports = await api
 			.get<ReportHistoryResponse>(`/model-portfolios/${first.id}/reports`)
 			.catch(() => ({ portfolio_id: first.id, reports: [], total: 0 }) as ReportHistoryResponse);

--- a/frontends/wealth/src/routes/(app)/screener/analytics/+page.svelte
+++ b/frontends/wealth/src/routes/(app)/screener/analytics/+page.svelte
@@ -92,6 +92,8 @@
 	}
 
 	// ── Selection state ─────────────────────────────────────────────
+	// Intentional single capture — URL-driven updates flow through the $effect below.
+	// svelte-ignore state_referenced_locally
 	let selectedFundId = $state(initialFundId);
 	let fundWindow = $state("1y");
 	const windows = ["3m", "6m", "1y", "3y", "5y"] as const;


### PR DESCRIPTION
## Summary
- Fix 3 `state_referenced_locally` errors + 1 `a11y_label_has_associated_control` error in `frontends/wealth/`
- Also fix 3 pre-existing TypeScript narrowing errors in `portfolio/model/+page.server.ts`
- `pnpm check` now reports **0 errors** (3 pre-existing warnings remain, out of sprint scope)

## Test plan
- [x] \`cd frontends/wealth && pnpm check\` → 0 errors
- [x] Svelte 5 reactivity: initial \$state capture is intentional (SSR hydration), \$effect re-syncs on prop change