### PR TITLE
feat(risk): globalize DTW drift + add return_5y/10y

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ frontends/
   wealth/           ← SvelteKit "netz-wealth-os"
 ```
 
-**Database:** PostgreSQL 16 + TimescaleDB + pgvector. Managed via Timescale Cloud (prod) or docker-compose (dev). Redis 7 via Upstash (prod) or docker-compose (dev). Migrations via Alembic. App uses async asyncpg. Current migration head: `0105_portfolio_calibration_fk_on_construction_runs`.
+**Database:** PostgreSQL 16 + TimescaleDB + pgvector. Managed via Timescale Cloud (prod) or docker-compose (dev). Redis 7 via Upstash (prod) or docker-compose (dev). Migrations via Alembic. App uses async asyncpg. Current migration head: `0131_return_5y_10y`.
 
 **Auth:** Clerk JWT v2. `organization_id` from `o.id` claim. RLS via `SET LOCAL app.current_organization_id`. Dev bypass: `X-DEV-ACTOR` header. **Tenant and user management is 100% via Clerk Dashboard** — no custom admin UI. Organizations, user invites, and role assignment (`ADMIN`, `INVESTMENT_TEAM`, `investor`) are all managed in Clerk. `ConfigService` defaults mean new tenants work immediately without provisioning.
 
@@ -153,7 +153,7 @@ Six non-negotiable principles enforced across the stack: **P1 Bounded**, **P2 Ba
 - **lazy="raise":** Set on ALL relationships. Forces explicit `selectinload()`/`joinedload()`.
 - **RLS subselect:** All RLS policies must use `(SELECT current_setting(...))` not bare `current_setting()`. Without subselect, per-row evaluation causes 1000x slowdown.
 - **Global tables:** `macro_data`, `allocation_blocks`, `vertical_config_defaults`, `benchmark_nav`, `macro_regional_snapshots`, `treasury_data`, `ofr_hedge_fund_data`, `bis_statistics`, `imf_weo_forecasts`, `sec_*` tables, `sec_insider_transactions`, `esma_funds`, `esma_managers`, `instruments_universe`, `nav_timeseries`, `sec_fund_prospectus_returns`, `sec_fund_prospectus_stats`, `fund_risk_metrics` have NO `organization_id`, NO RLS. They are shared across all tenants.
-- **`fund_risk_metrics`** is GLOBAL — pre-computed by `global_risk_metrics` worker (lock 900_071) for ALL active instruments in `instruments_universe`. `organization_id` column is nullable (NULL for global rows). RLS is disabled (hypertable compression incompatible). All tenants see the same risk metrics. Org-scoped `risk_calc` (lock 900_007) can overwrite rows with DTW drift for org-imported instruments, but the base metrics are always global. Routes must NOT filter by `organization_id` when reading risk metrics.
+- **`fund_risk_metrics`** is GLOBAL — pre-computed by `global_risk_metrics` worker (lock 900_071) for ALL active instruments in `instruments_universe`, including DTW drift (by strategy_label), 5Y/10Y annualized returns. `organization_id` column is nullable (NULL for global rows). RLS is disabled (hypertable compression incompatible). All tenants see the same risk metrics. Org-scoped `risk_calc` (lock 900_007) computes org-specific overrides (no DTW — handled globally). Routes must NOT filter by `organization_id` when reading risk metrics.
 - **`instruments_universe`** is a GLOBAL catalog (no RLS). Org-scoped instrument selection is via `instruments_org` (has RLS, `organization_id`, `block_id`, `approval_status`). The `Instrument` model has NO `organization_id`, `block_id`, or `approval_status` — those live on `InstrumentOrg`. All queries needing org-scoped instruments must JOIN `instruments_org`.
 - **`nav_timeseries`** is GLOBAL (no RLS, no `organization_id`). Prices are market data shared across all tenants. Org-scoping for NAV queries is via JOIN `instruments_org`.
 - **No module-level asyncio primitives:** Create `Semaphore`, `Lock`, `Event` lazily inside async functions. Module-level causes "attached to different event loop" errors.
@@ -218,8 +218,8 @@ Background workers ingest all external time-series data into hypertables. Routes
 | `ofr_ingestion` | 900_012 | global | `ofr_hedge_fund_data` (3mo chunks) | OFR API (leverage, AUM, strategy, repo, stress) | Weekly |
 | `benchmark_ingest` | 900_004 | global | `benchmark_nav` (1mo chunks) | Yahoo Finance | Daily |
 | `instrument_ingestion` | 900_010 | global | `nav_timeseries` | Yahoo Finance (or pluggable provider) | Daily |
-| `global_risk_metrics` | 900_071 | global | `fund_risk_metrics` | Computed (CVaR, Sharpe, volatility, momentum, scoring) for ALL instruments_universe | Daily |
-| `risk_calc` | 900_007 | org | `fund_risk_metrics` | Overwrites with DTW drift for org-imported instruments | Daily |
+| `global_risk_metrics` | 900_071 | global | `fund_risk_metrics` | Computed (CVaR, Sharpe, volatility, momentum, scoring, DTW drift by strategy_label, 5Y/10Y returns) for ALL instruments_universe | Daily |
+| `risk_calc` | 900_007 | org | `fund_risk_metrics` | Org-specific metric overrides for instruments in instruments_org (no DTW — handled globally) | Daily |
 | `portfolio_eval` | 900_008 | org | `portfolio_snapshots` | Computed (breach status, regime, cascade) | Daily |
 | `nport_ingestion` | 900_018 | global | `sec_nport_holdings` (3mo chunks) | SEC EDGAR N-PORT XML | Weekly |
 | `sec_13f_ingestion` | 900_021 | global | `sec_13f_holdings`, `sec_13f_diffs` | SEC EDGAR 13F-HR (edgartools) | Weekly |

--- a/backend/app/core/db/migrations/versions/0131_return_5y_10y.py
+++ b/backend/app/core/db/migrations/versions/0131_return_5y_10y.py
@@ -1,0 +1,192 @@
+"""Add return_5y_ann and return_10y_ann to fund_risk_metrics.
+
+Supports long-horizon annualized return computation by global_risk_metrics
+worker. ~82% of instruments have 5Y+ NAV history, ~60% have 10Y+.
+
+Also recreates mv_fund_risk_latest to include the new columns plus
+dtw_drift_score (now computed globally by strategy_label).
+
+Revision ID: 0131_return_5y_10y
+Revises: 0130_macro_regime_snapshot
+Create Date: 2026-04-14
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0131_return_5y_10y"
+down_revision = "0130_macro_regime_snapshot"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "fund_risk_metrics",
+        sa.Column("return_5y_ann", sa.Numeric(12, 8), nullable=True),
+    )
+    op.add_column(
+        "fund_risk_metrics",
+        sa.Column("return_10y_ann", sa.Numeric(12, 8), nullable=True),
+    )
+
+    # Recreate mv_fund_risk_latest with new columns
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_fund_risk_latest CASCADE")
+
+    op.execute("""
+        CREATE MATERIALIZED VIEW mv_fund_risk_latest AS
+        SELECT DISTINCT ON (instrument_id)
+            instrument_id,
+            calc_date,
+            manager_score,
+            score_components,
+            sharpe_1y,
+            sortino_1y,
+            volatility_1y,
+            volatility_garch,
+            cvar_95_12m,
+            cvar_95_conditional,
+            max_drawdown_1y,
+            return_1y,
+            return_5y_ann,
+            return_10y_ann,
+            dtw_drift_score,
+            blended_momentum_score,
+            peer_strategy_label,
+            peer_sharpe_pctl,
+            peer_sortino_pctl,
+            peer_return_pctl,
+            peer_drawdown_pctl,
+            peer_count,
+            elite_flag,
+            elite_rank_within_strategy,
+            elite_target_count_per_strategy,
+            -- FI analytics columns
+            empirical_duration,
+            empirical_duration_r2,
+            credit_beta,
+            credit_beta_r2,
+            yield_proxy_12m,
+            duration_adj_drawdown_1y,
+            scoring_model,
+            -- Cash analytics columns
+            seven_day_net_yield,
+            fed_funds_rate_at_calc,
+            nav_per_share_mmf,
+            pct_weekly_liquid,
+            weighted_avg_maturity_days,
+            -- Alternatives analytics columns
+            equity_correlation_252d,
+            downside_capture_1y,
+            upside_capture_1y,
+            crisis_alpha_score,
+            calmar_ratio_3y,
+            inflation_beta,
+            inflation_beta_r2
+        FROM fund_risk_metrics
+        WHERE organization_id IS NULL
+        ORDER BY instrument_id, calc_date DESC
+        WITH NO DATA
+    """)
+
+    op.execute("""
+        CREATE UNIQUE INDEX uq_mv_fund_risk_latest_instrument
+        ON mv_fund_risk_latest (instrument_id)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_elite
+        ON mv_fund_risk_latest (instrument_id)
+        WHERE elite_flag = true
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_sharpe
+        ON mv_fund_risk_latest (sharpe_1y DESC NULLS LAST)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_manager_score
+        ON mv_fund_risk_latest (manager_score DESC NULLS LAST)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_scoring_model
+        ON mv_fund_risk_latest (scoring_model)
+    """)
+
+
+def downgrade() -> None:
+    # Recreate mv_fund_risk_latest without the new columns (revert to 0125 version)
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_fund_risk_latest CASCADE")
+
+    op.execute("""
+        CREATE MATERIALIZED VIEW mv_fund_risk_latest AS
+        SELECT DISTINCT ON (instrument_id)
+            instrument_id,
+            calc_date,
+            manager_score,
+            score_components,
+            sharpe_1y,
+            sortino_1y,
+            volatility_1y,
+            volatility_garch,
+            cvar_95_12m,
+            cvar_95_conditional,
+            max_drawdown_1y,
+            return_1y,
+            blended_momentum_score,
+            peer_strategy_label,
+            peer_sharpe_pctl,
+            peer_sortino_pctl,
+            peer_return_pctl,
+            peer_drawdown_pctl,
+            peer_count,
+            elite_flag,
+            elite_rank_within_strategy,
+            elite_target_count_per_strategy,
+            empirical_duration,
+            empirical_duration_r2,
+            credit_beta,
+            credit_beta_r2,
+            yield_proxy_12m,
+            duration_adj_drawdown_1y,
+            scoring_model,
+            seven_day_net_yield,
+            fed_funds_rate_at_calc,
+            nav_per_share_mmf,
+            pct_weekly_liquid,
+            weighted_avg_maturity_days,
+            equity_correlation_252d,
+            downside_capture_1y,
+            upside_capture_1y,
+            crisis_alpha_score,
+            calmar_ratio_3y,
+            inflation_beta,
+            inflation_beta_r2
+        FROM fund_risk_metrics
+        WHERE organization_id IS NULL
+        ORDER BY instrument_id, calc_date DESC
+        WITH NO DATA
+    """)
+
+    op.execute("""
+        CREATE UNIQUE INDEX uq_mv_fund_risk_latest_instrument
+        ON mv_fund_risk_latest (instrument_id)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_elite
+        ON mv_fund_risk_latest (instrument_id)
+        WHERE elite_flag = true
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_sharpe
+        ON mv_fund_risk_latest (sharpe_1y DESC NULLS LAST)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_manager_score
+        ON mv_fund_risk_latest (manager_score DESC NULLS LAST)
+    """)
+    op.execute("""
+        CREATE INDEX idx_mv_fund_risk_latest_scoring_model
+        ON mv_fund_risk_latest (scoring_model)
+    """)
+
+    op.drop_column("fund_risk_metrics", "return_10y_ann")
+    op.drop_column("fund_risk_metrics", "return_5y_ann")

--- a/backend/app/domains/wealth/models/risk.py
+++ b/backend/app/domains/wealth/models/risk.py
@@ -51,6 +51,8 @@ class FundRiskMetrics(Base):
     return_6m: Mapped[Decimal | None] = mapped_column(Numeric(10, 6))
     return_1y: Mapped[Decimal | None] = mapped_column(Numeric(10, 6))
     return_3y_ann: Mapped[Decimal | None] = mapped_column(Numeric(10, 6))
+    return_5y_ann: Mapped[Decimal | None] = mapped_column(Numeric(12, 8), nullable=True)
+    return_10y_ann: Mapped[Decimal | None] = mapped_column(Numeric(12, 8), nullable=True)
 
     # Risk metrics
     volatility_1y: Mapped[Decimal | None] = mapped_column(Numeric(10, 6))

--- a/backend/app/domains/wealth/schemas/instrument.py
+++ b/backend/app/domains/wealth/schemas/instrument.py
@@ -74,6 +74,8 @@ class InstrumentRiskMetricsRead(BaseModel):
     # Return metrics
     return_1y: float | None = None
     return_3y_ann: float | None = None
+    return_5y_ann: float | None = None
+    return_10y_ann: float | None = None
 
     # Risk metrics (additional)
     sortino_1y: float | None = None

--- a/backend/app/domains/wealth/schemas/risk.py
+++ b/backend/app/domains/wealth/schemas/risk.py
@@ -39,6 +39,8 @@ class FundRiskRead(SanitizedScoreComponentsMixin):
     return_6m: Decimal | None = None
     return_1y: Decimal | None = None
     return_3y_ann: Decimal | None = None
+    return_5y_ann: Decimal | None = None
+    return_10y_ann: Decimal | None = None
     volatility_1y: Decimal | None = None
     max_drawdown_1y: Decimal | None = None
     max_drawdown_3y: Decimal | None = None

--- a/backend/app/domains/wealth/schemas/universe.py
+++ b/backend/app/domains/wealth/schemas/universe.py
@@ -66,6 +66,8 @@ class UniverseAssetRead(BaseModel):
     aum_usd: Decimal | None = None
     expense_ratio: Decimal | None = None
     return_3y_ann: Decimal | None = None
+    return_5y_ann: Decimal | None = None
+    return_10y_ann: Decimal | None = None
     sharpe_1y: Decimal | None = None
     max_drawdown_1y: Decimal | None = None
     blended_momentum_score: Decimal | None = None

--- a/backend/app/domains/wealth/workers/risk_calc.py
+++ b/backend/app/domains/wealth/workers/risk_calc.py
@@ -572,6 +572,8 @@ def _compute_metrics_from_returns(
     metrics["return_6m"] = _round_or_none(_compute_return(returns, 126))
     metrics["return_1y"] = _round_or_none(_compute_return(returns, 252))
     metrics["return_3y_ann"] = _round_or_none(_compute_annualized_return(returns, 3))
+    metrics["return_5y_ann"] = _round_or_none(_compute_annualized_return(returns, 5))
+    metrics["return_10y_ann"] = _round_or_none(_compute_annualized_return(returns, 10))
 
     # Volatility
     metrics["volatility_1y"] = _round_or_none(_compute_volatility(returns, 252))
@@ -829,6 +831,115 @@ async def _compute_block_dtw_scores(
         logger.debug(
             "DTW drift computed for block",
             block_id=block_id,
+            n_funds=len(fund_ids),
+            window=min_len,
+        )
+
+    return dtw_scores
+
+
+DTW_SUB_BATCH_SIZE = 200
+DTW_LARGE_GROUP_THRESHOLD = 500
+
+
+async def _compute_global_dtw_scores(
+    db: AsyncSession,
+    computed: "list[tuple[Instrument | _FundSnapshot, dict]]",
+    as_of_date: date,
+    strategy_map: dict[str, str | None],
+    dtw_window: int = 252,
+) -> dict[str, DtwDriftResult]:
+    """Compute DTW drift scores grouped by strategy_label (global).
+
+    Instead of allocation blocks (org-scoped), groups funds by their
+    strategy_label from mv_unified_funds. Each strategy group uses its
+    equal-weight average as the benchmark.
+
+    Funds with no strategy_label are grouped under "__unclassified__".
+    Groups with < 2 funds get degraded status (no peer comparison possible).
+    Groups with > 500 funds are split into sub-batches of 200, using the
+    full group mean as benchmark for all sub-batches.
+    """
+    # Group funds by strategy_label
+    strategy_funds: dict[str, list[tuple[_FundSnapshot, dict]]] = defaultdict(list)
+    for fund, metrics in computed:
+        fid_str = str(fund.instrument_id)
+        strategy = strategy_map.get(fid_str) or "__unclassified__"
+        strategy_funds[strategy].append((fund, metrics))
+
+    dtw_scores: dict[str, DtwDriftResult] = {}
+
+    for strategy, group in strategy_funds.items():
+        if len(group) < 2:
+            for fund, _ in group:
+                dtw_scores[str(fund.instrument_id)] = DtwDriftResult(
+                    score=None,
+                    status=DtwDriftStatus.degraded,
+                    reason=f"single fund in strategy '{strategy}' — no peer comparison possible",
+                )
+            continue
+
+        # Batch-fetch returns for all funds in this strategy group
+        group_fund_ids = [fund.instrument_id for fund, _ in group]
+        returns_by_fund = await _fetch_block_returns_batch(
+            db, group_fund_ids, as_of_date, window_days=dtw_window,
+        )
+
+        # Build arrays for all funds with data
+        fund_return_arrays: list[np.ndarray] = []
+        fund_ids: list[str] = []
+        for fund, _ in group:
+            fid = str(fund.instrument_id)
+            arr = returns_by_fund.get(fid, np.array([], dtype=float))
+            if len(arr) >= 10:
+                fund_return_arrays.append(arr)
+                fund_ids.append(fid)
+            else:
+                dtw_scores[fid] = DtwDriftResult(
+                    score=None,
+                    status=DtwDriftStatus.degraded,
+                    reason=f"insufficient data for DTW: {len(arr)} points (min 10)",
+                )
+
+        if len(fund_ids) < 2:
+            for fid in fund_ids:
+                dtw_scores[fid] = DtwDriftResult(
+                    score=None,
+                    status=DtwDriftStatus.degraded,
+                    reason=f"< 2 funds with data in strategy '{strategy}'",
+                )
+            continue
+
+        # Align to common length
+        min_len = min(len(a) for a in fund_return_arrays)
+        if min_len < 10:
+            for fid in fund_ids:
+                dtw_scores[fid] = DtwDriftResult(
+                    score=None,
+                    status=DtwDriftStatus.degraded,
+                    reason=f"insufficient common window: {min_len} points",
+                )
+            continue
+
+        matrix = np.vstack([a[-min_len:] for a in fund_return_arrays])
+        benchmark = matrix.mean(axis=0)
+
+        if len(fund_ids) > DTW_LARGE_GROUP_THRESHOLD:
+            # Sub-batch processing for large groups
+            for sb_start in range(0, len(fund_ids), DTW_SUB_BATCH_SIZE):
+                sb_ids = fund_ids[sb_start:sb_start + DTW_SUB_BATCH_SIZE]
+                sb_matrix = matrix[sb_start:sb_start + DTW_SUB_BATCH_SIZE]
+                results = compute_dtw_drift_batch(sb_matrix, benchmark, window=min_len)
+                for fid, result in zip(sb_ids, results, strict=False):
+                    dtw_scores[fid] = result
+        else:
+            results = compute_dtw_drift_batch(matrix, benchmark, window=min_len)
+            for fid, result in zip(fund_ids, results, strict=False):
+                dtw_scores[fid] = result
+
+        logger.debug(
+            "DTW drift computed for strategy",
+            strategy=strategy,
             n_funds=len(fund_ids),
             window=min_len,
         )
@@ -1173,7 +1284,7 @@ async def run_global_regime_detection(eval_date: date | None = None) -> None:
 
         try:
             inputs = await build_regime_inputs(db, as_of_date=target_date)
-            regime, reasons = classify_regime_multi_signal(**inputs)
+            regime, reasons, structured_signals = classify_regime_multi_signal(**inputs)
             stress_score = extract_stress_score(reasons)
             logger.info(
                 "global_regime_classified",
@@ -1187,6 +1298,7 @@ async def run_global_regime_detection(eval_date: date | None = None) -> None:
                 raw_regime=regime,
                 stress_score=stress_score,
                 signal_details=reasons,
+                signal_breakdown=structured_signals,
             )
             upsert_stmt = upsert_stmt.on_conflict_do_update(
                 index_elements=["as_of_date"],
@@ -1194,6 +1306,7 @@ async def run_global_regime_detection(eval_date: date | None = None) -> None:
                     "raw_regime": upsert_stmt.excluded.raw_regime,
                     "stress_score": upsert_stmt.excluded.stress_score,
                     "signal_details": upsert_stmt.excluded.signal_details,
+                    "signal_breakdown": upsert_stmt.excluded.signal_breakdown,
                 },
             )
             await db.execute(upsert_stmt)
@@ -1246,7 +1359,7 @@ async def _compute_and_persist_taa_state(
         )
         # Graceful fallback: compute inline (same as before)
         inputs = await build_regime_inputs(db, as_of_date=eval_date)
-        regime, reasons = classify_regime_multi_signal(**inputs)
+        regime, reasons, _ = classify_regime_multi_signal(**inputs)
         stress_score = extract_stress_score(reasons)
     else:
         regime = snapshot.raw_regime
@@ -1509,8 +1622,8 @@ async def run_risk_calc(org_id: "uuid.UUID", as_of_date: date | None = None) -> 
             logger.info("Funds to process", count=len(funds))
 
             eval_date = as_of_date or date.today()
-            # 3 years + 30-day buffer — same window used in compute_fund_risk_metrics
-            start_date = eval_date - timedelta(days=3 * 365 + 30)
+            # 10 years + 60-day buffer — supports 5Y/10Y annualized returns
+            start_date = eval_date - timedelta(days=10 * 365 + 60)
 
             all_fund_ids = [fund.instrument_id for fund in funds]
 
@@ -1697,31 +1810,9 @@ async def run_risk_calc(org_id: "uuid.UUID", as_of_date: date | None = None) -> 
                     strategy_label=strategy_lbl,
                 )
 
-            # Pass 2: compute DTW drift scores per block (reuses DB session, no extra query per fund)
-            logger.info("Computing DTW drift scores", n_funds=len(computed))
-            dtw_scores = await _compute_block_dtw_scores(db, computed, as_of_date=eval_date, block_id_map=block_id_map)
-            logger.info("DTW drift scores computed", n_scores=len(dtw_scores))
-
-            # Pass 3: upsert metrics + dtw_drift_score (all in one transaction)
+            # Pass 2: upsert metrics (DTW drift now handled by global worker)
             try:
                 for fund, metrics in computed:
-                    fid_str = str(fund.instrument_id)
-                    dtw_result = dtw_scores.get(
-                        fid_str,
-                        DtwDriftResult(score=None, status=DtwDriftStatus.degraded, reason="fund not in dtw_scores"),
-                    )
-                    # Use score_or_default so DB column always gets a float,
-                    # but the decision to fall back is explicit, not silent.
-                    metrics["dtw_drift_score"] = round(dtw_result.score_or_default(0.0), 6)
-                    if not dtw_result.is_usable:
-                        logger.warning(
-                            "dtw_drift_degraded",
-                            fund_id=fid_str,
-                            ticker=fund.ticker,
-                            status=dtw_result.status.value,
-                            reason=dtw_result.reason,
-                        )
-
                     metrics["organization_id"] = org_id
                     upsert = pg_insert(FundRiskMetrics).values(**metrics)
                     # Conflict target includes organization_id so this org's
@@ -1738,7 +1829,7 @@ async def run_risk_calc(org_id: "uuid.UUID", as_of_date: date | None = None) -> 
                     )
                     await db.execute(upsert)
                     results[fund.ticker or str(fund.instrument_id)] = 1
-                    logger.info("Risk metrics staged", ticker=fund.ticker, dtw_drift=metrics["dtw_drift_score"])
+                    logger.info("Risk metrics staged", ticker=fund.ticker)
 
                 # Single commit for the entire batch — atomic and WAL-efficient
                 await db.commit()
@@ -1775,12 +1866,12 @@ GLOBAL_RISK_BATCH_SIZE = 200
 async def run_global_risk_metrics(as_of_date: date | None = None) -> dict[str, int]:
     """Compute base risk metrics for ALL active instruments with NAV.
 
-    Global worker — no org_id, no RLS, no DTW drift.
+    Global worker — no org_id, no RLS.
     Writes to fund_risk_metrics with organization_id = NULL.
     Any tenant importing a fund immediately sees pre-computed metrics.
 
-    The org-scoped run_risk_calc() can later overwrite specific rows
-    with organization_id + DTW drift for instruments in instruments_org.
+    DTW drift is computed globally by strategy_label (from mv_unified_funds).
+    5Y and 10Y annualized returns computed when sufficient NAV history exists.
     """
     logger.info("global_risk_metrics.start", as_of_date=str(as_of_date))
     results: dict[str, int] = {"computed": 0, "skipped": 0, "error": 0}
@@ -1796,7 +1887,7 @@ async def run_global_risk_metrics(as_of_date: date | None = None) -> dict[str, i
         try:
             rfr = await get_risk_free_rate(db)
             eval_date = as_of_date or date.today()
-            start_date = eval_date - timedelta(days=3 * 365 + 30)
+            start_date = eval_date - timedelta(days=10 * 365 + 60)
 
             # All active funds with ticker (no org join)
             stmt = (
@@ -2008,11 +2099,41 @@ async def run_global_risk_metrics(as_of_date: date | None = None) -> dict[str, i
                         strategy_label=strategy_lbl,
                     )
 
-                # Upsert batch — no DTW drift, no org_id
+                # Pass 1.9: DTW drift scores by strategy_label (global)
+                batch_tickers_dtw = [f.ticker for f in batch if f.ticker]
+                strategy_map_batch: dict[str, str | None] = {}
+                if batch_tickers_dtw:
+                    placeholders_dtw = ", ".join(f"'{t}'" for t in batch_tickers_dtw)
+                    strat_result = await db.execute(text(f"""
+                        SELECT ticker, strategy_label FROM mv_unified_funds
+                        WHERE ticker IN ({placeholders_dtw})
+                          AND strategy_label IS NOT NULL
+                    """))
+                    ticker_to_strat = {r[0]: r[1] for r in strat_result.all()}
+                    for fund, _ in computed:
+                        if fund.ticker and fund.ticker in ticker_to_strat:
+                            strategy_map_batch[str(fund.instrument_id)] = ticker_to_strat[fund.ticker]
+
+                dtw_scores_batch = await _compute_global_dtw_scores(
+                    db, computed, as_of_date=eval_date,
+                    strategy_map=strategy_map_batch,
+                )
+                logger.info(
+                    "global_risk_metrics.dtw_computed",
+                    batch_start=batch_start,
+                    dtw_scores=len(dtw_scores_batch),
+                )
+
+                # Upsert batch with DTW drift, no org_id
                 try:
                     for fund, metrics in computed:
                         metrics["organization_id"] = None
-                        metrics["dtw_drift_score"] = None
+                        fid_str = str(fund.instrument_id)
+                        dtw_result = dtw_scores_batch.get(
+                            fid_str,
+                            DtwDriftResult(score=None, status=DtwDriftStatus.degraded, reason="not in dtw batch"),
+                        )
+                        metrics["dtw_drift_score"] = round(dtw_result.score_or_default(0.0), 6) if dtw_result.is_usable else None
                         upsert = pg_insert(FundRiskMetrics).values(**metrics)
                         # Conflict target includes organization_id (NULL here);
                         # NULLS NOT DISTINCT unique index from migration 0093
@@ -2496,7 +2617,7 @@ async def _compute_elite_ranking(
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Risk calculation worker")
-    parser.add_argument("--org-id", type=uuid.UUID, help="Compute org-scoped metrics with DTW drift for a specific tenant.")
+    parser.add_argument("--org-id", type=uuid.UUID, help="Compute org-scoped metrics for a specific tenant.")
     args = parser.parse_args()
 
     if args.org_id:

--- a/docs/prompts/2026-04-14-globalize-dtw-drift.md
+++ b/docs/prompts/2026-04-14-globalize-dtw-drift.md
@@ -1,0 +1,188 @@
+# Globalize DTW Drift Score
+
+**Date:** 2026-04-14
+**Branch:** `feat/globalize-dtw-drift`
+**Priority:** MEDIUM — unblocks dtw_drift_score for all 5,385 instruments (currently 0% coverage)
+**Sessions:** 1
+
+---
+
+## Problem
+
+`dtw_drift_score` in `fund_risk_metrics` is **100% empty** (0/5,385 rows) because it's only computed by the org-scoped `risk_calc` worker (lock 900_007), which requires instruments imported into `instruments_org` + assigned to `allocation_blocks`.
+
+The global worker `run_global_risk_metrics` (lock 900_071) explicitly sets `dtw_drift_score = None` for all 5,385+ instruments it computes.
+
+This made sense when DTW drift was a portfolio-context metric (drift vs your allocation block peers). But the model has evolved:
+
+1. **The optimizer uses the full catalog** (all instruments_universe except private funds and BDCs) — not just org-imported instruments.
+2. **Scoring, screening, and DD reports** read from `fund_risk_metrics` globally — they expect `dtw_drift_score` to be populated.
+3. **DTW drift is an intrinsic fund property** — it measures how much a fund's recent return pattern has diverged from its peer group average. The peer group is defined by `strategy_label`, which is a global catalog attribute, not an org-scoped one.
+
+Current architecture:
+```
+global_risk_metrics (900_071)  →  computes everything EXCEPT dtw_drift  →  org_id = NULL
+risk_calc (900_007, org)       →  overwrites with dtw_drift per block   →  org_id = {org}
+```
+
+Target architecture:
+```
+global_risk_metrics (900_071)  →  computes everything INCLUDING dtw_drift by strategy  →  org_id = NULL
+risk_calc (900_007, org)       →  no longer needed for dtw_drift (may still exist for org-specific overrides)
+```
+
+---
+
+## Solution
+
+### 1. Add `_compute_global_dtw_scores()` to `risk_calc.py`
+
+New function near `_compute_block_dtw_scores()` (~line 740). Reuses the same `compute_dtw_drift_batch()` from `quant_engine/drift_service.py`.
+
+```python
+async def _compute_global_dtw_scores(
+    db: AsyncSession,
+    computed: list[tuple[_FundSnapshot, dict]],
+    as_of_date: date,
+    strategy_map: dict[str, str | None],  # instrument_id → strategy_label
+    dtw_window: int = 252,
+) -> dict[str, DtwDriftResult]:
+    """Compute DTW drift scores grouped by strategy_label (global).
+
+    Instead of allocation blocks (org-scoped), groups funds by their
+    strategy_label from mv_unified_funds. Each strategy group uses its
+    equal-weight average as the benchmark.
+
+    Funds with no strategy_label are grouped under "__unclassified__".
+    Groups with < 2 funds get degraded status (no peer comparison possible).
+    """
+```
+
+Key differences from `_compute_block_dtw_scores()`:
+- Groups by `strategy_label` instead of `block_id`
+- No dependency on `instruments_org` or `allocation_blocks`
+- Uses `mv_unified_funds.strategy_label` (already available in global context)
+- Same `compute_dtw_drift_batch()` call, same DTW window (252 days)
+
+### 2. Wire into `run_global_risk_metrics()`
+
+In `run_global_risk_metrics()`, after Pass 1 (metric computation) and before the upsert:
+
+```python
+# Build strategy_label map from mv_unified_funds
+strategy_stmt = text("""
+    SELECT ticker, strategy_label FROM mv_unified_funds
+    WHERE ticker IS NOT NULL AND strategy_label IS NOT NULL
+""")
+strategy_rows = (await db.execute(strategy_stmt)).all()
+ticker_to_strategy = {r[0]: r[1] for r in strategy_rows}
+
+# Map instrument_id → strategy_label via ticker
+strategy_map = {}
+for fund in all_funds:
+    if fund.ticker and fund.ticker in ticker_to_strategy:
+        strategy_map[str(fund.instrument_id)] = ticker_to_strategy[fund.ticker]
+
+# Compute global DTW drift
+dtw_scores = await _compute_global_dtw_scores(
+    db, computed, eval_date, strategy_map,
+)
+```
+
+Then in the upsert loop, replace:
+```python
+metrics["dtw_drift_score"] = None  # ← current (line 2015)
+```
+With:
+```python
+dtw_result = dtw_scores.get(
+    str(fund.instrument_id),
+    DtwDriftResult(score=None, status=DtwDriftStatus.degraded, reason="not in dtw batch"),
+)
+metrics["dtw_drift_score"] = round(dtw_result.score_or_default(0.0), 6) if dtw_result.is_usable else None
+```
+
+### 3. Update `run_risk_calc()` (org-scoped)
+
+The org-scoped worker no longer needs to compute DTW drift. Two options:
+
+**Option A (recommended):** Remove DTW drift from `run_risk_calc()` entirely. The global worker handles it. The org worker still exists for org-specific overrides (future: custom scoring weights per tenant).
+
+**Option B:** Keep DTW in org worker but use allocation blocks as before. Org-scoped DTW would overwrite the global strategy-based DTW with a block-specific one. This adds complexity for marginal value — only do this if tenants need block-level drift distinct from strategy-level drift.
+
+Go with Option A.
+
+### 4. Batch processing for DTW
+
+DTW is O(n^2) per group. Strategy groups can be large (e.g., "Long/Short Equity" might have 500+ funds). Process in sub-batches if needed:
+
+- Groups with > 500 funds: split into sub-batches of 200, use the full group mean as benchmark for all sub-batches
+- Groups with 2-500 funds: process as-is
+- Groups with < 2 funds: degraded status
+
+### 5. Update docstring and CLAUDE.md
+
+- `run_global_risk_metrics` docstring: remove "no DTW drift" caveat
+- CLAUDE.md worker table: note that `global_risk_metrics` now includes DTW drift
+- Remove the statement "Org-scoped `risk_calc` (lock 900_007) can overwrite rows with DTW drift" — no longer accurate
+
+---
+
+## Also: Add return_5y and return_10y
+
+While touching `run_global_risk_metrics`, add two return columns. The NAV history supports it (60% of instruments have 10Y+ data).
+
+### 1. Migration
+
+```python
+# Add columns to fund_risk_metrics
+op.add_column("fund_risk_metrics", sa.Column("return_5y_ann", sa.Numeric(12, 8), nullable=True))
+op.add_column("fund_risk_metrics", sa.Column("return_10y_ann", sa.Numeric(12, 8), nullable=True))
+```
+
+### 2. Computation in `_compute_single_fund_metrics()`
+
+Find where `return_3y_ann` is computed (uses `compute_annualized_return()` from `return_statistics_service.py`). Add:
+
+```python
+# 5Y annualized return (requires 1825+ days of NAV)
+if len(returns) >= 1260:  # ~5Y trading days
+    metrics["return_5y_ann"] = compute_annualized_return(returns[-1260:], periods_per_year=252)
+
+# 10Y annualized return (requires 3650+ days of NAV)
+if len(returns) >= 2520:  # ~10Y trading days
+    metrics["return_10y_ann"] = compute_annualized_return(returns[-2520:], periods_per_year=252)
+```
+
+### 3. Update start_date in `run_global_risk_metrics()`
+
+Current: `start_date = eval_date - timedelta(days=3 * 365 + 30)` (line 1799)
+
+Change to: `start_date = eval_date - timedelta(days=10 * 365 + 60)` to fetch enough NAV history for 10Y returns.
+
+**Impact:** larger NAV query per batch. Mitigate by only fetching 10Y for funds that have data (check `min(nav_date)` in the batch).
+
+### 4. Schema + route updates
+
+- Add `return_5y_ann` and `return_10y_ann` to `FundRiskMetricsRead` schema
+- Add to screener sort options
+- Add to scoring service if desired (not mandatory — scoring currently uses 1Y/3Y only)
+
+---
+
+## Constraints
+
+- Do NOT change the `compute_dtw_drift_batch()` function in `drift_service.py` — it's correct
+- Do NOT change DTW threshold or scoring interpretation — just the grouping mechanism
+- Do NOT remove `risk_calc` worker entirely — it may still serve org-specific overrides
+- Do NOT change `fund_risk_metrics` table PK or unique constraint — the NULLS NOT DISTINCT index (migration 0093) handles global vs org-scoped rows
+- Must pass `make check` (lint + typecheck + test)
+- Run `run_global_risk_metrics` after deployment to populate the new columns
+
+## Verification
+
+1. `dtw_drift_score` has >80% coverage after global worker runs (vs 0% today)
+2. `return_5y_ann` populated for ~82% of instruments (those with 5Y+ NAV)
+3. `return_10y_ann` populated for ~60% of instruments (those with 10Y+ NAV)
+4. Screener and scoring routes serve the new data without regression
+5. Existing org-scoped `risk_calc` still works (just no longer writes DTW)


### PR DESCRIPTION
## Summary

- **Globalize DTW drift**: Move DTW drift computation from org-scoped `risk_calc` (block-based, 0% coverage) to `global_risk_metrics` (strategy_label-based), unlocking `dtw_drift_score` for all 5,385+ instruments
- **Add return_5y_ann / return_10y_ann**: New migration 0131 + computation in worker. 82% and 60% of instruments have sufficient NAV history respectively
- **Batch strategy processing**: Groups >500 funds split into sub-batches of 200; groups <2 funds get degraded status
- **10Y NAV window**: `start_date` expanded from 3Y to 10Y in both global and org workers
- **MV recreation**: `mv_fund_risk_latest` recreated with `return_5y_ann`, `return_10y_ann`, `dtw_drift_score`

## Files changed

| File | Change |
|------|--------|
| `risk_calc.py` | `_compute_global_dtw_scores()`, wire into global worker, remove DTW from org worker, 5Y/10Y returns |
| `risk.py` (model) | Add `return_5y_ann`, `return_10y_ann` columns |
| `risk.py` (schema) | Add fields to `FundRiskRead` |
| `instrument.py` | Add fields to instrument schema |
| `universe.py` | Add fields to universe schema |
| `0131_return_5y_10y.py` | Migration: columns + MV recreation |
| `CLAUDE.md` | Update worker docs, migration head |

## Test plan

- [x] All 3908 tests passing (0 failures)
- [x] 30 risk/DTW-specific tests passing
- [x] 31 architecture contracts passing
- [x] Lint clean on all changed files
- [ ] Run `global_risk_metrics` worker post-deploy to populate new columns
- [ ] Verify >80% DTW coverage in `fund_risk_metrics`
- [ ] Verify 5Y/10Y return population rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)