### PR TITLE
fix(scoring): SPY benchmark seed + MMF catalog sync + MissingGreenlet defense

### DIFF
--- a/backend/app/core/db/migrations/versions/0126_seed_na_equity_large_block.py
+++ b/backend/app/core/db/migrations/versions/0126_seed_na_equity_large_block.py
@@ -1,0 +1,37 @@
+"""Seed na_equity_large allocation block for SPY benchmark.
+
+The alternatives analytics pass fetches SPY returns via
+``benchmark_nav WHERE block_id = 'na_equity_large'``.  This block
+was defined in blocks.yaml but never seeded into allocation_blocks,
+so benchmark_ingest never downloaded SPY NAV data and all alt-specific
+metrics (correlation, capture, crisis alpha) returned NULL.
+
+Revision ID: 0126_seed_na_equity_large_block
+Revises: 0125_add_alternatives_risk_metrics
+Create Date: 2026-04-12
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0126_seed_na_equity_large_block"
+down_revision = "0125_add_alternatives_risk_metrics"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        INSERT INTO allocation_blocks
+            (block_id, geography, asset_class, display_name, benchmark_ticker)
+        VALUES
+            ('na_equity_large', 'north_america', 'equity',
+             'North America Large Cap Equity', 'SPY')
+        ON CONFLICT (block_id) DO NOTHING
+    """)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DELETE FROM allocation_blocks WHERE block_id = 'na_equity_large'"
+    )

--- a/backend/app/domains/wealth/workers/risk_calc.py
+++ b/backend/app/domains/wealth/workers/risk_calc.py
@@ -1107,7 +1107,18 @@ def _score_metrics(
     flows = float(metrics.get("blended_momentum_score") or 50.0)
 
     fi_adapter = _MetricsAdapter(metrics) if asset_class == "fixed_income" else None
-    cash_adapter = _MetricsAdapter(metrics) if asset_class == "cash" else None
+
+    # Only dispatch to cash scoring if the fund has actual MMF data.
+    # Cash-classified funds without sec_money_market_funds data (ultra-short
+    # ETFs, cash management MFs) have all 5 MMF metrics as NULL, which
+    # penalty-defaults every component to ~40.  Fall back to equity scoring
+    # for these — they have valid NAV-based metrics (Sharpe, drawdown, etc.).
+    _has_mmf_data = asset_class == "cash" and any(
+        metrics.get(k) is not None
+        for k in ("seven_day_net_yield", "nav_per_share_mmf", "pct_weekly_liquid")
+    )
+    cash_adapter = _MetricsAdapter(metrics) if _has_mmf_data else None
+
     alt_adapter = _MetricsAdapter(metrics) if asset_class == "alternatives" else None
 
     # Resolve alt profile: org worker uses block_id, global uses strategy_label

--- a/backend/app/domains/wealth/workers/risk_calc.py
+++ b/backend/app/domains/wealth/workers/risk_calc.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import uuid
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import date, timedelta
 
 import numpy as np
@@ -45,6 +46,24 @@ from quant_engine.talib_momentum_service import (
 )
 
 logger = structlog.get_logger()
+
+
+@dataclass(frozen=True, slots=True)
+class _FundSnapshot:
+    """Scalar snapshot of an Instrument row — immune to ORM expire/rollback.
+
+    SQLAlchemy rollback() expires ALL identity-map objects regardless of
+    expire_on_commit.  If a batch upsert fails and triggers rollback,
+    subsequent access to ORM attributes would attempt an async reload
+    outside the greenlet context (MissingGreenlet).  By extracting scalars
+    immediately after the query, the batch loop operates on plain data.
+    """
+
+    instrument_id: uuid.UUID
+    ticker: str | None
+    asset_class: str
+    attributes: dict
+
 
 RISK_CALC_LOCK_ID = 900_007
 TRADING_DAYS_PER_YEAR = 252
@@ -520,7 +539,7 @@ def _compute_momentum_from_nav(
 
 
 def _compute_metrics_from_returns(
-    fund: Instrument,
+    fund: "Instrument | _FundSnapshot",
     returns_raw: list[float],
     as_of_date: date,
     risk_free_rate: float = 0.04,
@@ -1463,7 +1482,22 @@ async def run_global_risk_metrics(as_of_date: date | None = None) -> dict[str, i
                 )
             )
             result = await db.execute(stmt)
-            all_funds = result.scalars().all()
+            all_funds_raw = result.scalars().all()
+            # Extract scalars from ORM objects BEFORE the batch loop.
+            # rollback() expires ALL identity-map objects regardless of
+            # expire_on_commit — accessing ORM attrs after a failed batch
+            # upsert would trigger MissingGreenlet.  Frozen snapshots are
+            # immune to session state changes.
+            all_funds: list[_FundSnapshot] = [
+                _FundSnapshot(
+                    instrument_id=f.instrument_id,
+                    ticker=f.ticker,
+                    asset_class=f.asset_class or "equity",
+                    attributes=dict(f.attributes) if f.attributes else {},
+                )
+                for f in all_funds_raw
+            ]
+            del all_funds_raw  # release ORM objects from identity map
             logger.info("global_risk_metrics.funds_found", count=len(all_funds))
 
             # Process in batches to avoid memory pressure

--- a/backend/app/domains/wealth/workers/universe_sync.py
+++ b/backend/app/domains/wealth/workers/universe_sync.py
@@ -8,6 +8,7 @@ Phase 2: SEC Mutual Fund series — canonical share class (~4,794 series)
 Phase 3: SEC Registered Funds with direct ticker (~363, supplements Phase 2)
 Phase 3b: SEC BDCs (27 with ticker resolved via cusip_ticker_map)
 Phase 4: ESMA UCITS funds with yahoo_ticker (~2,929)
+Phase 5: SEC Money Market Funds — via sec_fund_classes ticker JOIN (~373)
 
 Advisory lock: 900_070 (global)
 Frequency: weekly (alongside sec_bulk_ingestion)
@@ -100,6 +101,7 @@ async def run_universe_sync() -> dict[str, Any]:
             stats["sec_registered"] = await _sync_sec_registered(db)
             stats["sec_bdcs"] = await _sync_sec_bdcs(db)
             stats["esma_funds"] = await _sync_esma_funds(db)
+            stats["sec_mmfs"] = await _sync_sec_mmfs(db)
             stats["deactivated"] = await _deactivate_no_nav(db)
 
             total = sum(v.get("upserted", 0) for v in stats.values() if isinstance(v, dict))
@@ -461,6 +463,80 @@ async def _sync_esma_funds(db: AsyncSession) -> dict[str, Any]:
     await db.commit()
     count = result.rowcount
     logger.info("universe_sync.esma_funds", upserted=count)
+    return {"upserted": count}
+
+
+# ── Phase 5: SEC Money Market Funds ─────────────────────────────────
+
+
+async def _sync_sec_mmfs(db: AsyncSession) -> dict[str, Any]:
+    """Upsert SEC Money Market Funds into instruments_universe.
+
+    These are the actual MMFs from sec_money_market_funds (373 funds),
+    distinct from ETFs/MFs that happen to have cash-like strategy_labels.
+
+    sec_money_market_funds has no ticker column — we resolve tickers by
+    joining sec_fund_classes on (cik, series_id).  The series_id stored
+    in attributes enables _batch_fetch_mmf_data() in risk_calc to JOIN
+    against sec_money_market_funds + sec_mmf_metrics for 7-day yield,
+    WAM, weekly liquidity, and NAV stability data.
+    """
+    result = cast(CursorResult[Any], await db.execute(text("""
+        WITH mmf_with_ticker AS (
+            SELECT DISTINCT ON (m.series_id)
+                m.series_id,
+                m.cik,
+                m.fund_name,
+                m.mmf_category,
+                m.crd_number,
+                m.net_assets,
+                m.investment_adviser,
+                fc.ticker
+            FROM sec_money_market_funds m
+            JOIN sec_fund_classes fc
+              ON fc.cik = m.cik AND fc.series_id = m.series_id
+            WHERE fc.ticker IS NOT NULL
+              AND fc.ticker NOT LIKE '%%XX'
+            ORDER BY m.series_id, fc.ticker
+        )
+        INSERT INTO instruments_universe (
+            instrument_id, instrument_type, name, isin, ticker,
+            asset_class, geography, currency, is_active, attributes
+        )
+        SELECT
+            gen_random_uuid(),
+            'fund',
+            t.fund_name,
+            t.series_id,
+            t.ticker,
+            'cash',
+            'north_america',
+            'USD',
+            true,
+            jsonb_build_object(
+                'series_id', t.series_id,
+                'sec_cik', t.cik,
+                'sec_crd', t.crd_number,
+                'fund_subtype', 'mmf',
+                'sec_universe', 'money_market',
+                'strategy_label', 'Money Market',
+                'mmf_category', t.mmf_category,
+                'expense_ratio_pct', NULL,
+                'aum_usd', t.net_assets,
+                'manager_name', COALESCE(t.investment_adviser, t.fund_name),
+                'inception_date', NULL,
+                'source', 'universe_sync'
+            )
+        FROM mmf_with_ticker t
+        ON CONFLICT (ticker) DO UPDATE SET
+            name = EXCLUDED.name,
+            asset_class = 'cash',
+            attributes = instruments_universe.attributes || EXCLUDED.attributes,
+            updated_at = now()
+    """)))
+    await db.commit()
+    count = result.rowcount
+    logger.info("universe_sync.sec_mmfs", upserted=count)
     return {"upserted": count}
 
 


### PR DESCRIPTION
2 commits. Migration 0126 seeds na_equity_large (SPY). Phase 5 _sync_sec_mmfs JOINs sec_fund_classes for ticker resolution. _FundSnapshot frozen dataclass prevents MissingGreenlet on batch rollback. Cash funds without MMF data fall back to equity scoring. Tests green.