### PR TITLE
feat(live): Session B — rebalance FocusMode + trade execution flow

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -3657,6 +3657,7 @@ async def get_actual_holdings(
             portfolio_id=str(portfolio_id),
             source="actual",
             holdings=holdings,
+            holdings_version=actual_row.holdings_version,
             last_rebalanced_at=actual_row.last_rebalanced_at,
         )
 

--- a/backend/app/domains/wealth/schemas/shadow_oms.py
+++ b/backend/app/domains/wealth/schemas/shadow_oms.py
@@ -79,6 +79,10 @@ class ActualHoldingsResponse(BaseModel):
         ),
     )
     holdings: list[HoldingWeight]
+    holdings_version: int = Field(
+        1,
+        description="Optimistic lock version for execute-trades.",
+    )
     last_rebalanced_at: datetime | None = None
 
 

--- a/docs/prompts/2026-04-13-live-workbench-session-b.md
+++ b/docs/prompts/2026-04-13-live-workbench-session-b.md
@@ -1,0 +1,226 @@
+# Phase 5 Live Workbench — Session B: Rebalance FocusMode + Trade Execution
+
+## Context
+
+Live Workbench Session A (PR #134) + layout fix (PR #135) delivered a 3-column
+trading terminal with Watchlist, Chart (lightweight-charts + Tiingo WS), Holdings
+Table, Portfolio Summary, News Feed, Macro Regime Panel, and Trade Log.
+
+The PortfolioSummary currently has a "REBALANCE" button that shows a stub alert.
+This session makes it functional: RebalanceFocusMode with trade proposals, impact
+analysis, and trade execution.
+
+**Backend infrastructure (ALL VERIFIED — exists and is functional):**
+- `POST /model-portfolios/{id}/rebalance/preview` → `SuggestedTrade[]` + turnover + CVaR
+- `POST /model-portfolios/{id}/execute-trades` → `TradeTicket[]` + optimistic lock
+- `GET /model-portfolios/{id}/actual-holdings` → current holdings state
+- `GET /model-portfolios/{id}/trade-tickets` → paginated trade history
+- `TradeTicket` model (append-only log, org-scoped, RLS)
+- `PortfolioActualHoldings` model (mutable JSONB, optimistic lock via holdings_version)
+
+## Sanitization
+
+| Internal term | Terminal label |
+|---|---|
+| CVaR 95 | Tail Loss (95% confidence) |
+| cvar_warning | Risk limit approaching |
+| estimated_turnover_pct | Turnover |
+| delta_weight | Weight Change |
+| fill_status: "simulated" | Simulated |
+
+## MANDATORY: Read these files FIRST
+
+### Backend (verify schemas/signatures)
+1. `backend/app/domains/wealth/routes/model_portfolios.py` — search for "rebalance/preview", "execute-trades", "actual-holdings", "trade-tickets". Read the request/response schemas.
+2. `backend/app/domains/wealth/schemas/shadow_oms.py` — SuggestedTrade, ExecuteTradesRequest, ExecuteTradesResponse, TradeTicketResponse, RebalancePreviewResponse, ActualHoldingsResponse schemas
+3. `backend/app/domains/wealth/models/shadow_oms.py` — TradeTicket, PortfolioActualHoldings models
+
+### Frontend (extend these)
+4. `frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte` — current page (wire rebalance button)
+5. `frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte` — has REBALANCE button stub
+6. `frontends/wealth/src/lib/components/terminal/live/TradeLog.svelte` — will refresh after trade execution
+7. `frontends/wealth/src/lib/components/terminal/live/HoldingsTable.svelte` — will update with actual weights after execution
+
+### Primitives (reuse patterns)
+8. `frontends/wealth/src/lib/components/terminal/focus-mode/FocusMode.svelte` — generic FocusMode primitive (if it exists). If not, read the Builder's ConsequenceDialog pattern for modal overlay.
+9. `frontends/wealth/src/lib/components/terminal/builder/ConsequenceDialog.svelte` — reference for typed confirmation + focus trap pattern
+10. `packages/investintell-ui/src/lib/tokens/terminal.css` — terminal tokens
+
+## ARCHITECTURE RULES
+
+- Svelte 5 runes only. All formatters from `@investintell/ui`. Zero hex values.
+- Terminal tokens exclusively. Monospace, hairline borders, zero radius.
+- No localStorage. No new npm packages.
+- FocusMode for rebalance (full-screen overlay, NOT drawer, NOT inline expansion).
+- URL state: `?rebalance=open` added when FocusMode is open, removed on close.
+- Idempotent: the "Submit Proposal" button must disable on click and prevent double-submit.
+- Optimistic lock: `execute-trades` requires `expected_version` matching `holdings_version`.
+
+## DELIVERABLES (4 items)
+
+### 1. RebalanceFocusMode: `frontends/wealth/src/lib/components/terminal/live/RebalanceFocusMode.svelte`
+
+Full-screen overlay (95vw x 95vh, dark scrim, focus trap, ESC closes).
+Uses URL state `?rebalance=open` for reload safety.
+
+**Layout inside FocusMode (2-column, 50/50):**
+
+```
+┌──── [ REBALANCE ] // PORTFOLIO NAME // 2026-04-13 ─── [ ESC · CLOSE ] ────┐
+│                                                                              │
+│  ┌──── PROPOSED TRADES ──────────────┐  ┌──── IMPACT ANALYSIS ──────────┐  │
+│  │ FUND       ACTION  CURRENT TARGET │  │                               │  │
+│  │ ──────────────────────────────────  │  │  Turnover        12.4%       │  │
+│  │ VGSH       BUY     14.8%   15.0%  │  │  Tail Loss (95%) 8.2%        │  │
+│  │ VCIT       SELL    26.2%   25.0%  │  │  Risk Warning    No           │  │
+│  │ VTIP       BUY      9.1%   10.0%  │  │  Trades          5            │  │
+│  │ BND        HOLD    20.0%   20.0%  │  │                               │  │
+│  │ CASH       SELL     9.9%    5.0%  │  │  ─── TRADE VALUES ───        │  │
+│  │ ──────────────────────────────────  │  │  Total BUY       $1.24M     │  │
+│  │ 5 trades (3 BUY, 2 SELL, 0 HOLD)  │  │  Total SELL       $892K     │  │
+│  │                                    │  │  Net Flow         $348K      │  │
+│  └────────────────────────────────────┘  └───────────────────────────────┘  │
+│                                                                              │
+│  ┌──── CONFIRMATION ───────────────────────────────────────────────────┐    │
+│  │  This will generate trade orders for the active portfolio.          │    │
+│  │  Execution is simulated — no real broker orders will be placed.     │    │
+│  │                                                                     │    │
+│  │  [ CANCEL ]                                 [ SUBMIT PROPOSAL ]     │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Data flow:**
+1. On open: call `POST /model-portfolios/{id}/rebalance/preview` with current holdings
+2. Display `SuggestedTrade[]` in the left table (sorted by |delta_weight| desc)
+3. Display `RebalancePreviewResponse` metrics in the right panel (turnover, CVaR, warning)
+4. PM reviews and clicks "Submit Proposal"
+5. Before submit: show ConsequenceDialog-style confirmation (no typed ACTIVATE needed —
+   simpler than portfolio activation. Just a "Are you sure?" with Cancel/Confirm.)
+6. On confirm: call `POST /model-portfolios/{id}/execute-trades` with the trade tickets
+7. On success: close FocusMode, refresh TradeLog + HoldingsTable, show success toast
+8. On error (409 version conflict): show "Portfolio was modified by another user. Refresh and retry."
+
+**Proposed Trades table columns:**
+| Fund | Ticker | Action | Current | Target | Delta | Trade Value |
+- Action: BUY badge (green bg), SELL badge (red bg), HOLD badge (muted bg)
+- Delta: `formatPercent`, color-coded
+- Trade Value: `formatCurrency`, estimated from AUM * delta_weight
+
+**Impact Analysis panel:**
+- Turnover: `formatPercent` — amber if > 10%, red if > 20%
+- Tail Loss: `formatPercent` — with "Risk limit approaching" warning if `cvar_warning` is true
+- Trade count: number
+- Total BUY/SELL/Net: `formatCurrency`
+
+**Keyboard:** ESC closes. Tab trap inside modal. Enter on "Submit Proposal" if focused.
+
+**Loading state:** While `rebalance/preview` is fetching, show a terminal-style loading
+indicator (pulsing "COMPUTING REBALANCE..." text, not a spinner).
+
+### 2. Wire REBALANCE button in PortfolioSummary
+
+In `PortfolioSummary.svelte`, replace the stub alert with actual navigation:
+
+```typescript
+function handleRebalance() {
+    // Add ?rebalance=open to URL
+    const params = new URLSearchParams(page.url.searchParams);
+    params.set("rebalance", "open");
+    goto(`/portfolio/live?${params.toString()}`, { replaceState: true });
+}
+```
+
+In `+page.svelte`, conditionally render RebalanceFocusMode based on URL:
+
+```typescript
+const showRebalance = $derived(page.url.searchParams.get("rebalance") === "open");
+
+function handleRebalanceClose() {
+    const params = new URLSearchParams(page.url.searchParams);
+    params.delete("rebalance");
+    goto(`/portfolio/live?${params.toString()}`, { replaceState: true });
+}
+```
+
+### 3. Post-execution refresh
+
+After `execute-trades` succeeds:
+1. **TradeLog** must refresh — re-fetch `GET /trade-tickets` to show new entries
+2. **HoldingsTable** must update — re-fetch `GET /actual-holdings` to reflect new weights
+3. **PortfolioSummary** drift status may change (fewer breaches after rebalance)
+
+Implement this via a callback chain: RebalanceFocusMode `onsuccess` → parent page
+re-fetches holdings + trade tickets. Use `$effect` dependencies or explicit `refetch()` methods.
+
+### 4. Trade execution confirmation
+
+Before calling `execute-trades`, show a simple confirmation overlay (NOT the full
+ConsequenceDialog with typed ACTIVATE — this is less consequential than activation):
+
+```
+┌────────────────────────────────────────┐
+│  Execute 5 trades?                     │
+│                                        │
+│  3 BUY orders, 2 SELL orders           │
+│  Estimated turnover: 12.4%             │
+│  Execution: Simulated                  │
+│                                        │
+│  [ Cancel ]          [ Execute ]       │
+└────────────────────────────────────────┘
+```
+
+Simple modal, ESC closes, Enter confirms. Amber "Execute" button.
+After execution, show result status (success count, any failures).
+
+## FILE STRUCTURE
+
+```
+frontends/wealth/src/
+  routes/(terminal)/portfolio/live/
+    +page.svelte                          ← MODIFY: wire RebalanceFocusMode + URL state
+  lib/components/terminal/live/
+    RebalanceFocusMode.svelte             ← NEW: full-screen rebalance overlay
+    TradeConfirmation.svelte              ← NEW: simple execution confirmation
+    PortfolioSummary.svelte               ← MODIFY: wire REBALANCE button to URL
+```
+
+## GATE CRITERIA
+
+1. REBALANCE button in PortfolioSummary opens RebalanceFocusMode
+2. URL shows `?rebalance=open` when FocusMode is active (reload-safe)
+3. RebalanceFocusMode calls `POST /rebalance/preview` and displays trade proposals
+4. Trade table shows BUY/SELL/HOLD badges with correct color coding
+5. Impact panel shows turnover, tail loss, risk warning
+6. "Submit Proposal" opens TradeConfirmation dialog
+7. Confirming executes `POST /execute-trades` with correct payload
+8. After execution: TradeLog refreshes, HoldingsTable updates, FocusMode closes
+9. 409 version conflict shows meaningful error message
+10. ESC closes FocusMode, URL cleaned
+11. Zero hex colors, zero `.toFixed()`, all terminal tokens
+12. `svelte-check` — zero errors
+13. `pnpm build` — clean
+
+## What NOT to do
+
+- Do NOT modify NewsFeed, MacroRegimePanel, Watchlist, ChartToolbar, or chart components
+- Do NOT create real broker integration — all trades are `fill_status="simulated"`
+- Do NOT require typed "ACTIVATE" confirmation — simple Cancel/Execute is sufficient
+- Do NOT install new packages
+- Do NOT use hex colors
+- Do NOT hardcode trade data — wire to real backend endpoints
+
+## COMMIT
+
+```
+feat(live): Session B — rebalance FocusMode + trade execution flow
+
+Full-screen RebalanceFocusMode with trade proposals from POST /rebalance/preview,
+impact analysis (turnover, tail loss, risk warning), and trade execution via
+POST /execute-trades with optimistic lock. URL state ?rebalance=open for reload
+safety. Post-execution refresh of TradeLog + HoldingsTable.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+Push to origin/feat/live-workbench-session-b.

--- a/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
@@ -15,6 +15,7 @@
 		driftStatus: "aligned" | "watch" | "breach";
 		instrumentCount: number;
 		lastRebalance: string | null;
+		onRebalance?: () => void;
 	}
 
 	let {
@@ -25,6 +26,7 @@
 		driftStatus,
 		instrumentCount,
 		lastRebalance,
+		onRebalance,
 	}: Props = $props();
 
 	const isLive = $derived(state === "live");
@@ -44,7 +46,7 @@
 	});
 
 	function handleRebalance() {
-		alert("Rebalance mode coming in Session B");
+		onRebalance?.();
 	}
 </script>
 

--- a/frontends/wealth/src/lib/components/terminal/live/RebalanceFocusMode.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/RebalanceFocusMode.svelte
@@ -1,0 +1,771 @@
+<!--
+  RebalanceFocusMode — full-screen overlay for rebalance trade proposals.
+
+  Uses FocusMode primitive. Calls POST /rebalance/preview to get
+  SuggestedTrade[], displays in 2-column layout (trades + impact),
+  then executes via POST /execute-trades with optimistic lock.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatPercent, formatCurrency } from "@investintell/ui";
+	import { createClientApiClient } from "$lib/api/client";
+	import FocusMode from "$lib/components/terminal/focus-mode/FocusMode.svelte";
+	import TradeConfirmation from "./TradeConfirmation.svelte";
+
+	interface Props {
+		portfolioId: string;
+		portfolioName: string;
+		holdings: Array<{
+			instrument_id: string;
+			fund_name: string;
+			block_id: string;
+			weight: number;
+		}>;
+		holdingsVersion: number;
+		totalAum: number;
+		onClose: () => void;
+		onSuccess: () => void;
+	}
+
+	let {
+		portfolioId,
+		portfolioName,
+		holdings,
+		holdingsVersion,
+		totalAum,
+		onClose,
+		onSuccess,
+	}: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	// ---- State ----
+
+	interface SuggestedTrade {
+		instrument_id: string;
+		fund_name: string;
+		block_id: string;
+		action: "BUY" | "SELL" | "HOLD";
+		current_weight: number;
+		target_weight: number;
+		delta_weight: number;
+		current_value: number;
+		target_value: number;
+		trade_value: number;
+		estimated_quantity: number;
+	}
+
+	interface PreviewResponse {
+		portfolio_id: string;
+		portfolio_name: string;
+		profile: string;
+		total_aum: number;
+		cash_available: number;
+		total_trades: number;
+		estimated_turnover_pct: number;
+		trades: SuggestedTrade[];
+		weight_comparison: Array<{ block_id: string; current_weight: number; target_weight: number; delta: number }>;
+		cvar_95_projected: number | null;
+		cvar_limit: number | null;
+		cvar_warning: boolean;
+	}
+
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let preview = $state<PreviewResponse | null>(null);
+	let showConfirmation = $state(false);
+	let executing = $state(false);
+	let executionError = $state<string | null>(null);
+
+	// ---- Instrument ticker map ----
+
+	let instrumentMap = $state<Map<string, string>>(new Map());
+
+	$effect(() => {
+		let cancelled = false;
+		api.get<Array<{ instrument_id: string; ticker: string | null; name: string }>>(
+			"/instruments",
+		)
+			.then((instruments) => {
+				if (cancelled) return;
+				const m = new Map<string, string>();
+				for (const inst of instruments) {
+					if (inst.ticker) {
+						m.set(inst.instrument_id, inst.ticker);
+					}
+				}
+				instrumentMap = m;
+			})
+			.catch(() => {});
+		return () => { cancelled = true; };
+	});
+
+	function resolveTicker(instrumentId: string): string {
+		return instrumentMap.get(instrumentId) ?? instrumentId.slice(0, 8);
+	}
+
+	// ---- Fetch preview on mount ----
+
+	$effect(() => {
+		const _pid = portfolioId;
+		let cancelled = false;
+		loading = true;
+		error = null;
+
+		// Build current_holdings payload from actual holdings
+		const currentHoldings = holdings.map((h) => ({
+			instrument_id: h.instrument_id,
+			quantity: h.weight * totalAum,
+			current_price: 1.0,
+		}));
+
+		api.post<PreviewResponse>(
+			`/model-portfolios/${_pid}/rebalance/preview`,
+			{
+				total_aum: totalAum > 0 ? totalAum : undefined,
+				cash_available: 0,
+				current_holdings: currentHoldings,
+			},
+		)
+			.then((res) => {
+				if (!cancelled) {
+					preview = res;
+					loading = false;
+				}
+			})
+			.catch((err) => {
+				if (!cancelled) {
+					error = err instanceof Error ? err.message : "Failed to compute rebalance preview";
+					loading = false;
+				}
+			});
+
+		return () => { cancelled = true; };
+	});
+
+	// ---- Derived data ----
+
+	const sortedTrades = $derived.by(() => {
+		if (!preview) return [];
+		return [...preview.trades].sort(
+			(a, b) => Math.abs(b.delta_weight) - Math.abs(a.delta_weight),
+		);
+	});
+
+	const buys = $derived(sortedTrades.filter((t) => t.action === "BUY"));
+	const sells = $derived(sortedTrades.filter((t) => t.action === "SELL"));
+	const holds = $derived(sortedTrades.filter((t) => t.action === "HOLD"));
+
+	const totalBuyValue = $derived(
+		sortedTrades.filter((t) => t.action === "BUY").reduce((s, t) => s + t.trade_value, 0),
+	);
+	const totalSellValue = $derived(
+		sortedTrades.filter((t) => t.action === "SELL").reduce((s, t) => s + Math.abs(t.trade_value), 0),
+	);
+	const netFlow = $derived(totalBuyValue - totalSellValue);
+
+	const turnoverClass = $derived.by(() => {
+		if (!preview) return "";
+		if (preview.estimated_turnover_pct > 0.20) return "rfm-val--danger";
+		if (preview.estimated_turnover_pct > 0.10) return "rfm-val--warn";
+		return "";
+	});
+
+	// ---- Actions ----
+
+	function handleSubmitProposal() {
+		showConfirmation = true;
+	}
+
+	async function handleExecute() {
+		if (executing || !preview) return;
+		executing = true;
+		executionError = null;
+
+		const tickets = preview.trades
+			.filter((t) => t.action !== "HOLD")
+			.map((t) => ({
+				instrument_id: t.instrument_id,
+				action: t.action,
+				delta_weight: Math.abs(t.delta_weight),
+			}));
+
+		if (tickets.length === 0) {
+			executionError = "No trades to execute (all positions are HOLD).";
+			executing = false;
+			return;
+		}
+
+		try {
+			await api.post(`/model-portfolios/${portfolioId}/execute-trades`, {
+				tickets,
+				expected_version: holdingsVersion,
+			});
+			onSuccess();
+		} catch (err: unknown) {
+			if (err instanceof Error && err.name === "ConflictError") {
+				executionError = "Portfolio was modified by another user. Refresh and retry.";
+			} else {
+				executionError = err instanceof Error ? err.message : "Trade execution failed";
+			}
+		} finally {
+			executing = false;
+		}
+	}
+
+	function handleConfirmationClose() {
+		showConfirmation = false;
+	}
+</script>
+
+<FocusMode
+	entityKind="portfolio"
+	entityId={portfolioId}
+	entityLabel={portfolioName}
+	onClose={onClose}
+>
+	{#snippet reactor()}
+		<div class="rfm-content">
+			{#if loading}
+				<div class="rfm-loading">
+					<span class="rfm-loading-text">COMPUTING REBALANCE...</span>
+				</div>
+			{:else if error}
+				<div class="rfm-error">
+					<span class="rfm-error-label">ERROR</span>
+					<span class="rfm-error-msg">{error}</span>
+					<button type="button" class="rfm-retry" onclick={onClose}>CLOSE</button>
+				</div>
+			{:else if preview}
+				<div class="rfm-grid">
+					<!-- Left: Proposed Trades -->
+					<div class="rfm-trades-panel">
+						<div class="rfm-panel-header">
+							<span class="rfm-panel-title">PROPOSED TRADES</span>
+						</div>
+						<div class="rfm-trades-body">
+							<table class="rfm-table">
+								<thead>
+									<tr>
+										<th class="rfm-th rfm-th--name">Fund</th>
+										<th class="rfm-th rfm-th--ticker">Ticker</th>
+										<th class="rfm-th rfm-th--action">Action</th>
+										<th class="rfm-th rfm-th--num">Current</th>
+										<th class="rfm-th rfm-th--num">Target</th>
+										<th class="rfm-th rfm-th--num">Weight Change</th>
+										<th class="rfm-th rfm-th--num">Trade Value</th>
+									</tr>
+								</thead>
+								<tbody>
+									{#each sortedTrades as trade (trade.instrument_id)}
+										<tr class="rfm-row">
+											<td class="rfm-td rfm-td--name" title={trade.fund_name}>
+												{trade.fund_name}
+											</td>
+											<td class="rfm-td rfm-td--ticker">
+												{resolveTicker(trade.instrument_id)}
+											</td>
+											<td class="rfm-td rfm-td--action">
+												<span
+													class="rfm-badge"
+													class:rfm-badge--buy={trade.action === "BUY"}
+													class:rfm-badge--sell={trade.action === "SELL"}
+													class:rfm-badge--hold={trade.action === "HOLD"}
+												>
+													{trade.action}
+												</span>
+											</td>
+											<td class="rfm-td rfm-td--num">
+												{formatPercent(trade.current_weight, 1)}
+											</td>
+											<td class="rfm-td rfm-td--num">
+												{formatPercent(trade.target_weight, 1)}
+											</td>
+											<td
+												class="rfm-td rfm-td--num"
+												class:rfm-delta--pos={trade.delta_weight > 0}
+												class:rfm-delta--neg={trade.delta_weight < 0}
+											>
+												{trade.delta_weight > 0 ? "+" : ""}{formatPercent(trade.delta_weight, 2)}
+											</td>
+											<td class="rfm-td rfm-td--num">
+												{formatCurrency(Math.abs(trade.trade_value))}
+											</td>
+										</tr>
+									{/each}
+								</tbody>
+							</table>
+						</div>
+						<div class="rfm-trades-footer">
+							{sortedTrades.length} trades ({buys.length} BUY, {sells.length} SELL, {holds.length} HOLD)
+						</div>
+					</div>
+
+					<!-- Right: Impact Analysis -->
+					<div class="rfm-impact-panel">
+						<div class="rfm-panel-header">
+							<span class="rfm-panel-title">IMPACT ANALYSIS</span>
+						</div>
+						<div class="rfm-impact-body">
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Turnover</span>
+								<span class="rfm-metric-val {turnoverClass}">
+									{formatPercent(preview.estimated_turnover_pct, 1)}
+								</span>
+							</div>
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Tail Loss (95% confidence)</span>
+								<span class="rfm-metric-val">
+									{preview.cvar_95_projected != null
+										? formatPercent(preview.cvar_95_projected, 1)
+										: "\u2014"}
+								</span>
+							</div>
+							{#if preview.cvar_warning}
+								<div class="rfm-warning">
+									Risk limit approaching
+								</div>
+							{/if}
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Trades</span>
+								<span class="rfm-metric-val">{preview.total_trades}</span>
+							</div>
+
+							<div class="rfm-divider"></div>
+
+							<div class="rfm-section-label">TRADE VALUES</div>
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Total BUY</span>
+								<span class="rfm-metric-val rfm-val--success">
+									{formatCurrency(totalBuyValue)}
+								</span>
+							</div>
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Total SELL</span>
+								<span class="rfm-metric-val rfm-val--danger">
+									{formatCurrency(totalSellValue)}
+								</span>
+							</div>
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Net Flow</span>
+								<span
+									class="rfm-metric-val"
+									class:rfm-val--success={netFlow >= 0}
+									class:rfm-val--danger={netFlow < 0}
+								>
+									{formatCurrency(netFlow)}
+								</span>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- Confirmation bar -->
+				<div class="rfm-confirm-bar">
+					<div class="rfm-confirm-text">
+						This will generate trade orders for the active portfolio.
+						Execution is simulated &mdash; no real broker orders will be placed.
+					</div>
+
+					{#if executionError}
+						<div class="rfm-exec-error">{executionError}</div>
+					{/if}
+
+					<div class="rfm-confirm-actions">
+						<button type="button" class="rfm-btn rfm-btn--cancel" onclick={onClose}>
+							CANCEL
+						</button>
+						<button
+							type="button"
+							class="rfm-btn rfm-btn--submit"
+							onclick={handleSubmitProposal}
+							disabled={executing || sortedTrades.filter((t) => t.action !== "HOLD").length === 0}
+						>
+							SUBMIT PROPOSAL
+						</button>
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/snippet}
+</FocusMode>
+
+{#if showConfirmation && preview}
+	<TradeConfirmation
+		tradeCount={sortedTrades.filter((t) => t.action !== "HOLD").length}
+		buyCount={buys.length}
+		sellCount={sells.length}
+		turnoverPct={preview.estimated_turnover_pct}
+		{executing}
+		errorMessage={executionError}
+		onClose={handleConfirmationClose}
+		onConfirm={handleExecute}
+	/>
+{/if}
+
+<style>
+	.rfm-content {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		min-height: 0;
+		font-family: var(--terminal-font-mono);
+	}
+
+	/* Loading */
+	.rfm-loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex: 1;
+	}
+
+	.rfm-loading-text {
+		font-size: var(--terminal-text-14);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-accent-amber);
+		animation: rfm-pulse 1.4s ease-in-out infinite;
+	}
+
+	@keyframes rfm-pulse {
+		0%, 100% { opacity: 0.4; }
+		50% { opacity: 1; }
+	}
+
+	/* Error */
+	.rfm-error {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: var(--terminal-space-3);
+		flex: 1;
+	}
+
+	.rfm-error-label {
+		font-size: var(--terminal-text-12);
+		font-weight: 700;
+		color: var(--terminal-status-error);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rfm-error-msg {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		max-width: 500px;
+		text-align: center;
+	}
+
+	.rfm-retry {
+		appearance: none;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-primary);
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		cursor: pointer;
+	}
+
+	/* 2-column grid */
+	.rfm-grid {
+		display: grid;
+		grid-template-columns: 1fr 320px;
+		gap: 1px;
+		flex: 1;
+		min-height: 0;
+		background: var(--terminal-fg-muted);
+	}
+
+	/* Panel headers */
+	.rfm-panel-header {
+		display: flex;
+		align-items: center;
+		height: 32px;
+		padding: 0 var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+		flex-shrink: 0;
+	}
+
+	.rfm-panel-title {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	/* Trades panel */
+	.rfm-trades-panel {
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+	}
+
+	.rfm-trades-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.rfm-trades-footer {
+		flex-shrink: 0;
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border-top: var(--terminal-border-hairline);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	/* Table */
+	.rfm-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.rfm-th {
+		position: sticky;
+		top: 0;
+		z-index: 2;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		white-space: nowrap;
+	}
+
+	.rfm-th--name { text-align: left; }
+	.rfm-th--ticker { text-align: left; }
+	.rfm-th--action { text-align: center; }
+	.rfm-th--num { text-align: right; }
+
+	.rfm-td {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-secondary);
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		white-space: nowrap;
+	}
+
+	.rfm-td--name {
+		text-align: left;
+		font-size: var(--terminal-text-11);
+		font-weight: 500;
+		color: var(--terminal-fg-primary);
+		max-width: 220px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.rfm-td--ticker {
+		text-align: left;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rfm-td--action {
+		text-align: center;
+	}
+
+	.rfm-td--num {
+		text-align: right;
+	}
+
+	.rfm-row {
+		transition: background var(--terminal-motion-tick);
+	}
+
+	.rfm-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	/* Action badges */
+	.rfm-badge {
+		display: inline-block;
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		padding: 1px 6px;
+		text-transform: uppercase;
+	}
+
+	.rfm-badge--buy {
+		color: var(--terminal-bg-void);
+		background: var(--terminal-status-success);
+	}
+
+	.rfm-badge--sell {
+		color: var(--terminal-bg-void);
+		background: var(--terminal-status-error);
+	}
+
+	.rfm-badge--hold {
+		color: var(--terminal-fg-tertiary);
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	/* Delta colors */
+	.rfm-delta--pos {
+		color: var(--terminal-status-success);
+	}
+
+	.rfm-delta--neg {
+		color: var(--terminal-status-error);
+	}
+
+	/* Impact panel */
+	.rfm-impact-panel {
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+	}
+
+	.rfm-impact-body {
+		flex: 1;
+		padding: var(--terminal-space-3);
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-3);
+		overflow-y: auto;
+	}
+
+	.rfm-metric {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.rfm-metric-key {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rfm-metric-val {
+		font-size: var(--terminal-text-12);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.rfm-val--warn {
+		color: var(--terminal-status-warn);
+	}
+
+	.rfm-val--danger {
+		color: var(--terminal-status-error);
+	}
+
+	.rfm-val--success {
+		color: var(--terminal-status-success);
+	}
+
+	.rfm-warning {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-left: 2px solid var(--terminal-status-warn);
+		background: var(--terminal-bg-panel-raised);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-status-warn);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rfm-divider {
+		height: 1px;
+		background: var(--terminal-fg-muted);
+	}
+
+	.rfm-section-label {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-muted);
+		text-transform: uppercase;
+	}
+
+	/* Confirmation bar */
+	.rfm-confirm-bar {
+		flex-shrink: 0;
+		padding: var(--terminal-space-3) var(--terminal-space-4);
+		border-top: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+	}
+
+	.rfm-confirm-text {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		margin-bottom: var(--terminal-space-3);
+		line-height: 1.5;
+	}
+
+	.rfm-exec-error {
+		margin-bottom: var(--terminal-space-2);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-left: 2px solid var(--terminal-status-error);
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-status-error);
+		font-size: var(--terminal-text-11);
+	}
+
+	.rfm-confirm-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--terminal-space-2);
+	}
+
+	.rfm-btn {
+		appearance: none;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: var(--terminal-space-1) var(--terminal-space-4);
+		cursor: pointer;
+		transition:
+			background var(--terminal-motion-tick),
+			opacity var(--terminal-motion-tick);
+	}
+
+	.rfm-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.rfm-btn--cancel {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.rfm-btn--cancel:hover:not(:disabled) {
+		color: var(--terminal-fg-primary);
+	}
+
+	.rfm-btn--submit {
+		background: var(--terminal-accent-amber);
+		border: 1px solid var(--terminal-accent-amber);
+		color: var(--terminal-bg-void);
+	}
+
+	.rfm-btn--submit:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.rfm-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/live/TradeConfirmation.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/TradeConfirmation.svelte
@@ -1,0 +1,246 @@
+<!--
+  TradeConfirmation — simple confirmation dialog before trade execution.
+
+  Lighter than ConsequenceDialog (no typed ACTIVATE). ESC closes,
+  Enter confirms. Amber "Execute" button.
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+
+	interface Props {
+		tradeCount: number;
+		buyCount: number;
+		sellCount: number;
+		turnoverPct: number;
+		executing: boolean;
+		errorMessage: string | null;
+		onClose: () => void;
+		onConfirm: () => void;
+	}
+
+	let {
+		tradeCount,
+		buyCount,
+		sellCount,
+		turnoverPct,
+		executing,
+		errorMessage,
+		onClose,
+		onConfirm,
+	}: Props = $props();
+
+	let dialogEl: HTMLDivElement | undefined = $state();
+
+	// Auto-focus the dialog on mount
+	$effect(() => {
+		if (dialogEl) dialogEl.focus();
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === "Escape") {
+			e.preventDefault();
+			onClose();
+			return;
+		}
+		if (e.key === "Enter" && !executing) {
+			e.preventDefault();
+			onConfirm();
+			return;
+		}
+		// Focus trap
+		if (e.key === "Tab" && dialogEl) {
+			const focusable = dialogEl.querySelectorAll<HTMLElement>(
+				"button:not([disabled])",
+			);
+			if (focusable.length === 0) return;
+			const first = focusable[0] as HTMLElement | undefined;
+			const last = focusable[focusable.length - 1] as HTMLElement | undefined;
+			if (!first || !last) return;
+			if (e.shiftKey && document.activeElement === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && document.activeElement === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div
+	class="tc-overlay"
+	role="dialog"
+	aria-modal="true"
+	aria-label="Confirm trade execution"
+	onkeydown={handleKeydown}
+	bind:this={dialogEl}
+	tabindex="-1"
+>
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="tc-backdrop" onclick={onClose}></div>
+	<div class="tc-panel">
+		<h2 class="tc-title">Execute {tradeCount} trades?</h2>
+
+		<div class="tc-details">
+			<div class="tc-row">
+				<span class="tc-key">{buyCount} BUY orders, {sellCount} SELL orders</span>
+			</div>
+			<div class="tc-row">
+				<span class="tc-key">Estimated turnover:</span>
+				<span class="tc-val">{formatPercent(turnoverPct, 1)}</span>
+			</div>
+			<div class="tc-row">
+				<span class="tc-key">Execution:</span>
+				<span class="tc-val tc-val--muted">Simulated</span>
+			</div>
+		</div>
+
+		{#if errorMessage}
+			<div class="tc-error">{errorMessage}</div>
+		{/if}
+
+		<div class="tc-actions">
+			<button type="button" class="tc-btn tc-btn--cancel" onclick={onClose} disabled={executing}>
+				Cancel
+			</button>
+			<button
+				type="button"
+				class="tc-btn tc-btn--execute"
+				onclick={onConfirm}
+				disabled={executing}
+			>
+				{executing ? "Executing..." : "Execute"}
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.tc-overlay {
+		position: fixed;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: calc(var(--terminal-z-focusmode, 900) + 10);
+		outline: none;
+	}
+
+	.tc-backdrop {
+		position: absolute;
+		inset: 0;
+		background: var(--terminal-bg-void);
+		opacity: 0.85;
+	}
+
+	.tc-panel {
+		position: relative;
+		width: 400px;
+		max-width: 90vw;
+		padding: var(--terminal-space-6);
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-primary);
+	}
+
+	.tc-title {
+		font-size: 16px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		margin: 0 0 var(--terminal-space-4);
+		color: var(--terminal-accent-amber);
+	}
+
+	.tc-details {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		margin-bottom: var(--terminal-space-4);
+	}
+
+	.tc-row {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+
+	.tc-key {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.tc-val {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.tc-val--muted {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.tc-error {
+		margin-bottom: var(--terminal-space-3);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-left: 2px solid var(--terminal-status-error);
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-status-error);
+		font-size: var(--terminal-text-11);
+	}
+
+	.tc-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--terminal-space-2);
+	}
+
+	.tc-btn {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		border-radius: var(--terminal-radius-none);
+		cursor: pointer;
+		transition:
+			background var(--terminal-motion-tick),
+			opacity var(--terminal-motion-tick);
+	}
+
+	.tc-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.tc-btn--cancel {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.tc-btn--cancel:hover:not(:disabled) {
+		color: var(--terminal-fg-primary);
+	}
+
+	.tc-btn--execute {
+		background: var(--terminal-accent-amber);
+		border: 1px solid var(--terminal-accent-amber);
+		color: var(--terminal-bg-void);
+	}
+
+	.tc-btn--execute:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.tc-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+</style>

--- a/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
@@ -35,6 +35,7 @@
 	import NewsFeed from "$lib/components/terminal/live/NewsFeed.svelte";
 	import MacroRegimePanel from "$lib/components/terminal/live/MacroRegimePanel.svelte";
 	import TradeLog from "$lib/components/terminal/live/TradeLog.svelte";
+	import RebalanceFocusMode from "$lib/components/terminal/live/RebalanceFocusMode.svelte";
 	import TerminalPriceChart from "$lib/components/portfolio/live/charts/TerminalPriceChart.svelte";
 	import type { BarData, LiveTick } from "$lib/components/portfolio/live/charts/TerminalPriceChart.svelte";
 
@@ -130,6 +131,7 @@
 			block_id: string;
 			weight: number;
 		}>;
+		holdings_version: number;
 		last_rebalanced_at: string | null;
 	}
 
@@ -137,6 +139,7 @@
 
 	$effect(() => {
 		const pid = selected?.id;
+		const _refresh = refreshToken; // re-fetch when trades are executed
 		if (!pid) {
 			actualHoldingsData = null;
 			return;
@@ -375,6 +378,31 @@
 		return "offline" as const;
 	});
 
+	// ---- Refresh trigger (incremented after trade execution) ----
+
+	let refreshToken = $state(0);
+
+	// ---- Rebalance FocusMode (URL-driven) ----
+
+	const showRebalance = $derived(page.url.searchParams.get("rebalance") === "open");
+
+	function handleRebalanceOpen() {
+		const params = new URLSearchParams(page.url.searchParams);
+		params.set("rebalance", "open");
+		goto(resolve(`/portfolio/live?${params.toString()}`), { replaceState: true, noScroll: true, keepFocus: true });
+	}
+
+	function handleRebalanceClose() {
+		const params = new URLSearchParams(page.url.searchParams);
+		params.delete("rebalance");
+		goto(resolve(`/portfolio/live?${params.toString()}`), { replaceState: true, noScroll: true, keepFocus: true });
+	}
+
+	function handleRebalanceSuccess() {
+		handleRebalanceClose();
+		refreshToken++;
+	}
+
 	// ---- Portfolio summary data ----
 
 	const portfolioAum = $derived(marketStore.totalAum);
@@ -518,6 +546,7 @@
 						driftStatus={aggregateDrift}
 						{instrumentCount}
 						{lastRebalance}
+						onRebalance={handleRebalanceOpen}
 					/>
 				</div>
 
@@ -530,10 +559,24 @@
 				</div>
 
 				<div class="lw-tradelog">
-					<TradeLog portfolioId={selected?.id ?? null} />
+					{#key refreshToken}
+						<TradeLog portfolioId={selected?.id ?? null} />
+					{/key}
 				</div>
 			</div>
 		</div>
+
+		{#if showRebalance && selected}
+			<RebalanceFocusMode
+				portfolioId={selected.id}
+				portfolioName={selected.display_name ?? "Portfolio"}
+				holdings={actualHoldingsData?.holdings ?? []}
+				holdingsVersion={actualHoldingsData?.holdings_version ?? 1}
+				totalAum={portfolioAum}
+				onClose={handleRebalanceClose}
+				onSuccess={handleRebalanceSuccess}
+			/>
+		{/if}
 	{/if}
 
 	{#snippet failed(err: unknown, reset: () => void)}


### PR DESCRIPTION
## Summary
- RebalanceFocusMode (771L): full-screen overlay via FocusMode primitive, POST /rebalance/preview for trade proposals, BUY/SELL/HOLD badges, impact analysis (turnover, tail loss, risk warning)
- TradeConfirmation (246L): simple modal, POST /execute-trades with optimistic lock (expected_version), 409 conflict handling
- PortfolioSummary: REBALANCE button wired to URL state
- +page.svelte: ?rebalance=open URL state, refreshToken for post-execution re-fetch
- Backend: holdings_version added to ActualHoldingsResponse

## Test plan
- [ ] REBALANCE button opens FocusMode, URL shows ?rebalance=open
- [ ] Trade proposals table with sorted BUY/SELL/HOLD
- [ ] Impact panel shows turnover + tail loss + trade values
- [ ] Submit → confirm → execute-trades succeeds
- [ ] Post-execution: TradeLog + HoldingsTable refresh
- [ ] ESC closes, URL cleaned

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>