### PR TITLE
feat(terminal): Phase 7 Session B — Allocation Editor + TopNav activation

### DIFF
--- a/frontends/wealth/src/lib/components/terminal/allocation/ImpactPreview.svelte
+++ b/frontends/wealth/src/lib/components/terminal/allocation/ImpactPreview.svelte
@@ -1,0 +1,363 @@
+<!--
+  ImpactPreview.svelte — right-side panel showing effective allocation
+  visualization, regime state, simulation trigger, and builder link.
+
+  Terminal-native: no hex, no radius, mono font, TerminalChart only.
+-->
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { resolve } from "$app/paths";
+  import { formatNumber, formatPercent, createTerminalChartOptions } from "@investintell/ui";
+  import TerminalChart from "$lib/components/terminal/charts/TerminalChart.svelte";
+
+  interface EffectiveEntry {
+    name: string;
+    weight: number;
+  }
+
+  interface SimResult {
+    proposedCvar: number | null;
+    cvarLimit: number | null;
+    cvarUtilization: number | null;
+    cvarDelta: number | null;
+    withinLimit: boolean;
+    warnings: string[];
+  }
+
+  interface ImpactPreviewProps {
+    effective: EffectiveEntry[];
+    regime: string;
+    simulationResult: SimResult | null;
+    onSimulate: () => void;
+    isSimulating: boolean;
+  }
+
+  let { effective, regime, simulationResult, onSimulate, isSimulating }: ImpactPreviewProps =
+    $props();
+
+  // Regime label sanitization + color mapping
+  const REGIME_MAP: Record<string, { label: string; colorVar: string }> = {
+    REGIME_NORMAL: { label: "Normal", colorVar: "var(--terminal-status-ok)" },
+    normal: { label: "Normal", colorVar: "var(--terminal-status-ok)" },
+    REGIME_RISK_ON: { label: "Risk On", colorVar: "var(--terminal-accent-cyan)" },
+    risk_on: { label: "Risk On", colorVar: "var(--terminal-accent-cyan)" },
+    REGIME_RISK_OFF: { label: "Risk Off", colorVar: "var(--terminal-accent-amber)" },
+    risk_off: { label: "Risk Off", colorVar: "var(--terminal-accent-amber)" },
+    REGIME_CRISIS: { label: "Crisis", colorVar: "var(--terminal-status-error)" },
+    crisis: { label: "Crisis", colorVar: "var(--terminal-status-error)" },
+  };
+
+  const regimeDisplay = $derived(REGIME_MAP[regime] ?? { label: regime, colorVar: "var(--terminal-fg-muted)" });
+
+  // Stacked bar chart for effective allocation
+  const chartOption = $derived.by(() => {
+    if (effective.length === 0) return null;
+
+    const sorted = [...effective].sort((a, b) => b.weight - a.weight);
+    const data = sorted.map((e) => ({
+      name: e.name,
+      value: +(e.weight * 100).toFixed(1),
+    }));
+
+    return createTerminalChartOptions({
+      series: [
+        {
+          type: "bar",
+          data: data.map((d) => d.value),
+          barWidth: 16,
+          label: {
+            show: true,
+            position: "right",
+            formatter: "{c}%",
+            fontSize: 10,
+          },
+        },
+      ],
+      xAxis: {
+        type: "value",
+        min: 0,
+        max: 100,
+        axisLabel: {
+          formatter: "{value}%",
+        },
+      },
+      yAxis: {
+        type: "category",
+        data: data.map((d) => d.name),
+        inverse: true,
+        axisLabel: {
+          fontSize: 10,
+          width: 80,
+          overflow: "truncate",
+        },
+      },
+      slot: "secondary",
+      showLegend: false,
+    });
+  });
+
+  function handleBuilderNav() {
+    goto(resolve("/portfolio/builder") + "?alloc=default");
+  }
+</script>
+
+<div class="ip-root">
+  <!-- Regime badge -->
+  <div class="ip-regime">
+    <span class="ip-regime-label">REGIME</span>
+    <span class="ip-regime-value" style:color={regimeDisplay.colorVar}>
+      {regimeDisplay.label}
+    </span>
+  </div>
+
+  <!-- Effective allocation chart -->
+  <div class="ip-chart">
+    {#if chartOption}
+      <TerminalChart option={chartOption} ariaLabel="Effective allocation breakdown" />
+    {:else}
+      <div class="ip-empty">No allocation data</div>
+    {/if}
+  </div>
+
+  <!-- Simulation section -->
+  <div class="ip-sim">
+    <button
+      type="button"
+      class="ip-sim-btn"
+      disabled={isSimulating}
+      onclick={onSimulate}
+      title="Simulation requires portfolio instruments — block-level simulation coming soon"
+    >
+      {isSimulating ? "SIMULATING..." : "SIMULATE"}
+    </button>
+
+    {#if simulationResult}
+      <div class="ip-sim-results">
+        {#if simulationResult.proposedCvar !== null}
+          <div class="ip-sim-row">
+            <span class="ip-sim-label">CVaR (95%, 3M)</span>
+            <span class="ip-sim-value">
+              {formatPercent(simulationResult.proposedCvar, 2)}
+            </span>
+          </div>
+        {/if}
+        {#if simulationResult.cvarUtilization !== null}
+          <div class="ip-sim-row">
+            <span class="ip-sim-label">Risk Budget Used</span>
+            <span class="ip-sim-value">
+              {formatNumber(simulationResult.cvarUtilization, 1)}%
+            </span>
+          </div>
+        {/if}
+        {#if simulationResult.cvarDelta !== null}
+          <div class="ip-sim-row">
+            <span class="ip-sim-label">Risk Change</span>
+            <span
+              class="ip-sim-value"
+              class:ip-sim-value--positive={simulationResult.cvarDelta > 0}
+              class:ip-sim-value--negative={simulationResult.cvarDelta < 0}
+            >
+              {simulationResult.cvarDelta > 0 ? "+" : ""}
+              {formatPercent(simulationResult.cvarDelta, 3)}
+            </span>
+          </div>
+        {/if}
+        <div class="ip-sim-row">
+          <span class="ip-sim-label">Within Limit</span>
+          <span
+            class="ip-sim-value"
+            class:ip-sim-value--ok={simulationResult.withinLimit}
+            class:ip-sim-value--breach={!simulationResult.withinLimit}
+          >
+            {simulationResult.withinLimit ? "YES" : "NO"}
+          </span>
+        </div>
+        {#if simulationResult.warnings.length > 0}
+          <div class="ip-sim-warnings">
+            {#each simulationResult.warnings as warn}
+              <p class="ip-sim-warn">{warn}</p>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </div>
+
+  <!-- Builder navigation -->
+  <div class="ip-nav">
+    <button type="button" class="ip-builder-btn" onclick={handleBuilderNav}>
+      -&gt; BUILDER
+    </button>
+  </div>
+</div>
+
+<style>
+  .ip-root {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-3);
+    height: 100%;
+    font-family: var(--terminal-font-mono);
+  }
+
+  .ip-regime {
+    display: flex;
+    align-items: baseline;
+    gap: var(--terminal-space-2);
+    padding: var(--terminal-space-2) 0;
+    border-bottom: var(--terminal-border-hairline);
+    flex-shrink: 0;
+  }
+
+  .ip-regime-label {
+    font-size: var(--terminal-text-10);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-muted);
+  }
+
+  .ip-regime-value {
+    font-size: var(--terminal-text-14);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .ip-chart {
+    flex: 1;
+    min-height: 120px;
+    max-height: 300px;
+  }
+
+  .ip-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    font-size: var(--terminal-text-11);
+    color: var(--terminal-fg-muted);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .ip-sim {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-2);
+    flex-shrink: 0;
+  }
+
+  .ip-sim-btn {
+    width: 100%;
+    height: 28px;
+    background: transparent;
+    border: var(--terminal-border-hairline);
+    border-radius: var(--terminal-radius-none);
+    color: var(--terminal-accent-cyan);
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    cursor: pointer;
+    transition:
+      border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+      background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .ip-sim-btn:hover:not(:disabled) {
+    border-color: var(--terminal-accent-cyan);
+    background: var(--terminal-bg-panel-raised);
+  }
+
+  .ip-sim-btn:disabled {
+    color: var(--terminal-fg-muted);
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .ip-sim-results {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-1);
+    padding: var(--terminal-space-2);
+    border: var(--terminal-border-hairline);
+  }
+
+  .ip-sim-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: var(--terminal-text-11);
+  }
+
+  .ip-sim-label {
+    color: var(--terminal-fg-muted);
+    font-size: var(--terminal-text-10);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .ip-sim-value {
+    font-variant-numeric: tabular-nums;
+    color: var(--terminal-fg-primary);
+    font-weight: 600;
+  }
+
+  .ip-sim-value--positive {
+    color: var(--terminal-status-error);
+  }
+
+  .ip-sim-value--negative {
+    color: var(--terminal-status-ok);
+  }
+
+  .ip-sim-value--ok {
+    color: var(--terminal-status-ok);
+  }
+
+  .ip-sim-value--breach {
+    color: var(--terminal-status-error);
+  }
+
+  .ip-sim-warnings {
+    padding-top: var(--terminal-space-1);
+    border-top: var(--terminal-border-hairline);
+  }
+
+  .ip-sim-warn {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-muted);
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  .ip-nav {
+    flex-shrink: 0;
+    padding-top: var(--terminal-space-2);
+    border-top: var(--terminal-border-hairline);
+  }
+
+  .ip-builder-btn {
+    width: 100%;
+    height: 32px;
+    background: transparent;
+    border: var(--terminal-border-hairline);
+    border-radius: var(--terminal-radius-none);
+    color: var(--terminal-accent-amber);
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-11);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    cursor: pointer;
+    transition:
+      border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+      background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .ip-builder-btn:hover {
+    border-color: var(--terminal-accent-amber);
+    background: var(--terminal-bg-panel-raised);
+  }
+</style>

--- a/frontends/wealth/src/lib/components/terminal/allocation/WeightsEditor.svelte
+++ b/frontends/wealth/src/lib/components/terminal/allocation/WeightsEditor.svelte
@@ -1,0 +1,346 @@
+<!--
+  WeightsEditor.svelte — editable strategic + tactical allocation table.
+
+  Terminal-native: mono font, hairline borders, zero radius.
+  Weights display as 0–100% but backend stores as 0–1 decimals.
+  Total validation: sum of strategic weights must equal 100 (tolerance 0.1).
+-->
+<script lang="ts">
+  import { formatNumber } from "@investintell/ui";
+
+  interface BlockRow {
+    blockId: string;
+    name: string;
+    strategicWeight: number;
+    tacticalOverweight: number;
+  }
+
+  interface RegimeSuggestion {
+    blockId: string;
+    suggestedWeight: number;
+  }
+
+  interface WeightsEditorProps {
+    blocks: BlockRow[];
+    regimeSuggestions: RegimeSuggestion[] | null;
+    onSave: (
+      strategic: Array<{ blockId: string; weight: number }>,
+      tactical: Array<{ blockId: string; overweight: number }>,
+    ) => void;
+    isSaving: boolean;
+  }
+
+  let { blocks, regimeSuggestions, onSave, isSaving }: WeightsEditorProps = $props();
+
+  // Local editable state: display as 0-100 scale
+  let editRows = $state<Array<{
+    blockId: string;
+    name: string;
+    strategic: number;
+    tactical: number;
+    originalStrategic: number;
+    originalTactical: number;
+  }>>([]);
+
+  // Sync from props when blocks change
+  $effect(() => {
+    editRows = blocks.map((b) => ({
+      blockId: b.blockId,
+      name: b.name,
+      strategic: b.strategicWeight * 100,
+      tactical: b.tacticalOverweight * 100,
+      originalStrategic: b.strategicWeight * 100,
+      originalTactical: b.tacticalOverweight * 100,
+    }));
+  });
+
+  const strategicTotal = $derived(
+    editRows.reduce((sum, r) => sum + r.strategic, 0),
+  );
+
+  const totalValid = $derived(Math.abs(strategicTotal - 100) < 0.1);
+  const hasChanges = $derived(
+    editRows.some(
+      (r) =>
+        Math.abs(r.strategic - r.originalStrategic) > 0.001 ||
+        Math.abs(r.tactical - r.originalTactical) > 0.001,
+    ),
+  );
+
+  const canSave = $derived(totalValid && hasChanges && !isSaving);
+
+  function getRegimeSuggestion(blockId: string): number | null {
+    if (!regimeSuggestions) return null;
+    const s = regimeSuggestions.find((r) => r.blockId === blockId);
+    return s ? s.suggestedWeight * 100 : null;
+  }
+
+  function handleSave() {
+    if (!canSave) return;
+    onSave(
+      editRows.map((r) => ({ blockId: r.blockId, weight: r.strategic / 100 })),
+      editRows.map((r) => ({ blockId: r.blockId, overweight: r.tactical / 100 })),
+    );
+  }
+
+  function isModified(current: number, original: number): boolean {
+    return Math.abs(current - original) > 0.001;
+  }
+</script>
+
+<div class="we-root">
+  <div class="we-table">
+    <div class="we-header">
+      <span class="we-col we-col--name">Block</span>
+      <span class="we-col we-col--num">Strategic %</span>
+      <span class="we-col we-col--num">Tactical +/-</span>
+      <span class="we-col we-col--num">Effective %</span>
+      <span class="we-col we-col--num">Regime Sug.</span>
+    </div>
+
+    {#each editRows as row, i (row.blockId)}
+      {@const effective = row.strategic + row.tactical}
+      {@const suggestion = getRegimeSuggestion(row.blockId)}
+      <div class="we-row">
+        <span class="we-col we-col--name">{row.name}</span>
+        <span class="we-col we-col--num">
+          <input
+            type="number"
+            class="we-input"
+            class:we-input--modified={isModified(row.strategic, row.originalStrategic)}
+            min="0"
+            max="100"
+            step="0.1"
+            bind:value={row.strategic}
+          />
+        </span>
+        <span class="we-col we-col--num">
+          <input
+            type="number"
+            class="we-input we-input--tactical"
+            class:we-input--modified={isModified(row.tactical, row.originalTactical)}
+            min="-50"
+            max="50"
+            step="0.1"
+            bind:value={row.tactical}
+          />
+        </span>
+        <span
+          class="we-col we-col--num we-effective"
+          class:we-effective--warn={effective < 0 || effective > 100}
+        >
+          {formatNumber(effective, 1)}%
+        </span>
+        <span class="we-col we-col--num we-suggestion">
+          {#if suggestion !== null}
+            {formatNumber(suggestion, 1)}%
+          {:else}
+            --
+          {/if}
+        </span>
+      </div>
+    {/each}
+
+    <div class="we-total" class:we-total--error={!totalValid}>
+      <span class="we-col we-col--name">TOTAL</span>
+      <span class="we-col we-col--num we-total-value">
+        {formatNumber(strategicTotal, 1)}%
+      </span>
+      <span class="we-col we-col--num"></span>
+      <span class="we-col we-col--num we-total-value">
+        {formatNumber(
+          editRows.reduce((s, r) => s + r.strategic + r.tactical, 0),
+          1,
+        )}%
+      </span>
+      <span class="we-col we-col--num"></span>
+    </div>
+  </div>
+
+  <div class="we-actions">
+    {#if !totalValid}
+      <span class="we-validation-msg">Strategic weights must sum to 100%</span>
+    {/if}
+    <button
+      type="button"
+      class="we-save-btn"
+      disabled={!canSave}
+      onclick={handleSave}
+    >
+      {isSaving ? "SAVING..." : "SAVE WEIGHTS"}
+    </button>
+  </div>
+</div>
+
+<style>
+  .we-root {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-3);
+    height: 100%;
+    font-family: var(--terminal-font-mono);
+  }
+
+  .we-table {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .we-header {
+    display: flex;
+    align-items: center;
+    height: 28px;
+    padding: 0 var(--terminal-space-2);
+    border-bottom: var(--terminal-border-hairline);
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-muted);
+    flex-shrink: 0;
+  }
+
+  .we-row {
+    display: flex;
+    align-items: center;
+    height: 36px;
+    padding: 0 var(--terminal-space-2);
+    border-bottom: var(--terminal-border-hairline);
+    font-size: var(--terminal-text-11);
+    color: var(--terminal-fg-secondary);
+  }
+
+  .we-row:hover {
+    background: var(--terminal-bg-panel-raised);
+  }
+
+  .we-col {
+    display: flex;
+    align-items: center;
+  }
+
+  .we-col--name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--terminal-fg-primary);
+    font-weight: 600;
+  }
+
+  .we-col--num {
+    width: 110px;
+    flex-shrink: 0;
+    justify-content: flex-end;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .we-input {
+    width: 72px;
+    height: 24px;
+    padding: 0 var(--terminal-space-2);
+    background: var(--terminal-bg-void);
+    border: var(--terminal-border-hairline);
+    border-radius: var(--terminal-radius-none);
+    color: var(--terminal-fg-primary);
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-11);
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+    outline: none;
+  }
+
+  .we-input:focus {
+    border-color: var(--terminal-accent-amber);
+  }
+
+  .we-input--modified {
+    color: var(--terminal-accent-cyan);
+  }
+
+  .we-input--tactical {
+    width: 64px;
+  }
+
+  .we-effective {
+    color: var(--terminal-fg-primary);
+  }
+
+  .we-effective--warn {
+    color: var(--terminal-status-error);
+  }
+
+  .we-suggestion {
+    color: var(--terminal-fg-muted);
+    font-style: italic;
+  }
+
+  .we-total {
+    display: flex;
+    align-items: center;
+    height: 32px;
+    padding: 0 var(--terminal-space-2);
+    border-top: 1px solid var(--terminal-fg-muted);
+    font-size: var(--terminal-text-11);
+    font-weight: 700;
+    color: var(--terminal-fg-primary);
+    flex-shrink: 0;
+  }
+
+  .we-total--error {
+    color: var(--terminal-status-error);
+  }
+
+  .we-total-value {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .we-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--terminal-space-3);
+    padding: var(--terminal-space-2) 0;
+    flex-shrink: 0;
+  }
+
+  .we-validation-msg {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-status-error);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .we-save-btn {
+    height: 28px;
+    padding: 0 var(--terminal-space-4);
+    background: transparent;
+    border: var(--terminal-border-hairline);
+    border-radius: var(--terminal-radius-none);
+    color: var(--terminal-accent-amber);
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    cursor: pointer;
+    transition:
+      border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+      background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .we-save-btn:hover:not(:disabled) {
+    border-color: var(--terminal-accent-amber);
+    background: var(--terminal-bg-panel-raised);
+  }
+
+  .we-save-btn:disabled {
+    color: var(--terminal-fg-muted);
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+</style>

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte
@@ -30,6 +30,7 @@
 	// `resolve(...)`; hardcoding the three active route literals is
 	// the only pattern its AST matcher accepts.
 	const HREF_MACRO = resolve("/macro");
+	const HREF_ALLOC = resolve("/allocation");
 	const HREF_SCREENER = resolve("/terminal-screener");
 	const HREF_DD = resolve("/dd");
 	const HREF_BUILDER = resolve("/portfolio/builder");
@@ -91,7 +92,7 @@
 
 	const PRIMARY_TABS: ReadonlyArray<PrimaryTab> = [
 		{ id: "macro",    label: "MACRO",    href: HREF_MACRO,           status: "active" },
-		{ id: "alloc",    label: "ALLOC",    href: "/allocation",        status: "pending", pendingReason: "Phase 7 — Allocation" },
+		{ id: "alloc",    label: "ALLOC",    href: HREF_ALLOC,           status: "active" },
 		{ id: "screener", label: "SCREENER", href: HREF_SCREENER,        status: "active" },
 		{ id: "dd",       label: "DD",       href: HREF_DD,              status: "active" },
 		{ id: "builder",  label: "BUILDER",  href: HREF_BUILDER,         status: "active" },
@@ -103,6 +104,7 @@
 	function isHrefActive(href: string): boolean {
 		return (
 			href === HREF_MACRO ||
+			href === HREF_ALLOC ||
 			href === HREF_SCREENER ||
 			href === HREF_DD ||
 			href === HREF_BUILDER ||
@@ -114,6 +116,7 @@
 
 	function activePathSegment(href: string): string {
 		if (href === HREF_MACRO) return "/macro";
+		if (href === HREF_ALLOC) return "/allocation";
 		if (href === HREF_SCREENER) return "/terminal-screener";
 		if (href === HREF_DD) return "/dd";
 		if (href === HREF_BUILDER) return "/portfolio/builder";
@@ -180,6 +183,15 @@
 						class="tn-tab tn-tab--active"
 						class:tn-tab--current={isActiveTab(tab)}
 						href={HREF_MACRO}
+						data-sveltekit-preload-data="hover"
+					>
+						<span class="tn-tab-label">{tab.label}</span>
+					</a>
+				{:else if tab.id === "alloc"}
+					<a
+						class="tn-tab tn-tab--active"
+						class:tn-tab--current={isActiveTab(tab)}
+						href={HREF_ALLOC}
 						data-sveltekit-preload-data="hover"
 					>
 						<span class="tn-tab-label">{tab.label}</span>

--- a/frontends/wealth/src/routes/(terminal)/allocation/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/allocation/+page.svelte
@@ -1,0 +1,441 @@
+<!--
+  /allocation — Allocation Editor (Phase 7, Session B).
+
+  Three-column layout: block tree (left 250px) | weights editor
+  (center 1fr) | impact preview (right 350px). Terminal-native.
+  Weights are 0–1 in backend, displayed as 0–100% in the UI.
+-->
+<script lang="ts">
+  import { getContext } from "svelte";
+  import { createClientApiClient } from "$lib/api/client";
+  import Panel from "$lib/components/terminal/layout/Panel.svelte";
+  import PanelHeader from "$lib/components/terminal/layout/PanelHeader.svelte";
+  import WeightsEditor from "$lib/components/terminal/allocation/WeightsEditor.svelte";
+  import ImpactPreview from "$lib/components/terminal/allocation/ImpactPreview.svelte";
+
+  // -- Types -----------------------------------------------------------
+
+  interface StrategicAllocationRead {
+    allocation_id: string;
+    profile: string;
+    block_id: string;
+    target_weight: number;
+    min_weight: number;
+    max_weight: number;
+    risk_budget: number | null;
+    rationale: string | null;
+    approved_by: string | null;
+    effective_from: string;
+    effective_to: string | null;
+    created_at: string;
+  }
+
+  interface TacticalPositionRead {
+    position_id: string;
+    profile: string;
+    block_id: string;
+    overweight: number;
+    conviction_score: number | null;
+    signal_source: string | null;
+    rationale: string | null;
+    valid_from: string;
+    valid_to: string | null;
+    source: string | null;
+    created_at: string;
+  }
+
+  interface EffectiveAllocationRead {
+    profile: string;
+    block_id: string;
+    strategic_weight: number | null;
+    tactical_overweight: number | null;
+    effective_weight: number | null;
+    min_weight: number | null;
+    max_weight: number | null;
+  }
+
+  interface GlobalRegimeRead {
+    as_of_date: string;
+    raw_regime: string;
+    stress_score: number | null;
+    signal_details: Record<string, unknown>;
+  }
+
+  interface RegimeBandsRead {
+    profile: string;
+    as_of_date: string;
+    raw_regime: string;
+    stress_score: number | null;
+    smoothed_centers: Record<string, number>;
+    effective_bands: Record<string, { min: number; max: number; center?: number }>;
+    transition_velocity: Record<string, number> | null;
+    ips_clamps_applied: string[];
+  }
+
+  // -- API client ------------------------------------------------------
+
+  const getToken = getContext<() => Promise<string>>("netz:getToken");
+  const api = createClientApiClient(getToken);
+  const PROFILE = "default";
+
+  // -- State -----------------------------------------------------------
+
+  let strategicData = $state<StrategicAllocationRead[]>([]);
+  let tacticalData = $state<TacticalPositionRead[]>([]);
+  let effectiveData = $state<EffectiveAllocationRead[]>([]);
+  let regimeData = $state<GlobalRegimeRead | null>(null);
+  let regimeBands = $state<RegimeBandsRead | null>(null);
+
+  let loading = $state(true);
+  let fetchError = $state(false);
+  let isSaving = $state(false);
+  let isSimulating = $state(false);
+  let simulationResult = $state<{
+    proposedCvar: number | null;
+    cvarLimit: number | null;
+    cvarUtilization: number | null;
+    cvarDelta: number | null;
+    withinLimit: boolean;
+    warnings: string[];
+  } | null>(null);
+
+  let selectedBlockId = $state<string | null>(null);
+
+  // -- Block name helper -----------------------------------------------
+
+  function blockDisplayName(blockId: string): string {
+    return blockId
+      .split("_")
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(" ");
+  }
+
+  // -- Data fetching ---------------------------------------------------
+
+  async function fetchAllData() {
+    try {
+      const [strategic, tactical, effective, regime] = await Promise.all([
+        api.get<StrategicAllocationRead[]>(`/allocation/${PROFILE}/strategic`),
+        api.get<TacticalPositionRead[]>(`/allocation/${PROFILE}/tactical`),
+        api.get<EffectiveAllocationRead[]>(`/allocation/${PROFILE}/effective`),
+        api.get<GlobalRegimeRead>("/allocation/regime"),
+      ]);
+      strategicData = strategic;
+      tacticalData = tactical;
+      effectiveData = effective;
+      regimeData = regime;
+      fetchError = false;
+
+      // Fetch regime bands (non-blocking — may 404 if worker hasn't run)
+      try {
+        regimeBands = await api.get<RegimeBandsRead>(`/allocation/${PROFILE}/regime-bands`);
+      } catch {
+        regimeBands = null;
+      }
+    } catch {
+      fetchError = true;
+    } finally {
+      loading = false;
+    }
+  }
+
+  // -- Derived views ---------------------------------------------------
+
+  // Merge strategic + tactical into editor rows
+  const editorBlocks = $derived.by(() => {
+    const tacticalMap = new Map(tacticalData.map((t) => [t.block_id, t]));
+    return strategicData.map((s) => {
+      const t = tacticalMap.get(s.block_id);
+      return {
+        blockId: s.block_id,
+        name: blockDisplayName(s.block_id),
+        strategicWeight: Number(s.target_weight),
+        tacticalOverweight: t ? Number(t.overweight) : 0,
+      };
+    });
+  });
+
+  // Block tree entries
+  const blockTree = $derived(
+    strategicData.map((s) => ({
+      blockId: s.block_id,
+      name: blockDisplayName(s.block_id),
+      weight: Number(s.target_weight),
+    })),
+  );
+
+  // Effective for the impact chart
+  const effectiveForChart = $derived(
+    effectiveData.map((e) => ({
+      name: blockDisplayName(e.block_id),
+      weight: Number(e.effective_weight ?? 0),
+    })),
+  );
+
+  // Regime suggestions from bands
+  const regimeSuggestions = $derived.by(() => {
+    if (!regimeBands) return null;
+    return Object.entries(regimeBands.smoothed_centers).map(([blockId, center]) => ({
+      blockId,
+      suggestedWeight: center,
+    }));
+  });
+
+  // -- Save handler ----------------------------------------------------
+
+  async function handleSave(
+    strategic: Array<{ blockId: string; weight: number }>,
+    tactical: Array<{ blockId: string; overweight: number }>,
+  ) {
+    isSaving = true;
+    try {
+      // Build strategic update payload
+      const strategicMap = new Map(strategicData.map((s) => [s.block_id, s]));
+      const allocations = strategic.map((s) => {
+        const existing = strategicMap.get(s.blockId);
+        return {
+          block_id: s.blockId,
+          target_weight: s.weight,
+          min_weight: existing ? Number(existing.min_weight) : 0,
+          max_weight: existing ? Number(existing.max_weight) : 1,
+          risk_budget: existing?.risk_budget ?? null,
+          rationale: existing?.rationale ?? null,
+        };
+      });
+
+      // Build tactical update payload
+      const positions = tactical
+        .filter((t) => Math.abs(t.overweight) > 0.0001)
+        .map((t) => ({
+          block_id: t.blockId,
+          overweight: t.overweight,
+          source: "ic_manual",
+        }));
+
+      await Promise.all([
+        api.put(`/allocation/${PROFILE}/strategic`, { allocations }),
+        api.put(`/allocation/${PROFILE}/tactical`, { positions }),
+      ]);
+
+      // Refresh data
+      await fetchAllData();
+    } catch {
+      // Error handling — the API client will surface toast/error
+    } finally {
+      isSaving = false;
+    }
+  }
+
+  // -- Simulate handler ------------------------------------------------
+
+  async function handleSimulate() {
+    // The simulate endpoint expects instrument_id -> weight (not block_id).
+    // Block-level simulation is not supported by the current backend.
+    // Show informational message.
+    simulationResult = {
+      proposedCvar: null,
+      cvarLimit: null,
+      cvarUtilization: null,
+      cvarDelta: null,
+      withinLimit: true,
+      warnings: [
+        "Block-level simulation requires portfolio instruments. "
+        + "Navigate to the Builder to run full CVaR simulation with instrument-level weights.",
+      ],
+    };
+  }
+
+  // -- Effects ---------------------------------------------------------
+
+  $effect(() => {
+    fetchAllData();
+    return () => {};
+  });
+</script>
+
+<div class="alloc-page">
+  {#if loading}
+    <div class="alloc-state">Loading allocation data...</div>
+  {:else if fetchError}
+    <div class="alloc-state alloc-state--error">
+      Failed to load allocation data. Check backend connection.
+    </div>
+  {:else}
+    <!-- Left: Block tree -->
+    <div class="alloc-tree">
+      <Panel scrollable>
+        {#snippet header()}
+          <PanelHeader label="ALLOCATION BLOCKS" />
+        {/snippet}
+        <div class="alloc-block-list">
+          {#each blockTree as block (block.blockId)}
+            <button
+              type="button"
+              class="alloc-block-item"
+              class:alloc-block-item--selected={selectedBlockId === block.blockId}
+              onclick={() => { selectedBlockId = block.blockId; }}
+            >
+              <span class="alloc-block-name">{block.name}</span>
+              <span class="alloc-block-weight">
+                {(block.weight * 100).toFixed(1)}%
+              </span>
+            </button>
+          {/each}
+          {#if blockTree.length === 0}
+            <div class="alloc-block-empty">
+              No allocation blocks configured
+            </div>
+          {/if}
+        </div>
+      </Panel>
+    </div>
+
+    <!-- Center: Weights editor -->
+    <div class="alloc-editor">
+      <Panel>
+        {#snippet header()}
+          <PanelHeader label="WEIGHTS EDITOR">
+            {#snippet actions()}
+              {#if regimeData}
+                <span class="alloc-editor-regime">
+                  {regimeData.raw_regime}
+                </span>
+              {/if}
+            {/snippet}
+          </PanelHeader>
+        {/snippet}
+        <WeightsEditor
+          blocks={editorBlocks}
+          {regimeSuggestions}
+          onSave={handleSave}
+          {isSaving}
+        />
+      </Panel>
+    </div>
+
+    <!-- Right: Impact preview -->
+    <div class="alloc-preview">
+      <Panel>
+        {#snippet header()}
+          <PanelHeader label="IMPACT PREVIEW" />
+        {/snippet}
+        <ImpactPreview
+          effective={effectiveForChart}
+          regime={regimeData?.raw_regime ?? "unknown"}
+          {simulationResult}
+          onSimulate={handleSimulate}
+          {isSimulating}
+        />
+      </Panel>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .alloc-page {
+    display: grid;
+    grid-template-columns: 250px 1fr 350px;
+    gap: var(--terminal-space-3);
+    width: 100%;
+    height: 100%;
+    font-family: var(--terminal-font-mono);
+    overflow: hidden;
+  }
+
+  .alloc-tree {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .alloc-editor {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .alloc-preview {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .alloc-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    grid-column: 1 / -1;
+    font-size: var(--terminal-text-11);
+    color: var(--terminal-fg-muted);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .alloc-state--error {
+    color: var(--terminal-status-error);
+  }
+
+  /* Block tree items */
+  .alloc-block-list {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .alloc-block-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: var(--terminal-space-2) var(--terminal-space-3);
+    background: transparent;
+    border: none;
+    border-bottom: var(--terminal-border-hairline);
+    border-radius: var(--terminal-radius-none);
+    color: var(--terminal-fg-secondary);
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-11);
+    cursor: pointer;
+    text-align: left;
+    transition:
+      background var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+      color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .alloc-block-item:hover {
+    background: var(--terminal-bg-panel-raised);
+    color: var(--terminal-fg-primary);
+  }
+
+  .alloc-block-item--selected {
+    background: var(--terminal-bg-panel-raised);
+    color: var(--terminal-accent-amber);
+    border-left: 2px solid var(--terminal-accent-amber);
+  }
+
+  .alloc-block-name {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .alloc-block-weight {
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+    color: var(--terminal-fg-muted);
+  }
+
+  .alloc-block-empty {
+    padding: var(--terminal-space-4);
+    text-align: center;
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-muted);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .alloc-editor-regime {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-muted);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Three-column allocation editor at `(terminal)/allocation`: block tree (left 250px), weights editor (center), impact preview (right 350px)
- WeightsEditor: editable strategic + tactical weights with real-time effective computation, total validation (sum must equal 100%), modified-value highlighting
- ImpactPreview: horizontal stacked bar chart via TerminalChart, regime badge with color mapping, simulate button (informational — block-level sim not supported by current backend), `-> BUILDER` navigation with `?alloc=default` query param
- ALLOC tab activated in TopNav with `resolve("/allocation")`, added to `isHrefActive` + `activePathSegment`
- Backend weight contract preserved: display as 0-100%, save as 0-1 decimals

## Test plan
- [ ] `pnpm --filter @investintell/wealth check` passes (0 errors)
- [ ] ALLOC tab active and clickable in TopNav, navigates to `/allocation`
- [ ] Strategic weights load and display from `GET /allocation/default/strategic`
- [ ] Editing a weight updates effective column in real-time via `$derived`
- [ ] Total validation prevents save when strategic sum != 100%
- [ ] `-> BUILDER` navigates to `/portfolio/builder?alloc=default`
- [ ] No hex colors, no shadcn, no localStorage, terminal tokens only

🤖 Generated with [Claude Code](https://claude.com/claude-code)