### PR TITLE
FI Quant Session 1: benchmarks seed + fixed_income_analytics_service (Phase 0+1)

### DIFF
--- a/backend/app/core/db/migrations/versions/0122_add_fi_benchmark_blocks.py
+++ b/backend/app/core/db/migrations/versions/0122_add_fi_benchmark_blocks.py
@@ -1,0 +1,47 @@
+"""Seed 7 Fixed Income allocation blocks with benchmark tickers.
+
+Revision ID: 0122_add_fi_benchmark_blocks
+Revises: 0121_tiingo_default_source
+Create Date: 2026-04-12
+
+These blocks enable the benchmark_ingest worker to download FI index NAV
+data (via Tiingo) for the empirical duration and credit beta regressions
+in the upcoming FI Quant Engine. ON CONFLICT DO NOTHING avoids duplicates
+if blocks were already created manually.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0122_add_fi_benchmark_blocks"
+down_revision = "0121_tiingo_default_source"
+branch_labels = None
+depends_on = None
+
+_FI_BLOCKS = [
+    ("fi_aggregate", "us", "fixed_income", "US Aggregate Bond", "AGG"),
+    ("fi_ig_corporate", "us", "fixed_income", "Investment Grade Corporate", "LQD"),
+    ("fi_high_yield", "us", "fixed_income", "High Yield Corporate", "HYG"),
+    ("fi_tips", "us", "fixed_income", "Treasury Inflation-Protected", "TIP"),
+    ("fi_govt", "us", "fixed_income", "US Government Bond", "GOVT"),
+    ("fi_em_debt", "em", "fixed_income", "Emerging Market Debt", "EMB"),
+    ("fi_short_term", "us", "fixed_income", "1-3 Year Treasury", "SHY"),
+]
+
+
+def upgrade() -> None:
+    for block_id, geo, asset_class, display, ticker in _FI_BLOCKS:
+        op.execute(
+            f"""
+            INSERT INTO allocation_blocks
+                (block_id, geography, asset_class, display_name, benchmark_ticker)
+            VALUES
+                ('{block_id}', '{geo}', '{asset_class}', '{display}', '{ticker}')
+            ON CONFLICT (block_id) DO NOTHING
+            """
+        )
+
+
+def downgrade() -> None:
+    block_ids = ", ".join(f"'{b[0]}'" for b in _FI_BLOCKS)
+    op.execute(f"DELETE FROM allocation_blocks WHERE block_id IN ({block_ids})")

--- a/backend/quant_engine/fixed_income_analytics_service.py
+++ b/backend/quant_engine/fixed_income_analytics_service.py
@@ -1,0 +1,151 @@
+"""Fixed Income analytics — return-based style analysis regressions.
+
+Sync-pure module: zero I/O, zero imports from app.* or vertical_engines.*.
+Config is injected as parameter — never reads YAML, never uses @lru_cache.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True, slots=True)
+class FIAnalyticsResult:
+    """Result of fixed income regression analytics."""
+
+    empirical_duration: float | None  # OLS beta vs Treasury yield changes
+    duration_r_squared: float | None  # R² of duration regression
+    credit_beta: float | None  # OLS beta vs credit spread changes
+    credit_beta_r_squared: float | None  # R² of credit beta regression
+    yield_proxy_12m: float | None  # Trailing 12m income return proxy
+    duration_adj_drawdown: float | None  # max_drawdown_1y / max(duration, 1)
+
+
+@dataclass(frozen=True, slots=True)
+class FIRegressionConfig:
+    """Configuration for FI regressions."""
+
+    min_observations: int = 120  # ~6 months of daily data
+    regression_window_days: int = 504  # 2 years (2 * 252)
+    yield_change_series: str = "DGS10"  # FRED series for duration regression
+    credit_spread_series: str = "BAA10Y"  # FRED series for credit beta regression
+    min_r_squared: float = 0.05  # Minimum R² to consider result valid
+
+
+def _ols_regression(
+    y: np.ndarray,  # type: ignore[type-arg]
+    x: np.ndarray,  # type: ignore[type-arg]
+) -> tuple[float, float, float]:
+    """Simple OLS: y = alpha + beta * x. Returns (alpha, beta, r_squared)."""
+    X = np.column_stack([np.ones(len(x)), x])
+    result = np.linalg.lstsq(X, y, rcond=None)
+    coeffs = result[0]
+    alpha, beta = float(coeffs[0]), float(coeffs[1])
+
+    y_hat = X @ coeffs
+    ss_res = float(np.sum((y - y_hat) ** 2))
+    ss_tot = float(np.sum((y - np.mean(y)) ** 2))
+    r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
+
+    return alpha, beta, r_squared
+
+
+def compute_empirical_duration(
+    fund_returns: np.ndarray,  # type: ignore[type-arg]
+    treasury_yield_changes: np.ndarray,  # type: ignore[type-arg]
+    config: FIRegressionConfig | None = None,
+) -> tuple[float | None, float | None]:
+    """Empirical duration via OLS of fund returns vs Treasury yield changes.
+
+    R_fund(t) = alpha + beta * delta_Y_10Y(t) + epsilon(t)
+    empirical_duration = -beta
+
+    Returns (empirical_duration, r_squared) or (None, None) if insufficient
+    data or R² below threshold.
+    """
+    cfg = config or FIRegressionConfig()
+
+    if len(fund_returns) < cfg.min_observations or len(treasury_yield_changes) < cfg.min_observations:
+        return None, None
+
+    n = min(len(fund_returns), len(treasury_yield_changes), cfg.regression_window_days)
+    y = fund_returns[-n:]
+    x = treasury_yield_changes[-n:]
+
+    _, beta, r_sq = _ols_regression(y, x)
+
+    if r_sq < cfg.min_r_squared:
+        return None, None
+
+    return -beta, r_sq
+
+
+def compute_credit_beta(
+    fund_returns: np.ndarray,  # type: ignore[type-arg]
+    credit_spread_changes: np.ndarray,  # type: ignore[type-arg]
+    config: FIRegressionConfig | None = None,
+) -> tuple[float | None, float | None]:
+    """Credit beta via OLS of fund returns vs credit spread changes.
+
+    R_fund(t) = alpha + beta * delta_Spread(t) + epsilon(t)
+    credit_beta = -beta
+
+    Returns (credit_beta, r_squared) or (None, None) if insufficient data
+    or R² below threshold.
+    """
+    cfg = config or FIRegressionConfig()
+
+    if len(fund_returns) < cfg.min_observations or len(credit_spread_changes) < cfg.min_observations:
+        return None, None
+
+    n = min(len(fund_returns), len(credit_spread_changes), cfg.regression_window_days)
+    y = fund_returns[-n:]
+    x = credit_spread_changes[-n:]
+
+    _, beta, r_sq = _ols_regression(y, x)
+
+    if r_sq < cfg.min_r_squared:
+        return None, None
+
+    return -beta, r_sq
+
+
+def compute_yield_proxy(monthly_returns: np.ndarray) -> float | None:  # type: ignore[type-arg]
+    """Trailing 12-month income return proxy.
+
+    Uses the mean of positive monthly returns over the last 12 months
+    multiplied by 12 as a proxy for the carry/income component.
+
+    Returns yield_proxy_12m as a decimal (e.g. 0.045 = 4.5%) or None
+    if fewer than 12 months of data.
+    """
+    if len(monthly_returns) < 12:
+        return None
+
+    last_12 = monthly_returns[-12:]
+    positive = last_12[last_12 > 0]
+
+    if len(positive) == 0:
+        return 0.0
+
+    return float(np.mean(positive) * 12)
+
+
+def compute_duration_adjusted_drawdown(
+    max_drawdown_1y: float,
+    empirical_duration: float | None,
+) -> float | None:
+    """Drawdown normalized by duration.
+
+    duration_adj_drawdown = max_drawdown_1y / max(empirical_duration, 1.0)
+
+    A fund with duration 8 and drawdown -8% scores -1.0% (excellent
+    risk management). A fund with duration 2 and drawdown -5% scores
+    -2.5% (worse per unit of risk assumed).
+    """
+    if empirical_duration is None:
+        return None
+
+    return max_drawdown_1y / max(empirical_duration, 1.0)

--- a/backend/scripts/run_instrument_ingestion.py
+++ b/backend/scripts/run_instrument_ingestion.py
@@ -1,0 +1,22 @@
+"""One-shot script to run instrument NAV ingestion via Tiingo."""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent.parent / ".env")
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.domains.wealth.workers.instrument_ingestion import run_instrument_ingestion  # noqa: E402
+
+
+async def main() -> None:
+    result = await run_instrument_ingestion()
+    print(f"Result: {result}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_fixed_income_analytics_service.py
+++ b/backend/tests/test_fixed_income_analytics_service.py
@@ -1,0 +1,131 @@
+"""Tests for quant_engine.fixed_income_analytics_service.
+
+6 test cases using synthetic data as specified in the FI Quant Engine plan:
+1. Pure FI fund (duration ~7)
+2. Pure equity fund (no rate sensitivity)
+3. High yield fund (credit_beta ~2.5)
+4. Insufficient data (<120 obs)
+5. Yield proxy with 4% carry
+6. Duration-adjusted drawdown arithmetic
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quant_engine.fixed_income_analytics_service import (
+    FIRegressionConfig,
+    compute_credit_beta,
+    compute_duration_adjusted_drawdown,
+    compute_empirical_duration,
+    compute_yield_proxy,
+)
+
+
+@pytest.fixture()
+def config() -> FIRegressionConfig:
+    return FIRegressionConfig()
+
+
+class TestEmpiricalDuration:
+    def test_pure_fi_fund_recovers_duration(self, config: FIRegressionConfig) -> None:
+        """Fund with R = -7 * delta_Y + noise should recover duration ~7."""
+        rng = np.random.default_rng(42)
+        n = 504
+        yield_changes = rng.normal(0, 0.001, n)  # ~10bps daily std
+        noise = rng.normal(0, 0.0005, n)
+        fund_returns = -7.0 * yield_changes + noise
+
+        duration, r_sq = compute_empirical_duration(fund_returns, yield_changes, config)
+
+        assert duration is not None
+        assert r_sq is not None
+        assert abs(duration - 7.0) < 0.5, f"Expected ~7.0, got {duration}"
+        assert r_sq > 0.5, f"Expected R² > 0.5, got {r_sq}"
+
+    def test_equity_fund_returns_none(self, config: FIRegressionConfig) -> None:
+        """Equity fund with no rate sensitivity should have R² < 0.05 -> None."""
+        rng = np.random.default_rng(123)
+        n = 504
+        yield_changes = rng.normal(0, 0.001, n)
+        fund_returns = rng.normal(0.0003, 0.01, n)  # independent of yields
+
+        duration, r_sq = compute_empirical_duration(fund_returns, yield_changes, config)
+
+        assert duration is None
+        assert r_sq is None
+
+
+class TestCreditBeta:
+    def test_hy_fund_recovers_credit_beta(self, config: FIRegressionConfig) -> None:
+        """HY fund with R = -2.5 * delta_spread + noise recovers beta ~2.5."""
+        rng = np.random.default_rng(99)
+        n = 504
+        spread_changes = rng.normal(0, 0.002, n)
+        noise = rng.normal(0, 0.001, n)
+        fund_returns = -2.5 * spread_changes + noise
+
+        beta, r_sq = compute_credit_beta(fund_returns, spread_changes, config)
+
+        assert beta is not None
+        assert r_sq is not None
+        assert abs(beta - 2.5) < 0.5, f"Expected ~2.5, got {beta}"
+        assert r_sq > 0.5, f"Expected R² > 0.5, got {r_sq}"
+
+
+class TestInsufficientData:
+    def test_below_min_observations_returns_none(self) -> None:
+        """< 120 observations should return None for all fields."""
+        rng = np.random.default_rng(7)
+        n = 100  # below min_observations=120
+        fund_returns = rng.normal(0, 0.01, n)
+        yield_changes = rng.normal(0, 0.001, n)
+        spread_changes = rng.normal(0, 0.002, n)
+
+        d, d_r2 = compute_empirical_duration(fund_returns, yield_changes)
+        cb, cb_r2 = compute_credit_beta(fund_returns, spread_changes)
+
+        assert d is None and d_r2 is None
+        assert cb is None and cb_r2 is None
+
+
+class TestYieldProxy:
+    def test_carry_4pct(self) -> None:
+        """Monthly returns averaging ~0.33% positive should yield ~4% annual."""
+        rng = np.random.default_rng(55)
+        # 12 months, most positive around 0.33% (4%/12)
+        monthly = np.array([0.003, 0.004, 0.0035, -0.002, 0.003, 0.0038,
+                            0.0032, 0.004, -0.001, 0.003, 0.0035, 0.0033])
+
+        yp = compute_yield_proxy(monthly)
+
+        assert yp is not None
+        assert abs(yp - 0.04) < 0.01, f"Expected ~0.04, got {yp}"
+
+    def test_insufficient_months_returns_none(self) -> None:
+        monthly = np.array([0.003, 0.004, 0.002])
+        assert compute_yield_proxy(monthly) is None
+
+
+class TestDurationAdjustedDrawdown:
+    def test_high_duration_good_management(self) -> None:
+        """Duration=8, drawdown=-8% -> DAD = -1.0%."""
+        dad = compute_duration_adjusted_drawdown(-0.08, 8.0)
+        assert dad is not None
+        assert abs(dad - (-0.01)) < 1e-9
+
+    def test_low_duration_poor_management(self) -> None:
+        """Duration=2, drawdown=-5% -> DAD = -2.5%."""
+        dad = compute_duration_adjusted_drawdown(-0.05, 2.0)
+        assert dad is not None
+        assert abs(dad - (-0.025)) < 1e-9
+
+    def test_none_duration_returns_none(self) -> None:
+        assert compute_duration_adjusted_drawdown(-0.05, None) is None
+
+    def test_duration_floor_at_one(self) -> None:
+        """Duration < 1 should be floored at 1 to avoid division issues."""
+        dad = compute_duration_adjusted_drawdown(-0.03, 0.5)
+        assert dad is not None
+        assert abs(dad - (-0.03)) < 1e-9


### PR DESCRIPTION
4 files (+351 lines). Migration 0122 seeds 7 FI benchmark blocks. New pure-sync quant_engine/fixed_income_analytics_service.py with OLS regressions for duration/credit beta, yield proxy, duration-adjusted drawdown. 10 unit tests. All gates green. benchmark_ingest pending post-merge to populate NAV for FI tickers.