### PR TITLE
feat(terminal): Phase 7 Session C — Cross-wiring + Polish

### DIFF
--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalContextRail.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalContextRail.svelte
@@ -27,6 +27,7 @@
 	import type { Snippet } from "svelte";
 	import { fly } from "svelte/transition";
 	import { svelteTransitionFor } from "@investintell/ui";
+	import { pinnedRegime, type PinnedRegime } from "$lib/state/pinned-regime.svelte";
 
 	export type TerminalContextRailEntityKind =
 		| "fund"
@@ -61,6 +62,19 @@
 
 	let { entity, content, collapsed }: TerminalContextRailProps = $props();
 
+	const pinned = $derived(pinnedRegime.current);
+
+	const regimeColorClass = $derived.by(() => {
+		if (!pinned) return "";
+		switch (pinned.label) {
+			case "Normal": return "tcr-regime--ok";
+			case "Risk On": return "tcr-regime--cyan";
+			case "Risk Off": return "tcr-regime--amber";
+			case "Crisis": return "tcr-regime--error";
+			default: return "";
+		}
+	});
+
 	function kindLabel(kind: TerminalContextRailEntityKind): string {
 		switch (kind) {
 			case "fund":
@@ -93,6 +107,22 @@
 				<span class="tcr-entity-id" title={entity.id}>{entity.id}</span>
 			</header>
 			<div class="tcr-body">
+				{#if pinned}
+					<div class="tcr-regime-section">
+						<div class="tcr-regime-row">
+							<span class="tcr-regime-label">REGIME</span>
+							<span class="tcr-regime-value {regimeColorClass}">{pinned.label}</span>
+						</div>
+						<div class="tcr-regime-row">
+							<span class="tcr-regime-label">REGION</span>
+							<span class="tcr-regime-detail">{pinned.region}</span>
+						</div>
+						<div class="tcr-regime-row">
+							<span class="tcr-regime-label">SCORE</span>
+							<span class="tcr-regime-detail">{pinned.score}/100</span>
+						</div>
+					</div>
+				{/if}
 				{#if content}
 					{@render content(entity)}
 				{:else}
@@ -234,5 +264,58 @@
 		color: var(--terminal-fg-tertiary);
 		background: var(--terminal-bg-panel-raised);
 		padding: 0 3px;
+	}
+
+	/* ── Pinned regime section ────────────────────────── */
+
+	.tcr-regime-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-3);
+		margin-bottom: var(--terminal-space-3);
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-void);
+	}
+
+	.tcr-regime-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.tcr-regime-label {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.tcr-regime-value {
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+	}
+
+	.tcr-regime-detail {
+		color: var(--terminal-fg-secondary);
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.tcr-regime--ok {
+		color: var(--terminal-status-ok);
+	}
+
+	.tcr-regime--cyan {
+		color: var(--terminal-accent-cyan);
+	}
+
+	.tcr-regime--amber {
+		color: var(--terminal-accent-amber);
+	}
+
+	.tcr-regime--error {
+		color: var(--terminal-status-error);
 	}
 </style>

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
@@ -128,24 +128,36 @@
 	// dispatch surface). `active` entries invoke goto via resolve();
 	// `pending` entries open the palette so the user sees the
 	// pending badge for that route.
+	async function navMacro() {
+		await goto(resolve("/macro"));
+	}
+
+	async function navAlloc() {
+		await goto(resolve("/allocation"));
+	}
+
 	async function navScreener() {
-		const target = resolve("/terminal-screener");
-		await goto(target);
-	}
-
-	async function navLive() {
-		const target = resolve("/portfolio/live");
-		await goto(target);
-	}
-
-	async function navResearch() {
-		const target = resolve("/research");
-		await goto(target);
+		await goto(resolve("/terminal-screener"));
 	}
 
 	async function navDD() {
-		const target = resolve("/dd");
-		await goto(target);
+		await goto(resolve("/dd"));
+	}
+
+	async function navBuilder() {
+		await goto(resolve("/portfolio/builder"));
+	}
+
+	async function navLive() {
+		await goto(resolve("/portfolio/live"));
+	}
+
+	async function navResearch() {
+		await goto(resolve("/research"));
+	}
+
+	async function navAlerts() {
+		await goto(resolve("/alerts"));
 	}
 
 	function openPalette() {
@@ -155,14 +167,14 @@
 	type GoToHandler = () => void | Promise<void>;
 
 	const GO_TO_SHORTCUTS: Readonly<Record<string, GoToHandler>> = {
+		m: navMacro,
+		a: navAlloc,
 		s: navScreener,
+		d: navDD,
+		p: navBuilder,
 		l: navLive,
 		r: navResearch,
-		m: openPalette, // Macro — pending route
-		a: openPalette, // Alloc — pending
-		p: openPalette, // Portfolio Builder — pending
-		n: openPalette, // Alerts (n for notifications) — pending
-		d: navDD,       // DD — active
+		n: navAlerts,
 	};
 
 	const GO_TO_WINDOW_MS = 800;

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte
@@ -23,6 +23,8 @@
 <script lang="ts">
 	import { resolve } from "$app/paths";
 	import { goto } from "$app/navigation";
+	import { getContext, onDestroy } from "svelte";
+	import { createClientApiClient } from "$lib/api/client";
 
 	// Resolved hrefs for active routes. The lint rule
 	// `svelte/no-navigation-without-resolve` rejects any href that is
@@ -89,6 +91,60 @@
 		userInitials,
 		orgName,
 	}: TerminalTopNavProps = $props();
+
+	// ─── Live regime from /allocation/regime ───────────────────
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const regimeApi = createClientApiClient(getToken);
+
+	interface GlobalRegimeRead {
+		regime: string;
+		confidence: number;
+		as_of_date: string | null;
+	}
+
+	let regimeLabel = $state("STANDBY");
+	let regimeLoaded = $state(false);
+
+	const REGIME_DISPLAY: Record<string, string> = {
+		REGIME_NORMAL: "Normal",
+		normal: "Normal",
+		REGIME_RISK_ON: "Risk On",
+		risk_on: "Risk On",
+		REGIME_RISK_OFF: "Risk Off",
+		risk_off: "Risk Off",
+		REGIME_CRISIS: "Crisis",
+		crisis: "Crisis",
+	};
+
+	function sanitizeRegime(raw: string): string {
+		return REGIME_DISPLAY[raw] ?? raw;
+	}
+
+	const regimeColorClass = $derived.by(() => {
+		switch (regimeLabel) {
+			case "Normal": return "tn-regime-value--ok";
+			case "Risk On": return "tn-regime-value--cyan";
+			case "Risk Off": return "tn-regime-value--amber";
+			case "Crisis": return "tn-regime-value--error";
+			default: return "";
+		}
+	});
+
+	async function fetchRegime() {
+		try {
+			const res = await regimeApi.get<GlobalRegimeRead>("/allocation/regime");
+			regimeLabel = sanitizeRegime(res.regime);
+			regimeLoaded = true;
+		} catch {
+			// Keep current label on failure
+		}
+	}
+
+	$effect(() => {
+		fetchRegime();
+		const timer = setInterval(fetchRegime, 5 * 60 * 1000);
+		return () => clearInterval(timer);
+	});
 
 	const PRIMARY_TABS: ReadonlyArray<PrimaryTab> = [
 		{ id: "macro",    label: "MACRO",    href: HREF_MACRO,           status: "active" },
@@ -281,8 +337,8 @@
 		</button>
 
 		<span class="tn-regime" aria-live="polite">
-			<span class="tn-regime-label">MARKET</span>
-			<span class="tn-regime-value">STANDBY</span>
+			<span class="tn-regime-label">REGIME</span>
+			<span class="tn-regime-value {regimeColorClass}">{regimeLabel}</span>
 		</span>
 
 		<button
@@ -490,6 +546,22 @@
 
 	.tn-regime-value {
 		font-weight: 600;
+	}
+
+	.tn-regime-value--ok {
+		color: var(--terminal-status-ok);
+	}
+
+	.tn-regime-value--cyan {
+		color: var(--terminal-accent-cyan);
+	}
+
+	.tn-regime-value--amber {
+		color: var(--terminal-accent-amber);
+	}
+
+	.tn-regime-value--error {
+		color: var(--terminal-status-error);
 	}
 
 	.tn-tenant {

--- a/frontends/wealth/src/lib/state/pinned-regime.svelte.ts
+++ b/frontends/wealth/src/lib/state/pinned-regime.svelte.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared reactive state for pinned regime.
+ *
+ * Written by macro desk [PIN REGIME] button, read by
+ * TerminalContextRail and any downstream surface that
+ * needs regime context (Builder, Screener, etc.).
+ *
+ * Module-level $state — singleton across the app.
+ * No localStorage (terminal namespace forbids it).
+ */
+
+export interface PinnedRegime {
+	label: string;
+	region: string;
+	score: number;
+}
+
+let current = $state<PinnedRegime | null>(null);
+
+export const pinnedRegime = {
+	get current() {
+		return current;
+	},
+	pin(regime: PinnedRegime) {
+		current = regime;
+	},
+	clear() {
+		current = null;
+	},
+};

--- a/frontends/wealth/src/routes/(terminal)/macro/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/macro/+page.svelte
@@ -8,6 +8,7 @@
 <script lang="ts">
   import { getContext } from "svelte";
   import { createClientApiClient } from "$lib/api/client";
+  import { pinnedRegime } from "$lib/state/pinned-regime.svelte";
   import Panel from "$lib/components/terminal/layout/Panel.svelte";
   import PanelHeader from "$lib/components/terminal/layout/PanelHeader.svelte";
   import RegimeTile from "$lib/components/terminal/macro/RegimeTile.svelte";
@@ -211,6 +212,49 @@
     }),
   );
 
+  // -- Regime display helpers ------------------------------------------
+
+  const REGIME_DISPLAY: Record<string, string> = {
+    REGIME_NORMAL: "Normal",
+    normal: "Normal",
+    REGIME_RISK_ON: "Risk On",
+    risk_on: "Risk On",
+    REGIME_RISK_OFF: "Risk Off",
+    risk_off: "Risk Off",
+    REGIME_CRISIS: "Crisis",
+    crisis: "Crisis",
+  };
+
+  function sanitizeRegime(raw: string): string {
+    return REGIME_DISPLAY[raw] ?? raw;
+  }
+
+  const globalRegimeLabel = $derived(
+    regime ? sanitizeRegime(regime.global_regime) : "Unknown",
+  );
+
+  const isPinned = $derived(pinnedRegime.current !== null);
+
+  function handlePinRegime() {
+    if (!regime || !scores) return;
+
+    // Compute global composite from regional averages
+    const regionKeys = Object.keys(scores.regions);
+    const avgScore = regionKeys.length > 0
+      ? regionKeys.reduce((sum, k) => sum + (scores!.regions[k]?.composite_score ?? 0), 0) / regionKeys.length
+      : 0;
+
+    pinnedRegime.pin({
+      label: globalRegimeLabel,
+      region: "GLOBAL",
+      score: Math.round(avgScore),
+    });
+  }
+
+  function handleUnpinRegime() {
+    pinnedRegime.clear();
+  }
+
   // -- Effects ---------------------------------------------------------
 
   $effect(() => {
@@ -232,16 +276,40 @@
   {:else if fetchError}
     <div class="macro-state macro-state--error">Failed to load macro data. Retrying...</div>
   {:else}
-    <!-- Top row: 4 regime tiles -->
-    <div class="macro-tiles">
-      {#each tiles as tile (tile.region)}
-        <RegimeTile
-          region={tile.region}
-          compositeScore={tile.compositeScore}
-          regime={tile.regime}
-          dimensions={tile.dimensions}
-        />
-      {/each}
+    <!-- Top row: 4 regime tiles + pin action -->
+    <div class="macro-tiles-row">
+      <div class="macro-tiles">
+        {#each tiles as tile (tile.region)}
+          <RegimeTile
+            region={tile.region}
+            compositeScore={tile.compositeScore}
+            regime={tile.regime}
+            dimensions={tile.dimensions}
+          />
+        {/each}
+      </div>
+      <div class="macro-pin-bar">
+        <span class="macro-global-regime">
+          GLOBAL: <strong>{globalRegimeLabel}</strong>
+        </span>
+        {#if isPinned}
+          <button
+            type="button"
+            class="macro-pin-btn macro-pin-btn--active"
+            onclick={handleUnpinRegime}
+          >
+            UNPIN REGIME
+          </button>
+        {:else}
+          <button
+            type="button"
+            class="macro-pin-btn"
+            onclick={handlePinRegime}
+          >
+            PIN REGIME
+          </button>
+        {/if}
+      </div>
     </div>
 
     <!-- Bottom row: sparkline wall + committee feed -->
@@ -282,11 +350,71 @@
     overflow: hidden;
   }
 
+  .macro-tiles-row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-2);
+    flex-shrink: 0;
+  }
+
   .macro-tiles {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: var(--terminal-space-3);
-    flex-shrink: 0;
+  }
+
+  .macro-pin-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 var(--terminal-space-1);
+  }
+
+  .macro-global-regime {
+    font-size: var(--terminal-text-10);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-tertiary);
+  }
+
+  .macro-global-regime strong {
+    color: var(--terminal-fg-primary);
+    font-weight: 700;
+  }
+
+  .macro-pin-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--terminal-space-1);
+    padding: 2px var(--terminal-space-2);
+    background: transparent;
+    border: var(--terminal-border-hairline);
+    border-radius: var(--terminal-radius-none);
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-10);
+    font-weight: 600;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-secondary);
+    cursor: pointer;
+    transition:
+      border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+      color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .macro-pin-btn:hover {
+    border-color: var(--terminal-accent-amber);
+    color: var(--terminal-accent-amber);
+  }
+
+  .macro-pin-btn--active {
+    border-color: var(--terminal-accent-cyan);
+    color: var(--terminal-accent-cyan);
+  }
+
+  .macro-pin-btn--active:hover {
+    border-color: var(--terminal-status-error);
+    color: var(--terminal-status-error);
   }
 
   .macro-bottom {

--- a/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/builder/+page.svelte
@@ -10,6 +10,7 @@
 -->
 <script lang="ts">
 	import { getContext } from "svelte";
+	import { page } from "$app/state";
 	import { workspace } from "$lib/state/portfolio-workspace.svelte";
 	import type { ModelPortfolio } from "$lib/types/model-portfolio";
 	import type { PageData } from "./$types";
@@ -78,6 +79,9 @@
 	/** All tabs must be visited before activation unlocks (Session 3). */
 	const allTabsVisited = $derived(visitedTabs.size === TABS.length);
 
+	// Allocation profile from URL (linked from Allocation Editor)
+	const allocProfile = $derived(page.url.searchParams.get("alloc"));
+
 	// Cascade timeline phases from workspace
 	const cascadePhases = $derived(workspace.optimizerPhases);
 	const showCascade = $derived(workspace.runPhase !== "idle");
@@ -91,9 +95,14 @@
 	<!-- LEFT COLUMN (40%) — Command Panel -->
 	<div class="builder-left">
 		<!-- Breadcrumb back to screener -->
-		<a href={HREF_SCREENER} class="builder-backlink" data-sveltekit-preload-data="hover">
-			&larr; SCREENER
-		</a>
+		<div class="builder-header-row">
+			<a href={HREF_SCREENER} class="builder-backlink" data-sveltekit-preload-data="hover">
+				&larr; SCREENER
+			</a>
+			{#if allocProfile}
+				<span class="builder-alloc-badge">ALLOC: {allocProfile.toUpperCase()}</span>
+			{/if}
+		</div>
 
 		<!-- Portfolio selector -->
 		<div class="builder-portfolio-select">
@@ -200,6 +209,27 @@
 		border-right: var(--terminal-border-hairline);
 	}
 
+	.builder-header-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.builder-alloc-badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px var(--terminal-space-2);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-accent-cyan);
+		border: 1px solid var(--terminal-accent-cyan);
+		margin-right: var(--terminal-space-2);
+	}
+
 	.builder-backlink {
 		display: inline-flex;
 		align-items: center;
@@ -212,7 +242,6 @@
 		text-transform: uppercase;
 		text-decoration: none;
 		color: var(--terminal-fg-tertiary);
-		border-bottom: var(--terminal-border-hairline);
 		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
 	}
 


### PR DESCRIPTION
## Summary
- Wire live regime in TopNav — replaces static "MARKET STANDBY" with real `GET /allocation/regime` data, 5min poll, color-coded by regime state
- Add PIN REGIME button on macro desk → shared `pinnedRegime` store → displayed in TerminalContextRail
- Wire all go-to keyboard shortcuts: `g+m` macro, `g+a` alloc, `g+d` DD, `g+p` builder, `g+l` live, `g+r` research, `g+n` alerts
- Builder reads `?alloc=default` query param from allocation editor `[-> BUILDER]` link and shows cyan profile badge

## Test plan
- [ ] TopNav shows regime label with color (Normal=green, Risk On=cyan, Risk Off=amber, Crisis=red)
- [ ] Regime polls every 5 minutes
- [ ] Macro desk PIN REGIME button writes to context rail
- [ ] UNPIN REGIME button clears pinned state
- [ ] `g m` navigates to macro, `g a` to allocation, `g d` to DD
- [ ] Navigate from allocation `[-> BUILDER]` shows "ALLOC: DEFAULT" badge
- [ ] `pnpm --filter @investintell/wealth check` passes (0 errors)
- [ ] No hex colors, no Urbanist font, no localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)