### PR TITLE
refactor(builder): terminal-ize CalibrationPanel family (H3)

### DIFF
--- a/frontends/wealth/src/lib/components/portfolio/CalibrationPanel.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/CalibrationPanel.svelte
@@ -24,18 +24,12 @@
 -->
 <script lang="ts">
 	import { workspace } from "$lib/state/portfolio-workspace.svelte";
-	import {
-		EmptyState,
-		Button,
-		formatNumber,
-		formatShortDate,
-	} from "@investintell/ui";
+	import { formatNumber, formatShortDate } from "@investintell/ui";
 	import {
 		taaRegimeLabel,
 		taaRegimePosture,
 		taaRegimeColor,
 	} from "$lib/types/taa";
-	import * as Tabs from "@investintell/ui/components/ui/tabs";
 	import type {
 		PortfolioCalibration,
 		PortfolioCalibrationUpdate,
@@ -273,24 +267,24 @@
 
 {#if !workspace.portfolio}
 	<div class="cp-empty">
-		<EmptyState
-			title="No portfolio selected"
-			message="Select a model portfolio on the left to edit its calibration."
-		/>
+		<div class="cp-empty-block">
+			<span class="cp-empty-title">NO PORTFOLIO SELECTED</span>
+			<span class="cp-empty-msg">Select a model portfolio on the left to edit its calibration.</span>
+		</div>
 	</div>
 {:else if loading && !draft}
 	<div class="cp-empty">
-		<EmptyState
-			title="Loading calibration…"
-			message="Fetching the 63-input surface from the backend."
-		/>
+		<div class="cp-empty-block">
+			<span class="cp-empty-title">LOADING CALIBRATION</span>
+			<span class="cp-empty-msg">Fetching the 63-input surface from the backend.</span>
+		</div>
 	</div>
 {:else if !draft}
 	<div class="cp-empty">
-		<EmptyState
-			title="Calibration unavailable"
-			message={workspace.lastError?.message ?? "Calibration could not be loaded for this portfolio."}
-		/>
+		<div class="cp-empty-block">
+			<span class="cp-empty-title">CALIBRATION UNAVAILABLE</span>
+			<span class="cp-empty-msg">{workspace.lastError?.message ?? "Calibration could not be loaded for this portfolio."}</span>
+		</div>
 	</div>
 {:else}
 	<div class="cp-root">
@@ -302,7 +296,7 @@
 					<span class="cp-regime-date">{formatShortDate(regimeBands!.as_of_date)}</span>
 				</div>
 				<div class="cp-regime-row">
-					<span class="cp-regime-badge" style="background: {regimeColor}; color: #0e0f13">
+					<span class="cp-regime-badge" style="background: {regimeColor}; color: var(--terminal-fg-inverted)">
 						{regimeLabel}
 					</span>
 					{#if stressLevel !== null}
@@ -318,16 +312,18 @@
 			</div>
 		{/if}
 
-		<Tabs.Root value={tier} onValueChange={(v) => (tier = v as typeof tier)}>
-			<Tabs.List class="cp-tabs">
-				<Tabs.Trigger value="basic">Basic</Tabs.Trigger>
-				<Tabs.Trigger value="advanced">Advanced</Tabs.Trigger>
-				<Tabs.Trigger value="expert">Expert</Tabs.Trigger>
-			</Tabs.List>
+		<div class="cp-tabs" role="tablist">
+			<button type="button" role="tab" class="cp-tab" class:cp-tab--active={tier === "basic"}
+				aria-selected={tier === "basic"} onclick={() => (tier = "basic")}>BASIC</button>
+			<button type="button" role="tab" class="cp-tab" class:cp-tab--active={tier === "advanced"}
+				aria-selected={tier === "advanced"} onclick={() => (tier = "advanced")}>ADVANCED</button>
+			<button type="button" role="tab" class="cp-tab" class:cp-tab--active={tier === "expert"}
+				aria-selected={tier === "expert"} onclick={() => (tier = "expert")}>EXPERT</button>
+		</div>
 
+		{#if tier === "basic"}
 			<!-- ── Basic tier (5 fields) ───────────────────────────── -->
-			<Tabs.Content value="basic">
-				<section class="cp-section">
+			<section class="cp-section" role="tabpanel">
 					<CalibrationSelectField
 						id="cp-mandate"
 						label="Mandate"
@@ -386,11 +382,9 @@
 						options={STRESS_OPTIONS}
 					/>
 				</section>
-			</Tabs.Content>
-
+		{:else if tier === "advanced"}
 			<!-- ── Advanced tier (10 fields) ───────────────────────── -->
-			<Tabs.Content value="advanced">
-				<section class="cp-section">
+			<section class="cp-section" role="tabpanel">
 					<CalibrationSelectField
 						id="cp-regime-override"
 						label="Regime override"
@@ -504,11 +498,9 @@
 						digits={2}
 					/>
 				</section>
-			</Tabs.Content>
-
+		{:else if tier === "expert"}
 			<!-- ── Expert tier (arbitrary JSONB overrides) ─────────── -->
-			<Tabs.Content value="expert">
-				<section class="cp-section">
+			<section class="cp-section" role="tabpanel">
 					<p class="cp-expert-hint">
 						Expert overrides are free-form key/value pairs stored in
 						<code>expert_overrides</code> JSONB. Use only for optimizer knobs
@@ -549,18 +541,17 @@
 							placeholder="value (number / true / false / text)"
 							bind:value={newExpertValue}
 						/>
-						<Button
-							variant="outline"
-							size="sm"
+						<button
+							type="button"
+							class="cp-expert-add-btn"
 							onclick={addExpertKey}
 							disabled={!newExpertKey.trim()}
 						>
-							Add
-						</Button>
+							ADD
+						</button>
 					</div>
-				</section>
-			</Tabs.Content>
-		</Tabs.Root>
+			</section>
+		{/if}
 
 		<!-- ── Preview + Apply row (DL5) ───────────────────────── -->
 		<footer class="cp-footer">
@@ -581,30 +572,15 @@
 				{/if}
 			</div>
 			<div class="cp-footer-actions">
-				<Button
-					variant="ghost"
-					size="sm"
+				<button type="button" class="cp-action cp-action--ghost"
 					disabled={!dirty || applying || isPreviewing}
-					onclick={handleReset}
-				>
-					Reset
-				</Button>
-				<Button
-					variant="outline"
-					size="sm"
+					onclick={handleReset}>RESET</button>
+				<button type="button" class="cp-action cp-action--outline"
 					disabled={!dirty || applying || isPreviewing}
-					onclick={schedulePreview}
-				>
-					Preview
-				</Button>
-				<Button
-					variant="default"
-					size="sm"
+					onclick={schedulePreview}>PREVIEW</button>
+				<button type="button" class="cp-action cp-action--primary"
 					disabled={!dirty || applying || isPreviewing}
-					onclick={handleApply}
-				>
-					Apply
-				</Button>
+					onclick={handleApply}>APPLY</button>
 			</div>
 		</footer>
 	</div>
@@ -616,14 +592,14 @@
 		flex-direction: column;
 		height: 100%;
 		min-height: 0;
-		background: #141519;
-		font-family: "Urbanist", system-ui, sans-serif;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
 	}
 
 	/* ── Market Conditions regime indicator (TAA Sprint 4) ── */
 	.cp-regime-strip {
 		padding: 12px 16px;
-		border-bottom: 1px solid var(--ii-border-subtle, rgba(64, 66, 73, 0.4));
+		border-bottom: var(--terminal-border-hairline);
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
@@ -635,16 +611,16 @@
 		align-items: center;
 	}
 	.cp-regime-kicker {
-		font-size: 0.625rem;
+		font-size: var(--terminal-text-10);
 		font-weight: 700;
 		text-transform: uppercase;
-		letter-spacing: 0.06em;
-		color: var(--ii-text-muted, #85a0bd);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-muted);
 	}
 	.cp-regime-date {
-		font-size: 0.625rem;
+		font-size: var(--terminal-text-10);
 		font-weight: 500;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 		font-variant-numeric: tabular-nums;
 	}
 	.cp-regime-row {
@@ -655,40 +631,97 @@
 	.cp-regime-badge {
 		display: inline-flex;
 		align-items: center;
-		padding: 3px 12px;
-		border-radius: 999px;
-		font-size: 0.75rem;
+		padding: 1px 6px;
+		font-size: var(--terminal-text-10);
 		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
 		white-space: nowrap;
-		letter-spacing: 0.02em;
 	}
 	.cp-stress-bar-track {
 		flex: 1;
-		height: 6px;
-		border-radius: 3px;
-		background: rgba(255, 255, 255, 0.06);
+		height: 4px;
+		background: var(--terminal-fg-muted);
 		overflow: hidden;
 	}
 	.cp-stress-bar-fill {
 		height: 100%;
-		border-radius: 3px;
-		transition: width 400ms ease;
+		transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
 	}
 	.cp-regime-posture {
 		margin: 0;
-		font-size: 0.6875rem;
+		font-size: var(--terminal-text-11);
 		line-height: 1.4;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 	}
 	.cp-empty {
-		padding: 24px;
-	}
-	:global(.cp-tabs) {
 		display: flex;
-		gap: 6px;
-		padding: 16px 16px 0;
-		flex-shrink: 0;
+		align-items: center;
+		justify-content: center;
+		padding: var(--terminal-space-6);
+		height: 100%;
+		font-family: var(--terminal-font-mono);
+		background: var(--terminal-bg-panel);
 	}
+	.cp-empty-block {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+	.cp-empty-title {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+	}
+	.cp-empty-msg {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		text-align: center;
+		max-width: 280px;
+		line-height: var(--terminal-leading-normal);
+	}
+
+	.cp-tabs {
+		display: flex;
+		align-items: stretch;
+		height: 32px;
+		padding: 0;
+		flex-shrink: 0;
+		border-bottom: var(--terminal-border-hairline);
+	}
+	.cp-tab {
+		display: inline-flex;
+		align-items: center;
+		padding: 0 var(--terminal-space-3);
+		background: transparent;
+		border: none;
+		border-bottom: 2px solid transparent;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		cursor: pointer;
+		transition:
+			color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.cp-tab:hover {
+		color: var(--terminal-accent-amber);
+	}
+	.cp-tab--active {
+		color: var(--terminal-accent-amber);
+		border-bottom-color: var(--terminal-accent-amber);
+	}
+	.cp-tab:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -2px;
+	}
+
 	.cp-section {
 		display: flex;
 		flex-direction: column;
@@ -703,17 +736,16 @@
 		margin: 0;
 		font-size: 11px;
 		line-height: 1.5;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 	}
 	.cp-expert-hint code {
-		background: rgba(255, 255, 255, 0.06);
+		background: var(--terminal-bg-panel-raised);
 		padding: 1px 5px;
-		border-radius: 4px;
 		font-size: 10px;
 	}
 	.cp-expert-empty {
 		font-size: 12px;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 		font-style: italic;
 		margin: 0;
 	}
@@ -731,20 +763,19 @@
 		align-items: center;
 		gap: 8px;
 		padding: 6px 8px;
-		background: rgba(255, 255, 255, 0.02);
-		border-radius: 6px;
+		background: var(--terminal-bg-panel-sunken);
 	}
 	.cp-expert-key {
 		font-size: 12px;
 		font-weight: 600;
-		color: var(--ii-text-primary, #ffffff);
+		color: var(--terminal-fg-primary);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
 	.cp-expert-value {
 		font-size: 12px;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 		font-variant-numeric: tabular-nums;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -755,36 +786,55 @@
 		height: 20px;
 		border: none;
 		background: transparent;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 		cursor: pointer;
 		font-size: 14px;
 		line-height: 1;
-		border-radius: 4px;
 	}
 	.cp-expert-remove:hover {
-		background: rgba(255, 255, 255, 0.06);
-		color: var(--ii-danger, #fc1a1a);
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-status-error);
 	}
 	.cp-expert-add {
 		display: grid;
 		grid-template-columns: 1fr 1fr auto;
 		gap: 8px;
 		padding-top: 8px;
-		border-top: 1px solid var(--ii-border-subtle, rgba(64, 66, 73, 0.4));
+		border-top: var(--terminal-border-hairline);
 	}
 	.cp-expert-input {
 		height: 30px;
 		padding: 0 8px;
 		font-size: 12px;
-		border: 1px solid var(--ii-border-subtle, rgba(64, 66, 73, 0.6));
-		border-radius: 6px;
+		border: var(--terminal-border-hairline);
 		background: transparent;
-		color: var(--ii-text-primary, #ffffff);
+		color: var(--terminal-fg-primary);
 		font-family: inherit;
 	}
 	.cp-expert-input:focus {
 		outline: none;
-		border-color: var(--ii-primary, #0177fb);
+		border-color: var(--terminal-accent-amber);
+	}
+	.cp-expert-add-btn {
+		height: 28px;
+		padding: 0 var(--terminal-space-3);
+		background: transparent;
+		color: var(--terminal-fg-secondary);
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+	.cp-expert-add-btn:hover:not(:disabled) {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+	.cp-expert-add-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
 	}
 
 	/* Footer ── */
@@ -794,8 +844,8 @@
 		flex-direction: column;
 		gap: 10px;
 		padding: 12px 16px;
-		border-top: 1px solid var(--ii-border-subtle, rgba(64, 66, 73, 0.4));
-		background: #141519;
+		border-top: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
 	}
 	.cp-footer-status {
 		display: flex;
@@ -808,20 +858,66 @@
 		font-weight: 600;
 	}
 	.cp-status--clean {
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 	}
 	.cp-status--dirty {
-		color: var(--ii-warning, #f0a020);
+		color: var(--terminal-status-warn);
 	}
 	.cp-status--pending {
-		color: var(--ii-primary, #0177fb);
+		color: var(--terminal-accent-cyan);
 	}
 	.cp-status--error {
-		color: var(--ii-danger, #fc1a1a);
+		color: var(--terminal-status-error);
 	}
 	.cp-footer-actions {
 		display: flex;
 		justify-content: flex-end;
 		gap: 8px;
+	}
+	.cp-action {
+		height: 28px;
+		padding: 0 var(--terminal-space-3);
+		border: none;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		transition:
+			background var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			opacity var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.cp-action:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+	.cp-action:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+	.cp-action--ghost {
+		background: transparent;
+		color: var(--terminal-fg-tertiary);
+	}
+	.cp-action--ghost:hover:not(:disabled) {
+		color: var(--terminal-fg-primary);
+	}
+	.cp-action--outline {
+		background: transparent;
+		color: var(--terminal-fg-secondary);
+		border: var(--terminal-border-hairline);
+	}
+	.cp-action--outline:hover:not(:disabled) {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+	.cp-action--primary {
+		background: var(--terminal-accent-amber);
+		color: var(--terminal-fg-inverted);
+	}
+	.cp-action--primary:hover:not(:disabled) {
+		opacity: 0.9;
 	}
 </style>

--- a/frontends/wealth/src/lib/components/portfolio/CalibrationScenarioGroup.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/CalibrationScenarioGroup.svelte
@@ -75,7 +75,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
-		font-family: "Urbanist", system-ui, sans-serif;
+		font-family: var(--terminal-font-mono);
 	}
 	.csg-root--disabled {
 		opacity: 0.55;
@@ -90,18 +90,18 @@
 	.csg-label {
 		font-size: 13px;
 		font-weight: 600;
-		color: var(--ii-text-primary, #ffffff);
+		color: var(--terminal-fg-primary);
 	}
 	.csg-count {
 		font-size: 11px;
 		font-weight: 700;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 		font-variant-numeric: tabular-nums;
 	}
 	.csg-description {
 		margin: 0;
 		font-size: 11px;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 		line-height: 1.4;
 	}
 
@@ -115,11 +115,10 @@
 		align-items: center;
 		gap: 8px;
 		padding: 8px 10px;
-		border: 1px solid var(--ii-border-subtle, rgba(64, 66, 73, 0.6));
-		border-radius: 8px;
+		border: var(--terminal-border-hairline);
 		background: transparent;
 		cursor: pointer;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 		font-family: inherit;
 		font-size: 12px;
 		font-weight: 500;
@@ -127,13 +126,13 @@
 		transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
 	}
 	.csg-chip:hover:not(:disabled) {
-		background: rgba(255, 255, 255, 0.03);
-		color: var(--ii-text-primary, #ffffff);
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-fg-primary);
 	}
 	.csg-chip--on {
-		background: rgba(1, 119, 251, 0.08);
-		border-color: var(--ii-primary, #0177fb);
-		color: var(--ii-text-primary, #ffffff);
+		background: color-mix(in srgb, var(--terminal-accent-amber) 10%, transparent);
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-fg-primary);
 	}
 	.csg-chip-box {
 		display: inline-flex;
@@ -141,18 +140,17 @@
 		justify-content: center;
 		width: 16px;
 		height: 16px;
-		border-radius: 4px;
-		border: 1px solid rgba(255, 255, 255, 0.28);
+		border: 1px solid var(--terminal-fg-tertiary);
 		flex-shrink: 0;
 	}
 	.csg-chip--on .csg-chip-box {
-		background: var(--ii-primary, #0177fb);
-		border-color: var(--ii-primary, #0177fb);
+		background: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
 	}
 	.csg-chip-tick {
 		font-size: 11px;
 		font-weight: 700;
-		color: #ffffff;
+		color: var(--terminal-fg-inverted);
 		line-height: 1;
 	}
 	.csg-chip-label {

--- a/frontends/wealth/src/lib/components/portfolio/CalibrationSelectField.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/CalibrationSelectField.svelte
@@ -8,8 +8,6 @@
   touching internal state.
 -->
 <script lang="ts">
-	import { Select } from "@investintell/ui";
-
 	interface Option {
 		value: string;
 		label: string;
@@ -46,13 +44,17 @@
 		<p class="csf-description">{description}</p>
 	{/if}
 	<div class="csf-control">
-		<Select
-			{value}
-			onValueChange={onChange}
-			options={[...options]}
-			{placeholder}
+		<select
+			{id}
+			class="csf-select"
 			{disabled}
-		/>
+			value={value}
+			onchange={(e) => onChange((e.currentTarget as HTMLSelectElement).value)}
+		>
+			{#each options as opt (opt.value)}
+				<option value={opt.value}>{opt.label}</option>
+			{/each}
+		</select>
 	</div>
 </div>
 
@@ -61,7 +63,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
-		font-family: "Urbanist", system-ui, sans-serif;
+		font-family: var(--terminal-font-mono);
 	}
 	.csf-root--disabled {
 		opacity: 0.55;
@@ -75,15 +77,35 @@
 	.csf-label {
 		font-size: 13px;
 		font-weight: 600;
-		color: var(--ii-text-primary, #ffffff);
+		color: var(--terminal-fg-primary);
 	}
 	.csf-description {
 		margin: 0;
 		font-size: 11px;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 		line-height: 1.4;
 	}
 	.csf-control {
 		width: 100%;
+	}
+	.csf-select {
+		width: 100%;
+		height: 28px;
+		background: var(--terminal-bg-panel-sunken);
+		color: var(--terminal-fg-primary);
+		border: var(--terminal-border-hairline);
+		border-radius: 0;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		padding: 0 var(--terminal-space-2);
+		cursor: pointer;
+	}
+	.csf-select:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+	.csf-select:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
 	}
 </style>

--- a/frontends/wealth/src/lib/components/portfolio/CalibrationSliderField.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/CalibrationSliderField.svelte
@@ -130,7 +130,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
-		font-family: "Urbanist", system-ui, sans-serif;
+		font-family: var(--terminal-font-mono);
 	}
 	.csf-root--disabled {
 		opacity: 0.55;
@@ -145,25 +145,25 @@
 	.csf-label {
 		font-size: 13px;
 		font-weight: 600;
-		color: var(--ii-text-primary, #ffffff);
+		color: var(--terminal-fg-primary);
 	}
 	.csf-value {
 		font-size: 13px;
 		font-weight: 700;
 		font-variant-numeric: tabular-nums;
-		color: var(--ii-primary, #0177fb);
+		color: var(--terminal-accent-amber);
 	}
 	.csf-value[data-accent="danger"] {
-		color: var(--ii-danger, #fc1a1a);
+		color: var(--terminal-status-error);
 	}
 	.csf-value[data-accent="success"] {
-		color: var(--ii-success, #3fb950);
+		color: var(--terminal-status-success);
 	}
 
 	.csf-description {
 		margin: 0;
 		font-size: 11px;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 		line-height: 1.4;
 	}
 
@@ -183,8 +183,7 @@
 	.csf-slider::-webkit-slider-runnable-track {
 		width: 100%;
 		height: 4px;
-		background: rgba(64, 66, 73, 0.6);
-		border-radius: 999px;
+		background: var(--terminal-fg-muted);
 	}
 	.csf-slider::-webkit-slider-thumb {
 		-webkit-appearance: none;
@@ -192,8 +191,8 @@
 		height: 16px;
 		width: 16px;
 		border-radius: 50%;
-		background: #1a1b20;
-		border: 2px solid var(--ii-primary, #0177fb);
+		background: var(--terminal-bg-panel);
+		border: 2px solid var(--terminal-accent-amber);
 		margin-top: -6px;
 		cursor: pointer;
 		transition: transform 120ms ease, box-shadow 120ms ease;
@@ -205,20 +204,19 @@
 		outline: none;
 	}
 	.csf-slider:focus::-webkit-slider-thumb {
-		box-shadow: 0 0 0 4px rgba(1, 119, 251, 0.2);
+		box-shadow: 0 0 0 4px color-mix(in srgb, var(--terminal-accent-amber) 25%, transparent);
 	}
 	.csf-slider::-moz-range-track {
 		width: 100%;
 		height: 4px;
-		background: rgba(64, 66, 73, 0.6);
-		border-radius: 999px;
+		background: var(--terminal-fg-muted);
 	}
 	.csf-slider::-moz-range-thumb {
 		height: 16px;
 		width: 16px;
 		border-radius: 50%;
-		background: #1a1b20;
-		border: 2px solid var(--ii-primary, #0177fb);
+		background: var(--terminal-bg-panel);
+		border: 2px solid var(--terminal-accent-amber);
 		cursor: pointer;
 	}
 
@@ -228,16 +226,16 @@
 		font-size: 12px;
 		font-weight: 600;
 		font-variant-numeric: tabular-nums;
-		border: 1px solid var(--ii-border-subtle, rgba(64, 66, 73, 0.6));
-		border-radius: 6px;
+		border: var(--terminal-border-hairline);
+		border-radius: 0;
 		background: transparent;
-		color: var(--ii-text-primary, #ffffff);
+		color: var(--terminal-fg-primary);
 		text-align: right;
 		font-family: inherit;
 	}
 	.csf-number:focus {
 		outline: none;
-		border-color: var(--ii-primary, #0177fb);
+		border-color: var(--terminal-accent-amber);
 	}
 	.csf-number::-webkit-outer-spin-button,
 	.csf-number::-webkit-inner-spin-button {
@@ -254,6 +252,6 @@
 		justify-content: space-between;
 		font-size: 10px;
 		font-weight: 500;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 	}
 </style>

--- a/frontends/wealth/src/lib/components/portfolio/CalibrationToggleField.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/CalibrationToggleField.svelte
@@ -53,7 +53,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 6px;
-		font-family: "Urbanist", system-ui, sans-serif;
+		font-family: var(--terminal-font-mono);
 	}
 	.ctf-root--disabled {
 		opacity: 0.55;
@@ -68,12 +68,12 @@
 	.ctf-label {
 		font-size: 13px;
 		font-weight: 600;
-		color: var(--ii-text-primary, #ffffff);
+		color: var(--terminal-fg-primary);
 	}
 	.ctf-description {
 		margin: 0;
 		font-size: 11px;
-		color: var(--ii-text-muted, #85a0bd);
+		color: var(--terminal-fg-muted);
 		line-height: 1.4;
 	}
 
@@ -93,7 +93,7 @@
 	.ctf-slider {
 		position: absolute;
 		inset: 0;
-		background: rgba(64, 66, 73, 0.7);
+		background: var(--terminal-fg-muted);
 		border-radius: 999px;
 		transition: background 140ms ease;
 	}
@@ -104,17 +104,17 @@
 		top: 2px;
 		width: 16px;
 		height: 16px;
-		background: #ffffff;
+		background: var(--terminal-fg-primary);
 		border-radius: 999px;
 		transition: transform 140ms ease;
 	}
 	.ctf-switch input:checked + .ctf-slider {
-		background: var(--ii-primary, #0177fb);
+		background: var(--terminal-accent-amber);
 	}
 	.ctf-switch input:checked + .ctf-slider::before {
 		transform: translateX(16px);
 	}
 	.ctf-switch input:focus-visible + .ctf-slider {
-		box-shadow: 0 0 0 3px rgba(1, 119, 251, 0.25);
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--terminal-accent-amber) 25%, transparent);
 	}
 </style>

--- a/frontends/wealth/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte
@@ -14,6 +14,10 @@
 -->
 <script lang="ts">
 	import { onMount } from "svelte";
+	import {
+		createTerminalLightweightChartOptions,
+		terminalLWSeriesColors,
+	} from "@investintell/ui";
 
 	// ── Types ─────────────────────────────────────────────────
 	export interface BarData {
@@ -71,62 +75,26 @@
 			const lc = await import("lightweight-charts");
 			if (disposed || !containerEl) return;
 
-			const c = lc.createChart(containerEl, {
-				autoSize: true,
-				layout: {
-					background: { color: "transparent" },
-					textColor: "#5a6577",
-					fontFamily: "'JetBrains Mono', 'SF Mono', monospace",
-					fontSize: 10,
-				},
-				grid: {
-					vertLines: { color: "rgba(255, 255, 255, 0.04)" },
-					horzLines: { color: "rgba(255, 255, 255, 0.04)" },
-				},
-				crosshair: {
-					vertLine: {
-						color: "rgba(45, 126, 247, 0.3)",
-						labelBackgroundColor: "#2d7ef7",
-					},
-					horzLine: {
-						color: "rgba(45, 126, 247, 0.3)",
-						labelBackgroundColor: "#2d7ef7",
-					},
-				},
-				rightPriceScale: {
-					mode: lc.PriceScaleMode.Percentage,
-					borderVisible: false,
-					scaleMargins: { top: 0.08, bottom: 0.08 },
-				},
-				timeScale: {
-					borderColor: "rgba(255, 255, 255, 0.08)",
-					timeVisible: true,
-					secondsVisible: false,
-					rightOffset: 5,
-				},
-				handleScroll: true,
-				handleScale: true,
+			const opts = createTerminalLightweightChartOptions({
+				timeVisible: true,
+				priceScaleMode: lc.PriceScaleMode.Percentage,
 			});
+			const c = lc.createChart(containerEl, { autoSize: true, ...opts });
 
-			// Series 1: Instrument (baseline — blue/red)
+			// Series 1: Instrument (baseline — cyan/red)
+			const sc = terminalLWSeriesColors();
 			const s = c.addSeries(lc.BaselineSeries, {
 				baseValue: { type: "price", price: 0 },
-				topLineColor: "#2d7ef7",
-				topFillColor1: "rgba(45, 126, 247, 0.10)",
-				topFillColor2: "rgba(45, 126, 247, 0.01)",
-				bottomLineColor: "#e74c3c",
-				bottomFillColor1: "rgba(231, 76, 60, 0.01)",
-				bottomFillColor2: "rgba(231, 76, 60, 0.06)",
+				...sc.baseline,
 				lineWidth: 2,
 				priceLineVisible: true,
-				priceLineColor: "rgba(45, 126, 247, 0.4)",
 				lastValueVisible: true,
 				title: "",
 			});
 
-			// Series 2: Portfolio NAV (gold line)
+			// Series 2: Portfolio NAV (amber line)
 			const nav = c.addSeries(lc.LineSeries, {
-				color: "#fbbf24",
+				...sc.navOverlay,
 				lineWidth: 2,
 				title: "NAV",
 				crosshairMarkerVisible: true,
@@ -266,7 +234,7 @@
 		flex-shrink: 0;
 		height: 32px;
 		padding: 0 10px;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+		border-bottom: var(--terminal-border-hairline);
 		position: relative;
 		z-index: 10;
 	}
@@ -278,29 +246,29 @@
 	}
 
 	.tpc-ticker {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
-		font-size: 11px;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
 		font-weight: 700;
-		letter-spacing: 0.06em;
-		color: #c8d0dc;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-secondary);
 	}
 
 	.tpc-status-badge {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 8px;
 		font-weight: 800;
 		letter-spacing: 0.08em;
 		padding: 1px 5px;
 	}
 	.tpc-status-delayed {
-		color: #f59e0b;
-		background: rgba(245, 158, 11, 0.12);
-		border: 1px solid rgba(245, 158, 11, 0.25);
+		color: var(--terminal-status-warn);
+		background: color-mix(in srgb, var(--terminal-status-warn) 12%, transparent);
+		border: 1px solid color-mix(in srgb, var(--terminal-status-warn) 25%, transparent);
 	}
 	.tpc-status-offline {
-		color: #ef4444;
-		background: rgba(239, 68, 68, 0.12);
-		border: 1px solid rgba(239, 68, 68, 0.25);
+		color: var(--terminal-status-error);
+		background: color-mix(in srgb, var(--terminal-status-error) 12%, transparent);
+		border: 1px solid color-mix(in srgb, var(--terminal-status-error) 25%, transparent);
 	}
 
 	/* ── Right controls (toggle + timeframes) ────────────────── */
@@ -317,27 +285,27 @@
 		align-items: center;
 		gap: 4px;
 		padding: 3px 8px;
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 9px;
 		font-weight: 700;
 		letter-spacing: 0.04em;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 		background: transparent;
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		border: var(--terminal-border-hairline);
 		cursor: pointer;
 		transition: color 80ms, background 80ms, border-color 80ms;
 	}
 	.tpc-nav-toggle:hover {
-		color: #fbbf24;
-		border-color: rgba(251, 191, 36, 0.2);
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber-dim);
 	}
 	.tpc-nav-toggle--active {
-		color: #fbbf24;
-		background: rgba(251, 191, 36, 0.08);
-		border-color: rgba(251, 191, 36, 0.25);
+		color: var(--terminal-accent-amber);
+		background: color-mix(in srgb, var(--terminal-accent-amber) 8%, transparent);
+		border-color: var(--terminal-accent-amber-dim);
 	}
 	.tpc-nav-toggle:focus-visible {
-		outline: 2px solid #fbbf24;
+		outline: var(--terminal-border-focus);
 		outline-offset: 1px;
 	}
 	.tpc-nav-check {
@@ -349,7 +317,7 @@
 	/* ── Separator between toggle and timeframes ─────────────── */
 	.tpc-right-controls .tpc-timeframes {
 		padding-left: 8px;
-		border-left: 1px solid rgba(255, 255, 255, 0.06);
+		border-left: var(--terminal-border-hairline);
 	}
 
 	.tpc-timeframes {
@@ -360,27 +328,27 @@
 	.tpc-tf-btn {
 		appearance: none;
 		padding: 3px 8px;
-		font-family: "JetBrains Mono", "SF Mono", monospace;
-		font-size: 10px;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
 		font-weight: 600;
 		letter-spacing: 0.04em;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 		background: transparent;
 		border: 1px solid transparent;
 		cursor: pointer;
 		transition: color 80ms, background 80ms, border-color 80ms;
 	}
 	.tpc-tf-btn:hover {
-		color: #c8d0dc;
-		background: rgba(255, 255, 255, 0.04);
+		color: var(--terminal-fg-secondary);
+		background: var(--terminal-bg-panel-raised);
 	}
 	.tpc-tf-active {
-		color: #2d7ef7;
-		border-color: rgba(45, 126, 247, 0.3);
-		background: rgba(45, 126, 247, 0.08);
+		color: var(--terminal-accent-cyan);
+		border-color: var(--terminal-accent-cyan-dim);
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 8%, transparent);
 	}
 	.tpc-tf-btn:focus-visible {
-		outline: 2px solid #2d7ef7;
+		outline: 2px solid var(--terminal-accent-cyan);
 		outline-offset: 1px;
 	}
 

--- a/frontends/wealth/src/lib/components/research/terminal/TerminalResearchChart.svelte
+++ b/frontends/wealth/src/lib/components/research/terminal/TerminalResearchChart.svelte
@@ -15,6 +15,10 @@
 -->
 <script lang="ts">
 	import { formatNumber } from "@investintell/ui";
+	import {
+		createTerminalLightweightChartOptions,
+		terminalLWSeriesColors,
+	} from "@investintell/ui";
 	import { getContext, onMount } from "svelte";
 	import type { UTCTimestamp } from "lightweight-charts";
 	import {
@@ -115,42 +119,17 @@
 			}
 			charts = [];
 
-			const baseLayout = {
-				background: { color: "transparent" },
-				textColor: "#5a6577",
-				fontFamily: "'JetBrains Mono', 'SF Mono', monospace",
-				fontSize: 9,
-			};
-			const baseGrid = {
-				vertLines: { color: "rgba(255, 255, 255, 0.03)" },
-				horzLines: { color: "rgba(255, 255, 255, 0.03)" },
-			};
-			const baseTimeScale = {
-				borderColor: "rgba(255, 255, 255, 0.06)",
-				timeVisible: false,
-				secondsVisible: false,
-			};
+			const sc = terminalLWSeriesColors();
 
 			// ── Pane 1: Drawdown (baseline red) ─────────────
-			const ddChart = lc.createChart(dd, {
-				autoSize: true,
-				layout: baseLayout,
-				grid: baseGrid,
-				rightPriceScale: { borderVisible: false, scaleMargins: { top: 0.08, bottom: 0.08 } },
-				timeScale: baseTimeScale,
-				crosshair: {
-					vertLine: { color: "rgba(239, 68, 68, 0.3)" },
-					horzLine: { color: "rgba(239, 68, 68, 0.3)" },
-				},
+			const ddOpts = createTerminalLightweightChartOptions({
+				fontSize: 9,
+				crosshairColor: sc.drawdown.bottomLineColor,
 			});
+			const ddChart = lc.createChart(dd, { autoSize: true, ...ddOpts });
 			const ddSeries = ddChart.addSeries(lc.BaselineSeries, {
 				baseValue: { type: "price", price: 0 },
-				topLineColor: "rgba(34, 197, 94, 0.0)",
-				topFillColor1: "rgba(34, 197, 94, 0.00)",
-				topFillColor2: "rgba(34, 197, 94, 0.00)",
-				bottomLineColor: "#ef4444",
-				bottomFillColor1: "rgba(239, 68, 68, 0.20)",
-				bottomFillColor2: "rgba(239, 68, 68, 0.02)",
+				...sc.drawdown,
 				lineWidth: 2,
 				priceLineVisible: false,
 				lastValueVisible: true,
@@ -159,20 +138,15 @@
 			ddSeries.setData(data.drawdown.map((p) => ({ time: p.time as unknown as UTCTimestamp, value: p.value })));
 			ddChart.timeScale().fitContent();
 
-			// ── Pane 2: GARCH Volatility (purple line) ──────
-			const vlChart = lc.createChart(vl, {
-				autoSize: true,
-				layout: baseLayout,
-				grid: baseGrid,
-				rightPriceScale: { borderVisible: false, scaleMargins: { top: 0.15, bottom: 0.1 } },
-				timeScale: baseTimeScale,
-				crosshair: {
-					vertLine: { color: "rgba(139, 92, 246, 0.3)" },
-					horzLine: { color: "rgba(139, 92, 246, 0.3)" },
-				},
+			// ── Pane 2: GARCH Volatility (violet line) ──────
+			const vlOpts = createTerminalLightweightChartOptions({
+				fontSize: 9,
+				scaleMargins: { top: 0.15, bottom: 0.1 },
+				crosshairColor: sc.volatility.color,
 			});
+			const vlChart = lc.createChart(vl, { autoSize: true, ...vlOpts });
 			const vlSeries = vlChart.addSeries(lc.LineSeries, {
-				color: "#8b5cf6",
+				...sc.volatility,
 				lineWidth: 2,
 				priceLineVisible: false,
 				lastValueVisible: true,
@@ -183,25 +157,14 @@
 			);
 			vlChart.timeScale().fitContent();
 
-			// ── Pane 3: Regime Probability (grey area) ──────
-			const rgChart = lc.createChart(rg, {
-				autoSize: true,
-				layout: baseLayout,
-				grid: baseGrid,
-				rightPriceScale: {
-					borderVisible: false,
-					scaleMargins: { top: 0.08, bottom: 0.08 },
-				},
-				timeScale: { ...baseTimeScale, timeVisible: true },
-				crosshair: {
-					vertLine: { color: "rgba(90, 101, 119, 0.4)" },
-					horzLine: { color: "rgba(90, 101, 119, 0.4)" },
-				},
+			// ── Pane 3: Regime Probability (amber area) ──────
+			const rgOpts = createTerminalLightweightChartOptions({
+				fontSize: 9,
+				timeVisible: true,
 			});
+			const rgChart = lc.createChart(rg, { autoSize: true, ...rgOpts });
 			const rgSeries = rgChart.addSeries(lc.AreaSeries, {
-				topColor: "rgba(202, 138, 4, 0.30)",
-				bottomColor: "rgba(202, 138, 4, 0.02)",
-				lineColor: "#ca8a04",
+				...sc.regime,
 				lineWidth: 1,
 				priceLineVisible: false,
 				lastValueVisible: true,
@@ -312,7 +275,7 @@
 	.rc-root {
 		width: 100%;
 		height: 100%;
-		background: #05080f;
+		background: var(--terminal-bg-panel);
 		display: flex;
 		flex-direction: column;
 		overflow: hidden;
@@ -323,7 +286,7 @@
 		align-items: center;
 		justify-content: space-between;
 		padding: 8px 12px;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+		border-bottom: var(--terminal-border-hairline);
 		flex-shrink: 0;
 		height: 36px;
 	}
@@ -336,17 +299,17 @@
 	}
 
 	.rc-ticker {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
-		font-size: 13px;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-14);
 		font-weight: 800;
-		color: #e2e8f0;
+		color: var(--terminal-fg-primary);
 		letter-spacing: 0.04em;
 	}
 
 	.rc-label {
-		font-family: "Urbanist", system-ui, sans-serif;
-		font-size: 11px;
-		color: #5a6577;
+		font-family: var(--terminal-font-sans);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-tertiary);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -360,9 +323,9 @@
 	}
 
 	.rc-summary {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 9px;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
 		display: inline-flex;
@@ -373,14 +336,14 @@
 	.rc-summary strong {
 		font-size: 11px;
 		font-weight: 700;
-		color: #e2e8f0;
+		color: var(--terminal-fg-primary);
 		font-variant-numeric: tabular-nums;
 	}
 
 	.rc-tag {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 9px;
-		color: #3a4455;
+		color: var(--terminal-fg-muted);
 		letter-spacing: 0.06em;
 	}
 
@@ -390,7 +353,7 @@
 		min-height: 0;
 		display: flex;
 		flex-direction: column;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+		border-bottom: var(--terminal-border-hairline);
 	}
 	.rc-pane:last-child {
 		border-bottom: none;
@@ -399,11 +362,11 @@
 	.rc-pane-label {
 		flex-shrink: 0;
 		padding: 4px 10px 2px;
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 9px;
 		font-weight: 700;
 		letter-spacing: 0.08em;
-		color: #3a4455;
+		color: var(--terminal-fg-muted);
 		text-transform: uppercase;
 	}
 
@@ -428,21 +391,21 @@
 	}
 
 	.rc-placeholder-title {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 11px;
 		font-weight: 700;
 		letter-spacing: 0.12em;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 	}
 
 	.rc-placeholder-sub {
-		font-family: "Urbanist", system-ui, sans-serif;
+		font-family: var(--terminal-font-sans);
 		font-size: 11px;
-		color: #3a4455;
+		color: var(--terminal-fg-muted);
 		line-height: 1.5;
 	}
 
-	.neg { color: #ef4444; }
-	.purple { color: #8b5cf6; }
-	.amber { color: #ca8a04; }
+	.neg { color: var(--terminal-status-error); }
+	.purple { color: var(--terminal-accent-violet); }
+	.amber { color: var(--terminal-accent-amber); }
 </style>

--- a/frontends/wealth/src/lib/components/terminal/builder/RiskTab.svelte
+++ b/frontends/wealth/src/lib/components/terminal/builder/RiskTab.svelte
@@ -11,7 +11,7 @@
 -->
 <script lang="ts">
 	import { workspace } from "$lib/state/portfolio-workspace.svelte";
-	import { formatNumber, readTerminalTokens } from "@investintell/ui";
+	import { formatNumber, readTerminalTokens, createTerminalChartOptions } from "@investintell/ui";
 	import TerminalChart from "$lib/components/terminal/charts/TerminalChart.svelte";
 	import type { EChartsOption } from "echarts";
 
@@ -24,9 +24,6 @@
 		PC2: "Style Factor",
 		PC3: "Sector Factor",
 	};
-
-	/** Read terminal tokens once for chart colors (avoids hex in component). */
-	const tk = $derived.by(() => readTerminalTokens());
 
 	// ── Section A: CVaR Contribution ────────────────────────
 
@@ -52,21 +49,16 @@
 
 	const cvarOption = $derived.by<EChartsOption>(() => {
 		if (!hasCvar) return {};
+		const tk = readTerminalTokens();
 		const total = cvarContributions.reduce((sum, c) => sum + c.value, 0);
 
-		return {
-			textStyle: { fontFamily: tk.fontMono, fontSize: tk.text10 },
-			grid: { left: 0, right: 0, top: 0, bottom: 0 },
-			tooltip: {
-				trigger: "item" as const,
-				backgroundColor: tk.bgPanelRaised,
-				borderColor: tk.fgMuted,
-				borderWidth: 1,
-				textStyle: { fontFamily: tk.fontMono, fontSize: tk.text11, color: tk.fgPrimary },
-			},
+		const base = createTerminalChartOptions({
+			slot: "secondary",
+			disableAnimation: true,
+			showXAxisLabels: false,
+			showYAxisLabels: false,
 			xAxis: { type: "value" as const, show: false, max: total },
 			yAxis: { type: "category" as const, show: false, data: ["Tail Loss"] },
-			animation: false,
 			series: cvarContributions.map((c, i) => ({
 				type: "bar" as const,
 				stack: "cvar",
@@ -75,7 +67,8 @@
 				name: c.name,
 				itemStyle: { color: tk.dataviz[i % tk.dataviz.length] },
 			})),
-		};
+		});
+		return { ...base, grid: { left: 0, right: 0, top: 0, bottom: 0 } };
 	});
 
 	// ── Section B: Factor Exposure ──────────────────────────
@@ -100,41 +93,28 @@
 
 	const factorOption = $derived.by<EChartsOption>(() => {
 		if (!hasFactors) return {};
+		const tk = readTerminalTokens();
 
 		const labels = factorExposures.map((e) => e.label);
 		const values = factorExposures.map((e) => Math.round(e.value * 1000) / 1000);
 
-		return {
-			textStyle: { fontFamily: tk.fontMono, fontSize: tk.text11 },
-			grid: { left: 130, right: 50, top: 12, bottom: 24 },
-			tooltip: {
-				trigger: "axis" as const,
-				axisPointer: { type: "shadow" as const },
-				backgroundColor: tk.bgPanelRaised,
-				borderColor: tk.fgMuted,
-				borderWidth: 1,
-				textStyle: { fontFamily: tk.fontMono, fontSize: tk.text11, color: tk.fgPrimary },
-			},
+		const base = createTerminalChartOptions({
+			slot: "secondary",
+			disableAnimation: true,
 			xAxis: {
 				type: "value" as const,
 				axisLabel: {
 					formatter: (v: number) => formatNumber(v, 1),
-					fontSize: tk.text10,
-					color: tk.fgSecondary,
-				},
-				splitLine: {
-					lineStyle: { type: "dashed" as const, color: tk.fgMuted },
 				},
 			},
 			yAxis: {
 				type: "category" as const,
 				data: labels,
 				inverse: true,
-				axisLabel: { fontSize: tk.text11, fontWeight: 600 as const, color: tk.fgSecondary },
+				axisLabel: { fontWeight: 600 as const },
 				axisTick: { show: false },
 				axisLine: { show: false },
 			},
-			animation: false,
 			series: [
 				{
 					type: "bar" as const,
@@ -161,7 +141,9 @@
 					},
 				},
 			],
-		};
+		});
+
+		return { ...base, grid: { left: 130, right: 50, top: 12, bottom: 24 } };
 	});
 
 	const hasData = $derived(hasCvar || hasFactors);

--- a/frontends/wealth/src/lib/components/terminal/live/DriftMonitorPanel.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/DriftMonitorPanel.svelte
@@ -244,7 +244,7 @@
 		padding: var(--terminal-space-1) var(--terminal-space-2);
 		font-size: var(--terminal-text-10);
 		color: var(--terminal-fg-secondary);
-		border-bottom: 1px solid var(--terminal-fg-muted);
+		border-bottom: var(--terminal-border-hairline);
 		white-space: nowrap;
 	}
 

--- a/frontends/wealth/src/lib/components/terminal/live/HoldingsTable.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/HoldingsTable.svelte
@@ -188,7 +188,7 @@
 		padding: var(--terminal-space-1) var(--terminal-space-2);
 		font-size: var(--terminal-text-10);
 		color: var(--terminal-fg-secondary);
-		border-bottom: 1px solid var(--terminal-fg-muted);
+		border-bottom: var(--terminal-border-hairline);
 		white-space: nowrap;
 	}
 

--- a/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
@@ -6,6 +6,7 @@
 -->
 <script lang="ts">
 	import { formatAUM, formatPercent, formatDate } from "@investintell/ui";
+	import LiveDot from "$lib/components/terminal/data/LiveDot.svelte";
 
 	interface Props {
 		status: string;
@@ -60,11 +61,11 @@
 		<div class="ps-row">
 			<span class="ps-key">STATUS</span>
 			<span class="ps-val ps-status">
-				<span
-					class="ps-dot"
-					class:ps-dot-live={isLive}
-					class:ps-dot-paused={isPaused}
-				></span>
+				<LiveDot
+					status={isLive ? "success" : isPaused ? "warn" : "muted"}
+					pulse={isLive}
+					label="Portfolio state: {isLive ? 'live' : isPaused ? 'paused' : state}"
+				/>
 				{isLive ? "LIVE" : isPaused ? "PAUSED" : state.toUpperCase()}
 			</span>
 		</div>
@@ -182,21 +183,6 @@
 		display: flex;
 		align-items: center;
 		gap: 6px;
-	}
-
-	.ps-dot {
-		width: 6px;
-		height: 6px;
-		border-radius: 50%;
-		background: var(--terminal-fg-muted);
-	}
-
-	.ps-dot-live {
-		background: var(--terminal-status-success);
-	}
-
-	.ps-dot-paused {
-		background: var(--terminal-accent-amber);
 	}
 
 	/* P&L colors */

--- a/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
@@ -207,36 +207,10 @@
 		outline-offset: 2px;
 	}
 
-	/* Terminal overrides for CalibrationPanel */
 	.builder-calibration {
 		flex: 1;
 		overflow-y: auto;
 		border-bottom: var(--terminal-border-hairline);
-
-		/* Override @investintell/ui rounded corners */
-		--ii-radius-md: 0px;
-		--ii-radius-sm: 0px;
-		--ii-radius-lg: 0px;
-		--ii-radius-xl: 0px;
-		font-family: var(--terminal-font-mono);
-	}
-
-	/* Deep scoped overrides for CalibrationPanel child elements */
-	.builder-calibration :global(button) {
-		border-radius: var(--terminal-radius-none);
-	}
-
-	.builder-calibration :global([data-slot="tablist"]) {
-		border-radius: var(--terminal-radius-none);
-	}
-
-	.builder-calibration :global([data-slot="trigger"]) {
-		border-radius: var(--terminal-radius-none);
-		font-family: var(--terminal-font-mono);
-	}
-
-	.builder-calibration :global([data-slot="content"]) {
-		border-radius: var(--terminal-radius-none);
 	}
 
 	.builder-empty-zone {


### PR DESCRIPTION
## Summary
- **CalibrationPanel.svelte**: Replace `EmptyState`, `Button`, `Tabs.*` from `@investintell/ui` with terminal-native HTML elements; migrate all `--ii-*` tokens to `--terminal-*`; replace `#141519` hex with `var(--terminal-bg-panel)`; square regime badge + flat stress bar
- **CalibrationSliderField.svelte**: Terminal tokens + amber accent on slider thumb/focus ring
- **CalibrationSelectField.svelte**: Replace `@investintell/ui` `Select` component with native `<select>` styled to terminal dialect
- **CalibrationToggleField.svelte**: Terminal tokens + amber toggle (999px toggle radius preserved as native control idiom)
- **CalibrationScenarioGroup.svelte**: Terminal tokens + square chips + square checkboxes
- **RiskTab.svelte**: Route both charts (CVaR stacked bar, Factor exposure) through `createTerminalChartOptions()` factory with grid overrides
- **builder/+page.svelte**: Remove all `:global` CalibrationPanel overrides (no longer needed since panel is now terminal-native)

## Verification
- Zero `--ii-*` tokens in all 5 CalibrationPanel family files
- Zero `Urbanist` font references
- Zero hex color literals
- Zero `:global` overrides in builder page
- `border-radius` only on slider thumb (50%) and toggle (999px) — both native control idioms
- `pnpm check`: 0 errors, 20 warnings (all pre-existing)

## Test plan
- [ ] Open `/portfolio/builder` in terminal route, verify CalibrationPanel renders with terminal aesthetic
- [ ] Verify Basic/Advanced/Expert tab switching works
- [ ] Verify slider fields track and update correctly
- [ ] Verify select dropdowns open and select values
- [ ] Verify toggle switches animate correctly
- [ ] Verify stress scenario checkboxes toggle on/off
- [ ] Verify Reset/Preview/Apply buttons work
- [ ] Verify RiskTab charts render after construction run

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>