### PR TITLE
feat(terminal): Phase 6A — DD Track kanban + TopNav activation

### DIFF
--- a/frontends/wealth/src/lib/components/terminal/dd/DDQueueCard.svelte
+++ b/frontends/wealth/src/lib/components/terminal/dd/DDQueueCard.svelte
@@ -1,0 +1,171 @@
+<!--
+  DDQueueCard — terminal-native kanban card for a single DD report.
+
+  Renders as a keyboard-accessible <button> with instrument label,
+  status badge, version, confidence score, and decision anchor.
+  Terminal tokens only — no shadcn, no hex values.
+-->
+<script lang="ts">
+	import { formatDateTime, formatPercent } from "@investintell/ui";
+	import LiveDot from "$lib/components/terminal/data/LiveDot.svelte";
+
+	interface DDQueueCardProps {
+		id: string;
+		instrumentId: string;
+		instrumentLabel: string | null;
+		status: string;
+		version: number;
+		confidenceScore: number | null;
+		decisionAnchor: string | null;
+		createdAt: string;
+		approvedAt: string | null;
+		onClick: () => void;
+	}
+
+	let {
+		instrumentLabel,
+		status,
+		version,
+		confidenceScore,
+		decisionAnchor,
+		createdAt,
+		onClick,
+	}: DDQueueCardProps = $props();
+
+	const STATUS_LABELS: Record<string, string> = {
+		draft: "Queued",
+		generating: "Generating...",
+		pending_approval: "Pending Review",
+		approved: "Approved",
+		rejected: "Rejected",
+		failed: "Failed",
+	};
+
+	const STATUS_COLORS: Record<string, string> = {
+		draft: "var(--terminal-fg-secondary)",
+		generating: "var(--terminal-accent-amber)",
+		pending_approval: "var(--terminal-accent-cyan)",
+		approved: "var(--terminal-status-success)",
+		rejected: "var(--terminal-status-error)",
+		failed: "var(--terminal-status-error)",
+	};
+
+	const ANCHOR_LABELS: Record<string, { text: string; color: string }> = {
+		APPROVE: { text: "Recommend Approve", color: "var(--terminal-status-success)" },
+		REJECT: { text: "Recommend Reject", color: "var(--terminal-status-error)" },
+		CONDITIONAL: { text: "Conditional", color: "var(--terminal-accent-amber)" },
+	};
+
+	const statusLabel = $derived(STATUS_LABELS[status] ?? status);
+	const statusColor = $derived(STATUS_COLORS[status] ?? "var(--terminal-fg-secondary)");
+	const isGenerating = $derived(status === "generating");
+	const anchor = $derived(decisionAnchor ? ANCHOR_LABELS[decisionAnchor] ?? null : null);
+</script>
+
+<button
+	class="dqc-card"
+	type="button"
+	onclick={onClick}
+	aria-label={`${instrumentLabel ?? "Unknown Fund"} — ${statusLabel}`}
+>
+	<span class="dqc-label">{instrumentLabel ?? "Unknown Fund"}</span>
+
+	<span class="dqc-meta">
+		<span class="dqc-version">v{version}</span>
+		<span class="dqc-status" style:color={statusColor}>{statusLabel}</span>
+		{#if isGenerating}
+			<LiveDot status="warn" pulse label="Generating" />
+		{/if}
+	</span>
+
+	<span class="dqc-date">{formatDateTime(createdAt)}</span>
+
+	{#if confidenceScore !== null || anchor}
+		<span class="dqc-bottom">
+			{#if confidenceScore !== null}
+				<span class="dqc-conf">CONF: {formatPercent(confidenceScore / 100, 0)}</span>
+			{/if}
+			{#if anchor}
+				<span class="dqc-anchor" style:color={anchor.color}>{anchor.text}</span>
+			{/if}
+		</span>
+	{/if}
+</button>
+
+<style>
+	.dqc-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		width: 100%;
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		background: var(--terminal-bg-surface);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		text-align: left;
+		cursor: pointer;
+		transition: border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.dqc-card:hover {
+		border-color: var(--terminal-accent-amber);
+	}
+
+	.dqc-card:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -1px;
+	}
+
+	.dqc-label {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.dqc-meta {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+	}
+
+	.dqc-version {
+		color: var(--terminal-fg-tertiary);
+		font-weight: 600;
+	}
+
+	.dqc-status {
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.dqc-date {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+
+	.dqc-bottom {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+	}
+
+	.dqc-conf {
+		font-weight: 600;
+		color: var(--terminal-fg-secondary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.dqc-anchor {
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
@@ -36,9 +36,11 @@
 -->
 <script lang="ts">
 	import type { Snippet } from "svelte";
+	import { getContext } from "svelte";
 	import { page } from "$app/state";
 	import { goto } from "$app/navigation";
 	import { resolve } from "$app/paths";
+	import { createClientApiClient } from "$lib/api/client";
 	import TerminalTopNav from "./TerminalTopNav.svelte";
 	import TerminalStatusBar from "./TerminalStatusBar.svelte";
 	import TerminalContextRail, {
@@ -77,6 +79,26 @@
 	// Part C hardcodes "connecting" since no streams are mounted.
 	// Phase 5+ will aggregate real TerminalStream subscriptions.
 	const connectionStatus = "connecting" as const;
+
+	// ─── DD queue badge count ───────────────────────────────────
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const ddApi = createClientApiClient(getToken);
+	let ddQueueCount = $state(0);
+
+	async function fetchDDQueueCount() {
+		try {
+			const res = await ddApi.get<{ counts: Record<string, number> }>("/dd-reports/queue");
+			ddQueueCount = (res.counts.pending ?? 0) + (res.counts.in_progress ?? 0);
+		} catch {
+			// Silently ignore — badge stays at 0.
+		}
+	}
+
+	$effect(() => {
+		fetchDDQueueCount();
+		const timer = setInterval(fetchDDQueueCount, 60_000);
+		return () => clearInterval(timer);
+	});
 
 	// ─── URL-pinned entity ──────────────────────────────────────
 	const KNOWN_KINDS: ReadonlyArray<TerminalContextRailEntityKind> = [
@@ -121,6 +143,11 @@
 		await goto(target);
 	}
 
+	async function navDD() {
+		const target = resolve("/dd");
+		await goto(target);
+	}
+
 	function openPalette() {
 		paletteOpen = true;
 	}
@@ -135,7 +162,7 @@
 		a: openPalette, // Alloc — pending
 		p: openPalette, // Portfolio Builder — pending
 		n: openPalette, // Alerts (n for notifications) — pending
-		d: openPalette, // DD — pending
+		d: navDD,       // DD — active
 	};
 
 	const GO_TO_WINDOW_MS = 800;
@@ -243,6 +270,7 @@
 		<TerminalTopNav
 			activePath={page.url.pathname}
 			onOpenPalette={openPalette}
+			{ddQueueCount}
 			{userInitials}
 			{orgName}
 		/>

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte
@@ -30,6 +30,7 @@
 	// `resolve(...)`; hardcoding the three active route literals is
 	// the only pattern its AST matcher accepts.
 	const HREF_SCREENER = resolve("/terminal-screener");
+	const HREF_DD = resolve("/dd");
 	const HREF_BUILDER = resolve("/portfolio/builder");
 	const HREF_LIVE = resolve("/portfolio/live");
 	const HREF_RESEARCH = resolve("/research");
@@ -62,6 +63,11 @@
 		 */
 		alertCount?: number;
 		/**
+		 * DD queue count (pending + in_progress). Drives a badge on
+		 * the DD tab when > 0.
+		 */
+		ddQueueCount?: number;
+		/**
 		 * User initials rendered inside the session chip. Two-char mono
 		 * expected; empty string fallback renders "—".
 		 */
@@ -77,6 +83,7 @@
 		activePath,
 		onOpenPalette,
 		alertCount = 0,
+		ddQueueCount = 0,
 		userInitials,
 		orgName,
 	}: TerminalTopNavProps = $props();
@@ -85,16 +92,17 @@
 		{ id: "macro",    label: "MACRO",    href: "/macro",             status: "pending", pendingReason: "Phase 7 — Macro Desk" },
 		{ id: "alloc",    label: "ALLOC",    href: "/allocation",        status: "pending", pendingReason: "Phase 7 — Allocation" },
 		{ id: "screener", label: "SCREENER", href: HREF_SCREENER,        status: "active" },
+		{ id: "dd",       label: "DD",       href: HREF_DD,              status: "active" },
 		{ id: "builder",  label: "BUILDER",  href: HREF_BUILDER,         status: "active" },
 		{ id: "live",     label: "LIVE",     href: HREF_LIVE,            status: "active" },
 		{ id: "research", label: "RESEARCH", href: HREF_RESEARCH,        status: "active" },
 		{ id: "alerts",   label: "ALERTS",   href: HREF_ALERTS,          status: "active" },
-		{ id: "dd",       label: "DD",       href: "/dd",                status: "pending", pendingReason: "Phase 6 — DD Queue" },
 	];
 
 	function isHrefActive(href: string): boolean {
 		return (
 			href === HREF_SCREENER ||
+			href === HREF_DD ||
 			href === HREF_BUILDER ||
 			href === HREF_LIVE ||
 			href === HREF_RESEARCH ||
@@ -104,6 +112,7 @@
 
 	function activePathSegment(href: string): string {
 		if (href === HREF_SCREENER) return "/terminal-screener";
+		if (href === HREF_DD) return "/dd";
 		if (href === HREF_BUILDER) return "/portfolio/builder";
 		if (href === HREF_LIVE) return "/portfolio/live";
 		if (href === HREF_RESEARCH) return "/research";
@@ -171,6 +180,18 @@
 						data-sveltekit-preload-data="hover"
 					>
 						<span class="tn-tab-label">{tab.label}</span>
+					</a>
+				{:else if tab.id === "dd"}
+					<a
+						class="tn-tab tn-tab--active"
+						class:tn-tab--current={isActiveTab(tab)}
+						href={HREF_DD}
+						data-sveltekit-preload-data="hover"
+					>
+						<span class="tn-tab-label">{tab.label}</span>
+						{#if ddQueueCount > 0}
+							<span class="tn-dd-badge">{ddQueueCount > 99 ? "99+" : ddQueueCount}</span>
+						{/if}
 					</a>
 				{:else if tab.id === "builder"}
 					<a
@@ -552,5 +573,20 @@
 	.tn-session:focus-visible {
 		outline: var(--terminal-border-focus);
 		outline-offset: 2px;
+	}
+
+	.tn-dd-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 14px;
+		height: 14px;
+		padding: 0 3px;
+		background: var(--terminal-accent-cyan);
+		color: var(--terminal-fg-inverted);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0;
+		box-sizing: border-box;
 	}
 </style>

--- a/frontends/wealth/src/routes/(terminal)/dd/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/dd/+page.svelte
@@ -1,0 +1,257 @@
+<!--
+  /dd — DD Track Kanban (Phase 6, Session A).
+
+  Three-column kanban for DD report queue: QUEUE (pending),
+  IN PROGRESS, COMPLETED. Fetches from GET /dd-reports/queue
+  and polls every 30 seconds. Terminal-native primitives only.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
+	import { createClientApiClient } from "$lib/api/client";
+	import Panel from "$lib/components/terminal/layout/Panel.svelte";
+	import PanelHeader from "$lib/components/terminal/layout/PanelHeader.svelte";
+	import DDQueueCard from "$lib/components/terminal/dd/DDQueueCard.svelte";
+
+	interface DDReportQueueItem {
+		id: string;
+		instrument_id: string;
+		instrument_label: string | null;
+		report_type: string;
+		version: number;
+		status: string;
+		confidence_score: number | null;
+		decision_anchor: string | null;
+		created_at: string;
+		approved_at: string | null;
+		progress_pct: number | null;
+		current_chapter: string | null;
+	}
+
+	interface DDReportsQueueOut {
+		pending: DDReportQueueItem[];
+		in_progress: DDReportQueueItem[];
+		completed_recent: DDReportQueueItem[];
+		counts: Record<string, number>;
+	}
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	let pending = $state<DDReportQueueItem[]>([]);
+	let inProgress = $state<DDReportQueueItem[]>([]);
+	let completed = $state<DDReportQueueItem[]>([]);
+	let counts = $state<Record<string, number>>({});
+	let loading = $state(true);
+	let fetchError = $state(false);
+
+	async function fetchQueue() {
+		try {
+			const res = await api.get<DDReportsQueueOut>("/dd-reports/queue");
+			pending = res.pending;
+			inProgress = res.in_progress;
+			completed = res.completed_recent;
+			counts = res.counts;
+			fetchError = false;
+		} catch {
+			fetchError = true;
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		fetchQueue();
+		const timer = setInterval(fetchQueue, 30_000);
+		return () => clearInterval(timer);
+	});
+
+	const DD_BASE = resolve("/dd");
+
+	function navigateToReport(id: string) {
+		goto(`${DD_BASE}/${id}`);
+	}
+
+	const pendingCount = $derived(counts.pending ?? pending.length);
+	const inProgressCount = $derived(counts.in_progress ?? inProgress.length);
+	const completedCount = $derived(counts.completed_recent ?? completed.length);
+</script>
+
+<div class="dd-kanban" data-dd-root>
+	{#if loading}
+		<div class="dd-loading">Loading DD queue...</div>
+	{:else if fetchError}
+		<div class="dd-error">Failed to load DD queue. Retrying...</div>
+	{:else}
+		<div class="dd-columns">
+			<div class="dd-column">
+				<Panel scrollable>
+					{#snippet header()}
+						<PanelHeader label="QUEUE">
+							{#snippet actions()}
+								<span class="dd-count-badge dd-count-badge--secondary">{pendingCount}</span>
+							{/snippet}
+						</PanelHeader>
+					{/snippet}
+					<div class="dd-card-list">
+						{#each pending as item (item.id)}
+							<DDQueueCard
+								id={item.id}
+								instrumentId={item.instrument_id}
+								instrumentLabel={item.instrument_label}
+								status={item.status}
+								version={item.version}
+								confidenceScore={item.confidence_score}
+								decisionAnchor={item.decision_anchor}
+								createdAt={item.created_at}
+								approvedAt={item.approved_at}
+								onClick={() => navigateToReport(item.id)}
+							/>
+						{:else}
+							<span class="dd-empty">No reports queued</span>
+						{/each}
+					</div>
+				</Panel>
+			</div>
+
+			<div class="dd-column">
+				<Panel scrollable>
+					{#snippet header()}
+						<PanelHeader label="IN PROGRESS">
+							{#snippet actions()}
+								<span class="dd-count-badge dd-count-badge--amber">{inProgressCount}</span>
+							{/snippet}
+						</PanelHeader>
+					{/snippet}
+					<div class="dd-card-list">
+						{#each inProgress as item (item.id)}
+							<DDQueueCard
+								id={item.id}
+								instrumentId={item.instrument_id}
+								instrumentLabel={item.instrument_label}
+								status={item.status}
+								version={item.version}
+								confidenceScore={item.confidence_score}
+								decisionAnchor={item.decision_anchor}
+								createdAt={item.created_at}
+								approvedAt={item.approved_at}
+								onClick={() => navigateToReport(item.id)}
+							/>
+						{:else}
+							<span class="dd-empty">No reports in progress</span>
+						{/each}
+					</div>
+				</Panel>
+			</div>
+
+			<div class="dd-column">
+				<Panel scrollable>
+					{#snippet header()}
+						<PanelHeader label="COMPLETED">
+							{#snippet actions()}
+								<span class="dd-count-badge dd-count-badge--secondary">{completedCount}</span>
+							{/snippet}
+						</PanelHeader>
+					{/snippet}
+					<div class="dd-card-list">
+						{#each completed as item (item.id)}
+							<DDQueueCard
+								id={item.id}
+								instrumentId={item.instrument_id}
+								instrumentLabel={item.instrument_label}
+								status={item.status}
+								version={item.version}
+								confidenceScore={item.confidence_score}
+								decisionAnchor={item.decision_anchor}
+								createdAt={item.created_at}
+								approvedAt={item.approved_at}
+								onClick={() => navigateToReport(item.id)}
+							/>
+						{:else}
+							<span class="dd-empty">No completed reports</span>
+						{/each}
+					</div>
+				</Panel>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dd-kanban {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		font-family: var(--terminal-font-mono);
+		overflow: hidden;
+	}
+
+	.dd-columns {
+		display: grid;
+		grid-template-columns: 1fr 1fr 1fr;
+		gap: var(--terminal-space-3);
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+	}
+
+	.dd-column {
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.dd-card-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+	}
+
+	.dd-count-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 18px;
+		height: 16px;
+		padding: 0 4px;
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		border-radius: var(--terminal-radius-none);
+	}
+
+	.dd-count-badge--secondary {
+		background: var(--terminal-fg-muted);
+		color: var(--terminal-fg-inverted);
+	}
+
+	.dd-count-badge--amber {
+		background: var(--terminal-accent-amber);
+		color: var(--terminal-fg-inverted);
+	}
+
+	.dd-loading,
+	.dd-error {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.dd-error {
+		color: var(--terminal-status-error);
+	}
+
+	.dd-empty {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: var(--terminal-space-3);
+	}
+</style>


### PR DESCRIPTION
## Summary
- DDQueueCard.svelte — terminal-native kanban card (status badges, confidence score, LiveDot pulse, keyboard accessible)
- (terminal)/dd/+page.svelte — 3-column kanban (Queue / In Progress / Completed) with 30s polling
- TerminalTopNav — DD tab activated at position 4 (investment chain order), cyan badge when queue > 0
- TerminalShell — polls /dd-reports/queue every 60s for badge count, g+d shortcut wired

## Test plan
- [ ] DD tab active in TopNav between SCREENER and BUILDER
- [ ] Kanban renders 3 columns from /dd-reports/queue
- [ ] Badge shows on DD tab when pending/in-progress items exist
- [ ] Cards are keyboard accessible (Enter/Space)
- [ ] No hex colors, no shadcn imports, no localStorage
- [ ] `pnpm --filter @investintell/wealth check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)