### PR TITLE
Phase 2 Session C — API surface + retrofits + load-test gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: check test lint typecheck architecture serve migrate migration help pipeline \
        dev-ui build-ui dev-credit build-credit dev-wealth build-wealth \
        dev-all build-all lint-frontend check-all types coverage-runtime \
-       tokens-sync
+       tokens-sync loadtest
 
 # ── Unified gate ──────────────────────────────────────────
 check: lint architecture typecheck tokens-sync test
@@ -43,6 +43,28 @@ architecture:
 # ── Serve (dev) ───────────────────────────────────────────
 serve:
 	cd backend && uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
+
+# ── Load test — screener ELITE fast path ─────────────────
+# Proves the Phase 3 Screener hot path stays under 300ms p95
+# and that the mv_fund_risk_latest partial index is actually
+# used by the query planner. Must be green before every ship.
+#
+# Expects a backend already running on the port specified by
+# NETZ_LOADTEST_BASE_URL (default http://127.0.0.1:8765). Start
+# the backend with RATE_LIMIT_ENABLED=false so the throughput
+# phase is not gated by the production per-org rate cap. Example:
+#
+#   RATE_LIMIT_ENABLED=false ENV=development \
+#       uvicorn app.main:app --port 8765 --log-level warning &
+#   make loadtest
+#
+# Env vars:
+#   NETZ_LOADTEST_BASE_URL (default http://127.0.0.1:8765)
+#   NETZ_LOADTEST_P95_MS   (default 300 — DO NOT raise)
+#   NETZ_LOADTEST_DURATION (default 30 seconds)
+#   NETZ_LOADTEST_CONCURRENCY (default 20 workers)
+loadtest:
+	cd backend && python -m tests.loadtest.screener_elite
 
 # ── Database ──────────────────────────────────────────────
 migrate:
@@ -115,3 +137,6 @@ help:
 	@echo "make lint-frontend - ESLint all frontend packages"
 	@echo "make check-all   - Lint + check all frontend packages"
 	@echo "make types       - Generate TS types from OpenAPI schema"
+	@echo ""
+	@echo "── Performance ────────────────────────────────────"
+	@echo "make loadtest    - Screener ELITE p95 gate (must be <300ms)"

--- a/backend/app/core/db/migrations/versions/0120_portfolio_construction_runs_cancelled_status.py
+++ b/backend/app/core/db/migrations/versions/0120_portfolio_construction_runs_cancelled_status.py
@@ -1,0 +1,80 @@
+"""portfolio_construction_runs: extend status CHECK with 'cancelled'.
+
+Phase 2 Session C commit 3 — the cooperative cancellation pattern
+introduced by ``DELETE /jobs/{job_id}`` lets the
+``construction_run_executor`` exit gracefully when a client aborts
+a long-running optimiser cascade. The existing CHECK constraint
+only allows ``{running, succeeded, failed, superseded}``; this
+migration adds ``cancelled`` as a fifth legal state so the executor
+can persist the run's terminal status.
+
+The rewrite is atomic (DROP + ADD inside a single DDL transaction)
+and fast — there is no table rewrite since the column type is
+unchanged. Existing rows remain valid under the new constraint.
+
+Revision ID: 0120_portfolio_construction_runs_cancelled_status
+Revises: 0119_mv_drift_heatmap_weekly
+Create Date: 2026-04-11
+"""
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0120_portfolio_construction_runs_cancelled_status"
+down_revision: str | None = "0119_mv_drift_heatmap_weekly"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        DROP CONSTRAINT portfolio_construction_runs_status_check
+        """,
+    )
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        ADD CONSTRAINT portfolio_construction_runs_status_check
+        CHECK (status = ANY (ARRAY[
+            'running'::text,
+            'succeeded'::text,
+            'failed'::text,
+            'superseded'::text,
+            'cancelled'::text
+        ]))
+        """,
+    )
+
+
+def downgrade() -> None:
+    # Roll any existing 'cancelled' rows into 'failed' before
+    # tightening the constraint so the downgrade cannot fail on data.
+    op.execute(
+        """
+        UPDATE portfolio_construction_runs
+        SET status = 'failed',
+            failure_reason = COALESCE(failure_reason, '') || ' (was cancelled)'
+        WHERE status = 'cancelled'
+        """,
+    )
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        DROP CONSTRAINT portfolio_construction_runs_status_check
+        """,
+    )
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        ADD CONSTRAINT portfolio_construction_runs_status_check
+        CHECK (status = ANY (ARRAY[
+            'running'::text,
+            'succeeded'::text,
+            'failed'::text,
+            'superseded'::text
+        ]))
+        """,
+    )

--- a/backend/app/core/jobs/tracker.py
+++ b/backend/app/core/jobs/tracker.py
@@ -126,6 +126,57 @@ async def clear_job_owner(
         await r.aclose()
 
 
+async def request_cancellation(
+    job_id: str, ttl_seconds: int = 3600,
+) -> None:
+    """Mark a job for cooperative cancellation.
+
+    Writes ``job:cancel:{job_id}`` = "1" with a 1h TTL (long enough
+    for any reasonable construction run). The worker polls via
+    :func:`is_cancellation_requested` at phase boundaries and exits
+    gracefully when the flag is set. There is no forced termination
+    path — runners must cooperate.
+
+    Idempotent: calling this twice simply refreshes the TTL.
+    """
+    pool = get_redis_pool()
+    r = aioredis.Redis(connection_pool=pool)
+    try:
+        await r.set(f"job:cancel:{job_id}", "1", ex=ttl_seconds)
+    finally:
+        await r.aclose()
+
+
+async def is_cancellation_requested(job_id: str) -> bool:
+    """Non-blocking check for a pending cancellation request.
+
+    Returns True if ``job:cancel:{job_id}`` exists. Designed to be
+    called from tight loops or between phases of long-running jobs
+    — never cached on the worker side; always re-reads Redis.
+    """
+    pool = get_redis_pool()
+    r = aioredis.Redis(connection_pool=pool)
+    try:
+        return (await r.get(f"job:cancel:{job_id}")) is not None
+    finally:
+        await r.aclose()
+
+
+async def clear_cancellation_flag(job_id: str) -> None:
+    """Remove the cancel flag after the worker has acknowledged it.
+
+    Called by the worker once the graceful exit path has run so a
+    subsequent re-dispatch of the same job id (should it ever be
+    reused) starts with a clean slate.
+    """
+    pool = get_redis_pool()
+    r = aioredis.Redis(connection_pool=pool)
+    try:
+        await r.delete(f"job:cancel:{job_id}")
+    finally:
+        await r.aclose()
+
+
 async def verify_job_owner(job_id: str, organization_id: str) -> bool:
     """Check if job belongs to the given organization.
 

--- a/backend/app/domains/wealth/routes/dd_reports.py
+++ b/backend/app/domains/wealth/routes/dd_reports.py
@@ -37,9 +37,11 @@ from app.domains.wealth.schemas.dd_report import (
     DDReportApproveRequest,
     DDReportCreate,
     DDReportListItem,
+    DDReportQueueItem,
     DDReportRead,
     DDReportRegenerate,
     DDReportRejectRequest,
+    DDReportsQueueOut,
     DDReportSummary,
 )
 from app.shared.enums import Role
@@ -116,6 +118,125 @@ async def list_all_dd_reports(
         )
         for report, inst_name, inst_ticker in rows
     ]
+
+
+# ── Phase 2 Session C commit 5: DD reports queue aggregator ─────
+
+
+# Bucket mapping — aligned with the DDReportStatus enum in
+# ``app.domains.wealth.enums``:
+#
+# draft             → pending      (row exists, generation not started)
+# generating        → in_progress  (pipeline actively running)
+# pending_approval  → in_progress  (analytical work done, awaiting
+#                                   human review — still occupies
+#                                   a slot from the queue's POV)
+# approved          → completed_recent
+# rejected          → completed_recent
+# failed            → completed_recent
+_QUEUE_PENDING = ("draft",)
+_QUEUE_IN_PROGRESS = ("generating", "pending_approval")
+_QUEUE_COMPLETED = ("approved", "rejected", "failed")
+
+
+@router.get(
+    "/queue",
+    response_model=DDReportsQueueOut,
+    summary="DD reports queue state (pending / in_progress / completed_recent)",
+)
+async def get_dd_reports_queue(
+    recent_limit: int = Query(default=20, ge=1, le=100),
+    db: AsyncSession = Depends(get_db_with_rls),
+    user: CurrentUser = Depends(get_current_user),
+) -> DDReportsQueueOut:
+    """Return the tenant-scoped DD reports queue in three buckets.
+
+    Phase 6 DD Track UI consumes this endpoint to render its kanban
+    without stitching together three separate list calls. RLS
+    filters by ``organization_id`` automatically through
+    ``get_db_with_rls`` so cross-tenant leakage is impossible.
+
+    Bucket semantics (see ``_QUEUE_*`` constants above for the
+    exact status→bucket mapping):
+
+    * ``pending``          — rows where generation has not started
+    * ``in_progress``      — rows where the pipeline is running or
+      awaiting human approval (both states block a generation slot
+      so they belong in the same active-work bucket)
+    * ``completed_recent`` — the last ``recent_limit`` rows in any
+      terminal state (approved / rejected / failed), sorted by
+      ``created_at DESC``. The ``created_at`` fallback is used
+      because ``DDReport`` has no ``completed_at`` column today
+      and the queue shape is stable as soon as the row lands.
+
+    Every bucket is further constrained to ``is_current = TRUE``
+    so prior versions of a re-run report do not clutter the queue.
+
+    ``instrument_label`` denormalises the instrument's display name
+    via a single LEFT JOIN on ``instruments_universe``.
+    """
+    from app.domains.wealth.models.instrument import Instrument
+
+    base_query = (
+        select(
+            DDReport,
+            Instrument.name.label("instrument_label"),
+        )
+        .outerjoin(
+            Instrument, DDReport.instrument_id == Instrument.instrument_id,
+        )
+        .where(DDReport.is_current.is_(True))
+    )
+
+    pending_q = (
+        base_query.where(DDReport.status.in_(_QUEUE_PENDING))
+        .order_by(DDReport.created_at)
+    )
+    in_progress_q = (
+        base_query.where(DDReport.status.in_(_QUEUE_IN_PROGRESS))
+        .order_by(DDReport.created_at)
+    )
+    completed_q = (
+        base_query.where(DDReport.status.in_(_QUEUE_COMPLETED))
+        .order_by(DDReport.created_at.desc())
+        .limit(recent_limit)
+    )
+
+    pending_rows = (await db.execute(pending_q)).all()
+    in_progress_rows = (await db.execute(in_progress_q)).all()
+    completed_rows = (await db.execute(completed_q)).all()
+
+    def _to_item(row: Any) -> DDReportQueueItem:
+        report, label = row
+        return DDReportQueueItem(
+            id=report.id,
+            instrument_id=report.instrument_id,
+            instrument_label=label,
+            report_type=report.report_type,
+            version=report.version,
+            status=report.status,
+            confidence_score=report.confidence_score,
+            decision_anchor=report.decision_anchor,
+            created_at=report.created_at,
+            approved_at=report.approved_at,
+            progress_pct=None,
+            current_chapter=None,
+        )
+
+    pending = [_to_item(r) for r in pending_rows]
+    in_progress = [_to_item(r) for r in in_progress_rows]
+    completed_recent = [_to_item(r) for r in completed_rows]
+
+    return DDReportsQueueOut(
+        pending=pending,
+        in_progress=in_progress,
+        completed_recent=completed_recent,
+        counts={
+            "pending": len(pending),
+            "in_progress": len(in_progress),
+            "completed_recent": len(completed_recent),
+        },
+    )
 
 
 @router.post(

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -35,6 +35,9 @@ from app.domains.wealth.models.portfolio import PortfolioSnapshot
 from app.domains.wealth.schemas.generated_report import ReportGenerateRequest
 from app.domains.wealth.schemas.model_portfolio import (
     ConstructionAdviceRead,
+    ConstructionRunDiffOut,
+    ConstructionRunMetricDelta,
+    ConstructionRunWeightDelta,
     ConstructRunAccepted,
     CusipExposureRead,
     ModelPortfolioCreate,
@@ -3227,6 +3230,114 @@ async def get_latest_construction_run(
         "rationale_per_weight": run.rationale_per_weight,
         "weights_proposed": run.weights_proposed,
     }
+
+
+# ── Phase 2 Session C commit 4: mv_construction_run_diff endpoint ────
+
+
+@router.get(
+    "/{portfolio_id}/construction/runs/{run_id}/diff",
+    response_model=ConstructionRunDiffOut,
+    summary="Weight + metrics delta between a run and its predecessor",
+)
+async def get_construction_run_diff(
+    portfolio_id: uuid.UUID,
+    run_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db_with_rls),
+    user: CurrentUser = Depends(get_current_user),
+) -> ConstructionRunDiffOut:
+    """Return the weight and ex-ante metric deltas for this run.
+
+    Reads from the ``mv_construction_run_diff`` materialized view
+    (shipped in Session 2.B commit 0118). The view pre-computes, for
+    every run whose status is ``succeeded`` or ``superseded``, a
+    JSONB dict keyed by instrument_id for weight changes and keyed by
+    ex-ante metric name for metric changes, compared against the
+    immediately preceding run on the same portfolio.
+
+    404 is returned when:
+
+    * The ``(portfolio_id, run_id)`` pair has no row in the MV. This
+      happens for runs that have not reached a terminal success state,
+      or when the MV has not been refreshed since the run landed.
+
+    The response body shape is laid down by
+    ``ConstructionRunDiffOut`` in ``schemas/model_portfolio.py``. The
+    schema runs a belt-and-suspenders sanitisation pass on
+    ``metrics_delta`` keys via ``humanize_metric`` so any residual
+    jargon from a future upstream regression is stripped at the API
+    boundary.
+    """
+    result = await db.execute(
+        text(
+            """
+            SELECT
+                portfolio_id,
+                run_id,
+                previous_run_id,
+                requested_at,
+                weight_delta_jsonb,
+                metrics_delta_jsonb,
+                status_delta_text
+            FROM mv_construction_run_diff
+            WHERE portfolio_id = :portfolio_id
+              AND run_id = :run_id
+            """,
+        ),
+        {"portfolio_id": portfolio_id, "run_id": run_id},
+    )
+    row = result.mappings().one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                "Construction run diff not available yet. The run may "
+                "not have completed or the materialized view needs a "
+                "refresh."
+            ),
+        )
+
+    # The MV emits raw JSONB dicts — convert to the typed Pydantic
+    # model shape. Each weight_delta_jsonb value is a {from, to, delta}
+    # triple; metrics_delta_jsonb values are the same shape but with
+    # possibly-None numeric fields.
+    weight_delta_raw: dict[str, dict[str, Any]] = dict(row["weight_delta_jsonb"] or {})
+    metrics_delta_raw: dict[str, dict[str, Any]] = dict(row["metrics_delta_jsonb"] or {})
+
+    weight_delta: dict[str, ConstructionRunWeightDelta] = {
+        instrument_id: ConstructionRunWeightDelta.model_validate(delta)
+        for instrument_id, delta in weight_delta_raw.items()
+    }
+
+    metrics_delta: dict[str, ConstructionRunMetricDelta] = {}
+    for metric_key, delta in metrics_delta_raw.items():
+        # ``delta`` may be None if ex-ante metric was non-numeric —
+        # the MV emits {"from": "...", "to": "...", "delta": null}
+        def _coerce_optional_float(v: Any) -> float | None:
+            if v is None:
+                return None
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return None
+
+        metrics_delta[metric_key] = ConstructionRunMetricDelta(
+            **{
+                "from": _coerce_optional_float(delta.get("from")),
+                "to": _coerce_optional_float(delta.get("to")),
+                "delta": _coerce_optional_float(delta.get("delta")),
+            },
+        )
+
+    return ConstructionRunDiffOut(
+        portfolio_id=row["portfolio_id"],
+        run_id=row["run_id"],
+        previous_run_id=row["previous_run_id"],
+        requested_at=row["requested_at"],
+        weight_delta=weight_delta,
+        metrics_delta=metrics_delta,
+        status_delta_text=row["status_delta_text"],
+    )
 
 
 # Separate router prefixed /portfolio for the catalog + regime endpoints.

--- a/backend/app/domains/wealth/routes/risk_timeseries.py
+++ b/backend/app/domains/wealth/routes/risk_timeseries.py
@@ -34,12 +34,15 @@ router = APIRouter(prefix="/risk", tags=["risk"])
 @router.get(
     "/timeseries/{instrument_id}",
     response_model=RiskTimeseriesOut,
+    response_model_by_alias=True,
     summary="Risk timeseries for TradingView overlay",
     description=(
-        "Returns drawdown, GARCH volatility, and macro regime probability "
+        "Returns drawdown, conditional volatility, and macro regime probability "
         "series for a given instrument_id, indexed by date. All series are "
         "pre-computed from TimescaleDB hypertables — zero in-request "
-        "computation."
+        "computation. Sanitised through sanitized.py: the volatility field "
+        "is emitted as ``conditional_volatility`` and regime codes are "
+        "rewritten to Expansion / Cautious / Stress phrasing."
     ),
 )
 @route_cache(ttl=300, key_prefix="risk:timeseries")

--- a/backend/app/domains/wealth/routes/screener.py
+++ b/backend/app/domains/wealth/routes/screener.py
@@ -28,7 +28,7 @@ from typing import Any
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel
-from sqlalchemy import Float, Select, String, case, literal, select, union_all
+from sqlalchemy import Float, Select, String, case, literal, select, text, union_all
 from sqlalchemy import func as sa_func
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -133,6 +133,175 @@ def _require_investment_role(actor: Actor) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Investment Team or Admin role required",
         )
+
+
+# ── Phase 2 Session C commit 6: ELITE fast-path catalog ─────────
+
+
+class EliteCatalogItem(BaseModel):
+    """One row in the ELITE catalog response."""
+
+    instrument_id: uuid.UUID
+    name: str
+    ticker: str | None
+    asset_class: str
+    sharpe_1y: float | None
+    manager_score: float | None
+    cvar_95_12m: float | None
+    max_drawdown_1y: float | None
+    elite_rank_within_strategy: int | None
+
+
+class EliteCatalogPage(BaseModel):
+    """Response body for ``GET /screener/catalog/elite``."""
+
+    items: list[EliteCatalogItem]
+    total: int
+    limit: int
+
+
+@router.get(
+    "/catalog/elite",
+    response_model=EliteCatalogPage,
+    summary="ELITE fund fast-path catalog (Phase 3 Screener hot path)",
+)
+async def get_elite_catalog(
+    asset_class: str | None = Query(
+        None,
+        description=(
+            "Comma-separated asset_class filter "
+            "(equity | fixed_income | alternatives | cash | fund)"
+        ),
+    ),
+    limit: int = Query(50, ge=1, le=500),
+    db: AsyncSession = Depends(get_db_with_rls),
+) -> EliteCatalogPage:
+    """Fast-path ELITE catalog — reads directly from ``mv_fund_risk_latest``.
+
+    This is the Phase 3 Screener Fast Path hot query and the
+    gate that Session C commit 6's load test exercises. The query
+    is hand-shaped to FORCE the planner to use the partial index
+    ``idx_mv_fund_risk_latest_elite`` via a ``MATERIALIZED`` CTE:
+
+    1. The CTE materialises the ~300 ELITE-flagged rows via the
+       partial index (indexed by ``instrument_id``, covering only
+       ``WHERE elite_flag = true``).
+    2. The outer query joins on ``instruments_universe`` for
+       display metadata and sorts the small materialised set by
+       ``sharpe_1y DESC``.
+
+    A plain ``WHERE elite_flag = true ORDER BY sharpe_1y ...`` lets
+    the planner walk the sharpe btree and filter out non-elite rows
+    on the fly — still fast but does not exercise the partial
+    index. The ``MATERIALIZED`` hint removes that ambiguity and is
+    what the commit 6 ``verify_p95.py`` EXPLAIN check asserts on.
+
+    Parameters
+    ----------
+    asset_class
+        Optional comma-separated list of ``instruments_universe.asset_class``
+        values. When None, every ELITE fund is returned regardless
+        of asset class.
+    limit
+        Max rows in the response. Capped at 500.
+    """
+    asset_classes: list[str] = []
+    if asset_class:
+        asset_classes = [s.strip() for s in asset_class.split(",") if s.strip()]
+
+    if asset_classes:
+        stmt = text(
+            """
+            WITH elite_set AS MATERIALIZED (
+                SELECT
+                    instrument_id,
+                    sharpe_1y,
+                    manager_score,
+                    cvar_95_12m,
+                    max_drawdown_1y,
+                    elite_rank_within_strategy
+                FROM mv_fund_risk_latest
+                WHERE elite_flag = true
+            )
+            SELECT
+                es.instrument_id,
+                iu.name,
+                iu.ticker,
+                iu.asset_class,
+                es.sharpe_1y,
+                es.manager_score,
+                es.cvar_95_12m,
+                es.max_drawdown_1y,
+                es.elite_rank_within_strategy
+            FROM elite_set es
+            JOIN instruments_universe iu
+              ON iu.instrument_id = es.instrument_id
+            WHERE iu.asset_class = ANY(:asset_classes)
+            ORDER BY es.sharpe_1y DESC NULLS LAST
+            LIMIT :limit_rows
+            """,
+        )
+        rows = (
+            await db.execute(
+                stmt, {"asset_classes": asset_classes, "limit_rows": limit},
+            )
+        ).mappings().all()
+    else:
+        stmt = text(
+            """
+            WITH elite_set AS MATERIALIZED (
+                SELECT
+                    instrument_id,
+                    sharpe_1y,
+                    manager_score,
+                    cvar_95_12m,
+                    max_drawdown_1y,
+                    elite_rank_within_strategy
+                FROM mv_fund_risk_latest
+                WHERE elite_flag = true
+            )
+            SELECT
+                es.instrument_id,
+                iu.name,
+                iu.ticker,
+                iu.asset_class,
+                es.sharpe_1y,
+                es.manager_score,
+                es.cvar_95_12m,
+                es.max_drawdown_1y,
+                es.elite_rank_within_strategy
+            FROM elite_set es
+            JOIN instruments_universe iu
+              ON iu.instrument_id = es.instrument_id
+            ORDER BY es.sharpe_1y DESC NULLS LAST
+            LIMIT :limit_rows
+            """,
+        )
+        rows = (await db.execute(stmt, {"limit_rows": limit})).mappings().all()
+
+    items = [
+        EliteCatalogItem(
+            instrument_id=row["instrument_id"],
+            name=row["name"],
+            ticker=row["ticker"],
+            asset_class=row["asset_class"],
+            sharpe_1y=float(row["sharpe_1y"]) if row["sharpe_1y"] is not None else None,
+            manager_score=(
+                float(row["manager_score"]) if row["manager_score"] is not None else None
+            ),
+            cvar_95_12m=(
+                float(row["cvar_95_12m"]) if row["cvar_95_12m"] is not None else None
+            ),
+            max_drawdown_1y=(
+                float(row["max_drawdown_1y"])
+                if row["max_drawdown_1y"] is not None
+                else None
+            ),
+            elite_rank_within_strategy=row["elite_rank_within_strategy"],
+        )
+        for row in rows
+    ]
+    return EliteCatalogPage(items=items, total=len(items), limit=limit)
 
 
 @router.post(

--- a/backend/app/domains/wealth/schemas/dd_report.py
+++ b/backend/app/domains/wealth/schemas/dd_report.py
@@ -109,3 +109,52 @@ class AuditEventRead(BaseModel):
     before: dict | None
     after: dict | None
     created_at: str | None
+
+
+# ── DD reports queue aggregator (Session C commit 5) ────────────
+#
+# The Phase 6 DD Track UI renders a kanban with three columns:
+# pending, in_progress, completed_recent. This aggregator packs
+# all three into a single tenant-scoped request so the frontend
+# does not have to make three round-trips + a count endpoint.
+
+
+class DDReportQueueItem(BaseModel):
+    """Slim row shape for the queue kanban — one DD report per row.
+
+    ``instrument_label`` denormalises the fund/ETF display name from
+    ``instruments_universe`` so the UI can render the card without a
+    second lookup. ``progress_pct`` is left None until the DD pipeline
+    exposes a real progress counter — included here so the wire shape
+    is stable once it lands.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    instrument_id: uuid.UUID
+    instrument_label: str | None = None
+    report_type: str = "dd_report"
+    version: int
+    status: str
+    confidence_score: Decimal | None = None
+    decision_anchor: str | None = None
+    created_at: datetime
+    approved_at: datetime | None = None
+    progress_pct: int | None = None
+    current_chapter: str | None = None
+
+
+class DDReportsQueueOut(BaseModel):
+    """Full queue payload: three buckets + count dict.
+
+    The counts dict is a pre-computed sum for each bucket so the
+    frontend can render the badge numbers without counting the lists
+    client-side (especially important when ``completed_recent`` is
+    capped by ``recent_limit``).
+    """
+
+    pending: list[DDReportQueueItem]
+    in_progress: list[DDReportQueueItem]
+    completed_recent: list[DDReportQueueItem]
+    counts: dict[str, int]

--- a/backend/app/domains/wealth/schemas/model_portfolio.py
+++ b/backend/app/domains/wealth/schemas/model_portfolio.py
@@ -479,3 +479,90 @@ class ConstructionAdviceRead(BaseModel):
     minimum_viable_set: MinimumViableSetRead | None = None
     alternative_profiles: list[AlternativeProfileRead] = []
     projected_cvar_is_heuristic: bool = True
+
+
+# ── Construction Run Diff (Session C commit 4) ───────────────────────────
+#
+# Backing store: ``mv_construction_run_diff`` materialized view (shipped
+# in Session 2.B commit 0118). One row per successful construction run
+# that has a previous run. Consumed by Phase 4 Builder's "Compare to
+# previous run" analytics panel.
+#
+# Sanitisation posture: primary jargon stripping happens upstream when
+# construction_run_executor writes ``ex_ante_metrics`` and the diff view
+# is computed over those already-clean JSONB keys. We still run every
+# response body through ``sanitize_dict_keys`` at model-validator time
+# as a belt-and-suspenders guard against future upstream regressions.
+
+
+class ConstructionRunWeightDelta(BaseModel):
+    """Per-instrument weight comparison between two construction runs.
+
+    ``from_weight`` and ``to_weight`` are absolute portfolio weights
+    (0.0 - 1.0). ``delta`` is ``to_weight - from_weight``; positive
+    means the instrument gained weight in the newer run.
+    """
+
+    from_weight: float = Field(alias="from")
+    to_weight: float = Field(alias="to")
+    delta: float
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+
+class ConstructionRunMetricDelta(BaseModel):
+    """Per-metric before/after/delta triple.
+
+    ``from_value`` and ``to_value`` are the raw ex-ante metric values
+    (e.g. expected return, portfolio volatility). ``delta`` is the
+    numeric subtraction when both sides are numeric, otherwise ``None``
+    (the MV computes the delta only for numeric metrics).
+    """
+
+    from_value: float | None = Field(default=None, alias="from")
+    to_value: float | None = Field(default=None, alias="to")
+    delta: float | None = None
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+
+class ConstructionRunDiffOut(BaseModel):
+    """Response body for ``GET /{portfolio_id}/construction/runs/{run_id}/diff``.
+
+    Reads directly from ``mv_construction_run_diff``. 404 when the
+    requested ``(portfolio_id, run_id)`` pair has no row, which means
+    either the run has not completed yet or the materialized view is
+    stale — in both cases the caller should refresh the view or wait
+    for the run to finish.
+    """
+
+    portfolio_id: uuid.UUID
+    run_id: uuid.UUID
+    previous_run_id: uuid.UUID | None
+    requested_at: datetime | None
+    weight_delta: dict[str, ConstructionRunWeightDelta]
+    metrics_delta: dict[str, ConstructionRunMetricDelta]
+    status_delta_text: str
+
+    @model_validator(mode="after")
+    def _sanitize_metrics_delta(self) -> "ConstructionRunDiffOut":
+        """Belt-and-suspenders jargon stripping on metrics_delta keys.
+
+        Primary sanitisation happens upstream in
+        ``construction_run_executor`` (Session C commit 1) — by the
+        time values land in the MV, keys are already in institutional
+        phrasing. This validator translates any residual raw keys
+        through ``METRIC_LABELS`` so a future upstream regression
+        does not leak jargon through this endpoint. Values (the
+        ``ConstructionRunMetricDelta`` triples) are preserved
+        unchanged; only the outer dict keys are rewritten.
+        """
+        from app.domains.wealth.schemas.sanitized import humanize_metric
+
+        md = self.metrics_delta
+        if md:
+            translated: dict[str, ConstructionRunMetricDelta] = {
+                humanize_metric(k): v for k, v in md.items()
+            }
+            object.__setattr__(self, "metrics_delta", translated)
+        return self

--- a/backend/app/domains/wealth/schemas/risk_timeseries.py
+++ b/backend/app/domains/wealth/schemas/risk_timeseries.py
@@ -1,12 +1,36 @@
 """Response schemas for risk timeseries endpoint.
 
 Flat [{time, value}] arrays optimized for TradingView chart injection.
+
+Sanitisation retrofit — Phase 2 Session C commit 2
+--------------------------------------------------
+Audit §C.2 flagged this schema as leaking raw quant jargon
+(``volatility_garch`` field, ``RISK_ON``/``RISK_OFF``/``CRISIS``
+regime enums inside ``regime_prob``) directly to the frontend. This
+module now routes the wire format through
+``app.domains.wealth.schemas.sanitized`` at the API boundary:
+
+* ``volatility_garch`` still exists as the internal Python attribute
+  name (keeping every backend caller stable) but Pydantic emits it
+  as ``conditional_volatility`` on the wire via
+  ``serialization_alias``. Consumers call the route with
+  ``response_model_by_alias=True`` so FastAPI honours the alias.
+* Each ``regime_prob`` element's ``regime`` field is rewritten by a
+  model-level ``@model_validator(mode='after')`` before the schema
+  reaches ``model_dump()``: enum codes go through
+  ``humanize_regime`` and come out as ``Expansion`` / ``Cautious``
+  / ``Stress``.
+
+No ``v2/`` split — per sanitized.py §1 the engine is contract-
+breaking and the frontend adapts in the same PR wave.
 """
 
 from datetime import date
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.domains.wealth.schemas.sanitized import humanize_regime
 
 
 class TimeseriesPoint(BaseModel):
@@ -17,14 +41,42 @@ class TimeseriesPoint(BaseModel):
 class RegimePoint(BaseModel):
     time: str  # ISO-8601 date
     value: float  # p_high_vol probability
-    regime: str  # classified_regime label
+    regime: str  # sanitised regime label (Expansion / Cautious / Stress)
 
 
 class RiskTimeseriesOut(BaseModel):
+    """Risk timeseries payload consumed by TradingView overlays.
+
+    ``populate_by_name`` lets internal code construct the schema with
+    ``volatility_garch=...`` while the wire format uses
+    ``conditional_volatility``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
     instrument_id: str
     ticker: str | None  # resolved from instruments_universe for display only
     from_date: date
     to_date: date
     drawdown: list[dict[str, Any]]  # [{time, value}]
-    volatility_garch: list[dict[str, Any]]  # [{time, value}]
+    volatility_garch: list[dict[str, Any]] = Field(
+        serialization_alias="conditional_volatility",
+    )  # [{time, value}] — wire key is "conditional_volatility"
     regime_prob: list[dict[str, Any]]  # [{time, value, regime}]
+
+    @model_validator(mode="after")
+    def _sanitize_regime_points(self) -> "RiskTimeseriesOut":
+        """Translate enum regime codes to institutional phrasing in place.
+
+        Iterates the ``regime_prob`` list and rewrites each element's
+        ``regime`` field through ``humanize_regime``. Non-string values
+        and unknown codes pass through unchanged (by design — a new
+        regime state added to the backend must remain visible until a
+        label is registered).
+        """
+        rp = self.regime_prob
+        if isinstance(rp, list):
+            for point in rp:
+                if isinstance(point, dict) and "regime" in point:
+                    point["regime"] = humanize_regime(point["regime"])
+        return self

--- a/backend/app/domains/wealth/schemas/sanitized.py
+++ b/backend/app/domains/wealth/schemas/sanitized.py
@@ -114,6 +114,77 @@ REGIME_LABELS: dict[str, str] = {
     "STRESS": "Stress",
 }
 
+# Event-type labels used by construction_run_executor and any other
+# SSE-publishing worker. Raw internal names (e.g. "optimizer_started")
+# get translated to institutional phrasing before emission. Anything
+# not in this dict passes through unchanged so a new event type added
+# by a worker remains visible on the wire until a label is registered.
+EVENT_TYPE_LABELS: dict[str, str] = {
+    # Lifecycle
+    "run_started": "Construction started",
+    "run_cancelled": "Construction cancelled",
+    "run_succeeded": "Construction succeeded",
+    "run_failed": "Construction failed",
+    # Optimizer cascade
+    "optimizer_started": "Optimizer started",
+    "optimizer_phase_completed": "Optimizer phase completed",
+    "optimizer_cascade_completed": "Optimizer cascade completed",
+    # Stress suite
+    "stress_started": "Stress tests started",
+    "stress_scenario_completed": "Stress scenario completed",
+    "stress_completed": "Stress tests completed",
+    # Advisor
+    "advisor_started": "Advisor started",
+    "advisor_completed": "Advisor completed",
+    # Validation gate
+    "validation_started": "Validation gate started",
+    "validation_passed": "Validation gate passed",
+    "validation_failed": "Validation gate failed",
+    # Narrative
+    "narrative_started": "Narrative generation started",
+    "narrative_completed": "Narrative generation completed",
+}
+
+
+def humanize_event_type(raw: str) -> str:
+    """Translate a raw internal event type to its public label.
+
+    Pass-through for unknown event types — a worker that emits a new
+    event type remains visible until its label is added here.
+    """
+    if not isinstance(raw, str):
+        return raw
+    return EVENT_TYPE_LABELS.get(raw, raw)
+
+
+def sanitize_payload(raw: Any) -> Any:
+    """Walk an arbitrary payload recursively, translating jargon.
+
+    - Dict keys matching ``METRIC_LABELS`` are translated to institutional
+      labels.
+    - String values matching ``REGIME_LABELS`` are translated to the
+      tri-state phrasing (Expansion / Cautious / Stress).
+    - Lists are walked element-by-element.
+    - Anything else passes through unchanged (numbers, booleans, None,
+      unrecognised strings).
+
+    The transformation is non-mutating — the caller's original payload
+    is never touched. Used by construction_run_executor to sanitise
+    every SSE event before it crosses the wire AND before it lands in
+    ``portfolio_construction_runs.event_log``.
+    """
+    if isinstance(raw, dict):
+        out: dict[str, Any] = {}
+        for k, v in raw.items():
+            public_key = humanize_metric(k) if isinstance(k, str) else k
+            out[public_key] = sanitize_payload(v)
+        return out
+    if isinstance(raw, list):
+        return [sanitize_payload(item) for item in raw]
+    if isinstance(raw, str):
+        return humanize_regime(raw)
+    return raw
+
 
 def _normalise_metric_key(raw: str) -> str:
     return raw.strip().lower().replace("-", "_").replace(" ", "_")

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -60,7 +60,12 @@ from typing import Any
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.jobs.tracker import publish_event, publish_terminal_event
+from app.core.jobs.tracker import (
+    clear_cancellation_flag,
+    is_cancellation_requested,
+    publish_event,
+    publish_terminal_event,
+)
 from app.domains.wealth.models.model_portfolio import (
     ModelPortfolio,
     PortfolioCalibration,
@@ -97,6 +102,20 @@ LOCK_ID: int = 900_101
 CONSTRUCTION_TIMEOUT_SECONDS: float = 120.0
 
 
+class RunCancelledError(Exception):
+    """Raised internally when a cooperative cancellation flag is observed.
+
+    Bubbles out of ``_execute_inner`` to the top-level exception handler
+    in ``execute_construction_run``, which marks the run as ``cancelled``
+    and emits the terminal event. Not part of the public surface — the
+    runner catches it before returning to the caller.
+    """
+
+    def __init__(self, phase: str) -> None:
+        super().__init__(f"construction cancelled at phase {phase}")
+        self.phase = phase
+
+
 # ── Helpers ────────────────────────────────────────────────────
 
 
@@ -127,6 +146,20 @@ def compute_cache_key(
 def _portfolio_lock_key(portfolio_id: uuid.UUID | str) -> int:
     """Derive a stable 32-bit lock partition key for a portfolio UUID."""
     return zlib.crc32(str(portfolio_id).encode("utf-8")) & 0x7FFFFFFF
+
+
+async def _check_cancellation(job_id: str | None, phase: str) -> None:
+    """Raise ``RunCancelledError`` if the cooperative cancel flag is set.
+
+    Called at phase boundaries inside ``_execute_inner``. When no
+    ``job_id`` is attached (synchronous caller path), cancellation is
+    unsupported and this is a no-op — only async/SSE runs can be
+    cancelled.
+    """
+    if not job_id:
+        return
+    if await is_cancellation_requested(job_id):
+        raise RunCancelledError(phase)
 
 
 async def _publish_event_sanitized(
@@ -586,6 +619,34 @@ async def execute_construction_run(
             extra={"run_id": str(run_id), "portfolio_id": str(portfolio_id)},
         )
         return run
+    except RunCancelledError as cancel_exc:
+        run.status = "cancelled"
+        run.failure_reason = f"cancelled at phase {cancel_exc.phase}"
+        run.completed_at = datetime.now(tz=timezone.utc)
+        run.wall_clock_ms = int((time.perf_counter() - start_ts) * 1000)
+        await db.flush()
+        await _publish_terminal_event_sanitized(
+            db,
+            run_id=run_id,
+            job_id=job_id,
+            raw_type="run_cancelled",
+            raw_payload={
+                "run_id": str(run_id),
+                "phase": cancel_exc.phase,
+                "reason": "cancellation_requested",
+            },
+        )
+        if job_id:
+            await clear_cancellation_flag(job_id)
+        logger.info(
+            "construction_run_cancelled",
+            extra={
+                "run_id": str(run_id),
+                "portfolio_id": str(portfolio_id),
+                "phase": cancel_exc.phase,
+            },
+        )
+        return run
     except Exception as exc:  # noqa: BLE001
         run.status = "failed"
         run.failure_reason = f"{type(exc).__name__}: {exc}"
@@ -661,6 +722,7 @@ async def _execute_inner(
     profile = portfolio.profile
     organization_id = portfolio.organization_id
 
+    await _check_cancellation(job_id, "pre_optimizer")
     await _publish_event_sanitized(
         db,
         run_id=run.id,
@@ -700,6 +762,7 @@ async def _execute_inner(
     factor_exposure = optimization.get("factor_exposures") or {}
 
     # ── 5. Stress suite (sequence: after optimizer, before advisor) ──
+    await _check_cancellation(job_id, "pre_stress")
     await _publish_event_sanitized(
         db,
         run_id=run.id,
@@ -736,6 +799,7 @@ async def _execute_inner(
     # ── 6. Advisor fold-in (Task 3.3) — only if enabled ──
     advisor_result: dict[str, Any] | None = None
     if calibration_snapshot.get("advisor_enabled"):
+        await _check_cancellation(job_id, "pre_advisor")
         await _publish_event_sanitized(
             db,
             run_id=run.id,
@@ -755,6 +819,7 @@ async def _execute_inner(
             advisor_result = {"error": f"{type(exc).__name__}: {exc}"}
 
     # ── 7. Validation gate (15 checks, no fail-fast) ──
+    await _check_cancellation(job_id, "pre_validation")
     await _publish_event_sanitized(
         db,
         run_id=run.id,
@@ -782,6 +847,7 @@ async def _execute_inner(
     validation_jsonb = to_jsonb(validation_result)
 
     # ── 8. Narrative templater (pure Jinja2, no LLM) ──
+    await _check_cancellation(job_id, "pre_narrative")
     await _publish_event_sanitized(
         db,
         run_id=run.id,

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -67,6 +67,10 @@ from app.domains.wealth.models.model_portfolio import (
     PortfolioConstructionRun,
     PortfolioStressResult,
 )
+from app.domains.wealth.schemas.sanitized import (
+    humanize_event_type,
+    sanitize_payload,
+)
 from vertical_engines.wealth.model_portfolio.narrative_templater import (
     render_narrative,
 )
@@ -123,6 +127,132 @@ def compute_cache_key(
 def _portfolio_lock_key(portfolio_id: uuid.UUID | str) -> int:
     """Derive a stable 32-bit lock partition key for a portfolio UUID."""
     return zlib.crc32(str(portfolio_id).encode("utf-8")) & 0x7FFFFFFF
+
+
+async def _publish_event_sanitized(
+    db: AsyncSession,
+    *,
+    run_id: uuid.UUID,
+    job_id: str | None,
+    raw_type: str,
+    raw_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Emit a sanitised SSE event AND append it to ``event_log``.
+
+    Two side effects:
+
+    1. Publishes to the Redis SSE channel (same bus as the raw
+       ``publish_event``) with the raw event type mapped to an
+       institutional label via ``EVENT_TYPE_LABELS`` and the payload
+       walked through ``sanitize_payload`` so jargon keys and regime
+       enums are translated at the wire boundary.
+    2. Appends a structured ``{seq, type, raw_type, ts, payload}``
+       entry to ``portfolio_construction_runs.event_log`` so late
+       subscribers (Phase 4 Builder analytics replay) can reconstruct
+       the run history from the column without needing access to the
+       live SSE stream.
+
+    Returns the sanitised event dict for unit-test inspection.
+    """
+    raw_payload = raw_payload or {}
+    public_type = humanize_event_type(raw_type)
+    public_payload = sanitize_payload(raw_payload)
+
+    event: dict[str, Any] = {
+        "type": public_type,
+        "raw_type": raw_type,
+        "ts": datetime.now(tz=timezone.utc).isoformat(),
+        "payload": public_payload,
+    }
+
+    # Side effect 1 — SSE bus (only when a job is attached)
+    if job_id:
+        await publish_event(job_id, public_type, public_payload)
+
+    # Side effect 2 — DB append to event_log, assigning the next seq
+    # atomically via jsonb_array_length so concurrent appends remain
+    # strictly ordered. The UPDATE uses the run's server-side array
+    # length + 1 so callers don't need to track a counter.
+    await db.execute(
+        text(
+            """
+            UPDATE portfolio_construction_runs
+            SET event_log = event_log || jsonb_build_array(
+                jsonb_build_object(
+                    'seq', COALESCE(jsonb_array_length(event_log), 0),
+                    'type', CAST(:public_type AS text),
+                    'raw_type', CAST(:raw_type AS text),
+                    'ts', CAST(:ts AS text),
+                    'payload', CAST(:payload AS jsonb)
+                )
+            )
+            WHERE id = :run_id
+            """,
+        ),
+        {
+            "run_id": run_id,
+            "public_type": public_type,
+            "raw_type": raw_type,
+            "ts": event["ts"],
+            "payload": json.dumps(public_payload),
+        },
+    )
+    return event
+
+
+async def _publish_terminal_event_sanitized(
+    db: AsyncSession,
+    *,
+    run_id: uuid.UUID,
+    job_id: str | None,
+    raw_type: str,
+    raw_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Terminal variant — same sanitisation, then clear the ownership key.
+
+    ``publish_terminal_event`` differs from ``publish_event`` only in
+    that it additionally schedules cleanup of the job ownership key,
+    so late-reconnecting clients can still pick up the final event.
+    """
+    raw_payload = raw_payload or {}
+    public_type = humanize_event_type(raw_type)
+    public_payload = sanitize_payload(raw_payload)
+
+    event: dict[str, Any] = {
+        "type": public_type,
+        "raw_type": raw_type,
+        "ts": datetime.now(tz=timezone.utc).isoformat(),
+        "payload": public_payload,
+    }
+
+    if job_id:
+        await publish_terminal_event(job_id, public_type, public_payload)
+
+    await db.execute(
+        text(
+            """
+            UPDATE portfolio_construction_runs
+            SET event_log = event_log || jsonb_build_array(
+                jsonb_build_object(
+                    'seq', COALESCE(jsonb_array_length(event_log), 0),
+                    'type', CAST(:public_type AS text),
+                    'raw_type', CAST(:raw_type AS text),
+                    'ts', CAST(:ts AS text),
+                    'payload', CAST(:payload AS jsonb)
+                )
+            )
+            WHERE id = :run_id
+            """,
+        ),
+        {
+            "run_id": run_id,
+            "public_type": public_type,
+            "raw_type": raw_type,
+            "ts": event["ts"],
+            "payload": json.dumps(public_payload),
+        },
+    )
+    return event
 
 
 async def _acquire_advisory_lock(
@@ -416,12 +546,13 @@ async def execute_construction_run(
 
     run_id = run.id
 
-    if job_id:
-        await publish_event(
-            job_id,
-            "run_started",
-            {"run_id": str(run_id), "portfolio_id": str(portfolio_id)},
-        )
+    await _publish_event_sanitized(
+        db,
+        run_id=run_id,
+        job_id=job_id,
+        raw_type="run_started",
+        raw_payload={"run_id": str(run_id), "portfolio_id": str(portfolio_id)},
+    )
 
     try:
         # ── 3. Wall-clock bound (DL18 P1) ──
@@ -443,11 +574,13 @@ async def execute_construction_run(
         run.completed_at = datetime.now(tz=timezone.utc)
         run.wall_clock_ms = int((time.perf_counter() - start_ts) * 1000)
         await db.flush()
-        if job_id:
-            await publish_terminal_event(
-                job_id, "error",
-                {"run_id": str(run_id), "reason": "timeout"},
-            )
+        await _publish_terminal_event_sanitized(
+            db,
+            run_id=run_id,
+            job_id=job_id,
+            raw_type="run_failed",
+            raw_payload={"run_id": str(run_id), "reason": "timeout"},
+        )
         logger.warning(
             "construction_run_timeout",
             extra={"run_id": str(run_id), "portfolio_id": str(portfolio_id)},
@@ -459,11 +592,13 @@ async def execute_construction_run(
         run.completed_at = datetime.now(tz=timezone.utc)
         run.wall_clock_ms = int((time.perf_counter() - start_ts) * 1000)
         await db.flush()
-        if job_id:
-            await publish_terminal_event(
-                job_id, "error",
-                {"run_id": str(run_id), "reason": str(exc)},
-            )
+        await _publish_terminal_event_sanitized(
+            db,
+            run_id=run_id,
+            job_id=job_id,
+            raw_type="run_failed",
+            raw_payload={"run_id": str(run_id), "reason": str(exc)},
+        )
         logger.exception(
             "construction_run_failed",
             extra={"run_id": str(run_id), "portfolio_id": str(portfolio_id)},
@@ -475,15 +610,17 @@ async def execute_construction_run(
     run.wall_clock_ms = int((time.perf_counter() - start_ts) * 1000)
     await db.flush()
 
-    if job_id:
-        await publish_terminal_event(
-            job_id, "done",
-            {
-                "run_id": str(run_id),
-                "status": "succeeded",
-                "wall_clock_ms": run.wall_clock_ms,
-            },
-        )
+    await _publish_terminal_event_sanitized(
+        db,
+        run_id=run_id,
+        job_id=job_id,
+        raw_type="run_succeeded",
+        raw_payload={
+            "run_id": str(run_id),
+            "status": "succeeded",
+            "wall_clock_ms": run.wall_clock_ms,
+        },
+    )
 
     logger.info(
         "construction_run_succeeded",
@@ -524,8 +661,13 @@ async def _execute_inner(
     profile = portfolio.profile
     organization_id = portfolio.organization_id
 
-    if job_id:
-        await publish_event(job_id, "optimizer_started", {"profile": profile})
+    await _publish_event_sanitized(
+        db,
+        run_id=run.id,
+        job_id=job_id,
+        raw_type="optimizer_started",
+        raw_payload={"profile": profile},
+    )
 
     # ── 4. Optimizer cascade ──
     base_result = await _run_construction_async(
@@ -558,8 +700,13 @@ async def _execute_inner(
     factor_exposure = optimization.get("factor_exposures") or {}
 
     # ── 5. Stress suite (sequence: after optimizer, before advisor) ──
-    if job_id:
-        await publish_event(job_id, "stress_started", {})
+    await _publish_event_sanitized(
+        db,
+        run_id=run.id,
+        job_id=job_id,
+        raw_type="stress_started",
+        raw_payload={},
+    )
     active_scenarios = list(calibration_snapshot.get("stress_scenarios_active") or [])
     severity = float(calibration_snapshot.get("stress_severity_multiplier") or 1.0)
     stress_results = _run_stress_suite(base_result, active_scenarios, severity)
@@ -589,8 +736,13 @@ async def _execute_inner(
     # ── 6. Advisor fold-in (Task 3.3) — only if enabled ──
     advisor_result: dict[str, Any] | None = None
     if calibration_snapshot.get("advisor_enabled"):
-        if job_id:
-            await publish_event(job_id, "advisor_started", {})
+        await _publish_event_sanitized(
+            db,
+            run_id=run.id,
+            job_id=job_id,
+            raw_type="advisor_started",
+            raw_payload={},
+        )
         try:
             advisor_result = await _build_advisor_result(
                 db, portfolio_id, profile, base_result,
@@ -603,8 +755,13 @@ async def _execute_inner(
             advisor_result = {"error": f"{type(exc).__name__}: {exc}"}
 
     # ── 7. Validation gate (15 checks, no fail-fast) ──
-    if job_id:
-        await publish_event(job_id, "validation_started", {})
+    await _publish_event_sanitized(
+        db,
+        run_id=run.id,
+        job_id=job_id,
+        raw_type="validation_started",
+        raw_payload={},
+    )
 
     # Build the JSONB-shaped payload the validation gate expects.
     validation_payload: dict[str, Any] = {
@@ -625,8 +782,13 @@ async def _execute_inner(
     validation_jsonb = to_jsonb(validation_result)
 
     # ── 8. Narrative templater (pure Jinja2, no LLM) ──
-    if job_id:
-        await publish_event(job_id, "narrative_started", {})
+    await _publish_event_sanitized(
+        db,
+        run_id=run.id,
+        job_id=job_id,
+        raw_type="narrative_started",
+        raw_payload={},
+    )
 
     narrative_payload: dict[str, Any] = {
         **validation_payload,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,10 +23,18 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from app.core.config.settings import settings
+from app.core.db.audit import write_audit_event
 from app.core.db.engine import engine
 from app.core.jobs.sse import create_job_stream
-from app.core.jobs.tracker import close_redis_pool, get_job_state, publish_event, verify_job_owner
+from app.core.jobs.tracker import (
+    close_redis_pool,
+    get_job_state,
+    publish_event,
+    request_cancellation,
+    verify_job_owner,
+)
 from app.core.security.clerk_auth import Actor, get_actor
+from app.core.tenancy.middleware import get_db_with_rls
 
 # ── Admin domain routers ─────────────────────────────────────
 from app.domains.admin.routes.assets import router as admin_assets_router
@@ -440,6 +448,65 @@ async def get_job_status(job_id: str, actor: Actor = Depends(get_actor)):
     if state is None:
         raise HTTPException(status_code=404, detail="Job state not available yet")
     return state
+
+
+# ── Cooperative cancellation endpoint ────────────────────────
+
+@api_v1.delete("/jobs/{job_id}", tags=["jobs"], status_code=202)
+async def cancel_job(
+    job_id: str,
+    actor: Actor = Depends(get_actor),
+    db=Depends(get_db_with_rls),
+) -> JSONResponse:
+    """Request cooperative cancellation of an in-flight job.
+
+    Sets a Redis flag (``job:cancel:{job_id}``) that long-running
+    workers poll at phase boundaries. The worker exits gracefully,
+    publishes a terminal ``run_cancelled`` event, and marks the
+    underlying entity (e.g. ``portfolio_construction_runs.status``)
+    as ``cancelled``.
+
+    This endpoint returns 202 Accepted immediately — it does NOT
+    wait for the worker to acknowledge. Clients should subscribe to
+    the job stream (``GET /jobs/{job_id}/stream``) to observe the
+    cancellation taking effect, or poll
+    ``GET /jobs/{job_id}/status`` for the terminal state.
+
+    Authorisation is enforced via :func:`verify_job_owner` so a
+    client can only cancel jobs in its own organisation. Returns
+    404 for any job that is either unknown or belongs to another
+    tenant — the two cases are deliberately collapsed.
+
+    Every cancel request is recorded as an audit event via
+    :func:`write_audit_event`.
+    """
+    if not await verify_job_owner(job_id, str(actor.organization_id)):
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    await request_cancellation(job_id)
+
+    await write_audit_event(
+        db,
+        actor_id=actor.actor_id,
+        actor_roles=[r.value for r in actor.roles],
+        action="job.cancel_requested",
+        entity_type="job",
+        entity_id=job_id,
+        before=None,
+        after={"cancellation_requested": True},
+    )
+
+    return JSONResponse(
+        status_code=202,
+        content={
+            "job_id": job_id,
+            "status": "cancellation_requested",
+            "message": (
+                "Cancellation requested. Subscribe to the job stream to "
+                "observe the worker exiting gracefully."
+            ),
+        },
+    )
 
 
 # ── SSE test endpoint (dev only) ─────────────────────────────

--- a/backend/tests/loadtest/results/.gitignore
+++ b/backend/tests/loadtest/results/.gitignore
@@ -1,0 +1,2 @@
+*.csv
+!.gitignore

--- a/backend/tests/loadtest/screener_elite.py
+++ b/backend/tests/loadtest/screener_elite.py
@@ -1,0 +1,468 @@
+"""Screener ELITE fast-path load test harness.
+
+Phase 2 Session C commit 6 — proves that the physical schema +
+partial index work from Sessions 2.A and 2.B delivers the Phase 3
+Screener hot path p95 < 300ms target.
+
+Approach
+--------
+* Fires ``CONCURRENCY`` asyncio coroutines against the local backend
+  for ``DURATION_SECONDS`` seconds, each repeatedly calling
+  ``GET /screener/catalog/elite`` with a rotating set of realistic
+  filter combinations.
+* Measures wall-clock latency client-side for every request.
+* Writes a CSV summary with p50/p95/p99/max per scenario and an
+  aggregated row across all scenarios.
+* Captures ``EXPLAIN (ANALYZE, BUFFERS)`` against the hot-path
+  query directly through psycopg, asserts the partial index is
+  named in the plan.
+
+The script is deliberately lightweight and uses only ``httpx`` +
+``asyncio`` + ``psycopg`` (already in the project's dependency
+tree) so it runs in any developer environment without pulling in
+Locust or k6.
+
+Exit codes
+----------
+* 0 — PASS: all scenarios stayed under the p95 threshold AND the
+  EXPLAIN plan referenced one of the expected partial indexes.
+* 1 — FAIL: at least one scenario exceeded the threshold, or the
+  partial index was not used.
+* 2 — infrastructure error (backend not reachable, CSV not written).
+
+Environment variables
+---------------------
+``NETZ_LOADTEST_BASE_URL``
+    Base URL for the backend. Default: ``http://127.0.0.1:8765``.
+``NETZ_LOADTEST_ORG_ID``
+    Organisation UUID to use for the dev-actor header. Default
+    falls back to the ``DEV_ORG_ID`` env var or a hard-coded
+    canary org.
+``NETZ_LOADTEST_P95_MS``
+    Threshold in milliseconds. Default: 300. NEVER raise this
+    without Andrei's approval — the threshold is a shipping gate,
+    not an aspiration (see session C plan §NOT VALID ESCAPE
+    HATCHES).
+``NETZ_LOADTEST_DURATION``
+    Seconds to run the concurrent phase. Default: 30.
+``NETZ_LOADTEST_CONCURRENCY``
+    Number of simultaneous async clients. Default: 20.
+``NETZ_LOADTEST_DB_URL``
+    Sync libpq URL for the EXPLAIN check. Default reads
+    ``DATABASE_URL_SYNC`` from the project ``.env``.
+``NETZ_LOADTEST_OUTPUT``
+    Path for the CSV output. Default:
+    ``backend/tests/loadtest/results/screener_elite_stats.csv``.
+"""
+from __future__ import annotations
+
+import asyncio
+import csv
+import json
+import os
+import statistics
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+@dataclass
+class Scenario:
+    """One probe scenario: a query-string payload + a friendly label."""
+
+    label: str
+    params: dict[str, Any]
+
+
+@dataclass
+class ScenarioStats:
+    """Latency samples + derived summary for one scenario."""
+
+    label: str
+    latencies_ms: list[float] = field(default_factory=list)
+    errors: int = 0
+
+    def summary(self) -> dict[str, Any]:
+        if not self.latencies_ms:
+            return {
+                "label": self.label,
+                "count": 0,
+                "errors": self.errors,
+                "p50_ms": 0.0,
+                "p95_ms": 0.0,
+                "p99_ms": 0.0,
+                "max_ms": 0.0,
+                "mean_ms": 0.0,
+            }
+        sorted_latencies = sorted(self.latencies_ms)
+        return {
+            "label": self.label,
+            "count": len(sorted_latencies),
+            "errors": self.errors,
+            "p50_ms": round(_percentile(sorted_latencies, 0.50), 3),
+            "p95_ms": round(_percentile(sorted_latencies, 0.95), 3),
+            "p99_ms": round(_percentile(sorted_latencies, 0.99), 3),
+            "max_ms": round(max(sorted_latencies), 3),
+            "mean_ms": round(statistics.fmean(sorted_latencies), 3),
+        }
+
+
+def _percentile(sorted_values: list[float], q: float) -> float:
+    """Linear-interpolation percentile — matches numpy ``default``."""
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    idx = q * (len(sorted_values) - 1)
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = idx - lo
+    return sorted_values[lo] * (1.0 - frac) + sorted_values[hi] * frac
+
+
+SCENARIOS: list[Scenario] = [
+    Scenario(
+        label="elite_all",
+        params={"limit": 50},
+    ),
+    Scenario(
+        label="elite_equity_fixed_income",
+        params={"asset_class": "equity,fixed_income", "limit": 50},
+    ),
+    Scenario(
+        label="elite_equity_only",
+        params={"asset_class": "equity", "limit": 100},
+    ),
+    Scenario(
+        label="elite_multi_class",
+        params={
+            "asset_class": "equity,fixed_income,alternatives",
+            "limit": 50,
+        },
+    ),
+]
+
+
+async def _probe_loop(
+    client: httpx.AsyncClient,
+    scenarios: list[Scenario],
+    stats_by_label: dict[str, ScenarioStats],
+    deadline_ts: float,
+) -> None:
+    """Single async worker — rotates through scenarios until deadline."""
+    idx = 0
+    while time.perf_counter() < deadline_ts:
+        scenario = scenarios[idx % len(scenarios)]
+        idx += 1
+        started = time.perf_counter()
+        try:
+            resp = await client.get(
+                "/api/v1/screener/catalog/elite",
+                params=scenario.params,
+                timeout=5.0,
+            )
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+            if resp.status_code == 200:
+                stats_by_label[scenario.label].latencies_ms.append(elapsed_ms)
+            else:
+                stats_by_label[scenario.label].errors += 1
+        except Exception:
+            stats_by_label[scenario.label].errors += 1
+
+
+async def _run_load_phase(
+    base_url: str,
+    dev_actor_header: str,
+    concurrency: int,
+    duration_s: int,
+) -> dict[str, ScenarioStats]:
+    """Fan out ``concurrency`` workers for ``duration_s`` seconds."""
+    stats_by_label: dict[str, ScenarioStats] = {
+        s.label: ScenarioStats(label=s.label) for s in SCENARIOS
+    }
+
+    headers = {"X-DEV-ACTOR": dev_actor_header}
+    async with httpx.AsyncClient(
+        base_url=base_url, headers=headers, timeout=5.0,
+    ) as client:
+        deadline_ts = time.perf_counter() + duration_s
+        workers = [
+            _probe_loop(client, SCENARIOS, stats_by_label, deadline_ts)
+            for _ in range(concurrency)
+        ]
+        await asyncio.gather(*workers)
+    return stats_by_label
+
+
+def _write_csv(stats_by_label: dict[str, ScenarioStats], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "label",
+                "count",
+                "errors",
+                "p50_ms",
+                "p95_ms",
+                "p99_ms",
+                "max_ms",
+                "mean_ms",
+            ],
+        )
+        writer.writeheader()
+        for stats in stats_by_label.values():
+            writer.writerow(stats.summary())
+
+        # Aggregated row across all scenarios — p95 calculated on the
+        # concatenated sample set so it's a true worst-case view, not
+        # a mean of p95s.
+        all_latencies: list[float] = []
+        total_errors = 0
+        for stats in stats_by_label.values():
+            all_latencies.extend(stats.latencies_ms)
+            total_errors += stats.errors
+        aggregated = ScenarioStats(
+            label="aggregated",
+            latencies_ms=all_latencies,
+            errors=total_errors,
+        )
+        writer.writerow(aggregated.summary())
+
+
+_EXPLAIN_SQL = """
+EXPLAIN (ANALYZE, BUFFERS)
+WITH elite_set AS MATERIALIZED (
+    SELECT
+        instrument_id,
+        sharpe_1y,
+        manager_score,
+        cvar_95_12m,
+        max_drawdown_1y,
+        elite_rank_within_strategy
+    FROM mv_fund_risk_latest
+    WHERE elite_flag = true
+)
+SELECT
+    es.instrument_id,
+    iu.name,
+    iu.ticker,
+    iu.asset_class,
+    es.sharpe_1y,
+    es.manager_score,
+    es.cvar_95_12m,
+    es.max_drawdown_1y,
+    es.elite_rank_within_strategy
+FROM elite_set es
+JOIN instruments_universe iu
+  ON iu.instrument_id = es.instrument_id
+WHERE iu.asset_class = ANY(ARRAY['equity','fixed_income'])
+ORDER BY es.sharpe_1y DESC NULLS LAST
+LIMIT 50
+"""
+
+
+_EXPECTED_INDEX_NAMES = (
+    "idx_mv_fund_risk_latest_elite",
+    "idx_fund_risk_metrics_elite_partial",
+)
+
+
+def _load_sync_db_url() -> str:
+    """Resolve the sync libpq URL for the EXPLAIN probe."""
+    env_url = os.environ.get("NETZ_LOADTEST_DB_URL")
+    if env_url:
+        return env_url
+    # Fall back to DATABASE_URL_SYNC read directly from .env so the
+    # script works when invoked by `make loadtest` without loading
+    # the project's full settings stack.
+    env_path = Path(__file__).resolve().parents[3] / ".env"
+    if env_path.exists():
+        for raw in env_path.read_text(encoding="utf-8").splitlines():
+            if raw.startswith("DATABASE_URL_SYNC="):
+                return raw.split("=", 1)[1].strip()
+    raise RuntimeError(
+        "Cannot resolve sync DB URL. Set NETZ_LOADTEST_DB_URL or "
+        "DATABASE_URL_SYNC in .env.",
+    )
+
+
+def _normalize_pg_url(url: str) -> str:
+    """Strip the SQLAlchemy ``+psycopg`` / ``+asyncpg`` driver suffix."""
+    return url.replace("postgresql+psycopg://", "postgresql://").replace(
+        "postgresql+asyncpg://", "postgresql://",
+    )
+
+
+def verify_index_usage(db_url: str) -> tuple[bool, str]:
+    """Run EXPLAIN (ANALYZE, BUFFERS) and assert the partial index is used.
+
+    Returns ``(ok, plan_text)``. ``ok`` is True when the plan text
+    contains at least one of ``_EXPECTED_INDEX_NAMES``.
+    """
+    try:
+        import psycopg
+    except ImportError:  # pragma: no cover
+        return False, "psycopg not available — cannot run EXPLAIN probe"
+
+    normalized = _normalize_pg_url(db_url)
+    with psycopg.connect(normalized) as conn:
+        with conn.cursor() as cur:
+            cur.execute(_EXPLAIN_SQL)
+            plan_lines = [row[0] for row in cur.fetchall()]
+    plan_text = "\n".join(plan_lines)
+    ok = any(name in plan_text for name in _EXPECTED_INDEX_NAMES)
+    return ok, plan_text
+
+
+def _resolve_dev_actor_header() -> str:
+    """Build the JSON header value consumed by ``_parse_dev_actor``."""
+    org_id = os.environ.get("NETZ_LOADTEST_ORG_ID") or os.environ.get("DEV_ORG_ID")
+    if not org_id:
+        # Dev default — same UUID used in the project .env, kept
+        # here as a last-resort fallback so `make loadtest` works
+        # even when .env is not loaded into the current shell.
+        env_path = Path(__file__).resolve().parents[3] / ".env"
+        if env_path.exists():
+            for raw in env_path.read_text(encoding="utf-8").splitlines():
+                if raw.startswith("DEV_ORG_ID="):
+                    org_id = raw.split("=", 1)[1].strip()
+                    break
+    if not org_id:
+        raise RuntimeError(
+            "Cannot resolve DEV_ORG_ID for the load test dev-actor header.",
+        )
+    return json.dumps(
+        {"actor_id": "loadtest@netz.internal", "roles": ["ADMIN"], "org_id": org_id},
+    )
+
+
+def main() -> int:
+    base_url = os.environ.get("NETZ_LOADTEST_BASE_URL", "http://127.0.0.1:8765")
+    threshold_ms = float(os.environ.get("NETZ_LOADTEST_P95_MS", "300"))
+    duration_s = int(os.environ.get("NETZ_LOADTEST_DURATION", "30"))
+    concurrency = int(os.environ.get("NETZ_LOADTEST_CONCURRENCY", "20"))
+    output_path = Path(
+        os.environ.get(
+            "NETZ_LOADTEST_OUTPUT",
+            str(
+                Path(__file__).resolve().parent
+                / "results"
+                / "screener_elite_stats.csv",
+            ),
+        ),
+    )
+
+    try:
+        dev_actor_header = _resolve_dev_actor_header()
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    # Sanity probe — make sure the backend is reachable before the
+    # concurrent phase. A single GET surfaces connection errors as
+    # exit 2 (infrastructure) instead of polluting the CSV with
+    # client-side failures.
+    try:
+        probe = httpx.get(
+            f"{base_url}/api/v1/screener/catalog/elite",
+            params={"limit": 1},
+            headers={"X-DEV-ACTOR": dev_actor_header},
+            timeout=5.0,
+        )
+        probe.raise_for_status()
+    except Exception as exc:
+        print(
+            f"ERROR: backend not reachable at {base_url} — {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        f"Starting load test — {concurrency} workers x {duration_s}s, "
+        f"p95 gate {threshold_ms}ms",
+    )
+    stats_by_label = asyncio.run(
+        _run_load_phase(base_url, dev_actor_header, concurrency, duration_s),
+    )
+    _write_csv(stats_by_label, output_path)
+
+    # Per-scenario and aggregated reporting
+    print("\n=== Scenario summaries ===")
+    max_p95 = 0.0
+    any_errors = False
+    for stats in stats_by_label.values():
+        summary = stats.summary()
+        print(
+            f"{summary['label']:<32} "
+            f"n={summary['count']:>6} "
+            f"err={summary['errors']:>3} "
+            f"p50={summary['p50_ms']:>8.2f} "
+            f"p95={summary['p95_ms']:>8.2f} "
+            f"p99={summary['p99_ms']:>8.2f} "
+            f"max={summary['max_ms']:>8.2f}",
+        )
+        max_p95 = max(max_p95, summary["p95_ms"])
+        any_errors = any_errors or summary["errors"] > 0
+
+    all_latencies: list[float] = []
+    for stats in stats_by_label.values():
+        all_latencies.extend(stats.latencies_ms)
+    aggregated = ScenarioStats(label="aggregated", latencies_ms=all_latencies)
+    agg_summary = aggregated.summary()
+    print(
+        f"\naggregated{' ' * 22}"
+        f"n={agg_summary['count']:>6} "
+        f"p50={agg_summary['p50_ms']:>8.2f} "
+        f"p95={agg_summary['p95_ms']:>8.2f} "
+        f"p99={agg_summary['p99_ms']:>8.2f} "
+        f"max={agg_summary['max_ms']:>8.2f}",
+    )
+
+    # EXPLAIN probe — prove the partial index is actually used.
+    try:
+        db_url = _load_sync_db_url()
+    except RuntimeError as exc:
+        print(f"\nERROR: {exc}", file=sys.stderr)
+        return 2
+    ok, plan_text = verify_index_usage(db_url)
+    print("\n=== EXPLAIN plan (hot-path query) ===")
+    print(plan_text)
+    if not ok:
+        print(
+            "\nFAIL: plan did not reference any of "
+            f"{_EXPECTED_INDEX_NAMES}",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"\nPASS: plan uses one of {_EXPECTED_INDEX_NAMES}",
+    )
+
+    # Final p95 gate
+    print(f"\nThreshold: {threshold_ms}ms")
+    print(f"Max p95 across scenarios: {max_p95:.2f}ms")
+    print(f"Aggregated p95: {agg_summary['p95_ms']:.2f}ms")
+    if max_p95 > threshold_ms or agg_summary["p95_ms"] > threshold_ms:
+        print(
+            f"\nFAIL: p95 exceeded {threshold_ms}ms — see CSV at {output_path}",
+            file=sys.stderr,
+        )
+        return 1
+    if any_errors:
+        print(
+            "\nFAIL: scenarios reported client-side errors — see CSV",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nPASS: all p95 gates green, partial index usage verified.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/wealth/schemas/test_risk_timeseries_sanitized.py
+++ b/backend/tests/wealth/schemas/test_risk_timeseries_sanitized.py
@@ -1,0 +1,81 @@
+"""Tests for the RiskTimeseriesOut sanitise retrofit.
+
+Phase 2 Session C commit 2 — audit §C.2 flagged this schema as
+leaking raw ``volatility_garch`` and regime enum strings to the wire.
+These tests lock in the sanitised shape.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from app.domains.wealth.schemas.risk_timeseries import RiskTimeseriesOut
+
+
+def _make_payload() -> RiskTimeseriesOut:
+    return RiskTimeseriesOut(
+        instrument_id="00000000-0000-0000-0000-000000000001",
+        ticker="SPY",
+        from_date=date(2024, 1, 1),
+        to_date=date(2024, 12, 31),
+        drawdown=[{"time": "2024-06-01", "value": -3.5}],
+        volatility_garch=[{"time": "2024-06-01", "value": 14.2}],
+        regime_prob=[
+            {"time": "2024-06-01", "value": 0.75, "regime": "RISK_ON"},
+            {"time": "2024-07-01", "value": 0.60, "regime": "RISK_OFF"},
+            {"time": "2024-08-01", "value": 0.10, "regime": "CRISIS"},
+        ],
+    )
+
+
+def test_volatility_garch_wire_key_is_conditional_volatility() -> None:
+    payload = _make_payload()
+    dumped = payload.model_dump(by_alias=True)
+    assert "conditional_volatility" in dumped
+    assert "volatility_garch" not in dumped
+    assert dumped["conditional_volatility"] == [
+        {"time": "2024-06-01", "value": 14.2},
+    ]
+
+
+def test_internal_field_still_accessible_as_volatility_garch() -> None:
+    """Python-side code (tests, routes) keeps using the stable name."""
+    payload = _make_payload()
+    assert payload.volatility_garch == [{"time": "2024-06-01", "value": 14.2}]
+
+
+def test_regime_prob_enums_translated_to_tri_state() -> None:
+    payload = _make_payload()
+    dumped = payload.model_dump(by_alias=True)
+    regimes = [p["regime"] for p in dumped["regime_prob"]]
+    assert regimes == ["Expansion", "Cautious", "Stress"]
+
+
+def test_model_dump_json_has_no_banned_jargon() -> None:
+    """Full-payload string grep — no raw jargon substrings may appear."""
+    payload = _make_payload()
+    json_str = payload.model_dump_json(by_alias=True)
+    banned = [
+        "volatility_garch",
+        "RISK_ON",
+        "RISK_OFF",
+        "CRISIS",
+        "EXPANSION",
+        "NEUTRAL",
+    ]
+    for token in banned:
+        assert token not in json_str, f"Banned jargon {token!r} leaked: {json_str}"
+
+
+def test_unknown_regime_passes_through_unchanged() -> None:
+    """New backend regime states must remain visible until labelled."""
+    payload = RiskTimeseriesOut(
+        instrument_id="00000000-0000-0000-0000-000000000001",
+        ticker=None,
+        from_date=date(2024, 1, 1),
+        to_date=date(2024, 12, 31),
+        drawdown=[],
+        volatility_garch=[],
+        regime_prob=[{"time": "2024-06-01", "value": 0.5, "regime": "STAGFLATION"}],
+    )
+    dumped = payload.model_dump(by_alias=True)
+    assert dumped["regime_prob"][0]["regime"] == "STAGFLATION"

--- a/backend/tests/wealth/test_construction_run_diff_schema.py
+++ b/backend/tests/wealth/test_construction_run_diff_schema.py
@@ -1,0 +1,106 @@
+"""Tests for the ConstructionRunDiffOut schema.
+
+Phase 2 Session C commit 4 — locks in the wire contract of the
+``/model-portfolios/{id}/construction/runs/{runId}/diff`` endpoint.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from app.domains.wealth.schemas.model_portfolio import (
+    ConstructionRunDiffOut,
+    ConstructionRunMetricDelta,
+    ConstructionRunWeightDelta,
+)
+
+
+def _build_diff(
+    metrics_delta_override: dict[str, ConstructionRunMetricDelta] | None = None,
+) -> ConstructionRunDiffOut:
+    return ConstructionRunDiffOut(
+        portfolio_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        run_id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+        previous_run_id=uuid.UUID("33333333-3333-3333-3333-333333333333"),
+        requested_at=datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc),
+        weight_delta={
+            "inst-a": ConstructionRunWeightDelta(
+                **{"from": 0.10, "to": 0.15, "delta": 0.05},
+            ),
+            "inst-b": ConstructionRunWeightDelta(
+                **{"from": 0.20, "to": 0.18, "delta": -0.02},
+            ),
+        },
+        metrics_delta=metrics_delta_override or {
+            "expected_return": ConstructionRunMetricDelta(
+                **{"from": 0.072, "to": 0.078, "delta": 0.006},
+            ),
+        },
+        status_delta_text="delta computed",
+    )
+
+
+def test_weight_delta_populate_by_name_and_alias() -> None:
+    """Schema accepts both ``from_weight``/``to_weight`` and ``from``/``to``."""
+    via_alias = ConstructionRunWeightDelta(**{"from": 0.1, "to": 0.2, "delta": 0.1})
+    via_name = ConstructionRunWeightDelta(from_weight=0.1, to_weight=0.2, delta=0.1)
+    assert via_alias.from_weight == via_name.from_weight == 0.1
+    assert via_alias.to_weight == via_name.to_weight == 0.2
+    # Wire format uses the short ``from``/``to`` keys
+    dumped = via_alias.model_dump(by_alias=True)
+    assert dumped == {"from": 0.1, "to": 0.2, "delta": 0.1}
+
+
+def test_metric_delta_accepts_none_for_non_numeric() -> None:
+    """Non-numeric metrics land with delta=None from the MV."""
+    delta = ConstructionRunMetricDelta(
+        **{"from": None, "to": None, "delta": None},
+    )
+    assert delta.delta is None
+
+
+def test_diff_out_sanitizes_metrics_delta_keys() -> None:
+    """Residual raw jargon keys get humanised by the post-init validator."""
+    # Simulate a regression where the MV still carries raw keys.
+    raw_keys = {
+        "cvar_95": ConstructionRunMetricDelta(
+            **{"from": 0.05, "to": 0.04, "delta": -0.01},
+        ),
+        "volatility_garch": ConstructionRunMetricDelta(
+            **{"from": 0.15, "to": 0.12, "delta": -0.03},
+        ),
+    }
+    diff = _build_diff(metrics_delta_override=raw_keys)
+
+    # The two raw keys should be gone — replaced by institutional labels.
+    assert "cvar_95" not in diff.metrics_delta
+    assert "volatility_garch" not in diff.metrics_delta
+    # Human labels contain the institutional phrasing
+    labels = list(diff.metrics_delta.keys())
+    assert any("Conditional Tail Risk" in k for k in labels)
+    assert any("Conditional Volatility" in k for k in labels)
+
+
+def test_diff_out_round_trip_via_model_dump_json() -> None:
+    diff = _build_diff()
+    payload = diff.model_dump(by_alias=True)
+    assert payload["status_delta_text"] == "delta computed"
+    assert "weight_delta" in payload
+    assert payload["weight_delta"]["inst-a"] == {"from": 0.10, "to": 0.15, "delta": 0.05}
+    # Known-clean keys survive the sanitisation pass unchanged
+    assert "expected_return" in payload["metrics_delta"]
+
+
+def test_diff_out_empty_weight_and_metrics() -> None:
+    diff = ConstructionRunDiffOut(
+        portfolio_id=uuid.uuid4(),
+        run_id=uuid.uuid4(),
+        previous_run_id=None,
+        requested_at=None,
+        weight_delta={},
+        metrics_delta={},
+        status_delta_text="initial run",
+    )
+    assert diff.weight_delta == {}
+    assert diff.metrics_delta == {}
+    assert diff.previous_run_id is None

--- a/backend/tests/wealth/test_dd_reports_queue_schema.py
+++ b/backend/tests/wealth/test_dd_reports_queue_schema.py
@@ -1,0 +1,88 @@
+"""Tests for the DDReportsQueueOut aggregator schema.
+
+Phase 2 Session C commit 5 — locks in the wire contract of the
+``GET /dd-reports/queue`` endpoint.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from app.domains.wealth.schemas.dd_report import (
+    DDReportQueueItem,
+    DDReportsQueueOut,
+)
+
+
+def _item(*, status: str, decision: str | None = None) -> DDReportQueueItem:
+    return DDReportQueueItem(
+        id=uuid.uuid4(),
+        instrument_id=uuid.uuid4(),
+        instrument_label=f"Fund {status}",
+        report_type="dd_report",
+        version=1,
+        status=status,
+        confidence_score=Decimal("0.82"),
+        decision_anchor=decision,
+        created_at=datetime(2026, 4, 11, 10, 0, 0, tzinfo=timezone.utc),
+        approved_at=None,
+        progress_pct=None,
+        current_chapter=None,
+    )
+
+
+def test_queue_out_round_trip_and_counts() -> None:
+    pending = [_item(status="draft")]
+    in_progress = [_item(status="generating"), _item(status="pending_approval")]
+    completed = [
+        _item(status="approved", decision="approve"),
+        _item(status="rejected", decision="reject"),
+        _item(status="failed"),
+    ]
+    queue = DDReportsQueueOut(
+        pending=pending,
+        in_progress=in_progress,
+        completed_recent=completed,
+        counts={
+            "pending": len(pending),
+            "in_progress": len(in_progress),
+            "completed_recent": len(completed),
+        },
+    )
+    payload = queue.model_dump()
+    assert payload["counts"]["pending"] == 1
+    assert payload["counts"]["in_progress"] == 2
+    assert payload["counts"]["completed_recent"] == 3
+    assert len(payload["pending"]) == 1
+    assert payload["in_progress"][0]["status"] == "generating"
+    assert payload["completed_recent"][2]["status"] == "failed"
+
+
+def test_queue_out_empty_state_has_counts_of_zero() -> None:
+    queue = DDReportsQueueOut(
+        pending=[],
+        in_progress=[],
+        completed_recent=[],
+        counts={"pending": 0, "in_progress": 0, "completed_recent": 0},
+    )
+    assert queue.counts == {"pending": 0, "in_progress": 0, "completed_recent": 0}
+    assert queue.pending == []
+
+
+def test_queue_item_allows_optional_fields() -> None:
+    item = DDReportQueueItem(
+        id=uuid.uuid4(),
+        instrument_id=uuid.uuid4(),
+        instrument_label=None,
+        report_type="dd_report",
+        version=2,
+        status="draft",
+        confidence_score=None,
+        decision_anchor=None,
+        created_at=datetime.now(tz=timezone.utc),
+        approved_at=None,
+    )
+    assert item.progress_pct is None
+    assert item.current_chapter is None
+    assert item.instrument_label is None

--- a/backend/tests/wealth/test_job_cancellation.py
+++ b/backend/tests/wealth/test_job_cancellation.py
@@ -1,0 +1,57 @@
+"""Tests for the Redis-backed cooperative cancellation primitives.
+
+Phase 2 Session C commit 3 — exercises the low-level tracker helpers
+(``request_cancellation``, ``is_cancellation_requested``,
+``clear_cancellation_flag``). The DELETE /jobs/{id} route is covered
+by integration tests once the full test harness stands up; here we
+lock in the primitives a worker depends on.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.core.jobs.tracker import (
+    clear_cancellation_flag,
+    is_cancellation_requested,
+    request_cancellation,
+)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_flag_round_trip() -> None:
+    job_id = f"test-cancel-{uuid.uuid4()}"
+    try:
+        assert await is_cancellation_requested(job_id) is False
+        await request_cancellation(job_id, ttl_seconds=60)
+        assert await is_cancellation_requested(job_id) is True
+    finally:
+        await clear_cancellation_flag(job_id)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_idempotent() -> None:
+    """Calling request_cancellation twice refreshes TTL — no error."""
+    job_id = f"test-cancel-idem-{uuid.uuid4()}"
+    try:
+        await request_cancellation(job_id, ttl_seconds=60)
+        await request_cancellation(job_id, ttl_seconds=60)
+        assert await is_cancellation_requested(job_id) is True
+    finally:
+        await clear_cancellation_flag(job_id)
+
+
+@pytest.mark.asyncio
+async def test_clear_cancellation_flag() -> None:
+    job_id = f"test-cancel-clear-{uuid.uuid4()}"
+    await request_cancellation(job_id, ttl_seconds=60)
+    assert await is_cancellation_requested(job_id) is True
+    await clear_cancellation_flag(job_id)
+    assert await is_cancellation_requested(job_id) is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_job_reports_not_cancelled() -> None:
+    job_id = f"test-cancel-missing-{uuid.uuid4()}"
+    assert await is_cancellation_requested(job_id) is False

--- a/backend/tests/wealth/test_sanitized_payload.py
+++ b/backend/tests/wealth/test_sanitized_payload.py
@@ -1,0 +1,103 @@
+"""Tests for the sanitise helpers in ``wealth.schemas.sanitized``.
+
+These exercise the pure functions used by the construction_run_executor
+sanitise retrofit (Phase 2 Session C commit 1) and by the
+``RiskTimeseriesOut`` retrofit (commit 2). No DB — pure input/output.
+"""
+from __future__ import annotations
+
+from app.domains.wealth.schemas.sanitized import (
+    EVENT_TYPE_LABELS,
+    METRIC_LABELS,
+    REGIME_LABELS,
+    humanize_event_type,
+    sanitize_payload,
+)
+
+
+def test_humanize_event_type_known_mapping() -> None:
+    assert humanize_event_type("optimizer_started") == "Optimizer started"
+    assert humanize_event_type("narrative_started") == "Narrative generation started"
+    assert humanize_event_type("run_failed") == "Construction failed"
+
+
+def test_humanize_event_type_unknown_passes_through() -> None:
+    assert humanize_event_type("some_new_event") == "some_new_event"
+
+
+def test_event_type_labels_covers_all_worker_emitted_types() -> None:
+    """The executor emits these raw types — every one must have a label."""
+    emitted = {
+        "run_started",
+        "run_succeeded",
+        "run_failed",
+        "run_cancelled",
+        "optimizer_started",
+        "stress_started",
+        "advisor_started",
+        "validation_started",
+        "narrative_started",
+    }
+    missing = emitted - EVENT_TYPE_LABELS.keys()
+    assert not missing, f"Missing labels for emitted event types: {missing}"
+
+
+def test_sanitize_payload_translates_metric_keys() -> None:
+    raw = {
+        "cvar_95": 0.042,
+        "volatility_garch": 0.18,
+        "max_drawdown": -0.22,
+        "unknown_key": 7,
+    }
+    out = sanitize_payload(raw)
+    assert out[METRIC_LABELS["cvar_95"]] == 0.042
+    assert out[METRIC_LABELS["volatility_garch"]] == 0.18
+    assert out[METRIC_LABELS["max_drawdown"]] == -0.22
+    assert out["unknown_key"] == 7
+
+
+def test_sanitize_payload_translates_regime_string_values() -> None:
+    raw = {"global_regime": "RISK_ON", "regional_regimes": {"US": "RISK_OFF"}}
+    out = sanitize_payload(raw)
+    assert out["global_regime"] == REGIME_LABELS["RISK_ON"] == "Expansion"
+    assert out["regional_regimes"]["US"] == REGIME_LABELS["RISK_OFF"] == "Cautious"
+
+
+def test_sanitize_payload_walks_nested_dicts_and_lists() -> None:
+    raw = {
+        "phase": "optimizer",
+        "results": [
+            {"cvar_95": 0.05, "regime": "CRISIS"},
+            {"cvar_95": 0.07, "regime": "EXPANSION"},
+        ],
+    }
+    out = sanitize_payload(raw)
+    assert out["phase"] == "optimizer"
+    # Both the key (regime → "Market Regime") AND the value (CRISIS → Stress)
+    # get translated in a single recursive walk.
+    regime_key = METRIC_LABELS["regime"]
+    cvar_key = METRIC_LABELS["cvar_95"]
+    assert out["results"][0][regime_key] == "Stress"
+    assert out["results"][0][cvar_key] == 0.05
+    assert out["results"][1][regime_key] == "Expansion"
+
+
+def test_sanitize_payload_is_non_mutating() -> None:
+    raw = {"cvar_95": 0.05, "global_regime": "RISK_ON"}
+    sanitize_payload(raw)
+    # Original keys still intact
+    assert "cvar_95" in raw
+    assert raw["global_regime"] == "RISK_ON"
+
+
+def test_sanitize_payload_primitives_pass_through() -> None:
+    assert sanitize_payload(42) == 42
+    assert sanitize_payload(3.14) == 3.14
+    assert sanitize_payload(None) is None
+    assert sanitize_payload(True) is True
+    assert sanitize_payload("arbitrary string") == "arbitrary string"
+
+
+def test_sanitize_payload_empty_container() -> None:
+    assert sanitize_payload({}) == {}
+    assert sanitize_payload([]) == []

--- a/frontends/wealth/src/lib/services/risk-engine-client.ts
+++ b/frontends/wealth/src/lib/services/risk-engine-client.ts
@@ -27,6 +27,8 @@ export interface RiskTimeseries {
 	instrumentId: string;
 	ticker: string | null;
 	drawdown: TVPoint[];
+	/** Institutional label for GARCH-filtered volatility. Client key
+	 * kept stable for chart callers; wire key is `conditional_volatility`. */
 	volatilityGarch: TVPoint[];
 	regimeProb: RegimeTVPoint[];
 }
@@ -37,7 +39,7 @@ interface RawPoint {
 }
 
 interface RawRegimePoint extends RawPoint {
-	regime: string;
+	regime: string; // sanitised label: Expansion / Cautious / Stress
 }
 
 interface RawResponse {
@@ -46,7 +48,9 @@ interface RawResponse {
 	from_date: string;
 	to_date: string;
 	drawdown: RawPoint[];
-	volatility_garch: RawPoint[];
+	// Backend emits `conditional_volatility` as of Phase 2 Session C
+	// commit 2 — the previous `volatility_garch` key is gone.
+	conditional_volatility: RawPoint[];
 	regime_prob: RawRegimePoint[];
 }
 
@@ -100,7 +104,7 @@ export async function fetchRiskTimeseries(
 		instrumentId: data.instrument_id,
 		ticker: data.ticker,
 		drawdown: mapPoints(data.drawdown),
-		volatilityGarch: mapPoints(data.volatility_garch),
+		volatilityGarch: mapPoints(data.conditional_volatility),
 		regimeProb: mapRegimePoints(data.regime_prob),
 	};
 }


### PR DESCRIPTION
## Summary

Phase 2 Session C closes the Terminal Unification Phase 2 Data Plane by shipping the public API surface + sanitisation retrofits + the shipping load-test gate.

Six atomic commits (plan: `docs/plans/2026-04-11-phase-2-session-c-api-surface.md`):

1. `refactor(wealth/workers): construction_run_executor retrofit through sanitized.py` — every SSE event + every row appended to `portfolio_construction_runs.event_log` is walked through `sanitize_payload()` and `EVENT_TYPE_LABELS`; jargon keys and regime enums are stripped at the source.
2. `refactor(wealth/schemas): RiskTimeseriesOut retrofit through sanitized.py` — `volatility_garch` keeps its internal Python name but emits `conditional_volatility` on the wire via `serialization_alias`; regime enums inside `regime_prob` are translated to Expansion / Cautious / Stress; frontend `risk-engine-client.ts` updated to consume the new wire key.
3. `feat(jobs): DELETE /jobs/{id} cancel endpoint with cooperative cancellation` — Redis `job:cancel:{id}` flag, cooperative polling at 5 phase boundaries inside `construction_run_executor`, graceful exit publishes a sanitised `run_cancelled` terminal event, migration 0120 extends the `portfolio_construction_runs.status` CHECK to include `cancelled`.
4. `feat(wealth/routes): GET /model-portfolios/{id}/construction/runs/{runId}/diff` — reads `mv_construction_run_diff`, returns `ConstructionRunDiffOut` with belt-and-suspenders jargon stripping via `@model_validator`.
5. `feat(wealth/routes): GET /dd-reports/queue aggregator` — three buckets (pending / in_progress / completed_recent), counts dict, RLS scoped.
6. `test(perf): make loadtest target with screener ELITE p95 gate` — new `/screener/catalog/elite` endpoint (MATERIALIZED CTE that forces partial-index usage), lightweight httpx+asyncio harness, `make loadtest` target, PASS output attached below.

## Load-test gate result (shipping requirement)

```
elite_all                  n=2051  p50=69.57  p95=82.79  p99=136.03
elite_equity_fixed_income  n=2042  p50=70.19  p95=83.35  p99=94.71
elite_equity_only          n=2038  p50=71.31  p95=83.85  p99=94.84
elite_multi_class          n=2037  p50=70.12  p95=83.53  p99=94.14
aggregated                 n=8168  p50=70.30  p95=83.52  p99=97.19

EXPLAIN plan:
Index Scan using idx_mv_fund_risk_latest_elite on mv_fund_risk_latest
   (rows=411 actual time=0.032..0.625)
Execution Time: 3.205 ms

PASS: all p95 gates green, partial index usage verified.
```

Max p95 across scenarios **83.85ms** — 3.6x below the 300ms threshold. Partial index `idx_mv_fund_risk_latest_elite` demonstrably chosen by the planner. Zero client-side errors across 8168 requests.

## Database

Migration `0120_portfolio_construction_runs_cancelled_status` — extends the status CHECK constraint to include `cancelled`. Atomic DROP+ADD inside one transaction. Downgrade rolls existing `cancelled` rows back to `failed` before tightening. Verified reversible (`alembic downgrade -1` → `alembic upgrade head` on local dev DB).

## Verification

- [x] `ruff check backend/` — clean
- [x] `lint-imports` — 31 contracts kept, 0 broken
- [x] New tests (26): all green (`test_sanitized_payload`, `test_risk_timeseries_sanitized`, `test_job_cancellation`, `test_construction_run_diff_schema`, `test_dd_reports_queue_schema`)
- [x] Full `backend/tests/wealth/` suite (49 tests): all green, no regressions against Session B artefacts
- [x] `mypy --strict` on touched files — zero new errors introduced by commit 1-6 (pre-existing baseline debt untouched per session mandate)
- [x] `alembic upgrade head` clean; `alembic downgrade -1` + `upgrade head` round-trip clean
- [x] `make loadtest` — **PASS** with p95 < 300ms and partial index usage verified

## Test plan

- [x] Sessions 2.A and 2.B confirmed merged before start
- [x] Commit 1: construction_run_executor events sanitised, event_log populated
- [x] Commit 2: RiskTimeseriesOut response body has zero banned jargon substrings
- [x] Commit 3: DELETE /jobs/{id} round-trip against local Redis; cooperative polling wired at 5 phase boundaries; `RunCancelledError` handled with `cancelled` status
- [x] Commit 4: diff endpoint reads mv_construction_run_diff with correct shape
- [x] Commit 5: dd queue aggregator returns three buckets with RLS
- [x] Commit 6: make loadtest PASS, partial-index usage verified in EXPLAIN plan

## Phase 2 Data Plane: **COMPLETE**

Phase 3 Screener Fast Path unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)