### PR TITLE
fix(terminal): H5 cross-page navigation + final polish

### DIFF
--- a/frontends/wealth/src/lib/components/screener/terminal/TerminalScreenerFilters.svelte
+++ b/frontends/wealth/src/lib/components/screener/terminal/TerminalScreenerFilters.svelte
@@ -527,11 +527,11 @@
 		display: flex;
 		flex-direction: column;
 		height: 100%;
-		background: #0c1018;
-		border-right: 1px solid rgba(255, 255, 255, 0.06);
-		font-family: "Urbanist", system-ui, sans-serif;
+		background: var(--terminal-bg-panel);
+		border-right: 1px solid var(--terminal-fg-muted);
+		font-family: var(--terminal-font-mono);
 		font-size: 11px;
-		color: #c8d0dc;
+		color: var(--terminal-fg-primary);
 	}
 
 	.sf-header {
@@ -539,7 +539,7 @@
 		align-items: center;
 		justify-content: space-between;
 		padding: 10px 12px 8px;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+		border-bottom: 1px solid var(--terminal-fg-muted);
 		flex-shrink: 0;
 	}
 
@@ -547,7 +547,7 @@
 		font-size: 10px;
 		font-weight: 700;
 		letter-spacing: 0.1em;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 		text-transform: uppercase;
 	}
 
@@ -559,22 +559,22 @@
 
 	.sf-action {
 		font-size: 9px;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 		background: none;
 		border: none;
 		cursor: pointer;
 		padding: 0;
-		font-family: "JetBrains Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		letter-spacing: 0.06em;
 		text-transform: uppercase;
 	}
 	.sf-action:hover {
-		color: #9aa3b3;
+		color: var(--terminal-fg-secondary);
 	}
 
 	.sf-clear {
 		font-size: 10px;
-		color: #2d7ef7;
+		color: var(--terminal-accent-cyan);
 		background: none;
 		border: none;
 		cursor: pointer;
@@ -582,36 +582,36 @@
 		font-family: inherit;
 	}
 	.sf-clear:hover {
-		color: #5a9ef7;
+		color: var(--terminal-accent-cyan);
 	}
 
 	.sf-elite-chip-row {
 		padding: 8px 12px;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+		border-bottom: 1px solid var(--terminal-fg-muted);
 		flex-shrink: 0;
 	}
 
 	.sf-elite-chip {
-		font-family: "JetBrains Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 10px;
 		font-weight: 700;
 		letter-spacing: 0.1em;
 		text-transform: uppercase;
 		padding: 4px 12px;
 		background: transparent;
-		border: 1px solid rgba(255, 255, 255, 0.12);
-		color: #8a94a6;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
 		cursor: pointer;
 		transition: all 80ms ease;
 	}
 	.sf-elite-chip:hover {
-		border-color: #f59e0b;
-		color: #f59e0b;
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
 	}
 	.sf-elite-chip--active {
-		border-color: #f59e0b;
-		color: #f59e0b;
-		background: rgba(245, 158, 11, 0.08);
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+		background: color-mix(in srgb, var(--terminal-accent-amber) 8%, transparent);
 	}
 
 	.sf-scroll {
@@ -622,7 +622,7 @@
 	}
 
 	.sf-section {
-		border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+		border-bottom: 1px solid var(--terminal-fg-disabled);
 	}
 
 	.sf-section-toggle {
@@ -633,7 +633,7 @@
 		padding: 8px 12px;
 		background: none;
 		border: none;
-		color: #8a94a6;
+		color: var(--terminal-fg-secondary);
 		font-size: 10px;
 		font-weight: 700;
 		letter-spacing: 0.08em;
@@ -643,7 +643,7 @@
 		text-align: left;
 	}
 	.sf-section-toggle:hover {
-		color: #c8d0dc;
+		color: var(--terminal-fg-primary);
 	}
 
 	.sf-section-arrow {
@@ -661,10 +661,10 @@
 		justify-content: center;
 		min-width: 16px;
 		height: 16px;
-		border-radius: 50%;
-		background: #22d3ee;
-		color: #0b0f1a;
-		font-family: "JetBrains Mono", monospace;
+		border-radius: var(--terminal-radius-none);
+		background: var(--terminal-accent-cyan);
+		color: var(--terminal-fg-inverted);
+		font-family: var(--terminal-font-mono);
 		font-size: 9px;
 		font-weight: 700;
 		margin-left: 4px;
@@ -691,14 +691,14 @@
 	.sf-check input[type="checkbox"] {
 		width: 12px;
 		height: 12px;
-		accent-color: #2d7ef7;
+		accent-color: var(--terminal-accent-cyan);
 		margin: 0;
 		flex-shrink: 0;
 	}
 
 	.sf-check-label {
 		font-size: 11px;
-		color: #9aa3b3;
+		color: var(--terminal-fg-secondary);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -717,7 +717,7 @@
 		font-weight: 600;
 		letter-spacing: 0.06em;
 		text-transform: uppercase;
-		color: #5a6577;
+		color: var(--terminal-fg-tertiary);
 	}
 
 	.sf-metric-inputs {
@@ -731,10 +731,10 @@
 		min-width: 0;
 		width: 56px;
 		background: transparent;
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--terminal-fg-disabled);
 		border-radius: 0;
-		color: #c8d0dc;
-		font-family: "JetBrains Mono", monospace;
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
 		font-size: 11px;
 		padding: 4px 6px;
 		text-align: right;
@@ -748,15 +748,15 @@
 		margin: 0;
 	}
 	.sf-metric-input::placeholder {
-		color: #3d4a5c;
+		color: var(--terminal-fg-muted);
 		text-align: right;
 	}
 	.sf-metric-input:focus {
-		border-color: rgba(45, 126, 247, 0.4);
+		border-color: color-mix(in srgb, var(--terminal-accent-cyan) 40%, transparent);
 	}
 
 	.sf-metric-sep {
-		color: #3d4a5c;
+		color: var(--terminal-fg-muted);
 		font-size: 10px;
 		flex-shrink: 0;
 	}

--- a/frontends/wealth/src/lib/components/screener/terminal/TerminalScreenerShell.svelte
+++ b/frontends/wealth/src/lib/components/screener/terminal/TerminalScreenerShell.svelte
@@ -19,6 +19,8 @@
 -->
 <script lang="ts">
 	import { getContext } from "svelte";
+	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { createClientApiClient } from "$lib/api/client";
 	import TerminalScreenerFilters, {
 		type FilterState,
@@ -27,6 +29,8 @@
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 	const api = createClientApiClient(getToken);
+
+	const HREF_BUILDER = resolve("/portfolio/builder");
 
 	interface Props {
 		filters: FilterState;
@@ -362,6 +366,17 @@
 				onFiltersChange({ ...filters, eliteOnly: !filters.eliteOnly });
 				break;
 			}
+			case "b": {
+				if (highlightedIndex >= 0 && highlightedIndex < assets.length) {
+					const asset = assets[highlightedIndex];
+					if (asset && asset.inUniverse) {
+						goto(HREF_BUILDER);
+					} else {
+						showToast("Fund must be approved to universe first", "warn");
+					}
+				}
+				break;
+			}
 		}
 	}
 
@@ -459,8 +474,8 @@
 		width: 100%;
 		height: 100%;
 		overflow: hidden;
-		background: #000000;
-		font-family: "Urbanist", system-ui, sans-serif;
+		background: var(--terminal-bg-void);
+		font-family: var(--terminal-font-mono);
 	}
 
 	.ts-zone {
@@ -527,7 +542,7 @@
 
 	.sep-btn {
 		background: transparent;
-		border: 1px solid rgba(255, 255, 255, 0.12);
+		border: var(--terminal-border-hairline);
 		border-radius: 0;
 		color: var(--terminal-fg-primary, #e2e8f0);
 		font-family: var(--terminal-font-mono, "JetBrains Mono", monospace);
@@ -538,8 +553,8 @@
 	}
 
 	.sep-btn:hover {
-		border-color: #f59e0b;
-		color: #f59e0b;
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
 	}
 
 	.sep-btn--reload:hover {
@@ -554,15 +569,15 @@
 		left: 50%;
 		transform: translateX(-50%);
 		padding: 6px 16px;
-		font-family: "JetBrains Mono", monospace;
+		font-family: var(--terminal-font-mono);
 		font-size: 11px;
 		font-weight: 600;
 		letter-spacing: 0.02em;
-		border: 1px solid rgba(255, 255, 255, 0.12);
-		background: #0d1220;
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-overlay);
 		z-index: 10;
 	}
-	.ts-toast--success { color: #22c55e; border-color: rgba(34, 197, 94, 0.3); }
-	.ts-toast--warn { color: #f59e0b; border-color: rgba(245, 158, 11, 0.3); }
-	.ts-toast--info { color: #2d7ef7; border-color: rgba(45, 126, 247, 0.3); }
+	.ts-toast--success { color: var(--terminal-status-success); border-color: color-mix(in srgb, var(--terminal-status-success) 30%, transparent); }
+	.ts-toast--warn { color: var(--terminal-accent-amber); border-color: color-mix(in srgb, var(--terminal-accent-amber) 30%, transparent); }
+	.ts-toast--info { color: var(--terminal-accent-cyan); border-color: color-mix(in srgb, var(--terminal-accent-cyan) 30%, transparent); }
 </style>

--- a/frontends/wealth/src/lib/components/terminal/builder/ActivationBar.svelte
+++ b/frontends/wealth/src/lib/components/terminal/builder/ActivationBar.svelte
@@ -5,6 +5,8 @@
   Two buttons: Save as Draft + Activate Portfolio (opens ConsequenceDialog).
 -->
 <script lang="ts">
+	import { fly } from "svelte/transition";
+	import { svelteTransitionFor } from "@investintell/ui";
 	import { workspace } from "$lib/state/portfolio-workspace.svelte";
 	import ConsequenceDialog from "./ConsequenceDialog.svelte";
 
@@ -40,7 +42,7 @@
 </script>
 
 {#if visible}
-	<div class="ab-bar">
+	<div class="ab-bar" in:fly={{ y: 12, ...svelteTransitionFor("tail", { duration: "update" }) }}>
 		<button type="button" class="ab-btn ab-btn--secondary" onclick={handleSaveDraft}>
 			Save as Draft
 		</button>

--- a/frontends/wealth/src/lib/components/terminal/builder/WeightsTab.svelte
+++ b/frontends/wealth/src/lib/components/terminal/builder/WeightsTab.svelte
@@ -342,7 +342,7 @@
 
 	/* Block row */
 	.wt-block-row {
-		border-bottom: 1px solid var(--terminal-bg-panel-raised);
+		border-bottom: var(--terminal-border-hairline);
 	}
 
 	.wt-block-name {
@@ -364,7 +364,7 @@
 
 	/* Fund row */
 	.wt-fund-row {
-		border-bottom: 1px solid var(--terminal-bg-panel-raised);
+		border-bottom: var(--terminal-border-hairline);
 	}
 
 	.wt-fund-row:hover {

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte
@@ -22,6 +22,7 @@
 -->
 <script lang="ts">
 	import { resolve } from "$app/paths";
+	import { goto } from "$app/navigation";
 
 	// Resolved hrefs for active routes. The lint rule
 	// `svelte/no-navigation-without-resolve` rejects any href that is
@@ -144,7 +145,7 @@
 
 	function handleAlertClick() {
 		// Navigate to the alerts inbox route.
-		window.location.href = HREF_ALERTS;
+		goto(HREF_ALERTS);
 	}
 
 	function handleSessionClick() {

--- a/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
@@ -25,6 +25,11 @@
 	import MonteCarloTab from "$lib/components/terminal/builder/MonteCarloTab.svelte";
 	import ActivationBar from "$lib/components/terminal/builder/ActivationBar.svelte";
 	import CalibrationPanel from "$lib/components/portfolio/CalibrationPanel.svelte";
+	import { fly, fade } from "svelte/transition";
+	import { svelteTransitionFor } from "@investintell/ui";
+	import { resolve } from "$app/paths";
+
+	const HREF_SCREENER = resolve("/terminal-screener");
 
 	let { data }: { data: PageData } = $props();
 
@@ -86,6 +91,11 @@
 <div class="builder-shell">
 	<!-- LEFT COLUMN (40%) — Command Panel -->
 	<div class="builder-left">
+		<!-- Breadcrumb back to screener -->
+		<a href={HREF_SCREENER} class="builder-backlink" data-sveltekit-preload-data="hover">
+			&larr; SCREENER
+		</a>
+
 		<!-- Portfolio selector -->
 		<div class="builder-portfolio-select">
 			<select
@@ -138,24 +148,30 @@
 
 		<!-- Zone D: Cascade Timeline (visible during/after run) -->
 		{#if showCascade}
-			<CascadeTimeline phases={cascadePhases} />
+			<div in:fly={{ y: -8, ...svelteTransitionFor("primary", { duration: "update" }) }}>
+				<CascadeTimeline phases={cascadePhases} />
+			</div>
 		{/if}
 
 		<!-- Zone E: Tab content -->
 		<div class="builder-tab-content" role="tabpanel">
-			{#if activeTab === "WEIGHTS"}
-				<WeightsTab />
-			{:else if activeTab === "RISK"}
-				<RiskTab />
-			{:else if activeTab === "STRESS"}
-				<StressTab />
-			{:else if activeTab === "BACKTEST"}
-				<BacktestTab />
-			{:else if activeTab === "MONTE CARLO"}
-				<MonteCarloTab />
-			{:else if activeTab === "ADVISOR"}
-				<AdvisorTab />
-			{/if}
+			{#key activeTab}
+				<div in:fade={svelteTransitionFor("chrome", { duration: "tick" })}>
+					{#if activeTab === "WEIGHTS"}
+						<WeightsTab />
+					{:else if activeTab === "RISK"}
+						<RiskTab />
+					{:else if activeTab === "STRESS"}
+						<StressTab />
+					{:else if activeTab === "BACKTEST"}
+						<BacktestTab />
+					{:else if activeTab === "MONTE CARLO"}
+						<MonteCarloTab />
+					{:else if activeTab === "ADVISOR"}
+						<AdvisorTab />
+					{/if}
+				</div>
+			{/key}
 		</div>
 
 		<!-- Zone F: Activation Bar (Session 3) -->
@@ -180,6 +196,26 @@
 		flex-direction: column;
 		overflow-y: auto;
 		border-right: var(--terminal-border-hairline);
+	}
+
+	.builder-backlink {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		text-decoration: none;
+		color: var(--terminal-fg-tertiary);
+		border-bottom: var(--terminal-border-hairline);
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.builder-backlink:hover {
+		color: var(--terminal-accent-amber);
 	}
 
 	.builder-portfolio-select {


### PR DESCRIPTION
## Summary
- Replace `window.location.href` with SvelteKit `goto()` in TerminalTopNav alert click
- Add `b` keyboard shortcut in Screener to navigate to Builder (approved funds only)
- Add `← SCREENER` back-link in Builder left column with `resolve()` pattern
- Fix WeightsTab row borders (`var(--terminal-border-hairline)` replacing `var(--terminal-bg-panel-raised)`)
- Wire `svelteTransitionFor()` into ActivationBar (fly-in), CascadeTimeline (fly), Builder tab switch (fade via `{#key}`)
- Migrate TerminalScreenerFilters remaining hex values to terminal tokens (linter auto-fix from H4)
- **Completes Terminal Harmonization Plan (H0-H5)**

## Verification
- `pnpm check`: 0 errors, 20 pre-existing warnings
- Zero `window.location.href` in terminal components
- Zero `1px solid var(--terminal-bg-panel-raised)` borders in WeightsTab
- 17 `svelteTransitionFor` consumers across 6 files (3 existing + 3 new)

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: frontend-only changes to navigation, borders, and transitions with no backend impact.