### PR TITLE
fix(live): equalize columns, borders, force monospace fonts

### DIFF
--- a/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/PortfolioSummary.svelte
@@ -126,7 +126,7 @@
 		min-height: 0;
 		overflow: hidden;
 		background: var(--terminal-bg-panel);
-		font-family: var(--terminal-font-mono);
+		font-family: var(--terminal-font-mono), "JetBrains Mono", "SF Mono", monospace;
 		border-right: var(--terminal-border-hairline);
 	}
 
@@ -140,6 +140,7 @@
 	}
 
 	.ps-label {
+		font-family: var(--terminal-font-mono), "JetBrains Mono", "SF Mono", monospace;
 		font-size: var(--terminal-text-9);
 		font-weight: 700;
 		letter-spacing: var(--terminal-tracking-caps);
@@ -164,12 +165,14 @@
 	}
 
 	.ps-key {
+		font-family: var(--terminal-font-mono), "JetBrains Mono", "SF Mono", monospace;
 		font-size: var(--terminal-text-9);
 		color: var(--terminal-fg-tertiary);
 		letter-spacing: var(--terminal-tracking-caps);
 	}
 
 	.ps-val {
+		font-family: var(--terminal-font-mono), "JetBrains Mono", "SF Mono", monospace;
 		font-size: var(--terminal-text-10);
 		font-weight: 600;
 		color: var(--terminal-fg-primary);

--- a/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
@@ -713,7 +713,7 @@
 	/* -- Main grid: 3-column, full height -- */
 	.lw-shell {
 		display: grid;
-		grid-template-columns: 220px 1fr 280px;
+		grid-template-columns: 280px 1fr 280px;
 		height: calc(100vh - 88px);
 		background: var(--terminal-bg-void);
 		font-family: var(--terminal-font-mono);
@@ -726,6 +726,7 @@
 		min-height: 0;
 		overflow: hidden;
 		background: var(--terminal-bg-panel);
+		border-right: var(--terminal-border-hairline);
 	}
 
 	.lw-left-watchlist {
@@ -799,6 +800,7 @@
 		flex-direction: column;
 		min-height: 0;
 		overflow: hidden;
+		border-left: var(--terminal-border-hairline);
 	}
 
 	.lw-news {


### PR DESCRIPTION
## Summary

- Left column width 220px → 280px (matches right column)
- Hairline borders between all 3 columns
- PortfolioSummary: explicit monospace with JetBrains Mono fallback on every text class

## Test plan

- [x] svelte-check: 0 errors
- [x] Columns should be symmetric, chart slightly narrower
- [x] PortfolioSummary text should render in monospace

🤖 Generated with [Claude Code](https://claude.com/claude-code)