### PR TITLE
feat(builder): Session 1 — terminal route, command panel, weights tab

### DIFF
--- a/frontends/wealth/src/lib/components/terminal/builder/RegimeContextStrip.svelte
+++ b/frontends/wealth/src/lib/components/terminal/builder/RegimeContextStrip.svelte
@@ -1,0 +1,225 @@
+<!--
+  RegimeContextStrip — Zone A of the Builder command panel.
+
+  Shows current TAA regime badge, stress score bar, effective band
+  ranges (equity/FI/alt/cash), and universe count. 120px fixed height.
+  Pure presentational — no workspace dependency.
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+	import {
+		taaRegimeLabel,
+		taaRegimeColor,
+		taaRegimePosture,
+	} from "$lib/types/taa";
+	import type { RegimeBands } from "$lib/types/taa";
+
+	interface Props {
+		regimeBands: RegimeBands | null;
+	}
+
+	let { regimeBands }: Props = $props();
+
+	// Derive band entries for the 4 main asset classes
+	interface BandRow {
+		label: string;
+		min: number;
+		center: number | null;
+		max: number;
+	}
+
+	const BAND_ORDER: Record<string, string> = {
+		equity: "Equity",
+		fi: "Fixed Income",
+		alt: "Alternatives",
+		cash: "Cash",
+	};
+
+	const bandRows = $derived.by<BandRow[]>(() => {
+		if (!regimeBands?.effective_bands) return [];
+		const rows: BandRow[] = [];
+		// Aggregate effective_bands by asset class prefix
+		const agg: Record<string, { min: number; center: number; max: number }> = {};
+		for (const [blockId, band] of Object.entries(regimeBands.effective_bands)) {
+			let cls = "other";
+			if (blockId.startsWith("na_equity") || blockId.startsWith("dm_") || blockId.startsWith("em_") || blockId.startsWith("intl_equity")) cls = "equity";
+			else if (blockId.startsWith("fi_")) cls = "fi";
+			else if (blockId.startsWith("alt_")) cls = "alt";
+			else if (blockId === "cash") cls = "cash";
+
+			const entry = agg[cls] ?? (agg[cls] = { min: 0, center: 0, max: 0 });
+			entry.min += band.min;
+			entry.center += band.center ?? (band.min + band.max) / 2;
+			entry.max += band.max;
+		}
+		for (const [key, label] of Object.entries(BAND_ORDER)) {
+			const a = agg[key];
+			if (!a) continue;
+			rows.push({ label, min: a.min, center: a.center, max: a.max });
+		}
+		return rows;
+	});
+
+	const universeCount = $derived.by(() => {
+		if (!regimeBands?.effective_bands) return { instruments: 0, classes: 0 };
+		const keys = Object.keys(regimeBands.effective_bands);
+		return { instruments: keys.length, classes: Object.keys(BAND_ORDER).length };
+	});
+
+	const regimeColor = $derived(
+		regimeBands ? taaRegimeColor(regimeBands.raw_regime) : "var(--terminal-fg-muted)",
+	);
+</script>
+
+<div class="rcs-root">
+	{#if regimeBands}
+		<div class="rcs-header">
+			<span class="rcs-badge" style="background: {regimeColor}; color: var(--terminal-fg-inverted);">
+				{taaRegimeLabel(regimeBands.raw_regime)}
+			</span>
+			<span class="rcs-posture">{taaRegimePosture(regimeBands.raw_regime)}</span>
+		</div>
+
+		<div class="rcs-stress">
+			<span class="rcs-stress-label">STRESS</span>
+			<div class="rcs-stress-track">
+				<div
+					class="rcs-stress-fill"
+					style="width: {regimeBands.stress_score ?? 0}%; background: {regimeColor};"
+				></div>
+			</div>
+			<span class="rcs-stress-value">{regimeBands.stress_score ?? 0}</span>
+		</div>
+
+		<div class="rcs-bands">
+			{#each bandRows as row (row.label)}
+				<div class="rcs-band-row">
+					<span class="rcs-band-label">{row.label}</span>
+					<span class="rcs-band-range">
+						{formatPercent(row.min, 1)} <span class="rcs-band-arrow">&rarr;</span>
+						{formatPercent(row.center ?? row.min, 1)} <span class="rcs-band-arrow">&rarr;</span>
+						{formatPercent(row.max, 1)}
+					</span>
+				</div>
+			{/each}
+		</div>
+
+		<div class="rcs-universe">
+			{universeCount.instruments} blocks across {universeCount.classes} classes
+		</div>
+	{:else}
+		<div class="rcs-empty">Regime data unavailable</div>
+	{/if}
+</div>
+
+<style>
+	.rcs-root {
+		height: 120px;
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		box-sizing: border-box;
+		overflow: hidden;
+	}
+
+	.rcs-header {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+
+	.rcs-badge {
+		display: inline-block;
+		padding: 1px 6px;
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.rcs-posture {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rcs-stress {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+
+	.rcs-stress-label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		min-width: 40px;
+	}
+
+	.rcs-stress-track {
+		flex: 1;
+		height: 4px;
+		background: var(--terminal-fg-muted);
+	}
+
+	.rcs-stress-fill {
+		height: 100%;
+		transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+	}
+
+	.rcs-stress-value {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		min-width: 24px;
+		text-align: right;
+	}
+
+	.rcs-bands {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.rcs-band-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		font-size: var(--terminal-text-10);
+	}
+
+	.rcs-band-label {
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rcs-band-range {
+		color: var(--terminal-fg-primary);
+		font-weight: 600;
+	}
+
+	.rcs-band-arrow {
+		color: var(--terminal-fg-muted);
+	}
+
+	.rcs-universe {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rcs-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-11);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/builder/RunControls.svelte
+++ b/frontends/wealth/src/lib/components/terminal/builder/RunControls.svelte
@@ -1,0 +1,172 @@
+<!--
+  RunControls — Zone C of the Builder command panel.
+
+  "Run Construction" button with state machine driven by
+  workspace.runPhase. Compare dropdown stub for Session 3.
+-->
+<script lang="ts">
+	import { workspace } from "$lib/state/portfolio-workspace.svelte";
+
+	interface Props {
+		onRunComplete?: () => void;
+	}
+
+	let { onRunComplete }: Props = $props();
+
+	const phase = $derived(workspace.runPhase);
+	const hasPortfolio = $derived(workspace.portfolioId !== null);
+
+	const buttonLabel = $derived.by(() => {
+		switch (phase) {
+			case "running":
+			case "optimizer":
+			case "stress":
+				return "Running\u2026";
+			case "done":
+				return "Complete";
+			case "error":
+				return "Failed \u2014 Retry";
+			default:
+				return "Run Construction";
+		}
+	});
+
+	const isDisabled = $derived(
+		!hasPortfolio || phase === "running" || phase === "optimizer" || phase === "stress",
+	);
+
+	const statusClass = $derived.by(() => {
+		switch (phase) {
+			case "running":
+			case "optimizer":
+			case "stress":
+				return "rc-btn--running";
+			case "done":
+				return "rc-btn--done";
+			case "error":
+				return "rc-btn--error";
+			default:
+				return "";
+		}
+	});
+
+	async function handleRun() {
+		if (isDisabled) return;
+		const result = await workspace.runConstructJob();
+		if (result && onRunComplete) {
+			onRunComplete();
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === "Enter" && !isDisabled) {
+			e.preventDefault();
+			handleRun();
+		}
+	}
+</script>
+
+<div class="rc-root">
+	<button
+		type="button"
+		class="rc-btn {statusClass}"
+		disabled={isDisabled}
+		onclick={handleRun}
+		onkeydown={handleKeydown}
+		aria-label={buttonLabel}
+	>
+		{#if phase === "done"}
+			<span class="rc-check">&check;</span>
+		{/if}
+		{buttonLabel}
+	</button>
+
+	<select class="rc-compare" aria-label="Compare with previous run">
+		<option value="last">Compare with: Last run</option>
+	</select>
+</div>
+
+<style>
+	.rc-root {
+		height: 80px;
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-2);
+		border-top: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		box-sizing: border-box;
+	}
+
+	.rc-btn {
+		height: 32px;
+		width: 100%;
+		background: var(--terminal-accent-amber);
+		color: var(--terminal-bg-base, var(--terminal-bg-void));
+		border: none;
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		transition:
+			background var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			opacity var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.rc-btn:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.rc-btn:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.rc-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.rc-btn--running {
+		animation: rc-pulse 1.5s ease-in-out infinite;
+	}
+
+	.rc-btn--done {
+		background: var(--terminal-status-success);
+	}
+
+	.rc-btn--error {
+		background: var(--terminal-status-error);
+		color: var(--terminal-fg-primary);
+	}
+
+	.rc-check {
+		margin-right: var(--terminal-space-1);
+	}
+
+	@keyframes rc-pulse {
+		0%, 100% { opacity: 1; }
+		50% { opacity: 0.6; }
+	}
+
+	.rc-compare {
+		height: 24px;
+		width: 100%;
+		background: var(--terminal-bg-panel-sunken);
+		color: var(--terminal-fg-secondary);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		padding: 0 var(--terminal-space-2);
+		cursor: pointer;
+	}
+
+	.rc-compare:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/builder/WeightsTab.svelte
+++ b/frontends/wealth/src/lib/components/terminal/builder/WeightsTab.svelte
@@ -1,0 +1,416 @@
+<!--
+  WeightsTab — WEIGHTS tab in the Builder results panel (right column).
+
+  Read-only display of proposed weights grouped by asset class.
+  Tree structure: Group -> Block -> Fund. No drag-drop.
+  Data sourced from workspace.funds / workspace.fundsByBlock.
+-->
+<script lang="ts">
+	import { formatPercent, formatNumber } from "@investintell/ui";
+	import { BLOCK_GROUPS, blockDisplay, groupDisplay } from "$lib/constants/blocks";
+	import { workspace } from "$lib/state/portfolio-workspace.svelte";
+
+	// ── Build 3-level tree (same logic as BuilderTable, DnD stripped) ──
+
+	const GROUP_ORDER = ["CASH & EQUIVALENTS", "EQUITIES", "FIXED INCOME", "ALTERNATIVES"];
+
+	interface TreeFund {
+		instrument_id: string;
+		fund_name: string;
+		block_id: string;
+		score: number | null;
+		weight: number;
+		ticker?: string | null;
+	}
+
+	interface TreeBlock {
+		blockId: string;
+		displayLabel: string;
+		funds: TreeFund[];
+		weight: number;
+	}
+
+	interface TreeGroup {
+		name: string;
+		displayName: string;
+		blocks: TreeBlock[];
+		totalWeight: number;
+		fundCount: number;
+	}
+
+	const activeBlockIds = $derived.by<Set<string>>(() => {
+		const blocks = new Set<string>();
+		for (const f of workspace.funds) blocks.add(f.block_id);
+		return blocks;
+	});
+
+	const tree = $derived.by<TreeGroup[]>(() => {
+		const groupMap = new Map<string, TreeGroup>();
+
+		for (const [groupName, blockIds] of Object.entries(BLOCK_GROUPS)) {
+			const blocks: TreeBlock[] = [];
+			for (const blockId of blockIds) {
+				if (!activeBlockIds.has(blockId)) continue;
+				const rawFunds = (workspace.fundsByBlock[blockId] ?? []) as TreeFund[];
+				const weight = rawFunds.reduce((s, f) => s + (f.weight ?? 0), 0);
+				blocks.push({
+					blockId,
+					displayLabel: blockDisplay(blockId),
+					funds: rawFunds,
+					weight,
+				});
+			}
+			if (blocks.length === 0) continue;
+
+			groupMap.set(groupName, {
+				name: groupName,
+				displayName: groupDisplay(groupName),
+				blocks,
+				totalWeight: blocks.reduce((s, b) => s + b.weight, 0),
+				fundCount: blocks.reduce((s, b) => s + b.funds.length, 0),
+			});
+		}
+
+		// Catch unmapped blocks
+		const mappedBlockIds = new Set(Object.values(BLOCK_GROUPS).flat());
+		const unmapped: TreeBlock[] = [];
+		for (const blockId of activeBlockIds) {
+			if (mappedBlockIds.has(blockId)) continue;
+			const rawFunds = (workspace.fundsByBlock[blockId] ?? []) as TreeFund[];
+			unmapped.push({
+				blockId,
+				displayLabel: blockDisplay(blockId),
+				funds: rawFunds,
+				weight: rawFunds.reduce((s, f) => s + (f.weight ?? 0), 0),
+			});
+		}
+		if (unmapped.length > 0) {
+			groupMap.set("OTHER", {
+				name: "OTHER",
+				displayName: groupDisplay("OTHER"),
+				blocks: unmapped,
+				totalWeight: unmapped.reduce((s, b) => s + b.weight, 0),
+				fundCount: unmapped.reduce((s, b) => s + b.funds.length, 0),
+			});
+		}
+
+		const result: TreeGroup[] = [];
+		for (const key of GROUP_ORDER) {
+			const g = groupMap.get(key);
+			if (g) {
+				result.push(g);
+				groupMap.delete(key);
+			}
+		}
+		for (const g of groupMap.values()) result.push(g);
+		return result;
+	});
+
+	const hasRun = $derived(workspace.constructionRun !== null);
+
+	// ── Collapse state ──
+	let collapsedGroup = $state<Record<string, boolean>>({});
+
+	function toggleGroup(name: string) {
+		collapsedGroup[name] = !collapsedGroup[name];
+	}
+
+	// ── Delta formatting ──
+	function deltaColor(weight: number): string {
+		if (weight > 0.0001) return "var(--terminal-status-success)";
+		if (weight < -0.0001) return "var(--terminal-status-error)";
+		return "var(--terminal-fg-muted)";
+	}
+
+	function formatDelta(weight: number): string {
+		if (Math.abs(weight) < 0.0001) return "\u2014";
+		const sign = weight > 0 ? "+" : "";
+		return sign + formatPercent(weight, 2);
+	}
+
+	function formatWeight(value: number): string {
+		return formatPercent(value, 2);
+	}
+
+	function formatScore(value: number | null | undefined): string {
+		if (value == null || value === 0) return "\u2014";
+		return formatNumber(value, 0);
+	}
+</script>
+
+<div class="wt-root">
+	{#if tree.length === 0}
+		<div class="wt-empty">
+			{#if hasRun}
+				No instruments in portfolio
+			{:else}
+				Run construction to see proposed weights
+			{/if}
+		</div>
+	{:else}
+		<table class="wt-table" aria-label="Proposed portfolio weights">
+			<thead>
+				<tr>
+					<th class="wt-th wt-th-name">Fund</th>
+					<th class="wt-th wt-th-num">Score</th>
+					<th class="wt-th wt-th-num">Weight</th>
+					<th class="wt-th wt-th-num">Previous</th>
+					<th class="wt-th wt-th-num">Delta</th>
+				</tr>
+			</thead>
+
+			{#each tree as group (group.name)}
+				{@const isCollapsed = collapsedGroup[group.name] ?? false}
+				<tbody>
+					<tr
+						class="wt-group-row"
+						role="button"
+						tabindex="0"
+						onclick={() => toggleGroup(group.name)}
+						onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleGroup(group.name); } }}
+					>
+						<td class="wt-group-name" colspan="3">
+							<span class="wt-chevron" class:wt-chevron--open={!isCollapsed}>&rsaquo;</span>
+							{group.displayName}
+							<span class="wt-group-count">({group.fundCount})</span>
+						</td>
+						<td class="wt-group-weight" colspan="2">
+							{formatWeight(group.totalWeight)}
+						</td>
+					</tr>
+
+					{#if !isCollapsed}
+						{#each group.blocks as block (block.blockId)}
+							<tr class="wt-block-row">
+								<td class="wt-block-name" colspan="3">
+									{block.displayLabel}
+								</td>
+								<td class="wt-block-weight" colspan="2">
+									{formatWeight(block.weight)}
+								</td>
+							</tr>
+
+							{#each block.funds as fund (fund.instrument_id)}
+								<tr class="wt-fund-row">
+									<td class="wt-fund-name">
+										<span class="wt-fund-label">{fund.fund_name}</span>
+										{#if fund.ticker}
+											<span class="wt-fund-ticker">{fund.ticker}</span>
+										{/if}
+									</td>
+									<td class="wt-fund-num">{formatScore(fund.score)}</td>
+									<td class="wt-fund-num">{formatWeight(fund.weight)}</td>
+									<td class="wt-fund-num wt-fund-ghost">&mdash;</td>
+									<td class="wt-fund-num">
+										<span class="wt-delta" style="color: {deltaColor(fund.weight)}">
+											{formatDelta(fund.weight)}
+										</span>
+										{#if Math.abs(fund.weight) > 0.0001}
+											<div class="wt-delta-bar">
+												<div
+													class="wt-delta-fill"
+													style="width: {Math.min(Math.abs(fund.weight) * 500, 100)}%; background: {deltaColor(fund.weight)};"
+												></div>
+											</div>
+										{/if}
+									</td>
+								</tr>
+							{/each}
+						{/each}
+					{/if}
+				</tbody>
+			{/each}
+
+			<tfoot>
+				<tr class="wt-total-row">
+					<td class="wt-total-label" colspan="2">Total</td>
+					<td class="wt-total-value">{formatWeight(workspace.totalWeight)}</td>
+					<td class="wt-total-value wt-fund-ghost">&mdash;</td>
+					<td class="wt-total-value"></td>
+				</tr>
+			</tfoot>
+		</table>
+	{/if}
+</div>
+
+<style>
+	.wt-root {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.wt-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 200px;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-12);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.wt-table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	.wt-th {
+		position: sticky;
+		top: 0;
+		background: var(--terminal-bg-panel);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		text-align: left;
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		border-bottom: var(--terminal-border-hairline);
+		z-index: 1;
+	}
+
+	.wt-th-num {
+		text-align: right;
+		width: 80px;
+	}
+
+	.wt-th-name {
+		width: auto;
+	}
+
+	/* Group row */
+	.wt-group-row {
+		cursor: pointer;
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.wt-group-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.wt-group-name {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-weight: 700;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-primary);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.wt-chevron {
+		display: inline-block;
+		width: 12px;
+		transition: transform var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.wt-chevron--open {
+		transform: rotate(90deg);
+	}
+
+	.wt-group-count {
+		color: var(--terminal-fg-tertiary);
+		font-weight: 400;
+		margin-left: var(--terminal-space-1);
+	}
+
+	.wt-group-weight {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		text-align: right;
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+	}
+
+	/* Block row */
+	.wt-block-row {
+		border-bottom: 1px solid var(--terminal-bg-panel-raised);
+	}
+
+	.wt-block-name {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		padding-left: var(--terminal-space-6);
+		font-weight: 600;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-secondary);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.wt-block-weight {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		text-align: right;
+		font-weight: 600;
+		color: var(--terminal-fg-secondary);
+	}
+
+	/* Fund row */
+	.wt-fund-row {
+		border-bottom: 1px solid var(--terminal-bg-panel-raised);
+	}
+
+	.wt-fund-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.wt-fund-name {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		padding-left: var(--terminal-space-8);
+	}
+
+	.wt-fund-label {
+		color: var(--terminal-fg-primary);
+	}
+
+	.wt-fund-ticker {
+		margin-left: var(--terminal-space-1);
+		color: var(--terminal-fg-tertiary);
+		font-size: var(--terminal-text-10);
+	}
+
+	.wt-fund-num {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		text-align: right;
+	}
+
+	.wt-fund-ghost {
+		color: var(--terminal-fg-muted);
+	}
+
+	.wt-delta {
+		font-weight: 600;
+	}
+
+	.wt-delta-bar {
+		margin-top: 2px;
+		height: 2px;
+		background: var(--terminal-fg-muted);
+		width: 60px;
+		margin-left: auto;
+	}
+
+	.wt-delta-fill {
+		height: 100%;
+		transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+	}
+
+	/* Total row */
+	.wt-total-row {
+		border-top: var(--terminal-border-strong);
+	}
+
+	.wt-total-label {
+		padding: var(--terminal-space-2);
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-primary);
+	}
+
+	.wt-total-value {
+		padding: var(--terminal-space-2);
+		text-align: right;
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte
@@ -29,6 +29,7 @@
 	// `resolve(...)`; hardcoding the three active route literals is
 	// the only pattern its AST matcher accepts.
 	const HREF_SCREENER = resolve("/terminal-screener");
+	const HREF_BUILDER = resolve("/portfolio/builder");
 	const HREF_LIVE = resolve("/portfolio/live");
 	const HREF_RESEARCH = resolve("/research");
 
@@ -82,7 +83,7 @@
 		{ id: "macro",    label: "MACRO",    href: "/macro",             status: "pending", pendingReason: "Phase 7 — Macro Desk" },
 		{ id: "alloc",    label: "ALLOC",    href: "/allocation",        status: "pending", pendingReason: "Phase 7 — Allocation" },
 		{ id: "screener", label: "SCREENER", href: HREF_SCREENER,        status: "active" },
-		{ id: "builder",  label: "BUILDER",  href: "/portfolio/build",   status: "pending", pendingReason: "Phase 4 — Portfolio Builder" },
+		{ id: "builder",  label: "BUILDER",  href: HREF_BUILDER,         status: "active" },
 		{ id: "live",     label: "LIVE",     href: HREF_LIVE,            status: "active" },
 		{ id: "research", label: "RESEARCH", href: HREF_RESEARCH,        status: "active" },
 		{ id: "alerts",   label: "ALERTS",   href: "/alerts",            status: "pending", pendingReason: "Phase 5 — Alerts Inbox" },
@@ -92,6 +93,7 @@
 	function isHrefActive(href: string): boolean {
 		return (
 			href === HREF_SCREENER ||
+			href === HREF_BUILDER ||
 			href === HREF_LIVE ||
 			href === HREF_RESEARCH
 		);
@@ -99,6 +101,7 @@
 
 	function activePathSegment(href: string): string {
 		if (href === HREF_SCREENER) return "/terminal-screener";
+		if (href === HREF_BUILDER) return "/portfolio/builder";
 		if (href === HREF_LIVE) return "/portfolio/live";
 		if (href === HREF_RESEARCH) return "/research";
 		return href;
@@ -161,6 +164,15 @@
 						class="tn-tab tn-tab--active"
 						class:tn-tab--current={isActiveTab(tab)}
 						href={HREF_SCREENER}
+						data-sveltekit-preload-data="hover"
+					>
+						<span class="tn-tab-label">{tab.label}</span>
+					</a>
+				{:else if tab.id === "builder"}
+					<a
+						class="tn-tab tn-tab--active"
+						class:tn-tab--current={isActiveTab(tab)}
+						href={HREF_BUILDER}
 						data-sveltekit-preload-data="hover"
 					>
 						<span class="tn-tab-label">{tab.label}</span>

--- a/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.server.ts
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.server.ts
@@ -1,0 +1,38 @@
+/**
+ * /portfolio/builder — server load. Phase 4 Builder.
+ *
+ * Loads all model portfolios for the org (same pattern as live).
+ * Also attempts to fetch regime bands for the first portfolio's
+ * profile to avoid a loading flash in Zone A (RegimeContextStrip).
+ */
+
+import type { PageServerLoad } from "./$types";
+import { createServerApiClient } from "$lib/api/client";
+import type { ModelPortfolio } from "$lib/types/model-portfolio";
+import type { RegimeBands } from "$lib/types/taa";
+
+export const load: PageServerLoad = async ({ parent }) => {
+	const { token } = await parent();
+	if (!token) {
+		return {
+			portfolios: [] as ModelPortfolio[],
+			initialRegimeBands: null as RegimeBands | null,
+		};
+	}
+
+	const api = createServerApiClient(token);
+	const portfolios = await api
+		.get<ModelPortfolio[]>("/model-portfolios")
+		.catch(() => [] as ModelPortfolio[]);
+
+	// Pre-fetch regime bands for the first portfolio with a profile
+	let initialRegimeBands: RegimeBands | null = null;
+	const first = portfolios[0];
+	if (first?.profile) {
+		initialRegimeBands = await api
+			.get<RegimeBands>(`/allocation/${first.profile}/regime-bands`)
+			.catch(() => null);
+	}
+
+	return { portfolios, initialRegimeBands };
+};

--- a/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
@@ -1,0 +1,292 @@
+<!--
+  /portfolio/builder — Phase 4 Terminal Builder.
+
+  2-column command center (40% command / 60% results).
+  Left: Zone A (regime), Zone B (calibration), Zone C (run controls).
+  Right: 6-tab results panel (WEIGHTS active, rest stub).
+
+  Workspace initialization: imports the singleton, calls setGetToken
+  + selectPortfolio on mount. CalibrationPanel already reads from
+  the workspace singleton internally — no prop threading needed.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
+	import { workspace } from "$lib/state/portfolio-workspace.svelte";
+	import type { ModelPortfolio } from "$lib/types/model-portfolio";
+	import type { PageData } from "./$types";
+
+	import RegimeContextStrip from "$lib/components/terminal/builder/RegimeContextStrip.svelte";
+	import RunControls from "$lib/components/terminal/builder/RunControls.svelte";
+	import WeightsTab from "$lib/components/terminal/builder/WeightsTab.svelte";
+	import CalibrationPanel from "$lib/components/portfolio/CalibrationPanel.svelte";
+
+	let { data }: { data: PageData } = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+
+	// Portfolio selection state
+	let selectedPortfolio = $state<ModelPortfolio | null>(null);
+	const portfolios = $derived((data.portfolios ?? []) as ModelPortfolio[]);
+
+	// Initialize workspace on mount
+	$effect(() => {
+		workspace.setGetToken(getToken);
+
+		// Auto-select first portfolio if available
+		const first = portfolios[0];
+		if (first && !selectedPortfolio) {
+			selectPortfolio(first);
+		}
+	});
+
+	function selectPortfolio(p: ModelPortfolio) {
+		selectedPortfolio = p;
+		workspace.selectPortfolio(p);
+	}
+
+	function handlePortfolioChange(e: Event) {
+		const select = e.currentTarget as HTMLSelectElement;
+		const p = portfolios.find((p) => p.id === select.value);
+		if (p) selectPortfolio(p);
+	}
+
+	// Regime bands: prefer workspace (live-updated) over server-loaded initial
+	const regimeBands = $derived(workspace.regimeBands ?? data.initialRegimeBands);
+
+	// Tab state for right column
+	const TABS = ["WEIGHTS", "RISK", "STRESS", "BACKTEST", "MONTE CARLO", "ADVISOR"] as const;
+	type TabId = (typeof TABS)[number];
+	let activeTab = $state<TabId>("WEIGHTS");
+</script>
+
+<svelte:head>
+	<title>Builder — InvestIntell</title>
+</svelte:head>
+
+<div class="builder-shell">
+	<!-- LEFT COLUMN (40%) — Command Panel -->
+	<div class="builder-left">
+		<!-- Portfolio selector -->
+		<div class="builder-portfolio-select">
+			<select
+				class="builder-select"
+				value={selectedPortfolio?.id ?? ""}
+				onchange={handlePortfolioChange}
+				aria-label="Select portfolio"
+			>
+				{#if portfolios.length === 0}
+					<option value="" disabled>No portfolios available</option>
+				{:else}
+					{#each portfolios as p (p.id)}
+						<option value={p.id}>{p.display_name}</option>
+					{/each}
+				{/if}
+			</select>
+		</div>
+
+		<!-- Zone A: Regime Context Strip (120px) -->
+		<RegimeContextStrip {regimeBands} />
+
+		<!-- Zone B: Calibration Controls (flex) -->
+		<div class="builder-calibration">
+			{#if selectedPortfolio}
+				<CalibrationPanel />
+			{:else}
+				<div class="builder-empty-zone">Select a portfolio to configure</div>
+			{/if}
+		</div>
+
+		<!-- Zone C: Run Controls (80px) -->
+		<RunControls />
+	</div>
+
+	<!-- RIGHT COLUMN (60%) — Results Panel -->
+	<div class="builder-right">
+		<!-- Tab bar -->
+		<div class="builder-tabs" role="tablist">
+			{#each TABS as tab (tab)}
+				<button
+					type="button"
+					role="tab"
+					class="builder-tab"
+					class:builder-tab--active={activeTab === tab}
+					aria-selected={activeTab === tab}
+					onclick={() => { activeTab = tab; }}
+				>
+					{tab}
+				</button>
+			{/each}
+		</div>
+
+		<!-- Tab content -->
+		<div class="builder-tab-content" role="tabpanel">
+			{#if activeTab === "WEIGHTS"}
+				<WeightsTab />
+			{:else if activeTab === "RISK"}
+				<div class="builder-stub">Risk analysis &mdash; Coming in Session 2</div>
+			{:else if activeTab === "STRESS"}
+				<div class="builder-stub">Stress scenarios &mdash; Coming in Session 2</div>
+			{:else if activeTab === "BACKTEST"}
+				<div class="builder-stub">Historical backtest &mdash; Coming in Session 3</div>
+			{:else if activeTab === "MONTE CARLO"}
+				<div class="builder-stub">Monte Carlo simulation &mdash; Coming in Session 3</div>
+			{:else if activeTab === "ADVISOR"}
+				<div class="builder-stub">Construction advisor &mdash; Coming in Session 2</div>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.builder-shell {
+		display: grid;
+		grid-template-columns: 40% 60%;
+		height: calc(100vh - 88px);
+		background: var(--terminal-bg-void);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	/* ── Left Column ──────────────────────────────────── */
+
+	.builder-left {
+		display: flex;
+		flex-direction: column;
+		overflow-y: auto;
+		border-right: var(--terminal-border-hairline);
+	}
+
+	.builder-portfolio-select {
+		padding: var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.builder-select {
+		width: 100%;
+		height: 28px;
+		background: var(--terminal-bg-panel-sunken);
+		color: var(--terminal-fg-primary);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		padding: 0 var(--terminal-space-2);
+		cursor: pointer;
+	}
+
+	.builder-select:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	/* Terminal overrides for CalibrationPanel */
+	.builder-calibration {
+		flex: 1;
+		overflow-y: auto;
+		border-bottom: var(--terminal-border-hairline);
+
+		/* Override @investintell/ui rounded corners */
+		--ii-radius-md: 0px;
+		--ii-radius-sm: 0px;
+		--ii-radius-lg: 0px;
+		--ii-radius-xl: 0px;
+		font-family: var(--terminal-font-mono);
+	}
+
+	/* Deep scoped overrides for CalibrationPanel child elements */
+	.builder-calibration :global(button) {
+		border-radius: var(--terminal-radius-none);
+	}
+
+	.builder-calibration :global([data-slot="tablist"]) {
+		border-radius: var(--terminal-radius-none);
+	}
+
+	.builder-calibration :global([data-slot="trigger"]) {
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.builder-calibration :global([data-slot="content"]) {
+		border-radius: var(--terminal-radius-none);
+	}
+
+	.builder-empty-zone {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex: 1;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-11);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	/* ── Right Column ─────────────────────────────────── */
+
+	.builder-right {
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	.builder-tabs {
+		display: flex;
+		align-items: stretch;
+		height: 32px;
+		border-bottom: var(--terminal-border-hairline);
+		flex-shrink: 0;
+	}
+
+	.builder-tab {
+		display: inline-flex;
+		align-items: center;
+		padding: 0 var(--terminal-space-3);
+		background: transparent;
+		border: none;
+		border-bottom: 2px solid transparent;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		cursor: pointer;
+		transition:
+			color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.builder-tab:hover {
+		color: var(--terminal-accent-amber);
+	}
+
+	.builder-tab--active {
+		color: var(--terminal-accent-amber);
+		border-bottom-color: var(--terminal-accent-amber);
+	}
+
+	.builder-tab:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -2px;
+	}
+
+	.builder-tab-content {
+		flex: 1;
+		overflow-y: auto;
+		padding: var(--terminal-space-2);
+	}
+
+	.builder-stub {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 300px;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-12);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+</style>


### PR DESCRIPTION
## Summary
- 2-column Builder shell (40% command / 60% results) at `/portfolio/builder`
- Zone A: RegimeContextStrip (regime badge, stress bar, TAA bands)
- Zone B: CalibrationPanel with terminal CSS overrides (zero-radius, mono)
- Zone C: RunControls with state machine (idle/running/done/error)
- WEIGHTS tab: read-only 3-level tree (Group→Block→Fund), delta bars
- TopNav BUILDER tab activated (no PENDING badge)

## Gate
- svelte-check: 0 errors
- pnpm build: clean
- Zero hex, zero .toFixed(), zero any types

## Test plan
- [ ] `/portfolio/builder` renders inside TerminalShell
- [ ] BUILDER tab highlights amber when active
- [ ] Regime strip shows real TAA data
- [ ] CalibrationPanel renders with terminal styling
- [ ] Run Construction button state machine works
- [ ] WEIGHTS tab shows weights or empty state

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>