### PR TITLE
fix(terminal): harmonize Live Workbench hex to terminal tokens (H2)

### DIFF
--- a/frontends/wealth/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte
@@ -14,6 +14,10 @@
 -->
 <script lang="ts">
 	import { onMount } from "svelte";
+	import {
+		createTerminalLightweightChartOptions,
+		terminalLWSeriesColors,
+	} from "@investintell/ui";
 
 	// ── Types ─────────────────────────────────────────────────
 	export interface BarData {
@@ -71,62 +75,26 @@
 			const lc = await import("lightweight-charts");
 			if (disposed || !containerEl) return;
 
-			const c = lc.createChart(containerEl, {
-				autoSize: true,
-				layout: {
-					background: { color: "transparent" },
-					textColor: "#5a6577",
-					fontFamily: "'JetBrains Mono', 'SF Mono', monospace",
-					fontSize: 10,
-				},
-				grid: {
-					vertLines: { color: "rgba(255, 255, 255, 0.04)" },
-					horzLines: { color: "rgba(255, 255, 255, 0.04)" },
-				},
-				crosshair: {
-					vertLine: {
-						color: "rgba(45, 126, 247, 0.3)",
-						labelBackgroundColor: "#2d7ef7",
-					},
-					horzLine: {
-						color: "rgba(45, 126, 247, 0.3)",
-						labelBackgroundColor: "#2d7ef7",
-					},
-				},
-				rightPriceScale: {
-					mode: lc.PriceScaleMode.Percentage,
-					borderVisible: false,
-					scaleMargins: { top: 0.08, bottom: 0.08 },
-				},
-				timeScale: {
-					borderColor: "rgba(255, 255, 255, 0.08)",
-					timeVisible: true,
-					secondsVisible: false,
-					rightOffset: 5,
-				},
-				handleScroll: true,
-				handleScale: true,
+			const opts = createTerminalLightweightChartOptions({
+				timeVisible: true,
+				priceScaleMode: lc.PriceScaleMode.Percentage,
 			});
+			const c = lc.createChart(containerEl, { autoSize: true, ...opts });
 
-			// Series 1: Instrument (baseline — blue/red)
+			// Series 1: Instrument (baseline — cyan/red)
+			const sc = terminalLWSeriesColors();
 			const s = c.addSeries(lc.BaselineSeries, {
 				baseValue: { type: "price", price: 0 },
-				topLineColor: "#2d7ef7",
-				topFillColor1: "rgba(45, 126, 247, 0.10)",
-				topFillColor2: "rgba(45, 126, 247, 0.01)",
-				bottomLineColor: "#e74c3c",
-				bottomFillColor1: "rgba(231, 76, 60, 0.01)",
-				bottomFillColor2: "rgba(231, 76, 60, 0.06)",
+				...sc.baseline,
 				lineWidth: 2,
 				priceLineVisible: true,
-				priceLineColor: "rgba(45, 126, 247, 0.4)",
 				lastValueVisible: true,
 				title: "",
 			});
 
-			// Series 2: Portfolio NAV (gold line)
+			// Series 2: Portfolio NAV (amber line)
 			const nav = c.addSeries(lc.LineSeries, {
-				color: "#fbbf24",
+				...sc.navOverlay,
 				lineWidth: 2,
 				title: "NAV",
 				crosshairMarkerVisible: true,
@@ -266,7 +234,7 @@
 		flex-shrink: 0;
 		height: 32px;
 		padding: 0 10px;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+		border-bottom: var(--terminal-border-hairline);
 		position: relative;
 		z-index: 10;
 	}
@@ -278,29 +246,29 @@
 	}
 
 	.tpc-ticker {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
-		font-size: 11px;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
 		font-weight: 700;
-		letter-spacing: 0.06em;
-		color: #c8d0dc;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-secondary);
 	}
 
 	.tpc-status-badge {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 8px;
 		font-weight: 800;
 		letter-spacing: 0.08em;
 		padding: 1px 5px;
 	}
 	.tpc-status-delayed {
-		color: #f59e0b;
-		background: rgba(245, 158, 11, 0.12);
-		border: 1px solid rgba(245, 158, 11, 0.25);
+		color: var(--terminal-status-warn);
+		background: color-mix(in srgb, var(--terminal-status-warn) 12%, transparent);
+		border: 1px solid color-mix(in srgb, var(--terminal-status-warn) 25%, transparent);
 	}
 	.tpc-status-offline {
-		color: #ef4444;
-		background: rgba(239, 68, 68, 0.12);
-		border: 1px solid rgba(239, 68, 68, 0.25);
+		color: var(--terminal-status-error);
+		background: color-mix(in srgb, var(--terminal-status-error) 12%, transparent);
+		border: 1px solid color-mix(in srgb, var(--terminal-status-error) 25%, transparent);
 	}
 
 	/* ── Right controls (toggle + timeframes) ────────────────── */
@@ -317,27 +285,27 @@
 		align-items: center;
 		gap: 4px;
 		padding: 3px 8px;
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 9px;
 		font-weight: 700;
 		letter-spacing: 0.04em;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 		background: transparent;
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		border: var(--terminal-border-hairline);
 		cursor: pointer;
 		transition: color 80ms, background 80ms, border-color 80ms;
 	}
 	.tpc-nav-toggle:hover {
-		color: #fbbf24;
-		border-color: rgba(251, 191, 36, 0.2);
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber-dim);
 	}
 	.tpc-nav-toggle--active {
-		color: #fbbf24;
-		background: rgba(251, 191, 36, 0.08);
-		border-color: rgba(251, 191, 36, 0.25);
+		color: var(--terminal-accent-amber);
+		background: color-mix(in srgb, var(--terminal-accent-amber) 8%, transparent);
+		border-color: var(--terminal-accent-amber-dim);
 	}
 	.tpc-nav-toggle:focus-visible {
-		outline: 2px solid #fbbf24;
+		outline: var(--terminal-border-focus);
 		outline-offset: 1px;
 	}
 	.tpc-nav-check {
@@ -349,7 +317,7 @@
 	/* ── Separator between toggle and timeframes ─────────────── */
 	.tpc-right-controls .tpc-timeframes {
 		padding-left: 8px;
-		border-left: 1px solid rgba(255, 255, 255, 0.06);
+		border-left: var(--terminal-border-hairline);
 	}
 
 	.tpc-timeframes {
@@ -360,27 +328,27 @@
 	.tpc-tf-btn {
 		appearance: none;
 		padding: 3px 8px;
-		font-family: "JetBrains Mono", "SF Mono", monospace;
-		font-size: 10px;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
 		font-weight: 600;
 		letter-spacing: 0.04em;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 		background: transparent;
 		border: 1px solid transparent;
 		cursor: pointer;
 		transition: color 80ms, background 80ms, border-color 80ms;
 	}
 	.tpc-tf-btn:hover {
-		color: #c8d0dc;
-		background: rgba(255, 255, 255, 0.04);
+		color: var(--terminal-fg-secondary);
+		background: var(--terminal-bg-panel-raised);
 	}
 	.tpc-tf-active {
-		color: #2d7ef7;
-		border-color: rgba(45, 126, 247, 0.3);
-		background: rgba(45, 126, 247, 0.08);
+		color: var(--terminal-accent-cyan);
+		border-color: var(--terminal-accent-cyan-dim);
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 8%, transparent);
 	}
 	.tpc-tf-btn:focus-visible {
-		outline: 2px solid #2d7ef7;
+		outline: 2px solid var(--terminal-accent-cyan);
 		outline-offset: 1px;
 	}
 

--- a/frontends/wealth/src/lib/components/research/terminal/TerminalResearchChart.svelte
+++ b/frontends/wealth/src/lib/components/research/terminal/TerminalResearchChart.svelte
@@ -15,6 +15,10 @@
 -->
 <script lang="ts">
 	import { formatNumber } from "@investintell/ui";
+	import {
+		createTerminalLightweightChartOptions,
+		terminalLWSeriesColors,
+	} from "@investintell/ui";
 	import { getContext, onMount } from "svelte";
 	import type { UTCTimestamp } from "lightweight-charts";
 	import {
@@ -115,42 +119,17 @@
 			}
 			charts = [];
 
-			const baseLayout = {
-				background: { color: "transparent" },
-				textColor: "#5a6577",
-				fontFamily: "'JetBrains Mono', 'SF Mono', monospace",
-				fontSize: 9,
-			};
-			const baseGrid = {
-				vertLines: { color: "rgba(255, 255, 255, 0.03)" },
-				horzLines: { color: "rgba(255, 255, 255, 0.03)" },
-			};
-			const baseTimeScale = {
-				borderColor: "rgba(255, 255, 255, 0.06)",
-				timeVisible: false,
-				secondsVisible: false,
-			};
+			const sc = terminalLWSeriesColors();
 
 			// ── Pane 1: Drawdown (baseline red) ─────────────
-			const ddChart = lc.createChart(dd, {
-				autoSize: true,
-				layout: baseLayout,
-				grid: baseGrid,
-				rightPriceScale: { borderVisible: false, scaleMargins: { top: 0.08, bottom: 0.08 } },
-				timeScale: baseTimeScale,
-				crosshair: {
-					vertLine: { color: "rgba(239, 68, 68, 0.3)" },
-					horzLine: { color: "rgba(239, 68, 68, 0.3)" },
-				},
+			const ddOpts = createTerminalLightweightChartOptions({
+				fontSize: 9,
+				crosshairColor: sc.drawdown.bottomLineColor,
 			});
+			const ddChart = lc.createChart(dd, { autoSize: true, ...ddOpts });
 			const ddSeries = ddChart.addSeries(lc.BaselineSeries, {
 				baseValue: { type: "price", price: 0 },
-				topLineColor: "rgba(34, 197, 94, 0.0)",
-				topFillColor1: "rgba(34, 197, 94, 0.00)",
-				topFillColor2: "rgba(34, 197, 94, 0.00)",
-				bottomLineColor: "#ef4444",
-				bottomFillColor1: "rgba(239, 68, 68, 0.20)",
-				bottomFillColor2: "rgba(239, 68, 68, 0.02)",
+				...sc.drawdown,
 				lineWidth: 2,
 				priceLineVisible: false,
 				lastValueVisible: true,
@@ -159,20 +138,15 @@
 			ddSeries.setData(data.drawdown.map((p) => ({ time: p.time as unknown as UTCTimestamp, value: p.value })));
 			ddChart.timeScale().fitContent();
 
-			// ── Pane 2: GARCH Volatility (purple line) ──────
-			const vlChart = lc.createChart(vl, {
-				autoSize: true,
-				layout: baseLayout,
-				grid: baseGrid,
-				rightPriceScale: { borderVisible: false, scaleMargins: { top: 0.15, bottom: 0.1 } },
-				timeScale: baseTimeScale,
-				crosshair: {
-					vertLine: { color: "rgba(139, 92, 246, 0.3)" },
-					horzLine: { color: "rgba(139, 92, 246, 0.3)" },
-				},
+			// ── Pane 2: GARCH Volatility (violet line) ──────
+			const vlOpts = createTerminalLightweightChartOptions({
+				fontSize: 9,
+				scaleMargins: { top: 0.15, bottom: 0.1 },
+				crosshairColor: sc.volatility.color,
 			});
+			const vlChart = lc.createChart(vl, { autoSize: true, ...vlOpts });
 			const vlSeries = vlChart.addSeries(lc.LineSeries, {
-				color: "#8b5cf6",
+				...sc.volatility,
 				lineWidth: 2,
 				priceLineVisible: false,
 				lastValueVisible: true,
@@ -183,25 +157,14 @@
 			);
 			vlChart.timeScale().fitContent();
 
-			// ── Pane 3: Regime Probability (grey area) ──────
-			const rgChart = lc.createChart(rg, {
-				autoSize: true,
-				layout: baseLayout,
-				grid: baseGrid,
-				rightPriceScale: {
-					borderVisible: false,
-					scaleMargins: { top: 0.08, bottom: 0.08 },
-				},
-				timeScale: { ...baseTimeScale, timeVisible: true },
-				crosshair: {
-					vertLine: { color: "rgba(90, 101, 119, 0.4)" },
-					horzLine: { color: "rgba(90, 101, 119, 0.4)" },
-				},
+			// ── Pane 3: Regime Probability (amber area) ──────
+			const rgOpts = createTerminalLightweightChartOptions({
+				fontSize: 9,
+				timeVisible: true,
 			});
+			const rgChart = lc.createChart(rg, { autoSize: true, ...rgOpts });
 			const rgSeries = rgChart.addSeries(lc.AreaSeries, {
-				topColor: "rgba(202, 138, 4, 0.30)",
-				bottomColor: "rgba(202, 138, 4, 0.02)",
-				lineColor: "#ca8a04",
+				...sc.regime,
 				lineWidth: 1,
 				priceLineVisible: false,
 				lastValueVisible: true,
@@ -312,7 +275,7 @@
 	.rc-root {
 		width: 100%;
 		height: 100%;
-		background: #05080f;
+		background: var(--terminal-bg-panel);
 		display: flex;
 		flex-direction: column;
 		overflow: hidden;
@@ -323,7 +286,7 @@
 		align-items: center;
 		justify-content: space-between;
 		padding: 8px 12px;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+		border-bottom: var(--terminal-border-hairline);
 		flex-shrink: 0;
 		height: 36px;
 	}
@@ -336,17 +299,17 @@
 	}
 
 	.rc-ticker {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
-		font-size: 13px;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-14);
 		font-weight: 800;
-		color: #e2e8f0;
+		color: var(--terminal-fg-primary);
 		letter-spacing: 0.04em;
 	}
 
 	.rc-label {
-		font-family: "Urbanist", system-ui, sans-serif;
-		font-size: 11px;
-		color: #5a6577;
+		font-family: var(--terminal-font-sans);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-tertiary);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -360,9 +323,9 @@
 	}
 
 	.rc-summary {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 9px;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
 		display: inline-flex;
@@ -373,14 +336,14 @@
 	.rc-summary strong {
 		font-size: 11px;
 		font-weight: 700;
-		color: #e2e8f0;
+		color: var(--terminal-fg-primary);
 		font-variant-numeric: tabular-nums;
 	}
 
 	.rc-tag {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 9px;
-		color: #3a4455;
+		color: var(--terminal-fg-muted);
 		letter-spacing: 0.06em;
 	}
 
@@ -390,7 +353,7 @@
 		min-height: 0;
 		display: flex;
 		flex-direction: column;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+		border-bottom: var(--terminal-border-hairline);
 	}
 	.rc-pane:last-child {
 		border-bottom: none;
@@ -399,11 +362,11 @@
 	.rc-pane-label {
 		flex-shrink: 0;
 		padding: 4px 10px 2px;
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 9px;
 		font-weight: 700;
 		letter-spacing: 0.08em;
-		color: #3a4455;
+		color: var(--terminal-fg-muted);
 		text-transform: uppercase;
 	}
 
@@ -428,21 +391,21 @@
 	}
 
 	.rc-placeholder-title {
-		font-family: "JetBrains Mono", "SF Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 11px;
 		font-weight: 700;
 		letter-spacing: 0.12em;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 	}
 
 	.rc-placeholder-sub {
-		font-family: "Urbanist", system-ui, sans-serif;
+		font-family: var(--terminal-font-sans);
 		font-size: 11px;
-		color: #3a4455;
+		color: var(--terminal-fg-muted);
 		line-height: 1.5;
 	}
 
-	.neg { color: #ef4444; }
-	.purple { color: #8b5cf6; }
-	.amber { color: #ca8a04; }
+	.neg { color: var(--terminal-status-error); }
+	.purple { color: var(--terminal-accent-violet); }
+	.amber { color: var(--terminal-accent-amber); }
 </style>

--- a/frontends/wealth/src/lib/components/terminal/live/DriftMonitorPanel.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/DriftMonitorPanel.svelte
@@ -244,7 +244,7 @@
 		padding: var(--terminal-space-1) var(--terminal-space-2);
 		font-size: var(--terminal-text-10);
 		color: var(--terminal-fg-secondary);
-		border-bottom: 1px solid var(--terminal-fg-muted);
+		border-bottom: var(--terminal-border-hairline);
 		white-space: nowrap;
 	}
 

--- a/frontends/wealth/src/lib/components/terminal/live/HoldingsTable.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/HoldingsTable.svelte
@@ -188,7 +188,7 @@
 		padding: var(--terminal-space-1) var(--terminal-space-2);
 		font-size: var(--terminal-text-10);
 		color: var(--terminal-fg-secondary);
-		border-bottom: 1px solid var(--terminal-fg-muted);
+		border-bottom: var(--terminal-border-hairline);
 		white-space: nowrap;
 	}
 

--- a/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
@@ -6,6 +6,7 @@
 -->
 <script lang="ts">
 	import { formatAUM, formatPercent, formatDate } from "@investintell/ui";
+	import LiveDot from "$lib/components/terminal/data/LiveDot.svelte";
 
 	interface Props {
 		status: string;
@@ -60,11 +61,11 @@
 		<div class="ps-row">
 			<span class="ps-key">STATUS</span>
 			<span class="ps-val ps-status">
-				<span
-					class="ps-dot"
-					class:ps-dot-live={isLive}
-					class:ps-dot-paused={isPaused}
-				></span>
+				<LiveDot
+					status={isLive ? "success" : isPaused ? "warn" : "muted"}
+					pulse={isLive}
+					label="Portfolio state: {isLive ? 'live' : isPaused ? 'paused' : state}"
+				/>
 				{isLive ? "LIVE" : isPaused ? "PAUSED" : state.toUpperCase()}
 			</span>
 		</div>
@@ -182,21 +183,6 @@
 		display: flex;
 		align-items: center;
 		gap: 6px;
-	}
-
-	.ps-dot {
-		width: 6px;
-		height: 6px;
-		border-radius: 50%;
-		background: var(--terminal-fg-muted);
-	}
-
-	.ps-dot-live {
-		background: var(--terminal-status-success);
-	}
-
-	.ps-dot-paused {
-		background: var(--terminal-accent-amber);
 	}
 
 	/* P&L colors */


### PR DESCRIPTION
## Summary

- Replace ~45 hardcoded hex values in `TerminalPriceChart` and `TerminalResearchChart` with `createTerminalLightweightChartOptions()` factory + `terminalLWSeriesColors()` from `@investintell/ui`
- Migrate all CSS in both chart components to `--terminal-*` custom properties (fonts, colors, borders, focus rings)
- Fix border tokens in `HoldingsTable` and `DriftMonitorPanel` (`1px solid var(--terminal-fg-muted)` -> `var(--terminal-border-hairline)`)
- Compose `LiveDot` primitive into `PortfolioSummary` status indicator (replaces inline CSS dot)
- Remove hardcoded `Urbanist` font declarations from `TerminalResearchChart`

## Verification

- Zero hex literals in both chart files (grep confirmed)
- Zero `rgba(` in JS sections (grep confirmed)
- Zero `Urbanist` in TerminalResearchChart (grep confirmed)
- `pnpm check` passes with 0 errors

## Test plan

- [ ] Visual: Price chart renders cyan baseline (not blue #2d7ef7)
- [ ] Visual: NAV overlay is amber
- [ ] Visual: Crosshair labels are amber (not blue)
- [ ] Visual: Active timeframe pill is cyan
- [ ] Visual: Research chart 3 panes render correctly
- [ ] Visual: Holdings/Drift table rows have hairline borders
- [ ] Visual: Portfolio summary dot pulses green when live

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>