### PR TITLE
fix(terminal): Live chart string coercion + Builder dual scrollbar

### DIFF
--- a/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
@@ -117,15 +117,19 @@
 		<!-- Zone A: Regime Context Strip (120px) -->
 		<RegimeContextStrip {regimeBands} />
 
-		<!-- Zone B: Calibration Controls + Run Controls (flex) -->
+		<!-- Zone B: Calibration Controls (scrollable) -->
 		<div class="builder-calibration">
 			{#if selectedPortfolio}
 				<CalibrationPanel />
-				<RunControls />
 			{:else}
 				<div class="builder-empty-zone">Select a portfolio to configure</div>
 			{/if}
 		</div>
+
+		<!-- Zone C: Run Controls (pinned to bottom) -->
+		{#if selectedPortfolio}
+			<RunControls />
+		{/if}
 	</div>
 
 	<!-- RIGHT COLUMN (60%) — Results Panel -->
@@ -194,7 +198,7 @@
 	.builder-left {
 		display: flex;
 		flex-direction: column;
-		overflow-y: auto;
+		overflow: hidden;
 		border-right: var(--terminal-border-hairline);
 	}
 

--- a/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
@@ -275,7 +275,7 @@
 					.filter((b) => b.close != null)
 					.map((b) => ({
 						time: Math.floor(new Date(b.timestamp).getTime() / 1000),
-						value: b.close as number,
+						value: Number(b.close),
 					}));
 			})
 			.catch(() => {
@@ -353,7 +353,7 @@
 					.filter((b) => b.close != null)
 					.map((b) => ({
 						time: Math.floor(new Date(b.timestamp).getTime() / 1000),
-						value: b.close as number,
+						value: Number(b.close),
 					}));
 			})
 			.catch(() => {


### PR DESCRIPTION
## Summary

- **Live crash fix**: `Baseline series item data value must be a number, got=string` — `b.close` from market-data API may arrive as string. Replaced `as number` type assertion with `Number()` runtime coercion.
- **Builder dual scrollbar fix**: `overflow-y: auto` on both `.builder-left` and `.builder-calibration` created two nested scrollbars. Fix: parent gets `overflow: hidden`, only calibration area scrolls. RunControls pinned to bottom outside scroll area.

## Test plan

- [x] svelte-check: 0 errors
- [x] Live: chart should render without crash when market-data returns string-typed close values
- [x] Builder: single scrollbar on calibration, RunControls always visible at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)