### PR TITLE
feat(providers): Tiingo instrument provider + factory swap (PR-A)

### DIFF
--- a/backend/app/services/providers/__init__.py
+++ b/backend/app/services/providers/__init__.py
@@ -1,18 +1,25 @@
 from app.services.providers.csv_import_adapter import CsvImportAdapter
 from app.services.providers.protocol import InstrumentDataProvider, RawInstrumentData
+from app.services.providers.tiingo_instrument_provider import TiingoInstrumentProvider
 from app.services.providers.yahoo_finance_provider import YahooFinanceProvider
 
 __all__ = [
     "CsvImportAdapter",
     "InstrumentDataProvider",
     "RawInstrumentData",
+    "TiingoInstrumentProvider",
     "YahooFinanceProvider",
     "get_instrument_provider",
 ]
 
 
 def get_instrument_provider() -> InstrumentDataProvider:
-    """Factory — returns FEFundInfo when enabled, Yahoo otherwise."""
+    """Factory — returns FEFundInfo when enabled, Tiingo otherwise.
+
+    Tiingo is the production default for NAV ingestion across the global
+    catalog (~5.5k instruments). Yahoo Finance is retained only as a
+    legacy import symbol until PR-C removes the module entirely.
+    """
     from app.core.config.settings import settings
 
     if settings.feature_fefundinfo_enabled:
@@ -32,4 +39,4 @@ def get_instrument_provider() -> InstrumentDataProvider:
             subscription_key=settings.fefundinfo_subscription_key,
         )
         return FEFundInfoProvider(client)
-    return YahooFinanceProvider()
+    return TiingoInstrumentProvider()

--- a/backend/app/services/providers/tiingo_instrument_provider.py
+++ b/backend/app/services/providers/tiingo_instrument_provider.py
@@ -1,0 +1,319 @@
+"""Tiingo instrument data provider — synchronous, worker-facing.
+
+Implements ``InstrumentDataProvider`` for Netz background workers that
+ingest end-of-day NAV history into ``nav_timeseries`` and ``benchmark_nav``.
+
+Design notes
+------------
+- **Synchronous on purpose.** The NAV ingestion worker dispatches provider
+  calls through a ``ThreadPoolExecutor``, so the public surface must be
+  ordinary blocking methods. Mixing an async client here would force
+  ``asyncio.run()`` inside worker threads — a known reentrancy trap.
+- **Bounded fan-out.** Tiingo Premium has no hard REST rate limit, but the
+  local httpx connection pool and open file descriptors still cap throughput.
+  A per-call ``ThreadPoolExecutor(max_workers=BATCH_CONCURRENCY)`` bounds
+  concurrent HTTP requests to a single value tuned for a ~5k ticker universe.
+- **Metadata parity with yfinance is intentionally partial.** Production
+  workers only call ``fetch_batch_history``; ``fetch_instrument`` / ``fetch_batch``
+  exist for Protocol conformance and return a minimal ``RawInstrumentData``
+  from Tiingo's ``/tiingo/daily/{ticker}`` meta endpoint. Fund-level attributes
+  (AUM, expense ratio, category) are authoritative in SEC N-CEN + XBRL and
+  ESMA ingestion — this provider does not attempt to duplicate them.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.core.config.settings import settings
+from app.services.providers.protocol import RawInstrumentData
+
+logger = logging.getLogger(__name__)
+
+TIINGO_BASE_URL = "https://api.tiingo.com"
+DEFAULT_TIMEOUT = 30.0
+BATCH_CONCURRENCY = 50
+
+# yfinance period literals → calendar-day lookbacks. Preserves the
+# ``instrument_ingestion`` worker contract so migrating workers is a
+# single-line factory swap instead of rewiring the period vocabulary.
+_PERIOD_TO_DAYS: dict[str, int] = {
+    "1mo": 30,
+    "3mo": 90,
+    "6mo": 180,
+    "1y": 365,
+    "2y": 730,
+    "3y": 1095,
+    "5y": 1825,
+    "10y": 3650,
+    "ytd": 366,  # Upper bound; Tiingo honors startDate precisely.
+}
+
+# Tiingo's daily history begins 1962-01-02 for the longest-lived tickers.
+# Any earlier date is silently clamped server-side.
+_MAX_LOOKBACK_START = date(1970, 1, 1)
+
+
+class TiingoInstrumentProvider:
+    """Synchronous InstrumentDataProvider backed by the Tiingo REST API."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        batch_concurrency: int = BATCH_CONCURRENCY,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self._api_key = api_key or settings.tiingo_api_key
+        self._timeout = timeout
+        self._batch_concurrency = max(1, batch_concurrency)
+        self._client = http_client or httpx.Client(
+            timeout=self._timeout,
+            limits=httpx.Limits(
+                max_keepalive_connections=batch_concurrency,
+                max_connections=batch_concurrency * 2,
+            ),
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._api_key)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> TiingoInstrumentProvider:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "Authorization": f"Token {self._api_key}",
+        }
+
+    # ── InstrumentDataProvider Protocol ────────────────────────────────
+
+    def fetch_instrument(self, ticker: str) -> RawInstrumentData | None:
+        """Fetch minimal metadata for a single ticker.
+
+        Returns ``None`` on 401/404 or empty response. Production workers
+        do not call this method — it exists for Protocol conformance and
+        one-shot scripts.
+        """
+        if not self.enabled:
+            return None
+
+        ticker_clean = ticker.strip().lower()
+        if not ticker_clean:
+            return None
+
+        try:
+            resp = self._client.get(
+                f"{TIINGO_BASE_URL}/tiingo/daily/{ticker_clean}",
+                headers=self._headers(),
+            )
+            if resp.status_code in (401, 404):
+                return None
+            if resp.status_code != 200:
+                logger.warning(
+                    "tiingo_meta_non_200 ticker=%s status=%s",
+                    ticker_clean, resp.status_code,
+                )
+                return None
+            payload = resp.json()
+        except httpx.HTTPError as exc:
+            logger.warning("tiingo_meta_http_error ticker=%s error=%s", ticker_clean, exc)
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+
+        name = (payload.get("name") or payload.get("ticker") or ticker).strip()
+        exchange = payload.get("exchangeCode") or ""
+
+        return RawInstrumentData(
+            ticker=ticker.strip().upper(),
+            isin=None,
+            name=name or ticker,
+            instrument_type="fund",
+            asset_class="equity",
+            geography="US" if exchange.upper() in {"NYSE", "NASDAQ", "AMEX", "BATS"} else "unknown",
+            currency="USD",
+            source="tiingo",
+            raw_attributes={
+                "exchange": exchange,
+                "description": payload.get("description") or "",
+                "start_date": payload.get("startDate") or "",
+                "end_date": payload.get("endDate") or "",
+            },
+        )
+
+    def fetch_batch(self, tickers: list[str]) -> list[RawInstrumentData]:
+        """Fetch metadata for many tickers. Fans out through the thread pool."""
+        if not self.enabled or not tickers:
+            return []
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self._batch_concurrency,
+            thread_name_prefix="tiingo-meta",
+        ) as pool:
+            results = list(pool.map(self.fetch_instrument, tickers))
+
+        return [r for r in results if r is not None]
+
+    def fetch_batch_history(
+        self,
+        tickers: list[str],
+        period: str = "3y",
+    ) -> dict[str, pd.DataFrame]:
+        """Fetch EOD history for many tickers and return yfinance-shaped DataFrames.
+
+        The NAV ingestion worker consumes this as ``dict[ticker, DataFrame]``
+        where each DataFrame has a ``Close`` column and a ``DatetimeIndex``.
+        """
+        if not self.enabled or not tickers:
+            return {}
+
+        start_date, end_date = self._resolve_window(period)
+
+        unique_tickers = sorted({t.strip().upper() for t in tickers if t and t.strip()})
+        if not unique_tickers:
+            return {}
+
+        def _fetch_one(ticker: str) -> tuple[str, pd.DataFrame | None]:
+            bars = self._fetch_single_history(ticker, start_date, end_date)
+            if not bars:
+                return ticker, None
+            df = self._bars_to_dataframe(bars)
+            if df.empty:
+                return ticker, None
+            return ticker, df
+
+        result: dict[str, pd.DataFrame] = {}
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self._batch_concurrency,
+            thread_name_prefix="tiingo-history",
+        ) as pool:
+            for ticker, df in pool.map(_fetch_one, unique_tickers):
+                if df is not None:
+                    result[ticker] = df
+
+        return result
+
+    # ── Internals ──────────────────────────────────────────────────────
+
+    def _fetch_single_history(
+        self,
+        ticker: str,
+        start_date: date,
+        end_date: date,
+    ) -> list[dict[str, Any]]:
+        ticker_clean = ticker.strip().lower()
+        if not ticker_clean:
+            return []
+
+        params: dict[str, str] = {
+            "format": "json",
+            "resampleFreq": "daily",
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+        }
+
+        try:
+            resp = self._client.get(
+                f"{TIINGO_BASE_URL}/tiingo/daily/{ticker_clean}/prices",
+                headers=self._headers(),
+                params=params,
+            )
+            if resp.status_code in (401, 404):
+                return []
+            if resp.status_code != 200:
+                logger.warning(
+                    "tiingo_daily_non_200 ticker=%s status=%s",
+                    ticker_clean, resp.status_code,
+                )
+                return []
+            payload = resp.json()
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "tiingo_daily_http_error ticker=%s error=%s",
+                ticker_clean, exc,
+            )
+            return []
+
+        if not isinstance(payload, list):
+            return []
+        return payload
+
+    @staticmethod
+    def _bars_to_dataframe(bars: list[dict[str, Any]]) -> pd.DataFrame:
+        """Project Tiingo bar dicts onto a yfinance-compatible DataFrame.
+
+        Tiingo daily returns both raw and ``adj*`` columns. We prefer adjusted
+        OHLCV because the risk engine computes log returns downstream and
+        dividends/splits would otherwise create spurious jumps.
+        """
+        rows: list[dict[str, Any]] = []
+        for item in bars:
+            ts_raw = item.get("date") or ""
+            try:
+                ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+            except (ValueError, AttributeError):
+                continue
+
+            close = _first_float(item, "adjClose", "close")
+            if close is None:
+                continue
+
+            rows.append({
+                "date": ts,
+                "Open": _first_float(item, "adjOpen", "open"),
+                "High": _first_float(item, "adjHigh", "high"),
+                "Low": _first_float(item, "adjLow", "low"),
+                "Close": close,
+                "Volume": _first_float(item, "adjVolume", "volume") or 0.0,
+            })
+
+        if not rows:
+            return pd.DataFrame()
+
+        df = pd.DataFrame(rows)
+        df = df.set_index("date").sort_index()
+        df.index = pd.to_datetime(df.index).tz_convert("UTC")
+        return df
+
+    @staticmethod
+    def _resolve_window(period: str) -> tuple[date, date]:
+        """Translate a yfinance-style period string into (start, end) dates."""
+        today = date.today()
+        if period == "max":
+            return _MAX_LOOKBACK_START, today
+        days = _PERIOD_TO_DAYS.get(period)
+        if days is None:
+            logger.warning("tiingo_unknown_period period=%s fallback=3y", period)
+            days = _PERIOD_TO_DAYS["3y"]
+        start = today - timedelta(days=days)
+        return max(start, _MAX_LOOKBACK_START), today
+
+
+def _first_float(item: dict[str, Any], *keys: str) -> float | None:
+    for k in keys:
+        v = item.get(k)
+        if v is None:
+            continue
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            continue
+    return None

--- a/backend/app/services/providers/tiingo_provider.py
+++ b/backend/app/services/providers/tiingo_provider.py
@@ -18,6 +18,7 @@ Both endpoints are bounded by the institutional plan rate limit (10k req/h).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import date, datetime, timezone
 from typing import Any
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 TIINGO_BASE_URL = "https://api.tiingo.com"
 DEFAULT_TIMEOUT = 10.0
+BATCH_CONCURRENCY = 100
 
 
 class TiingoProvider:
@@ -41,10 +43,15 @@ class TiingoProvider:
     auth failures).
     """
 
-    def __init__(self, api_key: str | None = None, timeout: float = DEFAULT_TIMEOUT) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
         self._api_key = api_key or settings.tiingo_api_key
         self._timeout = timeout
-        self._client = httpx.AsyncClient(
+        self._client = http_client or httpx.AsyncClient(
             timeout=self._timeout,
             limits=httpx.Limits(max_keepalive_connections=20, max_connections=100)
         )
@@ -193,6 +200,49 @@ class TiingoProvider:
             return []
 
         return [self._normalize_bar(item) for item in payload]
+
+    async def fetch_historical_daily_batch(
+        self,
+        tickers: list[str],
+        start_date: date | None = None,
+        end_date: date | None = None,
+        concurrency: int = BATCH_CONCURRENCY,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Fetch EOD history for many tickers in parallel.
+
+        Tiingo Premium has no hard rate limit, but unbounded fan-out still
+        exhausts local sockets and httpx keepalive pools. A Semaphore bounds
+        concurrent in-flight requests. Each call goes through
+        ``fetch_historical_daily``, so 401/404 still degrade to empty list
+        per ticker instead of raising.
+
+        Returns a dict mapping ticker (upper-case) -> normalized bar list.
+        Tickers with no data are omitted — callers must handle missing keys.
+        """
+        if not tickers:
+            return {}
+
+        sem = asyncio.Semaphore(max(1, concurrency))
+
+        async def _one(ticker: str) -> tuple[str, list[dict[str, Any]]]:
+            async with sem:
+                bars = await self.fetch_historical_daily(ticker, start_date, end_date)
+                return ticker.strip().upper(), bars
+
+        results = await asyncio.gather(
+            *(_one(t) for t in tickers if t and t.strip()),
+            return_exceptions=True,
+        )
+
+        out: dict[str, list[dict[str, Any]]] = {}
+        for item in results:
+            if isinstance(item, BaseException):
+                logger.warning("tiingo_batch_task_failed error=%s", item)
+                continue
+            ticker_key, bars = item
+            if bars:
+                out[ticker_key] = bars
+        return out
 
     async def fetch_historical_intraday(
         self,

--- a/backend/tests/test_fefundinfo_provider.py
+++ b/backend/tests/test_fefundinfo_provider.py
@@ -503,15 +503,18 @@ class TestAssetClassInference:
 
 
 class TestProviderFactory:
-    def test_returns_yahoo_when_disabled(self) -> None:
+    def test_returns_tiingo_when_fefundinfo_disabled(self) -> None:
         from app.services.providers import get_instrument_provider
-        from app.services.providers.yahoo_finance_provider import YahooFinanceProvider
+        from app.services.providers.tiingo_instrument_provider import (
+            TiingoInstrumentProvider,
+        )
 
         with patch("app.core.config.settings.settings") as mock_settings:
             mock_settings.feature_fefundinfo_enabled = False
+            mock_settings.tiingo_api_key = "test-key"
             provider = get_instrument_provider()
 
-        assert isinstance(provider, YahooFinanceProvider)
+        assert isinstance(provider, TiingoInstrumentProvider)
 
     def test_returns_fefundinfo_when_enabled(self) -> None:
         from app.services.providers import get_instrument_provider

--- a/backend/tests/test_tiingo_provider_layer.py
+++ b/backend/tests/test_tiingo_provider_layer.py
@@ -1,0 +1,351 @@
+"""Tiingo provider layer — PR-A unit tests.
+
+Covers:
+- ``TiingoProvider.fetch_historical_daily_batch`` (async, Semaphore-bounded)
+- ``TiingoInstrumentProvider`` sync implementation of ``InstrumentDataProvider``
+- yfinance-style period translation
+- Graceful degradation on 401/404
+- Protocol conformance (duck-typed)
+
+All HTTP is mocked via ``httpx.MockTransport`` — no real Tiingo calls.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+import httpx
+import pandas as pd
+import pytest
+
+from app.services.providers import get_instrument_provider
+from app.services.providers.protocol import (
+    InstrumentDataProvider,
+    RawInstrumentData,
+)
+from app.services.providers.tiingo_instrument_provider import (
+    _MAX_LOOKBACK_START,
+    _PERIOD_TO_DAYS,
+    TiingoInstrumentProvider,
+)
+from app.services.providers.tiingo_provider import TiingoProvider
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+
+def _bar(day: date, close: float) -> dict[str, Any]:
+    """Minimal Tiingo /tiingo/daily/{ticker}/prices bar."""
+    return {
+        "date": f"{day.isoformat()}T00:00:00.000Z",
+        "open": close,
+        "high": close,
+        "low": close,
+        "close": close,
+        "volume": 1000.0,
+        "adjOpen": close,
+        "adjHigh": close,
+        "adjLow": close,
+        "adjClose": close,
+        "adjVolume": 1000.0,
+    }
+
+
+def _bars(n: int, start_close: float = 100.0) -> list[dict[str, Any]]:
+    today = date(2026, 4, 10)
+    return [_bar(today - timedelta(days=n - i), start_close + i) for i in range(n)]
+
+
+# ── TiingoProvider.fetch_historical_daily_batch (async) ─────────────────
+
+
+class TestAsyncBatchHistory:
+    @pytest.mark.asyncio
+    async def test_happy_path_three_tickers(self) -> None:
+        """Three tickers, all return bars — result contains all three."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            ticker = request.url.path.rsplit("/", 2)[-2]  # .../daily/{ticker}/prices
+            return httpx.Response(200, json=_bars(5))
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        provider = TiingoProvider(api_key="test-key", http_client=client)
+
+        result = await provider.fetch_historical_daily_batch(
+            ["AAPL", "MSFT", "NVDA"],
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 4, 10),
+        )
+
+        assert set(result.keys()) == {"AAPL", "MSFT", "NVDA"}
+        assert len(result["AAPL"]) == 5
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_partial_404_silently_dropped(self) -> None:
+        """One ticker 404s — it is omitted, others still returned."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            ticker = request.url.path.rsplit("/", 2)[-2]
+            if ticker == "badtick":
+                return httpx.Response(404)
+            return httpx.Response(200, json=_bars(3))
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        provider = TiingoProvider(api_key="test-key", http_client=client)
+
+        result = await provider.fetch_historical_daily_batch(
+            ["AAPL", "BADTICK", "MSFT"],
+        )
+
+        assert set(result.keys()) == {"AAPL", "MSFT"}
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_returns_empty(self) -> None:
+        """Global 401 — every ticker degrades to empty list, dict stays empty."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        provider = TiingoProvider(api_key="test-key", http_client=client)
+
+        result = await provider.fetch_historical_daily_batch(["AAPL", "MSFT"])
+
+        assert result == {}
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_empty_tickers_no_http(self) -> None:
+        """Empty list — no HTTP requests issued."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json=[])
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        provider = TiingoProvider(api_key="test-key", http_client=client)
+
+        result = await provider.fetch_historical_daily_batch([])
+
+        assert result == {}
+        assert call_count == 0
+        await client.aclose()
+
+
+# ── TiingoInstrumentProvider.fetch_batch_history (sync) ─────────────────
+
+
+class TestSyncBatchHistory:
+    def test_returns_dataframes_with_close_column(self) -> None:
+        """Worker contract: dict[ticker, DataFrame with Close column + DatetimeIndex]."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_bars(10))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        provider = TiingoInstrumentProvider(api_key="test-key", http_client=client)
+
+        result = provider.fetch_batch_history(["AAPL", "MSFT"], period="1y")
+
+        assert set(result.keys()) == {"AAPL", "MSFT"}
+        for df in result.values():
+            assert isinstance(df, pd.DataFrame)
+            assert "Close" in df.columns
+            assert isinstance(df.index, pd.DatetimeIndex)
+            assert len(df) == 10
+        provider.close()
+
+    def test_period_translation_uses_startdate_param(self) -> None:
+        """period='1y' → startDate ≈ today - 365 days, not yfinance 'period' literal."""
+        captured_params: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_params.append(dict(request.url.params))
+            return httpx.Response(200, json=_bars(3))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        provider = TiingoInstrumentProvider(api_key="test-key", http_client=client)
+
+        provider.fetch_batch_history(["AAPL"], period="1y")
+
+        assert len(captured_params) == 1
+        params = captured_params[0]
+        assert "startDate" in params
+        assert "endDate" in params
+        start = date.fromisoformat(params["startDate"])
+        end = date.fromisoformat(params["endDate"])
+        # 1y ≈ 365 days back, with small tolerance for clock skew across midnight.
+        assert (end - start).days == _PERIOD_TO_DAYS["1y"]
+        provider.close()
+
+    def test_period_max_clamps_to_1970(self) -> None:
+        """period='max' → startDate = 1970-01-01 (the provider floor)."""
+        captured_params: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_params.append(dict(request.url.params))
+            return httpx.Response(200, json=_bars(3))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        provider = TiingoInstrumentProvider(api_key="test-key", http_client=client)
+
+        provider.fetch_batch_history(["AAPL"], period="max")
+
+        start = date.fromisoformat(captured_params[0]["startDate"])
+        assert start == _MAX_LOOKBACK_START
+        provider.close()
+
+    def test_unknown_period_falls_back_to_3y(self) -> None:
+        """Unknown period string degrades to 3y instead of raising."""
+        captured_params: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_params.append(dict(request.url.params))
+            return httpx.Response(200, json=_bars(3))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        provider = TiingoInstrumentProvider(api_key="test-key", http_client=client)
+
+        provider.fetch_batch_history(["AAPL"], period="banana")
+
+        start = date.fromisoformat(captured_params[0]["startDate"])
+        end = date.fromisoformat(captured_params[0]["endDate"])
+        assert (end - start).days == _PERIOD_TO_DAYS["3y"]
+        provider.close()
+
+    def test_missing_close_rows_dropped(self) -> None:
+        """Bars without ``close``/``adjClose`` are filtered out of the DataFrame."""
+        payload = _bars(5)
+        payload[2]["close"] = None
+        payload[2]["adjClose"] = None
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=payload)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        provider = TiingoInstrumentProvider(api_key="test-key", http_client=client)
+
+        result = provider.fetch_batch_history(["AAPL"])
+        assert len(result["AAPL"]) == 4
+        provider.close()
+
+    def test_empty_tickers_returns_empty_dict(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[])
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        provider = TiingoInstrumentProvider(api_key="test-key", http_client=client)
+
+        assert provider.fetch_batch_history([]) == {}
+        assert provider.fetch_batch_history(["", "  "]) == {}
+        provider.close()
+
+    def test_deduplicates_tickers_case_insensitive(self) -> None:
+        """AAPL, aapl, AAPL → one HTTP call."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json=_bars(3))
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        provider = TiingoInstrumentProvider(api_key="test-key", http_client=client)
+
+        provider.fetch_batch_history(["AAPL", "aapl", "AAPL"])
+        assert call_count == 1
+        provider.close()
+
+
+# ── TiingoInstrumentProvider.fetch_instrument / fetch_batch ─────────────
+
+
+class TestSyncMetadata:
+    def test_fetch_instrument_happy_path(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "ticker": "AAPL",
+                    "name": "Apple Inc",
+                    "exchangeCode": "NASDAQ",
+                    "description": "Tech",
+                    "startDate": "1980-12-12",
+                    "endDate": "2026-04-10",
+                },
+            )
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        provider = TiingoInstrumentProvider(api_key="test-key", http_client=client)
+
+        result = provider.fetch_instrument("AAPL")
+
+        assert isinstance(result, RawInstrumentData)
+        assert result.ticker == "AAPL"
+        assert result.name == "Apple Inc"
+        assert result.source == "tiingo"
+        assert result.geography == "US"
+        assert result.raw_attributes["exchange"] == "NASDAQ"
+        provider.close()
+
+    def test_fetch_instrument_404_returns_none(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        provider = TiingoInstrumentProvider(api_key="test-key", http_client=client)
+
+        assert provider.fetch_instrument("NOPE") is None
+        provider.close()
+
+    def test_fetch_batch_filters_failures(self) -> None:
+        """fetch_batch returns only tickers that successfully resolve."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            ticker = request.url.path.rsplit("/", 1)[-1]
+            if ticker == "bad":
+                return httpx.Response(404)
+            return httpx.Response(
+                200,
+                json={"ticker": ticker.upper(), "name": f"Fund {ticker.upper()}"},
+            )
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        provider = TiingoInstrumentProvider(api_key="test-key", http_client=client)
+
+        result = provider.fetch_batch(["AAPL", "BAD", "MSFT"])
+        assert len(result) == 2
+        assert {r.ticker for r in result} == {"AAPL", "MSFT"}
+        provider.close()
+
+
+# ── Protocol conformance + factory wiring ──────────────────────────────
+
+
+class TestFactoryWiring:
+    def test_factory_returns_tiingo_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With FEFundInfo feature flag off, factory returns Tiingo, not Yahoo."""
+        from app.core.config.settings import settings
+
+        monkeypatch.setattr(settings, "feature_fefundinfo_enabled", False, raising=False)
+        provider = get_instrument_provider()
+        assert isinstance(provider, TiingoInstrumentProvider)
+
+    def test_tiingo_provider_satisfies_protocol(self) -> None:
+        """Duck-typed conformance check — required so workers can swap providers."""
+        provider = TiingoInstrumentProvider(api_key="test-key")
+        try:
+            assert isinstance(provider, InstrumentDataProvider)
+        finally:
+            provider.close()
+
+    def test_context_manager_closes_client(self) -> None:
+        """``with`` block releases the httpx.Client."""
+        with TiingoInstrumentProvider(api_key="test-key") as provider:
+            assert provider.enabled
+        # No assertion on internal state — close() is idempotent, further
+        # HTTP calls would raise on a closed client.


### PR DESCRIPTION
## Summary

- Add `TiingoInstrumentProvider` (sync, worker-facing) with `fetch_instrument`, `fetch_batch`, and `fetch_batch_history` backed by Tiingo REST API
- Add async `fetch_historical_daily_batch` to `TiingoProvider` for concurrent EOD fetches with semaphore-bounded fan-out
- Swap factory default from `YahooFinanceProvider` to `TiingoInstrumentProvider` -- Yahoo retained as import symbol until PR-C cleanup

First of 3 PRs retiring Yahoo Finance entirely per `docs/plans/2026-04-11-tiingo-migration-plan.md`.

## Test plan

- [x] 17 new unit tests (`test_tiingo_provider_layer.py`) using `httpx.MockTransport` -- no real HTTP
- [x] Factory wiring test updated in `test_fefundinfo_provider.py`
- [x] All 74 gate tests green (`test_tiingo_provider_layer + test_fefundinfo_provider + test_instrument_ingestion + test_market_data_ws`)
- [x] `ruff check` clean
- [x] `mypy` clean (1 pre-existing error in `protocol.py`, not a regression)
- [x] `lint-imports`: 31 contracts kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)