### PR TITLE
feat(live): Session A — terminal workbench rebuild with real-time Tiingo charts

### DIFF
--- a/docs/prompts/2026-04-13-live-workbench-session-a.md
+++ b/docs/prompts/2026-04-13-live-workbench-session-a.md
@@ -1,0 +1,381 @@
+# Phase 5 Live Workbench — Session A: Terminal Rebuild + Real-Time Chart + Watchlist
+
+## Context
+
+Phase 5 of 10-phase Terminal Unification. Phase 4 Builder COMPLETE (PRs #131-#133).
+The Live Workbench exists at `(terminal)/portfolio/live/` but was built BEFORE the
+terminal design system matured. It has 4,141 lines of hardcoded hex colors, mock data
+(`Math.random()`), Urbanist font, and a layout that doesn't match the terminal aesthetic.
+
+**Critical discovery:** The real-time infrastructure is MORE COMPLETE than expected:
+- `tiingo_bridge.py` (429L) — Tiingo IEX WebSocket streaming, 50ms buffer, Redis pub
+- `market_data.py` — Backend WebSocket endpoint with subscribe/unsubscribe protocol
+- `market-data.svelte.ts` (492L) — Frontend MarketDataStore with tick buffer (250ms)
+- `TerminalPriceChart.svelte` (398L) — lightweight-charts v5 with dual series
+- Shadow OMS models (TradeTicket, PortfolioActualHoldings) with routes
+
+**The gap is NOT infrastructure — it's wiring + UI rebuild.**
+
+## Design Vision
+
+The Live Workbench is a REAL trading terminal, not a simplified monitoring dashboard.
+The chart (lightweight-charts) is the HERO — center stage, receiving real-time data
+via Tiingo WebSocket. Portfolio holdings appear as a live watchlist. Any ticker
+available in Tiingo can be searched and compared on the chart.
+
+**Reference layout (adapted from investment dashboard reference):**
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ TERMINAL TOPNAV (32px) — already exists via TerminalShell     │
+├─────────────┬─────────────────────────────────────────────────┤
+│ WATCHLIST    │  CHART TOOLBAR (32px)                           │
+│ (240px,     │  [TICKER INPUT] [1D][1W][1M][3M][1Y] [Compare] │
+│  left,      ├─────────────────────────────────────────────────┤
+│  scrollable │                                                 │
+│  portfolio  │  CHART (lightweight-charts, hero, flex)          │
+│  holdings   │  Real-time Tiingo WS, crosshair, tooltip,       │
+│  as live    │  volume bars, percentage mode                    │
+│  tickers    │                                                 │
+│  with       │                                                 │
+│  prices,    │                                                 │
+│  change%,   │                                                 │
+│  spark)     │                                                 │
+│             ├──────────────────────┬──────────────────────────┤
+│             │ PORTFOLIO SUMMARY    │ HOLDINGS TABLE            │
+│             │ (240px, AUM, return, │ (flex, positions,         │
+│             │  status badge,       │  weight, actual vs target,│
+│             │  drift status)       │  P&L, last price)         │
+│             │                      │                           │
+├─────────────┴──────────────────────┴──────────────────────────┤
+│ STATUS BAR (24px) — already exists via TerminalShell           │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## Branch
+
+`feat/builder-session-2` — No, use: `feat/live-workbench-session-a`
+Create a new branch from main.
+
+## Sanitization — Mandatory Label Mapping
+
+| Internal term | Terminal label |
+|---|---|
+| DTW drift / dtw_distance | Strategy Drift |
+| CVaR 95 | Tail Loss (95% confidence) |
+| fill_status: "simulated" | Simulated |
+| REGIME_RISK_ON / RISK_OFF / CRISIS | Expansion / Defensive / Stress |
+| scoring composite | Quality Score |
+
+## MANDATORY: Read these files FIRST before writing ANY code
+
+### Existing Live Workbench (understand what to rebuild)
+1. `frontends/wealth/src/lib/components/portfolio/live/LiveWorkbenchShell.svelte` — 641L, current 3-col layout, mock data, hex colors. Understand the structure, then rebuild from scratch.
+2. `frontends/wealth/src/lib/components/portfolio/live/TerminalTickerStrip.svelte` — 395L, current header. Will NOT be reused — too different.
+3. `frontends/wealth/src/lib/components/portfolio/live/TerminalBlotter.svelte` — 318L, position table. Logic salvageable, UI needs rebuild.
+4. `frontends/wealth/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte` — 398L, lightweight-charts. THIS IS SALVAGEABLE — needs wiring to MarketDataStore.
+
+### Real-time infrastructure (wire these, don't rebuild)
+5. `frontends/wealth/src/lib/stores/market-data.svelte.ts` — 492L. MarketDataStore with tick buffer (250ms), WebSocket connection to `/api/v1/market-data/live/ws`. Key API: `start()`, `stop()`, `subscribe(tickers)`, `unsubscribe(tickers)`, `priceMap` (reactive Map), `holdings` (derived, live-fused), `status` (WsStatus).
+6. `frontends/wealth/src/lib/components/portfolio/live/workbench-state.ts` — context key for terminal-scoped MarketDataStore
+7. `frontends/wealth/src/routes/(terminal)/+layout.svelte` — terminal layout, creates MarketDataStore and sets context via `TERMINAL_MARKET_DATA_KEY`
+
+### Backend endpoints
+8. `backend/app/domains/wealth/routes/market_data.py` — WebSocket endpoint at `/api/v1/market-data/live/ws?token=<jwt>`. Protocol: `{"action":"subscribe","tickers":["SPY"]}` → `{"type":"price","data":{PriceTick}}`. Also has REST: `GET /market-data/quote/{ticker}` for single-shot price lookup.
+9. `backend/app/domains/wealth/routes/model_portfolios.py` — search for `actual-holdings`, `trade-tickets`, `rebalance/preview`, `execute-trades`, `activate`
+
+### Design reference
+10. `packages/investintell-ui/src/lib/tokens/terminal.css` — all terminal tokens
+11. `docs/plans/2026-04-13-phase-4-builder-design.md` — reference for terminal aesthetic (already implemented in Builder)
+12. `frontends/wealth/src/lib/components/terminal/builder/+page.svelte` — reference for how Builder uses terminal tokens, layout patterns
+
+## ARCHITECTURE RULES (non-negotiable)
+
+- Svelte 5 runes only: `$state`, `$derived`, `$effect`, `$props`.
+- All formatting via `@investintell/ui` formatters. Never `.toFixed()` or inline Intl.
+- CSS uses terminal tokens from `terminal.css` exclusively. ZERO hex values.
+- No localStorage. No EventSource.
+- `<svelte:boundary>` on async-dependent sections.
+- Monospace font, 1px borders, zero radius.
+- lightweight-charts for the hero chart (NOT svelte-echarts — this is a trading chart, not a dashboard chart).
+- WebSocket via MarketDataStore (already built) — do NOT create a new WS connection.
+
+## DELIVERABLES (6 items)
+
+### 1. New route page: `frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte`
+
+**COMPLETE REWRITE** of the existing +page.svelte. The current page imports
+LiveWorkbenchShell and passes portfolios. The new page IS the shell — no separate
+LiveWorkbenchShell component.
+
+**Layout structure (CSS Grid):**
+```css
+.live-shell {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    grid-template-rows: auto 1fr auto;
+    height: calc(100vh - 88px);
+    gap: 1px;
+    background: var(--terminal-bg-void);
+    font-family: var(--terminal-font-mono);
+}
+```
+
+Grid areas:
+- Left column (240px): Watchlist (full height)
+- Right top: Chart toolbar (32px) + Chart (flex)
+- Right bottom: Portfolio summary (240px fixed) + Holdings table (flex)
+
+**Portfolio selection:** Reuse PortfolioDropdown pattern from Builder. On portfolio
+change, update watchlist tickers and chart default series.
+
+**MarketDataStore integration:** Read from context (`TERMINAL_MARKET_DATA_KEY`).
+The (terminal)/+layout.svelte already creates and provides it. On portfolio selection:
+1. Get portfolio's fund tickers
+2. Call `marketStore.subscribe(tickers)` 
+3. Watchlist reads from `marketStore.priceMap`
+
+### 2. Watchlist component: `frontends/wealth/src/lib/components/terminal/live/Watchlist.svelte`
+
+Create new directory `frontends/wealth/src/lib/components/terminal/live/`.
+
+**Props:**
+```typescript
+interface WatchlistItem {
+    ticker: string;
+    name: string;
+    instrument_id: string;
+    price: number;
+    change: number;
+    change_pct: number;
+    weight: number; // portfolio weight
+}
+
+interface Props {
+    items: WatchlistItem[];
+    selectedTicker: string | null;
+    onSelect: (ticker: string) => void;
+}
+```
+
+**Visual (each row, 36px):**
+```
+ SPY          │ ▲ +0.42%
+ S&P 500 ETF  │ $523.18
+```
+- Ticker: `--terminal-fg-primary`, bold, 11px
+- Name: `--terminal-fg-tertiary`, 10px, truncated with ellipsis
+- Price: `--terminal-fg-primary`, tabular-nums, right-aligned
+- Change%: green (`--terminal-status-success`) if positive, red (`--terminal-status-error`) if negative
+- Selected row: `--terminal-bg-panel-raised` background + left 2px amber border
+- On click: fires `onSelect(ticker)` — chart switches to this instrument
+
+**Portfolio weight badge:** Small `12.5%` text in muted below the name, showing the
+instrument's allocation weight in the model portfolio.
+
+**Header (28px):** "WATCHLIST" label + portfolio name (truncated).
+
+**Footer:** Ticker search input (28px) — type to search any ticker. On Enter, calls
+`GET /market-data/quote/{ticker}` to validate, then subscribes via MarketDataStore
+and adds to the watchlist temporarily. This allows the PM to look up ANY Tiingo-available
+instrument, not just portfolio holdings.
+
+**Scrollable:** `overflow-y: auto` on the items container.
+
+### 3. Chart area: Wire TerminalPriceChart to MarketDataStore
+
+**DO NOT REWRITE TerminalPriceChart.svelte** — it's 398 lines of working lightweight-charts
+code with proper SSR handling, percentage mode, dual series, and timeframe selection.
+
+**What to change:**
+- Move it from `portfolio/live/charts/` to `terminal/live/charts/` (or keep and import)
+- Wire its `historicalBars` prop to real data from `GET /market-data/quote/{ticker}` (historical bars)
+- Wire its `lastTick` prop to `marketStore.priceMap.get(selectedTicker)`
+- Wire its `portfolioNavBars` prop to model portfolio NAV from `model_portfolio_nav` table
+  (via `GET /model-portfolios/{id}/nav-history` endpoint from Session 3)
+
+**Chart toolbar (32px, above chart):**
+```
+[ TICKER ▾ ] // INSTRUMENT NAME // PRICE // CHG% // │ [1D] [1W] [1M] [3M] [1Y] │ [Compare ▾] │ [Indicators]
+```
+- Ticker dropdown or display showing the currently selected instrument
+- Timeframe buttons (already exist in TerminalPriceChart — expose them in the toolbar)
+- Compare button: opens a dropdown to add a second series (any ticker from Tiingo)
+- Indicators button: stub for Session B (future)
+
+**Comparison mode:** When the PM clicks "Compare" and types a ticker (e.g., "SPY"),
+add a second line series to the chart in a different color. Both series use percentage
+mode so they're normalized. The TerminalPriceChart already supports dual series
+(baseline + line). Extend to support N comparison series if needed, or use the existing
+NAV overlay slot.
+
+**Real-time updates:** Set up an `$effect` that watches `marketStore.priceMap` and
+updates the chart's `lastTick` whenever the selected ticker gets a new price:
+```typescript
+$effect(() => {
+    const tick = marketStore.priceMap.get(selectedTicker);
+    if (tick) {
+        lastTick = { time: tick.timestamp, price: tick.price };
+    }
+});
+```
+
+### 4. Portfolio Summary panel
+
+Small panel (240px wide, bottom-left of the right column) showing aggregate portfolio stats.
+
+```
+┌ PORTFOLIO ──────────────────────────┐
+│                                     │
+│  STATUS          ● LIVE             │
+│  AUM             $125.4M            │
+│  RETURN (1Y)     +8.2%              │
+│  DRIFT STATUS    Aligned            │
+│  INSTRUMENTS     34                 │
+│  LAST REBALANCE  2026-04-10         │
+│                                     │
+│  [ REBALANCE ]                      │
+└─────────────────────────────────────┘
+```
+
+- Status badge: green dot + "LIVE" for active, amber dot + "PAUSED" for paused
+- AUM: `formatCurrency` from @investintell/ui
+- Return: green/red, `formatPercent`
+- Drift Status: "Aligned" (green) / "Watch" (amber) / "Breach" (red) — derived from
+  holdings drift data (Session B will add DriftMonitorPanel, for now show aggregate)
+- REBALANCE button: amber outline, opens RebalanceFocusMode (stub for Session B, shows
+  "Coming in Session B" alert for now)
+
+Data source: workspace portfolio state + `GET /model-portfolios/{id}` response fields.
+
+### 5. Holdings Table
+
+Bottom-right panel showing the portfolio's actual positions.
+
+**Columns:**
+| Fund | Ticker | Weight | Target | Drift | Price | Change |
+|---|---|---|---|---|---|---|
+
+- Fund: name, truncated, `--terminal-fg-primary`
+- Ticker: `--terminal-fg-tertiary`, 10px
+- Weight: actual weight (from actual-holdings or target as fallback), `formatPercent`
+- Target: target weight from construction, `formatPercent`, muted
+- Drift: `actual - target`, color-coded (green if aligned, amber if watch, red if breach)
+- Price: live from `marketStore.priceMap`, `formatCurrency`
+- Change: change_pct, green/red, `formatPercent`
+
+**Click row:** Selects ticker in the watchlist and switches chart to that instrument.
+
+**Sticky header.** Scrollable body. Terminal table styling (monospace, hairline borders,
+no radius, `--terminal-text-10` for data, `--terminal-text-10` uppercase for headers).
+
+**Data source:** 
+- Weights: from portfolio's `fund_selection_schema.funds` (or `GET /{id}/actual-holdings`)
+- Prices: live from `marketStore.priceMap`
+- If actual-holdings endpoint returns data, use it. Otherwise fallback to target weights.
+
+### 6. Update +page.server.ts
+
+Update `frontends/wealth/src/routes/(terminal)/portfolio/live/+page.server.ts` to also
+load the selected portfolio's holdings for SSR seeding:
+
+```typescript
+export const load: PageServerLoad = async ({ parent, url }) => {
+    const { token } = await parent();
+    if (!token) return { portfolios: [], selectedPortfolioData: null };
+
+    const api = createServerApiClient(token);
+    const portfolios = await api.get<ModelPortfolio[]>("/model-portfolios").catch(() => []);
+    
+    // Pre-load selected portfolio data if ID in query params
+    const selectedId = url.searchParams.get("portfolio");
+    let selectedPortfolioData = null;
+    if (selectedId) {
+        selectedPortfolioData = await api.get(`/model-portfolios/${selectedId}`).catch(() => null);
+    }
+    
+    return { portfolios, selectedPortfolioData };
+};
+```
+
+## FILE STRUCTURE (new + modified)
+
+```
+frontends/wealth/src/
+  routes/(terminal)/portfolio/live/
+    +page.server.ts                    ← MODIFY: add selected portfolio pre-load
+    +page.svelte                       ← REWRITE: new 2-zone grid layout
+  lib/components/terminal/live/
+    Watchlist.svelte                   ← NEW: live ticker watchlist (left panel)
+    ChartToolbar.svelte               ← NEW: ticker display + timeframe + compare
+    PortfolioSummary.svelte           ← NEW: aggregate stats panel
+    HoldingsTable.svelte              ← NEW: positions table with live prices
+```
+
+**Do NOT delete** the existing `portfolio/live/` components — they'll be removed in Phase 9
+when (app)/ routes are frozen. For now, the new `terminal/live/` components coexist.
+
+## GATE CRITERIA
+
+1. `/portfolio/live` renders inside TerminalShell with new layout (watchlist left, chart center, tables bottom)
+2. Watchlist shows portfolio holdings with live prices from MarketDataStore WebSocket
+3. Chart displays real historical data for selected ticker (lightweight-charts)
+4. Chart receives real-time tick updates from MarketDataStore (price updates on chart)
+5. Ticker search in watchlist footer can look up any Tiingo-available instrument
+6. Chart comparison: PM can add a second ticker as overlay series
+7. Holdings table shows positions with live prices, weight vs target, drift coloring
+8. Portfolio summary shows AUM, status badge, return, drift aggregate
+9. Click watchlist item → chart switches to that instrument
+10. Click holdings row → chart switches + watchlist highlights
+11. Zero hex color values — all terminal.css tokens
+12. Zero `.toFixed()` / inline Intl — all @investintell/ui formatters
+13. `cd frontends/wealth && pnpm exec svelte-check` — zero errors
+14. `cd frontends/wealth && pnpm build` — clean
+15. No TypeScript `any` types
+
+## IMPORTANT WARNINGS
+
+- Do NOT rewrite TerminalPriceChart.svelte (398L) — wire it to real data, don't rebuild
+- Do NOT rewrite market-data.svelte.ts (492L) — consume from context, don't modify
+- Do NOT create a new WebSocket connection — use MarketDataStore from (terminal)/+layout.svelte context
+- Do NOT delete existing `portfolio/live/` components (LiveWorkbenchShell etc.) — they stay for now
+- Do NOT install new npm packages — lightweight-charts v5 is already installed
+- Do NOT use svelte-echarts for the main trading chart — lightweight-charts is the correct library for real-time price data
+- Do NOT add mock/random data — wire to real endpoints or show empty state
+- Do NOT use hex colors — all from terminal.css tokens
+- The MarketDataStore is already created in `(terminal)/+layout.svelte` and provided via `TERMINAL_MARKET_DATA_KEY` context — just read it
+
+## Post-Session Checklist
+
+After commit and push, verify in browser at http://localhost:5173/portfolio/live:
+
+1. Watchlist renders with portfolio holdings and live prices updating
+2. Chart shows real historical data for selected instrument
+3. Price ticks appear on chart in real-time (verify WS connection in Network tab)
+4. Click watchlist item → chart switches
+5. Type ticker in search → chart shows that instrument
+6. Compare button → add second series
+7. Holdings table shows positions with live prices
+8. Portfolio summary shows AUM + status
+9. No console errors
+10. Terminal aesthetic: monospace, zero radius, hairline borders, amber/cyan accents
+
+If the Tiingo WebSocket is not available (no API key configured), the chart should
+still render historical data from the REST endpoint and the watchlist should show
+"Offline" status badges. Graceful degradation, never crash.
+
+## COMMIT
+
+When all gate criteria pass, commit with:
+```
+feat(live): Session A — terminal workbench rebuild with real-time Tiingo charts
+
+3-zone layout: watchlist (240px, live prices) + hero chart (lightweight-charts,
+Tiingo WS real-time) + holdings table (positions with drift). Portfolio summary
+panel with AUM/status/drift aggregate. Ticker search for any Tiingo instrument.
+Chart comparison mode. Wired to MarketDataStore WebSocket (existing infra).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+Push to origin/feat/live-workbench-session-a.

--- a/frontends/wealth/src/lib/components/terminal/live/ChartToolbar.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/ChartToolbar.svelte
@@ -1,0 +1,363 @@
+<!--
+  ChartToolbar -- 32px bar above the hero chart.
+
+  Displays: ticker name, instrument name, live price, change%.
+  Controls: timeframe buttons, compare toggle, indicators stub.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatCurrency, formatPercent } from "@investintell/ui";
+	import type { MarketDataStore, PriceTick } from "$lib/stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "$lib/components/portfolio/live/workbench-state";
+	import { createClientApiClient } from "$lib/api/client";
+
+	type Timeframe = "1D" | "1W" | "1M" | "3M" | "1Y";
+
+	interface Props {
+		ticker: string;
+		instrumentName: string;
+		timeframe: Timeframe;
+		onTimeframeChange: (tf: Timeframe) => void;
+		onCompare: (ticker: string) => void;
+		compareTicker: string | null;
+		onClearCompare: () => void;
+	}
+
+	let {
+		ticker,
+		instrumentName,
+		timeframe,
+		onTimeframeChange,
+		onCompare,
+		compareTicker,
+		onClearCompare,
+	}: Props = $props();
+
+	const marketStore = getContext<MarketDataStore>(TERMINAL_MARKET_DATA_KEY);
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	const TIMEFRAMES: Timeframe[] = ["1D", "1W", "1M", "3M", "1Y"];
+
+	// Live price from MarketDataStore
+	const tickData = $derived<PriceTick | undefined>(
+		marketStore.priceMap.get(ticker.toUpperCase()),
+	);
+	const price = $derived(tickData?.price ?? 0);
+	const changePct = $derived(tickData?.change_pct ?? 0);
+	const isPositive = $derived(changePct >= 0);
+
+	// Compare dropdown
+	let compareOpen = $state(false);
+	let compareInput = $state("");
+	let compareSearching = $state(false);
+	let compareError = $state<string | null>(null);
+
+	function toggleCompare() {
+		if (compareTicker) {
+			onClearCompare();
+			return;
+		}
+		compareOpen = !compareOpen;
+		if (compareOpen) {
+			compareInput = "";
+			compareError = null;
+		}
+	}
+
+	async function handleCompareSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		const q = compareInput.trim().toUpperCase();
+		if (!q) return;
+
+		compareSearching = true;
+		compareError = null;
+
+		try {
+			await api.get<{ ticker: string }>(`/market-data/quote/${encodeURIComponent(q)}`);
+			marketStore.subscribe([q]);
+			onCompare(q);
+			compareOpen = false;
+			compareInput = "";
+		} catch {
+			compareError = "Not found";
+			setTimeout(() => (compareError = null), 2000);
+		} finally {
+			compareSearching = false;
+		}
+	}
+</script>
+
+<div class="ct-root">
+	<!-- Left: ticker info -->
+	<div class="ct-info">
+		<span class="ct-ticker">{ticker || "---"}</span>
+		<span class="ct-sep">//</span>
+		<span class="ct-name" title={instrumentName}>{instrumentName}</span>
+		<span class="ct-sep">//</span>
+		<span class="ct-price">{price > 0 ? formatCurrency(price) : "\u2014"}</span>
+		<span
+			class="ct-change"
+			class:ct-up={isPositive}
+			class:ct-down={!isPositive}
+		>
+			{isPositive ? "+" : ""}{formatPercent(changePct, 2)}
+		</span>
+	</div>
+
+	<!-- Right: controls -->
+	<div class="ct-controls">
+		<!-- Timeframe pills -->
+		<div class="ct-timeframes" role="group" aria-label="Timeframe">
+			{#each TIMEFRAMES as tf}
+				<button
+					type="button"
+					class="ct-tf-btn"
+					class:ct-tf-active={timeframe === tf}
+					onclick={() => onTimeframeChange(tf)}
+					aria-pressed={timeframe === tf}
+				>
+					{tf}
+				</button>
+			{/each}
+		</div>
+
+		<span class="ct-divider"></span>
+
+		<!-- Compare -->
+		<div class="ct-compare-wrap">
+			<button
+				type="button"
+				class="ct-compare-btn"
+				class:ct-compare-active={!!compareTicker}
+				onclick={toggleCompare}
+			>
+				{compareTicker ? `vs ${compareTicker}` : "Compare"}
+				{#if compareTicker}
+					<span class="ct-compare-x" aria-label="Clear comparison">&times;</span>
+				{/if}
+			</button>
+
+			{#if compareOpen}
+				<form class="ct-compare-dropdown" onsubmit={handleCompareSubmit}>
+					<input
+						type="text"
+						class="ct-compare-input"
+						placeholder="Ticker..."
+						bind:value={compareInput}
+						disabled={compareSearching}
+					/>
+					{#if compareError}
+						<span class="ct-compare-error">{compareError}</span>
+					{/if}
+				</form>
+			{/if}
+		</div>
+
+		<span class="ct-divider"></span>
+
+		<!-- Indicators stub -->
+		<button type="button" class="ct-indicators-btn" disabled title="Coming in Session B">
+			Indicators
+		</button>
+	</div>
+</div>
+
+<style>
+	.ct-root {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		height: 32px;
+		padding: 0 var(--terminal-space-2);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		gap: var(--terminal-space-2);
+	}
+
+	/* -- Left info -- */
+	.ct-info {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		min-width: 0;
+	}
+
+	.ct-ticker {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.ct-sep {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+
+	.ct-name {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 200px;
+	}
+
+	.ct-price {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.ct-change {
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.ct-up {
+		color: var(--terminal-status-success);
+	}
+
+	.ct-down {
+		color: var(--terminal-status-error);
+	}
+
+	/* -- Right controls -- */
+	.ct-controls {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		flex-shrink: 0;
+	}
+
+	.ct-divider {
+		width: 1px;
+		height: 16px;
+		background: var(--terminal-fg-muted);
+	}
+
+	/* -- Timeframes -- */
+	.ct-timeframes {
+		display: flex;
+		gap: 2px;
+	}
+
+	.ct-tf-btn {
+		appearance: none;
+		padding: 3px 8px;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		color: var(--terminal-fg-tertiary);
+		background: transparent;
+		border: 1px solid transparent;
+		cursor: pointer;
+		transition: color var(--terminal-motion-tick), background var(--terminal-motion-tick);
+	}
+
+	.ct-tf-btn:hover {
+		color: var(--terminal-fg-primary);
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.ct-tf-active {
+		color: var(--terminal-accent-cyan);
+		border-color: var(--terminal-accent-cyan-dim);
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.ct-tf-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	/* -- Compare -- */
+	.ct-compare-wrap {
+		position: relative;
+	}
+
+	.ct-compare-btn {
+		appearance: none;
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 3px 8px;
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		color: var(--terminal-fg-tertiary);
+		background: transparent;
+		border: 1px solid var(--terminal-fg-muted);
+		cursor: pointer;
+		transition: color var(--terminal-motion-tick), background var(--terminal-motion-tick);
+	}
+
+	.ct-compare-btn:hover {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber-dim);
+	}
+
+	.ct-compare-active {
+		color: var(--terminal-accent-amber);
+		background: var(--terminal-bg-panel-raised);
+		border-color: var(--terminal-accent-amber-dim);
+	}
+
+	.ct-compare-x {
+		font-size: var(--terminal-text-12);
+		line-height: 1;
+	}
+
+	.ct-compare-dropdown {
+		position: absolute;
+		top: calc(100% + 4px);
+		right: 0;
+		z-index: var(--terminal-z-dropdown);
+		background: var(--terminal-bg-overlay);
+		border: 1px solid var(--terminal-fg-muted);
+		padding: var(--terminal-space-1);
+	}
+
+	.ct-compare-input {
+		appearance: none;
+		width: 120px;
+		height: 24px;
+		padding: 0 var(--terminal-space-1);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-primary);
+		background: var(--terminal-bg-panel-sunken);
+		border: none;
+		outline: none;
+	}
+
+	.ct-compare-input:focus {
+		box-shadow: inset 0 0 0 1px var(--terminal-accent-amber);
+	}
+
+	.ct-compare-error {
+		display: block;
+		font-size: 9px;
+		color: var(--terminal-status-error);
+		padding-top: 2px;
+	}
+
+	/* -- Indicators -- */
+	.ct-indicators-btn {
+		appearance: none;
+		padding: 3px 8px;
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		color: var(--terminal-fg-disabled);
+		background: transparent;
+		border: 1px solid transparent;
+		cursor: not-allowed;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/live/HoldingsTable.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/HoldingsTable.svelte
@@ -1,0 +1,260 @@
+<!--
+  HoldingsTable -- portfolio positions with live prices.
+
+  Bottom-right panel. Columns: Fund, Ticker, Weight, Target,
+  Drift, Price, Change. Row click selects ticker for chart.
+  Sticky header, scrollable body.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatPercent, formatCurrency } from "@investintell/ui";
+	import type { MarketDataStore, PriceTick } from "$lib/stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "$lib/components/portfolio/live/workbench-state";
+
+	export interface HoldingRow {
+		instrument_id: string;
+		fund_name: string;
+		ticker: string;
+		weight: number;
+		target_weight: number;
+	}
+
+	interface Props {
+		holdings: HoldingRow[];
+		selectedTicker: string | null;
+		onSelect: (ticker: string) => void;
+	}
+
+	let { holdings, selectedTicker, onSelect }: Props = $props();
+
+	const marketStore = getContext<MarketDataStore>(TERMINAL_MARKET_DATA_KEY);
+
+	function getTickData(ticker: string): PriceTick | undefined {
+		return marketStore.priceMap.get(ticker.toUpperCase());
+	}
+
+	function driftStatus(drift: number): "aligned" | "watch" | "breach" {
+		const abs = Math.abs(drift);
+		if (abs >= 0.03) return "breach";
+		if (abs >= 0.02) return "watch";
+		return "aligned";
+	}
+</script>
+
+<div class="ht-root">
+	<div class="ht-header">
+		<span class="ht-label">HOLDINGS</span>
+		<span class="ht-count">{holdings.length}</span>
+	</div>
+
+	<div class="ht-body">
+		<table class="ht-table">
+			<thead>
+				<tr>
+					<th class="ht-th ht-th--name" scope="col">Fund</th>
+					<th class="ht-th ht-th--ticker" scope="col">Ticker</th>
+					<th class="ht-th ht-th--num" scope="col">Weight</th>
+					<th class="ht-th ht-th--num" scope="col">Target</th>
+					<th class="ht-th ht-th--num" scope="col">Drift</th>
+					<th class="ht-th ht-th--num" scope="col">Price</th>
+					<th class="ht-th ht-th--num" scope="col">Change</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each holdings as h (h.instrument_id)}
+					{@const tick = getTickData(h.ticker)}
+					{@const drift = h.weight - h.target_weight}
+					{@const ds = driftStatus(drift)}
+					{@const changePct = tick?.change_pct ?? 0}
+					<!-- svelte-ignore a11y_click_events_have_key_events -->
+					<tr
+						class="ht-row"
+						class:ht-row--selected={selectedTicker?.toUpperCase() === h.ticker.toUpperCase()}
+						onclick={() => onSelect(h.ticker)}
+					>
+						<td class="ht-td ht-td--name" title={h.fund_name}>{h.fund_name}</td>
+						<td class="ht-td ht-td--ticker">{h.ticker}</td>
+						<td class="ht-td ht-td--num">{formatPercent(h.weight, 1)}</td>
+						<td class="ht-td ht-td--num ht-muted">{formatPercent(h.target_weight, 1)}</td>
+						<td
+							class="ht-td ht-td--num"
+							class:ht-drift-aligned={ds === "aligned"}
+							class:ht-drift-watch={ds === "watch"}
+							class:ht-drift-breach={ds === "breach"}
+						>
+							{drift >= 0 ? "+" : ""}{formatPercent(drift, 2)}
+						</td>
+						<td class="ht-td ht-td--num">
+							{tick?.price ? formatCurrency(tick.price) : "\u2014"}
+						</td>
+						<td
+							class="ht-td ht-td--num"
+							class:ht-up={changePct >= 0}
+							class:ht-down={changePct < 0}
+						>
+							{changePct !== 0 ? formatPercent(changePct, 2) : "\u2014"}
+						</td>
+					</tr>
+				{/each}
+
+				{#if holdings.length === 0}
+					<tr>
+						<td class="ht-td ht-empty" colspan="7">No holdings</td>
+					</tr>
+				{/if}
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<style>
+	.ht-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.ht-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.ht-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.ht-count {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.ht-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.ht-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-variant-numeric: tabular-nums;
+	}
+
+	/* -- Headers -- */
+	.ht-th {
+		position: sticky;
+		top: 0;
+		z-index: 2;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		white-space: nowrap;
+	}
+
+	.ht-th--name {
+		text-align: left;
+	}
+
+	.ht-th--ticker {
+		text-align: left;
+	}
+
+	.ht-th--num {
+		text-align: right;
+	}
+
+	/* -- Cells -- */
+	.ht-td {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-secondary);
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		white-space: nowrap;
+	}
+
+	.ht-td--name {
+		text-align: left;
+		font-size: var(--terminal-text-11);
+		font-weight: 500;
+		color: var(--terminal-fg-primary);
+		max-width: 200px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.ht-td--ticker {
+		text-align: left;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.ht-td--num {
+		text-align: right;
+	}
+
+	.ht-muted {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.ht-empty {
+		text-align: center;
+		padding: var(--terminal-space-6);
+		color: var(--terminal-fg-muted);
+	}
+
+	/* -- Row interaction -- */
+	.ht-row {
+		cursor: pointer;
+		transition: background var(--terminal-motion-tick);
+	}
+
+	.ht-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.ht-row--selected {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	/* -- Drift colors -- */
+	.ht-drift-aligned {
+		color: var(--terminal-status-success);
+	}
+
+	.ht-drift-watch {
+		color: var(--terminal-status-warn);
+	}
+
+	.ht-drift-breach {
+		color: var(--terminal-status-error);
+	}
+
+	/* -- P&L colors -- */
+	.ht-up {
+		color: var(--terminal-status-success);
+	}
+
+	.ht-down {
+		color: var(--terminal-status-error);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
@@ -1,0 +1,253 @@
+<!--
+  PortfolioSummary -- aggregate stats panel (bottom-left of right column).
+
+  Shows: status badge, AUM, return (1Y), drift status,
+  instrument count, last rebalance date, rebalance button (stub).
+-->
+<script lang="ts">
+	import { formatAUM, formatPercent, formatDate } from "@investintell/ui";
+
+	interface Props {
+		status: string;
+		state: string;
+		aum: number;
+		returnPct: number | null;
+		driftStatus: "aligned" | "watch" | "breach";
+		instrumentCount: number;
+		lastRebalance: string | null;
+	}
+
+	let {
+		status,
+		state,
+		aum,
+		returnPct,
+		driftStatus,
+		instrumentCount,
+		lastRebalance,
+	}: Props = $props();
+
+	const isLive = $derived(state === "live");
+	const isPaused = $derived(state === "paused");
+
+	const driftLabel = $derived.by(() => {
+		switch (driftStatus) {
+			case "aligned":
+				return "Aligned";
+			case "watch":
+				return "Watch";
+			case "breach":
+				return "Breach";
+			default:
+				return "Unknown";
+		}
+	});
+
+	function handleRebalance() {
+		alert("Rebalance mode coming in Session B");
+	}
+</script>
+
+<div class="ps-root">
+	<div class="ps-header">
+		<span class="ps-label">PORTFOLIO</span>
+	</div>
+
+	<div class="ps-body">
+		<!-- Status -->
+		<div class="ps-row">
+			<span class="ps-key">STATUS</span>
+			<span class="ps-val ps-status">
+				<span
+					class="ps-dot"
+					class:ps-dot-live={isLive}
+					class:ps-dot-paused={isPaused}
+				></span>
+				{isLive ? "LIVE" : isPaused ? "PAUSED" : state.toUpperCase()}
+			</span>
+		</div>
+
+		<!-- AUM -->
+		<div class="ps-row">
+			<span class="ps-key">AUM</span>
+			<span class="ps-val">{formatAUM(aum)}</span>
+		</div>
+
+		<!-- Return -->
+		<div class="ps-row">
+			<span class="ps-key">RETURN (1Y)</span>
+			<span
+				class="ps-val"
+				class:ps-up={returnPct != null && returnPct >= 0}
+				class:ps-down={returnPct != null && returnPct < 0}
+			>
+				{returnPct != null ? formatPercent(returnPct, 1, "en-US", true) : "\u2014"}
+			</span>
+		</div>
+
+		<!-- Drift Status -->
+		<div class="ps-row">
+			<span class="ps-key">DRIFT STATUS</span>
+			<span
+				class="ps-val"
+				class:ps-drift-aligned={driftStatus === "aligned"}
+				class:ps-drift-watch={driftStatus === "watch"}
+				class:ps-drift-breach={driftStatus === "breach"}
+			>
+				{driftLabel}
+			</span>
+		</div>
+
+		<!-- Instruments -->
+		<div class="ps-row">
+			<span class="ps-key">INSTRUMENTS</span>
+			<span class="ps-val">{instrumentCount}</span>
+		</div>
+
+		<!-- Last Rebalance -->
+		<div class="ps-row">
+			<span class="ps-key">LAST REBALANCE</span>
+			<span class="ps-val">{lastRebalance ? formatDate(lastRebalance, "short") : "\u2014"}</span>
+		</div>
+	</div>
+
+	<div class="ps-footer">
+		<button type="button" class="ps-rebalance-btn" onclick={handleRebalance}>
+			REBALANCE
+		</button>
+	</div>
+</div>
+
+<style>
+	.ps-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.ps-header {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.ps-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.ps-body {
+		flex: 1;
+		min-height: 0;
+		padding: var(--terminal-space-3);
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+	}
+
+	.ps-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.ps-key {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.ps-val {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	/* Status dot */
+	.ps-status {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.ps-dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: var(--terminal-fg-muted);
+	}
+
+	.ps-dot-live {
+		background: var(--terminal-status-success);
+	}
+
+	.ps-dot-paused {
+		background: var(--terminal-accent-amber);
+	}
+
+	/* P&L colors */
+	.ps-up {
+		color: var(--terminal-status-success);
+	}
+
+	.ps-down {
+		color: var(--terminal-status-error);
+	}
+
+	/* Drift colors */
+	.ps-drift-aligned {
+		color: var(--terminal-status-success);
+	}
+
+	.ps-drift-watch {
+		color: var(--terminal-status-warn);
+	}
+
+	.ps-drift-breach {
+		color: var(--terminal-status-error);
+	}
+
+	/* Footer */
+	.ps-footer {
+		flex-shrink: 0;
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border-top: var(--terminal-border-hairline);
+	}
+
+	.ps-rebalance-btn {
+		appearance: none;
+		width: 100%;
+		height: 28px;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-accent-amber);
+		background: transparent;
+		border: 1px solid var(--terminal-accent-amber-dim);
+		cursor: pointer;
+		transition: background var(--terminal-motion-tick), border-color var(--terminal-motion-tick);
+	}
+
+	.ps-rebalance-btn:hover {
+		background: var(--terminal-bg-panel-raised);
+		border-color: var(--terminal-accent-amber);
+	}
+
+	.ps-rebalance-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/live/Watchlist.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/Watchlist.svelte
@@ -1,0 +1,328 @@
+<!--
+  Watchlist -- left panel of the Live Workbench.
+
+  Shows portfolio holdings as live tickers with prices from
+  MarketDataStore. Footer has a ticker search input to look up
+  any Tiingo-available instrument via REST quote endpoint.
+
+  Layout: 240px fixed-width sidebar, scrollable items, sticky
+  header + footer.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatPercent, formatCurrency } from "@investintell/ui";
+	import type { MarketDataStore, PriceTick } from "$lib/stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "$lib/components/portfolio/live/workbench-state";
+	import { createClientApiClient } from "$lib/api/client";
+
+	export interface WatchlistItem {
+		ticker: string;
+		name: string;
+		instrument_id: string;
+		weight: number;
+	}
+
+	interface Props {
+		items: WatchlistItem[];
+		selectedTicker: string | null;
+		onSelect: (ticker: string) => void;
+		portfolioName: string;
+	}
+
+	let { items, selectedTicker, onSelect, portfolioName }: Props = $props();
+
+	const marketStore = getContext<MarketDataStore>(TERMINAL_MARKET_DATA_KEY);
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	// Ad-hoc tickers added via search (not part of portfolio)
+	let adHocItems = $state<WatchlistItem[]>([]);
+	let searchQuery = $state("");
+	let searching = $state(false);
+	let searchError = $state<string | null>(null);
+
+	const allItems = $derived([...items, ...adHocItems]);
+
+	function getTickData(ticker: string): PriceTick | undefined {
+		return marketStore.priceMap.get(ticker.toUpperCase());
+	}
+
+	async function handleSearch(e: SubmitEvent) {
+		e.preventDefault();
+		const q = searchQuery.trim().toUpperCase();
+		if (!q) return;
+
+		// Already in the list?
+		if (allItems.some((i) => i.ticker.toUpperCase() === q)) {
+			onSelect(q);
+			searchQuery = "";
+			return;
+		}
+
+		searching = true;
+		searchError = null;
+
+		try {
+			const quote = await api.get<{ ticker: string; price: number; name?: string }>(
+				`/market-data/quote/${encodeURIComponent(q)}`,
+			);
+			adHocItems = [
+				...adHocItems,
+				{
+					ticker: quote.ticker,
+					name: quote.name ?? quote.ticker,
+					instrument_id: "",
+					weight: 0,
+				},
+			];
+			marketStore.subscribe([quote.ticker]);
+			onSelect(quote.ticker);
+			searchQuery = "";
+		} catch {
+			searchError = "Ticker not found";
+			setTimeout(() => (searchError = null), 2000);
+		} finally {
+			searching = false;
+		}
+	}
+</script>
+
+<div class="wl-root">
+	<!-- Header -->
+	<div class="wl-header">
+		<span class="wl-label">WATCHLIST</span>
+		<span class="wl-portfolio" title={portfolioName}>{portfolioName}</span>
+	</div>
+
+	<!-- Items -->
+	<div class="wl-items">
+		{#each allItems as item (item.ticker)}
+			{@const tick = getTickData(item.ticker)}
+			{@const price = tick?.price ?? 0}
+			{@const changePct = tick?.change_pct ?? 0}
+			{@const isPositive = changePct >= 0}
+			<!-- svelte-ignore a11y_click_events_have_key_events -->
+			<button
+				type="button"
+				class="wl-row"
+				class:wl-row--selected={selectedTicker?.toUpperCase() === item.ticker.toUpperCase()}
+				onclick={() => onSelect(item.ticker)}
+			>
+				<div class="wl-row-left">
+					<span class="wl-ticker">{item.ticker}</span>
+					<span class="wl-name" title={item.name}>{item.name}</span>
+					{#if item.weight > 0}
+						<span class="wl-weight">{formatPercent(item.weight, 1)}</span>
+					{/if}
+				</div>
+				<div class="wl-row-right">
+					<span
+						class="wl-change"
+						class:wl-up={isPositive}
+						class:wl-down={!isPositive}
+					>
+						{isPositive ? "\u25B2" : "\u25BC"}
+						{formatPercent(Math.abs(changePct), 2)}
+					</span>
+					<span class="wl-price">
+						{price > 0 ? formatCurrency(price) : "\u2014"}
+					</span>
+				</div>
+			</button>
+		{/each}
+
+		{#if allItems.length === 0}
+			<div class="wl-empty">No instruments</div>
+		{/if}
+	</div>
+
+	<!-- Footer: search -->
+	<form class="wl-search" onsubmit={handleSearch}>
+		<input
+			type="text"
+			class="wl-search-input"
+			placeholder="Search ticker..."
+			bind:value={searchQuery}
+			disabled={searching}
+		/>
+		{#if searchError}
+			<span class="wl-search-error">{searchError}</span>
+		{/if}
+	</form>
+</div>
+
+<style>
+	.wl-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	/* -- Header -- */
+	.wl-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.wl-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.wl-portfolio {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+		max-width: 120px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	/* -- Items -- */
+	.wl-items {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.wl-row {
+		appearance: none;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		height: 36px;
+		padding: 0 var(--terminal-space-2);
+		background: transparent;
+		border: none;
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		border-left: 2px solid transparent;
+		cursor: pointer;
+		transition: background var(--terminal-motion-tick);
+		text-align: left;
+	}
+
+	.wl-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.wl-row--selected {
+		background: var(--terminal-bg-panel-raised);
+		border-left-color: var(--terminal-accent-amber);
+	}
+
+	.wl-row-left {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		min-width: 0;
+	}
+
+	.wl-ticker {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.wl-name {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 110px;
+	}
+
+	.wl-weight {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+
+	.wl-row-right {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 1px;
+		flex-shrink: 0;
+	}
+
+	.wl-change {
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.wl-up {
+		color: var(--terminal-status-success);
+	}
+
+	.wl-down {
+		color: var(--terminal-status-error);
+	}
+
+	.wl-price {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.wl-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 80px;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+	}
+
+	/* -- Search footer -- */
+	.wl-search {
+		flex-shrink: 0;
+		height: 28px;
+		border-top: var(--terminal-border-hairline);
+		position: relative;
+	}
+
+	.wl-search-input {
+		appearance: none;
+		width: 100%;
+		height: 100%;
+		padding: 0 var(--terminal-space-2);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-primary);
+		background: var(--terminal-bg-panel-sunken);
+		border: none;
+		outline: none;
+	}
+
+	.wl-search-input::placeholder {
+		color: var(--terminal-fg-muted);
+	}
+
+	.wl-search-input:focus {
+		box-shadow: inset 0 0 0 1px var(--terminal-accent-amber);
+	}
+
+	.wl-search-error {
+		position: absolute;
+		top: -20px;
+		left: var(--terminal-space-2);
+		font-size: 9px;
+		color: var(--terminal-status-error);
+	}
+</style>

--- a/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.server.ts
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.server.ts
@@ -1,26 +1,20 @@
 /**
- * /portfolio/live — server load. Phase 8 Live Workbench.
+ * /portfolio/live -- server load. Phase 5 Live Workbench (Session A).
  *
- * Loads every model portfolio for the org and filters to the live
- * state client-side — the backend list route returns the full set
- * ordered by created_at DESC which is cheap for the workbench scope
- * (few hundred portfolios per org max). A dedicated
- * ``?state=live`` filter can land in a follow-up sprint when the
- * volume demands it.
+ * Loads model portfolios and optionally pre-loads the selected
+ * portfolio's detail data when ?portfolio=<id> is present in the URL.
  *
- * Per CLAUDE.md — async-first, never block on a single failed fetch.
- * The catch() ensures a partial backend failure still renders the
- * empty state instead of crashing the whole route.
+ * Per CLAUDE.md -- async-first, never block on a single failed fetch.
  */
 
 import type { PageServerLoad } from "./$types";
 import { createServerApiClient } from "$lib/api/client";
 import type { ModelPortfolio } from "$lib/types/model-portfolio";
 
-export const load: PageServerLoad = async ({ parent }) => {
+export const load: PageServerLoad = async ({ parent, url }) => {
 	const { token } = await parent();
 	if (!token) {
-		return { portfolios: [] as ModelPortfolio[] };
+		return { portfolios: [] as ModelPortfolio[], selectedPortfolioData: null };
 	}
 
 	const api = createServerApiClient(token);
@@ -28,5 +22,14 @@ export const load: PageServerLoad = async ({ parent }) => {
 		.get<ModelPortfolio[]>("/model-portfolios")
 		.catch(() => [] as ModelPortfolio[]);
 
-	return { portfolios };
+	// Pre-load selected portfolio data if ID in query params
+	const selectedId = url.searchParams.get("portfolio");
+	let selectedPortfolioData: ModelPortfolio | null = null;
+	if (selectedId) {
+		selectedPortfolioData = await api
+			.get<ModelPortfolio>(`/model-portfolios/${selectedId}`)
+			.catch(() => null);
+	}
+
+	return { portfolios, selectedPortfolioData };
 };

--- a/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
@@ -1,56 +1,710 @@
 <!--
-  /portfolio/live — Phase 2 Terminal Grid Shell.
+  /portfolio/live -- Phase 5 Live Workbench (Session A).
 
-  Owns the URL-derived portfolio selection and hands it to the shell
-  as pure props. The old tool state machine (overview, drift_analysis,
-  execution_desk) was removed — the terminal grid is a fixed 4-zone
-  layout with no tab switching.
+  2-zone grid layout: watchlist (240px left) + chart/holdings right.
+  Wired to MarketDataStore via TERMINAL_MARKET_DATA_KEY context.
+  Real-time Tiingo WebSocket prices via existing infrastructure.
 
-  URL state (DL15 — Zero localStorage):
-    ?portfolio=<id>   — the currently-selected live portfolio
+  URL state (DL15 -- Zero localStorage):
+    ?portfolio=<id>   -- the currently-selected live portfolio
 -->
 <script lang="ts">
 	import { page } from "$app/state";
 	import { goto } from "$app/navigation";
 	import { resolve } from "$app/paths";
-	import LiveWorkbenchShell from "$lib/components/portfolio/live/LiveWorkbenchShell.svelte";
+	import { getContext } from "svelte";
+	import { PanelErrorState } from "@investintell/ui/runtime";
+	import { createClientApiClient } from "$lib/api/client";
+	import type { MarketDataStore } from "$lib/stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "$lib/components/portfolio/live/workbench-state";
 	import type { PageData } from "./$types";
-	import type { ModelPortfolio } from "$lib/types/model-portfolio";
+	import type {
+		ModelPortfolio,
+		InstrumentWeight,
+	} from "$lib/types/model-portfolio";
+
+	// Components
+	import Watchlist, {
+		type WatchlistItem,
+	} from "$lib/components/terminal/live/Watchlist.svelte";
+	import ChartToolbar from "$lib/components/terminal/live/ChartToolbar.svelte";
+	import PortfolioSummary from "$lib/components/terminal/live/PortfolioSummary.svelte";
+	import HoldingsTable, {
+		type HoldingRow,
+	} from "$lib/components/terminal/live/HoldingsTable.svelte";
+	import TerminalPriceChart from "$lib/components/portfolio/live/charts/TerminalPriceChart.svelte";
+	import type { BarData, LiveTick } from "$lib/components/portfolio/live/charts/TerminalPriceChart.svelte";
 
 	let { data }: { data: PageData } = $props();
 
-	const livePortfolios = $derived.by<ModelPortfolio[]>(() => {
-		const rows = (data.portfolios ?? []) as ModelPortfolio[];
-		return rows;
-	});
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const marketStore = getContext<MarketDataStore>(TERMINAL_MARKET_DATA_KEY);
+	const api = createClientApiClient(getToken);
 
+	// ---- Portfolio selection (URL-driven) ----
+
+	const portfolios = $derived((data.portfolios ?? []) as ModelPortfolio[]);
 	const selectedId = $derived<string | null>(
 		page.url.searchParams.get("portfolio"),
 	);
 
-	const initialMode = $derived<"LIVE" | "EDIT">(
-		page.url.searchParams.get("mode") === "edit" ? "EDIT" : "LIVE",
-	);
+	const selected = $derived.by(() => {
+		if (!selectedId) return portfolios[0] ?? null;
+		return portfolios.find((p) => p.id === selectedId) ?? portfolios[0] ?? null;
+	});
 
-	async function handleSelect(portfolio: ModelPortfolio) {
+	async function handlePortfolioSelect(portfolio: ModelPortfolio) {
 		const params = new URLSearchParams(page.url.searchParams);
 		params.set("portfolio", portfolio.id);
 		const target = resolve(`/portfolio/live?${params.toString()}`);
-		await goto(target, {
-			replaceState: true,
-			noScroll: true,
-			keepFocus: true,
-		});
+		await goto(target, { replaceState: true, noScroll: true, keepFocus: true });
+	}
+
+	// ---- Instrument ticker resolution ----
+
+	interface InstrumentInfo {
+		instrument_id: string;
+		ticker: string;
+		name: string;
+	}
+
+	let instrumentMap = $state<Map<string, InstrumentInfo>>(new Map());
+
+	// Fetch instruments to resolve instrument_id -> ticker
+	$effect(() => {
+		const _id = selected?.id;
+		if (!_id) {
+			instrumentMap = new Map();
+			return;
+		}
+		let cancelled = false;
+		api.get<Array<{ instrument_id: string; ticker: string | null; name: string }>>(
+			"/instruments",
+		)
+			.then((instruments) => {
+				if (cancelled) return;
+				const m = new Map<string, InstrumentInfo>();
+				for (const inst of instruments) {
+					if (inst.ticker) {
+						m.set(inst.instrument_id, {
+							instrument_id: inst.instrument_id,
+							ticker: inst.ticker,
+							name: inst.name,
+						});
+					}
+				}
+				instrumentMap = m;
+			})
+			.catch(() => {
+				// Instruments not available -- degrade gracefully
+			});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	// ---- Target funds + resolved tickers ----
+
+	const targetFunds = $derived<InstrumentWeight[]>(
+		selected?.fund_selection_schema?.funds ?? [],
+	);
+
+	function resolveTicker(instrumentId: string, fallbackName: string): string {
+		return instrumentMap.get(instrumentId)?.ticker ?? fallbackName;
+	}
+
+	function resolveName(instrumentId: string, fallbackName: string): string {
+		return instrumentMap.get(instrumentId)?.name ?? fallbackName;
+	}
+
+	// ---- Actual holdings ----
+
+	interface ActualHoldingsData {
+		source: string;
+		holdings: Array<{
+			instrument_id: string;
+			fund_name: string;
+			block_id: string;
+			weight: number;
+		}>;
+		last_rebalanced_at: string | null;
+	}
+
+	let actualHoldingsData = $state<ActualHoldingsData | null>(null);
+
+	$effect(() => {
+		const pid = selected?.id;
+		if (!pid) {
+			actualHoldingsData = null;
+			return;
+		}
+		let cancelled = false;
+		api.get<ActualHoldingsData>(`/model-portfolios/${pid}/actual-holdings`)
+			.then((res) => {
+				if (!cancelled) actualHoldingsData = res;
+			})
+			.catch(() => {
+				if (!cancelled) actualHoldingsData = null;
+			});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	// ---- Subscribe portfolio tickers to MarketDataStore ----
+
+	$effect(() => {
+		if (targetFunds.length === 0 || instrumentMap.size === 0) return;
+		const tickers = targetFunds
+			.map((f) => instrumentMap.get(f.instrument_id)?.ticker)
+			.filter((t): t is string => !!t);
+		if (tickers.length > 0) {
+			marketStore.subscribe(tickers);
+			marketStore.start();
+		}
+		return () => {
+			if (tickers.length > 0) {
+				marketStore.unsubscribe(tickers);
+			}
+		};
+	});
+
+	// ---- Watchlist items ----
+
+	const watchlistItems = $derived<WatchlistItem[]>(
+		targetFunds
+			.map((f) => {
+				const ticker = resolveTicker(f.instrument_id, "");
+				if (!ticker) return null;
+				return {
+					ticker,
+					name: resolveName(f.instrument_id, f.fund_name),
+					instrument_id: f.instrument_id,
+					weight: f.weight,
+				};
+			})
+			.filter((item): item is WatchlistItem => item !== null),
+	);
+
+	// ---- Holdings table rows ----
+
+	const holdingsRows = $derived.by<HoldingRow[]>(() => {
+		const actual = actualHoldingsData?.holdings ?? [];
+		const actualMap = new Map(actual.map((h) => [h.instrument_id, h.weight]));
+
+		return targetFunds
+			.map((f) => {
+				const ticker = resolveTicker(f.instrument_id, "");
+				if (!ticker) return null;
+				return {
+					instrument_id: f.instrument_id,
+					fund_name: resolveName(f.instrument_id, f.fund_name),
+					ticker,
+					weight: actualMap.get(f.instrument_id) ?? f.weight,
+					target_weight: f.weight,
+				};
+			})
+			.filter((r): r is HoldingRow => r !== null);
+	});
+
+	// ---- Chart state ----
+
+	type Timeframe = "1D" | "1W" | "1M" | "3M" | "1Y";
+	let selectedTicker = $state<string | null>(null);
+	let chartTimeframe = $state<Timeframe>("1M");
+	let compareTicker = $state<string | null>(null);
+
+	// Reset selection when portfolio changes
+	$effect(() => {
+		const _id = selected?.id;
+		void _id;
+		selectedTicker = null;
+		compareTicker = null;
+	});
+
+	// Effective ticker for the chart (first instrument if none selected)
+	const effectiveTicker = $derived(
+		selectedTicker ?? watchlistItems[0]?.ticker ?? "",
+	);
+
+	const effectiveInstrumentName = $derived.by(() => {
+		if (!effectiveTicker) return "";
+		const item = watchlistItems.find(
+			(w) => w.ticker.toUpperCase() === effectiveTicker.toUpperCase(),
+		);
+		return item?.name ?? effectiveTicker;
+	});
+
+	// Historical bars from REST quote endpoint
+	let historicalBars = $state<BarData[]>([]);
+	let portfolioNavBars = $state<BarData[]>([]);
+
+	$effect(() => {
+		const t = effectiveTicker;
+		const _tf = chartTimeframe;
+		if (!t) {
+			historicalBars = [];
+			return;
+		}
+		let cancelled = false;
+		api.get<{
+			ticker: string;
+			price: number;
+			bars?: Array<{ time: number; value: number }>;
+		}>(`/market-data/quote/${encodeURIComponent(t)}`)
+			.then((res) => {
+				if (cancelled) return;
+				historicalBars = res.bars ?? [];
+			})
+			.catch(() => {
+				if (!cancelled) historicalBars = [];
+			});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	// Load portfolio NAV series for overlay
+	$effect(() => {
+		const pid = selected?.id;
+		if (!pid) {
+			portfolioNavBars = [];
+			return;
+		}
+		let cancelled = false;
+		api.get<{
+			nav_series: Array<{ date: string; nav: number }> | null;
+		}>(`/model-portfolios/${pid}/nav-history`)
+			.then((res) => {
+				if (cancelled) return;
+				if (res.nav_series) {
+					portfolioNavBars = res.nav_series.map((p) => ({
+						time: Math.floor(new Date(p.date).getTime() / 1000),
+						value: p.nav,
+					}));
+				} else {
+					portfolioNavBars = [];
+				}
+			})
+			.catch(() => {
+				if (!cancelled) portfolioNavBars = [];
+			});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	// Live tick from MarketDataStore -> chart
+	const lastTick = $derived.by((): LiveTick | null => {
+		if (!effectiveTicker) return null;
+		const tick = marketStore.priceMap.get(effectiveTicker.toUpperCase());
+		if (!tick) return null;
+		return {
+			time: Math.floor(new Date(tick.timestamp).getTime() / 1000),
+			value: tick.price,
+		};
+	});
+
+	// Comparison NAV bars (placeholder: uses same quote endpoint)
+	let compareNavBars = $state<BarData[]>([]);
+
+	$effect(() => {
+		const ct = compareTicker;
+		if (!ct) {
+			compareNavBars = [];
+			return;
+		}
+		let cancelled = false;
+		api.get<{
+			ticker: string;
+			bars?: Array<{ time: number; value: number }>;
+		}>(`/market-data/quote/${encodeURIComponent(ct)}`)
+			.then((res) => {
+				if (cancelled) return;
+				compareNavBars = res.bars ?? [];
+			})
+			.catch(() => {
+				if (!cancelled) compareNavBars = [];
+			});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	// Use compare bars as portfolioNavBars when comparing, else real NAV
+	const effectiveNavBars = $derived(
+		compareTicker ? compareNavBars : portfolioNavBars,
+	);
+
+	function handleTimeframeChange(tf: Timeframe) {
+		chartTimeframe = tf;
+	}
+
+	function handleWatchlistSelect(ticker: string) {
+		selectedTicker = ticker;
+	}
+
+	function handleHoldingsSelect(ticker: string) {
+		selectedTicker = ticker;
+	}
+
+	function handleCompare(ticker: string) {
+		compareTicker = ticker;
+	}
+
+	function handleClearCompare() {
+		compareTicker = null;
+	}
+
+	// Data status for chart
+	const dataStatus = $derived.by(() => {
+		const s = marketStore.status;
+		if (s === "connected") return "live" as const;
+		if (s === "reconnecting" || s === "connecting") return "delayed" as const;
+		return "offline" as const;
+	});
+
+	// ---- Portfolio summary data ----
+
+	const portfolioAum = $derived(marketStore.totalAum);
+	const instrumentCount = $derived(targetFunds.length);
+	const lastRebalance = $derived(actualHoldingsData?.last_rebalanced_at ?? null);
+
+	// Aggregate drift status
+	const aggregateDrift = $derived.by((): "aligned" | "watch" | "breach" => {
+		if (!actualHoldingsData?.holdings) return "aligned";
+		const actualMap = new Map(
+			actualHoldingsData.holdings.map((h) => [h.instrument_id, h.weight]),
+		);
+		let maxDrift = 0;
+		for (const f of targetFunds) {
+			const actual = actualMap.get(f.instrument_id) ?? f.weight;
+			maxDrift = Math.max(maxDrift, Math.abs(actual - f.weight));
+		}
+		if (maxDrift >= 0.03) return "breach";
+		if (maxDrift >= 0.02) return "watch";
+		return "aligned";
+	});
+
+	// Portfolio dropdown
+	let showDropdown = $state(false);
+
+	function toggleDropdown() {
+		showDropdown = !showDropdown;
+	}
+
+	function selectFromDropdown(p: ModelPortfolio) {
+		showDropdown = false;
+		handlePortfolioSelect(p);
 	}
 </script>
 
 <svelte:head>
-	<title>Terminal — InvestIntell</title>
+	<title>Live Workbench -- InvestIntell</title>
 </svelte:head>
 
-<LiveWorkbenchShell
-	portfolios={livePortfolios}
-	{selectedId}
-	{initialMode}
-	onSelect={handleSelect}
-/>
+<svelte:boundary>
+	{#if portfolios.length === 0}
+		<div class="lw-empty">
+			<span class="lw-empty-label">No live portfolios</span>
+			<span class="lw-empty-sub">Activate a portfolio in the Builder to see it here.</span>
+		</div>
+	{:else}
+		<div class="lw-shell">
+			<!-- LEFT: Watchlist -->
+			<aside class="lw-watchlist" aria-label="Watchlist">
+				<!-- Portfolio selector in watchlist header -->
+				<div class="lw-portfolio-selector">
+					<button
+						type="button"
+						class="lw-portfolio-trigger"
+						onclick={toggleDropdown}
+						aria-haspopup="listbox"
+						aria-expanded={showDropdown}
+					>
+						<span class="lw-portfolio-name">
+							{selected?.display_name ?? "Select"}
+						</span>
+						<span class="lw-portfolio-chevron" aria-hidden="true">
+							{showDropdown ? "\u25B4" : "\u25BE"}
+						</span>
+					</button>
+
+					{#if showDropdown}
+						<ul
+							class="lw-portfolio-list"
+							role="listbox"
+							aria-label="Portfolios"
+						>
+							{#each portfolios as p (p.id)}
+								<!-- svelte-ignore a11y_click_events_have_key_events -->
+								<li
+									role="option"
+									class="lw-portfolio-item"
+									class:lw-portfolio-item--active={p.id === selected?.id}
+									aria-selected={p.id === selected?.id}
+									onclick={() => selectFromDropdown(p)}
+								>
+									<span class="lw-portfolio-item-name">{p.display_name}</span>
+									<span class="lw-portfolio-item-profile">{p.profile}</span>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				</div>
+
+				<Watchlist
+					items={watchlistItems}
+					selectedTicker={effectiveTicker}
+					onSelect={handleWatchlistSelect}
+					portfolioName={selected?.display_name ?? ""}
+				/>
+			</aside>
+
+			<!-- RIGHT TOP: Chart toolbar + chart -->
+			<div class="lw-toolbar">
+				<ChartToolbar
+					ticker={effectiveTicker}
+					instrumentName={effectiveInstrumentName}
+					timeframe={chartTimeframe}
+					onTimeframeChange={handleTimeframeChange}
+					onCompare={handleCompare}
+					{compareTicker}
+					onClearCompare={handleClearCompare}
+				/>
+			</div>
+
+			<section class="lw-chart" aria-label="Price chart">
+				<TerminalPriceChart
+					ticker={effectiveTicker}
+					{historicalBars}
+					portfolioNavBars={effectiveNavBars}
+					{lastTick}
+					timeframe={chartTimeframe === "1Y" ? "3M" : chartTimeframe}
+					onTimeframeChange={handleTimeframeChange}
+					{dataStatus}
+				/>
+			</section>
+
+			<!-- RIGHT BOTTOM LEFT: Portfolio Summary -->
+			<div class="lw-summary">
+				<PortfolioSummary
+					status={selected?.status ?? ""}
+					state={selected?.state ?? "draft"}
+					aum={portfolioAum}
+					returnPct={marketStore.totalReturnPct}
+					driftStatus={aggregateDrift}
+					{instrumentCount}
+					{lastRebalance}
+				/>
+			</div>
+
+			<!-- RIGHT BOTTOM RIGHT: Holdings Table -->
+			<div class="lw-holdings">
+				<HoldingsTable
+					holdings={holdingsRows}
+					selectedTicker={effectiveTicker}
+					onSelect={handleHoldingsSelect}
+				/>
+			</div>
+		</div>
+	{/if}
+
+	{#snippet failed(err: unknown, reset: () => void)}
+		<PanelErrorState
+			title="Live Workbench error"
+			message={err instanceof Error ? err.message : "Unexpected error"}
+			onRetry={reset}
+		/>
+	{/snippet}
+</svelte:boundary>
+
+<style>
+	/* -- Empty state -- */
+	.lw-empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: var(--terminal-space-2);
+		height: 100%;
+		background: var(--terminal-bg-void);
+	}
+
+	.lw-empty-label {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-14);
+		font-weight: 700;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.lw-empty-sub {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+	}
+
+	/* -- Main grid (3 columns for bottom split) -- */
+	.lw-shell {
+		display: grid;
+		grid-template-columns: 240px 240px 1fr;
+		grid-template-rows: 32px 1fr 240px;
+		grid-template-areas:
+			"watchlist toolbar  toolbar"
+			"watchlist chart    chart"
+			"watchlist summary  holdings";
+		height: calc(100vh - 88px);
+		gap: 1px;
+		background: var(--terminal-bg-void);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.lw-watchlist {
+		grid-area: watchlist;
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+	}
+
+	.lw-toolbar {
+		grid-area: toolbar;
+		min-width: 0;
+		overflow: hidden;
+	}
+
+	.lw-chart {
+		grid-area: chart;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		position: relative;
+	}
+
+	.lw-summary {
+		grid-area: summary;
+		display: flex;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.lw-holdings {
+		grid-area: holdings;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	/* -- Portfolio selector dropdown -- */
+	.lw-portfolio-selector {
+		position: relative;
+		flex-shrink: 0;
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.lw-portfolio-trigger {
+		appearance: none;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		height: 32px;
+		padding: 0 var(--terminal-space-2);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-accent-amber);
+		background: var(--terminal-bg-panel);
+		border: none;
+		cursor: pointer;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.lw-portfolio-trigger:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.lw-portfolio-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.lw-portfolio-chevron {
+		flex-shrink: 0;
+		font-size: 9px;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.lw-portfolio-list {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		z-index: var(--terminal-z-dropdown);
+		margin: 0;
+		padding: var(--terminal-space-1) 0;
+		list-style: none;
+		background: var(--terminal-bg-overlay);
+		border: 1px solid var(--terminal-fg-muted);
+		max-height: 280px;
+		overflow-y: auto;
+	}
+
+	.lw-portfolio-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 6px var(--terminal-space-2);
+		cursor: pointer;
+		transition: background var(--terminal-motion-tick);
+	}
+
+	.lw-portfolio-item:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.lw-portfolio-item--active {
+		border-left: 2px solid var(--terminal-accent-amber);
+	}
+
+	.lw-portfolio-item-name {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.lw-portfolio-item--active .lw-portfolio-item-name {
+		color: var(--terminal-accent-amber);
+	}
+
+	.lw-portfolio-item-profile {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		flex-shrink: 0;
+	}
+
+	/* -- Mobile lock -- */
+	@media (max-width: 1200px) {
+		.lw-shell {
+			display: none !important;
+		}
+
+		.lw-empty::after {
+			content: "Terminal requires desktop resolution (>1200px)";
+			font-family: var(--terminal-font-mono);
+			font-size: var(--terminal-text-11);
+			color: var(--terminal-fg-muted);
+			margin-top: var(--terminal-space-4);
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
- Complete rewrite of Live Workbench at `/portfolio/live`
- 3-zone grid: Watchlist (240px) + Chart hero (lightweight-charts, Tiingo WS) + Holdings/Summary
- Watchlist: portfolio holdings as live tickers, ticker search for any Tiingo instrument
- Chart: wired to MarketDataStore WebSocket for real-time tick updates, comparison mode
- HoldingsTable: positions with live prices, actual vs target weight, drift coloring
- PortfolioSummary: AUM, status badge, drift aggregate, rebalance stub

## Infrastructure wired (not rebuilt)
- MarketDataStore (492L) — consumed from terminal layout context
- TerminalPriceChart (398L) — reused, wired to real data
- Tiingo WS bridge — existing backend pipeline (tiingo_bridge.py → Redis → market_data WS)

## Test plan
- [ ] Watchlist shows portfolio holdings with live prices
- [ ] Chart displays historical data + receives real-time ticks
- [ ] Ticker search finds any Tiingo instrument
- [ ] Compare mode adds overlay series
- [ ] Holdings table shows drift coloring
- [ ] Portfolio selector switches data

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>