### PR TITLE
feat(research): add Library + Reports tabs to Research shell

### DIFF
--- a/docs/prompts/2026-04-14-phase8-research.md
+++ b/docs/prompts/2026-04-14-phase8-research.md
@@ -1,0 +1,350 @@
+# Phase 8 — Research: Kill Mocks + Wire Real Data
+
+**Date:** 2026-04-14
+**Branch:** `feat/terminal-research-real-data`
+**Sessions:** 2 (Session A: Kill mocks + tokenize, Session B: Library + Content tabs)
+**Depends on:** main (Phases 1-7 + regime unification merged)
+
+---
+
+## Strategic Rationale
+
+The Research surface (`(terminal)/research`) is ACTIVE in the TopNav and renders a 3-column layout (asset tree | chart | KPIs). The asset tree and chart fetch real API data. But the right-side KPI panel (`TerminalRiskKpis.svelte`) uses **deterministic mock data** generated from a hash of the node ID. Additionally, all research components use hex colors and Urbanist font instead of terminal tokens. This violates `feedback_infra_before_visual.md`: no surface can be declared done while reporting fake data.
+
+---
+
+## Session A — Kill Mocks + Tokenize Research Components
+
+### CONTEXT
+
+The research components live in `frontends/wealth/src/lib/components/research/terminal/`. There are 5 components:
+- `TerminalResearchShell.svelte` — 3-column layout orchestrator
+- `TerminalAssetTree.svelte` — fund browser (REAL data from `/screener/catalog`)
+- `TerminalResearchChart.svelte` — risk timeseries (REAL data from `/risk/timeseries/{id}`)
+- `TerminalRiskKpis.svelte` — risk KPIs (**MOCK data** from `mockRisk()` function)
+- `TerminalHoldingsGrid.svelte` — holdings (REAL data from `/discovery/funds/{ticker}/analysis/holdings/top`)
+- `ScoreBreakdownPopover.svelte` — score breakdown (**MOCK data** derived from mock `managerScore`)
+
+The mock function `mockRisk(node)` at `TerminalRiskKpis.svelte` generates fake metrics (annReturn, annVolatility, sharpe, sortino, maxDrawdown, beta, trackingError, infoRatio, managerScore) from a deterministic hash of node.id. The score breakdown popover also uses mock data.
+
+**Real endpoint available:** `GET /api/wealth/instruments/{instrument_id}/risk-metrics` returns `InstrumentRiskMetricsRead`:
+```typescript
+{
+    instrument_id: string;
+    score_components: Record<string, number> | null;  // 6 scoring components with weights
+    manager_score: number | null;                     // 0-100 composite
+    sharpe_1y: number | null;
+    volatility_1y: number | null;
+    max_drawdown_1y: number | null;
+    cvar_95_1m: number | null;
+}
+```
+
+The `fund_risk_metrics` table also has: `sortino_1y`, `beta_1y`, `information_ratio_1y`, `tracking_error_1y`, `return_1y`, `return_3y_ann`, `alpha_1y`, `max_drawdown_3y`, `rsi_14`, `bb_position`, `blended_momentum_score`, `volatility_garch`, `dtw_drift_score`. These are pre-computed by the `global_risk_metrics` worker daily — real data, not computed on request.
+
+**Problem:** The `InstrumentRiskMetricsRead` schema only exposes 5 fields. To show the full KPI set, either:
+- Option A: Expand `InstrumentRiskMetricsRead` to include more fields from `FundRiskMetrics` model
+- Option B: Create a new endpoint/schema that returns the full KPI set
+
+**Choose Option A** — add the missing fields to `InstrumentRiskMetricsRead` at `backend/app/domains/wealth/schemas/instrument.py:63`. The schema already has `from_attributes=True` + `extra="ignore"`, so just add the fields and the ORM will populate them. Fields to add:
+
+```python
+# Return metrics
+return_1y: float | None = None
+return_3y_ann: float | None = None
+
+# Risk metrics (additional)
+sortino_1y: float | None = None
+max_drawdown_3y: float | None = None
+
+# Relative metrics
+alpha_1y: float | None = None
+beta_1y: float | None = None
+information_ratio_1y: float | None = None
+tracking_error_1y: float | None = None
+
+# Momentum
+blended_momentum_score: float | None = None
+
+# GARCH
+volatility_garch: float | None = None
+```
+
+### OBJECTIVE
+
+1. Expand `InstrumentRiskMetricsRead` schema with additional fields from `FundRiskMetrics`.
+2. Replace `mockRisk()` in `TerminalRiskKpis.svelte` with real API call to `GET /instruments/{instrumentId}/risk-metrics`.
+3. Replace mock score breakdown with real `score_components` from the API response.
+4. Migrate all 5 research components from hex colors to `--terminal-*` tokens.
+5. Migrate all fonts from Urbanist to `var(--terminal-font-mono)`.
+
+### CONSTRAINTS
+
+- All colors via `--terminal-*` CSS custom properties. No hex values anywhere.
+- Font: `var(--terminal-font-mono)` only. No Urbanist, no sans-serif.
+- Border radius: `var(--terminal-radius-none)` (0). No rounding.
+- Formatters from `@netz/ui` exclusively (`formatPercent`, `formatNumber`, `formatCurrency`).
+- No localStorage. State is in-memory via `$state` runes.
+- Svelte 5 runes: `$state`, `$derived`, `$effect`.
+- Smart backend / dumb frontend: show "Annual Return: 12.3%" not "return_1y: 0.123". Show "Netz Score: 82" not "manager_score: 82.00".
+- The tree node provides `instrumentId` (UUID) for the risk-metrics endpoint. Some tree nodes may have `instrumentId = null` (no NAV data). Handle gracefully: show "No risk data available" instead of crashing.
+- API calls use `createClientApiClient` from `$lib/api/client` with auth.
+
+### DELIVERABLES
+
+#### 1. Expand `InstrumentRiskMetricsRead` schema
+
+File: `backend/app/domains/wealth/schemas/instrument.py`
+
+Add the 10 fields listed above to `InstrumentRiskMetricsRead`. No other backend changes needed — the endpoint already does `model_validate(row)` from the ORM model which has all columns.
+
+#### 2. Rewrite `TerminalRiskKpis.svelte`
+
+File: `frontends/wealth/src/lib/components/research/terminal/TerminalRiskKpis.svelte`
+
+Changes:
+- **Delete** the entire `mockRisk()` function and `mockScoreData` generation.
+- **Add** a prop: `instrumentId: string | null` (passed from parent when tree selection changes).
+- **Add** `$effect` that fetches `GET /api/wealth/instruments/{instrumentId}/risk-metrics` when `instrumentId` changes. Include cleanup for stale requests.
+- **Handle** 404 (no risk metrics) gracefully — show "No risk data available" message.
+- **Map** API response fields to display KPIs. Human-readable labels (smart backend/dumb frontend):
+
+| API field | Display label | Format |
+|---|---|---|
+| `return_1y` | Annual Return | formatPercent |
+| `volatility_1y` | Annual Volatility | formatPercent |
+| `sharpe_1y` | Sharpe Ratio | formatNumber (2 decimals) |
+| `sortino_1y` | Sortino Ratio | formatNumber (2 decimals) |
+| `max_drawdown_1y` | Max Drawdown (1Y) | formatPercent |
+| `max_drawdown_3y` | Max Drawdown (3Y) | formatPercent |
+| `cvar_95_1m` | Risk Budget (1M) | formatPercent |
+| `beta_1y` | Beta | formatNumber (2 decimals) |
+| `tracking_error_1y` | Tracking Error | formatPercent |
+| `information_ratio_1y` | Information Ratio | formatNumber (2 decimals) |
+| `alpha_1y` | Alpha | formatPercent |
+| `blended_momentum_score` | Momentum | formatNumber (0 decimals) + "/100" |
+| `manager_score` | Netz Score | formatNumber (0 decimals) + "/100" |
+
+- **Score display** (bottom of KPI panel): Show `manager_score` with the same ELITE/EVICTION logic but using terminal tokens:
+  - `>= 75`: `[ ELITE ]` in `--terminal-accent-cyan`
+  - `< 40`: `[ EVICTION ]` in `--terminal-accent-amber`
+  - Otherwise: numeric in `--terminal-fg-primary`
+- **Tear Sheet button**: Keep the existing real API call (`POST /wealth/funds/{externalId}/reports/tear-sheet`). Already works.
+- **Replace all hex colors** with `--terminal-*` tokens.
+- **Replace all Urbanist** with `var(--terminal-font-mono)`.
+
+#### 3. Rewrite `ScoreBreakdownPopover.svelte`
+
+File: `frontends/wealth/src/lib/components/research/terminal/ScoreBreakdownPopover.svelte`
+
+Changes:
+- **Delete** mock score computation.
+- **Accept** `scoreComponents: Record<string, number> | null` and `managerScore: number | null` as props (from API response).
+- **Render** real `score_components` dict. Keys are component names (e.g., "return_consistency", "risk_adjusted_return", etc.). Map to human labels:
+  - "return_consistency" → "Return Consistency"
+  - "risk_adjusted_return" → "Risk-Adjusted Return"
+  - "drawdown_control" → "Drawdown Control"
+  - "information_ratio" → "Information Ratio"
+  - "flows_momentum" → "Flows Momentum"
+  - "fee_efficiency" → "Fee Efficiency"
+  - Fallback: title-case the key
+- **Replace all hex colors** with `--terminal-*` tokens.
+
+#### 4. Tokenize `TerminalResearchShell.svelte`
+
+File: `frontends/wealth/src/lib/components/research/terminal/TerminalResearchShell.svelte`
+
+Changes:
+- Replace `background: #000000` with `var(--terminal-bg-root)`.
+- Replace `#0c1018` with `var(--terminal-bg-surface)`.
+- Replace `#05080f` with `var(--terminal-bg-base)`.
+- Replace `font-family: "Urbanist"` with `var(--terminal-font-mono)`.
+- Replace all `rgba(255, 255, 255, 0.0X)` borders with `var(--terminal-border-hairline)`.
+- Replace `#2d7ef7` (active tab) with `var(--terminal-accent-cyan)`.
+- Replace `#64748b` (inactive text) with `var(--terminal-fg-secondary)`.
+- Replace `#e2e8f0` (primary text) with `var(--terminal-fg-primary)`.
+- Pass `instrumentId` from tree selection down to `TerminalRiskKpis`.
+
+#### 5. Tokenize `TerminalAssetTree.svelte`
+
+File: `frontends/wealth/src/lib/components/research/terminal/TerminalAssetTree.svelte`
+
+Changes:
+- Replace all hex colors with `--terminal-*` tokens (same mapping as shell).
+- Replace Urbanist with `var(--terminal-font-mono)`.
+
+#### 6. Tokenize `TerminalHoldingsGrid.svelte`
+
+File: `frontends/wealth/src/lib/components/research/terminal/TerminalHoldingsGrid.svelte`
+
+Changes:
+- Replace all hex colors with `--terminal-*` tokens.
+- Replace Urbanist and JetBrains Mono references with `var(--terminal-font-mono)`.
+
+#### 7. Tokenize `TerminalResearchChart.svelte`
+
+File: `frontends/wealth/src/lib/components/research/terminal/TerminalResearchChart.svelte`
+
+This component already uses `createTerminalLightweightChartOptions()` and `terminalLWSeriesColors()` from `@investintell/ui`. Check if any hex values remain and replace. Font should be `var(--terminal-font-mono)`.
+
+### VERIFICATION
+
+1. `make test` passes (schema expansion is additive, no breaking changes).
+2. `make typecheck` passes.
+3. `pnpm --filter @investintell/wealth check` passes.
+4. Select a fund in the asset tree → KPI panel shows REAL risk metrics from API.
+5. Select a fund with no risk data → panel shows "No risk data available".
+6. Score breakdown popover shows real component weights.
+7. Tear sheet export still works.
+8. `grep -r "#[0-9a-fA-F]\{3,8\}" frontends/wealth/src/lib/components/research/terminal/` returns zero matches.
+9. `grep -r "Urbanist" frontends/wealth/src/lib/components/research/terminal/` returns zero matches.
+
+### ANTI-PATTERNS
+
+- Do NOT keep `mockRisk()` as a fallback. Delete it entirely. If the API returns 404, show "No risk data".
+- Do NOT import shadcn components. Use terminal-native HTML with `--terminal-*` tokens.
+- Do NOT use `.toFixed()` or `.toLocaleString()`. Use formatters from `@netz/ui`.
+- Do NOT create `+page.server.ts` load functions. Fetch client-side with auth.
+- Do NOT add new dependencies or libraries.
+
+---
+
+## Session B — Library + Content Tabs
+
+### CONTEXT
+
+Session A delivered real data in the Research ANALYTICS view. Now we add two more views: LIBRARY (document browser) and REPORTS (content generation).
+
+The existing library system lives in `frontends/wealth/src/routes/(app)/library/` with 12+ components in `$lib/components/library/`. The content system lives in `frontends/wealth/src/routes/(app)/content/` with inline SSE + polling.
+
+**Key architectural decision:** Do NOT rewrite library components. Wrap them in the terminal shell and port tokens progressively. The library system is complex (tree loader, preview pane, pins, bundles, context menus, filter bar) and rewriting would take 3+ sessions with high regression risk.
+
+### OBJECTIVE
+
+1. Add a tab bar to `TerminalResearchShell`: `ANALYTICS | LIBRARY | REPORTS`.
+2. ANALYTICS tab renders the existing 3-column research layout.
+3. LIBRARY tab embeds `LibraryShell` with a terminal-compatible wrapper.
+4. REPORTS tab shows content list with generation buttons and SSE streaming.
+
+### DELIVERABLES
+
+#### 1. Modify `TerminalResearchShell.svelte`
+
+Add a top-level tab switcher above the current content:
+
+```
+┌─────────────────────────────────────────────┐
+│  [ ANALYTICS ]  [ LIBRARY ]  [ REPORTS ]    │
+├─────────────────────────────────────────────┤
+│  (content changes based on active tab)      │
+└─────────────────────────────────────────────┘
+```
+
+- Tab bar styled as inline text tabs (not pills — avoid confusion with TopNav).
+- Active tab: `--terminal-accent-cyan` with bottom border.
+- Inactive tab: `--terminal-fg-secondary`.
+- Default tab: ANALYTICS.
+- Use `$state` for active tab. No URL mutation (tabs are ephemeral within Research).
+
+When ANALYTICS is active: render existing 3-column layout (tree | chart/holdings | KPIs).
+When LIBRARY is active: render `LibraryWrapper` component (see below).
+When REPORTS is active: render `ReportsPanel` component (see below).
+
+#### 2. Create `frontends/wealth/src/lib/components/terminal/research/LibraryWrapper.svelte`
+
+A wrapper that embeds the existing `LibraryShell` with terminal styling overrides.
+
+Implementation:
+- Import `LibraryShell` from `$lib/components/library/LibraryShell.svelte`.
+- Wrap in a `<div class="library-terminal-wrapper">` that applies terminal token overrides via CSS cascade:
+  ```css
+  .library-terminal-wrapper {
+    --ii-bg-surface: var(--terminal-bg-surface);
+    --ii-bg-base: var(--terminal-bg-base);
+    --ii-fg-primary: var(--terminal-fg-primary);
+    --ii-fg-secondary: var(--terminal-fg-secondary);
+    --ii-border: var(--terminal-border-hairline);
+    --ii-accent: var(--terminal-accent-cyan);
+    font-family: var(--terminal-font-mono);
+    border-radius: 0;
+  }
+  ```
+- This CSS variable remapping trick makes the library components use terminal colors without rewriting them. The library components reference `--ii-*` tokens internally; by overriding those custom properties in a parent wrapper, we retheme them.
+- Check which `--ii-*` tokens the library components actually use (grep `$lib/components/library/` for `--ii-`) and map each one to the appropriate `--terminal-*` equivalent.
+- If some library components use raw hex values instead of `--ii-*` tokens, those will need targeted `:global()` overrides in the wrapper.
+
+Data fetching:
+- Library needs the tree data. The `(app)/library/+page.server.ts` fetches it via server-side load. Since Research is client-side only, fetch the tree data client-side:
+  ```typescript
+  const treeRes = await api.get('/library/tree');
+  ```
+- Pass the tree data to `LibraryShell` as a prop (check what props it expects).
+
+#### 3. Create `frontends/wealth/src/lib/components/terminal/research/ReportsPanel.svelte`
+
+A panel for content generation (Investment Outlooks, Flash Reports, Manager Spotlights).
+
+Data fetching:
+- Fetch `GET /api/wealth/content` on mount for list of existing reports.
+- Poll every 30s for status updates on generating reports.
+
+Layout:
+```
+┌──────────────────────────────────────────────┐
+│  GENERATE: [ OUTLOOK ] [ FLASH ] [ SPOTLIGHT ]│
+├──────────────────────────────────────────────┤
+│  Report list (scrollable)                    │
+│  ┌────────────────────────────────────────┐  │
+│  │ Quarterly Outlook — Apr 2026           │  │
+│  │ Status: PUBLISHED  [DOWNLOAD PDF]      │  │
+│  ├────────────────────────────────────────┤  │
+│  │ Flash Report — Apr 10 2026             │  │
+│  │ Status: GENERATING... (LiveDot)        │  │
+│  ├────────────────────────────────────────┤  │
+│  │ Manager Spotlight — Bridgewater        │  │
+│  │ Status: READY  [DOWNLOAD PDF]          │  │
+│  └────────────────────────────────────────┘  │
+└──────────────────────────────────────────────┘
+```
+
+Generation buttons:
+- `[ OUTLOOK ]` → `POST /api/wealth/content/outlooks` (returns 202 + jobId)
+- `[ FLASH ]` → `POST /api/wealth/content/flash-reports` (returns 202 + jobId)
+- `[ SPOTLIGHT ]` → opens a mini fund picker dialog, then `POST /api/wealth/content/spotlights?instrument_id={id}`
+
+SSE streaming for generating reports:
+- Use `createTerminalStream` from `$lib/components/terminal/runtime/stream.ts`
+- Connect to `GET /api/wealth/content/{contentId}/stream/{jobId}`
+- On completion: refresh report list
+- Fallback: if SSE fails, poll `GET /api/wealth/content` every 5s until status changes
+
+Report cards:
+- Status badges: `generating` (LiveDot + amber), `ready`/`published` (green), `failed` (red), `draft` (secondary)
+- Download button: `GET /api/wealth/content/{id}/download` → PDF blob → browser download
+- All styled with `--terminal-*` tokens
+
+Fund picker dialog for Spotlight:
+- Simple terminal-native dialog (same pattern as DDApprovalDialog)
+- Search input that filters funds from the asset tree data or fetches `/api/wealth/funds`
+- Select fund → POST → close dialog
+
+### VERIFICATION
+
+1. `pnpm --filter @investintell/wealth check` passes.
+2. Tab switcher renders 3 tabs. Default is ANALYTICS.
+3. ANALYTICS tab shows the existing research layout with real KPI data (Session A).
+4. LIBRARY tab shows the library tree and document readers.
+5. REPORTS tab shows existing reports with status badges.
+6. Generating a report shows LiveDot and SSE progress.
+7. Download PDF works from Reports tab.
+8. No hex colors in new files.
+9. Library components render with terminal-compatible colors via CSS variable remapping.
+
+### ANTI-PATTERNS
+
+- Do NOT rewrite library components. Wrap them with CSS variable remapping.
+- Do NOT create server-side load functions. Fetch client-side with auth.
+- Do NOT use `EventSource`. Use `createTerminalStream` or `fetch` + `ReadableStream`.
+- Do NOT add `localStorage`.
+- Do NOT create complex state management for the tab switcher. Simple `$state` string.
+- Do NOT show raw content type enums ("investment_outlook"). Map to "Investment Outlook".

--- a/docs/prompts/2026-04-14-regime-dynamic-weights.md
+++ b/docs/prompts/2026-04-14-regime-dynamic-weights.md
@@ -1,0 +1,720 @@
+# Regime Model Upgrade — Dynamic Weights + Econometric Rebalance
+
+**Date:** 2026-04-14
+**Branch:** `feat/regime-dynamic-weights`
+**Sessions:** 3 (sequenced — each session depends on the previous)
+**Priority:** HIGH — regime model is producing false-negative readings
+
+---
+
+## Problem
+
+The regime classifier (`classify_regime_multi_signal` in `backend/quant_engine/regime_service.py`) uses static weights that:
+
+1. **Over-weight VIX** (20%) — a structurally suppressed indicator (dealer gamma hedging, passive flows, vol-selling carry). With WTI at $114 (+84% in 3m), VIX at 19.5 is an anomaly, not a signal of calm.
+2. **Under-weight real-economy signals** (45%) — econometric indicators (CFNAI, Sahm, energy, employment) are harder to manipulate and serve as leading indicators of stress.
+3. **Use fixed weights** that can't adapt to signal amplitude — an energy shock at 100/100 contributes only 10 points to the composite regardless of magnitude.
+
+Result: composite = 22.2/100, classified RISK_ON (Expansion) despite an extreme energy shock.
+
+## Solution — Three Phases (Strict Sequence)
+
+### Phase 1: Data Ingestion (Session A)
+Add 3 new FRED series to macro_ingestion worker, populate historical data.
+
+### Phase 2: Dynamic Weights + Profile A (Session B)
+Implement the dynamic weight amplification mechanism and new signal weight profile. New signals use `None` gracefully until data is available.
+
+### Phase 3: Backtest Validation (Session C)
+Backtest both weight profiles against 2007-2008, 2020, 2022 macro data in the hypertable.
+
+**CRITICAL SEQUENCING:** Phase 2 must handle missing signals gracefully (they'll be `None` until Phase 1 ingestion runs). The existing renormalization logic already handles missing signals — when a signal is `None`, it's excluded from the signals list and weights are renormalized over available signals. Phase 2 code must follow this same pattern for the 3 new signals.
+
+---
+
+## Session A — Data Ingestion (3 New FRED Series)
+
+**Branch:** `feat/regime-dynamic-weights`
+**Scope:** Backend only — macro_ingestion worker + regime_service inputs
+
+### 1. Add series to macro_ingestion worker
+
+File: `backend/app/domains/wealth/workers/macro_ingestion.py`
+
+Add these 3 series to the ingestion list (wherever the FRED series IDs are defined):
+
+| Series ID | Name | Frequency | Category |
+|---|---|---|---|
+| `ICSA` | Initial Jobless Claims | Weekly | Employment leading |
+| `TOTBKCR` | Total Bank Credit, All Commercial Banks | Weekly | Credit cycle |
+| `PERMIT` | New Private Housing Units Authorized (Building Permits) | Monthly | Housing leading |
+
+These series are free FRED data, same API as all existing series. The ingestion worker already handles weekly and monthly frequencies — no special handling needed.
+
+### 2. Add staleness thresholds
+
+File: `backend/quant_engine/regime_service.py`
+
+Find `REGIME_SERIES_STALENESS` dict and add:
+
+```python
+"ICSA": 14,        # Weekly — stale after 2 weeks
+"TOTBKCR": 14,     # Weekly — stale after 2 weeks
+"PERMIT": 45,      # Monthly — stale after 45 days
+```
+
+### 3. Add computation helpers in regime_service.py
+
+Add 3 new `_compute_*` async helpers near the existing ones (around `_compute_series_zscore`, `_compute_series_roc`):
+
+```python
+async def _compute_icsa_zscore(
+    db: AsyncSession,
+    *,
+    as_of_date: date | None = None,
+) -> float | None:
+    """Z-score of 4-week MA of initial claims vs 52-week rolling stats.
+
+    ICSA is weekly. Compute:
+    1. 4-week moving average of ICSA (smooth weekly noise)
+    2. Mean and stddev of the 4wk MA over the trailing 52 weeks
+    3. Z-score = (current_4wk_ma - mean_52wk) / std_52wk
+    """
+    effective_date = as_of_date or date.today()
+
+    stmt = (
+        select(MacroData.obs_date, MacroData.value)
+        .where(
+            MacroData.series_id == "ICSA",
+            MacroData.obs_date > effective_date - timedelta(days=400),
+            MacroData.obs_date <= effective_date,
+        )
+        .order_by(MacroData.obs_date.asc())
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    if len(rows) < 8:  # Need at least 8 weeks for meaningful z-score
+        return None
+
+    values = [float(r.value) for r in rows]
+
+    # 4-week moving average
+    ma4 = []
+    for i in range(3, len(values)):
+        ma4.append(sum(values[i-3:i+1]) / 4.0)
+
+    if len(ma4) < 26:  # Need at least 26 weeks of MA for stats
+        return None
+
+    current_ma = ma4[-1]
+    # Use trailing 52 4wk-MA values (or all available if less)
+    lookback = ma4[-52:] if len(ma4) >= 52 else ma4
+    mean_val = sum(lookback) / len(lookback)
+    variance = sum((x - mean_val) ** 2 for x in lookback) / len(lookback)
+    std_val = variance ** 0.5
+
+    if std_val < 1.0:  # Avoid division by near-zero
+        return None
+
+    return (current_ma - mean_val) / std_val
+
+
+async def _compute_credit_impulse(
+    db: AsyncSession,
+    *,
+    as_of_date: date | None = None,
+) -> float | None:
+    """Credit impulse: 6-month rate-of-change of total bank credit.
+
+    Falling credit impulse (negative RoC) = credit contraction = stress.
+    Uses TOTBKCR (Total Bank Credit, All Commercial Banks, Weekly).
+
+    Returns percentage change over 6 months. Negative = contraction.
+    """
+    effective_date = as_of_date or date.today()
+
+    # Get latest value
+    stmt_latest = (
+        select(MacroData.value)
+        .where(
+            MacroData.series_id == "TOTBKCR",
+            MacroData.obs_date <= effective_date,
+        )
+        .order_by(MacroData.obs_date.desc())
+        .limit(1)
+    )
+    result_latest = await db.execute(stmt_latest)
+    latest = result_latest.scalar_one_or_none()
+    if latest is None:
+        return None
+
+    # Get value ~6 months ago
+    target_date = effective_date - timedelta(days=180)
+    stmt_old = (
+        select(MacroData.value)
+        .where(
+            MacroData.series_id == "TOTBKCR",
+            MacroData.obs_date <= target_date,
+        )
+        .order_by(MacroData.obs_date.desc())
+        .limit(1)
+    )
+    result_old = await db.execute(stmt_old)
+    old = result_old.scalar_one_or_none()
+    if old is None or float(old) == 0:
+        return None
+
+    return ((float(latest) - float(old)) / float(old)) * 100.0
+
+
+async def _compute_permits_roc(
+    db: AsyncSession,
+    *,
+    months: int = 6,
+    as_of_date: date | None = None,
+) -> float | None:
+    """6-month rate-of-change of building permits (PERMIT).
+
+    Falling permits = leading recession indicator (9-12 month lead).
+    Returns percentage change. Negative = declining permits.
+    """
+    return await _compute_series_roc(
+        db, "PERMIT", months=months, as_of_date=as_of_date,
+    )
+```
+
+Note: `_compute_series_roc` already exists in the file — reuse it for PERMIT. ICSA and TOTBKCR need custom helpers because they require specific transformations (4-week MA for ICSA, 6-month credit impulse for TOTBKCR).
+
+### 4. Extend `build_regime_inputs()` to include new signals
+
+In `build_regime_inputs()` (line ~827), add computation of the 3 new signals. Find where the existing signals are computed (around the `_compute_series_zscore` and `_compute_series_roc` calls) and add:
+
+```python
+# ── Initial Jobless Claims Z-score ──
+icsa_zscore = await _compute_icsa_zscore(db, as_of_date=effective_date)
+
+# ── Credit Impulse ──
+credit_impulse = await _compute_credit_impulse(db, as_of_date=effective_date)
+
+# ── Building Permits 6m RoC ──
+permits_roc = await _compute_permits_roc(db, as_of_date=effective_date)
+```
+
+Add to the return dict:
+
+```python
+return {
+    # ... existing keys ...
+    "icsa_zscore": icsa_zscore,
+    "credit_impulse": credit_impulse,
+    "permits_roc": permits_roc,
+}
+```
+
+### 5. Add new kwargs to `classify_regime_multi_signal()`
+
+Add 3 new optional parameters to the function signature:
+
+```python
+def classify_regime_multi_signal(
+    # ... existing params ...
+    icsa_zscore: float | None = None,
+    credit_impulse: float | None = None,
+    permits_roc: float | None = None,
+) -> tuple[str, dict[str, str]]:
+```
+
+Add signal entries (using Profile A weights — Session B will make these configurable):
+
+```python
+# Initial Jobless Claims Z-score (8%): weekly frequency, leads Sahm by 4-8 weeks
+if icsa_zscore is not None:
+    s = _ramp(icsa_zscore, calm=0.5, panic=2.5)
+    signals.append(("icsa", s, 0.08, f"ICSA_z={icsa_zscore:+.2f}\u03c3 (stress={s:.0f}/100)"))
+
+# Credit Impulse (5%): 6m RoC of bank credit. Negative = contraction = stress.
+# Inverted: we ramp on the negative side.
+if credit_impulse is not None:
+    s = _ramp(-credit_impulse, calm=-0.5, panic=2.0)
+    signals.append(("credit_impulse", s, 0.05, f"CreditImpulse={credit_impulse:+.1f}% (stress={s:.0f}/100)"))
+
+# Building Permits 6m RoC (4%): longest-lead recession indicator (9-12 months).
+# Falling permits = stress. Inverted.
+if permits_roc is not None:
+    s = _ramp(-permits_roc, calm=-5.0, panic=20.0)
+    signals.append(("permits", s, 0.04, f"Permits_\u03946m={permits_roc:+.1f}% (stress={s:.0f}/100)"))
+```
+
+### 6. Wire new signals through `get_current_regime()`
+
+In `get_current_regime()` (line ~923), where `classify_regime_multi_signal` is called with `inputs.get(...)`, add:
+
+```python
+icsa_zscore=inputs.get("icsa_zscore"),
+credit_impulse=inputs.get("credit_impulse"),
+permits_roc=inputs.get("permits_roc"),
+```
+
+Similarly in `run_global_regime_detection()` in `risk_calc.py` — find where `classify_regime_multi_signal` is called and add the same 3 kwargs.
+
+### 7. Run ingestion to populate historical data
+
+After deploying the worker changes, run the macro ingestion worker to backfill historical data for the 3 new series:
+
+```bash
+python -m app.domains.wealth.workers.macro_ingestion
+```
+
+FRED API returns up to 10 years of history by default. This populates the `macro_data` hypertable with ICSA, TOTBKCR, and PERMIT data.
+
+### 8. Tests
+
+Add tests for the 3 new computation helpers:
+
+File: `backend/tests/quant_engine/test_regime_new_signals.py`
+
+```python
+"""Tests for new regime signals: ICSA z-score, credit impulse, building permits."""
+
+import pytest
+from quant_engine.regime_service import classify_regime_multi_signal
+
+
+class TestIcsaSignal:
+    def test_calm_icsa_produces_low_stress(self):
+        """ICSA z-score below calm threshold produces zero stress."""
+        _, reasons = classify_regime_multi_signal(
+            vix=20.0, icsa_zscore=0.3,
+        )
+        assert "icsa" not in reasons or "stress=0" in reasons.get("icsa", "")
+
+    def test_extreme_icsa_produces_high_stress(self):
+        """ICSA z-score at panic level produces high stress."""
+        _, reasons = classify_regime_multi_signal(
+            vix=20.0, icsa_zscore=3.0,
+        )
+        assert "icsa" in {k for k in reasons if k.startswith("icsa") or "ICSA" in reasons.get(k, "")}
+
+
+class TestCreditImpulseSignal:
+    def test_positive_impulse_low_stress(self):
+        """Positive credit growth produces low stress."""
+        _, reasons = classify_regime_multi_signal(
+            vix=20.0, credit_impulse=2.0,
+        )
+        # Positive impulse → inverted ramp → low stress
+        assert any("CreditImpulse" in v and "stress=0" in v for v in reasons.values())
+
+    def test_negative_impulse_high_stress(self):
+        """Credit contraction produces high stress."""
+        _, reasons = classify_regime_multi_signal(
+            vix=20.0, credit_impulse=-3.0,
+        )
+        assert any("CreditImpulse" in v for v in reasons.values())
+
+
+class TestPermitsSignal:
+    def test_growing_permits_low_stress(self):
+        """Rising building permits produce low stress."""
+        _, reasons = classify_regime_multi_signal(
+            vix=20.0, permits_roc=10.0,
+        )
+        assert any("Permits" in v and "stress=0" in v for v in reasons.values())
+
+    def test_falling_permits_high_stress(self):
+        """Sharply falling permits produce high stress."""
+        _, reasons = classify_regime_multi_signal(
+            vix=20.0, permits_roc=-25.0,
+        )
+        assert any("Permits" in v for v in reasons.values())
+```
+
+### Verification (Session A)
+
+1. `make test` passes.
+2. `make lint` passes (on changed files).
+3. The 3 new series appear in `macro_data` after running ingestion.
+4. `build_regime_inputs()` returns non-None values for `icsa_zscore`, `credit_impulse`, `permits_roc`.
+5. `classify_regime_multi_signal()` accepts and processes the 3 new kwargs.
+6. When new signals are `None` (data not yet ingested), behavior is identical to before — they're simply excluded from the signals list.
+
+---
+
+## Session B — Dynamic Weight Amplification + Profile A
+
+**Branch:** same `feat/regime-dynamic-weights`
+**Depends on:** Session A committed
+**Scope:** `regime_service.py` only — mechanism + weight rebalance
+
+### 1. Add `_amplify_weights()` helper
+
+Add this function near the top of `regime_service.py`, after the existing helpers (`_ramp`, `_validate_plausibility`):
+
+```python
+def _amplify_weights(
+    signals: list[tuple[str, float, float, str]],
+    alpha: float = 2.0,
+    gamma: float = 2.0,
+    w_max: float = 0.35,
+) -> list[tuple[str, float, float, str]]:
+    """Compute dynamic weights based on signal amplitude.
+
+    Extreme signals get amplified weights via convex scaling.
+    Calm signals are nearly transparent to the amplification.
+
+    Formula: w_eff_i = w_base_i * (1 + alpha * (s_i / 100)^gamma)
+    Then renormalize to unit sum, cap at w_max with redistribution.
+
+    Args:
+        signals: List of (label, score, weight, reason) tuples.
+        alpha: Max amplification multiplier. 2.0 means a maxed signal
+               gets 3x its base weight before renormalization.
+        gamma: Convexity exponent. 2.0 (quadratic) means score=50 gets
+               25% of max amplification, score=80 gets 64%.
+        w_max: Hard cap on any single signal's final weight. Prevents
+               single-factor tyranny.
+
+    Returns:
+        New signals list with adjusted weights summing to ~1.0.
+    """
+    if not signals:
+        return signals
+
+    # Step 1: amplify
+    amplified: list[tuple[str, float, float, str]] = []
+    for label, score, weight, reason in signals:
+        amp = weight * (1.0 + alpha * (score / 100.0) ** gamma)
+        amplified.append((label, score, amp, reason))
+
+    # Step 2: normalize to unit sum
+    total = sum(w for _, _, w, _ in amplified)
+    if total <= 0:
+        return signals
+
+    normalized = [
+        (label, score, w / total, reason)
+        for label, score, w, reason in amplified
+    ]
+
+    # Step 3: enforce w_max cap with redistribution
+    for _ in range(5):  # Max 5 iterations to converge
+        excess = 0.0
+        uncapped_total = 0.0
+        has_capped = False
+        result: list[tuple[str, float, float, str]] = []
+
+        for label, score, w, reason in normalized:
+            if w > w_max:
+                excess += w - w_max
+                result.append((label, score, w_max, reason))
+                has_capped = True
+            else:
+                uncapped_total += w
+                result.append((label, score, w, reason))
+
+        if not has_capped or excess <= 0 or uncapped_total <= 0:
+            normalized = result
+            break
+
+        # Redistribute excess proportionally among uncapped signals
+        normalized = [
+            (
+                label, score,
+                w + (excess * w / uncapped_total) if w < w_max else w,
+                reason,
+            )
+            for label, score, w, reason in result
+        ]
+
+    return normalized
+```
+
+### 2. Update base weights to Profile A (40/60)
+
+In `classify_regime_multi_signal()`, update the weight values in each `signals.append(...)` call:
+
+| Signal | Old weight | New weight (Profile A) |
+|---|---|---|
+| VIX | 0.15 | **0.10** |
+| HY OAS | 0.15 | **0.12** |
+| BAA-10Y | 0.10 | **0.05** |
+| Yield Curve | 0.10 | **0.05** |
+| DXY | 0.05 | **0.08** |
+| Energy Shock | 0.10 | **0.12** |
+| CFNAI | 0.15 | **0.18** |
+| Sahm Rule | 0.10 | **0.08** |
+| Fed Funds ROC | 0.05 | **0.05** |
+| ICSA (new) | — | **0.08** |
+| Credit Impulse (new) | — | **0.05** |
+| Building Permits (new) | — | **0.04** |
+
+**Sum = 1.00** (verify this).
+
+### 3. Replace static composite with dynamic composite
+
+In `classify_regime_multi_signal()`, find the composite score computation (around line 279-282 after the prompt's regime unification changes). Replace:
+
+```python
+# CURRENT (static weighted sum with renormalization):
+raw_score = sum(s * w for _, s, w, _ in signals)
+weight_sum = sum(w for _, _, w, _ in signals)
+stress_score = raw_score / weight_sum if weight_sum > 0 else 50.0
+```
+
+With:
+
+```python
+# Step 1: renormalize base weights for available signals
+weight_sum = sum(w for _, _, w, _ in signals)
+if weight_sum > 0 and abs(weight_sum - 1.0) > 0.001:
+    signals = [(l, s, w / weight_sum, r) for l, s, w, r in signals]
+
+# Step 2: resolve amplification config
+amp_config: dict[str, Any] = {}
+if config:
+    amp_config = config.get("regime_amplification", {})
+amp_alpha = float(amp_config.get("alpha", 2.0))
+amp_gamma = float(amp_config.get("gamma", 2.0))
+amp_w_max = float(amp_config.get("w_max", 0.35))
+
+# Step 3: apply dynamic weight amplification
+base_signals = list(signals)  # snapshot before amplification
+signals = _amplify_weights(signals, alpha=amp_alpha, gamma=amp_gamma, w_max=amp_w_max)
+
+# Step 4: log weight changes for audit trail
+for (label, _, w_final, _), (_, _, w_base, _) in zip(signals, base_signals):
+    if abs(w_final - w_base) > 0.005:
+        reasons[f"w_dyn_{label}"] = f"{w_base:.3f}\u2192{w_final:.3f}"
+
+reasons["amplification"] = f"alpha={amp_alpha}, gamma={amp_gamma}, w_max={amp_w_max}"
+
+# Step 5: compute composite
+stress_score = sum(s * w for _, s, w, _ in signals)
+```
+
+Note: the `reasons` dict already exists in the function. The `config` parameter already exists. No signature changes needed for this part.
+
+### 4. ConfigService integration
+
+The amplification parameters are configurable per-org via the existing config mechanism. The default values (alpha=2.0, gamma=2.0, w_max=0.35) are used when no config override exists.
+
+Config path: `ConfigService.get("liquid_funds", "calibration", org_id)` → `config["regime_amplification"]`.
+
+Example YAML seed (for `calibration/` seed data — NOT used at runtime, just documentation):
+
+```yaml
+regime_amplification:
+  alpha: 2.0      # max amplification factor (2.0 = up to 3x base)
+  gamma: 2.0      # convexity exponent (2.0 = quadratic)
+  w_max: 0.35     # hard cap per signal (35%)
+```
+
+### 5. Update `signal_details` in snapshot
+
+The `signal_details` dict persisted in `macro_regime_snapshot` should include the effective weights so the frontend can display them. The existing `reasons` dict already captures this via the `w_dyn_*` keys and the `amplification` key added above. No additional changes needed — the snapshot persistence in `run_global_regime_detection()` already writes the full `reasons` dict to `signal_details`.
+
+### 6. Tests
+
+File: `backend/tests/quant_engine/test_regime_dynamic_weights.py`
+
+```python
+"""Tests for dynamic weight amplification in regime classification."""
+
+import pytest
+from quant_engine.regime_service import _amplify_weights, classify_regime_multi_signal
+
+
+class TestAmplifyWeights:
+    def test_calm_signals_unchanged(self):
+        """When all signals are calm, weights barely change."""
+        signals = [
+            ("a", 5.0, 0.5, ""),
+            ("b", 3.0, 0.5, ""),
+        ]
+        result = _amplify_weights(signals)
+        w_a = next(w for l, _, w, _ in result if l == "a")
+        w_b = next(w for l, _, w, _ in result if l == "b")
+        # Both calm → nearly equal amplification → weights ~unchanged
+        assert abs(w_a - 0.5) < 0.02
+        assert abs(w_b - 0.5) < 0.02
+
+    def test_extreme_signal_amplified(self):
+        """A maxed-out signal gets amplified weight."""
+        signals = [
+            ("extreme", 100.0, 0.10, ""),
+            ("calm1", 5.0, 0.30, ""),
+            ("calm2", 5.0, 0.30, ""),
+            ("calm3", 5.0, 0.30, ""),
+        ]
+        result = _amplify_weights(signals)
+        w_extreme = next(w for l, _, w, _ in result if l == "extreme")
+        # 0.10 * 3.0 = 0.30 before renorm; after renorm ~0.24
+        assert w_extreme > 0.20  # significantly above base 0.10
+
+    def test_w_max_cap_enforced(self):
+        """No signal exceeds w_max after amplification."""
+        signals = [
+            ("extreme", 100.0, 0.30, ""),  # 0.30 * 3.0 = 0.90 pre-norm
+            ("calm", 5.0, 0.70, ""),
+        ]
+        result = _amplify_weights(signals, w_max=0.35)
+        w_extreme = next(w for l, _, w, _ in result if l == "extreme")
+        assert w_extreme <= 0.35 + 0.001
+
+    def test_weights_sum_to_one(self):
+        """Weights always sum to ~1.0 after amplification."""
+        signals = [
+            ("a", 100.0, 0.20, ""),
+            ("b", 50.0, 0.30, ""),
+            ("c", 10.0, 0.25, ""),
+            ("d", 0.0, 0.25, ""),
+        ]
+        result = _amplify_weights(signals)
+        total = sum(w for _, _, w, _ in result)
+        assert abs(total - 1.0) < 0.001
+
+    def test_empty_signals(self):
+        """Empty signal list returns empty."""
+        assert _amplify_weights([]) == []
+
+    def test_single_signal(self):
+        """Single signal gets weight 1.0 regardless."""
+        signals = [("only", 80.0, 0.15, "")]
+        result = _amplify_weights(signals)
+        assert len(result) == 1
+        assert abs(result[0][2] - 1.0) < 0.001
+
+
+class TestProfileAWeights:
+    def test_energy_shock_crosses_risk_off(self):
+        """With Profile A weights + dynamic amplification,
+        energy=100 and calm markets should produce RISK_OFF."""
+        regime, reasons = classify_regime_multi_signal(
+            vix=19.5,
+            hy_oas=2.90,
+            baa_spread=1.73,
+            energy_shock=100.0,
+            cfnai=-0.11,
+            sahm_rule=0.20,
+            fed_funds_delta_6m=-0.46,
+            dxy_zscore=0.03,
+        )
+        # With dynamic weights, energy at 100/100 should push
+        # composite above 25 → RISK_OFF
+        assert regime in ("RISK_OFF", "CRISIS")
+
+    def test_all_calm_still_risk_on(self):
+        """When all signals are calm, dynamic weights don't change regime."""
+        regime, _ = classify_regime_multi_signal(
+            vix=15.0,
+            hy_oas=2.0,
+            baa_spread=1.0,
+            energy_shock=5.0,
+            cfnai=0.10,
+            sahm_rule=0.05,
+            fed_funds_delta_6m=0.0,
+            dxy_zscore=0.0,
+        )
+        assert regime == "RISK_ON"
+
+    def test_multi_extreme_produces_crisis(self):
+        """Multiple extreme signals should produce CRISIS."""
+        regime, _ = classify_regime_multi_signal(
+            vix=45.0,
+            hy_oas=8.0,
+            baa_spread=3.0,
+            energy_shock=100.0,
+            cfnai=-0.80,
+            sahm_rule=0.60,
+            fed_funds_delta_6m=2.0,
+            dxy_zscore=2.5,
+        )
+        assert regime == "CRISIS"
+```
+
+### Verification (Session B)
+
+1. `make test` passes (including new test file).
+2. `make lint` passes.
+3. Run `regime_detection` worker → snapshot shows dynamic weight audit trail in `signal_details`:
+   - `w_dyn_energy_shock: "0.126→0.258"` (or similar)
+   - `amplification: "alpha=2.0, gamma=2.0, w_max=0.35"`
+4. With current data (energy=100, VIX=19.5), regime should be **RISK_OFF** (not RISK_ON).
+5. With all-calm data, regime remains RISK_ON (dynamic weights are transparent).
+
+---
+
+## Session C — Backtest Validation
+
+**Branch:** same `feat/regime-dynamic-weights`
+**Depends on:** Sessions A + B committed, macro_data populated with historical ICSA/TOTBKCR/PERMIT
+**Scope:** New backtest script + analysis
+
+### 1. Create backtest script
+
+File: `backend/scripts/backtest_regime_weights.py`
+
+This script should:
+
+1. Query `macro_data` for historical values of all regime signals
+2. For each month in the backtest period, call `classify_regime_multi_signal()` with:
+   - **Static weights** (old 55/45 split, no dynamic amplification)
+   - **Profile A** (40/60 split, with dynamic amplification)
+   - **Profile B** (25/75 split, with dynamic amplification)
+3. Output a CSV or structured JSON with columns:
+   - `date`, `static_regime`, `static_score`, `profile_a_regime`, `profile_a_score`, `profile_b_regime`, `profile_b_score`
+4. Highlight regime transitions and divergences between profiles
+
+### 2. Backtest periods
+
+| Period | Event | Key Signal | Expected Behavior |
+|---|---|---|---|
+| 2007-06 to 2009-06 | GFC | HY OAS blowout, oil spike then crash, CFNAI collapse | All profiles should detect CRISIS by Q4 2007 |
+| 2019-09 to 2020-06 | COVID | VIX spike, credit blowout, Sahm spike | Market-heavy profiles detect faster |
+| 2022-01 to 2022-12 | Ukraine/Energy | WTI +60%, moderate VIX, credit widening | **Discriminating test** — Profile A/B should detect RISK_OFF earlier than static |
+| 2014-06 to 2015-06 | Oil crash | WTI -60%, VIX calm, economy OK | **False-positive test** — falling oil shouldn't trigger stress (current energy shock is upward-only) |
+
+### 3. Analysis output
+
+For each period, report:
+- **Lead time**: how many weeks before NBER recession onset (or market drawdown >10%) did each profile trigger RISK_OFF or CRISIS?
+- **False positives**: how many months of RISK_OFF/CRISIS occurred when no recession or >10% drawdown followed within 6 months?
+- **Regime accuracy**: what was the regime at the market trough?
+
+### 4. Calibration adjustment (if needed)
+
+If backtesting reveals:
+- Profile A too aggressive (many false positives) → lower alpha to 1.5 or raise gamma to 2.5
+- Profile A too conservative (misses 2022 Ukraine) → raise alpha to 2.5 or lower gamma to 1.5
+- Thresholds need adjustment → propose new thresholds but DO NOT change them without separate approval
+
+Document findings in `docs/reference/regime-backtest-results.md`.
+
+### Verification (Session C)
+
+1. Backtest script runs successfully against historical data in `macro_data`.
+2. Profile A detects 2022 Ukraine energy crisis as RISK_OFF (static model shows RISK_ON).
+3. No significant increase in false positives for Profile A vs static.
+4. Results documented in `docs/reference/regime-backtest-results.md`.
+5. Final parameter recommendations (alpha, gamma, w_max) documented.
+
+---
+
+## Constraints
+
+- Do NOT change regime thresholds (25/50) — calibrate weights/amplification against them.
+- Do NOT change `_ramp()` helper — it's used across the codebase.
+- Do NOT change `macro_regime_snapshot` table schema — the `signal_details` JSONB column accommodates the new audit data.
+- Do NOT change `GET /macro/regime` or `GET /allocation/regime` routes — they read from the snapshot.
+- Do NOT change `run_global_regime_detection()` worker interface — only the internal call to `classify_regime_multi_signal` gains new kwargs.
+- The 3 new signals must be **None-safe** — when data is missing, they're excluded from the signals list and weights renormalize over available signals. This is the existing pattern.
+- All changes must pass `make check` (lint + typecheck + test).
+
+## Anti-Patterns
+
+- Do NOT hardcode weight profiles in the function body. The base weights in the `signals.append()` calls ARE the Profile A defaults. Profile B can be activated via ConfigService override of the base weights — but this is a future config feature, not part of this PR.
+- Do NOT add a separate "weight profile" parameter to `classify_regime_multi_signal()`. The weights are in the code (defaults) and overridable via config. Keep it simple.
+- Do NOT create a separate "dynamic regime" function. The dynamic amplification is an enhancement of the existing function, not a parallel path.
+- Do NOT change the `RegimeResult` or `RegimeRead` schemas. The dynamic weights are internal to the computation; the output (regime label + stress score + signal details) is unchanged.
+- Do NOT run the backtest in Session B. Backtest requires historical data that needs ingestion (Session A) to have run first. Session C is explicitly for backtesting.

--- a/frontends/wealth/src/lib/components/research/terminal/LibraryWrapper.svelte
+++ b/frontends/wealth/src/lib/components/research/terminal/LibraryWrapper.svelte
@@ -1,0 +1,159 @@
+<!--
+  LibraryWrapper — embeds the existing LibraryShell in the terminal
+  Research surface with CSS variable remapping so library components
+  render with terminal tokens without rewriting them.
+
+  Data fetching is client-side (no +page.server.ts) — the tree
+  payload is fetched on mount via the auth'd API client.
+-->
+<script lang="ts">
+	import { getContext, onMount } from "svelte";
+	import LibraryShell from "$lib/components/library/LibraryShell.svelte";
+	import { createClientApiClient } from "$lib/api/client";
+	import type { LibraryTree } from "$lib/types/library";
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	let tree = $state<LibraryTree | null>(null);
+	let loading = $state(true);
+	let errorMsg = $state<string | null>(null);
+
+	onMount(async () => {
+		try {
+			tree = await api.get<LibraryTree>("/library/tree");
+		} catch (err: unknown) {
+			errorMsg = err instanceof Error ? err.message : "Failed to load library tree";
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<div class="library-terminal-wrapper">
+	{#if loading}
+		<div class="lw-empty">
+			<span class="lw-empty-text">Loading library...</span>
+		</div>
+	{:else if errorMsg}
+		<div class="lw-empty">
+			<span class="lw-empty-text lw-err">{errorMsg}</span>
+		</div>
+	{:else if tree}
+		<LibraryShell {tree} initialPath={null} actorRole={null} />
+	{:else}
+		<div class="lw-empty">
+			<span class="lw-empty-text">Library is empty</span>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.library-terminal-wrapper {
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+
+		/* ── CSS variable remapping: --ii-* → --terminal-* ── */
+
+		/* Surfaces */
+		--ii-surface: var(--terminal-bg-surface);
+		--ii-surface-alt: var(--terminal-bg-panel);
+		--ii-surface-elevated: var(--terminal-bg-panel-raised);
+
+		/* Text */
+		--ii-text-primary: var(--terminal-fg-primary);
+		--ii-text-secondary: var(--terminal-fg-secondary);
+		--ii-text-muted: var(--terminal-fg-muted);
+		--ii-text-on-brand: var(--terminal-fg-primary);
+
+		/* Borders */
+		--ii-border-subtle: var(--terminal-border-hairline);
+		--ii-border-accent: var(--terminal-accent-cyan);
+		--ii-border: var(--terminal-border-hairline);
+
+		/* Brand / status */
+		--ii-brand-primary: var(--terminal-accent-cyan);
+		--ii-success: var(--terminal-status-success);
+		--ii-danger: var(--terminal-status-error);
+		--ii-warning: var(--terminal-status-warn);
+		--ii-info: var(--terminal-accent-cyan);
+
+		/* Font */
+		--ii-font-sans: var(--terminal-font-mono);
+		--ii-font-mono: var(--terminal-font-mono);
+
+		/* Radius — terminal uses 0 */
+		--ii-radius-sm: 0px;
+		--ii-radius-pill: 0px;
+
+		font-family: var(--terminal-font-mono);
+		border-radius: 0;
+	}
+
+	/* Override hex colors that library components use directly */
+	.library-terminal-wrapper :global(.library-shell) {
+		background: var(--terminal-bg-surface);
+		color: var(--terminal-fg-secondary);
+		border-radius: 0;
+		height: 100%;
+	}
+
+	.library-terminal-wrapper :global(.library-header) {
+		background: var(--terminal-bg-surface);
+		border-bottom-color: var(--terminal-border-hairline-color, rgba(255, 255, 255, 0.06));
+	}
+
+	.library-terminal-wrapper :global(.pane--tree) {
+		background: var(--terminal-bg-surface);
+		border-right-color: var(--terminal-border-hairline-color, rgba(255, 255, 255, 0.06));
+	}
+
+	.library-terminal-wrapper :global(.pane--content) {
+		background: var(--terminal-bg-surface);
+	}
+
+	.library-terminal-wrapper :global(.pane--preview) {
+		background: var(--terminal-bg-surface);
+		border-left-color: var(--terminal-border-hairline-color, rgba(255, 255, 255, 0.06));
+	}
+
+	.library-terminal-wrapper :global(.view-placeholder) {
+		color: var(--terminal-fg-muted);
+	}
+
+	.library-terminal-wrapper :global(.view-placeholder__title) {
+		color: var(--terminal-fg-primary);
+	}
+
+	.library-terminal-wrapper :global(.content-empty) {
+		color: var(--terminal-fg-muted);
+	}
+
+	.library-terminal-wrapper :global(.content-empty__title) {
+		color: var(--terminal-fg-primary);
+	}
+
+	.library-terminal-wrapper :global(.content-empty__sub) {
+		color: var(--terminal-fg-muted);
+	}
+
+	/* ── Empty / loading states ── */
+	.lw-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		color: var(--terminal-fg-muted);
+	}
+
+	.lw-empty-text {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		letter-spacing: 0.04em;
+	}
+
+	.lw-err {
+		color: var(--terminal-status-error);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/research/terminal/ReportsPanel.svelte
+++ b/frontends/wealth/src/lib/components/research/terminal/ReportsPanel.svelte
@@ -1,0 +1,694 @@
+<!--
+  ReportsPanel — terminal-native content generation surface.
+
+  Renders existing reports (outlooks, flash reports, spotlights)
+  with generate buttons, SSE streaming progress, and PDF download.
+  Uses createTerminalStream for SSE, createClientApiClient for auth.
+-->
+<script lang="ts">
+	import { getContext, onDestroy, onMount } from "svelte";
+	import { formatDateTime } from "@investintell/ui";
+	import { createClientApiClient } from "$lib/api/client";
+	import { createTerminalStream, type TerminalStreamHandle } from "$lib/components/terminal/runtime/stream";
+	import LiveDot from "$lib/components/terminal/data/LiveDot.svelte";
+	import type { ContentSummary } from "$lib/types/content";
+	import { contentTypeLabel } from "$lib/types/content";
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	// ── State ─────────────────────────────────────────────────────
+	let reports = $state<ContentSummary[]>([]);
+	let loading = $state(true);
+	let errorMsg = $state<string | null>(null);
+	let generating = $state(false);
+	let downloadingId = $state<string | null>(null);
+
+	// Fund picker for spotlight
+	let spotlightOpen = $state(false);
+	let spotlightSearch = $state("");
+	let fundResults = $state<{ fund_id: string; name: string; manager_name?: string | null }[]>([]);
+	let fundLoading = $state(false);
+
+	// SSE handles
+	let activeStreamHandle = $state<TerminalStreamHandle | null>(null);
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+	// ── Lifecycle ─────────────────────────────────────────────────
+
+	onMount(async () => {
+		await fetchReports();
+	});
+
+	onDestroy(() => {
+		if (pollTimer) clearInterval(pollTimer);
+		activeStreamHandle?.close();
+	});
+
+	// Poll while any item is generating
+	let hasGenerating = $derived(reports.some((r) => r.status === "draft" || r.status === "generating"));
+
+	$effect(() => {
+		if (hasGenerating && !pollTimer) {
+			pollTimer = setInterval(() => { void fetchReports(); }, 5000);
+		} else if (!hasGenerating && pollTimer) {
+			clearInterval(pollTimer);
+			pollTimer = null;
+		}
+	});
+
+	// ── Data fetching ─────────────────────────────────────────────
+
+	async function fetchReports() {
+		try {
+			reports = await api.get<ContentSummary[]>("/content");
+			errorMsg = null;
+		} catch (err: unknown) {
+			if (loading) {
+				errorMsg = err instanceof Error ? err.message : "Failed to load reports";
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	// ── Generation ────────────────────────────────────────────────
+
+	async function generateContent(endpoint: string, params?: Record<string, string>) {
+		generating = true;
+		errorMsg = null;
+		try {
+			const qs = params ? "?" + new URLSearchParams(params).toString() : "";
+			const res = await api.post<ContentSummary & { job_id?: string }>(`/content/${endpoint}${qs}`, {});
+			await fetchReports();
+			if (res.job_id && res.id) {
+				startSSE(String(res.id), res.job_id);
+			}
+		} catch (err: unknown) {
+			if (err instanceof Error && err.message.includes("409")) {
+				errorMsg = "A flash report was already generated recently. Please wait before generating another.";
+			} else {
+				errorMsg = err instanceof Error ? err.message : "Generation failed";
+			}
+		} finally {
+			generating = false;
+		}
+	}
+
+	function startSSE(contentId: string, jobId: string) {
+		const apiBase = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+		const abortController = new AbortController();
+
+		// Get token async and start stream
+		(async () => {
+			const token = await getToken();
+			activeStreamHandle = createTerminalStream<Record<string, unknown>>({
+				url: `${apiBase}/content/${contentId}/stream/${jobId}`,
+				headers: { Authorization: `Bearer ${token}` },
+				signal: abortController.signal,
+				reconnect: false,
+				onMessage: (data) => {
+					if (data.type === "done" || data.type === "error") {
+						void fetchReports();
+						activeStreamHandle?.close();
+					}
+				},
+				onError: () => {
+					void fetchReports();
+				},
+				onClose: () => {
+					activeStreamHandle = null;
+				},
+			});
+		})();
+	}
+
+	// ── Spotlight fund picker ────────────────────────────────────
+
+	function openSpotlightPicker() {
+		spotlightOpen = true;
+		spotlightSearch = "";
+		fundResults = [];
+	}
+
+	async function searchFunds() {
+		if (!spotlightSearch.trim()) {
+			fundResults = [];
+			return;
+		}
+		fundLoading = true;
+		try {
+			fundResults = await api.get<typeof fundResults>(`/funds?q=${encodeURIComponent(spotlightSearch.trim())}&limit=10`);
+		} catch {
+			fundResults = [];
+		} finally {
+			fundLoading = false;
+		}
+	}
+
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function handleSearchInput() {
+		if (searchDebounce) clearTimeout(searchDebounce);
+		searchDebounce = setTimeout(searchFunds, 300);
+	}
+
+	async function selectSpotlightFund(fundId: string) {
+		spotlightOpen = false;
+		await generateContent("spotlights", { instrument_id: fundId });
+	}
+
+	// ── Download ──────────────────────────────────────────────────
+
+	async function downloadPdf(item: ContentSummary) {
+		downloadingId = item.id;
+		try {
+			const blob = await api.getBlob(`/content/${item.id}/download`);
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${item.content_type}_${item.language}.pdf`;
+			a.click();
+			URL.revokeObjectURL(url);
+		} catch (err: unknown) {
+			errorMsg = err instanceof Error ? err.message : "Download failed";
+		} finally {
+			downloadingId = null;
+		}
+	}
+
+	// ── Retry ─────────────────────────────────────────────────────
+
+	function retryContent(item: ContentSummary) {
+		if (item.content_type === "manager_spotlight") {
+			openSpotlightPicker();
+			return;
+		}
+		const endpointMap: Record<string, string> = {
+			investment_outlook: "outlooks",
+			flash_report: "flash-reports",
+		};
+		const endpoint = endpointMap[item.content_type];
+		if (endpoint) void generateContent(endpoint);
+	}
+
+	// ── Status helpers ────────────────────────────────────────────
+
+	function statusLabel(s: string): string {
+		switch (s) {
+			case "draft":
+			case "generating": return "GENERATING";
+			case "ready":
+			case "published": return "PUBLISHED";
+			case "failed": return "FAILED";
+			default: return s.toUpperCase();
+		}
+	}
+
+	type DotStatus = "success" | "warn" | "error" | "muted";
+
+	function statusDot(s: string): DotStatus {
+		switch (s) {
+			case "draft":
+			case "generating": return "warn";
+			case "ready":
+			case "published": return "success";
+			case "failed": return "error";
+			default: return "muted";
+		}
+	}
+</script>
+
+<div class="rp-root">
+	<!-- Generate bar -->
+	<div class="rp-generate-bar">
+		<span class="rp-generate-label">GENERATE:</span>
+		<button
+			class="rp-gen-btn"
+			onclick={() => generateContent("outlooks")}
+			disabled={generating}
+		>
+			[ OUTLOOK ]
+		</button>
+		<button
+			class="rp-gen-btn"
+			onclick={() => generateContent("flash-reports")}
+			disabled={generating}
+		>
+			[ FLASH ]
+		</button>
+		<button
+			class="rp-gen-btn"
+			onclick={openSpotlightPicker}
+			disabled={generating}
+		>
+			[ SPOTLIGHT ]
+		</button>
+	</div>
+
+	{#if errorMsg}
+		<div class="rp-error">
+			<span>{errorMsg}</span>
+			<button class="rp-error-dismiss" onclick={() => errorMsg = null} type="button">x</button>
+		</div>
+	{/if}
+
+	<!-- Report list -->
+	<div class="rp-list">
+		{#if loading}
+			<div class="rp-empty">
+				<span class="rp-empty-text">Loading reports...</span>
+			</div>
+		{:else if reports.length === 0}
+			<div class="rp-empty">
+				<span class="rp-empty-text">No reports yet. Generate an outlook or flash report to start.</span>
+			</div>
+		{:else}
+			{#each reports as item (item.id)}
+				<div class="rp-card">
+					<div class="rp-card-top">
+						<div class="rp-card-info">
+							<span class="rp-card-type">{contentTypeLabel(item.content_type)}</span>
+							<span class="rp-card-title">{item.title ?? contentTypeLabel(item.content_type)}</span>
+						</div>
+						<div class="rp-card-meta">
+							<span class="rp-card-lang">{item.language.toUpperCase()}</span>
+							<span class="rp-card-date">{formatDateTime(item.created_at)}</span>
+						</div>
+					</div>
+					<div class="rp-card-bottom">
+						<div class="rp-card-status">
+							<LiveDot
+								status={statusDot(item.status)}
+								pulse={item.status === "draft" || item.status === "generating"}
+							/>
+							<span class="rp-status-text">{statusLabel(item.status)}</span>
+						</div>
+						<div class="rp-card-actions">
+							{#if item.status === "draft" || item.status === "generating"}
+								<span class="rp-btn rp-btn-generating">[ GENERATING... ]</span>
+							{:else if item.status === "published" || item.status === "ready"}
+								<button
+									class="rp-btn rp-btn-download"
+									onclick={() => downloadPdf(item)}
+									disabled={downloadingId === item.id}
+								>
+									{downloadingId === item.id ? "[ DOWNLOADING... ]" : "[ DOWNLOAD PDF ]"}
+								</button>
+							{:else if item.status === "failed"}
+								<button class="rp-btn rp-btn-retry" onclick={() => retryContent(item)}>
+									[ REGENERATE ]
+								</button>
+							{/if}
+						</div>
+					</div>
+				</div>
+			{/each}
+		{/if}
+	</div>
+</div>
+
+<!-- Spotlight fund picker dialog -->
+{#if spotlightOpen}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="rp-overlay" onclick={() => spotlightOpen = false}>
+		<div class="rp-dialog" onclick={(e) => e.stopPropagation()}>
+			<div class="rp-dialog-header">
+				<span class="rp-dialog-title">SELECT FUND FOR SPOTLIGHT</span>
+				<button class="rp-dialog-close" onclick={() => spotlightOpen = false}>x</button>
+			</div>
+			<div class="rp-dialog-body">
+				<input
+					type="text"
+					class="rp-dialog-search"
+					placeholder="Search funds..."
+					bind:value={spotlightSearch}
+					oninput={handleSearchInput}
+				/>
+				{#if fundLoading}
+					<div class="rp-dialog-msg">Searching...</div>
+				{:else if spotlightSearch && fundResults.length === 0}
+					<div class="rp-dialog-msg">No funds found</div>
+				{:else}
+					<div class="rp-dialog-results">
+						{#each fundResults as fund (fund.fund_id)}
+							<button
+								class="rp-dialog-fund"
+								onclick={() => selectSpotlightFund(fund.fund_id)}
+							>
+								<span class="rp-fund-name">{fund.name}</span>
+								{#if fund.manager_name}
+									<span class="rp-fund-manager">{fund.manager_name}</span>
+								{/if}
+							</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.rp-root {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+		overflow: hidden;
+	}
+
+	/* ── Generate bar ── */
+	.rp-generate-bar {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 12px 16px;
+		border-bottom: var(--terminal-border-hairline);
+		flex-shrink: 0;
+	}
+
+	.rp-generate-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		color: var(--terminal-fg-muted);
+		text-transform: uppercase;
+	}
+
+	.rp-gen-btn {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-accent-cyan);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		padding: 4px 10px;
+		cursor: pointer;
+		transition: all 150ms ease;
+		outline: none;
+	}
+
+	.rp-gen-btn:hover:not(:disabled) {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 10%, transparent);
+		border-color: var(--terminal-accent-cyan);
+	}
+
+	.rp-gen-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	/* ── Error banner ── */
+	.rp-error {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 6px 16px;
+		background: color-mix(in srgb, var(--terminal-status-error) 10%, transparent);
+		color: var(--terminal-status-error);
+		font-size: var(--terminal-text-11);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.rp-error-dismiss {
+		background: none;
+		border: none;
+		color: var(--terminal-status-error);
+		cursor: pointer;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		padding: 0 4px;
+	}
+
+	/* ── Report list ── */
+	.rp-list {
+		flex: 1;
+		overflow-y: auto;
+		padding: 8px 0;
+	}
+
+	.rp-card {
+		border-bottom: var(--terminal-border-hairline);
+		padding: 10px 16px;
+	}
+
+	.rp-card-top {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 12px;
+		margin-bottom: 6px;
+	}
+
+	.rp-card-info {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
+	}
+
+	.rp-card-type {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		color: var(--terminal-accent-cyan);
+		text-transform: uppercase;
+	}
+
+	.rp-card-title {
+		font-size: var(--terminal-text-12);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.rp-card-meta {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-shrink: 0;
+	}
+
+	.rp-card-lang {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rp-card-date {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.rp-card-bottom {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+	}
+
+	.rp-card-status {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.rp-status-text {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		color: var(--terminal-fg-secondary);
+	}
+
+	.rp-card-actions {
+		display: flex;
+		gap: 8px;
+	}
+
+	/* ── Action buttons ── */
+	.rp-btn {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		padding: 3px 8px;
+		cursor: pointer;
+		transition: all 150ms ease;
+		outline: none;
+	}
+
+	.rp-btn-generating {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+		cursor: default;
+		animation: rp-pulse 1.5s infinite alternate;
+	}
+
+	@keyframes rp-pulse {
+		0% { opacity: 0.5; }
+		100% { opacity: 1; }
+	}
+
+	.rp-btn-download {
+		color: var(--terminal-accent-cyan);
+		border-color: var(--terminal-accent-cyan);
+	}
+
+	.rp-btn-download:hover:not(:disabled) {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 10%, transparent);
+	}
+
+	.rp-btn-download:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.rp-btn-retry {
+		color: var(--terminal-status-error);
+		border-color: var(--terminal-status-error);
+	}
+
+	.rp-btn-retry:hover {
+		background: color-mix(in srgb, var(--terminal-status-error) 10%, transparent);
+	}
+
+	/* ── Empty state ── */
+	.rp-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		padding: 24px;
+	}
+
+	.rp-empty-text {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		letter-spacing: 0.04em;
+	}
+
+	/* ── Spotlight dialog ── */
+	.rp-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: var(--terminal-z-modal, 1000);
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.rp-dialog {
+		width: 420px;
+		max-height: 480px;
+		display: flex;
+		flex-direction: column;
+		background: var(--terminal-bg-surface);
+		border: var(--terminal-border-hairline);
+		overflow: hidden;
+	}
+
+	.rp-dialog-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 10px 14px;
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.rp-dialog-title {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		color: var(--terminal-fg-secondary);
+	}
+
+	.rp-dialog-close {
+		background: none;
+		border: none;
+		color: var(--terminal-fg-muted);
+		cursor: pointer;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-12);
+		padding: 2px 4px;
+	}
+
+	.rp-dialog-body {
+		display: flex;
+		flex-direction: column;
+		padding: 10px 14px;
+		gap: 8px;
+		overflow: hidden;
+	}
+
+	.rp-dialog-search {
+		width: 100%;
+		padding: 6px 10px;
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		outline: none;
+	}
+
+	.rp-dialog-search::placeholder {
+		color: var(--terminal-fg-muted);
+	}
+
+	.rp-dialog-search:focus {
+		border-color: var(--terminal-accent-cyan);
+	}
+
+	.rp-dialog-msg {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		padding: 8px 0;
+	}
+
+	.rp-dialog-results {
+		display: flex;
+		flex-direction: column;
+		overflow-y: auto;
+		max-height: 320px;
+	}
+
+	.rp-dialog-fund {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		padding: 6px 8px;
+		background: transparent;
+		border: none;
+		border-bottom: var(--terminal-border-hairline);
+		cursor: pointer;
+		text-align: left;
+		font-family: var(--terminal-font-mono);
+		transition: background 100ms ease;
+	}
+
+	.rp-dialog-fund:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.rp-fund-name {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+
+	.rp-fund-manager {
+		font-size: 9px;
+		color: var(--terminal-fg-muted);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/research/terminal/TerminalResearchShell.svelte
+++ b/frontends/wealth/src/lib/components/research/terminal/TerminalResearchShell.svelte
@@ -21,8 +21,14 @@
 	import TerminalResearchChart from "./TerminalResearchChart.svelte";
 	import TerminalHoldingsGrid from "./TerminalHoldingsGrid.svelte";
 	import TerminalRiskKpis from "./TerminalRiskKpis.svelte";
+	import LibraryWrapper from "./LibraryWrapper.svelte";
+	import ReportsPanel from "./ReportsPanel.svelte";
 
-	// ── Selection state ───────────────────────────────
+	// ── Top-level view tab ────────────────────────────
+	type ViewTab = "ANALYTICS" | "LIBRARY" | "REPORTS";
+	let activeView = $state<ViewTab>("ANALYTICS");
+
+	// ── Analytics selection state ─────────────────────
 	let selectedNode = $state<TreeNode | null>(null);
 	let activeTab = $state<"CHART" | "HOLDINGS">("CHART");
 
@@ -37,43 +43,120 @@
 	}
 </script>
 
-<div class="tr-root">
-	<div class="tr-zone tr-tree" aria-label="Asset browser">
-		<TerminalAssetTree {selectedId} onSelect={handleSelect} />
-	</div>
-	<div class="tr-zone tr-chart" aria-label="Chart workspace">
-		<div class="tr-panel-header">
+<div class="tr-shell">
+	<!-- Top-level view tab bar -->
+	<div class="tr-view-bar">
+		{#each (["ANALYTICS", "LIBRARY", "REPORTS"] as ViewTab[]) as tab (tab)}
 			<button
-				class="tr-tab {activeTab === 'CHART' ? 'tr-tab-active' : ''}"
-				onclick={() => activeTab = 'CHART'}
+				class="tr-view-tab {activeView === tab ? 'tr-view-tab-active' : ''}"
+				onclick={() => activeView = tab}
 			>
-				CHART
+				{tab}
 			</button>
-			<button
-				class="tr-tab {activeTab === 'HOLDINGS' ? 'tr-tab-active' : ''}"
-				onclick={() => activeTab = 'HOLDINGS'}
-			>
-				HOLDINGS
-			</button>
-		</div>
-		<div class="tr-panel-content">
-			{#if activeTab === 'CHART'}
-				<TerminalResearchChart
-					ticker={chartTicker}
-					tickerLabel={chartLabel}
-					instrumentId={chartInstrumentId}
-				/>
-			{:else}
-				<TerminalHoldingsGrid ticker={chartTicker} />
-			{/if}
-		</div>
+		{/each}
 	</div>
-	<div class="tr-zone tr-kpis" aria-label="Risk KPIs">
-		<TerminalRiskKpis {selectedNode} />
+
+	<!-- View content -->
+	<div class="tr-view-content">
+		{#if activeView === "ANALYTICS"}
+			<div class="tr-root">
+				<div class="tr-zone tr-tree" aria-label="Asset browser">
+					<TerminalAssetTree {selectedId} onSelect={handleSelect} />
+				</div>
+				<div class="tr-zone tr-chart" aria-label="Chart workspace">
+					<div class="tr-panel-header">
+						<button
+							class="tr-tab {activeTab === 'CHART' ? 'tr-tab-active' : ''}"
+							onclick={() => activeTab = 'CHART'}
+						>
+							CHART
+						</button>
+						<button
+							class="tr-tab {activeTab === 'HOLDINGS' ? 'tr-tab-active' : ''}"
+							onclick={() => activeTab = 'HOLDINGS'}
+						>
+							HOLDINGS
+						</button>
+					</div>
+					<div class="tr-panel-content">
+						{#if activeTab === 'CHART'}
+							<TerminalResearchChart
+								ticker={chartTicker}
+								tickerLabel={chartLabel}
+								instrumentId={chartInstrumentId}
+							/>
+						{:else}
+							<TerminalHoldingsGrid ticker={chartTicker} />
+						{/if}
+					</div>
+				</div>
+				<div class="tr-zone tr-kpis" aria-label="Risk KPIs">
+					<TerminalRiskKpis {selectedNode} />
+				</div>
+			</div>
+		{:else if activeView === "LIBRARY"}
+			<LibraryWrapper />
+		{:else}
+			<ReportsPanel />
+		{/if}
 	</div>
 </div>
 
 <style>
+	.tr-shell {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+		background: var(--terminal-bg-void);
+		font-family: var(--terminal-font-mono);
+	}
+
+	/* ── View tab bar ── */
+	.tr-view-bar {
+		display: flex;
+		align-items: flex-end;
+		gap: 20px;
+		padding: 0 16px;
+		height: 30px;
+		flex-shrink: 0;
+		border-bottom: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+	}
+
+	.tr-view-tab {
+		height: 100%;
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		color: var(--terminal-fg-tertiary);
+		background: transparent;
+		border: none;
+		border-bottom: 2px solid transparent;
+		padding: 0 2px;
+		cursor: pointer;
+		outline: none;
+		font-family: var(--terminal-font-mono);
+		transition: color 120ms ease;
+	}
+
+	.tr-view-tab:hover {
+		color: var(--terminal-fg-secondary);
+	}
+
+	.tr-view-tab-active {
+		color: var(--terminal-fg-primary);
+		border-bottom-color: var(--terminal-accent-cyan);
+	}
+
+	.tr-view-content {
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	/* ── Analytics grid ── */
 	.tr-root {
 		display: grid;
 		grid-template-areas: "tree chart kpis";


### PR DESCRIPTION
## Summary
- TerminalResearchShell now has 3 tabs: ANALYTICS | LIBRARY | REPORTS
- LibraryWrapper — wraps existing LibraryShell with CSS variable remapping (--ii-* → --terminal-*), no rewrite
- ReportsPanel — content generation (Outlook, Flash, Spotlight), SSE streaming via createTerminalStream, PDF download, fund picker dialog

## Test plan
- [ ] Tab switcher renders 3 tabs, default ANALYTICS
- [ ] LIBRARY tab shows library tree and document readers
- [ ] REPORTS tab shows existing reports with status badges
- [ ] Generate Outlook/Flash/Spotlight triggers SSE stream with LiveDot
- [ ] PDF download works
- [ ] No hex colors in new files
- [ ] `pnpm --filter @investintell/wealth check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)