### PR TITLE
feat(scoring): Alternatives Sprint 3 — worker pass + profile dispatch + E2E

### DIFF
--- a/backend/app/domains/wealth/models/risk.py
+++ b/backend/app/domains/wealth/models/risk.py
@@ -103,6 +103,15 @@ class FundRiskMetrics(Base):
     pct_weekly_liquid: Mapped[Decimal | None] = mapped_column(Numeric(8, 4), nullable=True)
     weighted_avg_maturity_days: Mapped[int | None] = mapped_column(sa.Integer, nullable=True)
 
+    # Alternatives analytics (pre-computed by risk_calc alternatives analytics pass)
+    equity_correlation_252d: Mapped[Decimal | None] = mapped_column(Numeric(6, 4), nullable=True)
+    downside_capture_1y: Mapped[Decimal | None] = mapped_column(Numeric(8, 4), nullable=True)
+    upside_capture_1y: Mapped[Decimal | None] = mapped_column(Numeric(8, 4), nullable=True)
+    crisis_alpha_score: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
+    calmar_ratio_3y: Mapped[Decimal | None] = mapped_column(Numeric(8, 4), nullable=True)
+    inflation_beta: Mapped[Decimal | None] = mapped_column(Numeric(8, 4), nullable=True)
+    inflation_beta_r2: Mapped[Decimal | None] = mapped_column(Numeric(6, 4), nullable=True)
+
     # Audit & data quality flags
     data_quality_flags: Mapped[dict | None] = mapped_column(JSONB, server_default=text("'{}'::jsonb"), nullable=True)
 

--- a/backend/app/domains/wealth/workers/risk_calc.py
+++ b/backend/app/domains/wealth/workers/risk_calc.py
@@ -28,6 +28,7 @@ from app.domains.wealth.models.instrument_org import InstrumentOrg
 from app.domains.wealth.models.macro import MacroData
 from app.domains.wealth.models.nav import NavTimeseries
 from app.domains.wealth.models.risk import FundRiskMetrics
+from quant_engine.alternatives_analytics_service import AltAnalyticsConfig, compute_alt_analytics
 from quant_engine.cvar_service import compute_cvar_from_returns
 from quant_engine.drift_service import DtwDriftResult, DtwDriftStatus, compute_dtw_drift_batch
 from quant_engine.fixed_income_analytics_service import FIRegressionConfig, compute_fi_analytics
@@ -976,6 +977,94 @@ async def _batch_fetch_mmf_yields(
     return out
 
 
+async def _fetch_benchmark_dated_returns(
+    db: AsyncSession,
+    block_id: str,
+    start_date: date,
+    as_of_date: date,
+) -> list[tuple[date, float]]:
+    """Fetch daily returns for a benchmark (e.g. SPY via na_equity_large).
+
+    Returns list of (nav_date, return_1d) tuples from benchmark_nav.
+    """
+    result = await db.execute(
+        text("""
+            SELECT nav_date, return_1d FROM benchmark_nav
+            WHERE block_id = :block_id
+              AND nav_date >= :start_date AND nav_date <= :as_of
+              AND return_1d IS NOT NULL
+            ORDER BY nav_date
+        """),
+        {"block_id": block_id, "start_date": start_date, "as_of": as_of_date},
+    )
+    return [(row[0], float(row[1])) for row in result.all()]
+
+
+async def _fetch_monthly_cpi_changes(
+    db: AsyncSession,
+    start_date: date,
+    as_of_date: date,
+) -> list[tuple[date, float]]:
+    """Fetch monthly CPI changes from macro_data (CPIAUCSL).
+
+    CPI is an index level (e.g. 310.5). We compute month-over-month
+    percentage change: delta = (CPI_t - CPI_{t-1}) / CPI_{t-1}.
+    Returns list of (obs_date, pct_change) tuples.
+    """
+    result = await db.execute(
+        text("""
+            SELECT observation_date, value FROM macro_data
+            WHERE series_id = 'CPIAUCSL'
+              AND observation_date >= :start_date AND observation_date <= :as_of
+              AND value IS NOT NULL
+            ORDER BY observation_date
+        """),
+        {"start_date": start_date, "as_of": as_of_date},
+    )
+    raw = [(row[0], float(row[1])) for row in result.all()]
+    if len(raw) < 2:
+        return []
+    changes: list[tuple[date, float]] = []
+    for i in range(1, len(raw)):
+        prev_val = raw[i - 1][1]
+        if prev_val > 0:
+            delta = (raw[i][1] - prev_val) / prev_val
+            changes.append((raw[i][0], delta))
+    return changes
+
+
+# ── Alternatives profile resolution ──────────────────────────────
+_BLOCK_TO_ALT_PROFILE: dict[str, str] = {
+    "alt_real_estate": "reit",
+    "alt_commodities": "commodity",
+    "alt_gold": "gold",
+    "alt_hedge_fund": "hedge",
+    "alt_managed_futures": "cta",
+}
+
+
+def _resolve_alt_profile(block_id: str | None) -> str:
+    """Resolve alt profile from block_id. Used in org-scoped worker."""
+    if not block_id:
+        return "generic_alt"
+    return _BLOCK_TO_ALT_PROFILE.get(block_id, "generic_alt")
+
+
+def _resolve_alt_profile_from_strategy(strategy_label: str | None) -> str:
+    """Resolve alt profile from strategy_label via block_mapping.
+
+    Used in GLOBAL worker where block_id is NOT available.
+    """
+    if not strategy_label:
+        return "generic_alt"
+    from vertical_engines.wealth.model_portfolio.block_mapping import blocks_for_strategy_label
+    blocks = blocks_for_strategy_label(strategy_label)
+    for b in blocks:
+        if b in _BLOCK_TO_ALT_PROFILE:
+            return _BLOCK_TO_ALT_PROFILE[b]
+    return "generic_alt"
+
+
 class _MetricsAdapter:
     """Adapter to expose a metrics dict as the RiskMetrics protocol for scoring."""
 
@@ -991,6 +1080,8 @@ def _score_metrics(
     scoring_config: dict | None = None,
     expense_ratio_pct: float | None = None,
     asset_class: str = "equity",
+    block_id: str | None = None,
+    strategy_label: str | None = None,
 ) -> None:
     """Compute manager_score and score_components from base metrics in-place."""
     adapter = _MetricsAdapter(metrics)
@@ -998,6 +1089,15 @@ def _score_metrics(
 
     fi_adapter = _MetricsAdapter(metrics) if asset_class == "fixed_income" else None
     cash_adapter = _MetricsAdapter(metrics) if asset_class == "cash" else None
+    alt_adapter = _MetricsAdapter(metrics) if asset_class == "alternatives" else None
+
+    # Resolve alt profile: org worker uses block_id, global uses strategy_label
+    alt_profile: str | None = None
+    if asset_class == "alternatives":
+        if block_id:
+            alt_profile = _resolve_alt_profile(block_id)
+        else:
+            alt_profile = _resolve_alt_profile_from_strategy(strategy_label)
 
     score_val, components = compute_fund_score(
         adapter,
@@ -1007,8 +1107,13 @@ def _score_metrics(
         asset_class=asset_class,
         fi_metrics=fi_adapter,
         cash_metrics=cash_adapter,
+        alt_metrics=alt_adapter,
+        alt_profile=alt_profile,
     )
     metrics["manager_score"] = round(score_val, 2)
+    # Store alt_profile in score_components for frontend rendering
+    if alt_profile:
+        components["_alt_profile"] = alt_profile
     metrics["score_components"] = components
 
 
@@ -1196,7 +1301,45 @@ async def run_risk_calc(org_id: "uuid.UUID", as_of_date: date | None = None) -> 
                     metrics["weighted_avg_maturity_days"] = mmf_info.get("weighted_avg_maturity")
                 logger.info("cash_analytics_computed", cash_funds=len(cash_fund_ids))
 
-            # Assign scoring_model = "equity" for funds not covered by FI or Cash
+            # Pass 1.78: Alternatives analytics (correlation, capture, crisis alpha, inflation beta)
+            alt_fund_ids = {str(f.instrument_id) for f, _ in computed if f.asset_class == "alternatives"}
+            if alt_fund_ids:
+                alt_config = AltAnalyticsConfig()
+                # Fetch SPY benchmark returns (via na_equity_large block)
+                spy_returns = await _fetch_benchmark_dated_returns(db, "na_equity_large", start_date, eval_date)
+                # Fetch monthly CPI changes for inflation beta regression
+                cpi_changes = await _fetch_monthly_cpi_changes(db, start_date, eval_date)
+                # Reuse dated_returns if already fetched, else fetch now
+                if not stress_dates and not fi_fund_ids:
+                    dated_returns_by_fund = await _batch_fetch_dated_returns(
+                        db, all_fund_ids, return_type_by_fund, start_date, eval_date,
+                    )
+                for fund, metrics in computed:
+                    fid_str = str(fund.instrument_id)
+                    if fid_str not in alt_fund_ids:
+                        continue
+                    metrics["scoring_model"] = "alternatives"
+                    fund_dated_returns = dated_returns_by_fund.get(fid_str, [])
+                    if not fund_dated_returns:
+                        continue
+                    alt_result = compute_alt_analytics(
+                        fund_dated_returns=fund_dated_returns,
+                        benchmark_dated_returns=spy_returns,
+                        cpi_monthly_changes=cpi_changes,
+                        return_3y_ann=metrics.get("return_3y_ann"),
+                        max_drawdown_3y=metrics.get("max_drawdown_3y"),
+                        config=alt_config,
+                    )
+                    metrics["equity_correlation_252d"] = round(alt_result.equity_correlation_252d, 4) if alt_result.equity_correlation_252d is not None else None
+                    metrics["downside_capture_1y"] = round(alt_result.downside_capture_1y, 4) if alt_result.downside_capture_1y is not None else None
+                    metrics["upside_capture_1y"] = round(alt_result.upside_capture_1y, 4) if alt_result.upside_capture_1y is not None else None
+                    metrics["crisis_alpha_score"] = round(alt_result.crisis_alpha_score, 6) if alt_result.crisis_alpha_score is not None else None
+                    metrics["calmar_ratio_3y"] = round(alt_result.calmar_ratio_3y, 4) if alt_result.calmar_ratio_3y is not None else None
+                    metrics["inflation_beta"] = round(alt_result.inflation_beta, 4) if alt_result.inflation_beta is not None else None
+                    metrics["inflation_beta_r2"] = round(alt_result.inflation_beta_r2, 4) if alt_result.inflation_beta_r2 is not None else None
+                logger.info("alt_analytics_computed", alt_funds=len(alt_fund_ids))
+
+            # Assign scoring_model = "equity" for funds not covered by FI, Cash, or Alternatives
             for fund, metrics in computed:
                 if "scoring_model" not in metrics:
                     metrics["scoring_model"] = "equity"
@@ -1204,11 +1347,15 @@ async def run_risk_calc(org_id: "uuid.UUID", as_of_date: date | None = None) -> 
             # Pass 1.8: compute manager_score from base metrics + momentum + config
             for fund, metrics in computed:
                 er = (fund.attributes or {}).get("expense_ratio_pct")
+                bid = block_id_map.get(str(fund.instrument_id))
+                strategy_lbl = (fund.attributes or {}).get("strategy_label")
                 _score_metrics(
                     metrics,
                     scoring_config=scoring_config,
                     expense_ratio_pct=float(er) if er is not None else None,
                     asset_class=fund.asset_class or "equity",
+                    block_id=bid,
+                    strategy_label=strategy_lbl,
                 )
 
             # Pass 2: compute DTW drift scores per block (reuses DB session, no extra query per fund)
@@ -1436,7 +1583,42 @@ async def run_global_risk_metrics(as_of_date: date | None = None) -> dict[str, i
                         metrics["weighted_avg_maturity_days"] = mmf_info.get("weighted_avg_maturity")
                     logger.info("cash_analytics_computed", cash_funds=len(cash_fund_ids_g), batch_start=batch_start)
 
-                # Assign scoring_model = "equity" for funds not covered by FI or Cash
+                # Pass 1.78: Alternatives analytics for alt funds in this batch
+                alt_fund_ids_g = {str(f.instrument_id) for f, _ in computed if f.asset_class == "alternatives"}
+                if alt_fund_ids_g:
+                    alt_config = AltAnalyticsConfig()
+                    spy_returns = await _fetch_benchmark_dated_returns(db, "na_equity_large", start_date, eval_date)
+                    cpi_changes = await _fetch_monthly_cpi_changes(db, start_date, eval_date)
+                    if not stress_dates and not fi_fund_ids:
+                        dated_returns_by_fund = await _batch_fetch_dated_returns(
+                            db, batch_ids, return_type_by_fund, start_date, eval_date,
+                        )
+                    for fund, metrics in computed:
+                        fid_str = str(fund.instrument_id)
+                        if fid_str not in alt_fund_ids_g:
+                            continue
+                        metrics["scoring_model"] = "alternatives"
+                        fund_dated_returns = dated_returns_by_fund.get(fid_str, [])
+                        if not fund_dated_returns:
+                            continue
+                        alt_result = compute_alt_analytics(
+                            fund_dated_returns=fund_dated_returns,
+                            benchmark_dated_returns=spy_returns,
+                            cpi_monthly_changes=cpi_changes,
+                            return_3y_ann=metrics.get("return_3y_ann"),
+                            max_drawdown_3y=metrics.get("max_drawdown_3y"),
+                            config=alt_config,
+                        )
+                        metrics["equity_correlation_252d"] = round(alt_result.equity_correlation_252d, 4) if alt_result.equity_correlation_252d is not None else None
+                        metrics["downside_capture_1y"] = round(alt_result.downside_capture_1y, 4) if alt_result.downside_capture_1y is not None else None
+                        metrics["upside_capture_1y"] = round(alt_result.upside_capture_1y, 4) if alt_result.upside_capture_1y is not None else None
+                        metrics["crisis_alpha_score"] = round(alt_result.crisis_alpha_score, 6) if alt_result.crisis_alpha_score is not None else None
+                        metrics["calmar_ratio_3y"] = round(alt_result.calmar_ratio_3y, 4) if alt_result.calmar_ratio_3y is not None else None
+                        metrics["inflation_beta"] = round(alt_result.inflation_beta, 4) if alt_result.inflation_beta is not None else None
+                        metrics["inflation_beta_r2"] = round(alt_result.inflation_beta_r2, 4) if alt_result.inflation_beta_r2 is not None else None
+                    logger.info("alt_analytics_computed", alt_funds=len(alt_fund_ids_g), batch_start=batch_start)
+
+                # Assign scoring_model = "equity" for funds not covered by FI, Cash, or Alternatives
                 for fund, metrics in computed:
                     if "scoring_model" not in metrics:
                         metrics["scoring_model"] = "equity"
@@ -1458,10 +1640,12 @@ async def run_global_risk_metrics(as_of_date: date | None = None) -> dict[str, i
 
                 for fund, metrics in computed:
                     er = er_map.get(fund.ticker) if fund.ticker else None
+                    strategy_lbl = (fund.attributes or {}).get("strategy_label")
                     _score_metrics(
                         metrics,
                         expense_ratio_pct=er,
                         asset_class=fund.asset_class or "equity",
+                        strategy_label=strategy_lbl,
                     )
 
                 # Upsert batch — no DTW drift, no org_id

--- a/backend/quant_engine/scoring_service.py
+++ b/backend/quant_engine/scoring_service.py
@@ -445,7 +445,10 @@ def _compute_alternatives_score(
     weights = resolve_alt_profile_weights(profile, config)
 
     score = sum(components.get(k, 50.0) * w for k, w in weights.items())
-    return round(score, 2), {k: round(v, 2) for k, v in components.items()}
+    # Only return components that carry weight in this profile.
+    # Prevents nonsensical display (e.g., "Income Generation: 38" on a CTA fund).
+    active_components = {k: round(v, 2) for k, v in components.items() if weights.get(k, 0) > 0}
+    return round(score, 2), active_components
 
 
 def compute_fund_score(

--- a/backend/tests/test_alt_scoring_integration.py
+++ b/backend/tests/test_alt_scoring_integration.py
@@ -1,0 +1,359 @@
+"""E2E integration tests for Alternatives scoring pipeline (Sprint 3).
+
+Tests the full chain: worker Pass 1.78 → _score_metrics → profile resolution → scoring.
+Validates that alternatives funds are scored using the correct model/profile, not equity.
+
+Covers:
+1. Worker pass computes alt metrics and stores correct scoring_model
+2. _score_metrics dispatches to alternatives with profile resolution
+3. REIT fund: profile-specific scoring vs equity model
+4. Commodity fund: inflation_hedge component recognized
+5. CTA fund: crisis_alpha component dominates (0.40 weight)
+6. ELITE validation: all 4 scoring_models present
+7. Block-to-profile resolution
+8. Strategy-label-to-profile resolution (global worker path)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from quant_engine.scoring_service import (
+    _DEFAULT_ALT_CTA_WEIGHTS,
+    _DEFAULT_ALT_REIT_WEIGHTS,
+    compute_fund_score,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_equity_metrics(
+    return_1y: float | None = 0.10,
+    sharpe_1y: float | None = 1.2,
+    max_drawdown_1y: float | None = -0.08,
+    information_ratio_1y: float | None = 0.6,
+) -> MagicMock:
+    m = MagicMock()
+    m.return_1y = return_1y
+    m.sharpe_1y = sharpe_1y
+    m.max_drawdown_1y = max_drawdown_1y
+    m.information_ratio_1y = information_ratio_1y
+    return m
+
+
+def _make_alt_metrics(
+    equity_correlation_252d: float | None = 0.2,
+    downside_capture_1y: float | None = 0.5,
+    upside_capture_1y: float | None = 0.7,
+    crisis_alpha_score: float | None = 0.08,
+    calmar_ratio_3y: float | None = 1.2,
+    sortino_1y: float | None = 1.5,
+    inflation_beta: float | None = 1.8,
+    yield_proxy_12m: float | None = 0.06,
+    tracking_error_1y: float | None = 0.02,
+) -> MagicMock:
+    m = MagicMock()
+    m.equity_correlation_252d = equity_correlation_252d
+    m.downside_capture_1y = downside_capture_1y
+    m.upside_capture_1y = upside_capture_1y
+    m.crisis_alpha_score = crisis_alpha_score
+    m.calmar_ratio_3y = calmar_ratio_3y
+    m.sortino_1y = sortino_1y
+    m.inflation_beta = inflation_beta
+    m.yield_proxy_12m = yield_proxy_12m
+    m.tracking_error_1y = tracking_error_1y
+    return m
+
+
+# ── Worker Pass Integration (via _score_metrics) ────────────────────
+
+
+class TestWorkerScoreMetricsIntegration:
+    """Test _score_metrics with alternatives dispatch (mirrors worker behavior)."""
+
+    def test_alt_fund_scored_as_alternatives(self) -> None:
+        """_score_metrics produces scoring_model=alternatives + alt components."""
+        from app.domains.wealth.workers.risk_calc import _score_metrics
+
+        metrics: dict = {
+            "return_1y": 0.06,
+            "sharpe_1y": 0.7,
+            "max_drawdown_1y": -0.08,
+            "information_ratio_1y": 0.2,
+            "blended_momentum_score": 50.0,
+            "scoring_model": "alternatives",
+            # Alt analytics columns
+            "equity_correlation_252d": 0.15,
+            "downside_capture_1y": 0.4,
+            "upside_capture_1y": 0.7,
+            "crisis_alpha_score": 0.12,
+            "calmar_ratio_3y": 1.3,
+            "sortino_1y": 1.8,
+            "inflation_beta": 2.1,
+            "yield_proxy_12m": 0.05,
+            "tracking_error_1y": 0.015,
+        }
+        _score_metrics(
+            metrics,
+            asset_class="alternatives",
+            block_id="alt_real_estate",
+        )
+        assert "manager_score" in metrics
+        assert metrics["manager_score"] > 0
+        assert "score_components" in metrics
+        comps = metrics["score_components"]
+        # Should have alternatives components, not equity
+        assert "diversification_value" in comps or "income_generation" in comps
+        assert "return_consistency" not in comps
+        # Profile stored for frontend
+        assert comps.get("_alt_profile") == "reit"
+
+    def test_alt_fund_via_strategy_label(self) -> None:
+        """Global worker path: resolve profile from strategy_label."""
+        from app.domains.wealth.workers.risk_calc import _score_metrics
+
+        metrics: dict = {
+            "return_1y": 0.08,
+            "sharpe_1y": 0.9,
+            "max_drawdown_1y": -0.10,
+            "information_ratio_1y": 0.3,
+            "blended_momentum_score": 50.0,
+            "scoring_model": "alternatives",
+            "equity_correlation_252d": -0.05,
+            "downside_capture_1y": 0.3,
+            "upside_capture_1y": 0.6,
+            "crisis_alpha_score": 0.20,
+            "calmar_ratio_3y": 1.5,
+            "sortino_1y": 2.0,
+            "inflation_beta": 0.5,
+            "yield_proxy_12m": None,
+            "tracking_error_1y": None,
+        }
+        _score_metrics(
+            metrics,
+            asset_class="alternatives",
+            strategy_label="Managed Futures",
+        )
+        comps = metrics["score_components"]
+        assert comps.get("_alt_profile") == "cta"
+        assert "crisis_alpha" in comps
+        assert metrics["manager_score"] > 0
+
+    def test_equity_fund_unchanged(self) -> None:
+        """Equity funds should not be affected by the new alt path."""
+        from app.domains.wealth.workers.risk_calc import _score_metrics
+
+        metrics: dict = {
+            "return_1y": 0.15,
+            "sharpe_1y": 1.5,
+            "max_drawdown_1y": -0.12,
+            "information_ratio_1y": 0.8,
+            "blended_momentum_score": 60.0,
+        }
+        _score_metrics(metrics, asset_class="equity")
+        assert "score_components" in metrics
+        comps = metrics["score_components"]
+        assert "return_consistency" in comps
+        assert "diversification_value" not in comps
+        assert "_alt_profile" not in comps
+
+
+# ── Profile Resolution ───────────────────────────────────────────────
+
+
+class TestAltProfileResolution:
+    """Test block_id → profile and strategy_label → profile resolution."""
+
+    def test_block_to_profile_mapping(self) -> None:
+        from app.domains.wealth.workers.risk_calc import _resolve_alt_profile
+
+        assert _resolve_alt_profile("alt_real_estate") == "reit"
+        assert _resolve_alt_profile("alt_commodities") == "commodity"
+        assert _resolve_alt_profile("alt_gold") == "gold"
+        assert _resolve_alt_profile("alt_hedge_fund") == "hedge"
+        assert _resolve_alt_profile("alt_managed_futures") == "cta"
+        assert _resolve_alt_profile(None) == "generic_alt"
+        assert _resolve_alt_profile("na_equity_large") == "generic_alt"
+
+    def test_strategy_label_to_profile(self) -> None:
+        from app.domains.wealth.workers.risk_calc import _resolve_alt_profile_from_strategy
+
+        assert _resolve_alt_profile_from_strategy("Real Estate") == "reit"
+        assert _resolve_alt_profile_from_strategy("Commodities Broad Basket") == "commodity"
+        assert _resolve_alt_profile_from_strategy("Precious Metals") == "gold"
+        assert _resolve_alt_profile_from_strategy("Long/Short Equity") == "hedge"
+        assert _resolve_alt_profile_from_strategy("Managed Futures") == "cta"
+        assert _resolve_alt_profile_from_strategy(None) == "generic_alt"
+        assert _resolve_alt_profile_from_strategy("Unknown Strategy") == "generic_alt"
+
+
+# ── REIT E2E: Alt model vs Equity model ─────────────────────────────
+
+
+class TestREITFundE2E:
+    """REIT fund should score better on alternatives model than equity model
+    when it has good diversification + income but modest equity-style metrics."""
+
+    def test_reit_alt_vs_equity(self) -> None:
+        risk = _make_equity_metrics(
+            return_1y=0.05,          # Modest equity return
+            sharpe_1y=0.6,           # Low Sharpe (REIT vol is high)
+            max_drawdown_1y=-0.15,   # Moderate drawdown
+            information_ratio_1y=0.1,
+        )
+        alt = _make_alt_metrics(
+            yield_proxy_12m=0.08,         # High yield (REIT strength)
+            equity_correlation_252d=0.3,  # Moderate diversification
+            downside_capture_1y=0.6,      # Good protection
+            inflation_beta=2.5,           # Strong inflation hedge
+            crisis_alpha_score=0.05,
+            calmar_ratio_3y=0.8,
+            sortino_1y=0.7,
+        )
+
+        equity_score, eq_comps = compute_fund_score(
+            risk, asset_class="equity", expense_ratio_pct=0.008,
+        )
+        alt_score, alt_comps = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="reit",
+            expense_ratio_pct=0.008,
+        )
+
+        assert alt_score > equity_score, (
+            f"REIT with strong income/diversification should score higher on alt model. "
+            f"Alt={alt_score}, Equity={equity_score}"
+        )
+        assert "income_generation" in alt_comps
+        assert "inflation_hedge" in alt_comps
+        # REIT profile weights
+        for k in _DEFAULT_ALT_REIT_WEIGHTS:
+            assert k in alt_comps, f"REIT profile should include {k}"
+
+
+# ── Commodity E2E: inflation_hedge component ─────────────────────────
+
+
+class TestCommodityFundE2E:
+    """Commodity fund: inflation_hedge is the dominant component (0.30 weight)."""
+
+    def test_commodity_inflation_hedge_dominates(self) -> None:
+        risk = _make_equity_metrics(return_1y=0.03, sharpe_1y=0.4)
+        alt = _make_alt_metrics(
+            inflation_beta=3.5,            # Very strong inflation hedge
+            equity_correlation_252d=0.05,  # Near-zero correlation
+            crisis_alpha_score=0.10,       # Positive crisis alpha
+            calmar_ratio_3y=0.7,
+            downside_capture_1y=0.5,
+        )
+
+        score, comps = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="commodity",
+            expense_ratio_pct=0.005,
+        )
+
+        assert "inflation_hedge" in comps
+        # With beta=3.5, inflation_hedge should score very high
+        assert comps["inflation_hedge"] > 70, (
+            f"inflation_beta=3.5 should produce inflation_hedge > 70, got {comps['inflation_hedge']}"
+        )
+        assert score > 50
+
+
+# ── CTA E2E: crisis_alpha dominates ──────────────────────────────────
+
+
+class TestCTAFundE2E:
+    """CTA fund: crisis_alpha has 0.40 weight — the highest single weight in any profile."""
+
+    def test_cta_crisis_alpha_dominance(self) -> None:
+        risk = _make_equity_metrics(return_1y=0.07, sharpe_1y=0.8)
+        alt = _make_alt_metrics(
+            crisis_alpha_score=0.25,        # Outstanding crisis performance
+            equity_correlation_252d=-0.15,  # Negative correlation (ideal CTA)
+            calmar_ratio_3y=1.8,            # Strong risk-adjusted
+            inflation_beta=0.5,             # Weak inflation hedge (irrelevant for CTA)
+        )
+
+        score, comps = compute_fund_score(
+            risk, asset_class="alternatives", alt_metrics=alt, alt_profile="cta",
+            expense_ratio_pct=0.015,
+        )
+
+        assert "crisis_alpha" in comps
+        assert _DEFAULT_ALT_CTA_WEIGHTS["crisis_alpha"] == 0.40
+        # Only crisis_alpha, diversification, risk_adjusted_return, fee_efficiency
+        assert "income_generation" not in comps, "CTA should not show income_generation"
+        assert "inflation_hedge" not in comps, "CTA should not show inflation_hedge"
+        assert score > 55, f"Strong CTA should score > 55, got {score}"
+
+
+# ── ELITE Validation ─────────────────────────────────────────────────
+
+
+class TestELITECrossAssetValidation:
+    """Validate that ELITE ranking can handle all 4 asset classes fairly."""
+
+    def test_four_scoring_models_produce_valid_scores(self) -> None:
+        """Each scoring model should produce a valid 0-100 score."""
+        risk = _make_equity_metrics()
+        alt = _make_alt_metrics()
+
+        # Mock FI metrics
+        fi = MagicMock()
+        fi.empirical_duration = 5.2
+        fi.credit_beta = 0.8
+        fi.yield_proxy_12m = 0.04
+        fi.duration_adj_drawdown_1y = -1.5
+
+        # Mock Cash metrics
+        cash = MagicMock()
+        cash.seven_day_net_yield = 5.25
+        cash.fed_funds_rate_at_calc = 5.33
+        cash.nav_per_share_mmf = 1.0000
+        cash.pct_weekly_liquid = 55.0
+        cash.weighted_avg_maturity_days = 25
+
+        scores = {}
+
+        s, _ = compute_fund_score(risk, asset_class="equity")
+        scores["equity"] = s
+
+        s, _ = compute_fund_score(risk, asset_class="fixed_income", fi_metrics=fi)
+        scores["fixed_income"] = s
+
+        s, _ = compute_fund_score(risk, asset_class="cash", cash_metrics=cash)
+        scores["cash"] = s
+
+        s, _ = compute_fund_score(risk, asset_class="alternatives", alt_metrics=alt, alt_profile="hedge")
+        scores["alternatives"] = s
+
+        for model, score in scores.items():
+            assert 0 <= score <= 100, f"{model} score {score} out of range"
+            assert score > 0, f"{model} score should be > 0 with valid data"
+
+    def test_elite_fairness_no_model_penalized(self) -> None:
+        """A 'good' fund in each class should score reasonably (> 40)."""
+        # Good equity fund
+        risk_eq = _make_equity_metrics(return_1y=0.15, sharpe_1y=1.5, max_drawdown_1y=-0.08)
+        s_eq, _ = compute_fund_score(risk_eq, asset_class="equity")
+
+        # Good alt fund
+        risk_alt = _make_equity_metrics(return_1y=0.08, sharpe_1y=0.9)
+        alt = _make_alt_metrics(
+            equity_correlation_252d=0.1, crisis_alpha_score=0.15,
+            calmar_ratio_3y=1.5, sortino_1y=2.0, downside_capture_1y=0.3,
+        )
+        s_alt, _ = compute_fund_score(risk_alt, asset_class="alternatives", alt_metrics=alt, alt_profile="hedge")
+
+        # Good cash fund
+        cash = MagicMock()
+        cash.seven_day_net_yield = 5.50
+        cash.fed_funds_rate_at_calc = 5.33
+        cash.nav_per_share_mmf = 1.0000
+        cash.pct_weekly_liquid = 70.0
+        cash.weighted_avg_maturity_days = 15
+        risk_cash = _make_equity_metrics()
+        s_cash, _ = compute_fund_score(risk_cash, asset_class="cash", cash_metrics=cash)
+
+        for label, score in [("equity", s_eq), ("alternatives", s_alt), ("cash", s_cash)]:
+            assert score > 40, f"Good {label} fund should score > 40, got {score}"

--- a/backend/tests/test_cash_scoring.py
+++ b/backend/tests/test_cash_scoring.py
@@ -13,19 +13,20 @@ from __future__ import annotations
 import pytest
 
 from quant_engine.cash_analytics_service import (
+    _DEFAULT_CASH_SCORING_WEIGHTS,
     CashAnalyticsResult,
     CashScoreResult,
-    _DEFAULT_CASH_SCORING_WEIGHTS,
     compute_cash_score,
 )
 from quant_engine.scoring_service import (
     _DEFAULT_CASH_SCORING_WEIGHTS as SCORING_CASH_WEIGHTS,
+)
+from quant_engine.scoring_service import (
     compute_fund_score,
     resolve_scoring_weights,
 )
 from vertical_engines.wealth.screener.layer_evaluator import LayerEvaluator
 from vertical_engines.wealth.screener.quant_metrics import CashQuantMetrics
-
 
 # ═══════════════════════════════════════════════════════════════════
 #  Helpers

--- a/docs/plans/2026-04-12-dynamic-taa-system.md
+++ b/docs/plans/2026-04-12-dynamic-taa-system.md
@@ -1,0 +1,507 @@
+# Dynamic Tactical Asset Allocation (TAA) System
+
+**Date:** 2026-04-12
+**Status:** PLANNED
+**Branch:** TBD
+**Depends on:** Scoring dispatch (PR #123 merged), regime_service.py, allocation_proposal_service.py
+
+---
+
+## 1. Situation Analysis
+
+### 1.1 What Exists Today
+
+Three relevant layers that are currently **disconnected**:
+
+**Layer A -- Regime Detection** (`regime_service.py`): Multi-signal classifier (`classify_regime_multi_signal`) scores 10 signals across two frequency tiers (55% fast / 45% slow) to classify RISK_ON / RISK_OFF / INFLATION / CRISIS. Regional regime detection via ICE BofA OAS spreads per geography. Asymmetric hysteresis documented but not yet implemented in code.
+
+**Layer B -- Allocation Proposal** (`allocation_proposal_service.py`): Fully functional `compute_regime_tilted_weights()` that takes a regime classification and per-block strategic config with min/max/target, applies regime tilts (hardcoded `REGIME_TILTS` dict), regional score tilts, and renormalizes to sum=1.0. Produces `AllocationProposalResult` with `BlockProposal` per block. **This service EXISTS but is NEVER called in the construction pipeline.**
+
+**Layer C -- Optimizer** (`optimizer_service.py`): CLARABEL 4-phase cascade reads `BlockConstraint(min_weight, max_weight)` from `StrategicAllocation` rows directly (line ~1851 of `model_portfolios.py`). These are static IPS bounds. The optimizer also receives `regime_cvar_multiplier` (RISK_OFF=0.85, CRISIS=0.70) but this only tightens the CVaR limit -- does NOT adjust allocation bands.
+
+**Layer D -- Tactical Positions** (`TacticalPosition` model + allocation routes): Manual IC override mechanism where `overweight` per block is stored and combined with strategic weights via `get_effective()`. Manual-only today.
+
+**Layer E -- ELITE Ranking** (`elite_ranking/allocation_source.py`): Distributes 300 global top funds proportionally to the `moderate` profile's static strategic weights: equity=50%, FI=33%, alt=12%, cash=5%. Source is `get_global_default_strategy_weights()` from `vertical_config_defaults`.
+
+### 1.2 The Gap
+
+Line ~1851 of `model_portfolios.py` is the bottleneck. `_run_construction_async` reads `StrategicAllocation` rows and passes their `min_weight`/`max_weight` verbatim to `BlockConstraint`. In CRISIS, the optimizer is constrained to keep equity at 45-55% (per IPS) when the optimal allocation might be equity:25%, FI:40%, alt:15%, cash:20%. The optimizer can minimize risk WITHIN blocks but not redistribute BETWEEN blocks.
+
+The `allocation_proposal_service` already computes the correct regime-aware targets, but nobody calls it.
+
+### 1.3 What This Plan Does NOT Change
+
+- The CLARABEL 4-phase cascade -- kept intact, only constraint inputs change
+- The `StrategicAllocation` model -- kept as IPS outer bounds
+- The `AllocationBlock` taxonomy -- kept as-is
+- The scoring dispatch (4-model) -- scoring is independent of allocation
+- The `regime_service.py` classifier -- kept as signal source, only wired differently
+
+---
+
+## 2. Regime-to-Allocation Band Mapping
+
+### 2.1 The Band Model
+
+IPS bounds are outer guardrails; regime bands are inner operating ranges. The optimizer operates within regime bands, which are always a subset of IPS bounds.
+
+```
+IPS min          Regime min    Regime center    Regime max         IPS max
+ |=================[===============|===============]==================|
+ 15%               25%            35%             45%               55%
+                   <------------- band width = 20pp -------------->
+```
+
+### 2.2 Regime Band Configuration
+
+Move `REGIME_TILTS` from hardcoded dict to ConfigService under `config_type = 'taa_bands'`:
+
+```json
+{
+  "regime_bands": {
+    "RISK_ON": {
+      "equity":       {"center": 0.52, "half_width": 0.08},
+      "fixed_income": {"center": 0.30, "half_width": 0.06},
+      "alternatives": {"center": 0.12, "half_width": 0.04},
+      "cash":         {"center": 0.06, "half_width": 0.03}
+    },
+    "RISK_OFF": {
+      "equity":       {"center": 0.38, "half_width": 0.08},
+      "fixed_income": {"center": 0.36, "half_width": 0.06},
+      "alternatives": {"center": 0.13, "half_width": 0.04},
+      "cash":         {"center": 0.13, "half_width": 0.05}
+    },
+    "INFLATION": {
+      "equity":       {"center": 0.42, "half_width": 0.08},
+      "fixed_income": {"center": 0.25, "half_width": 0.06},
+      "alternatives": {"center": 0.22, "half_width": 0.06},
+      "cash":         {"center": 0.11, "half_width": 0.04}
+    },
+    "CRISIS": {
+      "equity":       {"center": 0.25, "half_width": 0.06},
+      "fixed_income": {"center": 0.35, "half_width": 0.06},
+      "alternatives": {"center": 0.15, "half_width": 0.05},
+      "cash":         {"center": 0.25, "half_width": 0.08}
+    }
+  },
+  "transition": {
+    "ema_halflife_days": 5,
+    "min_confidence_to_act": 0.60,
+    "max_daily_shift_pct": 0.03
+  },
+  "ips_override_priority": true
+}
+```
+
+**Center sum validation:** Each regime's centers must sum to 1.00 (within tolerance). Validated at ConfigService write time.
+
+**Numerical calibration rationale:**
+
+| Regime | Equity center | Rationale |
+|--------|--------------|-----------|
+| RISK_ON | 52% | Above-neutral: risk appetite drives equity overweight |
+| RISK_OFF | 38% | Below-neutral: reduce equity ~12pp, flight to quality |
+| INFLATION | 42% | Moderate reduction: equities partial inflation hedge |
+| CRISIS | 25% | Maximum de-risk: equity to floor, cash/FI to ceiling |
+
+### 2.3 Per-Block Disaggregation
+
+Config operates at the asset-class level (equity, fixed_income, alternatives, cash). Per-block weights within each asset class derived by preserving the strategic allocation's internal proportions:
+
+```
+equity center = 38% (RISK_OFF)
+na_equity_large target/total_equity_target = 0.19/0.50 = 38%
+na_equity_large regime center = 0.38 * 0.38 = 0.1444 (14.44%)
+```
+
+Preserves IC committee's geographic/style preferences within each asset class while shifting the macro envelope.
+
+---
+
+## 3. IPS Compliance Layer
+
+### 3.1 The Invariant
+
+IPS bounds from `StrategicAllocation.min_weight` and `StrategicAllocation.max_weight` are HARD constraints that can NEVER be violated. These represent the Investment Policy Statement agreed with the client.
+
+### 3.2 Band Clamping Algorithm
+
+```python
+def compute_effective_band(
+    ips_min: float,
+    ips_max: float,
+    regime_center: float,
+    regime_half_width: float,
+) -> tuple[float, float]:
+    """Compute effective optimizer band = intersection of IPS and regime band."""
+    regime_min = regime_center - regime_half_width
+    regime_max = regime_center + regime_half_width
+
+    effective_min = max(ips_min, regime_min)
+    effective_max = min(ips_max, regime_max)
+
+    # If regime band falls entirely outside IPS, clamp to nearest IPS edge
+    if effective_min > effective_max:
+        if regime_center < ips_min:
+            return ips_min, min(ips_min + 2 * regime_half_width, ips_max)
+        elif regime_center > ips_max:
+            return max(ips_max - 2 * regime_half_width, ips_min), ips_max
+        else:
+            return effective_min, effective_max
+
+    return effective_min, effective_max
+```
+
+### 3.3 Priority Stack
+
+```
+1. IPS bounds (StrategicAllocation min/max)     -- HARD, never violated
+2. Regime bands (ConfigService taa_bands)        -- SOFT, clamped by IPS
+3. IC tactical overrides (TacticalPosition)     -- OVERRIDE, shifts center within IPS
+4. Optimizer (CLARABEL)                          -- OPERATES within effective bands
+```
+
+When an IC member sets a manual tactical override (source='ic_manual'), it takes priority over the regime-computed center but is still clamped by IPS bounds.
+
+---
+
+## 4. Transition Management
+
+### 4.1 The Whipsaw Problem
+
+Regime transitions are noisy. A VIX spike from 24 to 26 flips RISK_ON to RISK_OFF. The next day VIX drops to 23 and flips back. Without smoothing, the optimizer would propose radically different portfolios on consecutive days, generating turnover costs that eat any defensive alpha.
+
+### 4.2 Exponential Moving Average on Regime Centers
+
+Smooth the ALLOCATION CENTERS, not the discrete regime classification:
+
+```python
+def smooth_regime_center(
+    current_center: float,
+    previous_smoothed_center: float,
+    halflife_days: int = 5,
+) -> float:
+    """EMA smoothing on the regime-implied center.
+
+    Halflife=5: ~50% of shift absorbed in 5 business days.
+    Full convergence (>95%) in ~22 business days (~1 calendar month).
+
+    Alpha = 1 - exp(-ln(2) / halflife)
+    At halflife=5: alpha = 0.1294
+    """
+    alpha = 1 - math.exp(-math.log(2) / halflife_days)
+    return alpha * current_center + (1 - alpha) * previous_smoothed_center
+```
+
+**Why EMA on centers, not on regime labels:**
+1. Regime labels are categorical -- can't average "RISK_OFF" and "CRISIS"
+2. The composite stress score (0-100) from `classify_regime_multi_signal` is already continuous
+3. Smoothing centers directly gives the optimizer a gradually shifting feasible region
+4. `max_daily_shift_pct` (default 3pp/day) provides a hard cap on single-day band movement
+
+### 4.3 Persistence of Smoothed State
+
+New table `taa_regime_state` stores smoothed centers per organization + profile, updated daily by `risk_calc` worker:
+
+```sql
+CREATE TABLE taa_regime_state (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL,
+    profile VARCHAR(20) NOT NULL,
+    as_of_date DATE NOT NULL,
+    raw_regime VARCHAR(20) NOT NULL,
+    stress_score NUMERIC(5,1),
+    smoothed_centers JSONB NOT NULL,  -- {"equity": 0.42, "fixed_income": 0.33, ...}
+    effective_bands JSONB NOT NULL,   -- {"equity": {"min": 0.35, "max": 0.49}, ...}
+    transition_velocity JSONB,        -- {"equity": -0.012, ...} daily delta for audit
+    created_at TIMESTAMPTZ DEFAULT now(),
+    UNIQUE (organization_id, profile, as_of_date)
+);
+```
+
+Org-scoped (has RLS). Daily snapshot allows full audit trail.
+
+### 4.4 Confidence Gating
+
+`min_confidence_to_act` (default 0.60) prevents regime shifts from acting unless the composite stress score has a clear directional signal. When `|stress_score - previous_score| < threshold`, smoothed centers hold previous values.
+
+---
+
+## 5. Dynamic ELITE Re-ranking
+
+### 5.1 Current State
+
+`get_global_default_strategy_weights()` returns static weights from moderate profile: `{equity: 0.50, fixed_income: 0.33, alternatives: 0.12, cash: 0.05}`. `compute_target_counts()` converts to `{equity: 150, fixed_income: 99, alternatives: 36, cash: 15}`.
+
+### 5.2 Regime-Responsive ELITE
+
+ELITE ranking is GLOBAL (no org context, runs in `global_risk_metrics` worker, lock 900_071). Approach: **pre-compute per-regime ELITE sets.**
+
+Store 4 ELITE flags per fund: `elite_flag` (RISK_ON, existing), `elite_risk_off`, `elite_inflation`, `elite_crisis`. The `global_risk_metrics` worker computes all 4 sets in each daily run. Construction pipeline reads the flag matching current regime.
+
+**Target counts per regime:**
+
+| Regime | Equity | FI | Alt | Cash | Total |
+|--------|--------|----|-----|------|-------|
+| RISK_ON | 156 | 90 | 36 | 18 | 300 |
+| RISK_OFF | 114 | 108 | 39 | 39 | 300 |
+| INFLATION | 126 | 75 | 66 | 33 | 300 |
+| CRISIS | 75 | 105 | 45 | 75 | 300 |
+
+Derived from `round(300 * center)` per regime's asset-class centers.
+
+### 5.3 Implementation
+
+Add 3 new boolean columns to `fund_risk_metrics`:
+
+```sql
+ALTER TABLE fund_risk_metrics
+    ADD COLUMN elite_risk_off BOOLEAN DEFAULT FALSE,
+    ADD COLUMN elite_inflation BOOLEAN DEFAULT FALSE,
+    ADD COLUMN elite_crisis BOOLEAN DEFAULT FALSE;
+```
+
+Existing `elite_flag` serves as RISK_ON set (backward compatible).
+
+---
+
+## 6. Optimizer Constraint Formulation Changes
+
+### 6.1 Current Flow (Static)
+
+```
+StrategicAllocation rows
+  -> BlockConstraint(block_id, min_weight, max_weight)  [IPS bounds]
+  -> ProfileConstraints(blocks=[...], cvar_limit=...)
+  -> optimize_fund_portfolio(constraints=constraints)
+```
+
+### 6.2 New Flow (Dynamic)
+
+```
+1. Read StrategicAllocation rows                       [IPS bounds]
+2. Read taa_regime_state for current org+profile       [smoothed centers]
+3. Disaggregate asset-class centers to per-block       [preserve IC proportions]
+4. Clamp regime bands by IPS bounds                    [IPS compliance]
+5. Apply IC tactical overrides if any                  [ic_manual priority]
+6. Build BlockConstraint(block_id, effective_min, effective_max)
+7. Pass to optimize_fund_portfolio()                   [unchanged optimizer]
+```
+
+### 6.3 Changes to `_run_construction_async`
+
+Replace static bound reading at line ~1851 with a call to `resolve_effective_bands()` that:
+
+1. Reads latest `taa_regime_state` row for org+profile
+2. Disaggregates asset-class centers to per-block centers using `allocation_blocks.asset_class` join
+3. Clamps each block's regime band by IPS min/max from `StrategicAllocation`
+4. Applies any active `TacticalPosition` overrides (source='ic_manual')
+5. Returns `list[BlockConstraint]` with regime-aware bands
+
+**The optimizer itself does NOT change.** Only its input constraints change. CLARABEL cascade, robust SOCP, CVaR multipliers, turnover penalty -- all remain identical.
+
+### 6.4 Interaction with CLARABEL Cascade
+
+- Phase 1 (max risk-adj return): may find better solutions with tighter regime bands (less room for degenerate solutions)
+- Phase 1.5 (robust SOCP): benefits from tighter bands (smaller ellipsoidal uncertainty set)
+- Phase 2 (variance-capped): may be reached less often because regime bands already steer toward lower-risk allocations in RISK_OFF/CRISIS
+- Phase 3 (min-variance): unchanged
+- Regime CVaR multiplier (RISK_OFF=0.85, CRISIS=0.70) continues to work orthogonally -- tightens CVaR limit while TAA tightens allocation bands
+
+---
+
+## 7. Interaction with Scoring Dispatch
+
+**Scoring is independent of allocation.** The 4-model scoring dispatch (equity, fixed_income, alternatives, cash) scores each fund based on its asset class, not on the portfolio's allocation regime. A fund's `manager_score` does not change based on whether the portfolio is in RISK_ON or CRISIS.
+
+What DOES change: which funds enter the optimization universe (ELITE set per regime) and how much weight the optimizer allocates to each asset class. No scoring model changes needed.
+
+---
+
+## 8. TacticalPosition Enhancement
+
+### 8.1 Source Discriminator
+
+```sql
+ALTER TABLE tactical_positions
+    ADD COLUMN source VARCHAR(20) DEFAULT 'ic_manual'
+    CHECK (source IN ('ic_manual', 'regime_auto', 'model_signal'));
+```
+
+- `ic_manual`: IC committee override (current behavior, always wins within IPS)
+- `regime_auto`: Machine-generated from TAA regime bands
+- `model_signal`: Future extensibility for factor-model signals
+
+### 8.2 Priority Logic
+
+When both `ic_manual` and `regime_auto` exist for the same block:
+- `ic_manual` overrides `regime_auto` (IC committee has final authority)
+- `regime_auto` positions still persisted for audit trail
+- If `ic_manual` position expired (valid_to < today), `regime_auto` resumes
+
+---
+
+## 9. Audit and Provenance
+
+### 9.1 Construction Run Enrichment
+
+`portfolio_construction_runs.calibration_snapshot` JSONB gains TAA section:
+
+```json
+{
+  "taa": {
+    "enabled": true,
+    "raw_regime": "RISK_OFF",
+    "stress_score": 38.2,
+    "smoothed_centers": {"equity": 0.42, "fixed_income": 0.34},
+    "effective_bands": {"na_equity_large": {"min": 0.15, "max": 0.22}},
+    "ips_clamps_applied": ["na_equity_large_min_raised"],
+    "ic_overrides_active": [],
+    "transition_velocity": {"equity": -0.008}
+  }
+}
+```
+
+### 9.2 Narrative Templater
+
+TAA section added to Jinja2 narrative:
+
+> "The portfolio was constructed under RISK_OFF market conditions (composite stress score: 38.2/100). Regime-adjusted allocation bands shifted equity exposure from the strategic center of 50% to an effective range of 35-49%, and increased fixed income to 30-42%. The smoothed transition reflects a 5-day EMA from the previous RISK_ON allocation. All regime-adjusted bands remain within Investment Policy Statement constraints."
+
+---
+
+## 10. Migration Plan
+
+### 10.1 New Database Objects
+
+**Migration `0126_taa_regime_state`:**
+- `taa_regime_state` table (Section 4.3)
+- RLS policy (org-scoped)
+- Index on `(organization_id, profile, as_of_date DESC)`
+
+**Migration `0127_elite_regime_flags`:**
+- Add `elite_risk_off`, `elite_inflation`, `elite_crisis` columns to `fund_risk_metrics`
+- Add `source` column to `tactical_positions`
+
+**Migration `0128_taa_config_seed`:**
+- Seed `vertical_config_defaults` with `config_type = 'taa_bands'`
+
+### 10.2 Worker Changes
+
+**`risk_calc` worker (lock 900_007, daily):**
+- After computing fund-level risk metrics, run regime detection via `classify_regime_multi_signal`
+- Compute smoothed centers via EMA against previous `taa_regime_state` row
+- Compute effective bands (intersect with IPS from `StrategicAllocation`)
+- Upsert `taa_regime_state` row for org+profile+date
+
+**`global_risk_metrics` worker (lock 900_071, daily):**
+- After scoring all funds, run ELITE ranking 4 times (once per regime scenario)
+- Write `elite_risk_off`, `elite_inflation`, `elite_crisis` flags
+
+### 10.3 Route Changes
+
+**`_run_construction_async` in `model_portfolios.py`:**
+- Replace static `BlockConstraint` construction with `resolve_effective_bands()` call
+- Log regime source and effective bands in construction run's `optimizer_trace`
+- Pass effective bands to `construction_run_executor` for persistence in `calibration_snapshot`
+
+**Allocation routes:**
+- `GET /allocation/{profile}/effective` -- include regime-adjusted bands alongside strategic+tactical
+- New `GET /allocation/{profile}/regime-bands` -- expose current smoothed centers + effective bands
+- `GET /allocation/{profile}/taa-history` -- time series of regime states for audit
+
+---
+
+## 11. Files Touched
+
+| File | Change Type |
+|------|------------|
+| `quant_engine/taa_band_service.py` | NEW -- core TAA logic |
+| `quant_engine/allocation_proposal_service.py` | EVOLVE -- move REGIME_TILTS to config |
+| `app/domains/wealth/workers/risk_calc.py` | MODIFY -- compute + persist taa_regime_state |
+| `app/domains/wealth/workers/construction_run_executor.py` | MODIFY -- read regime state |
+| `app/domains/wealth/routes/model_portfolios.py` | MODIFY -- call resolve_effective_bands |
+| `app/domains/wealth/routes/allocation.py` | MODIFY -- new regime-bands + taa-history routes |
+| `app/domains/wealth/models/allocation.py` | MODIFY -- add source to TacticalPosition |
+| `app/domains/wealth/schemas/allocation.py` | MODIFY -- add regime band schemas |
+| `vertical_engines/wealth/elite_ranking/allocation_source.py` | MODIFY -- per-regime weight computation |
+| `app/domains/wealth/models/risk.py` | MODIFY -- add elite regime flag columns |
+| `vertical_engines/wealth/model_portfolio/narrative_templater.py` | MODIFY -- TAA narrative section |
+| `vertical_engines/wealth/model_portfolio/validation_gate.py` | MODIFY -- add check #16 |
+| Migrations 0126, 0127, 0128 | NEW |
+
+---
+
+## 12. Phased Execution
+
+### Sprint 1: Wire the Existing Plumbing (3-4 days)
+
+**Goal:** Make the construction pipeline regime-responsive using existing code.
+
+1. Create `taa_band_service.py` in `quant_engine/` with:
+   - `resolve_effective_bands()` -- reads `taa_regime_state`, disaggregates to per-block, clamps by IPS
+   - `smooth_regime_centers()` -- EMA computation
+   - `compute_effective_band()` -- single-block IPS clamp
+2. Migration `0126_taa_regime_state`
+3. Migration `0128_taa_config_seed` -- seed default TAA config
+4. Modify `_run_construction_async` to call `resolve_effective_bands()` instead of reading static bounds
+5. Modify `risk_calc` worker to compute and persist `taa_regime_state` rows daily
+6. Add `taa_enabled` toggle to `PortfolioCalibration.expert_overrides` (default `true`)
+7. Tests: unit tests for band clamping, EMA smoothing, IPS invariant, optimizer with dynamic bands
+
+**Deliverable:** Construction runs produce regime-responsive portfolios. Existing behavior preserved when `taa_enabled=false`.
+
+### Sprint 2: ELITE Dynamic + Transition Polish (2-3 days)
+
+**Goal:** ELITE ranking becomes regime-aware, transition smoothing is production-quality.
+
+1. Migration `0127_elite_regime_flags` -- add 3 boolean columns
+2. Modify `global_risk_metrics` worker to compute 4 ELITE sets
+3. Modify construction pipeline to filter universe by regime-appropriate ELITE flag
+4. Add `source` discriminator to `tactical_positions`
+5. Implement confidence gating (`min_confidence_to_act`) and max daily shift cap
+6. Tests: ELITE count validation per regime, transition smoothing edge cases
+
+**Deliverable:** ELITE ranking shifts with regime. Transition smoothing prevents whipsaw.
+
+### Sprint 3: IPS Compliance + Audit + Routes (2-3 days)
+
+**Goal:** Full audit trail, institutional routes, narrative enrichment.
+
+1. Enrich `calibration_snapshot` JSONB with TAA provenance data
+2. Add TAA section to narrative templater
+3. New routes: `GET /allocation/{profile}/regime-bands`, `GET /allocation/{profile}/taa-history`
+4. Update `GET /allocation/{profile}/effective` to include regime-adjusted info
+5. Add `write_audit_event()` calls for TAA state transitions
+6. Validation gate: add check #16 "TAA bands within IPS"
+7. Tests: audit trail completeness, route contract validation, narrative output
+
+**Deliverable:** Full institutional audit trail. IC can reconstruct why any portfolio was proposed.
+
+### Sprint 4 (optional): Frontend Visualization (2 days)
+
+**Goal:** Builder UI shows regime bands and TAA state.
+
+1. CalibrationPanel gains "Market Regime" indicator (current regime + stress score)
+2. Allocation chart shows IPS bounds (grey), regime bands (colored), current weights (dots)
+3. Transition history sparkline showing smoothed center evolution over 60 days
+4. All labels use institutional vocabulary (`formatPercent` from `@netz/ui`, no quant jargon)
+
+---
+
+## 13. Risk Analysis
+
+| Risk | Mitigation |
+|------|-----------|
+| EMA smoother creates phantom drift in stable regimes | Confidence gating: no shift when `abs(delta_score) < threshold` |
+| Regime flips at market close generate overnight trades | `max_daily_shift_pct` caps single-day movement at 3pp |
+| IPS clamp makes regime bands degenerate (min > max) | `compute_effective_band()` has explicit degenerate-band handler |
+| Missing `taa_regime_state` row (first run, new org) | Fallback to static IPS bands (identical to current behavior) |
+| ELITE 4x computation doubles `global_risk_metrics` runtime | Scoring already computed; ELITE selection is O(n log n) sort -- negligible |
+| Config drift between `taa_bands` and `portfolio_profiles` | Validation at write time: centers must sum to 1.0, must fit within default IPS ranges |
+
+### Backward Compatibility
+
+- **Default behavior unchanged.** Without `taa_regime_state` row, falls back to static `StrategicAllocation` bounds
+- **`taa_enabled` toggle** in `expert_overrides` allows per-portfolio opt-out
+- **`elite_flag`** (existing column) continues to serve as RISK_ON set

--- a/docs/plans/2026-04-12-taa-execution-wrapper.md
+++ b/docs/plans/2026-04-12-taa-execution-wrapper.md
@@ -1,0 +1,181 @@
+# Dynamic TAA System — Execution Wrapper
+
+**Date:** 2026-04-12
+**Specification:** `docs/plans/2026-04-12-dynamic-taa-system.md` (authoritative spec, 508 lines)
+**Status:** Ready for execution in 4 sprints
+**Priority:** CORE SYSTEM — the allocation engine is the reason the platform exists
+
+## Context updates
+
+### Alembic head
+
+After Alt Sprint 3 merges: `0125_add_alternatives_risk_metrics` (or current head). TAA migrations start at `0126+`. Verify via `alembic heads`.
+
+### Key discovery from the plan
+
+**`allocation_proposal_service.py` already exists and computes regime-tilted weights — but is NEVER called in the construction pipeline.** Line ~1851 of `model_portfolios.py` reads static `StrategicAllocation` bounds verbatim. The gap is WIRING, not missing infrastructure.
+
+### Scoring dispatch state (complete)
+
+4-model scoring dispatch is fully operational:
+- equity: 6 components (original)
+- fixed_income: 5 components (FI Quant)
+- alternatives: 5 components × 5 profiles (Alt Scoring)
+- cash: 5 components (Cash Scoring)
+
+ELITE ranking: 300 funds across 4 asset classes. Scoring is INDEPENDENT of allocation — no scoring changes needed for TAA.
+
+### What does NOT change
+
+- CLARABEL 4-phase cascade optimizer — only its INPUT constraints change
+- StrategicAllocation model — kept as IPS outer bounds
+- AllocationBlock taxonomy — kept as-is
+- Scoring dispatch — independent of allocation
+- regime_service.py classifier — kept as signal source
+
+## 4-sprint execution
+
+### Sprint 1 — Wire the Existing Plumbing (core wiring)
+
+**Branch:** `feat/taa-sprint-1`
+**Scope:** TAA band service + migrations + wire construction pipeline
+**Read:** plan §1-4, §6, §10.1-10.3
+
+**Deliverable:**
+1. `quant_engine/taa_band_service.py` (NEW) — `resolve_effective_bands()`, `smooth_regime_centers()`, `compute_effective_band()` (band clamping). Pure-sync, config-driven.
+2. Migration `0126_taa_regime_state` — new table with RLS, org-scoped daily snapshots of smoothed centers + effective bands
+3. Migration `0128_taa_config_seed` — seed `vertical_config_defaults` with `config_type='taa_bands'` (regime band config JSON from plan §2.2)
+4. Modify `_run_construction_async` in `model_portfolios.py` (~line 1851) — replace static `BlockConstraint` with `resolve_effective_bands()` call
+5. Modify `risk_calc` worker — after risk metrics, run regime detection → compute smoothed centers via EMA → upsert `taa_regime_state` row
+6. Add `taa_enabled` toggle to `PortfolioCalibration.expert_overrides` (default `true`)
+7. Tests: band clamping (IPS invariant), EMA smoothing, optimizer with dynamic bands, fallback to static when no taa_regime_state row
+
+**Critical test:** with `taa_enabled=false`, construction output must be IDENTICAL to current behavior. Zero regression.
+
+**Instruction for Opus:**
+```
+Read docs/plans/2026-04-12-dynamic-taa-system.md sections 1-4, 6, and 10.1-10.3 fully, and docs/plans/2026-04-12-taa-execution-wrapper.md Sprint 1 section fully. Also read backend/quant_engine/allocation_proposal_service.py to understand the EXISTING regime-tilt computation that you are now wiring into the construction pipeline. Read backend/app/domains/wealth/routes/model_portfolios.py around line 1851 to understand the current static BlockConstraint construction. Implement Sprint 1: taa_band_service.py, 2 migrations, wire _run_construction_async, modify risk_calc worker for regime state persistence, add taa_enabled toggle. Critical: with taa_enabled=false, behavior must be identical to current. Report including EMA smoothing test output and band clamping IPS invariant proof.
+```
+
+### Sprint 2 — ELITE Dynamic + Transition Polish
+
+**Branch:** `feat/taa-sprint-2`
+**Depends on:** Sprint 1 merged
+**Scope:** 4 ELITE sets + transition confidence gating + tactical position source
+**Read:** plan §5, §4.4, §8
+
+**Deliverable:**
+1. Migration `0127_elite_regime_flags` — add `elite_risk_off`, `elite_inflation`, `elite_crisis` boolean columns to `fund_risk_metrics` + add `source` VARCHAR to `tactical_positions`
+2. Modify `global_risk_metrics` worker — after scoring, compute ELITE ranking 4 times (once per regime scenario: RISK_ON uses existing `elite_flag`, plus 3 new sets)
+3. Modify construction pipeline — filter universe by regime-appropriate ELITE flag (read current regime from `taa_regime_state`, pick matching flag column)
+4. Confidence gating — `min_confidence_to_act` (0.60): no regime shift when `|stress_score - previous| < threshold`
+5. Max daily shift cap — `max_daily_shift_pct` (3pp/day)
+6. `TacticalPosition.source` discriminator — `ic_manual` overrides `regime_auto` within IPS
+7. Tests: ELITE count = 300 per regime set, transition smoothing edge cases, confidence gating, IC override priority
+
+**ELITE target counts per regime (from plan §5.2):**
+
+| Regime | Equity | FI | Alt | Cash | Total |
+|---|---|---|---|---|---|
+| RISK_ON | 156 | 90 | 36 | 18 | 300 |
+| RISK_OFF | 114 | 108 | 39 | 39 | 300 |
+| INFLATION | 126 | 75 | 66 | 33 | 300 |
+| CRISIS | 75 | 105 | 45 | 75 | 300 |
+
+**Instruction for Opus:**
+```
+Read docs/plans/2026-04-12-dynamic-taa-system.md sections 5, 4.4, and 8 fully, and docs/plans/2026-04-12-taa-execution-wrapper.md Sprint 2 section fully. Verify Sprint 1 merged (taa_regime_state table exists, taa_band_service importable). Implement ELITE 4-set computation in global_risk_metrics worker, regime-appropriate ELITE filtering in construction pipeline, confidence gating, max daily shift, TacticalPosition source discriminator. Verify each regime's ELITE set sums to 300. Report including ELITE distribution table per regime.
+```
+
+### Sprint 3 — IPS Compliance + Audit + Routes
+
+**Branch:** `feat/taa-sprint-3`
+**Depends on:** Sprint 2 merged
+**Scope:** Audit trail, routes, narrative, validation gate
+**Read:** plan §3, §9, §10.3 routes
+
+**Deliverable:**
+1. Enrich `calibration_snapshot` JSONB with TAA provenance (raw regime, stress score, smoothed centers, effective bands, IPS clamps applied, IC overrides active, transition velocity)
+2. TAA section in narrative templater (Jinja2) — institutional language per plan §9.2
+3. New routes:
+   - `GET /allocation/{profile}/regime-bands` — current smoothed centers + effective bands
+   - `GET /allocation/{profile}/taa-history` — time series of regime states for audit
+   - Update `GET /allocation/{profile}/effective` — include regime-adjusted info alongside strategic + tactical
+4. Validation gate check #16: "TAA bands within IPS" — verify effective bands are always subset of IPS bounds
+5. `write_audit_event()` calls for TAA state transitions (regime change, band shift, IC override applied)
+6. Tests: audit trail completeness (construction run has full TAA provenance), route contracts, narrative output, validation gate fires when bands violate IPS (should never happen but defense-in-depth)
+
+**Instruction for Opus:**
+```
+Read docs/plans/2026-04-12-dynamic-taa-system.md sections 3, 9, 10.3, and 12 Sprint 3 fully, and docs/plans/2026-04-12-taa-execution-wrapper.md Sprint 3 section fully. Verify Sprint 2 merged (4 ELITE sets computed, confidence gating active). Implement calibration_snapshot TAA enrichment, narrative templater TAA section, 3 routes (regime-bands, taa-history, effective update), validation gate check #16, audit events. Report including sample calibration_snapshot TAA JSON and narrative output.
+```
+
+### Sprint 4 — Frontend Visualization
+
+**Branch:** `feat/taa-sprint-4`
+**Depends on:** Sprint 3 merged
+**Scope:** Builder UI shows regime bands and TAA state
+**Read:** plan §12 Sprint 4
+
+**Deliverable:**
+1. CalibrationPanel gains "Market Regime" indicator — current regime label + stress score (0-100) with color coding
+2. Allocation chart shows 3 layers:
+   - Grey: IPS outer bounds (hard limits)
+   - Colored (regime-specific): regime bands (where the optimizer can operate)
+   - Dots: current portfolio weights (where the optimizer placed the allocation)
+3. Transition history sparkline — 60-day smoothed center evolution per asset class
+4. All labels use institutional vocabulary — `formatPercent` from `@netz/ui`, zero quant jargon (no "EMA halflife", no "stress score" — say "Market Conditions" and "Defensive Posture")
+5. Responsive to regime changes — when a new `taa_regime_state` row lands (SSE or polling), the chart updates
+
+**Instruction for Opus:**
+```
+Read docs/plans/2026-04-12-dynamic-taa-system.md section 12 Sprint 4 fully, and docs/plans/2026-04-12-taa-execution-wrapper.md Sprint 4 section fully. Verify Sprint 3 merged (regime-bands route available, calibration_snapshot has TAA provenance). Implement CalibrationPanel regime indicator, 3-layer allocation chart (IPS/regime/current), transition history sparkline, institutional labels (smart backend/dumb frontend — no quant jargon). Report including screenshot of the regime visualization.
+```
+
+## Post-completion validation
+
+After all 4 sprints merge:
+
+```sql
+-- Verify taa_regime_state has daily snapshots
+SELECT as_of_date, raw_regime, stress_score, smoothed_centers
+FROM taa_regime_state
+WHERE organization_id = '<test-org>'
+ORDER BY as_of_date DESC
+LIMIT 5;
+
+-- Verify 4 ELITE sets all sum to 300
+SELECT
+  COUNT(*) FILTER (WHERE elite_flag) AS risk_on,
+  COUNT(*) FILTER (WHERE elite_risk_off) AS risk_off,
+  COUNT(*) FILTER (WHERE elite_inflation) AS inflation,
+  COUNT(*) FILTER (WHERE elite_crisis) AS crisis
+FROM fund_risk_metrics
+WHERE calc_date = (SELECT MAX(calc_date) FROM fund_risk_metrics);
+
+-- Verify construction run has TAA provenance
+SELECT calibration_snapshot->'taa' FROM portfolio_construction_runs
+ORDER BY started_at DESC LIMIT 1;
+```
+
+## Backward compatibility guarantee
+
+- **`taa_enabled=false` or missing `taa_regime_state` row → identical to current behavior.** Static IPS bounds passed to optimizer. No regime adjustment. This is the safety net.
+- **`elite_flag` (existing) = RISK_ON set.** Backward compatible. New columns are additive.
+- **All new routes are NEW paths.** No existing route contract changed.
+
+## Valid escape hatches
+
+1. `allocation_proposal_service.py` API differs from what the plan assumes → read the actual function signatures, adapt `taa_band_service` to call them correctly
+2. `classify_regime_multi_signal` returns a different format than expected → read `regime_service.py` actual output, adapt
+3. `taa_regime_state` table conflicts with an existing table name → rename to `portfolio_regime_state` or similar
+4. EMA smoothing produces numerical drift over hundreds of days → add periodic re-anchoring to raw regime centers (e.g., every 30 days, reset smoothed = raw)
+5. ELITE 4x computation exceeds worker time budget → profile; ELITE selection is O(n log n) per regime and should be negligible vs the scoring computation
+6. Sprint 4 frontend components conflict with existing CalibrationPanel → read the current component, compose alongside existing content, don't replace
+
+## Not valid escape hatches
+
+- "TAA is too complex for one sprint" → each sprint is scoped to 3-4 days. If it's taking longer, the brief needs adjustment, not abandonment.
+- "Let's skip the EMA smoothing and just use raw regime" → NO, whipsaw would generate massive turnover and erode alpha. The plan §4.1 explains why.
+- "IPS clamping is unnecessary, regime bands are already reasonable" → NO, IPS is a fiduciary obligation. The band MUST be clamped. One violation = one lawsuit.
+- "Let's keep ELITE static and just change allocation bands" → NO, if allocation shifts to 25% equity but ELITE still has 150 equity slots, the universe doesn't match the allocation. Both must be regime-responsive.

--- a/frontends/wealth/src/lib/components/analytics/entity/ScoreCompositionPanel.svelte
+++ b/frontends/wealth/src/lib/components/analytics/entity/ScoreCompositionPanel.svelte
@@ -50,6 +50,62 @@
 		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
 	};
 
+	const ALT_REIT_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		income_generation: { label: "Income Generation", weight: 0.25 },
+		diversification_value: { label: "Diversification", weight: 0.25 },
+		downside_protection: { label: "Downside Protection", weight: 0.20 },
+		inflation_hedge: { label: "Inflation Hedge", weight: 0.20 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_COMMODITY_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		inflation_hedge: { label: "Inflation Hedge", weight: 0.30 },
+		diversification_value: { label: "Diversification", weight: 0.25 },
+		crisis_alpha: { label: "Crisis Alpha", weight: 0.20 },
+		drawdown_control: { label: "Drawdown Control", weight: 0.15 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_GOLD_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		crisis_alpha: { label: "Crisis Alpha", weight: 0.30 },
+		diversification_value: { label: "Diversification", weight: 0.30 },
+		inflation_hedge: { label: "Inflation Hedge", weight: 0.20 },
+		tracking_efficiency: { label: "Tracking Efficiency", weight: 0.10 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_HEDGE_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		alpha_generation: { label: "Alpha Generation", weight: 0.30 },
+		downside_protection: { label: "Downside Protection", weight: 0.25 },
+		diversification_value: { label: "Diversification", weight: 0.20 },
+		crisis_alpha: { label: "Crisis Alpha", weight: 0.15 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_CTA_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		crisis_alpha: { label: "Crisis Alpha", weight: 0.40 },
+		diversification_value: { label: "Diversification", weight: 0.25 },
+		risk_adjusted_return: { label: "Risk-Adj Return", weight: 0.25 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_GENERIC_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		diversification_value: { label: "Diversification", weight: 0.30 },
+		downside_protection: { label: "Downside Protection", weight: 0.25 },
+		risk_adjusted_return: { label: "Risk-Adj Return", weight: 0.20 },
+		crisis_alpha: { label: "Crisis Alpha", weight: 0.15 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_PROFILE_MAPS: Record<string, Record<string, { label: string; weight: number }>> = {
+		reit: ALT_REIT_WEIGHTS,
+		commodity: ALT_COMMODITY_WEIGHTS,
+		gold: ALT_GOLD_WEIGHTS,
+		hedge: ALT_HEDGE_WEIGHTS,
+		cta: ALT_CTA_WEIGHTS,
+		generic_alt: ALT_GENERIC_WEIGHTS,
+	};
+
 	const WEIGHT_MAPS: Record<string, Record<string, { label: string; weight: number }>> = {
 		fixed_income: FI_WEIGHTS,
 		cash: CASH_WEIGHTS,
@@ -73,8 +129,14 @@
 					compositeScore = sm.manager_score;
 				}
 				scoringModel = sm?.scoring_model || "equity";
-				const weightMap = WEIGHT_MAPS[scoringModel] ?? EQUITY_WEIGHTS;
 				const sc = sm?.score_components;
+				let weightMap: Record<string, { label: string; weight: number }>;
+				if (scoringModel === "alternatives") {
+					const altProfile = sc?._alt_profile || "generic_alt";
+					weightMap = ALT_PROFILE_MAPS[altProfile] ?? ALT_GENERIC_WEIGHTS;
+				} else {
+					weightMap = WEIGHT_MAPS[scoringModel] ?? EQUITY_WEIGHTS;
+				}
 				if (sc && typeof sc === "object") {
 					const parsed: ScoreComponent[] = [];
 					for (const [key, meta] of Object.entries(weightMap)) {


### PR DESCRIPTION
## Summary

- Adds Alternatives analytics pass (1.78) to both org-scoped and global risk workers, computing equity correlation, capture ratios, crisis alpha, Calmar ratio, and inflation beta from SPY benchmark and CPI data
- Updates `_score_metrics` with alt-profile resolution (block_id for org worker, strategy_label for global worker) dispatching to 6 scoring profiles (REIT, Commodity, Gold, Hedge, CTA, Generic)
- Adds per-profile weight maps to `ScoreCompositionPanel.svelte` with dynamic dispatch based on `_alt_profile` from score_components
- Filters alt score_components to only show active-weight components per profile (no "Income Generation: 38" on a CTA fund)
- 7 ORM columns added to FundRiskMetrics model (migration 0125 already exists from Sprint 2)

## Test plan

- [x] 10 new E2E tests covering worker integration, profile resolution, REIT/Commodity/CTA vs equity scoring, ELITE cross-asset validation
- [x] 31 existing alt scoring dispatch tests still passing
- [x] 3783 total tests passing, 0 failed
- [x] 31 architecture contracts kept
- [x] Lint clean (ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)