### PR TITLE
fix(live): restore PortfolioSummary as vertical panel beside Holdings

### DIFF
--- a/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
@@ -1,11 +1,11 @@
 <!--
-  PortfolioSummary -- compact horizontal KPI strip between chart and holdings.
+  PortfolioSummary -- vertical KPI panel to the left of Holdings.
 
-  Single-row layout: STATUS | AUM | RETURN | DRIFT | INSTRUMENTS | REBALANCE
-  Height: 32px. Terminal-native styling.
+  Shows: status badge, AUM, return (1Y), drift status,
+  instrument count, last rebalance date, rebalance button.
 -->
 <script lang="ts">
-	import { formatAUM, formatPercent } from "@investintell/ui";
+	import { formatAUM, formatPercent, formatDate } from "@investintell/ui";
 	import LiveDot from "$lib/components/terminal/data/LiveDot.svelte";
 
 	interface Props {
@@ -51,102 +51,122 @@
 	}
 </script>
 
-<div class="ps-strip">
-	<!-- Status -->
-	<div class="ps-cell">
-		<span class="ps-key">STATUS</span>
-		<span class="ps-val ps-status">
-			<LiveDot
-				status={isLive ? "success" : isPaused ? "warn" : "muted"}
-				pulse={isLive}
-				label="Portfolio state"
-			/>
-			{isLive ? "LIVE" : isPaused ? "PAUSED" : state.toUpperCase()}
-		</span>
+<div class="ps-root">
+	<div class="ps-header">
+		<span class="ps-label">PORTFOLIO</span>
 	</div>
 
-	<span class="ps-sep" aria-hidden="true"></span>
+	<div class="ps-body">
+		<div class="ps-row">
+			<span class="ps-key">STATUS</span>
+			<span class="ps-val ps-status">
+				<LiveDot
+					status={isLive ? "success" : isPaused ? "warn" : "muted"}
+					pulse={isLive}
+					label="Portfolio state"
+				/>
+				{isLive ? "LIVE" : isPaused ? "PAUSED" : state.toUpperCase()}
+			</span>
+		</div>
 
-	<!-- AUM -->
-	<div class="ps-cell">
-		<span class="ps-key">AUM</span>
-		<span class="ps-val">{formatAUM(aum)}</span>
+		<div class="ps-row">
+			<span class="ps-key">AUM</span>
+			<span class="ps-val">{formatAUM(aum)}</span>
+		</div>
+
+		<div class="ps-row">
+			<span class="ps-key">RETURN (1Y)</span>
+			<span
+				class="ps-val"
+				class:ps-up={returnPct != null && returnPct >= 0}
+				class:ps-down={returnPct != null && returnPct < 0}
+			>
+				{returnPct != null ? formatPercent(returnPct, 1, "en-US", true) : "\u2014"}
+			</span>
+		</div>
+
+		<div class="ps-row">
+			<span class="ps-key">DRIFT</span>
+			<span
+				class="ps-val"
+				class:ps-drift-aligned={driftStatus === "aligned"}
+				class:ps-drift-watch={driftStatus === "watch"}
+				class:ps-drift-breach={driftStatus === "breach"}
+			>
+				{driftLabel}
+			</span>
+		</div>
+
+		<div class="ps-row">
+			<span class="ps-key">INSTRUMENTS</span>
+			<span class="ps-val">{instrumentCount}</span>
+		</div>
+
+		<div class="ps-row">
+			<span class="ps-key">LAST REBALANCE</span>
+			<span class="ps-val">{lastRebalance ? formatDate(lastRebalance, "short") : "\u2014"}</span>
+		</div>
 	</div>
 
-	<span class="ps-sep" aria-hidden="true"></span>
-
-	<!-- Return -->
-	<div class="ps-cell">
-		<span class="ps-key">RETURN</span>
-		<span
-			class="ps-val"
-			class:ps-up={returnPct != null && returnPct >= 0}
-			class:ps-down={returnPct != null && returnPct < 0}
-		>
-			{returnPct != null ? formatPercent(returnPct, 1, "en-US", true) : "\u2014"}
-		</span>
-	</div>
-
-	<span class="ps-sep" aria-hidden="true"></span>
-
-	<!-- Drift -->
-	<div class="ps-cell">
-		<span class="ps-key">DRIFT</span>
-		<span
-			class="ps-val"
-			class:ps-drift-aligned={driftStatus === "aligned"}
-			class:ps-drift-watch={driftStatus === "watch"}
-			class:ps-drift-breach={driftStatus === "breach"}
-		>
-			{driftLabel}
-		</span>
-	</div>
-
-	<span class="ps-sep" aria-hidden="true"></span>
-
-	<!-- Instruments -->
-	<div class="ps-cell">
-		<span class="ps-key">INSTRUMENTS</span>
-		<span class="ps-val">{instrumentCount}</span>
-	</div>
-
-	<!-- Spacer pushes rebalance to far right -->
-	<div class="ps-spacer"></div>
-
-	<!-- Rebalance button (only when drift is not aligned) -->
 	{#if driftStatus !== "aligned"}
-		<button type="button" class="ps-rebalance-btn" onclick={handleRebalance}>
-			REBALANCE
-		</button>
+		<div class="ps-footer">
+			<button type="button" class="ps-rebalance-btn" onclick={handleRebalance}>
+				REBALANCE
+			</button>
+		</div>
 	{/if}
 </div>
 
 <style>
-	.ps-strip {
+	.ps-root {
 		display: flex;
-		align-items: center;
-		height: 32px;
-		padding: 0 var(--terminal-space-2);
-		gap: var(--terminal-space-3);
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
 		background: var(--terminal-bg-panel);
 		font-family: var(--terminal-font-mono);
-		border-top: var(--terminal-border-hairline);
-		border-bottom: var(--terminal-border-hairline);
-		flex-shrink: 0;
+		border-right: var(--terminal-border-hairline);
 	}
 
-	.ps-cell {
+	.ps-header {
 		display: flex;
 		align-items: center;
+		flex-shrink: 0;
+		height: 24px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.ps-label {
+		font-size: var(--terminal-text-9);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.ps-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		padding: var(--terminal-space-2);
+		display: flex;
+		flex-direction: column;
 		gap: var(--terminal-space-1);
-		white-space: nowrap;
+	}
+
+	.ps-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
 	}
 
 	.ps-key {
 		font-size: var(--terminal-text-9);
 		color: var(--terminal-fg-tertiary);
 		letter-spacing: var(--terminal-tracking-caps);
-		text-transform: uppercase;
 	}
 
 	.ps-val {
@@ -162,40 +182,21 @@
 		gap: 4px;
 	}
 
-	.ps-sep {
-		width: 1px;
-		height: 14px;
-		background: var(--terminal-fg-muted);
+	.ps-up { color: var(--terminal-status-success); }
+	.ps-down { color: var(--terminal-status-error); }
+	.ps-drift-aligned { color: var(--terminal-status-success); }
+	.ps-drift-watch { color: var(--terminal-status-warn); }
+	.ps-drift-breach { color: var(--terminal-status-error); }
+
+	.ps-footer {
 		flex-shrink: 0;
-	}
-
-	.ps-spacer {
-		flex: 1;
-	}
-
-	.ps-up {
-		color: var(--terminal-status-success);
-	}
-
-	.ps-down {
-		color: var(--terminal-status-error);
-	}
-
-	.ps-drift-aligned {
-		color: var(--terminal-status-success);
-	}
-
-	.ps-drift-watch {
-		color: var(--terminal-status-warn);
-	}
-
-	.ps-drift-breach {
-		color: var(--terminal-status-error);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-top: var(--terminal-border-hairline);
 	}
 
 	.ps-rebalance-btn {
-		height: 22px;
-		padding: 0 var(--terminal-space-2);
+		width: 100%;
+		height: 24px;
 		background: var(--terminal-accent-amber);
 		color: var(--terminal-bg-void);
 		border: none;
@@ -206,12 +207,9 @@
 		letter-spacing: var(--terminal-tracking-caps);
 		text-transform: uppercase;
 		cursor: pointer;
-		flex-shrink: 0;
 	}
 
-	.ps-rebalance-btn:hover {
-		opacity: 0.9;
-	}
+	.ps-rebalance-btn:hover { opacity: 0.9; }
 
 	.ps-rebalance-btn:focus-visible {
 		outline: var(--terminal-border-focus);

--- a/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
@@ -602,7 +602,7 @@
 				</div>
 			</aside>
 
-			<!-- CENTER: Toolbar + Chart + Summary + Holdings -->
+			<!-- CENTER: Toolbar + Chart (top) + [Summary | Holdings] (bottom) -->
 			<div class="lw-center">
 				<div class="lw-toolbar">
 					<ChartToolbar
@@ -628,25 +628,27 @@
 					/>
 				</section>
 
-				<div class="lw-summary">
-					<PortfolioSummary
-						status={selected?.status ?? ""}
-						state={selected?.state ?? "draft"}
-						aum={portfolioAum}
-						returnPct={marketStore.totalReturnPct}
-						driftStatus={aggregateDrift}
-						{instrumentCount}
-						{lastRebalance}
-						onRebalance={handleRebalanceOpen}
-					/>
-				</div>
+				<div class="lw-bottom">
+					<div class="lw-summary">
+						<PortfolioSummary
+							status={selected?.status ?? ""}
+							state={selected?.state ?? "draft"}
+							aum={portfolioAum}
+							returnPct={marketStore.totalReturnPct}
+							driftStatus={aggregateDrift}
+							{instrumentCount}
+							{lastRebalance}
+							onRebalance={handleRebalanceOpen}
+						/>
+					</div>
 
-				<div class="lw-holdings">
-					<HoldingsTable
-						holdings={holdingsRows}
-						selectedTicker={effectiveTicker}
-						onSelect={handleHoldingsSelect}
-					/>
+					<div class="lw-holdings">
+						<HoldingsTable
+							holdings={holdingsRows}
+							selectedTicker={effectiveTicker}
+							onSelect={handleHoldingsSelect}
+						/>
+					</div>
 				</div>
 			</div>
 
@@ -746,7 +748,7 @@
 		overflow: hidden;
 	}
 
-	/* CENTER COLUMN: toolbar + chart + summary + holdings */
+	/* CENTER COLUMN: toolbar + chart (top) + [summary | holdings] (bottom) */
 	.lw-center {
 		display: flex;
 		flex-direction: column;
@@ -771,17 +773,24 @@
 		position: relative;
 	}
 
+	.lw-bottom {
+		flex: 45;
+		display: grid;
+		grid-template-columns: 200px 1fr;
+		min-height: 0;
+		overflow: hidden;
+		border-top: var(--terminal-border-hairline);
+	}
+
 	.lw-summary {
-		flex-shrink: 0;
+		min-height: 0;
 		overflow: hidden;
 	}
 
 	.lw-holdings {
-		flex: 45;
 		min-width: 0;
 		min-height: 0;
 		overflow: hidden;
-		border-top: var(--terminal-border-hairline);
 	}
 
 	/* RIGHT COLUMN: News + Macro stacked */


### PR DESCRIPTION
## Summary

- Restored PortfolioSummary as 200px vertical panel to the left of Holdings
- Bottom area uses sub-grid: `200px 1fr` (Summary | Holdings)
- Chart takes top 55%, bottom area takes 45%
- REBALANCE button contained within PortfolioSummary footer
- Full-bleed columns (no visible gap between grid columns)

## Test plan

- [x] svelte-check: 0 errors
- [x] PortfolioSummary should appear as vertical panel between watchlist and holdings

🤖 Generated with [Claude Code](https://claude.com/claude-code)