### PR TITLE
Alt Scoring Sprint 2: analytics service + 5 profiles + 7 columns + screener gates

### DIFF
--- a/backend/app/core/db/migrations/versions/0125_add_alternatives_risk_metrics.py
+++ b/backend/app/core/db/migrations/versions/0125_add_alternatives_risk_metrics.py
@@ -1,0 +1,198 @@
+"""Add alternatives risk metrics columns to fund_risk_metrics.
+
+Adds 7 new columns for Alternatives analytics (equity correlation,
+capture ratios, crisis alpha, Calmar ratio, inflation beta) used by
+the alternatives scoring model.  Adds 2 new allocation blocks
+(alt_hedge_fund, alt_managed_futures) to blocks seed data.
+Recreates mv_fund_risk_latest to include alternatives columns.
+
+Revision ID: 0125_add_alternatives_risk_metrics
+Revises: 0124_add_cash_risk_metrics
+Create Date: 2026-04-12
+"""
+
+from alembic import op
+
+revision = "0125_add_alternatives_risk_metrics"
+down_revision = "0124_add_cash_risk_metrics"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- 1. Add Alternatives analytics columns to fund_risk_metrics ---
+    op.execute("""
+        ALTER TABLE fund_risk_metrics
+            ADD COLUMN IF NOT EXISTS equity_correlation_252d NUMERIC(6, 4),
+            ADD COLUMN IF NOT EXISTS downside_capture_1y NUMERIC(8, 4),
+            ADD COLUMN IF NOT EXISTS upside_capture_1y NUMERIC(8, 4),
+            ADD COLUMN IF NOT EXISTS crisis_alpha_score NUMERIC(10, 6),
+            ADD COLUMN IF NOT EXISTS calmar_ratio_3y NUMERIC(8, 4),
+            ADD COLUMN IF NOT EXISTS inflation_beta NUMERIC(8, 4),
+            ADD COLUMN IF NOT EXISTS inflation_beta_r2 NUMERIC(6, 4)
+    """)
+
+    # --- 2. Recreate mv_fund_risk_latest with Alternatives columns ---
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_fund_risk_latest CASCADE")
+
+    op.execute("""
+        CREATE MATERIALIZED VIEW mv_fund_risk_latest AS
+        SELECT DISTINCT ON (instrument_id)
+            instrument_id,
+            calc_date,
+            manager_score,
+            score_components,
+            sharpe_1y,
+            sortino_1y,
+            volatility_1y,
+            volatility_garch,
+            cvar_95_12m,
+            cvar_95_conditional,
+            max_drawdown_1y,
+            return_1y,
+            blended_momentum_score,
+            peer_strategy_label,
+            peer_sharpe_pctl,
+            peer_sortino_pctl,
+            peer_return_pctl,
+            peer_drawdown_pctl,
+            peer_count,
+            elite_flag,
+            elite_rank_within_strategy,
+            elite_target_count_per_strategy,
+            -- FI analytics columns
+            empirical_duration,
+            empirical_duration_r2,
+            credit_beta,
+            credit_beta_r2,
+            yield_proxy_12m,
+            duration_adj_drawdown_1y,
+            scoring_model,
+            -- Cash analytics columns
+            seven_day_net_yield,
+            fed_funds_rate_at_calc,
+            nav_per_share_mmf,
+            pct_weekly_liquid,
+            weighted_avg_maturity_days,
+            -- Alternatives analytics columns
+            equity_correlation_252d,
+            downside_capture_1y,
+            upside_capture_1y,
+            crisis_alpha_score,
+            calmar_ratio_3y,
+            inflation_beta,
+            inflation_beta_r2
+        FROM fund_risk_metrics
+        WHERE organization_id IS NULL
+        ORDER BY instrument_id, calc_date DESC
+        WITH NO DATA
+    """)
+
+    # Recreate indexes
+    op.execute("""
+        CREATE UNIQUE INDEX uq_mv_fund_risk_latest_instrument
+        ON mv_fund_risk_latest (instrument_id)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_elite
+        ON mv_fund_risk_latest (instrument_id)
+        WHERE elite_flag = true
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_sharpe
+        ON mv_fund_risk_latest (sharpe_1y DESC NULLS LAST)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_manager_score
+        ON mv_fund_risk_latest (manager_score DESC NULLS LAST)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_scoring_model
+        ON mv_fund_risk_latest (scoring_model)
+    """)
+
+    op.execute("REFRESH MATERIALIZED VIEW mv_fund_risk_latest")
+
+
+def downgrade() -> None:
+    # Recreate MV without Alternatives columns (restore 0124 definition)
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_fund_risk_latest CASCADE")
+
+    op.execute("""
+        CREATE MATERIALIZED VIEW mv_fund_risk_latest AS
+        SELECT DISTINCT ON (instrument_id)
+            instrument_id,
+            calc_date,
+            manager_score,
+            score_components,
+            sharpe_1y,
+            sortino_1y,
+            volatility_1y,
+            volatility_garch,
+            cvar_95_12m,
+            cvar_95_conditional,
+            max_drawdown_1y,
+            return_1y,
+            blended_momentum_score,
+            peer_strategy_label,
+            peer_sharpe_pctl,
+            peer_sortino_pctl,
+            peer_return_pctl,
+            peer_drawdown_pctl,
+            peer_count,
+            elite_flag,
+            elite_rank_within_strategy,
+            elite_target_count_per_strategy,
+            empirical_duration,
+            empirical_duration_r2,
+            credit_beta,
+            credit_beta_r2,
+            yield_proxy_12m,
+            duration_adj_drawdown_1y,
+            scoring_model,
+            seven_day_net_yield,
+            fed_funds_rate_at_calc,
+            nav_per_share_mmf,
+            pct_weekly_liquid,
+            weighted_avg_maturity_days
+        FROM fund_risk_metrics
+        WHERE organization_id IS NULL
+        ORDER BY instrument_id, calc_date DESC
+        WITH NO DATA
+    """)
+
+    op.execute("""
+        CREATE UNIQUE INDEX uq_mv_fund_risk_latest_instrument
+        ON mv_fund_risk_latest (instrument_id)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_elite
+        ON mv_fund_risk_latest (instrument_id)
+        WHERE elite_flag = true
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_sharpe
+        ON mv_fund_risk_latest (sharpe_1y DESC NULLS LAST)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_manager_score
+        ON mv_fund_risk_latest (manager_score DESC NULLS LAST)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_scoring_model
+        ON mv_fund_risk_latest (scoring_model)
+    """)
+
+    op.execute("REFRESH MATERIALIZED VIEW mv_fund_risk_latest")
+
+    # Drop Alternatives columns
+    op.execute("""
+        ALTER TABLE fund_risk_metrics
+            DROP COLUMN IF EXISTS equity_correlation_252d,
+            DROP COLUMN IF EXISTS downside_capture_1y,
+            DROP COLUMN IF EXISTS upside_capture_1y,
+            DROP COLUMN IF EXISTS crisis_alpha_score,
+            DROP COLUMN IF EXISTS calmar_ratio_3y,
+            DROP COLUMN IF EXISTS inflation_beta,
+            DROP COLUMN IF EXISTS inflation_beta_r2
+    """)

--- a/backend/quant_engine/alternatives_analytics_service.py
+++ b/backend/quant_engine/alternatives_analytics_service.py
@@ -1,0 +1,320 @@
+"""Alternatives analytics -- correlation, capture ratios, crisis alpha, inflation beta.
+
+Sync-pure module: zero I/O, zero imports from app.* or vertical_engines.*.
+Config is injected as parameter -- never reads YAML, never uses @lru_cache.
+
+All metrics are computed from NAV timeseries (nav_timeseries), benchmark
+returns (benchmark_nav), and macro data (macro_data CPIAUCSL).  The worker
+pre-fetches data and passes it to these pure functions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True, slots=True)
+class AltAnalyticsResult:
+    """Result of alternatives fund analytics."""
+
+    equity_correlation_252d: float | None  # Rolling 252-day correlation with SPY
+    downside_capture_1y: float | None  # Down-market capture ratio
+    upside_capture_1y: float | None  # Up-market capture ratio
+    crisis_alpha_score: float | None  # Performance during equity drawdowns > 10%
+    calmar_ratio_3y: float | None  # 3Y annualized return / max drawdown
+    inflation_beta: float | None  # Regression beta vs CPI changes
+    inflation_beta_r2: float | None  # R^2 of inflation regression
+
+
+@dataclass(frozen=True, slots=True)
+class AltAnalyticsConfig:
+    """Configuration for alternatives analytics."""
+
+    min_observations: int = 120  # ~6 months of daily data
+    correlation_window_days: int = 252  # 1 year rolling
+    crisis_drawdown_threshold: float = -0.10  # 10% drawdown = crisis period
+    min_crisis_days: int = 20  # Minimum crisis days to compute crisis alpha
+    inflation_min_months: int = 12  # Minimum months for inflation beta regression
+    inflation_min_r2: float = 0.02  # Minimum R^2 to consider result valid
+
+
+def _ols_regression(
+    y: np.ndarray,  # type: ignore[type-arg]
+    x: np.ndarray,  # type: ignore[type-arg]
+) -> tuple[float, float, float]:
+    """Simple OLS: y = alpha + beta * x. Returns (alpha, beta, r_squared)."""
+    X = np.column_stack([np.ones(len(x)), x])
+    result = np.linalg.lstsq(X, y, rcond=None)
+    coeffs = result[0]
+    alpha, beta = float(coeffs[0]), float(coeffs[1])
+
+    y_hat = X @ coeffs
+    ss_res = float(np.sum((y - y_hat) ** 2))
+    ss_tot = float(np.sum((y - np.mean(y)) ** 2))
+    r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
+
+    return alpha, beta, r_squared
+
+
+def compute_equity_correlation(
+    fund_returns: np.ndarray,  # type: ignore[type-arg]
+    benchmark_returns: np.ndarray,  # type: ignore[type-arg]
+    window: int = 252,
+    min_observations: int = 120,
+) -> float | None:
+    """Rolling correlation with equity benchmark (SPY).
+
+    Returns Pearson correlation coefficient [-1.0, 1.0].
+    For alternatives: LOWER correlation = BETTER diversification.
+    """
+    n = min(len(fund_returns), len(benchmark_returns))
+    if n < min_observations:
+        return None
+
+    # Use the last `window` observations (or all if fewer)
+    k = min(n, window)
+    fund_tail = fund_returns[-k:]
+    bench_tail = benchmark_returns[-k:]
+
+    corr_matrix = np.corrcoef(fund_tail, bench_tail)
+    corr = float(corr_matrix[0, 1])
+
+    if np.isnan(corr):
+        return None
+
+    return round(corr, 4)
+
+
+def compute_capture_ratios(
+    fund_monthly: np.ndarray,  # type: ignore[type-arg]
+    bench_monthly: np.ndarray,  # type: ignore[type-arg]
+    min_periods: int = 3,
+) -> tuple[float | None, float | None]:
+    """Downside and upside capture ratios.
+
+    Downside capture = fund return in down months / benchmark return in down months.
+    Upside capture = fund return in up months / benchmark return in up months.
+
+    Institutional interpretation:
+    - Downside capture < 1.0 = fund loses LESS than benchmark in down months = GOOD.
+    - Upside capture > 1.0 = fund gains MORE than benchmark in up months = GOOD.
+    """
+    n = min(len(fund_monthly), len(bench_monthly))
+    if n < min_periods:
+        return None, None
+
+    fund_m = fund_monthly[-n:]
+    bench_m = bench_monthly[-n:]
+
+    down_mask = bench_m < 0
+    up_mask = bench_m > 0
+
+    downside_capture = None
+    if down_mask.sum() >= min_periods:
+        bench_down_mean = float(bench_m[down_mask].mean())
+        if abs(bench_down_mean) > 1e-10:
+            downside_capture = round(float(fund_m[down_mask].mean() / bench_down_mean), 4)
+
+    upside_capture = None
+    if up_mask.sum() >= min_periods:
+        bench_up_mean = float(bench_m[up_mask].mean())
+        if abs(bench_up_mean) > 1e-10:
+            upside_capture = round(float(fund_m[up_mask].mean() / bench_up_mean), 4)
+
+    return downside_capture, upside_capture
+
+
+def compute_crisis_alpha(
+    fund_daily: np.ndarray,  # type: ignore[type-arg]
+    bench_daily: np.ndarray,  # type: ignore[type-arg]
+    threshold: float = -0.10,
+    min_crisis_days: int = 20,
+) -> float | None:
+    """Performance during equity drawdown periods > threshold.
+
+    Crisis alpha = fund cumulative return - benchmark cumulative return
+    during periods when benchmark is in drawdown > threshold.
+    Positive = fund outperformed during crisis = diversification value.
+    """
+    n = min(len(fund_daily), len(bench_daily))
+    if n < 60:
+        return None
+
+    fund_d = fund_daily[-n:]
+    bench_d = bench_daily[-n:]
+
+    # Compute benchmark cumulative drawdown
+    bench_cum = np.cumprod(1 + bench_d)
+    bench_peak = np.maximum.accumulate(bench_cum)
+    bench_dd = (bench_cum - bench_peak) / bench_peak
+
+    crisis_mask = bench_dd < threshold
+
+    if crisis_mask.sum() < min_crisis_days:
+        return None
+
+    # Fund return during crisis vs benchmark return during crisis
+    fund_crisis_return = float(np.prod(1 + fund_d[crisis_mask]) - 1)
+    bench_crisis_return = float(np.prod(1 + bench_d[crisis_mask]) - 1)
+
+    return round(fund_crisis_return - bench_crisis_return, 6)
+
+
+def compute_calmar_ratio(
+    return_3y_ann: float | None,
+    max_drawdown_3y: float | None,
+) -> float | None:
+    """Calmar ratio: 3Y annualized return / abs(max drawdown 3Y).
+
+    Higher = better risk-adjusted return.
+    """
+    if return_3y_ann is None or max_drawdown_3y is None:
+        return None
+    if max_drawdown_3y >= 0:  # No drawdown or positive (data error)
+        return None
+    return round(return_3y_ann / abs(max_drawdown_3y), 4)
+
+
+def compute_inflation_beta(
+    fund_monthly_returns: np.ndarray,  # type: ignore[type-arg]
+    cpi_monthly_changes: np.ndarray,  # type: ignore[type-arg]
+    config: AltAnalyticsConfig | None = None,
+) -> tuple[float | None, float | None]:
+    """Inflation beta via OLS: R_fund(t) = alpha + beta * delta_CPI(t).
+
+    Positive beta = fund returns go up with inflation = inflation hedge.
+    Returns (inflation_beta, r_squared) or (None, None) if insufficient data.
+    """
+    cfg = config or AltAnalyticsConfig()
+
+    n = min(len(fund_monthly_returns), len(cpi_monthly_changes))
+    if n < cfg.inflation_min_months:
+        return None, None
+
+    fund_m = fund_monthly_returns[-n:]
+    cpi_m = cpi_monthly_changes[-n:]
+
+    _, beta, r_sq = _ols_regression(fund_m, cpi_m)
+
+    if r_sq < cfg.inflation_min_r2:
+        return None, None
+
+    return round(beta, 4), round(r_sq, 4)
+
+
+def compute_alt_analytics(
+    fund_dated_returns: list[tuple],
+    benchmark_dated_returns: list[tuple],
+    cpi_monthly_changes: list[tuple],
+    return_3y_ann: float | None,
+    max_drawdown_3y: float | None,
+    config: AltAnalyticsConfig | None = None,
+) -> AltAnalyticsResult:
+    """Compute all alternatives analytics from dated returns and macro data.
+
+    Aligns fund returns with benchmark by date (inner join), then runs
+    correlation, capture ratios, crisis alpha, Calmar, and inflation beta.
+
+    Args:
+        fund_dated_returns: list of (date, return) tuples.
+        benchmark_dated_returns: list of (date, return) tuples for SPY.
+        cpi_monthly_changes: list of (date, delta_cpi) tuples (monthly).
+        return_3y_ann: 3Y annualized return (already in fund_risk_metrics).
+        max_drawdown_3y: 3Y max drawdown (already in fund_risk_metrics).
+        config: analytics configuration.
+    """
+    cfg = config or AltAnalyticsConfig()
+
+    # Build date-keyed dicts for alignment
+    fund_by_date = {d: r for d, r in fund_dated_returns}
+    bench_by_date = {d: r for d, r in benchmark_dated_returns}
+    cpi_by_date = {d: r for d, r in cpi_monthly_changes}
+
+    # Align daily fund returns with benchmark (inner join)
+    daily_dates = sorted(set(fund_by_date.keys()) & set(bench_by_date.keys()))
+
+    eq_corr = None
+    downside_cap = None
+    upside_cap = None
+    crisis_alpha = None
+
+    if len(daily_dates) >= cfg.min_observations:
+        fund_daily = np.array([fund_by_date[d] for d in daily_dates])
+        bench_daily = np.array([bench_by_date[d] for d in daily_dates])
+
+        # Equity correlation
+        eq_corr = compute_equity_correlation(
+            fund_daily, bench_daily,
+            window=cfg.correlation_window_days,
+            min_observations=cfg.min_observations,
+        )
+
+        # Crisis alpha
+        crisis_alpha = compute_crisis_alpha(
+            fund_daily, bench_daily,
+            threshold=cfg.crisis_drawdown_threshold,
+            min_crisis_days=cfg.min_crisis_days,
+        )
+
+        # Capture ratios (monthly)
+        # Resample daily to monthly by grouping on year-month
+        fund_monthly_map: dict[tuple[int, int], list[float]] = {}
+        bench_monthly_map: dict[tuple[int, int], list[float]] = {}
+        for d, fr, br in zip(daily_dates, fund_daily, bench_daily, strict=True):
+            key = (d.year, d.month)
+            fund_monthly_map.setdefault(key, []).append(float(fr))
+            bench_monthly_map.setdefault(key, []).append(float(br))
+
+        # Convert daily to monthly compound returns
+        common_months = sorted(set(fund_monthly_map.keys()) & set(bench_monthly_map.keys()))
+        if len(common_months) >= 3:
+            fund_monthly_arr = np.array([
+                np.prod(1 + np.array(fund_monthly_map[m])) - 1
+                for m in common_months
+            ])
+            bench_monthly_arr = np.array([
+                np.prod(1 + np.array(bench_monthly_map[m])) - 1
+                for m in common_months
+            ])
+            downside_cap, upside_cap = compute_capture_ratios(
+                fund_monthly_arr, bench_monthly_arr,
+            )
+
+    # Calmar ratio (uses pre-computed 3Y data)
+    calmar = compute_calmar_ratio(return_3y_ann, max_drawdown_3y)
+
+    # Inflation beta (monthly)
+    fund_monthly_by_date = {}
+    for d, r in fund_dated_returns:
+        key = (d.year, d.month)
+        fund_monthly_by_date.setdefault(key, []).append(r)
+
+    common_cpi_months = sorted(set(fund_monthly_by_date.keys()) & set(
+        (d.year, d.month) for d in cpi_by_date
+    ))
+
+    infl_beta = None
+    infl_r2 = None
+    if len(common_cpi_months) >= cfg.inflation_min_months:
+        fund_monthly_for_cpi = np.array([
+            np.prod(1 + np.array(fund_monthly_by_date[m])) - 1
+            for m in common_cpi_months
+        ])
+        # CPI changes indexed by (year, month)
+        cpi_by_ym = {(d.year, d.month): r for d, r in cpi_monthly_changes}
+        cpi_aligned = np.array([cpi_by_ym[m] for m in common_cpi_months])
+        infl_beta, infl_r2 = compute_inflation_beta(
+            fund_monthly_for_cpi, cpi_aligned, cfg,
+        )
+
+    return AltAnalyticsResult(
+        equity_correlation_252d=eq_corr,
+        downside_capture_1y=downside_cap,
+        upside_capture_1y=upside_cap,
+        crisis_alpha_score=crisis_alpha,
+        calmar_ratio_3y=calmar,
+        inflation_beta=infl_beta,
+        inflation_beta_r2=infl_r2,
+    )

--- a/backend/quant_engine/scoring_service.py
+++ b/backend/quant_engine/scoring_service.py
@@ -46,6 +46,20 @@ class CashMetrics(Protocol):
     weighted_avg_maturity_days: int | float | None
 
 
+class AltMetrics(Protocol):
+    """Protocol for alternatives metrics — satisfied by FundRiskMetrics ORM or adapter."""
+
+    equity_correlation_252d: Decimal | float | None
+    downside_capture_1y: Decimal | float | None
+    upside_capture_1y: Decimal | float | None
+    crisis_alpha_score: Decimal | float | None
+    calmar_ratio_3y: Decimal | float | None
+    sortino_1y: Decimal | float | None
+    inflation_beta: Decimal | float | None
+    yield_proxy_12m: Decimal | float | None  # Reused from FI (for REIT income)
+    tracking_error_1y: Decimal | float | None  # For gold tracking efficiency
+
+
 # Hardcoded fallback — used only if config parameter is not provided.
 # fee_efficiency replaces Lipper rating (provider never contracted).
 # insider_sentiment is opt-in (add weight > 0 in config to activate).
@@ -89,6 +103,86 @@ _DEFAULT_CASH_SCORING_WEIGHTS: dict[str, float] = {
     "fee_efficiency": 0.10,
 }
 
+# ── Alternatives scoring weights per profile ──────────────────────────
+# All profiles share 5 components (sum = 1.0) but with different weights
+# reflecting what matters most for each alternative strategy.
+
+_DEFAULT_ALT_REIT_WEIGHTS: dict[str, float] = {
+    "income_generation": 0.25,
+    "diversification_value": 0.25,
+    "downside_protection": 0.20,
+    "inflation_hedge": 0.20,
+    "fee_efficiency": 0.10,
+}
+
+_DEFAULT_ALT_COMMODITY_WEIGHTS: dict[str, float] = {
+    "inflation_hedge": 0.30,
+    "diversification_value": 0.25,
+    "crisis_alpha": 0.20,
+    "drawdown_control": 0.15,
+    "fee_efficiency": 0.10,
+}
+
+_DEFAULT_ALT_GOLD_WEIGHTS: dict[str, float] = {
+    "crisis_alpha": 0.30,
+    "diversification_value": 0.30,
+    "inflation_hedge": 0.20,
+    "tracking_efficiency": 0.10,
+    "fee_efficiency": 0.10,
+}
+
+_DEFAULT_ALT_HEDGE_WEIGHTS: dict[str, float] = {
+    "alpha_generation": 0.30,
+    "downside_protection": 0.25,
+    "diversification_value": 0.20,
+    "crisis_alpha": 0.15,
+    "fee_efficiency": 0.10,
+}
+
+_DEFAULT_ALT_CTA_WEIGHTS: dict[str, float] = {
+    "crisis_alpha": 0.40,
+    "diversification_value": 0.25,
+    "risk_adjusted_return": 0.25,
+    "fee_efficiency": 0.10,
+}
+
+_DEFAULT_ALT_GENERIC_WEIGHTS: dict[str, float] = {
+    "diversification_value": 0.30,
+    "downside_protection": 0.25,
+    "risk_adjusted_return": 0.20,
+    "crisis_alpha": 0.15,
+    "fee_efficiency": 0.10,
+}
+
+# Profile name → default weight dict
+_ALT_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
+    "reit": _DEFAULT_ALT_REIT_WEIGHTS,
+    "commodity": _DEFAULT_ALT_COMMODITY_WEIGHTS,
+    "gold": _DEFAULT_ALT_GOLD_WEIGHTS,
+    "hedge": _DEFAULT_ALT_HEDGE_WEIGHTS,
+    "cta": _DEFAULT_ALT_CTA_WEIGHTS,
+    "generic_alt": _DEFAULT_ALT_GENERIC_WEIGHTS,
+}
+
+
+def resolve_alt_profile_weights(
+    profile: str,
+    config: dict[str, Any] | None = None,
+) -> dict[str, float]:
+    """Resolve alternatives scoring weights for a specific profile.
+
+    Falls back to generic_alt if profile is unknown. Config override
+    takes precedence when provided.
+    """
+    if config is not None:
+        try:
+            weights = config.get("scoring_weights", config)
+            if isinstance(weights, dict) and weights:
+                return {k: float(v) for k, v in weights.items()}
+        except (TypeError, ValueError):
+            pass
+    return _ALT_PROFILE_WEIGHTS.get(profile, _DEFAULT_ALT_GENERIC_WEIGHTS)
+
 
 def resolve_scoring_weights(
     config: dict[str, Any] | None = None,
@@ -97,10 +191,12 @@ def resolve_scoring_weights(
     """Extract scoring weights from config dict.
 
     Falls back to asset-class-appropriate defaults if config is None or malformed.
+    For alternatives, use resolve_alt_profile_weights() instead (profile-specific).
     """
     _defaults_by_class = {
         "fixed_income": _DEFAULT_FI_SCORING_WEIGHTS,
         "cash": _DEFAULT_CASH_SCORING_WEIGHTS,
+        "alternatives": _DEFAULT_ALT_GENERIC_WEIGHTS,
     }
     default = _defaults_by_class.get(asset_class, _DEFAULT_SCORING_WEIGHTS)
     if config is None:
@@ -272,6 +368,86 @@ def _compute_cash_score(
     return round(score, 2), {k: round(v, 2) for k, v in components.items()}
 
 
+def _compute_alternatives_score(
+    alt: AltMetrics,
+    profile: str,
+    config: dict[str, Any] | None,
+    expense_ratio_pct: float | None,
+    peer_medians: dict[str, float] | None,
+) -> tuple[float, dict[str, float]]:
+    """Compute Alternatives composite score. Returns (score, components).
+
+    Profile-specific weights determine which components matter most.
+    All components are computed for all alt funds; weights select relevance.
+    """
+    pm = peer_medians or {}
+    components: dict[str, float] = {}
+
+    # diversification_value: 1 - abs(equity_correlation_252d)
+    # Lower equity correlation = higher diversification. Score 100 at corr=0.
+    eq_corr = float(alt.equity_correlation_252d) if alt.equity_correlation_252d is not None else None
+    if eq_corr is not None:
+        div_value = 1.0 - abs(eq_corr)
+        components["diversification_value"] = _normalize(div_value, 0.0, 1.0, pm.get("diversification_value"))
+    else:
+        components["diversification_value"] = pm.get("diversification_value", 45.0) - 5.0
+
+    # downside_protection: 1 - downside_capture_1y
+    # Score 100 at capture=0, score 50 at capture=1.0, score 0 at capture >= 2.0.
+    dc = float(alt.downside_capture_1y) if alt.downside_capture_1y is not None else None
+    if dc is not None:
+        protection = 1.0 - dc
+        components["downside_protection"] = _normalize(protection, -1.0, 1.0, pm.get("downside_protection"))
+    else:
+        components["downside_protection"] = pm.get("downside_protection", 45.0) - 5.0
+
+    # crisis_alpha: excess return vs benchmark during drawdown periods
+    # Range: -0.20 to 0.30. Score 100 = outperforms by 30% in crises.
+    ca = float(alt.crisis_alpha_score) if alt.crisis_alpha_score is not None else None
+    components["crisis_alpha"] = _normalize(ca, -0.20, 0.30, pm.get("crisis_alpha"))
+
+    # inflation_hedge: inflation beta (regression of returns vs CPI changes)
+    # Range: -2.0 to 4.0. Score 100 at beta=4, score 50 at beta=1.
+    ib = float(alt.inflation_beta) if alt.inflation_beta is not None else None
+    components["inflation_hedge"] = _normalize(ib, -2.0, 4.0, pm.get("inflation_hedge"))
+
+    # income_generation: yield_proxy_12m (reused from FI for REITs)
+    # Range: 0% to 10%.
+    yp = float(alt.yield_proxy_12m) if alt.yield_proxy_12m is not None else None
+    components["income_generation"] = _normalize(yp, 0.0, 0.10, pm.get("income_generation"))
+
+    # alpha_generation: sortino_1y (not Sharpe -- Sharpe penalizes upside vol)
+    # Range: -1.0 to 3.0. Sortino isolates downside risk.
+    sortino = float(alt.sortino_1y) if alt.sortino_1y is not None else None
+    components["alpha_generation"] = _normalize(sortino, -1.0, 3.0, pm.get("alpha_generation"))
+
+    # risk_adjusted_return: calmar_ratio_3y (return / max drawdown)
+    # Range: 0 to 2.0. Score 100 at Calmar 2.0.
+    calmar = float(alt.calmar_ratio_3y) if alt.calmar_ratio_3y is not None else None
+    components["risk_adjusted_return"] = _normalize(calmar, 0.0, 2.0, pm.get("risk_adjusted_return"))
+
+    # drawdown_control: calmar_ratio_3y (same metric, different normalization for commodity profile)
+    components["drawdown_control"] = _normalize(calmar, 0.0, 2.0, pm.get("drawdown_control"))
+
+    # tracking_efficiency: lower tracking error = better (for gold passive exposure)
+    # Range: 0 to 5% TE. Score 100 at TE=0, score 0 at TE >= 5%.
+    te = float(alt.tracking_error_1y) if alt.tracking_error_1y is not None else None
+    if te is not None:
+        # Inverted: lower TE is better
+        te_score = max(0.0, min(100.0, (1.0 - te / 0.05) * 100))
+        components["tracking_efficiency"] = te_score
+    else:
+        components["tracking_efficiency"] = pm.get("tracking_efficiency", 45.0) - 5.0
+
+    # fee_efficiency: shared formula
+    components["fee_efficiency"] = _compute_fee_efficiency(expense_ratio_pct, pm)
+
+    weights = resolve_alt_profile_weights(profile, config)
+
+    score = sum(components.get(k, 50.0) * w for k, w in weights.items())
+    return round(score, 2), {k: round(v, 2) for k, v in components.items()}
+
+
 def compute_fund_score(
     metrics: RiskMetrics,
     flows_momentum_score: float = 50.0,
@@ -282,6 +458,8 @@ def compute_fund_score(
     asset_class: str = "equity",
     fi_metrics: FIMetrics | None = None,
     cash_metrics: CashMetrics | None = None,
+    alt_metrics: AltMetrics | None = None,
+    alt_profile: str | None = None,
 ) -> tuple[float, dict[str, float]]:
     """Compute composite score from risk metrics. Returns (score, components).
 
@@ -296,13 +474,24 @@ def compute_fund_score(
         peer_medians: Dict of component_name → median score from strategy peers.
                Used as fallback for missing data (with -5pt penalty) instead of
                blind neutral 50. Penalizes opaque/short-history funds.
-        asset_class: "equity" (default), "fixed_income", or "cash". Determines scoring model.
+        asset_class: "equity" (default), "fixed_income", "cash", or "alternatives".
+               Determines scoring model.
         fi_metrics: Fixed income metrics. Required when asset_class="fixed_income".
                Falls back to equity scoring if None.
         cash_metrics: Cash/MMF metrics. Required when asset_class="cash".
                Falls back to equity scoring if None.
+        alt_metrics: Alternatives metrics. Required when asset_class="alternatives".
+               Falls back to equity scoring if None.
+        alt_profile: Alternatives profile name (reit, commodity, gold, hedge, cta,
+               generic_alt). Determines weight distribution across components.
 
     """
+    # Dispatch to Alternatives scoring when asset_class is alternatives AND alt_metrics provided
+    if asset_class == "alternatives" and alt_metrics is not None:
+        return _compute_alternatives_score(
+            alt_metrics, alt_profile or "generic_alt", config, expense_ratio_pct, peer_medians,
+        )
+
     # Dispatch to Cash scoring when asset_class is cash AND cash_metrics provided
     if asset_class == "cash" and cash_metrics is not None:
         return _compute_cash_score(cash_metrics, config, expense_ratio_pct, peer_medians)

--- a/backend/tests/test_alt_scoring_dispatch.py
+++ b/backend/tests/test_alt_scoring_dispatch.py
@@ -1,0 +1,310 @@
+"""Tests for Alternatives scoring dispatch in scoring_service.py.
+
+Covers:
+1. All 6 profile weight dicts sum to 1.0
+2. REIT profile: income_generation + diversification dominate
+3. Commodity profile: inflation_hedge dominates
+4. Gold profile: crisis_alpha + diversification dominate
+5. Hedge fund profile: alpha_generation dominates
+6. CTA profile: crisis_alpha dominates (0.40 weight)
+7. Generic alt profile: balanced weights
+8. Dispatch in compute_fund_score routes to alternatives
+9. Missing alt_metrics falls back to equity
+10. resolve_alt_profile_weights with config override
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from quant_engine.scoring_service import (
+    _ALT_PROFILE_WEIGHTS,
+    _DEFAULT_ALT_COMMODITY_WEIGHTS,
+    _DEFAULT_ALT_CTA_WEIGHTS,
+    _DEFAULT_ALT_GENERIC_WEIGHTS,
+    _DEFAULT_ALT_GOLD_WEIGHTS,
+    _DEFAULT_ALT_HEDGE_WEIGHTS,
+    _DEFAULT_ALT_REIT_WEIGHTS,
+    compute_fund_score,
+    resolve_alt_profile_weights,
+)
+
+
+def _make_equity_metrics(
+    return_1y: float | None = 0.10,
+    sharpe_1y: float | None = 1.2,
+    max_drawdown_1y: float | None = -0.08,
+    information_ratio_1y: float | None = 0.6,
+) -> MagicMock:
+    m = MagicMock()
+    m.return_1y = return_1y
+    m.sharpe_1y = sharpe_1y
+    m.max_drawdown_1y = max_drawdown_1y
+    m.information_ratio_1y = information_ratio_1y
+    return m
+
+
+def _make_alt_metrics(
+    equity_correlation_252d: float | None = 0.2,
+    downside_capture_1y: float | None = 0.5,
+    upside_capture_1y: float | None = 0.7,
+    crisis_alpha_score: float | None = 0.08,
+    calmar_ratio_3y: float | None = 1.2,
+    sortino_1y: float | None = 1.5,
+    inflation_beta: float | None = 1.8,
+    yield_proxy_12m: float | None = 0.06,
+    tracking_error_1y: float | None = 0.02,
+) -> MagicMock:
+    m = MagicMock()
+    m.equity_correlation_252d = equity_correlation_252d
+    m.downside_capture_1y = downside_capture_1y
+    m.upside_capture_1y = upside_capture_1y
+    m.crisis_alpha_score = crisis_alpha_score
+    m.calmar_ratio_3y = calmar_ratio_3y
+    m.sortino_1y = sortino_1y
+    m.inflation_beta = inflation_beta
+    m.yield_proxy_12m = yield_proxy_12m
+    m.tracking_error_1y = tracking_error_1y
+    return m
+
+
+class TestProfileWeightsSumToOne:
+    """Every profile weight dict must sum to 1.0."""
+
+    @pytest.mark.parametrize("profile,weights", [
+        ("reit", _DEFAULT_ALT_REIT_WEIGHTS),
+        ("commodity", _DEFAULT_ALT_COMMODITY_WEIGHTS),
+        ("gold", _DEFAULT_ALT_GOLD_WEIGHTS),
+        ("hedge", _DEFAULT_ALT_HEDGE_WEIGHTS),
+        ("cta", _DEFAULT_ALT_CTA_WEIGHTS),
+        ("generic_alt", _DEFAULT_ALT_GENERIC_WEIGHTS),
+    ])
+    def test_weights_sum(self, profile: str, weights: dict[str, float]) -> None:
+        total = sum(weights.values())
+        assert abs(total - 1.0) < 0.001, f"{profile} weights sum to {total}, should be 1.0"
+
+    def test_all_profiles_registered(self) -> None:
+        assert set(_ALT_PROFILE_WEIGHTS.keys()) == {
+            "reit", "commodity", "gold", "hedge", "cta", "generic_alt",
+        }
+
+
+class TestREITProfile:
+    """REIT profile: income_generation (0.25) + diversification_value (0.25) dominate."""
+
+    def test_reit_scores_income_fund_high(self) -> None:
+        risk = _make_equity_metrics()
+        alt = _make_alt_metrics(
+            yield_proxy_12m=0.08,          # High yield (REIT)
+            equity_correlation_252d=0.3,    # Moderate diversification
+            downside_capture_1y=0.6,        # Good protection
+            inflation_beta=2.0,             # Good inflation hedge
+        )
+        score, components = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="reit",
+            expense_ratio_pct=0.005,
+        )
+        assert "income_generation" in components
+        assert "diversification_value" in components
+        assert score > 50, f"Good REIT should score > 50, got {score}"
+
+
+class TestCommodityProfile:
+    """Commodity profile: inflation_hedge (0.30) dominates."""
+
+    def test_commodity_scores_inflation_hedge_high(self) -> None:
+        risk = _make_equity_metrics()
+        alt = _make_alt_metrics(
+            inflation_beta=3.0,             # Strong inflation hedge
+            equity_correlation_252d=0.1,    # Low equity correlation
+            crisis_alpha_score=0.15,        # Positive crisis alpha
+            calmar_ratio_3y=1.0,            # Decent Calmar
+        )
+        score, components = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="commodity",
+            expense_ratio_pct=0.005,
+        )
+        assert "inflation_hedge" in components
+        assert components["inflation_hedge"] > 70, "Strong inflation hedge should score > 70"
+        assert score > 55, f"Good commodity fund should score > 55, got {score}"
+
+
+class TestGoldProfile:
+    """Gold profile: crisis_alpha (0.30) + diversification_value (0.30) dominate."""
+
+    def test_gold_scores_crisis_hedge_high(self) -> None:
+        risk = _make_equity_metrics()
+        alt = _make_alt_metrics(
+            crisis_alpha_score=0.20,        # Strong crisis alpha
+            equity_correlation_252d=0.05,   # Near-zero equity correlation
+            inflation_beta=1.5,             # Moderate inflation hedge
+            tracking_error_1y=0.01,         # Low tracking error vs GLD
+        )
+        score, components = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="gold",
+            expense_ratio_pct=0.004,
+        )
+        assert "crisis_alpha" in components
+        assert "tracking_efficiency" in components
+        assert score > 60, f"Good gold fund should score > 60, got {score}"
+
+
+class TestHedgeFundProfile:
+    """Hedge fund profile: alpha_generation (0.30) dominates."""
+
+    def test_hedge_fund_scores_alpha_high(self) -> None:
+        risk = _make_equity_metrics()
+        alt = _make_alt_metrics(
+            sortino_1y=2.5,                 # Strong risk-adjusted returns
+            downside_capture_1y=0.3,        # Excellent downside protection
+            equity_correlation_252d=0.3,    # Low-moderate correlation
+            crisis_alpha_score=0.10,        # Positive crisis alpha
+        )
+        score, components = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="hedge",
+            expense_ratio_pct=0.020,  # 2% management fee typical for HFs
+        )
+        assert "alpha_generation" in components
+        assert "downside_protection" in components
+        assert components["alpha_generation"] > 70, "Strong Sortino should produce high alpha_generation"
+        assert score > 50, f"Good hedge fund should score > 50, got {score}"
+
+
+class TestCTAProfile:
+    """CTA profile: crisis_alpha (0.40) dominates."""
+
+    def test_cta_scores_crisis_alpha_high(self) -> None:
+        risk = _make_equity_metrics()
+        alt = _make_alt_metrics(
+            crisis_alpha_score=0.25,        # Excellent crisis performance
+            equity_correlation_252d=-0.1,   # Negative correlation (ideal for CTA)
+            calmar_ratio_3y=1.5,            # Good risk-adjusted return
+        )
+        score, components = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="cta",
+            expense_ratio_pct=0.015,
+        )
+        assert "crisis_alpha" in components
+        assert _DEFAULT_ALT_CTA_WEIGHTS["crisis_alpha"] == 0.40
+        assert score > 55, f"Good CTA should score > 55, got {score}"
+
+
+class TestGenericAltProfile:
+    """Generic alt profile: balanced diversification_value (0.30) + downside_protection (0.25)."""
+
+    def test_generic_scores_balanced(self) -> None:
+        risk = _make_equity_metrics()
+        alt = _make_alt_metrics()
+        score, components = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="generic_alt",
+        )
+        assert isinstance(score, float)
+        assert "diversification_value" in components
+        assert "downside_protection" in components
+        assert "crisis_alpha" in components
+
+
+class TestAlternativesDispatch:
+    """Test compute_fund_score dispatches to alternatives path."""
+
+    def test_dispatch_produces_alt_components(self) -> None:
+        risk = _make_equity_metrics()
+        alt = _make_alt_metrics()
+        score, components = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt,
+        )
+        assert "diversification_value" in components
+        assert "return_consistency" not in components, "Should NOT use equity components"
+        assert "yield_consistency" not in components, "Should NOT use FI components"
+        assert "yield_vs_risk_free" not in components, "Should NOT use cash components"
+
+    def test_fallback_to_equity_if_no_alt_metrics(self) -> None:
+        risk = _make_equity_metrics()
+        score, components = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=None,
+        )
+        assert "return_consistency" in components, "Should fall back to equity"
+        assert "diversification_value" not in components
+
+    def test_default_profile_is_generic(self) -> None:
+        risk = _make_equity_metrics()
+        alt = _make_alt_metrics()
+        # No alt_profile specified => generic_alt
+        score_default, _ = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt,
+        )
+        score_explicit, _ = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="generic_alt",
+        )
+        assert score_default == score_explicit
+
+
+class TestResolveAltProfileWeights:
+    def test_known_profile(self) -> None:
+        weights = resolve_alt_profile_weights("reit")
+        assert weights == _DEFAULT_ALT_REIT_WEIGHTS
+
+    def test_unknown_profile_falls_back_to_generic(self) -> None:
+        weights = resolve_alt_profile_weights("nonexistent_profile")
+        assert weights == _DEFAULT_ALT_GENERIC_WEIGHTS
+
+    def test_config_override(self) -> None:
+        custom = {"scoring_weights": {"crisis_alpha": 1.0}}
+        weights = resolve_alt_profile_weights("reit", config=custom)
+        assert weights == {"crisis_alpha": 1.0}
+
+
+class TestAlternativesVsEquityScoring:
+    """The credibility test: alt fund with diversification should score better
+    on the alternatives model than on the equity model."""
+
+    def test_alt_fund_scores_higher_on_alt_model(self) -> None:
+        risk = _make_equity_metrics(
+            return_1y=0.06,     # Modest return (typical for alternatives)
+            sharpe_1y=0.7,      # Decent but not equity-level
+            max_drawdown_1y=-0.08,
+            information_ratio_1y=0.2,
+        )
+        alt = _make_alt_metrics(
+            equity_correlation_252d=0.1,    # Great diversification
+            downside_capture_1y=0.3,        # Excellent downside protection
+            crisis_alpha_score=0.15,        # Positive crisis alpha
+            calmar_ratio_3y=1.5,            # Strong risk-adjusted return
+            sortino_1y=1.8,                 # Good Sortino
+            inflation_beta=2.0,             # Good inflation hedge
+        )
+
+        equity_score, _ = compute_fund_score(
+            risk, asset_class="equity", expense_ratio_pct=0.010,
+        )
+        alt_score, _ = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="hedge",
+            expense_ratio_pct=0.010,
+        )
+
+        assert alt_score > equity_score, (
+            f"Alt model should score higher than equity model for a skilled alternatives fund. "
+            f"Alt={alt_score}, Equity={equity_score}"
+        )
+
+    def test_missing_data_penalty_applied(self) -> None:
+        """Alt fund with all None metrics gets penalized."""
+        risk = _make_equity_metrics()
+        alt = _make_alt_metrics(
+            equity_correlation_252d=None,
+            downside_capture_1y=None,
+            upside_capture_1y=None,
+            crisis_alpha_score=None,
+            calmar_ratio_3y=None,
+            sortino_1y=None,
+            inflation_beta=None,
+            yield_proxy_12m=None,
+            tracking_error_1y=None,
+        )
+        score, components = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt,
+        )
+        # Most components should get the 45-5=40 penalty
+        assert score < 50, f"All-None alt fund should score < 50, got {score}"

--- a/backend/tests/test_alternatives_analytics_service.py
+++ b/backend/tests/test_alternatives_analytics_service.py
@@ -1,0 +1,258 @@
+"""Tests for quant_engine.alternatives_analytics_service.
+
+Test cases using synthetic data:
+1. Equity correlation — correlated vs uncorrelated fund
+2. Capture ratios — protective fund vs equity-like fund
+3. Crisis alpha — positive vs negative during drawdowns
+4. Calmar ratio — arithmetic correctness
+5. Inflation beta — commodity-like vs equity-like fund
+6. Insufficient data returns None
+7. compute_alt_analytics integration
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import pytest
+
+from quant_engine.alternatives_analytics_service import (
+    AltAnalyticsConfig,
+    AltAnalyticsResult,
+    compute_alt_analytics,
+    compute_calmar_ratio,
+    compute_capture_ratios,
+    compute_crisis_alpha,
+    compute_equity_correlation,
+    compute_inflation_beta,
+)
+
+
+@pytest.fixture()
+def config() -> AltAnalyticsConfig:
+    return AltAnalyticsConfig()
+
+
+class TestEquityCorrelation:
+    def test_high_correlation_with_spy(self) -> None:
+        """Fund tracking SPY should have correlation ~1.0."""
+        rng = np.random.default_rng(42)
+        n = 252
+        spy_returns = rng.normal(0.0004, 0.01, n)
+        noise = rng.normal(0, 0.001, n)
+        fund_returns = spy_returns + noise  # highly correlated
+
+        corr = compute_equity_correlation(fund_returns, spy_returns)
+        assert corr is not None
+        assert corr > 0.8, f"Expected high correlation, got {corr}"
+
+    def test_uncorrelated_fund(self) -> None:
+        """Independent fund should have correlation near 0."""
+        rng = np.random.default_rng(123)
+        n = 252
+        spy_returns = rng.normal(0.0004, 0.01, n)
+        fund_returns = rng.normal(0.0003, 0.008, n)  # independent
+
+        corr = compute_equity_correlation(fund_returns, spy_returns)
+        assert corr is not None
+        assert abs(corr) < 0.3, f"Expected near-zero correlation, got {corr}"
+
+    def test_insufficient_data_returns_none(self) -> None:
+        """< 120 observations should return None."""
+        rng = np.random.default_rng(7)
+        n = 100
+        corr = compute_equity_correlation(
+            rng.normal(0, 0.01, n), rng.normal(0, 0.01, n),
+        )
+        assert corr is None
+
+
+class TestCaptureRatios:
+    def test_protective_fund(self) -> None:
+        """Fund that loses less in down months and gains less in up months."""
+        rng = np.random.default_rng(55)
+        n = 36  # 3 years monthly
+        bench = rng.normal(0.008, 0.04, n)
+
+        # Fund captures 50% of both up and down
+        fund = bench * 0.5 + rng.normal(0, 0.005, n)
+
+        down_cap, up_cap = compute_capture_ratios(fund, bench)
+
+        assert down_cap is not None
+        assert up_cap is not None
+        # Should capture roughly 50% of movements
+        assert 0.2 < down_cap < 0.8, f"Expected ~0.5 downside capture, got {down_cap}"
+        assert 0.2 < up_cap < 0.8, f"Expected ~0.5 upside capture, got {up_cap}"
+
+    def test_equity_like_fund(self) -> None:
+        """Fund tracking benchmark should have capture ratios ~1.0."""
+        rng = np.random.default_rng(99)
+        n = 36
+        bench = rng.normal(0.008, 0.04, n)
+        fund = bench + rng.normal(0, 0.003, n)
+
+        down_cap, up_cap = compute_capture_ratios(fund, bench)
+
+        assert down_cap is not None
+        assert up_cap is not None
+        assert abs(down_cap - 1.0) < 0.3, f"Expected ~1.0 downside capture, got {down_cap}"
+        assert abs(up_cap - 1.0) < 0.3, f"Expected ~1.0 upside capture, got {up_cap}"
+
+    def test_insufficient_months_returns_none(self) -> None:
+        """< 3 observations should return None."""
+        fund = np.array([0.01, -0.02])
+        bench = np.array([-0.03, 0.02])
+        down, up = compute_capture_ratios(fund, bench)
+        assert down is None
+        assert up is None
+
+
+class TestCrisisAlpha:
+    def test_positive_crisis_alpha(self) -> None:
+        """Fund that outperforms during benchmark drawdowns."""
+        rng = np.random.default_rng(42)
+        n = 504  # 2 years
+
+        # Create benchmark with a crisis period (drawdown > 10%)
+        bench = rng.normal(0.0003, 0.01, n)
+        # Insert a significant drawdown in the middle
+        bench[150:200] = -0.005  # steady decline over 50 days
+
+        # Fund holds steady during the crisis
+        fund = rng.normal(0.0002, 0.005, n)
+        fund[150:200] = rng.normal(0.001, 0.003, 50)  # positive during crisis
+
+        ca = compute_crisis_alpha(fund, bench)
+
+        if ca is not None:
+            assert ca > 0, f"Fund outperforming in crisis should have positive alpha, got {ca}"
+
+    def test_no_crisis_period_returns_none(self) -> None:
+        """If benchmark never draws down > 10%, return None."""
+        rng = np.random.default_rng(77)
+        n = 252
+        # Gentle uptrend, no major drawdown
+        bench = rng.normal(0.001, 0.003, n)
+        fund = rng.normal(0.0005, 0.003, n)
+
+        ca = compute_crisis_alpha(fund, bench)
+        assert ca is None
+
+    def test_insufficient_data_returns_none(self) -> None:
+        rng = np.random.default_rng(10)
+        ca = compute_crisis_alpha(rng.normal(0, 0.01, 30), rng.normal(0, 0.01, 30))
+        assert ca is None
+
+
+class TestCalmarRatio:
+    def test_normal_computation(self) -> None:
+        """10% annual return, 20% max drawdown -> Calmar = 0.5."""
+        calmar = compute_calmar_ratio(0.10, -0.20)
+        assert calmar is not None
+        assert abs(calmar - 0.5) < 1e-4
+
+    def test_high_return_low_drawdown(self) -> None:
+        """20% annual return, 10% drawdown -> Calmar = 2.0."""
+        calmar = compute_calmar_ratio(0.20, -0.10)
+        assert calmar is not None
+        assert abs(calmar - 2.0) < 1e-4
+
+    def test_none_inputs(self) -> None:
+        assert compute_calmar_ratio(None, -0.10) is None
+        assert compute_calmar_ratio(0.10, None) is None
+
+    def test_no_drawdown_returns_none(self) -> None:
+        """Zero or positive drawdown is a data error."""
+        assert compute_calmar_ratio(0.10, 0.0) is None
+        assert compute_calmar_ratio(0.10, 0.05) is None
+
+
+class TestInflationBeta:
+    def test_commodity_like_fund(self) -> None:
+        """Fund returns positively correlated with CPI changes."""
+        rng = np.random.default_rng(42)
+        n = 36  # 3 years monthly
+        cpi_changes = rng.normal(0.003, 0.002, n)  # ~3.6% annual CPI
+        noise = rng.normal(0, 0.005, n)
+        # Fund moves 2x CPI changes (positive inflation hedge)
+        fund_returns = 2.0 * cpi_changes + noise
+
+        beta, r2 = compute_inflation_beta(fund_returns, cpi_changes)
+
+        assert beta is not None
+        assert r2 is not None
+        assert beta > 1.0, f"Expected positive inflation beta > 1.0, got {beta}"
+        assert r2 > 0.1, f"Expected R^2 > 0.1, got {r2}"
+
+    def test_uncorrelated_fund_returns_none(self) -> None:
+        """Fund with no inflation sensitivity should return None (low R^2)."""
+        rng = np.random.default_rng(123)
+        n = 36
+        cpi_changes = rng.normal(0.003, 0.002, n)
+        fund_returns = rng.normal(0.005, 0.02, n)  # independent
+
+        beta, r2 = compute_inflation_beta(fund_returns, cpi_changes)
+
+        # Either None (R^2 below threshold) or very low beta
+        if beta is not None:
+            assert abs(beta) < 3.0
+
+    def test_insufficient_months_returns_none(self) -> None:
+        rng = np.random.default_rng(10)
+        beta, r2 = compute_inflation_beta(
+            rng.normal(0, 0.01, 6), rng.normal(0, 0.002, 6),
+        )
+        assert beta is None
+        assert r2 is None
+
+
+class TestComputeAltAnalytics:
+    """Integration test for the full compute_alt_analytics pipeline."""
+
+    def test_full_computation(self) -> None:
+        """All fields populated with sufficient data."""
+        rng = np.random.default_rng(42)
+        n = 504  # 2 years daily
+        base_date = date(2024, 1, 1)
+        dates = [base_date + timedelta(days=i) for i in range(n)]
+
+        spy_returns = rng.normal(0.0004, 0.012, n)
+        fund_returns = spy_returns * 0.3 + rng.normal(0.0002, 0.005, n)
+
+        fund_dated = list(zip(dates, fund_returns.tolist(), strict=True))
+        spy_dated = list(zip(dates, spy_returns.tolist(), strict=True))
+
+        # Monthly CPI
+        cpi_dates = [date(2024, m, 15) for m in range(1, 13)] + [date(2025, m, 15) for m in range(1, 13)]
+        cpi_changes = rng.normal(0.003, 0.001, len(cpi_dates)).tolist()
+        cpi_dated = list(zip(cpi_dates, cpi_changes, strict=True))
+
+        result = compute_alt_analytics(
+            fund_dated_returns=fund_dated,
+            benchmark_dated_returns=spy_dated,
+            cpi_monthly_changes=cpi_dated,
+            return_3y_ann=0.12,
+            max_drawdown_3y=-0.15,
+        )
+
+        assert isinstance(result, AltAnalyticsResult)
+        assert result.equity_correlation_252d is not None
+        assert result.calmar_ratio_3y is not None
+        assert abs(result.calmar_ratio_3y - 0.80) < 0.01
+
+    def test_empty_returns(self) -> None:
+        """No returns should produce all-None result."""
+        result = compute_alt_analytics(
+            fund_dated_returns=[],
+            benchmark_dated_returns=[],
+            cpi_monthly_changes=[],
+            return_3y_ann=None,
+            max_drawdown_3y=None,
+        )
+        assert result.equity_correlation_252d is None
+        assert result.downside_capture_1y is None
+        assert result.crisis_alpha_score is None
+        assert result.calmar_ratio_3y is None
+        assert result.inflation_beta is None

--- a/backend/vertical_engines/wealth/model_portfolio/block_mapping.py
+++ b/backend/vertical_engines/wealth/model_portfolio/block_mapping.py
@@ -20,8 +20,10 @@ STRATEGY_LABEL_TO_BLOCKS: dict[str, list[str]] = {
     "Large Growth": ["na_equity_large", "na_equity_growth"],
     "Large Value": ["na_equity_large", "na_equity_value"],
     "Multi-Cap Core": ["na_equity_large"],
-    "Long/Short Equity": ["na_equity_large"],
-    "Multi-Strategy": ["na_equity_large"],
+    "Long/Short Equity": ["alt_hedge_fund", "na_equity_large"],
+    "Multi-Strategy": ["alt_hedge_fund"],
+    "Market Neutral": ["alt_hedge_fund"],
+    "Managed Futures": ["alt_managed_futures"],
     # Equity — US growth
     "Growth": ["na_equity_growth"],
     "Growth Equity": ["na_equity_growth"],

--- a/backend/vertical_engines/wealth/screener/layer_evaluator.py
+++ b/backend/vertical_engines/wealth/screener/layer_evaluator.py
@@ -72,6 +72,16 @@ class LayerEvaluator:
                 if result is not None:
                     results.append(result)
 
+        # Compound Alternatives gate: if fund is alternatives, also evaluate fund_alternatives rules
+        if instrument_type == "fund" and attributes.get("asset_class") == "alternatives":
+            alt_criteria = criteria.get("fund_alternatives", {})
+            for criterion, expected in alt_criteria.items():
+                result = self._evaluate_criterion(
+                    criterion, expected, attributes, "fund_alternatives", layer=1,
+                )
+                if result is not None:
+                    results.append(result)
+
         return results
 
     def evaluate_layer2(

--- a/backend/vertical_engines/wealth/screener/quant_metrics.py
+++ b/backend/vertical_engines/wealth/screener/quant_metrics.py
@@ -87,6 +87,22 @@ class CashQuantMetrics:
 
 
 @dataclass(frozen=True, slots=True)
+class AltQuantMetrics:
+    """Alternatives fund screening metrics from fund_risk_metrics (pre-computed).
+
+    Profile-specific scoring uses these common metrics with different weights.
+    """
+
+    diversification_value: float
+    downside_protection: float
+    crisis_alpha: float
+    inflation_hedge: float
+    risk_adjusted_return: float
+    fee_efficiency: float
+    alt_profile: str  # reit | commodity | gold | hedge | cta | generic_alt
+
+
+@dataclass(frozen=True, slots=True)
 class BondQuantMetrics:
     """Bond screening metrics from attributes (no timeseries needed)."""
 

--- a/backend/vertical_engines/wealth/screener/service.py
+++ b/backend/vertical_engines/wealth/screener/service.py
@@ -25,6 +25,7 @@ from vertical_engines.wealth.screener.models import (
     ScreeningRunResult,
 )
 from vertical_engines.wealth.screener.quant_metrics import (
+    AltQuantMetrics,
     BondQuantMetrics,
     CashQuantMetrics,
     FIQuantMetrics,
@@ -217,7 +218,7 @@ class ScreenerService:
     def _compute_layer3_score(
         self,
         instrument_type: str,
-        quant_metrics: QuantMetrics | BondQuantMetrics | FIQuantMetrics | CashQuantMetrics | None,
+        quant_metrics: QuantMetrics | BondQuantMetrics | FIQuantMetrics | CashQuantMetrics | AltQuantMetrics | None,
         peer_values: dict[str, list[float]] | None,
     ) -> float | None:
         """Compute Layer 3 composite score."""
@@ -229,6 +230,8 @@ class ScreenerService:
             config_key = "fund_fixed_income"
         elif isinstance(quant_metrics, CashQuantMetrics):
             config_key = "fund_cash"
+        elif isinstance(quant_metrics, AltQuantMetrics):
+            config_key = "fund_alternatives"
         else:
             config_key = instrument_type
 
@@ -253,6 +256,15 @@ class ScreenerService:
                 "nav_stability": quant_metrics.nav_stability,
                 "liquidity_quality": quant_metrics.liquidity_quality,
                 "maturity_discipline": quant_metrics.maturity_discipline,
+                "fee_efficiency": quant_metrics.fee_efficiency,
+            }
+        elif isinstance(quant_metrics, AltQuantMetrics):
+            metrics_dict = {
+                "diversification_value": quant_metrics.diversification_value,
+                "downside_protection": quant_metrics.downside_protection,
+                "crisis_alpha": quant_metrics.crisis_alpha,
+                "inflation_hedge": quant_metrics.inflation_hedge,
+                "risk_adjusted_return": quant_metrics.risk_adjusted_return,
                 "fee_efficiency": quant_metrics.fee_efficiency,
             }
         elif isinstance(quant_metrics, QuantMetrics):

--- a/calibration/config/blocks.yaml
+++ b/calibration/config/blocks.yaml
@@ -113,6 +113,20 @@ blocks:
     benchmark_ticker: GLD
     description: "Physical gold exposure"
 
+  alt_hedge_fund:
+    geography: global
+    asset_class: alternatives
+    display_name: "Hedge Funds / Multi-Strategy"
+    benchmark_ticker: QAI
+    description: "Alternative multi-strategy exposure"
+
+  alt_managed_futures:
+    geography: global
+    asset_class: alternatives
+    display_name: "Managed Futures / CTA"
+    benchmark_ticker: DBMF
+    description: "Trend-following CTA strategies"
+
   # Cash
   cash:
     geography: north_america

--- a/docs/plans/alternatives_cash_scoring_engine.md
+++ b/docs/plans/alternatives_cash_scoring_engine.md
@@ -1,0 +1,1180 @@
+# Alternatives & Cash/MMF Scoring Engine -- Plano Completo
+
+> **Problema de credibilidade:** O scoring model equity-centrico (6 componentes: Sharpe, return consistency, drawdown, IR, flows, fee) produz resultados absurdos para alternatives e cash. Um money market fund com vol ~0.5% produz Sharpe > 10 (numericamente instavel), e e descartado pelo guard `MIN_ANNUALIZED_VOL = 0.01` no screener -- ou seja, **zero Layer 3 score** para MMFs. Um REIT fund com correlacao negativa ao equity (diversification alpha) pontua mal porque drawdown_control mede drawdown absoluto, nao relativo ao benchmark VNQ. Para portfolios institucionais com 5-15% em alternatives e 2-5% em cash, isso contamina o ELITE ranking e o Portfolio Builder.
+
+> [!IMPORTANT]
+> **Arquitetura DB-First:** Igual ao FI plan. Nenhum calculo novo roda em user-facing request. Tudo pre-computa no worker `global_risk_metrics` (lock 900_071) e persiste em `fund_risk_metrics`. Rotas leem O(1). Scoring dispatch via `scoring_model` column.
+
+---
+
+## Taxonomia de Asset Classes e Dispatch
+
+### Hierarquia de dispatch
+
+```
+asset_class (Instrument.asset_class)
+  |
+  +-- "equity"          --> scoring_model = "equity"     (existing)
+  +-- "fixed_income"    --> scoring_model = "fixed_income" (FI plan)
+  +-- "alternatives"    --> scoring_model = "alternatives"
+  |     sub-dispatch by block_id:
+  |       alt_real_estate  --> profile "reit"
+  |       alt_commodities  --> profile "commodity"
+  |       alt_gold         --> profile "gold"
+  |       (unmatched)      --> profile "generic_alt"
+  +-- "cash"            --> scoring_model = "cash"
+  +-- "multi_asset"     --> scoring_model = "equity" (fallback -- multi-asset is closest to equity)
+  +-- (other)           --> scoring_model = "equity" (safe fallback)
+```
+
+### Sub-strategy mapping (Alternatives)
+
+O dispatch usa `block_id` do `block_mapping.py` (ja existente) como chave de profile. Nao cria novos scoring_model values para cada sub-estrategia -- mantem `scoring_model = "alternatives"` com config-driven differentiation via `ConfigService`.
+
+Mapeamento strategy_label -> block_id (ja existe em `block_mapping.py`):
+
+| strategy_label | block_id | Alt profile |
+|---|---|---|
+| Real Estate, Real Estate Fund | alt_real_estate | reit |
+| Commodities Broad Basket, Natural Resources, Infrastructure | alt_commodities | commodity |
+| Precious Metals | alt_gold | gold |
+| Long/Short Equity, Multi-Strategy, Managed Futures | (need new blocks) | hedge |
+
+**Gap identificado:** Hedge fund strategy_labels (Long/Short Equity, Multi-Strategy) atualmente mapeiam para `na_equity_large` no block_mapping -- INCORRETO para scoring. Precisam de novo block `alt_hedge_fund` com benchmark HFRI (proxy: HDG ou QAI ETF). Managed Futures precisa de `alt_managed_futures` com benchmark DBMF.
+
+**Acao:** Adicionar ao block_mapping.py e blocks.yaml:
+
+```yaml
+alt_hedge_fund:
+  geography: global
+  asset_class: alternatives
+  display_name: "Hedge Funds / Multi-Strategy"
+  benchmark_ticker: QAI
+  description: "Alternative multi-strategy exposure"
+
+alt_managed_futures:
+  geography: global
+  asset_class: alternatives
+  display_name: "Managed Futures / CTA"
+  benchmark_ticker: DBMF
+  description: "Trend-following CTA strategies"
+```
+
+Atualizar strategy_label mapping (ADDITIVE -- keep existing equity blocks for funds that appear in both):
+
+```python
+"Long/Short Equity": ["alt_hedge_fund", "na_equity_large"],  # Both: some are equity-style, some are alt
+"Multi-Strategy": ["alt_hedge_fund"],
+"Market Neutral": ["alt_hedge_fund"],
+"Managed Futures": ["alt_managed_futures"],
+```
+
+**IMPORTANTE:** O `asset_class` na `instruments_universe` e o que determina o scoring model, NAO o block_mapping. Um fundo com `asset_class="equity"` e `strategy_label="Long/Short Equity"` sera scored pelo equity model. Um fundo com `asset_class="alternatives"` e `strategy_label="Long/Short Equity"` sera scored pelo alt model. O block mapping e para candidate discovery (portfolio builder), nao para scoring dispatch.
+
+---
+
+## Fase 1 -- Cash/MMF Scoring Model (Prioridade ALTA)
+
+### Motivacao
+
+Cash/MMF scoring e a correcao mais urgente: o `MIN_ANNUALIZED_VOL = 0.01` guard descarta MMFs do Layer 3 do screener. Alem disso, ja temos dados ricos em `sec_money_market_funds` (WAM, yield, liquidity) e `sec_mmf_metrics` (daily metrics) que NAO estao sendo usados no scoring.
+
+### 1.1 Cash Scoring Components
+
+5 componentes (sum = 1.0):
+
+| Componente | Peso | Metrica | Fonte | Normalizacao |
+|---|---|---|---|---|
+| `yield_vs_risk_free` | 0.30 | `(seven_day_net_yield - DFF) / DFF` | sec_mmf_metrics.seven_day_net_yield vs macro_data.DFF | Range: -0.20 to +0.20. Score 100 = fund yields 20% more than fed funds. Score 50 = matches exactly. Score 0 = yields 20% less. |
+| `nav_stability` | 0.25 | `1 - abs(shadow_nav - 1.0) * 1000` | Computed: if `seeks_stable_nav`, use `stable_nav_price` from sec_money_market_funds. Else compute vol from daily NAV. | Range: score 100 = perfect $1.00. Score 0 = deviation >= 0.1% ($0.999 or $1.001). This is the "break the buck" metric. |
+| `liquidity_quality` | 0.20 | `pct_weekly_liquid_latest` | sec_money_market_funds | Range: 30% (regulatory min) to 100%. Score 0 at 30%, score 100 at 100%. SEC Rule 2a-7 requires 30% weekly liquid. |
+| `maturity_discipline` | 0.15 | `1 - (WAM / 60)` | sec_money_market_funds.weighted_avg_maturity | Range: 0 to 60 days. Score 100 = WAM 0 (all overnight). Score 0 = WAM 60 (regulatory max). Lower WAM = less interest rate risk = better for cash vehicle. |
+| `fee_efficiency` | 0.10 | Same formula as equity/FI | expense_ratio_pct from XBRL enrichment | Same normalization. More impactful for cash: at 5% yield, 0.50% ER eats 10% of return. |
+
+**Formulas:**
+
+```python
+def _compute_cash_score(
+    cash_metrics: CashMetrics,
+    config: dict[str, Any] | None,
+    expense_ratio_pct: float | None,
+    peer_medians: dict[str, float] | None,
+) -> tuple[float, dict[str, float]]:
+    pm = peer_medians or {}
+    components: dict[str, float] = {}
+
+    # yield_vs_risk_free: relative yield advantage over fed funds
+    # seven_day_net_yield is in percent (e.g., 5.25).
+    # fed_funds_rate is in percent (e.g., 5.33).
+    if cash_metrics.seven_day_net_yield is not None and cash_metrics.fed_funds_rate is not None:
+        ffr = cash_metrics.fed_funds_rate
+        if ffr > 0:
+            relative_yield = (cash_metrics.seven_day_net_yield - ffr) / ffr
+        else:
+            relative_yield = 0.10 if cash_metrics.seven_day_net_yield > 0 else 0.0
+        components["yield_vs_risk_free"] = _normalize(relative_yield, -0.20, 0.20, pm.get("yield_vs_risk_free"))
+    else:
+        components["yield_vs_risk_free"] = pm.get("yield_vs_risk_free", 45.0) - 5.0
+
+    # nav_stability: deviation from $1.00 par
+    if cash_metrics.nav_per_share is not None:
+        deviation = abs(cash_metrics.nav_per_share - 1.0)
+        stability = max(0.0, 1.0 - deviation * 1000)  # 0.001 deviation = 0 score
+        components["nav_stability"] = stability * 100
+    else:
+        components["nav_stability"] = pm.get("nav_stability", 45.0) - 5.0
+
+    # liquidity_quality: weekly liquid assets %
+    if cash_metrics.pct_weekly_liquid is not None:
+        # Range 30% (regulatory min) to 100%
+        components["liquidity_quality"] = _normalize(
+            cash_metrics.pct_weekly_liquid, 30.0, 100.0, pm.get("liquidity_quality"),
+        )
+    else:
+        components["liquidity_quality"] = pm.get("liquidity_quality", 45.0) - 5.0
+
+    # maturity_discipline: lower WAM = better
+    if cash_metrics.weighted_avg_maturity is not None:
+        # 0 days = 100, 60 days = 0. Inverted scale.
+        wam_score = max(0.0, (1.0 - cash_metrics.weighted_avg_maturity / 60.0)) * 100
+        components["maturity_discipline"] = wam_score
+    else:
+        components["maturity_discipline"] = pm.get("maturity_discipline", 45.0) - 5.0
+
+    # fee_efficiency: shared formula
+    components["fee_efficiency"] = _compute_fee_efficiency(expense_ratio_pct, pm)
+
+    weights = resolve_scoring_weights(config, asset_class="cash")
+    score = sum(components.get(k, 50.0) * w for k, w in weights.items())
+    return round(score, 2), {k: round(v, 2) for k, v in components.items()}
+```
+
+### 1.2 New Protocol and Defaults
+
+```python
+class CashMetrics(Protocol):
+    """Protocol for cash/MMF metrics -- satisfied by FundRiskMetrics ORM or adapter."""
+    seven_day_net_yield: Decimal | float | None
+    fed_funds_rate: Decimal | float | None
+    nav_per_share: Decimal | float | None
+    pct_weekly_liquid: Decimal | float | None
+    weighted_avg_maturity: int | float | None
+
+_DEFAULT_CASH_SCORING_WEIGHTS: dict[str, float] = {
+    "yield_vs_risk_free": 0.30,
+    "nav_stability": 0.25,
+    "liquidity_quality": 0.20,
+    "maturity_discipline": 0.15,
+    "fee_efficiency": 0.10,
+}
+```
+
+### 1.3 New fund_risk_metrics Columns (Cash)
+
+```sql
+ALTER TABLE fund_risk_metrics
+    ADD COLUMN seven_day_net_yield NUMERIC(8, 4),
+    ADD COLUMN fed_funds_rate_at_calc NUMERIC(8, 4),
+    ADD COLUMN nav_per_share NUMERIC(12, 6),
+    ADD COLUMN pct_weekly_liquid NUMERIC(8, 4),
+    ADD COLUMN weighted_avg_maturity INTEGER;
+```
+
+- `seven_day_net_yield`: From sec_mmf_metrics JOIN on class_id. 7-day net yield in percent (e.g., 5.25).
+- `fed_funds_rate_at_calc`: DFF from macro_data at calc_date. Stored for audit trail -- lets us reconstruct the relative yield signal.
+- `nav_per_share`: From sec_money_market_funds.stable_nav_price (for stable NAV funds) or computed from nav_timeseries.
+- `pct_weekly_liquid`: From sec_money_market_funds.pct_weekly_liquid_latest.
+- `weighted_avg_maturity`: From sec_money_market_funds.weighted_avg_maturity. Days.
+
+### 1.4 Worker Integration (Cash Pass)
+
+New pass in `risk_calc.py` global worker, inserted before scoring:
+
+```python
+# Pass 1.9: Cash/MMF analytics
+# Only for funds with asset_class = 'cash' or scoring_model = 'cash'
+cash_fund_ids = [str(f.instrument_id) for f, _ in computed if f.asset_class == "cash"]
+if cash_fund_ids:
+    # Batch fetch: latest DFF from macro_data
+    fed_funds_rate = await _fetch_latest_macro_value(db, "DFF", as_of_date)
+    
+    # Batch fetch: MMF metadata from sec_money_market_funds
+    # JOIN instruments_universe.attributes->>'sec_series_id' to sec_money_market_funds.series_id
+    mmf_data = await _batch_fetch_mmf_data(db, cash_fund_ids)
+    
+    # Batch fetch: latest sec_mmf_metrics for 7-day yield
+    mmf_yields = await _batch_fetch_mmf_yields(db, cash_fund_ids)
+    
+    for fund, metrics_dict in computed:
+        if str(fund.instrument_id) not in cash_fund_ids:
+            continue
+        
+        mmf_info = mmf_data.get(str(fund.instrument_id), {})
+        yield_info = mmf_yields.get(str(fund.instrument_id), {})
+        
+        metrics_dict["seven_day_net_yield"] = yield_info.get("seven_day_net_yield")
+        metrics_dict["fed_funds_rate_at_calc"] = fed_funds_rate
+        metrics_dict["nav_per_share"] = mmf_info.get("stable_nav_price") or mmf_info.get("nav_per_share")
+        metrics_dict["pct_weekly_liquid"] = mmf_info.get("pct_weekly_liquid_latest")
+        metrics_dict["weighted_avg_maturity"] = mmf_info.get("weighted_avg_maturity")
+        metrics_dict["scoring_model"] = "cash"
+```
+
+### 1.5 Screener Gate Extensions (Cash)
+
+**Layer 1 -- Eliminatory (fund_cash):**
+
+```json
+{
+  "fund_cash": {
+    "min_pct_weekly_liquid": 30.0,
+    "max_weighted_avg_maturity": 60,
+    "min_net_assets": 100000000
+  }
+}
+```
+
+Compound gate logic (same pattern as fund_fixed_income):
+
+```python
+# In LayerEvaluator.evaluate_layer1():
+if instrument_type == "fund" and attributes.get("asset_class") == "cash":
+    cash_criteria = criteria.get("fund_cash", {})
+    for criterion, expected in cash_criteria.items():
+        result = self._evaluate_criterion(
+            criterion, expected, attributes, "fund_cash", layer=1,
+        )
+        if result is not None:
+            results.append(result)
+```
+
+**Layer 2 -- Mandate fit (cash block):**
+
+```json
+{
+  "blocks": {
+    "cash": {
+      "criteria": {
+        "max_weighted_avg_maturity": 60,
+        "min_pct_weekly_liquid": 30.0,
+        "allowed_mmf_category": ["Government", "Prime", "Tax-Exempt"]
+      }
+    }
+  }
+}
+```
+
+**Layer 3 -- Quant scoring:**
+
+New `CashQuantMetrics` dataclass in `quant_metrics.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class CashQuantMetrics:
+    """Cash/MMF screening metrics from fund_risk_metrics + sec_mmf data."""
+    yield_vs_risk_free: float
+    nav_stability: float
+    liquidity_quality: float
+    maturity_discipline: float
+    fee_efficiency: float
+    data_source: str  # mmf_filing | nav_proxy
+```
+
+The `_compute_layer3_score()` in `ScreenerService` adds:
+
+```python
+if isinstance(quant_metrics, CashQuantMetrics):
+    config_key = "fund_cash"
+```
+
+### 1.6 Benchmark Mapping (Cash)
+
+Already exists: `cash` block -> `SHV` (iShares Short Treasury Bond ETF).
+
+Adequate for relative performance. SHV tracks 1-12 month Treasury bills, which is the appropriate comparison for money market funds.
+
+### 1.7 Data Availability (Cash)
+
+| Metric | Source | Availability | Notes |
+|---|---|---|---|
+| seven_day_net_yield | sec_mmf_metrics | HIGH -- 20k daily rows, N-MFP filings | Class-level yield |
+| fed_funds_rate | macro_data (DFF) | HIGH -- daily ingestion | Already ingested |
+| nav_per_share | sec_money_market_funds.stable_nav_price | HIGH -- from N-MFP | Stable NAV funds report this directly |
+| pct_weekly_liquid | sec_money_market_funds | HIGH -- from N-MFP | Required SEC disclosure |
+| weighted_avg_maturity | sec_money_market_funds | HIGH -- from N-MFP | Required SEC disclosure, in days |
+| expense_ratio_pct | sec_fund_classes XBRL | MODERATE -- 61% coverage for mutual funds | Missing for some MMFs |
+
+**Key data join:** The link from `instruments_universe` to `sec_money_market_funds` goes through `attributes->>'sec_series_id'` (populated during import). The join to `sec_mmf_metrics` requires the class_id which is stored in `sec_fund_classes`.
+
+---
+
+## Fase 2 -- Alternatives Scoring Model (Core Infrastructure)
+
+### 2.1 Alternatives Analytics Service
+
+`backend/quant_engine/alternatives_analytics_service.py` [NEW]
+
+Sync-pure module. Zero I/O. Config as parameter. Same architecture as `fixed_income_analytics_service.py`.
+
+```python
+"""Alternatives analytics -- correlation, downside capture, crisis alpha.
+
+Sync-pure module: zero I/O, zero imports from app.* or vertical_engines.*.
+Config is injected as parameter -- never reads YAML, never uses @lru_cache.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+import numpy as np
+
+@dataclass(frozen=True, slots=True)
+class AltAnalyticsResult:
+    """Result of alternatives fund analytics."""
+    equity_correlation_252d: float | None    # Rolling 252-day correlation with SPY
+    downside_capture_1y: float | None        # Down-market capture ratio
+    upside_capture_1y: float | None          # Up-market capture ratio
+    crisis_alpha_score: float | None         # Performance during equity drawdowns > 10%
+    calmar_ratio_3y: float | None            # 3Y annualized return / max drawdown
+    sortino_ratio_1y: float | None           # Return / downside deviation (already in fund_risk_metrics)
+    inflation_beta: float | None             # Regression beta vs CPI changes (for commodities/REIT)
+    inflation_beta_r2: float | None          # R^2 of inflation regression
+
+@dataclass(frozen=True, slots=True)
+class AltAnalyticsConfig:
+    """Configuration for alternatives analytics."""
+    min_observations: int = 120
+    correlation_window_days: int = 252       # 1 year rolling
+    crisis_drawdown_threshold: float = -0.10 # 10% drawdown = crisis period
+    equity_benchmark_ticker: str = "SPY"     # For correlation + capture ratios
+    inflation_series: str = "CPIAUCSL"       # For inflation beta regression
+```
+
+### 2.2 Core Analytics Functions
+
+#### `compute_equity_correlation(fund_returns, benchmark_returns, window=252) -> float | None`
+
+Rolling correlation with equity benchmark (SPY). This is THE fundamental metric for alternatives -- the whole point of alternatives is low/negative equity correlation.
+
+```
+corr = np.corrcoef(fund_returns[-252:], spy_returns[-252:])[0, 1]
+```
+
+- Guard: len(aligned) < 120 -> None.
+- Returns correlation coefficient [-1.0, 1.0].
+- For scoring: LOWER correlation = BETTER (inverted normalization).
+
+#### `compute_capture_ratios(fund_returns, benchmark_returns) -> tuple[float | None, float | None]`
+
+Downside capture = fund return in down months / benchmark return in down months.
+Upside capture = fund return in up months / benchmark return in up months.
+
+```python
+def compute_capture_ratios(
+    fund_monthly: np.ndarray, bench_monthly: np.ndarray,
+) -> tuple[float | None, float | None]:
+    down_mask = bench_monthly < 0
+    up_mask = bench_monthly > 0
+    
+    downside_capture = None
+    if down_mask.sum() >= 3:
+        downside_capture = float(fund_monthly[down_mask].mean() / bench_monthly[down_mask].mean())
+    
+    upside_capture = None
+    if up_mask.sum() >= 3:
+        upside_capture = float(fund_monthly[up_mask].mean() / bench_monthly[up_mask].mean())
+    
+    return downside_capture, upside_capture
+```
+
+Institutional interpretation:
+- Downside capture < 1.0 = fund loses LESS than benchmark in down months = GOOD.
+- Upside capture > 1.0 = fund gains MORE than benchmark in up months = GOOD.
+- Ideal alternatives fund: downside_capture = 0.3, upside_capture = 0.7 (protects in drawdowns, participates in rallies).
+
+#### `compute_crisis_alpha(fund_returns, benchmark_returns, threshold=-0.10) -> float | None`
+
+Performance of the fund during periods when the equity benchmark is in a drawdown > 10%.
+
+```python
+def compute_crisis_alpha(
+    fund_daily: np.ndarray, bench_daily: np.ndarray, dates: np.ndarray,
+    threshold: float = -0.10,
+) -> float | None:
+    # Compute benchmark cumulative drawdown
+    bench_cum = np.cumprod(1 + bench_daily)
+    bench_peak = np.maximum.accumulate(bench_cum)
+    bench_dd = (bench_cum - bench_peak) / bench_peak
+    
+    crisis_mask = bench_dd < threshold  # Periods where benchmark is down > 10%
+    
+    if crisis_mask.sum() < 20:  # Need at least 20 crisis days
+        return None
+    
+    # Fund return during crisis vs benchmark return during crisis
+    fund_crisis_return = float(np.prod(1 + fund_daily[crisis_mask]) - 1)
+    bench_crisis_return = float(np.prod(1 + bench_daily[crisis_mask]) - 1)
+    
+    # Crisis alpha = fund return - benchmark return during crisis periods
+    # Positive = fund outperformed during crisis = diversification value
+    return fund_crisis_return - bench_crisis_return
+```
+
+#### `compute_calmar_ratio(return_3y_ann, max_drawdown_3y) -> float | None`
+
+```python
+def compute_calmar_ratio(return_3y_ann: float | None, max_drawdown_3y: float | None) -> float | None:
+    if return_3y_ann is None or max_drawdown_3y is None:
+        return None
+    if max_drawdown_3y >= 0:  # No drawdown or positive (data error)
+        return None
+    return return_3y_ann / abs(max_drawdown_3y)
+```
+
+Calmar already uses data in `fund_risk_metrics` (return_3y_ann, max_drawdown_3y) -- no new data needed.
+
+#### `compute_inflation_beta(fund_returns, cpi_changes, config) -> tuple[float | None, float | None]`
+
+Same OLS approach as FI's credit_beta, but regressing against monthly CPI changes.
+
+```
+R_fund(t) = alpha + beta * delta_CPI(t) + epsilon(t)
+inflation_beta = beta
+```
+
+- CPI is monthly (CPIAUCSL from macro_data). Convert fund returns to monthly before regression.
+- Positive inflation_beta = fund returns go up with inflation = inflation hedge = GOOD for REIT/commodities.
+- Guard: R^2 < 0.02 -> None (no meaningful inflation sensitivity).
+
+**Data availability:** CPIAUCSL is already ingested monthly by `macro_ingestion` worker. No new external data needed.
+
+### 2.3 Scoring Components per Alternative Profile
+
+All profiles share 5 components (sum = 1.0) but with DIFFERENT weights and normalization ranges:
+
+#### Profile: REIT (`alt_real_estate`)
+
+| Componente | Peso | Metrica | Normalizacao |
+|---|---|---|---|
+| `income_generation` | 0.25 | yield_proxy_12m (reuse FI metric) | Range: 0% to 10%. REITs are yield vehicles -- income stability is primary. |
+| `diversification_value` | 0.25 | 1 - abs(equity_correlation_252d) | Range: 0 to 1. Lower equity correlation = higher diversification. Score 100 at corr=0, score 50 at corr=0.5, score 0 at corr=1.0. |
+| `downside_protection` | 0.20 | 1 - downside_capture_1y | Range: 0 to 2. Score 100 at capture=0 (no downside), score 50 at capture=1.0, score 0 at capture >= 2.0. |
+| `inflation_hedge` | 0.20 | inflation_beta | Range: -2.0 to 4.0. Score 100 at beta=4 (strong inflation hedge), score 50 at beta=1, score 0 at beta <= -2. |
+| `fee_efficiency` | 0.10 | Same formula | Same |
+
+```python
+_DEFAULT_ALT_REIT_WEIGHTS: dict[str, float] = {
+    "income_generation": 0.25,
+    "diversification_value": 0.25,
+    "downside_protection": 0.20,
+    "inflation_hedge": 0.20,
+    "fee_efficiency": 0.10,
+}
+```
+
+#### Profile: Commodity (`alt_commodities`)
+
+| Componente | Peso | Metrica | Normalizacao |
+|---|---|---|---|
+| `inflation_hedge` | 0.30 | inflation_beta | Range: -2.0 to 4.0. THE primary reason to hold commodities. |
+| `diversification_value` | 0.25 | 1 - abs(equity_correlation_252d) | Same as REIT. |
+| `crisis_alpha` | 0.20 | crisis_alpha_score | Range: -0.20 to 0.30. Score 100 = outperforms SPY by 30% in crises. Score 50 = neutral. Score 0 = underperforms by 20%. |
+| `drawdown_control` | 0.15 | calmar_ratio_3y | Range: 0 to 2.0. Score 100 at Calmar 2.0, score 50 at 1.0, score 0 at 0. |
+| `fee_efficiency` | 0.10 | Same | Same |
+
+```python
+_DEFAULT_ALT_COMMODITY_WEIGHTS: dict[str, float] = {
+    "inflation_hedge": 0.30,
+    "diversification_value": 0.25,
+    "crisis_alpha": 0.20,
+    "drawdown_control": 0.15,
+    "fee_efficiency": 0.10,
+}
+```
+
+#### Profile: Gold (`alt_gold`)
+
+| Componente | Peso | Metrica | Normalizacao |
+|---|---|---|---|
+| `crisis_alpha` | 0.30 | crisis_alpha_score | Range: -0.20 to 0.30. Gold's primary value is crisis hedge. |
+| `diversification_value` | 0.30 | 1 - abs(equity_correlation_252d) | Gold should be near-zero equity correlation. |
+| `inflation_hedge` | 0.20 | inflation_beta | Gold as real asset. |
+| `tracking_efficiency` | 0.10 | Tracking error vs GLD benchmark. Lower = better (for passive gold exposure). | Range: 0 to 5% TE. Score 100 at TE=0, score 0 at TE >= 5%. |
+| `fee_efficiency` | 0.10 | Same | Same |
+
+```python
+_DEFAULT_ALT_GOLD_WEIGHTS: dict[str, float] = {
+    "crisis_alpha": 0.30,
+    "diversification_value": 0.30,
+    "inflation_hedge": 0.20,
+    "tracking_efficiency": 0.10,
+    "fee_efficiency": 0.10,
+}
+```
+
+#### Profile: Hedge Fund (`alt_hedge_fund`) [NEW BLOCK]
+
+| Componente | Peso | Metrica | Normalizacao |
+|---|---|---|---|
+| `alpha_generation` | 0.30 | sortino_1y (not Sharpe -- Sharpe penalizes upside vol) | Range: -1.0 to 3.0. Sortino isolates downside risk. |
+| `downside_protection` | 0.25 | 1 - downside_capture_1y | Same as REIT. |
+| `diversification_value` | 0.20 | 1 - abs(equity_correlation_252d) | Market-neutral should have near-zero. Long/short should have 0.3-0.6. |
+| `crisis_alpha` | 0.15 | crisis_alpha_score | Hedge funds should protect in stress. |
+| `fee_efficiency` | 0.10 | Same | Particularly important for HFs with 2/20. |
+
+```python
+_DEFAULT_ALT_HEDGE_WEIGHTS: dict[str, float] = {
+    "alpha_generation": 0.30,
+    "downside_protection": 0.25,
+    "diversification_value": 0.20,
+    "crisis_alpha": 0.15,
+    "fee_efficiency": 0.10,
+}
+```
+
+#### Profile: Managed Futures / CTA (`alt_managed_futures`) [NEW BLOCK]
+
+| Componente | Peso | Metrica | Normalizacao |
+|---|---|---|---|
+| `crisis_alpha` | 0.35 | crisis_alpha_score | THE defining characteristic of trend-followers. 2008 GFC: managed futures +20% when equity -38%. |
+| `diversification_value` | 0.25 | 1 - abs(equity_correlation_252d) | CTAs should be near-zero or negative correlation. |
+| `risk_adjusted_return` | 0.20 | calmar_ratio_3y | CTAs have volatile P&L; Calmar penalizes large drawdowns relative to return. |
+| `fee_efficiency` | 0.10 | Same | CTA fees are high (1.5/20 typical). |
+```python
+_DEFAULT_ALT_CTA_WEIGHTS: dict[str, float] = {
+    "crisis_alpha": 0.40,
+    "diversification_value": 0.25,
+    "risk_adjusted_return": 0.25,
+    "fee_efficiency": 0.10,
+}
+```
+
+**Nota:** `trend_capture` foi removido -- usar `sortino_1y` como proxy causaria double-counting com `alpha_generation` (mesmo metric subjacente). O peso de 0.10 foi redistribuido para `crisis_alpha` (+0.05) e `risk_adjusted_return` (+0.05), ambos com metricas independentes (crisis excess return e Calmar 3Y, respectivamente).
+
+#### Profile: Generic Alt (unclassified alternatives)
+
+For alternatives that don't match any specific block, use a balanced profile:
+
+```python
+_DEFAULT_ALT_GENERIC_WEIGHTS: dict[str, float] = {
+    "diversification_value": 0.30,
+    "downside_protection": 0.25,
+    "risk_adjusted_return": 0.20,
+    "crisis_alpha": 0.15,
+    "fee_efficiency": 0.10,
+}
+```
+
+### 2.4 New fund_risk_metrics Columns (Alternatives)
+
+```sql
+ALTER TABLE fund_risk_metrics
+    ADD COLUMN equity_correlation_252d NUMERIC(6, 4),
+    ADD COLUMN downside_capture_1y NUMERIC(8, 4),
+    ADD COLUMN upside_capture_1y NUMERIC(8, 4),
+    ADD COLUMN crisis_alpha_score NUMERIC(10, 6),
+    ADD COLUMN calmar_ratio_3y NUMERIC(8, 4),
+    ADD COLUMN inflation_beta NUMERIC(8, 4),
+    ADD COLUMN inflation_beta_r2 NUMERIC(6, 4);
+```
+
+- `equity_correlation_252d`: rolling 252-day Pearson correlation with SPY. Range [-1, 1].
+- `downside_capture_1y`: ratio of fund down-month return / SPY down-month return. Range [0, 3+].
+- `upside_capture_1y`: ratio of fund up-month return / SPY up-month return. Range [0, 3+].
+- `crisis_alpha_score`: cumulative excess return vs SPY during SPY drawdowns > 10%. Decimal.
+- `calmar_ratio_3y`: 3Y annualized return / abs(max_drawdown_3y). Higher = better risk-adjusted return.
+- `inflation_beta`: OLS beta of monthly returns vs monthly CPI changes.
+- `inflation_beta_r2`: R^2 of the inflation regression.
+
+**Note:** `sortino_1y` already exists in fund_risk_metrics. No new column needed.
+
+### 2.5 Protocol
+
+```python
+class AltMetrics(Protocol):
+    """Protocol for alternatives metrics -- satisfied by FundRiskMetrics ORM or adapter."""
+    equity_correlation_252d: Decimal | float | None
+    downside_capture_1y: Decimal | float | None
+    upside_capture_1y: Decimal | float | None
+    crisis_alpha_score: Decimal | float | None
+    calmar_ratio_3y: Decimal | float | None
+    sortino_1y: Decimal | float | None
+    inflation_beta: Decimal | float | None
+    yield_proxy_12m: Decimal | float | None  # Reused from FI (for REIT income)
+    tracking_error_1y: Decimal | float | None  # Already exists (for gold tracking)
+```
+
+### 2.6 Worker Integration (Alternatives Pass)
+
+New pass in `risk_calc.py`, after FI analytics (Pass 1.8) and before scoring (Pass 1.9):
+
+```python
+# Pass 1.85: Alternatives analytics (correlation, capture, crisis alpha, inflation beta)
+# For funds with asset_class = 'alternatives'
+alt_fund_ids = [str(f.instrument_id) for f, _ in computed if f.asset_class == "alternatives"]
+if alt_fund_ids:
+    # Batch fetch: SPY returns from benchmark_nav (already available)
+    spy_returns = await _fetch_benchmark_returns(db, "SPY", start_date, as_of_date)
+    
+    # Batch fetch: monthly CPI changes from macro_data
+    cpi_changes = await _fetch_monthly_macro_changes(db, "CPIAUCSL", start_date, as_of_date)
+    
+    for fund, metrics_dict in computed:
+        if str(fund.instrument_id) not in alt_fund_ids:
+            continue
+        
+        fund_returns = dated_returns_by_fund.get(str(fund.instrument_id), [])
+        if not fund_returns:
+            metrics_dict["scoring_model"] = "alternatives"
+            continue
+        
+        alt_result = compute_alt_analytics(
+            fund_dated_returns=fund_returns,
+            benchmark_returns=spy_returns,
+            cpi_monthly_changes=cpi_changes,
+            return_3y_ann=metrics_dict.get("return_3y_ann"),
+            max_drawdown_3y=metrics_dict.get("max_drawdown_3y"),
+            config=alt_config,
+        )
+        
+        metrics_dict["equity_correlation_252d"] = alt_result.equity_correlation_252d
+        metrics_dict["downside_capture_1y"] = alt_result.downside_capture_1y
+        metrics_dict["upside_capture_1y"] = alt_result.upside_capture_1y
+        metrics_dict["crisis_alpha_score"] = alt_result.crisis_alpha_score
+        metrics_dict["calmar_ratio_3y"] = alt_result.calmar_ratio_3y
+        metrics_dict["inflation_beta"] = alt_result.inflation_beta
+        metrics_dict["inflation_beta_r2"] = alt_result.inflation_beta_r2
+        metrics_dict["scoring_model"] = "alternatives"
+```
+
+### 2.7 Screener Gate Extensions (Alternatives)
+
+**Layer 1 -- Eliminatory (fund_alternatives):**
+
+```json
+{
+  "fund_alternatives": {
+    "min_aum_usd": 50000000,
+    "min_track_record_years": 3
+  }
+}
+```
+
+Compound gate in `LayerEvaluator.evaluate_layer1()`:
+
+```python
+if instrument_type == "fund" and attributes.get("asset_class") == "alternatives":
+    alt_criteria = criteria.get("fund_alternatives", {})
+    for criterion, expected in alt_criteria.items():
+        result = self._evaluate_criterion(
+            criterion, expected, attributes, "fund_alternatives", layer=1,
+        )
+        if result is not None:
+            results.append(result)
+```
+
+**Layer 2 -- Block-specific mandate fit:**
+
+```json
+{
+  "blocks": {
+    "alt_real_estate": {
+      "criteria": {
+        "max_equity_correlation_252d": 0.80,
+        "min_yield_proxy_12m": 0.02
+      }
+    },
+    "alt_commodities": {
+      "criteria": {
+        "max_equity_correlation_252d": 0.60
+      }
+    },
+    "alt_gold": {
+      "criteria": {
+        "max_equity_correlation_252d": 0.30,
+        "max_tracking_error_1y": 0.05
+      }
+    },
+    "alt_hedge_fund": {
+      "criteria": {
+        "max_equity_correlation_252d": 0.70,
+        "min_sortino_1y": -0.5
+      }
+    },
+    "alt_managed_futures": {
+      "criteria": {
+        "max_equity_correlation_252d": 0.40
+      }
+    }
+  }
+}
+```
+
+**Layer 3 -- Quant scoring:**
+
+New `AltQuantMetrics` dataclass in `quant_metrics.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class AltQuantMetrics:
+    """Alternatives fund screening metrics from fund_risk_metrics."""
+    equity_correlation_252d: float
+    downside_capture_1y: float
+    crisis_alpha_score: float
+    calmar_ratio_3y: float
+    inflation_beta: float
+    sortino_1y: float
+    yield_proxy_12m: float | None
+    tracking_error_1y: float | None
+    annual_return_pct: float
+    data_period_days: int
+    alt_profile: str  # reit | commodity | gold | hedge | cta | generic
+    data_quality_flag: str | None = None
+```
+
+### 2.8 Benchmark Mapping (Alternatives)
+
+| Block | Benchmark Ticker | Already Ingested? | Action |
+|---|---|---|---|
+| alt_real_estate | VNQ | YES (blocks.yaml) | None |
+| alt_commodities | DJP | YES (blocks.yaml) | None |
+| alt_gold | GLD | YES (blocks.yaml) | None |
+| alt_hedge_fund | QAI | NO -- NEW | Add to blocks.yaml + seed migration |
+| alt_managed_futures | DBMF | NO -- NEW | Add to blocks.yaml + seed migration |
+
+QAI (IQ Hedge Multi-Strategy Tracker ETF) and DBMF (iMGP DBi Managed Futures Strategy ETF) are the best liquid proxies for hedge fund and CTA benchmarks. Both have 5+ years of history and are available on Yahoo Finance.
+
+---
+
+## Fase 3 -- Scoring Dispatch Refactor
+
+### 3.1 Unified Dispatch in `scoring_service.py`
+
+Extend `resolve_scoring_weights()`:
+
+```python
+def resolve_scoring_weights(
+    config: dict[str, Any] | None = None,
+    asset_class: str = "equity",
+    alt_profile: str | None = None,  # NEW
+) -> dict[str, float]:
+    defaults = {
+        "equity": _DEFAULT_SCORING_WEIGHTS,
+        "fixed_income": _DEFAULT_FI_SCORING_WEIGHTS,
+        "cash": _DEFAULT_CASH_SCORING_WEIGHTS,
+        "alternatives": _resolve_alt_defaults(alt_profile),
+    }
+    default = defaults.get(asset_class, _DEFAULT_SCORING_WEIGHTS)
+    if config is None:
+        return default
+    try:
+        weights = config.get("scoring_weights", config)
+        if isinstance(weights, dict) and weights:
+            return {k: float(v) for k, v in weights.items()}
+        return default
+    except (TypeError, ValueError):
+        return default
+
+
+def _resolve_alt_defaults(alt_profile: str | None) -> dict[str, float]:
+    profile_defaults = {
+        "reit": _DEFAULT_ALT_REIT_WEIGHTS,
+        "commodity": _DEFAULT_ALT_COMMODITY_WEIGHTS,
+        "gold": _DEFAULT_ALT_GOLD_WEIGHTS,
+        "hedge": _DEFAULT_ALT_HEDGE_WEIGHTS,
+        "cta": _DEFAULT_ALT_CTA_WEIGHTS,
+    }
+    return profile_defaults.get(alt_profile or "", _DEFAULT_ALT_GENERIC_WEIGHTS)
+```
+
+### 3.2 Unified `compute_fund_score()` Dispatch
+
+```python
+def compute_fund_score(
+    metrics: RiskMetrics,
+    flows_momentum_score: float = 50.0,
+    config: dict[str, Any] | None = None,
+    expense_ratio_pct: float | None = None,
+    insider_sentiment_score: float | None = None,
+    peer_medians: dict[str, float] | None = None,
+    asset_class: str = "equity",
+    fi_metrics: FIMetrics | None = None,
+    alt_metrics: AltMetrics | None = None,     # NEW
+    alt_profile: str | None = None,             # NEW
+    cash_metrics: CashMetrics | None = None,    # NEW
+) -> tuple[float, dict[str, float]]:
+    # Dispatch chain (most specific first)
+    if asset_class == "cash" and cash_metrics is not None:
+        return _compute_cash_score(cash_metrics, config, expense_ratio_pct, peer_medians)
+    
+    if asset_class == "fixed_income" and fi_metrics is not None:
+        return _compute_fi_score(fi_metrics, config, expense_ratio_pct, peer_medians)
+    
+    if asset_class == "alternatives" and alt_metrics is not None:
+        return _compute_alt_score(alt_metrics, config, expense_ratio_pct, peer_medians, alt_profile)
+    
+    # Default: equity scoring (also handles multi_asset and unknown)
+    # ... existing equity path ...
+```
+
+### 3.3 Alternatives Score Computation
+
+```python
+def _compute_alt_score(
+    alt: AltMetrics,
+    config: dict[str, Any] | None,
+    expense_ratio_pct: float | None,
+    peer_medians: dict[str, float] | None,
+    alt_profile: str | None = None,
+) -> tuple[float, dict[str, float]]:
+    pm = peer_medians or {}
+    components: dict[str, float] = {}
+    
+    # diversification_value: 1 - |correlation with equity|
+    # Lower correlation = better diversification
+    corr = float(alt.equity_correlation_252d) if alt.equity_correlation_252d is not None else None
+    if corr is not None:
+        div_value = 1.0 - abs(corr)
+        components["diversification_value"] = div_value * 100
+    else:
+        components["diversification_value"] = pm.get("diversification_value", 45.0) - 5.0
+    
+    # downside_protection: 1 - downside_capture (lower capture = better protection)
+    dc = float(alt.downside_capture_1y) if alt.downside_capture_1y is not None else None
+    if dc is not None:
+        # Capture 0 = perfect (100), capture 1.0 = neutral (50), capture >= 2.0 = terrible (0)
+        components["downside_protection"] = _normalize(1.0 - dc, -1.0, 1.0, pm.get("downside_protection"))
+    else:
+        components["downside_protection"] = pm.get("downside_protection", 45.0) - 5.0
+    
+    # crisis_alpha: excess return during equity drawdowns
+    ca = float(alt.crisis_alpha_score) if alt.crisis_alpha_score is not None else None
+    components["crisis_alpha"] = _normalize(ca, -0.20, 0.30, pm.get("crisis_alpha"))
+    
+    # inflation_hedge: inflation beta
+    ib = float(alt.inflation_beta) if alt.inflation_beta is not None else None
+    components["inflation_hedge"] = _normalize(ib, -2.0, 4.0, pm.get("inflation_hedge"))
+    
+    # income_generation: yield proxy (for REIT profile)
+    yp = float(alt.yield_proxy_12m) if alt.yield_proxy_12m is not None else None
+    components["income_generation"] = _normalize(yp, 0.0, 0.10, pm.get("income_generation"))
+    
+    # alpha_generation: Sortino ratio (for hedge fund profile)
+    sort = float(alt.sortino_1y) if alt.sortino_1y is not None else None
+    components["alpha_generation"] = _normalize(sort, -1.0, 3.0, pm.get("alpha_generation"))
+    
+    # risk_adjusted_return: Calmar ratio (for CTA/commodity profiles)
+    calm = float(alt.calmar_ratio_3y) if alt.calmar_ratio_3y is not None else None
+    components["risk_adjusted_return"] = _normalize(calm, 0.0, 2.0, pm.get("risk_adjusted_return"))
+    
+    # drawdown_control: Calmar (for commodity profile)
+    components["drawdown_control"] = components.get("risk_adjusted_return", 50.0)
+    
+    # tracking_efficiency: tracking error vs benchmark (for gold profile)
+    te = float(alt.tracking_error_1y) if alt.tracking_error_1y is not None else None
+    if te is not None:
+        # Lower TE = better tracking. 0% = 100, 5% = 0.
+        components["tracking_efficiency"] = max(0.0, (1.0 - te / 0.05) * 100)
+    else:
+        components["tracking_efficiency"] = pm.get("tracking_efficiency", 45.0) - 5.0
+    
+    # fee_efficiency: shared
+    components["fee_efficiency"] = _compute_fee_efficiency(expense_ratio_pct, pm)
+    
+    weights = resolve_scoring_weights(config, asset_class="alternatives", alt_profile=alt_profile)
+    
+    score = sum(components.get(k, 50.0) * w for k, w in weights.items())
+    
+    # Filter to only include components that carry weight in this profile.
+    # Prevents nonsensical display (e.g., "Income Generation: 38" on a CTA fund).
+    active_components = {k: round(v, 2) for k, v in components.items() if weights.get(k, 0) > 0}
+    return round(score, 2), active_components
+```
+
+Key design decision: ALL components are computed for ALL alternatives funds, but WEIGHTS determine which ones matter. A REIT fund gets scored on income_generation (0.25) but a CTA gets 0.0 weight on income_generation. This means we don't need separate scoring functions per profile -- just different weight vectors.
+
+---
+
+## Fase 4 -- Migration Plan
+
+### Migration 1: `add_cash_scoring_columns` (Cash)
+
+```sql
+ALTER TABLE fund_risk_metrics
+    ADD COLUMN seven_day_net_yield NUMERIC(8, 4),
+    ADD COLUMN fed_funds_rate_at_calc NUMERIC(8, 4),
+    ADD COLUMN nav_per_share_mmf NUMERIC(12, 6),
+    ADD COLUMN pct_weekly_liquid NUMERIC(8, 4),
+    ADD COLUMN weighted_avg_maturity_days INTEGER;
+```
+
+Named `nav_per_share_mmf` to avoid collision with any future generic NAV column.
+
+### Migration 2: `add_alternatives_scoring_columns` (Alternatives)
+
+```sql
+ALTER TABLE fund_risk_metrics
+    ADD COLUMN equity_correlation_252d NUMERIC(6, 4),
+    ADD COLUMN downside_capture_1y NUMERIC(8, 4),
+    ADD COLUMN upside_capture_1y NUMERIC(8, 4),
+    ADD COLUMN crisis_alpha_score NUMERIC(10, 6),
+    ADD COLUMN calmar_ratio_3y NUMERIC(8, 4),
+    ADD COLUMN inflation_beta NUMERIC(8, 4),
+    ADD COLUMN inflation_beta_r2 NUMERIC(6, 4);
+```
+
+### Migration 3: `add_alt_benchmark_blocks` (New blocks)
+
+```sql
+INSERT INTO allocation_blocks (block_id, asset_class, geography, display_name, benchmark_ticker, is_active)
+VALUES
+    ('alt_hedge_fund', 'alternatives', 'global', 'Hedge Funds / Multi-Strategy', 'QAI', true),
+    ('alt_managed_futures', 'alternatives', 'global', 'Managed Futures / CTA', 'DBMF', true)
+ON CONFLICT (block_id) DO NOTHING;
+```
+
+### Materialized View Updates
+
+`mv_unified_funds` and `mv_unified_assets` may need refresh after new instruments get proper alt profiles. No schema change needed -- the scoring_model column already exists.
+
+---
+
+## Fase 5 -- Scoring Model in Worker (Dispatch Logic)
+
+### Determining `scoring_model` in `_score_metrics()`
+
+```python
+def _score_metrics(
+    metrics: dict,
+    scoring_config: dict | None = None,
+    expense_ratio_pct: float | None = None,
+    asset_class: str = "equity",
+    block_id: str | None = None,  # NEW -- for alt profile resolution
+) -> None:
+    adapter = _MetricsAdapter(metrics)
+    flows = float(metrics.get("blended_momentum_score") or 50.0)
+    
+    # Determine scoring model and build appropriate adapter
+    if asset_class == "cash":
+        cash_adapter = _CashMetricsAdapter(metrics)
+        score_val, components = compute_fund_score(
+            adapter,
+            config=scoring_config,
+            expense_ratio_pct=expense_ratio_pct,
+            asset_class="cash",
+            cash_metrics=cash_adapter,
+        )
+    elif asset_class == "fixed_income":
+        fi_adapter = _FIMetricsAdapter(metrics)
+        score_val, components = compute_fund_score(
+            adapter,
+            flows_momentum_score=flows,
+            config=scoring_config,
+            expense_ratio_pct=expense_ratio_pct,
+            asset_class="fixed_income",
+            fi_metrics=fi_adapter,
+        )
+    elif asset_class == "alternatives":
+        alt_adapter = _AltMetricsAdapter(metrics)
+        # Global worker (900_071): resolve from strategy_label (no block_id available).
+        # Org worker (900_007): resolve from block_id if available, else strategy_label.
+        if block_id:
+            alt_profile = _resolve_alt_profile(block_id)
+        else:
+            alt_profile = _resolve_alt_profile_from_strategy_label(
+                metrics.get("_strategy_label"),  # injected earlier from instrument attributes
+            )
+        score_val, components = compute_fund_score(
+            adapter,
+            config=scoring_config,
+            expense_ratio_pct=expense_ratio_pct,
+            asset_class="alternatives",
+            alt_metrics=alt_adapter,
+            alt_profile=alt_profile,
+        )
+    else:
+        # Equity path (default)
+        score_val, components = compute_fund_score(
+            adapter,
+            flows_momentum_score=flows,
+            config=scoring_config,
+            expense_ratio_pct=expense_ratio_pct,
+            asset_class="equity",
+        )
+    
+    metrics["manager_score"] = round(score_val, 2)
+    metrics["score_components"] = components
+
+
+_BLOCK_TO_ALT_PROFILE = {
+    "alt_real_estate": "reit",
+    "alt_commodities": "commodity",
+    "alt_gold": "gold",
+    "alt_hedge_fund": "hedge",
+    "alt_managed_futures": "cta",
+}
+
+def _resolve_alt_profile(block_id: str | None) -> str:
+    """Resolve alt profile from block_id. Used in org-scoped worker (has block_id)."""
+    if not block_id:
+        return "generic"
+    return _BLOCK_TO_ALT_PROFILE.get(block_id, "generic")
+
+
+def _resolve_alt_profile_from_strategy_label(strategy_label: str | None) -> str:
+    """Resolve alt profile from strategy_label via block_mapping.
+    
+    Used in GLOBAL worker (lock 900_071) where block_id is NOT available
+    (block assignment is org-scoped via instruments_org).
+    Chain: strategy_label -> blocks_for_strategy_label() -> first block -> profile.
+    """
+    if not strategy_label:
+        return "generic"
+    from vertical_engines.wealth.model_portfolio.block_mapping import blocks_for_strategy_label
+    blocks = blocks_for_strategy_label(strategy_label)
+    for b in blocks:
+        if b in _BLOCK_TO_ALT_PROFILE:
+            return _BLOCK_TO_ALT_PROFILE[b]
+    return "generic"
+```
+
+---
+
+## Fase 6 -- Tests
+
+### Unit Tests
+
+#### `test_scoring_service.py` (extend)
+
+1. **Cash scoring -- high yield MMF:** seven_day_net_yield=5.5%, DFF=5.33%, WAM=15, weekly_liquid=80%, ER=0.15% -> score > 75.
+2. **Cash scoring -- poor MMF:** seven_day_net_yield=4.0%, DFF=5.33%, WAM=55, weekly_liquid=32% -> score < 40.
+3. **Cash scoring -- nav_stability edge case:** nav_per_share=0.9998 (2bp deviation) -> nav_stability ~80. nav_per_share=0.9970 (30bp break the buck) -> nav_stability = 0.
+4. **Cash vs equity -- MMF should not get equity scored:** verify scoring_model="cash" when asset_class="cash" and cash_metrics provided.
+5. **Alt REIT -- income + low correlation:** yield_proxy=0.06, equity_corr=0.3, downside_capture=0.5, inflation_beta=1.5 -> score > 70 on reit profile.
+6. **Alt REIT -- high correlation (bad diversifier):** equity_corr=0.85 -> diversification_value < 20.
+7. **Alt CTA -- crisis alpha:** crisis_alpha=0.15 (outperformed SPY by 15% in crises), equity_corr=-0.1 -> score > 75 on cta profile.
+8. **Alt Hedge -- alpha generation:** sortino=2.0, downside_capture=0.4, equity_corr=0.3 -> score > 70 on hedge profile.
+9. **Alt Gold -- tracking efficiency:** tracking_error=0.01 (1% TE) -> tracking_efficiency = 80. tracking_error=0.05 -> tracking_efficiency = 0.
+10. **Profile weight verification:** same metrics scored with reit vs cta profile -> different scores (income matters for REIT, crisis_alpha matters for CTA).
+
+#### `test_alternatives_analytics_service.py` (new)
+
+1. **Equity correlation:** Fund with returns = 0.8 * SPY + noise -> correlation ~0.8.
+2. **Zero correlation:** Fund with random returns independent of SPY -> correlation ~0.
+3. **Capture ratios:** Fund that drops 50% of SPY drop in down months -> downside_capture ~0.5.
+4. **Crisis alpha:** Fund that is flat during 15% SPY drawdown -> crisis_alpha ~+0.15.
+5. **Inflation beta -- REIT with CPI sensitivity:** Fund returns = 2.0 * CPI_change + noise -> inflation_beta ~2.0.
+6. **Calmar ratio:** return_3y=0.10, max_dd=-0.05 -> calmar=2.0.
+7. **Insufficient data:** < 120 observations -> all None.
+
+#### `test_screener_cash_gates.py` (new)
+
+1. **Layer 1 fund_cash gate:** WAM=70 (> max 60) -> FAIL at layer 1.
+2. **Layer 1 fund_cash gate:** weekly_liquid=25% (< min 30%) -> FAIL.
+3. **Layer 2 cash block:** mmf_category="Prime" with allowed list -> PASS.
+4. **Layer 3 CashQuantMetrics:** composite score via percentile rank.
+
+---
+
+## Fase 7 -- Phase Sequencing
+
+### Implementacao Order
+
+| Seq | Fase | Deps | Parallelizavel? | Estimativa |
+|---|---|---|---|---|
+| 1 | Migration 1 (cash columns) | None | YES with 2 | 30min |
+| 2 | Migration 2 (alt columns) | None | YES with 1 | 30min |
+| 3 | Migration 3 (new blocks) | None | YES with 1,2 | 20min |
+| 4 | `alternatives_analytics_service.py` | None | YES with 1-3 | 2h |
+| 5 | Cash scoring in `scoring_service.py` | Migration 1 | After 1 | 1.5h |
+| 6 | Alt scoring in `scoring_service.py` | Migration 2, service | After 2,4 | 2h |
+| 7 | Screener gates (cash + alt) | Scoring done | After 5,6 | 1.5h |
+| 8 | Worker: cash pass | Migration 1, scoring | After 5 | 2h |
+| 9 | Worker: alt pass | Migration 2, service | After 6 | 2h |
+| 10 | Block mapping updates | Migration 3 | After 3 | 30min |
+| 11 | Unit tests | All above | After each phase | Continuous |
+| 12 | Integration test (full worker run) | All above | After 8,9 | 1h |
+
+**Critical path:** Migrations -> analytics service -> scoring service -> worker integration -> tests.
+
+**Parallelizable:** Migrations 1-3 are independent. Cash scoring (5) and alt analytics service (4) are independent. Worker passes (8, 9) depend on scoring but are independent of each other.
+
+### Recommended Execution Order
+
+**Sprint 1 -- Cash/MMF (simpler, most impactful):**
+1. Migration 1 (cash columns)
+2. Cash defaults + CashMetrics protocol in scoring_service.py
+3. `_compute_cash_score()` function
+4. Cash pass in risk_calc worker
+5. Layer 1/2/3 cash gates in screener
+6. Tests
+
+**Sprint 2 -- Alternatives Core (infrastructure):**
+1. Migration 2 (alt columns) + Migration 3 (new blocks)
+2. `alternatives_analytics_service.py` (pure functions)
+3. Tests for analytics service
+4. Alt defaults + AltMetrics protocol in scoring_service.py
+5. `_compute_alt_score()` with profile-based weights
+
+**Sprint 3 -- Alternatives Integration (worker + screener):**
+1. Block mapping updates
+2. Alt analytics pass in risk_calc worker
+3. Alt profile resolution in `_score_metrics()`
+4. Layer 1/2/3 alt gates in screener
+5. AltQuantMetrics in screener quant_metrics
+6. Integration tests
+
+---
+
+## Data Availability Reality Check
+
+### What We CAN Compute from Existing Data
+
+| Metric | Data Source | Available? | Notes |
+|---|---|---|---|
+| equity_correlation_252d | nav_timeseries + benchmark_nav (SPY) | YES | Both already ingested daily |
+| downside_capture_1y | nav_timeseries + benchmark_nav (SPY) | YES | Monthly returns from daily NAV |
+| upside_capture_1y | nav_timeseries + benchmark_nav (SPY) | YES | Same as above |
+| crisis_alpha_score | nav_timeseries + benchmark_nav (SPY) | YES | Need to identify crisis periods from SPY drawdowns |
+| calmar_ratio_3y | fund_risk_metrics (return_3y_ann, max_drawdown_3y) | YES | Already pre-computed columns |
+| sortino_1y | fund_risk_metrics | YES | Already exists |
+| inflation_beta | nav_timeseries + macro_data (CPIAUCSL) | YES | CPI already ingested monthly |
+| tracking_error_1y | fund_risk_metrics | YES | Already exists |
+| yield_proxy_12m | nav_timeseries | YES | Same FI computation (reuse) |
+| seven_day_net_yield | sec_mmf_metrics | YES | 20k daily rows |
+| fed_funds_rate | macro_data (DFF) | YES | Daily |
+| nav_per_share (MMF) | sec_money_market_funds.stable_nav_price | YES | From N-MFP |
+| pct_weekly_liquid | sec_money_market_funds | YES | From N-MFP |
+| weighted_avg_maturity | sec_money_market_funds | YES | From N-MFP |
+
+### What We CANNOT Compute (Would Need New Data Sources)
+
+| Metric | Would Need | Priority | Workaround |
+|---|---|---|---|
+| Real occupancy rates (REITs) | REIT 10-K filings | LOW | Use returns vs VNQ as proxy |
+| Actual roll yield (commodities) | Commodity futures curve data | LOW | Use DJP tracking error as proxy |
+| Hedge fund AUM flows | HFR/Preqin database | LOW | Use NAV-based flow proxy (existing) |
+| Daily NAV for shadow pricing (MMF) | Institutional NAV feed | MEDIUM | Use stable_nav_price from N-MFP |
+
+**Conclusion:** Every metric in the plan is computable from existing data sources. No new external data integrations needed.
+
+---
+
+## Audit & Provenance
+
+- `scoring_model` column already exists in fund_risk_metrics -- extend values to include "alternatives" and "cash".
+- `score_components` JSONB stores the actual component scores. Consumers (frontend, fact sheet) use `scoring_model` to interpret keys.
+- Worker sets `scoring_model` before calling `_score_metrics()` -- audit trail is clear.
+- All analytics regressions store R^2 values (`inflation_beta_r2`) for confidence auditing.
+- ConfigService overrides are tenant-specific -- if a tenant wants different alt weights, they override via ConfigService without affecting global scoring.
+
+## Frontend Implications
+
+- Score composition panel (`ScoreCompositionPanel.svelte`) needs to handle new component keys. The panel already reads `score_components` JSONB dynamically.
+- `scoring_model` label should translate to institutional vocabulary:
+  - "equity" -> "Equity Score"
+  - "fixed_income" -> "Fixed Income Score"  
+  - "alternatives" -> "Alternatives Score"
+  - "cash" -> "Cash/MMF Score"
+- Alternatives sub-profile (REIT, commodity, etc.) shown as subtitle: "Alternatives Score (Real Estate)".
+- NO quant jargon in UI: "crisis_alpha" -> "Stress Protection", "inflation_beta" -> "Inflation Sensitivity", "downside_capture" -> "Downside Protection".
+- **Zero-weight component filtering:** `_compute_alt_score` computes ALL components regardless of profile, but only some carry weight. The backend MUST filter `score_components` JSONB to only include components with weight > 0 before persisting. Otherwise a CTA fund would show "Income Generation: 38.5" in the ScoreCompositionPanel, which is nonsensical. Implementation: `components = {k: v for k, v in components.items() if weights.get(k, 0) > 0}` before returning from `_compute_alt_score`.


### PR DESCRIPTION
11 files, +2513. alternatives_analytics_service.py (correlation, capture, crisis alpha, Calmar, inflation beta), 6 profile weight configs (REIT/Commodity/Gold/Hedge/CTA/Generic), migration 0125 (7 columns), 2 new benchmark blocks (QAI/DBMF), screener gates. 39 new tests, 96 total scoring, zero regressions.