### PR TITLE
fix(builder): remove duplicate regime + move RunControls inside card

### DIFF
--- a/frontends/wealth/src/lib/components/portfolio/CalibrationPanel.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/CalibrationPanel.svelte
@@ -25,11 +25,6 @@
 <script lang="ts">
 	import { workspace } from "$lib/state/portfolio-workspace.svelte";
 	import { formatNumber, formatShortDate } from "@investintell/ui";
-	import {
-		taaRegimeLabel,
-		taaRegimePosture,
-		taaRegimeColor,
-	} from "$lib/types/taa";
 	import type {
 		PortfolioCalibration,
 		PortfolioCalibrationUpdate,
@@ -53,13 +48,6 @@
 	const applying = $derived(workspace.isApplyingCalibration);
 
 	// ── TAA regime indicator state (Sprint 4) ────────────────────
-	const regimeBands = $derived(workspace.regimeBands);
-	const hasRegimeData = $derived(regimeBands !== null && regimeBands.taa_enabled);
-	const regimeLabel = $derived(regimeBands ? taaRegimeLabel(regimeBands.raw_regime) : null);
-	const regimePosture = $derived(regimeBands ? taaRegimePosture(regimeBands.raw_regime) : null);
-	const regimeColor = $derived(regimeBands ? taaRegimeColor(regimeBands.raw_regime) : null);
-	/** Stress level normalized to 0-100 for the visual bar. */
-	const stressLevel = $derived(regimeBands?.stress_score != null ? Number(regimeBands.stress_score) : null);
 
 	// Local working copy of the calibration — cloned on load + on portfolio switch.
 	let draft = $state<PortfolioCalibration | null>(null);
@@ -288,30 +276,6 @@
 	</div>
 {:else}
 	<div class="cp-root">
-		<!-- ── Market Conditions indicator (TAA Sprint 4) ──────── -->
-		{#if hasRegimeData}
-			<div class="cp-regime-strip">
-				<div class="cp-regime-header">
-					<span class="cp-regime-kicker">MARKET CONDITIONS</span>
-					<span class="cp-regime-date">{formatShortDate(regimeBands!.as_of_date)}</span>
-				</div>
-				<div class="cp-regime-row">
-					<span class="cp-regime-badge" style="background: {regimeColor}; color: var(--terminal-fg-inverted)">
-						{regimeLabel}
-					</span>
-					{#if stressLevel !== null}
-						<div class="cp-stress-bar-track">
-							<div
-								class="cp-stress-bar-fill"
-								style="width: {Math.min(stressLevel, 100)}%; background: {regimeColor}"
-							></div>
-						</div>
-					{/if}
-				</div>
-				<p class="cp-regime-posture">{regimePosture}</p>
-			</div>
-		{/if}
-
 		<div class="cp-tabs" role="tablist">
 			<button type="button" role="tab" class="cp-tab" class:cp-tab--active={tier === "basic"}
 				aria-selected={tier === "basic"} onclick={() => (tier = "basic")}>BASIC</button>
@@ -596,64 +560,6 @@
 		font-family: var(--terminal-font-mono);
 	}
 
-	/* ── Market Conditions regime indicator (TAA Sprint 4) ── */
-	.cp-regime-strip {
-		padding: 12px 16px;
-		border-bottom: var(--terminal-border-hairline);
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-		flex-shrink: 0;
-	}
-	.cp-regime-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-	}
-	.cp-regime-kicker {
-		font-size: var(--terminal-text-10);
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: var(--terminal-tracking-caps);
-		color: var(--terminal-fg-muted);
-	}
-	.cp-regime-date {
-		font-size: var(--terminal-text-10);
-		font-weight: 500;
-		color: var(--terminal-fg-muted);
-		font-variant-numeric: tabular-nums;
-	}
-	.cp-regime-row {
-		display: flex;
-		align-items: center;
-		gap: 10px;
-	}
-	.cp-regime-badge {
-		display: inline-flex;
-		align-items: center;
-		padding: 1px 6px;
-		font-size: var(--terminal-text-10);
-		font-weight: 700;
-		letter-spacing: var(--terminal-tracking-caps);
-		text-transform: uppercase;
-		white-space: nowrap;
-	}
-	.cp-stress-bar-track {
-		flex: 1;
-		height: 4px;
-		background: var(--terminal-fg-muted);
-		overflow: hidden;
-	}
-	.cp-stress-bar-fill {
-		height: 100%;
-		transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
-	}
-	.cp-regime-posture {
-		margin: 0;
-		font-size: var(--terminal-text-11);
-		line-height: 1.4;
-		color: var(--terminal-fg-muted);
-	}
 	.cp-empty {
 		display: flex;
 		align-items: center;

--- a/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
@@ -107,17 +107,15 @@
 		<!-- Zone A: Regime Context Strip (120px) -->
 		<RegimeContextStrip {regimeBands} />
 
-		<!-- Zone B: Calibration Controls (flex) -->
+		<!-- Zone B: Calibration Controls + Run Controls (flex) -->
 		<div class="builder-calibration">
 			{#if selectedPortfolio}
 				<CalibrationPanel />
+				<RunControls />
 			{:else}
 				<div class="builder-empty-zone">Select a portfolio to configure</div>
 			{/if}
 		</div>
-
-		<!-- Zone C: Run Controls (80px) -->
-		<RunControls />
 	</div>
 
 	<!-- RIGHT COLUMN (60%) — Results Panel -->
@@ -210,7 +208,6 @@
 	.builder-calibration {
 		flex: 1;
 		overflow-y: auto;
-		border-bottom: var(--terminal-border-hairline);
 	}
 
 	.builder-empty-zone {


### PR DESCRIPTION
## Summary

- Removed MARKET CONDITIONS block from CalibrationPanel — redundant with RegimeContextStrip already showing same regime/stress data above
- Moved RunControls (RUN CONSTRUCTION button + Compare dropdown) inside the calibration card area instead of as a standalone 80px zone, giving more vertical space to calibration fields
- Cleaned up 97 lines of orphaned CSS, imports, and derived state

## Test plan

- [x] svelte-check: 0 errors
- [x] Visual: regime info shows once (in RegimeContextStrip), calibration card has more breathing room, all buttons (Reset/Preview/Apply/Run Construction) accessible without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)