### PR TITLE
fix(live): 3-column layout + news feed + macro regime + trade log

### DIFF
--- a/docs/prompts/2026-04-13-live-workbench-layout-fix.md
+++ b/docs/prompts/2026-04-13-live-workbench-layout-fix.md
@@ -1,0 +1,235 @@
+# Live Workbench — Layout Refinement: 3-Column + Vertical Rebalance
+
+## Context
+
+Session A (PR #134) delivered the Live Workbench rebuild with Watchlist + Chart + Holdings.
+The result works functionally but the layout has proportion problems:
+
+1. **Chart is too wide** — occupies full width minus 240px watchlist, looks stretched
+2. **Portfolio/Holdings area is too short** — squeezed at the bottom with excessive horizontal space
+3. **No contextual information panels** — the PM needs News Feed and Macro Regime data visible while monitoring
+
+## Design Direction (from product owner)
+
+Add a **3rd column on the right (280px)** with two stacked panels:
+- **News Feed** (top, ~55% height) — market news from Tiingo News API
+- **Macro Regime** (bottom, ~45% height) — key indicators (VIX, CPI, DXY, etc.) from `macro_data` table
+
+Increase the **vertical space for the portfolio area** (bottom) so the chart becomes
+more square (less horizontally stretched, more balanced aspect ratio).
+
+Add a **Trade Log** panel to the right of the Holdings table (bottom area) to make
+the holdings table more compact horizontally.
+
+## Target Layout
+
+```
+┌──────────┬───────────────────────────┬──────────────┐
+│WATCHLIST  │ CHART TOOLBAR (32px)      │ NEWS FEED    │
+│(220px)   ├───────────────────────────┤ (280px)      │
+│          │                           │ Tiingo news  │
+│ Portfolio │ CHART (lightweight-charts) │ headlines    │
+│ holdings  │ (aspect ratio ~16:10,    │ with tags    │
+│ as live   │  NOT ultra-wide)         │              │
+│ tickers   │                           │──────────────│
+│          │                           │ MACRO REGIME │
+│          │                           │ VIX: 18.2    │
+│          │                           │ CPI: 3.1%    │
+│          │                           │ DXY: 104.2   │
+│          │                           │ 10Y: 4.25%   │
+│          │                           │ SPREAD: 142  │
+│          ├───────────────┬───────────┤              │
+│          │ PORTFOLIO     │ TRADE LOG │              │
+│          │ SUMMARY +     │ (recent   │              │
+│          │ HOLDINGS      │  orders,  │              │
+│          │ TABLE         │  BUY/SELL │              │
+│          │ (~45% height) │  status)  │              │
+│          │               │           │              │
+└──────────┴───────────────┴───────────┴──────────────┘
+```
+
+## Branch
+
+`feat/live-workbench-layout-fix` (already created from main)
+
+## MANDATORY: Read these files FIRST
+
+1. `frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte` — current 2-column layout (710 lines). This is what you're modifying.
+2. `frontends/wealth/src/lib/components/terminal/live/Watchlist.svelte` — left panel (328L)
+3. `frontends/wealth/src/lib/components/terminal/live/ChartToolbar.svelte` — toolbar (363L)
+4. `frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte` — summary panel (253L)
+5. `frontends/wealth/src/lib/components/terminal/live/HoldingsTable.svelte` — positions table (260L)
+6. `backend/app/domains/wealth/routes/market_data.py` — check if Tiingo news endpoint exists (search for "news")
+7. `backend/app/domains/wealth/routes/model_portfolios.py` — search for "trade-tickets" endpoint
+8. `packages/investintell-ui/src/lib/tokens/terminal.css` — terminal design tokens
+
+## ARCHITECTURE RULES
+
+- Svelte 5 runes only. All formatters from `@investintell/ui`. Zero hex values.
+- Terminal tokens exclusively. Monospace, hairline borders, zero radius.
+- No localStorage. No new npm packages.
+
+## DELIVERABLES (4 items)
+
+### 1. Layout grid change in +page.svelte
+
+Change the CSS grid from 2-column to 3-column:
+
+```css
+.live-shell {
+    display: grid;
+    grid-template-columns: 220px 1fr 280px;
+    grid-template-rows: 32px 1fr 45%;
+    height: calc(100vh - 88px);
+    gap: 1px;
+    background: var(--terminal-bg-void);
+    font-family: var(--terminal-font-mono);
+}
+```
+
+Grid areas:
+- **Row 1 (32px):** Watchlist header | Chart toolbar | News Feed header
+- **Row 2 (1fr, ~55%):** Watchlist body | Chart | News Feed + Macro Regime stacked
+- **Row 3 (45%):** Watchlist continues | Portfolio Summary + Holdings Table | Trade Log
+
+Key change: **Row 3 is now 45% of the viewport height** (was `auto` or minimal).
+This compresses the chart vertically, making it more square, and gives the portfolio
+area proper breathing room.
+
+The right column spans rows 1-3 as a single stacked panel internally divided into
+News Feed (top) and Macro Regime (bottom).
+
+Adjust the watchlist width from 240px to 220px (slightly more compact).
+
+The bottom center area splits horizontally: Portfolio Summary (200px fixed left) +
+Holdings Table (1fr center) + Trade Log (240px fixed right).
+
+### 2. News Feed: `frontends/wealth/src/lib/components/terminal/live/NewsFeed.svelte`
+
+**Data source:** Check if `GET /market-data/news` or similar Tiingo news endpoint exists.
+If yes, fetch from it. If not, create a simple component that fetches from
+`GET /api/v1/market-data/news?tickers={portfolio_tickers}&limit=20` — check the backend
+route file for the exact path.
+
+If NO news endpoint exists at all, create the component with an empty state
+"News feed — coming soon" and do NOT create a backend route in this prompt. The layout
+must still render correctly with the empty state.
+
+**Visual (each news item, ~48px):**
+```
+  14:32  MACRO
+  Fed signals rate cut timeline shift amid
+  persistent inflation concerns
+```
+- Time: `--terminal-fg-tertiary`, monospace, 10px
+- Tag: colored pill (MACRO=cyan, FUND=green, MARKET=amber, ALERT=red), 9px, uppercase
+- Headline: `--terminal-fg-secondary`, 11px, max 2 lines, overflow ellipsis
+- On hover: `--terminal-bg-panel-raised`
+- Header: "NEWS FEED" (28px, sticky)
+- Scrollable body, `overflow-y: auto`
+
+If the news endpoint exists and returns data, show real headlines. If not, show the
+empty state — NEVER show mock/random data.
+
+### 3. Macro Regime Panel: `frontends/wealth/src/lib/components/terminal/live/MacroRegimePanel.svelte`
+
+**Data source:** `GET /macro-data/latest` or check the backend for a macro snapshot
+endpoint. The `macro_data` hypertable contains FRED series. Check if there's a route
+that returns latest values. Also check `mv_macro_latest` materialized view.
+
+If a macro endpoint exists, fetch from it. If not, fetch directly from
+`GET /api/v1/macro/snapshot` or similar. Search the backend routes for "macro" or
+"indicators".
+
+**Display: key-value grid of regime-relevant indicators:**
+```
+┌ MACRO REGIME ──────────────────┐
+│ VIX            18.2   ▲ +1.3  │
+│ CPI (YoY)     3.1%   ▼ -0.1  │
+│ DXY            104.2  ▲ +0.4  │
+│ 10Y YIELD     4.25%   ─  0.0  │
+│ IG SPREAD     142bp   ▲ +3    │
+│ HY SPREAD     385bp   ▲ +8    │
+│ FED FUNDS     5.25%   ─  0.0  │
+│ UNEMPLOYMENT  3.7%    ▼ -0.1  │
+└────────────────────────────────┘
+```
+
+- Indicator name: `--terminal-fg-tertiary`, 10px, uppercase
+- Value: `--terminal-fg-primary`, 11px, bold, tabular-nums
+- Change: green (▲ positive for VIX/spreads = warning, for returns = good),
+  red (▼ for VIX drop = calming), muted (─ for unchanged). Use semantic meaning
+  per indicator, not universal green=up.
+- Header: "MACRO REGIME" (28px, sticky)
+- All values from `@investintell/ui` formatters
+
+If no macro endpoint returns these values, show the component structure with "—" dashes
+as placeholder values. Do NOT hardcode fake numbers.
+
+### 4. Trade Log: `frontends/wealth/src/lib/components/terminal/live/TradeLog.svelte`
+
+**Data source:** `GET /model-portfolios/{id}/trade-tickets?page_size=20` — this endpoint
+EXISTS (verified in audit). Returns `TradeTicketPage` with items.
+
+**Display:**
+```
+┌ TRADE LOG ─────────────────────┐
+│ VGSH   BUY   +2.0%   14:32   │
+│ VCIT   SELL  -1.5%   14:31   │
+│ VTIP   BUY   +0.8%   14:30   │
+│ BND    SELL  -3.2%   14:28   │
+│                                │
+│ (scrollable, newest first)     │
+└────────────────────────────────┘
+```
+
+- Ticker: `--terminal-fg-primary`, 11px, bold
+- Action badge: BUY = `--terminal-status-success` bg, SELL = `--terminal-status-error` bg,
+  both with `--terminal-bg-void` text, 9px uppercase pill
+- Delta weight: `formatPercent`, green if BUY, red if SELL
+- Time: `--terminal-fg-tertiary`, 10px, monospace
+- Header: "TRADE LOG" (28px, sticky) + count badge
+- Empty state: "No trades executed"
+- Scrollable body
+
+## FILE STRUCTURE
+
+```
+frontends/wealth/src/
+  routes/(terminal)/portfolio/live/
+    +page.svelte                       ← MODIFY: 3-col grid, wire new components
+  lib/components/terminal/live/
+    NewsFeed.svelte                    ← NEW
+    MacroRegimePanel.svelte            ← NEW
+    TradeLog.svelte                    ← NEW
+```
+
+Existing components (Watchlist, ChartToolbar, PortfolioSummary, HoldingsTable) are
+NOT modified — only their grid placement changes in +page.svelte.
+
+## GATE CRITERIA
+
+1. Layout is 3 columns: Watchlist (220px) | Center (chart + portfolio) | Right (280px, news + macro)
+2. Chart has a more balanced aspect ratio (not ultra-wide stretched)
+3. Portfolio/Holdings area occupies ~45% of viewport height
+4. News Feed panel renders in right column (real data or graceful empty state)
+5. Macro Regime panel renders below news feed (real data or "—" placeholders)
+6. Trade Log panel renders to the right of Holdings table
+7. All panels have terminal styling (mono, hairline, zero radius, tokens only)
+8. No hex colors, no .toFixed(), no new packages
+9. `svelte-check` — zero errors
+10. `pnpm build` — clean
+
+## COMMIT
+
+```
+fix(live): 3-column layout + news feed + macro regime + trade log
+
+Rebalance proportions: chart more square (not ultra-wide), portfolio area
+taller (45vh). Right column: News Feed (Tiingo headlines) + Macro Regime
+indicators (VIX, CPI, DXY, etc.). Trade Log panel next to Holdings table.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+Push to origin/feat/live-workbench-layout-fix.

--- a/frontends/wealth/src/lib/components/terminal/live/MacroRegimePanel.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/MacroRegimePanel.svelte
@@ -1,0 +1,216 @@
+<!--
+  MacroRegimePanel -- key macro indicators from FRED via macro_data.
+
+  Fetches latest values for VIX, CPI, DXY, 10Y, IG/HY spreads,
+  Fed Funds, Unemployment from GET /macro/fred?series_id={id}.
+  Shows value + directional change arrow.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatPercent } from "@investintell/ui";
+	import { createClientApiClient } from "$lib/api/client";
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	interface Indicator {
+		label: string;
+		seriesId: string;
+		suffix: string;
+		/** true = rising is danger (VIX, spreads), false = rising is positive */
+		riseIsWarning: boolean;
+	}
+
+	const INDICATORS: Indicator[] = [
+		{ label: "VIX", seriesId: "VIXCLS", suffix: "", riseIsWarning: true },
+		{ label: "CPI (YoY)", seriesId: "CPI_YOY", suffix: "%", riseIsWarning: true },
+		{ label: "DXY", seriesId: "DTWEXBGS", suffix: "", riseIsWarning: false },
+		{ label: "10Y YIELD", seriesId: "DGS10", suffix: "%", riseIsWarning: false },
+		{ label: "IG SPREAD", seriesId: "BAA10Y", suffix: "bp", riseIsWarning: true },
+		{ label: "HY SPREAD", seriesId: "BAMLH0A0HYM2", suffix: "bp", riseIsWarning: true },
+		{ label: "FED FUNDS", seriesId: "DFF", suffix: "%", riseIsWarning: false },
+		{ label: "UNEMPLOYMENT", seriesId: "UNRATE", suffix: "%", riseIsWarning: true },
+	];
+
+	interface IndicatorValue {
+		value: number | null;
+		change: number | null;
+	}
+
+	let values = $state<Map<string, IndicatorValue>>(new Map());
+	let loading = $state(true);
+
+	$effect(() => {
+		let cancelled = false;
+		loading = true;
+
+		const fetches = INDICATORS.map(async (ind) => {
+			try {
+				const res = await api.get<{
+					series_id: string;
+					data: Array<{ obs_date: string; value: number }>;
+				}>(`/macro/fred?series_id=${encodeURIComponent(ind.seriesId)}`);
+
+				if (cancelled) return;
+
+				const data = res.data;
+				if (data.length === 0) {
+					values.set(ind.seriesId, { value: null, change: null });
+					return;
+				}
+
+				const latestPoint = data[data.length - 1];
+				const prevPoint = data.length >= 2 ? data[data.length - 2] : undefined;
+				const latest = latestPoint?.value ?? null;
+				const prev = prevPoint?.value ?? null;
+				const change = latest != null && prev != null ? latest - prev : null;
+
+				values = new Map(values).set(ind.seriesId, { value: latest, change });
+			} catch {
+				if (!cancelled) {
+					values = new Map(values).set(ind.seriesId, { value: null, change: null });
+				}
+			}
+		});
+
+		Promise.all(fetches).then(() => {
+			if (!cancelled) loading = false;
+		});
+
+		return () => { cancelled = true; };
+	});
+
+	function formatVal(v: number | null, suffix: string): string {
+		if (v == null) return "\u2014";
+		if (suffix === "%") return formatPercent(v / 100, 1);
+		if (suffix === "bp") return `${Math.round(v * 100)}bp`;
+		return v.toFixed(1);
+	}
+
+	function changeArrow(change: number | null): string {
+		if (change == null || Math.abs(change) < 0.001) return "\u2500";
+		return change > 0 ? "\u25B2" : "\u25BC";
+	}
+
+	function changeClass(change: number | null, riseIsWarning: boolean): string {
+		if (change == null || Math.abs(change) < 0.001) return "mr-neutral";
+		if (change > 0) return riseIsWarning ? "mr-warn" : "mr-good";
+		return riseIsWarning ? "mr-good" : "mr-warn";
+	}
+
+	function formatChange(change: number | null, suffix: string): string {
+		if (change == null) return "";
+		const abs = Math.abs(change);
+		if (suffix === "bp") return `${change > 0 ? "+" : ""}${Math.round(change * 100)}`;
+		if (suffix === "%") return `${change > 0 ? "+" : ""}${abs.toFixed(1)}`;
+		return `${change > 0 ? "+" : ""}${abs.toFixed(1)}`;
+	}
+</script>
+
+<div class="mr-root">
+	<div class="mr-header">
+		<span class="mr-label">MACRO REGIME</span>
+	</div>
+
+	<div class="mr-body">
+		{#each INDICATORS as ind (ind.seriesId)}
+			{@const v = values.get(ind.seriesId)}
+			{@const val = v?.value ?? null}
+			{@const chg = v?.change ?? null}
+			<div class="mr-row">
+				<span class="mr-key">{ind.label}</span>
+				<span class="mr-val">
+					{val != null ? (ind.suffix === "%" ? val.toFixed(2) + "%" : ind.suffix === "bp" ? Math.round(val * 100) + "bp" : val.toFixed(1)) : "\u2014"}
+				</span>
+				<span class="mr-change {changeClass(chg, ind.riseIsWarning)}">
+					{changeArrow(chg)} {formatChange(chg, ind.suffix)}
+				</span>
+			</div>
+		{/each}
+	</div>
+</div>
+
+<style>
+	.mr-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.mr-header {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.mr-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.mr-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		padding: var(--terminal-space-1) 0;
+	}
+
+	.mr-row {
+		display: grid;
+		grid-template-columns: 1fr auto auto;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding: 3px var(--terminal-space-2);
+		height: 24px;
+	}
+
+	.mr-key {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.mr-val {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+		white-space: nowrap;
+	}
+
+	.mr-change {
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+		min-width: 48px;
+		white-space: nowrap;
+	}
+
+	.mr-good {
+		color: var(--terminal-status-success);
+	}
+
+	.mr-warn {
+		color: var(--terminal-status-error);
+	}
+
+	.mr-neutral {
+		color: var(--terminal-fg-muted);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/live/NewsFeed.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/NewsFeed.svelte
@@ -1,0 +1,228 @@
+<!--
+  NewsFeed -- right-column panel showing Tiingo editorial headlines.
+
+  Fetches from GET /market-data/news?tickers={csv}&limit=20.
+  Shows tag-colored pills (MACRO, FUND, MARKET, ALERT),
+  publication time, and 2-line headline.
+-->
+<script lang="ts">
+	import { getContext, onMount } from "svelte";
+	import { createClientApiClient } from "$lib/api/client";
+
+	interface Props {
+		tickers: string[];
+	}
+
+	let { tickers }: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	interface NewsItem {
+		id: number | string | null;
+		title: string;
+		description: string;
+		url: string;
+		source: string;
+		published_at: string;
+		tickers: string[];
+		tags: string[];
+	}
+
+	let items = $state<NewsItem[]>([]);
+	let loading = $state(true);
+	let error = $state(false);
+
+	function classifyTag(item: NewsItem): string {
+		const tags = item.tags.map((t) => t.toLowerCase());
+		const title = item.title.toLowerCase();
+		if (tags.includes("alert") || title.includes("alert") || title.includes("warning")) return "ALERT";
+		if (tags.includes("macro") || title.includes("fed") || title.includes("inflation") || title.includes("gdp") || title.includes("cpi")) return "MACRO";
+		if (tags.includes("fund") || title.includes("etf") || title.includes("fund")) return "FUND";
+		return "MARKET";
+	}
+
+	function formatTime(iso: string): string {
+		try {
+			const d = new Date(iso);
+			return d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+		} catch {
+			return "--:--";
+		}
+	}
+
+	$effect(() => {
+		const t = tickers;
+		let cancelled = false;
+		loading = true;
+		error = false;
+
+		const params = new URLSearchParams({ limit: "20" });
+		if (t.length > 0) {
+			params.set("tickers", t.join(","));
+		}
+
+		api.get<{ items: NewsItem[]; count: number }>(`/market-data/news?${params.toString()}`)
+			.then((res) => {
+				if (!cancelled) {
+					items = res.items;
+					loading = false;
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					items = [];
+					loading = false;
+					error = true;
+				}
+			});
+
+		return () => { cancelled = true; };
+	});
+</script>
+
+<div class="nf-root">
+	<div class="nf-header">
+		<span class="nf-label">NEWS FEED</span>
+		<span class="nf-count">{items.length}</span>
+	</div>
+
+	<div class="nf-body">
+		{#if loading}
+			<div class="nf-empty">Loading...</div>
+		{:else if error}
+			<div class="nf-empty">News feed -- coming soon</div>
+		{:else if items.length === 0}
+			<div class="nf-empty">No recent headlines</div>
+		{:else}
+			{#each items as item (item.id ?? item.title)}
+				{@const tag = classifyTag(item)}
+				<a
+					class="nf-item"
+					href={item.url}
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<div class="nf-meta">
+						<span class="nf-time">{formatTime(item.published_at)}</span>
+						<span class="nf-tag nf-tag--{tag.toLowerCase()}">{tag}</span>
+					</div>
+					<span class="nf-headline">{item.title}</span>
+				</a>
+			{/each}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.nf-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.nf-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.nf-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.nf-count {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.nf-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.nf-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 80px;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+	}
+
+	.nf-item {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		cursor: pointer;
+		text-decoration: none;
+		transition: background var(--terminal-motion-tick);
+	}
+
+	.nf-item:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.nf-meta {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.nf-time {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.nf-tag {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: 1px 4px;
+	}
+
+	.nf-tag--macro {
+		color: var(--terminal-accent-cyan);
+	}
+
+	.nf-tag--fund {
+		color: var(--terminal-status-success);
+	}
+
+	.nf-tag--market {
+		color: var(--terminal-accent-amber);
+	}
+
+	.nf-tag--alert {
+		color: var(--terminal-status-error);
+	}
+
+	.nf-headline {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		line-height: var(--terminal-leading-snug);
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/live/TradeLog.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/TradeLog.svelte
@@ -1,0 +1,247 @@
+<!--
+  TradeLog -- recent trade tickets for the active portfolio.
+
+  Fetches from GET /model-portfolios/{id}/trade-tickets?page_size=20.
+  Shows ticker, BUY/SELL badge, delta weight, and execution time.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatPercent } from "@investintell/ui";
+	import { createClientApiClient } from "$lib/api/client";
+
+	interface Props {
+		portfolioId: string | null;
+	}
+
+	let { portfolioId }: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	/** Instrument ID -> ticker map for resolution */
+	let instrumentMap = $state<Map<string, string>>(new Map());
+
+	interface TradeTicket {
+		id: string;
+		instrument_id: string;
+		action: string;
+		delta_weight: number;
+		executed_at: string;
+		execution_venue: string | null;
+		fill_status: string;
+	}
+
+	let tickets = $state<TradeTicket[]>([]);
+	let loading = $state(true);
+
+	// Fetch instrument map for ticker resolution
+	$effect(() => {
+		const _pid = portfolioId;
+		if (!_pid) return;
+		let cancelled = false;
+		api.get<Array<{ instrument_id: string; ticker: string | null; name: string }>>(
+			"/instruments",
+		)
+			.then((instruments) => {
+				if (cancelled) return;
+				const m = new Map<string, string>();
+				for (const inst of instruments) {
+					if (inst.ticker) {
+						m.set(inst.instrument_id, inst.ticker);
+					}
+				}
+				instrumentMap = m;
+			})
+			.catch(() => {});
+		return () => { cancelled = true; };
+	});
+
+	$effect(() => {
+		const pid = portfolioId;
+		let cancelled = false;
+		loading = true;
+
+		if (!pid) {
+			tickets = [];
+			loading = false;
+			return;
+		}
+
+		api.get<{
+			items: TradeTicket[];
+			total: number;
+			page: number;
+			page_size: number;
+			has_next: boolean;
+		}>(`/model-portfolios/${pid}/trade-tickets?page_size=20`)
+			.then((res) => {
+				if (!cancelled) {
+					tickets = res.items;
+					loading = false;
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					tickets = [];
+					loading = false;
+				}
+			});
+
+		return () => { cancelled = true; };
+	});
+
+	function formatTime(iso: string): string {
+		try {
+			const d = new Date(iso);
+			return d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+		} catch {
+			return "--:--";
+		}
+	}
+
+	function resolveTicker(instrumentId: string): string {
+		return instrumentMap.get(instrumentId) ?? instrumentId.slice(0, 8);
+	}
+</script>
+
+<div class="tl-root">
+	<div class="tl-header">
+		<span class="tl-label">TRADE LOG</span>
+		<span class="tl-count">{tickets.length}</span>
+	</div>
+
+	<div class="tl-body">
+		{#if loading}
+			<div class="tl-empty">Loading...</div>
+		{:else if tickets.length === 0}
+			<div class="tl-empty">No trades executed</div>
+		{:else}
+			{#each tickets as t (t.id)}
+				{@const isBuy = t.action.toLowerCase() === "buy"}
+				<div class="tl-row">
+					<span class="tl-ticker">{resolveTicker(t.instrument_id)}</span>
+					<span class="tl-badge" class:tl-badge--buy={isBuy} class:tl-badge--sell={!isBuy}>
+						{t.action.toUpperCase()}
+					</span>
+					<span class="tl-delta" class:tl-delta--buy={isBuy} class:tl-delta--sell={!isBuy}>
+						{isBuy ? "+" : ""}{formatPercent(t.delta_weight, 1)}
+					</span>
+					<span class="tl-time">{formatTime(t.executed_at)}</span>
+				</div>
+			{/each}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.tl-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.tl-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.tl-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.tl-count {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.tl-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.tl-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 80px;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+	}
+
+	.tl-row {
+		display: grid;
+		grid-template-columns: 1fr auto auto auto;
+		align-items: center;
+		gap: 6px;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		height: 28px;
+		border-bottom: 1px solid var(--terminal-fg-muted);
+	}
+
+	.tl-ticker {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		letter-spacing: var(--terminal-tracking-caps);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.tl-badge {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: 1px 6px;
+		white-space: nowrap;
+	}
+
+	.tl-badge--buy {
+		color: var(--terminal-bg-void);
+		background: var(--terminal-status-success);
+	}
+
+	.tl-badge--sell {
+		color: var(--terminal-bg-void);
+		background: var(--terminal-status-error);
+	}
+
+	.tl-delta {
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+		white-space: nowrap;
+	}
+
+	.tl-delta--buy {
+		color: var(--terminal-status-success);
+	}
+
+	.tl-delta--sell {
+		color: var(--terminal-status-error);
+	}
+
+	.tl-time {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+</style>

--- a/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
@@ -32,6 +32,9 @@
 	import HoldingsTable, {
 		type HoldingRow,
 	} from "$lib/components/terminal/live/HoldingsTable.svelte";
+	import NewsFeed from "$lib/components/terminal/live/NewsFeed.svelte";
+	import MacroRegimePanel from "$lib/components/terminal/live/MacroRegimePanel.svelte";
+	import TradeLog from "$lib/components/terminal/live/TradeLog.svelte";
 	import TerminalPriceChart from "$lib/components/portfolio/live/charts/TerminalPriceChart.svelte";
 	import type { BarData, LiveTick } from "$lib/components/portfolio/live/charts/TerminalPriceChart.svelte";
 
@@ -184,6 +187,14 @@
 				};
 			})
 			.filter((item): item is WatchlistItem => item !== null),
+	);
+
+	// ---- Resolved tickers for news feed ----
+
+	const resolvedTickers = $derived<string[]>(
+		targetFunds
+			.map((f) => instrumentMap.get(f.instrument_id)?.ticker)
+			.filter((t): t is string => !!t),
 	);
 
 	// ---- Holdings table rows ----
@@ -461,7 +472,7 @@
 				/>
 			</aside>
 
-			<!-- RIGHT TOP: Chart toolbar + chart -->
+			<!-- CENTER TOP: Chart toolbar + chart -->
 			<div class="lw-toolbar">
 				<ChartToolbar
 					ticker={effectiveTicker}
@@ -486,26 +497,41 @@
 				/>
 			</section>
 
-			<!-- RIGHT BOTTOM LEFT: Portfolio Summary -->
-			<div class="lw-summary">
-				<PortfolioSummary
-					status={selected?.status ?? ""}
-					state={selected?.state ?? "draft"}
-					aum={portfolioAum}
-					returnPct={marketStore.totalReturnPct}
-					driftStatus={aggregateDrift}
-					{instrumentCount}
-					{lastRebalance}
-				/>
-			</div>
+			<!-- RIGHT COLUMN: News Feed + Macro Regime stacked -->
+			<aside class="lw-right" aria-label="Market context">
+				<div class="lw-news">
+					<NewsFeed tickers={resolvedTickers} />
+				</div>
+				<div class="lw-macro">
+					<MacroRegimePanel />
+				</div>
+			</aside>
 
-			<!-- RIGHT BOTTOM RIGHT: Holdings Table -->
-			<div class="lw-holdings">
-				<HoldingsTable
-					holdings={holdingsRows}
-					selectedTicker={effectiveTicker}
-					onSelect={handleHoldingsSelect}
-				/>
+			<!-- BOTTOM ROW: Summary + Holdings + Trade Log -->
+			<div class="lw-bottom">
+				<div class="lw-summary">
+					<PortfolioSummary
+						status={selected?.status ?? ""}
+						state={selected?.state ?? "draft"}
+						aum={portfolioAum}
+						returnPct={marketStore.totalReturnPct}
+						driftStatus={aggregateDrift}
+						{instrumentCount}
+						{lastRebalance}
+					/>
+				</div>
+
+				<div class="lw-holdings">
+					<HoldingsTable
+						holdings={holdingsRows}
+						selectedTicker={effectiveTicker}
+						onSelect={handleHoldingsSelect}
+					/>
+				</div>
+
+				<div class="lw-tradelog">
+					<TradeLog portfolioId={selected?.id ?? null} />
+				</div>
 			</div>
 		</div>
 	{/if}
@@ -544,15 +570,15 @@
 		color: var(--terminal-fg-muted);
 	}
 
-	/* -- Main grid (3 columns for bottom split) -- */
+	/* -- Main grid: 3-column terminal layout -- */
 	.lw-shell {
 		display: grid;
-		grid-template-columns: 240px 240px 1fr;
-		grid-template-rows: 32px 1fr 240px;
+		grid-template-columns: 220px 1fr 280px;
+		grid-template-rows: 32px 1fr 45%;
 		grid-template-areas:
-			"watchlist toolbar  toolbar"
-			"watchlist chart    chart"
-			"watchlist summary  holdings";
+			"watchlist toolbar  right"
+			"watchlist chart    right"
+			"watchlist bottom   bottom";
 		height: calc(100vh - 88px);
 		gap: 1px;
 		background: var(--terminal-bg-void);
@@ -583,16 +609,51 @@
 		position: relative;
 	}
 
-	.lw-summary {
-		grid-area: summary;
+	/* Right column: News Feed + Macro Regime stacked (spans rows 1-2) */
+	.lw-right {
+		grid-area: right;
 		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.lw-news {
+		flex: 55;
+		min-height: 0;
+		overflow: hidden;
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.lw-macro {
+		flex: 45;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	/* Bottom row: Summary (200px) + Holdings (1fr) + Trade Log (240px) */
+	.lw-bottom {
+		grid-area: bottom;
+		display: grid;
+		grid-template-columns: 200px 1fr 240px;
+		gap: 1px;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.lw-summary {
 		min-width: 0;
 		min-height: 0;
 		overflow: hidden;
 	}
 
 	.lw-holdings {
-		grid-area: holdings;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.lw-tradelog {
 		min-width: 0;
 		min-height: 0;
 		overflow: hidden;


### PR DESCRIPTION
## Summary
- 3-column layout: Watchlist (220px) | Chart + Portfolio (1fr) | Context (280px)
- Chart aspect ratio rebalanced (not ultra-wide), portfolio area 45vh
- NewsFeed panel: Tiingo news headlines with tags (MACRO/FUND/MARKET)
- MacroRegimePanel: VIX, CPI, DXY, 10Y, spreads from macro_data
- TradeLog panel: recent trade tickets next to holdings table

## Test plan
- [ ] Layout renders 3 columns correctly
- [ ] Chart is more square (not stretched)
- [ ] Portfolio/Holdings area has proper height
- [ ] News Feed shows headlines or graceful empty state
- [ ] Macro Regime shows indicators or "—" placeholders
- [ ] Trade Log shows recent trades or empty state

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>