### PR TITLE
feat(macro): redesign as terminal command center with structured signals

### DIFF
--- a/backend/app/core/db/migrations/versions/0110_signal_breakdown_macro_regime.py
+++ b/backend/app/core/db/migrations/versions/0110_signal_breakdown_macro_regime.py
@@ -1,0 +1,29 @@
+"""add signal_breakdown to macro_regime_snapshot
+
+Revision ID: 0110
+Revises: 0109
+Create Date: 2026-04-14 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '0110'
+down_revision: Union[str, None] = '0109'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'macro_regime_snapshot',
+        sa.Column('signal_breakdown', postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('macro_regime_snapshot', 'signal_breakdown')

--- a/backend/app/domains/wealth/models/allocation.py
+++ b/backend/app/domains/wealth/models/allocation.py
@@ -50,6 +50,7 @@ class MacroRegimeSnapshot(Base):
     raw_regime: Mapped[str] = mapped_column(String(20), nullable=False)
     stress_score: Mapped[Decimal | None] = mapped_column(Numeric(5, 1))
     signal_details: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    signal_breakdown: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False,
     )

--- a/backend/app/domains/wealth/routes/allocation.py
+++ b/backend/app/domains/wealth/routes/allocation.py
@@ -419,6 +419,7 @@ async def get_global_regime(
         raw_regime=snapshot.raw_regime,
         stress_score=snapshot.stress_score,
         signal_details=snapshot.signal_details,
+        signal_breakdown=snapshot.signal_breakdown or [],
     )
 
 

--- a/backend/app/domains/wealth/routes/macro.py
+++ b/backend/app/domains/wealth/routes/macro.py
@@ -257,6 +257,7 @@ async def get_regime(
         raw_regime=snapshot.raw_regime,
         stress_score=snapshot.stress_score,
         signal_details=snapshot.signal_details,
+        signal_breakdown=snapshot.signal_breakdown or [],
     )
 
 
@@ -891,6 +892,8 @@ _FRED_ALLOWLIST: set[str] = {
     "BRACPIALLMINMEI", "INDCPIALLMINMEI", "INTDSRBRM193N", "BAMLEMCBPIOAS",
     # Global
     "GPRH", "USEPUINDXD", "DTWEXBGS",
+    # Regime signal sparklines
+    "CFNAI", "ICSA", "TOTBKCR",
 }
 
 

--- a/backend/app/domains/wealth/schemas/allocation.py
+++ b/backend/app/domains/wealth/schemas/allocation.py
@@ -140,6 +140,20 @@ class SimulationResult(BaseModel):
     computed_at: datetime
 
 
+class RegimeSignalRead(BaseModel):
+    """Structured breakdown of a single regime signal."""
+
+    key: str
+    label: str
+    raw_value: float | None = None
+    unit: str = ""
+    stress_score: float = 0.0
+    weight_base: float = 0.0
+    weight_effective: float = 0.0
+    category: str = "financial"
+    fred_series: str | None = None
+
+
 class GlobalRegimeRead(BaseModel):
     """Global regime snapshot — no org context needed."""
 
@@ -147,6 +161,7 @@ class GlobalRegimeRead(BaseModel):
     raw_regime: str
     stress_score: Decimal | None = None
     signal_details: dict[str, object] = {}
+    signal_breakdown: list[RegimeSignalRead] = []
 
     @model_validator(mode="after")
     def _humanize(self) -> "GlobalRegimeRead":

--- a/backend/quant_engine/regime_service.py
+++ b/backend/quant_engine/regime_service.py
@@ -58,8 +58,11 @@ _RAW_VALUE_RE = re.compile(r"[-+]?\d+\.?\d*")
 
 
 def _extract_raw_value(reason_str: str) -> float | None:
-    """Parse the first number from reason strings like 'VIX=19.5 (stress=...)'."""
+    """Parse the raw value from reason strings like 'VIX=19.5 (stress=...)'."""
+    # Extract the value portion: split on '(' to drop stress suffix, then on '=' to get RHS
     prefix = reason_str.split("(")[0] if "(" in reason_str else reason_str
+    if "=" in prefix:
+        prefix = prefix.split("=", 1)[1]
     m = _RAW_VALUE_RE.search(prefix)
     if m:
         try:

--- a/backend/quant_engine/regime_service.py
+++ b/backend/quant_engine/regime_service.py
@@ -22,6 +22,7 @@ Config is injected as parameter by callers via ConfigService.get("liquid_funds",
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from datetime import date
 from typing import Any, TypedDict
@@ -35,6 +36,37 @@ from app.shared.models import MacroData
 from app.shared.schemas import RegimeRead
 
 logger = structlog.get_logger()
+
+# ── Signal metadata for structured breakdown ──────────────────────────────
+
+SIGNAL_METADATA: dict[str, dict[str, str]] = {
+    "vix":            {"label": "VIX",              "unit": "",     "category": "financial",    "fred_series": "VIXCLS"},
+    "hy_oas":         {"label": "Credit Spread",    "unit": "%",    "category": "financial",    "fred_series": "BAMLH0A0HYM2"},
+    "energy_shock":   {"label": "Energy Shock",     "unit": "/100", "category": "financial",    "fred_series": "DCOILWTICO"},
+    "dxy":            {"label": "USD Strength",     "unit": "\u03c3",    "category": "financial",    "fred_series": "DTWEXBGS"},
+    "yield_curve":    {"label": "Yield Curve",      "unit": "%",    "category": "financial",    "fred_series": "DGS10"},
+    "baa_spread":     {"label": "Corp. Stress",     "unit": "%",    "category": "financial",    "fred_series": "BAA10Y"},
+    "cfnai":          {"label": "Activity Index",   "unit": "",     "category": "real_economy", "fred_series": "CFNAI"},
+    "sahm":           {"label": "Employment",       "unit": "",     "category": "real_economy", "fred_series": "SAHMREALTIME"},
+    "ff_roc":         {"label": "Fed Policy",       "unit": "%",    "category": "real_economy", "fred_series": "DFF"},
+    "icsa":           {"label": "Jobless Claims",   "unit": "\u03c3",    "category": "real_economy", "fred_series": "ICSA"},
+    "credit_impulse": {"label": "Credit Impulse",   "unit": "%",    "category": "real_economy", "fred_series": "TOTBKCR"},
+    "permits":        {"label": "Building Permits", "unit": "%",    "category": "real_economy", "fred_series": "PERMIT"},
+}
+
+_RAW_VALUE_RE = re.compile(r"[-+]?\d+\.?\d*")
+
+
+def _extract_raw_value(reason_str: str) -> float | None:
+    """Parse the first number from reason strings like 'VIX=19.5 (stress=...)'."""
+    prefix = reason_str.split("(")[0] if "(" in reason_str else reason_str
+    m = _RAW_VALUE_RE.search(prefix)
+    if m:
+        try:
+            return float(m.group())
+        except ValueError:
+            return None
+    return None
 
 
 class RegimeThresholds(TypedDict):
@@ -233,7 +265,7 @@ def classify_regime_multi_signal(
     icsa_zscore: float | None = None,
     credit_impulse: float | None = None,
     permits_roc: float | None = None,
-) -> tuple[str, dict[str, str]]:
+) -> tuple[str, dict[str, str], list[dict[str, Any]]]:
     """Classify regime using multi-factor stress scoring.
 
     Combines financial market signals with real-economy indicators to avoid
@@ -292,7 +324,7 @@ def classify_regime_multi_signal(
     if cpi_yoy is not None and cpi_yoy >= thresholds["cpi_yoy_high"]:
         reasons["cpi"] = f"CPI_YoY={cpi_yoy:.1f}% >= {thresholds['cpi_yoy_high']}% (INFLATION)"
         reasons["decision"] = "INFLATION: CPI above threshold overrides stress score"
-        return "INFLATION", reasons
+        return "INFLATION", reasons, []
 
     # ── Multi-factor stress scoring ──
     # Each signal produces a sub-score 0-100 via _ramp().
@@ -378,7 +410,7 @@ def classify_regime_multi_signal(
     # Need at least 2 signals for confident classification
     if len(signals) < 2:
         reasons["decision"] = "RISK_OFF: insufficient signals for confident classification"
-        return "RISK_OFF", reasons
+        return "RISK_OFF", reasons, []
 
     # Step 1: renormalize base weights for available signals
     weight_sum = sum(w for _, _, w, _ in signals)
@@ -427,7 +459,24 @@ def classify_regime_multi_signal(
         regime = "RISK_ON"
         reasons["decision"] = f"RISK_ON: composite stress {stress_score}/100 — benign conditions"
 
-    return regime, reasons
+    # ── Build structured signal breakdown ──
+    base_weight_map = {label: w for label, _, w, _ in base_signals}
+    structured_signals: list[dict[str, Any]] = []
+    for label, sub_score, weight, reason_str in signals:
+        meta = SIGNAL_METADATA.get(label, {})
+        structured_signals.append({
+            "key": label,
+            "label": meta.get("label", label),
+            "raw_value": _extract_raw_value(reason_str),
+            "unit": meta.get("unit", ""),
+            "stress_score": round(sub_score, 1),
+            "weight_base": round(base_weight_map.get(label, weight), 4),
+            "weight_effective": round(weight, 4),
+            "category": meta.get("category", "financial"),
+            "fred_series": meta.get("fred_series"),
+        })
+
+    return regime, reasons, structured_signals
 
 
 def _ramp(value: float, calm: float, panic: float) -> float:
@@ -942,7 +991,7 @@ async def get_current_regime(
 
     # Need at least VIX or HY OAS or energy data to classify
     if inputs.get("vix") is not None or inputs.get("hy_oas") is not None or inputs.get("energy_shock") is not None:
-        regime, reasons = classify_regime_multi_signal(
+        regime, reasons, _ = classify_regime_multi_signal(
             vix=inputs.get("vix"),
             yield_curve_spread=inputs.get("yield_curve_spread"),
             cpi_yoy=inputs.get("cpi_yoy"),

--- a/backend/tests/e2e_smoke_test.py
+++ b/backend/tests/e2e_smoke_test.py
@@ -473,10 +473,10 @@ async def main() -> None:
         try:
             from quant_engine.regime_service import classify_regime_multi_signal
 
-            regime, signals = classify_regime_multi_signal(
+            regime, signals, _ = classify_regime_multi_signal(
                 vix=18, yield_curve_spread=0.5, cpi_yoy=2.5, sahm_rule=0.2,
             )
-            crisis_regime, _ = classify_regime_multi_signal(
+            crisis_regime, _, _ = classify_regime_multi_signal(
                 vix=45, yield_curve_spread=-1.0, cpi_yoy=5.0, sahm_rule=0.8,
             )
             ok("4.2 Regime", f"normal={regime}, crisis={crisis_regime}")

--- a/backend/tests/quant_engine/test_regime_dynamic_weights.py
+++ b/backend/tests/quant_engine/test_regime_dynamic_weights.py
@@ -70,7 +70,7 @@ class TestProfileAWeights:
     def test_energy_shock_crosses_risk_off(self):
         """With Profile A weights + dynamic amplification,
         energy=100 and calm markets should produce RISK_OFF."""
-        regime, reasons = classify_regime_multi_signal(
+        regime, reasons, _ = classify_regime_multi_signal(
             vix=19.5,
             yield_curve_spread=None,
             cpi_yoy=None,
@@ -88,7 +88,7 @@ class TestProfileAWeights:
 
     def test_all_calm_still_risk_on(self):
         """When all signals are calm, dynamic weights don't change regime."""
-        regime, _ = classify_regime_multi_signal(
+        regime, _, _ = classify_regime_multi_signal(
             vix=15.0,
             yield_curve_spread=None,
             cpi_yoy=None,
@@ -104,7 +104,7 @@ class TestProfileAWeights:
 
     def test_multi_extreme_produces_crisis(self):
         """Multiple extreme signals should produce CRISIS."""
-        regime, _ = classify_regime_multi_signal(
+        regime, _, _ = classify_regime_multi_signal(
             vix=45.0,
             yield_curve_spread=None,
             cpi_yoy=None,
@@ -120,7 +120,7 @@ class TestProfileAWeights:
 
     def test_audit_trail_in_reasons(self):
         """Dynamic weight changes appear in reasons dict."""
-        _, reasons = classify_regime_multi_signal(
+        _, reasons, _ = classify_regime_multi_signal(
             vix=19.5,
             yield_curve_spread=None,
             cpi_yoy=None,
@@ -137,7 +137,7 @@ class TestProfileAWeights:
 
     def test_missing_signals_still_work(self):
         """When only a few signals are present, renormalization + amplification work."""
-        regime, reasons = classify_regime_multi_signal(
+        regime, reasons, _ = classify_regime_multi_signal(
             vix=20.0,
             yield_curve_spread=None,
             cpi_yoy=None,

--- a/backend/tests/quant_engine/test_regime_global_scoping.py
+++ b/backend/tests/quant_engine/test_regime_global_scoping.py
@@ -141,7 +141,7 @@ class TestTaaStateFallbackWithoutSnapshot:
             ) as mock_build,
             patch(
                 "quant_engine.regime_service.classify_regime_multi_signal",
-                return_value=("RISK_ON", {"composite_stress": "10.0/100"}),
+                return_value=("RISK_ON", {"composite_stress": "10.0/100"}, []),
             ) as mock_classify,
         ):
             from app.domains.wealth.workers.risk_calc import _compute_and_persist_taa_state

--- a/backend/tests/quant_engine/test_regime_new_signals.py
+++ b/backend/tests/quant_engine/test_regime_new_signals.py
@@ -8,7 +8,7 @@ from quant_engine.regime_service import classify_regime_multi_signal
 class TestIcsaSignal:
     def test_calm_icsa_produces_low_stress(self):
         """ICSA z-score below calm threshold produces zero stress."""
-        _, reasons = classify_regime_multi_signal(
+        _, reasons, _ = classify_regime_multi_signal(
             vix=20.0, yield_curve_spread=1.0, cpi_yoy=2.0,
             icsa_zscore=0.3,
         )
@@ -16,7 +16,7 @@ class TestIcsaSignal:
 
     def test_extreme_icsa_produces_high_stress(self):
         """ICSA z-score at panic level produces high stress."""
-        _, reasons = classify_regime_multi_signal(
+        _, reasons, _ = classify_regime_multi_signal(
             vix=20.0, yield_curve_spread=1.0, cpi_yoy=2.0,
             icsa_zscore=3.0,
         )
@@ -24,10 +24,10 @@ class TestIcsaSignal:
 
     def test_none_icsa_excluded(self):
         """When icsa_zscore is None, signal is excluded from composite."""
-        _, reasons_without = classify_regime_multi_signal(
+        _, reasons_without, _ = classify_regime_multi_signal(
             vix=20.0, yield_curve_spread=1.0, cpi_yoy=2.0,
         )
-        _, reasons_with = classify_regime_multi_signal(
+        _, reasons_with, _ = classify_regime_multi_signal(
             vix=20.0, yield_curve_spread=1.0, cpi_yoy=2.0,
             icsa_zscore=None,
         )
@@ -39,7 +39,7 @@ class TestIcsaSignal:
 class TestCreditImpulseSignal:
     def test_positive_impulse_low_stress(self):
         """Positive credit growth produces low stress."""
-        _, reasons = classify_regime_multi_signal(
+        _, reasons, _ = classify_regime_multi_signal(
             vix=20.0, yield_curve_spread=1.0, cpi_yoy=2.0,
             credit_impulse=2.0,
         )
@@ -48,7 +48,7 @@ class TestCreditImpulseSignal:
 
     def test_negative_impulse_high_stress(self):
         """Credit contraction produces high stress."""
-        _, reasons = classify_regime_multi_signal(
+        _, reasons, _ = classify_regime_multi_signal(
             vix=20.0, yield_curve_spread=1.0, cpi_yoy=2.0,
             credit_impulse=-3.0,
         )
@@ -56,7 +56,7 @@ class TestCreditImpulseSignal:
 
     def test_none_credit_impulse_excluded(self):
         """When credit_impulse is None, signal is excluded."""
-        _, reasons = classify_regime_multi_signal(
+        _, reasons, _ = classify_regime_multi_signal(
             vix=20.0, yield_curve_spread=1.0, cpi_yoy=2.0,
             credit_impulse=None,
         )
@@ -66,7 +66,7 @@ class TestCreditImpulseSignal:
 class TestPermitsSignal:
     def test_growing_permits_low_stress(self):
         """Rising building permits produce low stress."""
-        _, reasons = classify_regime_multi_signal(
+        _, reasons, _ = classify_regime_multi_signal(
             vix=20.0, yield_curve_spread=1.0, cpi_yoy=2.0,
             permits_roc=10.0,
         )
@@ -74,7 +74,7 @@ class TestPermitsSignal:
 
     def test_falling_permits_high_stress(self):
         """Sharply falling permits produce high stress."""
-        _, reasons = classify_regime_multi_signal(
+        _, reasons, _ = classify_regime_multi_signal(
             vix=20.0, yield_curve_spread=1.0, cpi_yoy=2.0,
             permits_roc=-25.0,
         )
@@ -82,7 +82,7 @@ class TestPermitsSignal:
 
     def test_none_permits_excluded(self):
         """When permits_roc is None, signal is excluded."""
-        _, reasons = classify_regime_multi_signal(
+        _, reasons, _ = classify_regime_multi_signal(
             vix=20.0, yield_curve_spread=1.0, cpi_yoy=2.0,
             permits_roc=None,
         )
@@ -92,7 +92,7 @@ class TestPermitsSignal:
 class TestNewSignalsIntegration:
     def test_all_13_signals_calm_still_risk_on(self):
         """All 13 signals at calm values -> RISK_ON."""
-        regime, reasons = classify_regime_multi_signal(
+        regime, reasons, _ = classify_regime_multi_signal(
             vix=15.0,
             yield_curve_spread=1.5,
             cpi_yoy=2.0,
@@ -111,7 +111,7 @@ class TestNewSignalsIntegration:
 
     def test_all_13_signals_stressed_produces_crisis(self):
         """All 13 signals at panic -> CRISIS."""
-        regime, reasons = classify_regime_multi_signal(
+        regime, reasons, _ = classify_regime_multi_signal(
             vix=35.0,
             yield_curve_spread=-0.5,
             cpi_yoy=3.0,

--- a/backend/tests/quant_engine/test_regime_service.py
+++ b/backend/tests/quant_engine/test_regime_service.py
@@ -8,7 +8,7 @@ from quant_engine.regime_service import classify_regime_multi_signal
 class TestClassifyRegimeAllSignalsStressed:
     def test_all_signals_at_panic_produces_crisis(self):
         """All 10 signals at panic thresholds → CRISIS with stress >= 75."""
-        regime, reasons = classify_regime_multi_signal(
+        regime, reasons, _ = classify_regime_multi_signal(
             vix=35.0,
             yield_curve_spread=-0.5,
             cpi_yoy=3.0,  # below inflation override (4.0)
@@ -28,7 +28,7 @@ class TestClassifyRegimeAllSignalsStressed:
 class TestClassifyRegimeAllSignalsCalm:
     def test_all_signals_calm_produces_risk_on(self):
         """All 10 signals at calm values → RISK_ON with stress < 15."""
-        regime, reasons = classify_regime_multi_signal(
+        regime, reasons, _ = classify_regime_multi_signal(
             vix=15.0,
             yield_curve_spread=1.5,
             cpi_yoy=2.0,

--- a/backend/tests/quant_engine/test_regime_signal_completeness.py
+++ b/backend/tests/quant_engine/test_regime_signal_completeness.py
@@ -163,7 +163,7 @@ class TestSignalCountDifference:
     def test_10_signals_vs_7_signals_score_differs(self):
         """10-signal classification produces different stress than 7-signal."""
         # 7 signals (old behavior: 3 missing)
-        _, reasons_7 = classify_regime_multi_signal(
+        _, reasons_7, _ = classify_regime_multi_signal(
             vix=22.0,
             yield_curve_spread=0.5,
             cpi_yoy=2.5,
@@ -177,7 +177,7 @@ class TestSignalCountDifference:
         )
 
         # 10 signals (with moderate stress values)
-        _, reasons_10 = classify_regime_multi_signal(
+        _, reasons_10, _ = classify_regime_multi_signal(
             vix=22.0,
             yield_curve_spread=0.5,
             cpi_yoy=2.5,

--- a/backend/tests/test_phase_a_integration.py
+++ b/backend/tests/test_phase_a_integration.py
@@ -214,19 +214,19 @@ class TestRegimeDecoupled:
     def test_classify_regime_risk_on(self) -> None:
         from quant_engine.regime_service import classify_regime_multi_signal
 
-        regime, reasons = classify_regime_multi_signal(vix=15.0, yield_curve_spread=1.0, cpi_yoy=2.0)
+        regime, reasons, _ = classify_regime_multi_signal(vix=15.0, yield_curve_spread=1.0, cpi_yoy=2.0)
         assert regime == "RISK_ON"
 
     def test_classify_regime_crisis(self) -> None:
         from quant_engine.regime_service import classify_regime_multi_signal
 
-        regime, reasons = classify_regime_multi_signal(vix=40.0, yield_curve_spread=-0.5, cpi_yoy=2.0)
+        regime, reasons, _ = classify_regime_multi_signal(vix=40.0, yield_curve_spread=-0.5, cpi_yoy=2.0)
         assert regime == "CRISIS"
 
     def test_classify_regime_inflation(self) -> None:
         from quant_engine.regime_service import classify_regime_multi_signal
 
-        regime, reasons = classify_regime_multi_signal(vix=20.0, yield_curve_spread=1.0, cpi_yoy=5.0)
+        regime, reasons, _ = classify_regime_multi_signal(vix=20.0, yield_curve_spread=1.0, cpi_yoy=5.0)
         assert regime == "INFLATION"
 
     def test_plausibility_rejects_extreme_vix(self) -> None:
@@ -237,7 +237,7 @@ class TestRegimeDecoupled:
         # lands in the RISK_OFF band (~25-50). The point of the test is
         # that the implausible VIX is dropped — it must NOT propagate as
         # CRISIS just because the raw value was extreme.
-        regime, reasons = classify_regime_multi_signal(vix=300.0, yield_curve_spread=1.0, cpi_yoy=2.0)
+        regime, reasons, _ = classify_regime_multi_signal(vix=300.0, yield_curve_spread=1.0, cpi_yoy=2.0)
         assert regime in {"RISK_ON", "RISK_OFF"}
         assert regime != "CRISIS"
         # vix label is absent because the value was rejected before scoring
@@ -247,7 +247,7 @@ class TestRegimeDecoupled:
         from quant_engine.regime_service import classify_regime_multi_signal
 
         # CPI=50% is implausible → rejected
-        regime, reasons = classify_regime_multi_signal(vix=20.0, yield_curve_spread=1.0, cpi_yoy=50.0)
+        regime, reasons, _ = classify_regime_multi_signal(vix=20.0, yield_curve_spread=1.0, cpi_yoy=50.0)
         assert regime == "RISK_ON"
 
 

--- a/docs/prompts/2026-04-14-globalize-dtw-drift.md
+++ b/docs/prompts/2026-04-14-globalize-dtw-drift.md
@@ -1,0 +1,188 @@
+# Globalize DTW Drift Score
+
+**Date:** 2026-04-14
+**Branch:** `feat/globalize-dtw-drift`
+**Priority:** MEDIUM — unblocks dtw_drift_score for all 5,385 instruments (currently 0% coverage)
+**Sessions:** 1
+
+---
+
+## Problem
+
+`dtw_drift_score` in `fund_risk_metrics` is **100% empty** (0/5,385 rows) because it's only computed by the org-scoped `risk_calc` worker (lock 900_007), which requires instruments imported into `instruments_org` + assigned to `allocation_blocks`.
+
+The global worker `run_global_risk_metrics` (lock 900_071) explicitly sets `dtw_drift_score = None` for all 5,385+ instruments it computes.
+
+This made sense when DTW drift was a portfolio-context metric (drift vs your allocation block peers). But the model has evolved:
+
+1. **The optimizer uses the full catalog** (all instruments_universe except private funds and BDCs) — not just org-imported instruments.
+2. **Scoring, screening, and DD reports** read from `fund_risk_metrics` globally — they expect `dtw_drift_score` to be populated.
+3. **DTW drift is an intrinsic fund property** — it measures how much a fund's recent return pattern has diverged from its peer group average. The peer group is defined by `strategy_label`, which is a global catalog attribute, not an org-scoped one.
+
+Current architecture:
+```
+global_risk_metrics (900_071)  →  computes everything EXCEPT dtw_drift  →  org_id = NULL
+risk_calc (900_007, org)       →  overwrites with dtw_drift per block   →  org_id = {org}
+```
+
+Target architecture:
+```
+global_risk_metrics (900_071)  →  computes everything INCLUDING dtw_drift by strategy  →  org_id = NULL
+risk_calc (900_007, org)       →  no longer needed for dtw_drift (may still exist for org-specific overrides)
+```
+
+---
+
+## Solution
+
+### 1. Add `_compute_global_dtw_scores()` to `risk_calc.py`
+
+New function near `_compute_block_dtw_scores()` (~line 740). Reuses the same `compute_dtw_drift_batch()` from `quant_engine/drift_service.py`.
+
+```python
+async def _compute_global_dtw_scores(
+    db: AsyncSession,
+    computed: list[tuple[_FundSnapshot, dict]],
+    as_of_date: date,
+    strategy_map: dict[str, str | None],  # instrument_id → strategy_label
+    dtw_window: int = 252,
+) -> dict[str, DtwDriftResult]:
+    """Compute DTW drift scores grouped by strategy_label (global).
+
+    Instead of allocation blocks (org-scoped), groups funds by their
+    strategy_label from mv_unified_funds. Each strategy group uses its
+    equal-weight average as the benchmark.
+
+    Funds with no strategy_label are grouped under "__unclassified__".
+    Groups with < 2 funds get degraded status (no peer comparison possible).
+    """
+```
+
+Key differences from `_compute_block_dtw_scores()`:
+- Groups by `strategy_label` instead of `block_id`
+- No dependency on `instruments_org` or `allocation_blocks`
+- Uses `mv_unified_funds.strategy_label` (already available in global context)
+- Same `compute_dtw_drift_batch()` call, same DTW window (252 days)
+
+### 2. Wire into `run_global_risk_metrics()`
+
+In `run_global_risk_metrics()`, after Pass 1 (metric computation) and before the upsert:
+
+```python
+# Build strategy_label map from mv_unified_funds
+strategy_stmt = text("""
+    SELECT ticker, strategy_label FROM mv_unified_funds
+    WHERE ticker IS NOT NULL AND strategy_label IS NOT NULL
+""")
+strategy_rows = (await db.execute(strategy_stmt)).all()
+ticker_to_strategy = {r[0]: r[1] for r in strategy_rows}
+
+# Map instrument_id → strategy_label via ticker
+strategy_map = {}
+for fund in all_funds:
+    if fund.ticker and fund.ticker in ticker_to_strategy:
+        strategy_map[str(fund.instrument_id)] = ticker_to_strategy[fund.ticker]
+
+# Compute global DTW drift
+dtw_scores = await _compute_global_dtw_scores(
+    db, computed, eval_date, strategy_map,
+)
+```
+
+Then in the upsert loop, replace:
+```python
+metrics["dtw_drift_score"] = None  # ← current (line 2015)
+```
+With:
+```python
+dtw_result = dtw_scores.get(
+    str(fund.instrument_id),
+    DtwDriftResult(score=None, status=DtwDriftStatus.degraded, reason="not in dtw batch"),
+)
+metrics["dtw_drift_score"] = round(dtw_result.score_or_default(0.0), 6) if dtw_result.is_usable else None
+```
+
+### 3. Update `run_risk_calc()` (org-scoped)
+
+The org-scoped worker no longer needs to compute DTW drift. Two options:
+
+**Option A (recommended):** Remove DTW drift from `run_risk_calc()` entirely. The global worker handles it. The org worker still exists for org-specific overrides (future: custom scoring weights per tenant).
+
+**Option B:** Keep DTW in org worker but use allocation blocks as before. Org-scoped DTW would overwrite the global strategy-based DTW with a block-specific one. This adds complexity for marginal value — only do this if tenants need block-level drift distinct from strategy-level drift.
+
+Go with Option A.
+
+### 4. Batch processing for DTW
+
+DTW is O(n^2) per group. Strategy groups can be large (e.g., "Long/Short Equity" might have 500+ funds). Process in sub-batches if needed:
+
+- Groups with > 500 funds: split into sub-batches of 200, use the full group mean as benchmark for all sub-batches
+- Groups with 2-500 funds: process as-is
+- Groups with < 2 funds: degraded status
+
+### 5. Update docstring and CLAUDE.md
+
+- `run_global_risk_metrics` docstring: remove "no DTW drift" caveat
+- CLAUDE.md worker table: note that `global_risk_metrics` now includes DTW drift
+- Remove the statement "Org-scoped `risk_calc` (lock 900_007) can overwrite rows with DTW drift" — no longer accurate
+
+---
+
+## Also: Add return_5y and return_10y
+
+While touching `run_global_risk_metrics`, add two return columns. The NAV history supports it (60% of instruments have 10Y+ data).
+
+### 1. Migration
+
+```python
+# Add columns to fund_risk_metrics
+op.add_column("fund_risk_metrics", sa.Column("return_5y_ann", sa.Numeric(12, 8), nullable=True))
+op.add_column("fund_risk_metrics", sa.Column("return_10y_ann", sa.Numeric(12, 8), nullable=True))
+```
+
+### 2. Computation in `_compute_single_fund_metrics()`
+
+Find where `return_3y_ann` is computed (uses `compute_annualized_return()` from `return_statistics_service.py`). Add:
+
+```python
+# 5Y annualized return (requires 1825+ days of NAV)
+if len(returns) >= 1260:  # ~5Y trading days
+    metrics["return_5y_ann"] = compute_annualized_return(returns[-1260:], periods_per_year=252)
+
+# 10Y annualized return (requires 3650+ days of NAV)
+if len(returns) >= 2520:  # ~10Y trading days
+    metrics["return_10y_ann"] = compute_annualized_return(returns[-2520:], periods_per_year=252)
+```
+
+### 3. Update start_date in `run_global_risk_metrics()`
+
+Current: `start_date = eval_date - timedelta(days=3 * 365 + 30)` (line 1799)
+
+Change to: `start_date = eval_date - timedelta(days=10 * 365 + 60)` to fetch enough NAV history for 10Y returns.
+
+**Impact:** larger NAV query per batch. Mitigate by only fetching 10Y for funds that have data (check `min(nav_date)` in the batch).
+
+### 4. Schema + route updates
+
+- Add `return_5y_ann` and `return_10y_ann` to `FundRiskMetricsRead` schema
+- Add to screener sort options
+- Add to scoring service if desired (not mandatory — scoring currently uses 1Y/3Y only)
+
+---
+
+## Constraints
+
+- Do NOT change the `compute_dtw_drift_batch()` function in `drift_service.py` — it's correct
+- Do NOT change DTW threshold or scoring interpretation — just the grouping mechanism
+- Do NOT remove `risk_calc` worker entirely — it may still serve org-specific overrides
+- Do NOT change `fund_risk_metrics` table PK or unique constraint — the NULLS NOT DISTINCT index (migration 0093) handles global vs org-scoped rows
+- Must pass `make check` (lint + typecheck + test)
+- Run `run_global_risk_metrics` after deployment to populate the new columns
+
+## Verification
+
+1. `dtw_drift_score` has >80% coverage after global worker runs (vs 0% today)
+2. `return_5y_ann` populated for ~82% of instruments (those with 5Y+ NAV)
+3. `return_10y_ann` populated for ~60% of instruments (those with 10Y+ NAV)
+4. Screener and scoring routes serve the new data without regression
+5. Existing org-scoped `risk_calc` still works (just no longer writes DTW)

--- a/frontends/wealth/src/lib/components/terminal/macro/RegionalHealthTile.svelte
+++ b/frontends/wealth/src/lib/components/terminal/macro/RegionalHealthTile.svelte
@@ -1,10 +1,12 @@
 <!--
-  RegimeTile — regional macro regime tile for the macro desk.
+  RegionalHealthTile — regional macro health tile for the macro desk.
 
-  Displays composite score, regime badge, and dimension progress bars
-  for a single region (US / EU / JP / EM). Terminal tokens only.
+  Displays composite score and dimension progress bars for a single
+  region (US / EU / JP / EM). No regime badge. Terminal tokens only.
 -->
 <script lang="ts">
+  import { formatNumber } from "@investintell/ui/utils";
+
   interface DimensionScore {
     name: string;
     score: number;
@@ -13,19 +15,10 @@
   interface Props {
     region: string;
     compositeScore: number;
-    regime: string;
     dimensions: DimensionScore[];
   }
 
-  let { region, compositeScore, regime, dimensions }: Props = $props();
-
-  const REGIME_COLORS: Record<string, string> = {
-    Expansion: "var(--terminal-status-success)",
-    Cautious: "var(--terminal-accent-amber)",
-    Stress: "var(--terminal-status-error)",
-  };
-
-  const regimeColor = $derived(REGIME_COLORS[regime] ?? "var(--terminal-fg-secondary)");
+  let { region, compositeScore, dimensions }: Props = $props();
 
   const DIMENSION_LABELS: Record<string, string> = {
     growth: "Growth",
@@ -39,34 +32,31 @@
   }
 </script>
 
-<div class="rt-root">
-  <div class="rt-header">
-    <span class="rt-region">{region}</span>
-    <span class="rt-regime-badge" style:color={regimeColor} style:border-color={regimeColor}>
-      {regime}
-    </span>
+<div class="rht-root">
+  <div class="rht-header">
+    <span class="rht-region">{region}</span>
   </div>
 
-  <div class="rt-score">
-    <span class="rt-score-value">{Math.round(compositeScore)}</span>
-    <span class="rt-score-unit">/100</span>
+  <div class="rht-score">
+    <span class="rht-score-value">{formatNumber(compositeScore, 0)}</span>
+    <span class="rht-score-unit">/100</span>
   </div>
 
-  <div class="rt-dimensions">
+  <div class="rht-dimensions">
     {#each dimensions as dim (dim.name)}
-      <div class="rt-dim">
-        <span class="rt-dim-label">{dimensionLabel(dim.name)}</span>
-        <div class="rt-dim-bar">
-          <div class="rt-dim-fill" style:width="{Math.min(100, Math.max(0, dim.score))}%"></div>
+      <div class="rht-dim">
+        <span class="rht-dim-label">{dimensionLabel(dim.name)}</span>
+        <div class="rht-dim-bar">
+          <div class="rht-dim-fill" style:width="{Math.min(100, Math.max(0, dim.score))}%"></div>
         </div>
-        <span class="rt-dim-value">{Math.round(dim.score)}</span>
+        <span class="rht-dim-value">{formatNumber(dim.score, 0)}</span>
       </div>
     {/each}
   </div>
 </div>
 
 <style>
-  .rt-root {
+  .rht-root {
     display: flex;
     flex-direction: column;
     gap: var(--terminal-space-3);
@@ -77,13 +67,12 @@
     height: 100%;
   }
 
-  .rt-header {
+  .rht-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
   }
 
-  .rt-region {
+  .rht-region {
     font-size: var(--terminal-text-12);
     font-weight: 700;
     letter-spacing: var(--terminal-tracking-caps);
@@ -91,47 +80,38 @@
     color: var(--terminal-fg-primary);
   }
 
-  .rt-regime-badge {
-    font-size: var(--terminal-text-10);
-    font-weight: 600;
-    letter-spacing: var(--terminal-tracking-caps);
-    text-transform: uppercase;
-    padding: 2px 6px;
-    border: 1px solid;
-  }
-
-  .rt-score {
+  .rht-score {
     display: flex;
     align-items: baseline;
     gap: 2px;
   }
 
-  .rt-score-value {
+  .rht-score-value {
     font-size: var(--terminal-text-24);
     font-weight: 700;
     color: var(--terminal-accent-amber);
     font-variant-numeric: tabular-nums;
   }
 
-  .rt-score-unit {
+  .rht-score-unit {
     font-size: var(--terminal-text-11);
     color: var(--terminal-fg-tertiary);
   }
 
-  .rt-dimensions {
+  .rht-dimensions {
     display: flex;
     flex-direction: column;
     gap: var(--terminal-space-2);
   }
 
-  .rt-dim {
+  .rht-dim {
     display: grid;
     grid-template-columns: 90px 1fr 24px;
     align-items: center;
     gap: var(--terminal-space-2);
   }
 
-  .rt-dim-label {
+  .rht-dim-label {
     font-size: var(--terminal-text-10);
     color: var(--terminal-fg-secondary);
     letter-spacing: var(--terminal-tracking-caps);
@@ -141,13 +121,13 @@
     text-overflow: ellipsis;
   }
 
-  .rt-dim-bar {
+  .rht-dim-bar {
     height: 4px;
     background: var(--terminal-fg-muted);
     position: relative;
   }
 
-  .rt-dim-fill {
+  .rht-dim-fill {
     position: absolute;
     top: 0;
     left: 0;
@@ -156,7 +136,7 @@
     transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
   }
 
-  .rt-dim-value {
+  .rht-dim-value {
     font-size: var(--terminal-text-10);
     font-weight: 600;
     color: var(--terminal-fg-secondary);

--- a/frontends/wealth/src/lib/components/terminal/macro/SignalBreakdown.svelte
+++ b/frontends/wealth/src/lib/components/terminal/macro/SignalBreakdown.svelte
@@ -1,0 +1,209 @@
+<!--
+  SignalBreakdown — two-column signal panel for regime stress decomposition.
+
+  Left: financial signals. Right: real economy signals.
+  Each row shows label, raw value, stress bar, and weight amplification.
+  Terminal tokens only. No hex. No radius.
+-->
+<script lang="ts">
+  import { formatNumber } from "@investintell/ui/utils";
+
+  interface RegimeSignalRead {
+    key: string;
+    label: string;
+    raw_value: number | null;
+    unit: string;
+    stress_score: number;
+    weight_base: number;
+    weight_effective: number;
+    category: "financial" | "real_economy";
+    fred_series: string | null;
+  }
+
+  interface Props {
+    signals: RegimeSignalRead[];
+  }
+
+  let { signals }: Props = $props();
+
+  const financialSignals = $derived(
+    signals
+      .filter((s) => s.category === "financial")
+      .sort((a, b) => b.weight_effective - a.weight_effective),
+  );
+
+  const realEconSignals = $derived(
+    signals
+      .filter((s) => s.category === "real_economy")
+      .sort((a, b) => b.weight_effective - a.weight_effective),
+  );
+
+  function stressColor(score: number): string {
+    if (score < 33) return "var(--terminal-status-ok, var(--terminal-status-success))";
+    if (score < 66) return "var(--terminal-accent-amber)";
+    return "var(--terminal-status-error)";
+  }
+
+  function formatRawValue(value: number | null, unit: string): string {
+    if (value == null) return "--";
+    const formatted = formatNumber(value, 2);
+    if (unit === "%") return formatted + "%";
+    if (unit) return formatted + unit;
+    return formatted;
+  }
+
+  function weightColor(base: number, effective: number): string {
+    if (effective > base * 1.2) return "var(--terminal-accent-amber)";
+    return "var(--terminal-fg-muted)";
+  }
+</script>
+
+<div class="sb-root">
+  <div class="sb-column">
+    <span class="sb-column-header">FINANCIAL SIGNALS ({financialSignals.length})</span>
+    {#each financialSignals as sig (sig.key)}
+      {@const color = stressColor(sig.stress_score)}
+      <div class="sb-row">
+        <div class="sb-row-top">
+          <span class="sb-label">{sig.label.toUpperCase()}</span>
+          <span class="sb-value">{formatRawValue(sig.raw_value, sig.unit)}</span>
+          <span class="sb-stress" style:color={color}>{formatNumber(sig.stress_score, 0)}/100</span>
+        </div>
+        <div class="sb-row-bottom">
+          <div class="sb-bar">
+            <div
+              class="sb-bar-fill"
+              style:width="{Math.min(100, Math.max(0, sig.stress_score))}%"
+              style:background={color}
+            ></div>
+          </div>
+          <span class="sb-weight" style:color={weightColor(sig.weight_base, sig.weight_effective)}>
+            w: {formatNumber(sig.weight_base, 2)} &rarr; {formatNumber(sig.weight_effective, 2)}
+          </span>
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  <div class="sb-column">
+    <span class="sb-column-header">REAL ECONOMY SIGNALS ({realEconSignals.length})</span>
+    {#each realEconSignals as sig (sig.key)}
+      {@const color = stressColor(sig.stress_score)}
+      <div class="sb-row">
+        <div class="sb-row-top">
+          <span class="sb-label">{sig.label.toUpperCase()}</span>
+          <span class="sb-value">{formatRawValue(sig.raw_value, sig.unit)}</span>
+          <span class="sb-stress" style:color={color}>{formatNumber(sig.stress_score, 0)}/100</span>
+        </div>
+        <div class="sb-row-bottom">
+          <div class="sb-bar">
+            <div
+              class="sb-bar-fill"
+              style:width="{Math.min(100, Math.max(0, sig.stress_score))}%"
+              style:background={color}
+            ></div>
+          </div>
+          <span class="sb-weight" style:color={weightColor(sig.weight_base, sig.weight_effective)}>
+            w: {formatNumber(sig.weight_base, 2)} &rarr; {formatNumber(sig.weight_effective, 2)}
+          </span>
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .sb-root {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--terminal-space-4);
+    padding: var(--terminal-space-3);
+    background: var(--terminal-bg-panel);
+    border: var(--terminal-border-hairline);
+    font-family: var(--terminal-font-mono);
+    flex-shrink: 0;
+  }
+
+  .sb-column {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-3);
+  }
+
+  .sb-column-header {
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    color: var(--terminal-fg-tertiary);
+    text-transform: uppercase;
+    padding-bottom: var(--terminal-space-1);
+    border-bottom: var(--terminal-border-hairline);
+  }
+
+  .sb-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .sb-row-top {
+    display: flex;
+    align-items: baseline;
+    gap: var(--terminal-space-2);
+  }
+
+  .sb-label {
+    width: 120px;
+    flex-shrink: 0;
+    font-size: var(--terminal-text-10);
+    font-weight: 600;
+    letter-spacing: var(--terminal-tracking-caps);
+    color: var(--terminal-fg-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .sb-value {
+    flex: 1;
+    text-align: right;
+    font-size: var(--terminal-text-11);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--terminal-fg-primary);
+  }
+
+  .sb-stress {
+    flex-shrink: 0;
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .sb-row-bottom {
+    display: flex;
+    align-items: center;
+    gap: var(--terminal-space-2);
+  }
+
+  .sb-bar {
+    flex: 1;
+    height: 4px;
+    background: var(--terminal-fg-muted);
+    position: relative;
+  }
+
+  .sb-bar-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+  }
+
+  .sb-weight {
+    flex-shrink: 0;
+    font-size: var(--terminal-text-10);
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/frontends/wealth/src/lib/components/terminal/macro/StressHero.svelte
+++ b/frontends/wealth/src/lib/components/terminal/macro/StressHero.svelte
@@ -1,0 +1,251 @@
+<!--
+  StressHero — full-width stress score banner for the macro desk.
+
+  Displays global regime stress score as a horizontal bar with
+  dynamic weight category breakdown and regime pin/proceed actions.
+  Terminal tokens only. No hex. No radius.
+-->
+<script lang="ts">
+  import { formatNumber, formatShortDate } from "@investintell/ui/utils";
+
+  interface Props {
+    stressScore: number;
+    regimeLabel: string;
+    asOfDate: string;
+    financialEffWeight: number;
+    realEconEffWeight: number;
+    isPinned: boolean;
+    onPin: () => void;
+    onUnpin: () => void;
+    onProceedToAlloc: () => void;
+  }
+
+  let {
+    stressScore,
+    regimeLabel,
+    asOfDate,
+    financialEffWeight,
+    realEconEffWeight,
+    isPinned,
+    onPin,
+    onUnpin,
+    onProceedToAlloc,
+  }: Props = $props();
+
+  function stressColor(score: number): string {
+    if (score < 33) return "var(--terminal-status-ok, var(--terminal-status-success))";
+    if (score < 66) return "var(--terminal-accent-amber)";
+    return "var(--terminal-status-error)";
+  }
+
+  const fillColor = $derived(stressColor(stressScore));
+  const fillPct = $derived(Math.min(100, Math.max(0, stressScore)));
+
+  const financialPct = $derived(
+    financialEffWeight + realEconEffWeight > 0
+      ? formatNumber((financialEffWeight / (financialEffWeight + realEconEffWeight)) * 100, 0)
+      : "0"
+  );
+
+  const realEconPct = $derived(
+    financialEffWeight + realEconEffWeight > 0
+      ? formatNumber((realEconEffWeight / (financialEffWeight + realEconEffWeight)) * 100, 0)
+      : "0"
+  );
+</script>
+
+<div class="sh-root">
+  <div class="sh-top">
+    <div class="sh-score-group">
+      <span class="sh-score" style:color={fillColor}>{formatNumber(stressScore, 0)}</span>
+      <span class="sh-regime">{regimeLabel.toUpperCase()}</span>
+    </div>
+    <span class="sh-date">as of {formatShortDate(new Date(asOfDate))}</span>
+  </div>
+
+  <div class="sh-bar-wrap">
+    <div class="sh-bar">
+      <div class="sh-bar-fill" style:width="{fillPct}%" style:background={fillColor}></div>
+    </div>
+    <div class="sh-bar-ticks">
+      <div class="sh-tick" style:left="33%"></div>
+      <div class="sh-tick" style:left="66%"></div>
+    </div>
+    <span class="sh-bar-label">/100</span>
+  </div>
+
+  <div class="sh-bottom">
+    <div class="sh-weights">
+      <span class="sh-weight">FINANCIAL {financialPct}%</span>
+      <span class="sh-weight">REAL ECONOMY {realEconPct}%</span>
+    </div>
+    <div class="sh-actions">
+      {#if isPinned}
+        <button type="button" class="sh-btn sh-btn--active" onclick={onUnpin}>UNPIN</button>
+      {:else}
+        <button type="button" class="sh-btn" onclick={onPin}>PIN REGIME</button>
+      {/if}
+      <button type="button" class="sh-btn sh-btn--proceed" onclick={onProceedToAlloc}>
+        PROCEED TO ALLOC &rarr;
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .sh-root {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-2);
+    padding: var(--terminal-space-3) var(--terminal-space-4);
+    background: var(--terminal-bg-panel);
+    border: var(--terminal-border-hairline);
+    font-family: var(--terminal-font-mono);
+    flex-shrink: 0;
+  }
+
+  .sh-top {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+
+  .sh-score-group {
+    display: flex;
+    align-items: baseline;
+    gap: var(--terminal-space-3);
+  }
+
+  .sh-score {
+    font-size: 32px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+
+  .sh-regime {
+    font-size: var(--terminal-text-16, 16px);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    color: var(--terminal-fg-primary);
+  }
+
+  .sh-date {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-muted);
+    letter-spacing: var(--terminal-tracking-caps);
+  }
+
+  .sh-bar-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: var(--terminal-space-2);
+  }
+
+  .sh-bar {
+    flex: 1;
+    height: 6px;
+    background: var(--terminal-fg-muted);
+    position: relative;
+  }
+
+  .sh-bar-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+  }
+
+  .sh-bar-ticks {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 40px;
+    height: 6px;
+    pointer-events: none;
+  }
+
+  .sh-tick {
+    position: absolute;
+    top: -2px;
+    width: 1px;
+    height: 10px;
+    background: var(--terminal-fg-tertiary);
+  }
+
+  .sh-bar-label {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-muted);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+
+  .sh-bottom {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .sh-weights {
+    display: flex;
+    gap: var(--terminal-space-4);
+  }
+
+  .sh-weight {
+    font-size: var(--terminal-text-10);
+    font-weight: 600;
+    letter-spacing: var(--terminal-tracking-caps);
+    color: var(--terminal-fg-tertiary);
+  }
+
+  .sh-actions {
+    display: flex;
+    gap: var(--terminal-space-2);
+  }
+
+  .sh-btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px var(--terminal-space-2);
+    background: transparent;
+    border: var(--terminal-border-hairline);
+    border-radius: 0;
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-10);
+    font-weight: 600;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-secondary);
+    cursor: pointer;
+    transition:
+      border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+      color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .sh-btn:hover {
+    border-color: var(--terminal-accent-amber);
+    color: var(--terminal-accent-amber);
+  }
+
+  .sh-btn--active {
+    border-color: var(--terminal-accent-cyan);
+    color: var(--terminal-accent-cyan);
+  }
+
+  .sh-btn--active:hover {
+    border-color: var(--terminal-status-error);
+    color: var(--terminal-status-error);
+  }
+
+  .sh-btn--proceed {
+    border-color: var(--terminal-accent-cyan);
+    color: var(--terminal-accent-cyan);
+  }
+
+  .sh-btn--proceed:hover {
+    border-color: var(--terminal-fg-primary);
+    color: var(--terminal-fg-primary);
+  }
+</style>

--- a/frontends/wealth/src/routes/(terminal)/macro/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/macro/+page.svelte
@@ -1,17 +1,20 @@
 <!--
-  /macro — Macro Desk (Phase 7, Session A).
+  /macro — Macro Desk (Terminal Command Center).
 
-  12-column grid dashboard: 4 regional regime tiles (top),
-  sparkline wall (bottom-left 9 cols), committee review feed
-  (bottom-right 3 cols). Terminal-native primitives only.
+  Layout: StressHero (full-width) → SignalBreakdown (2-col) →
+  Bottom grid: Regional Health (5fr) | Indicators (4fr) | Committee (3fr).
+  Terminal-native primitives only.
 -->
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import { getContext } from "svelte";
   import { createClientApiClient } from "$lib/api/client";
   import { pinnedRegime } from "$lib/state/pinned-regime.svelte";
   import Panel from "$lib/components/terminal/layout/Panel.svelte";
   import PanelHeader from "$lib/components/terminal/layout/PanelHeader.svelte";
-  import RegimeTile from "$lib/components/terminal/macro/RegimeTile.svelte";
+  import StressHero from "$lib/components/terminal/macro/StressHero.svelte";
+  import SignalBreakdown from "$lib/components/terminal/macro/SignalBreakdown.svelte";
+  import RegionalHealthTile from "$lib/components/terminal/macro/RegionalHealthTile.svelte";
   import SparklineWall from "$lib/components/terminal/macro/SparklineWall.svelte";
   import CommitteeReviewFeed from "$lib/components/terminal/macro/CommitteeReviewFeed.svelte";
 
@@ -42,11 +45,24 @@
     };
   }
 
+  interface RegimeSignalRead {
+    key: string;
+    label: string;
+    raw_value: number | null;
+    unit: string;
+    stress_score: number;
+    weight_base: number;
+    weight_effective: number;
+    category: "financial" | "real_economy";
+    fred_series: string | null;
+  }
+
   interface GlobalRegimeRead {
     as_of_date: string;
     raw_regime: string;
     stress_score: number | null;
     signal_details: Record<string, string>;
+    signal_breakdown: RegimeSignalRead[];
   }
 
   interface FredTimePoint {
@@ -119,30 +135,35 @@
 
   // -- Data fetching ---------------------------------------------------
 
-  async function fetchMacroData() {
+  async function fetchAllData(signal: AbortSignal) {
     try {
       const [scoresRes, regimeRes, reviewsRes] = await Promise.all([
-        api.get<MacroScoresResponse>("/macro/scores"),
-        api.get<GlobalRegimeRead>("/macro/regime"),
-        api.get<MacroReviewRead[]>("/macro/reviews?limit=10"),
+        api.get<MacroScoresResponse>("/macro/scores", undefined, { signal }),
+        api.get<GlobalRegimeRead>("/macro/regime", undefined, { signal }),
+        api.get<MacroReviewRead[]>("/macro/reviews?limit=10", undefined, { signal }),
       ]);
       scores = scoresRes;
       regime = regimeRes;
       reviews = reviewsRes;
       fetchError = false;
-    } catch {
+    } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
       fetchError = true;
     } finally {
       loading = false;
     }
   }
 
-  async function fetchSparklines() {
+  async function fetchSparklines(signal: AbortSignal) {
     const results: typeof sparklineData = [];
 
     const fetches = SPARKLINE_SERIES.map(async (cfg) => {
       try {
-        const res = await api.get<FredDataResponse>(`/macro/fred?series_id=${cfg.seriesId}`);
+        const res = await api.get<FredDataResponse>(
+          `/macro/fred?series_id=${cfg.seriesId}`,
+          undefined,
+          { signal },
+        );
         if (res.data.length > 0) {
           const history = res.data.map((pt) => ({ date: pt.obs_date, value: pt.value }));
           const last = history[history.length - 1]!;
@@ -156,14 +177,18 @@
             unit: cfg.unit,
           });
         }
-      } catch {
+      } catch (e: unknown) {
+        if (e instanceof DOMException && e.name === "AbortError") throw e;
         // Skip unavailable series silently
       }
     });
 
-    await Promise.all(fetches);
+    try {
+      await Promise.all(fetches);
+    } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+    }
 
-    // Preserve config ordering
     const order = new Map(SPARKLINE_SERIES.map((s, i) => [s.name, i]));
     results.sort((a, b) => (order.get(a.name) ?? 99) - (order.get(b.name) ?? 99));
     sparklineData = results;
@@ -171,27 +196,44 @@
 
   // -- Derived views ---------------------------------------------------
 
+  const financialSignals = $derived(
+    (regime?.signal_breakdown ?? [])
+      .filter((s) => s.category === "financial")
+      .sort((a, b) => b.weight_effective - a.weight_effective),
+  );
+
+  const realEconSignals = $derived(
+    (regime?.signal_breakdown ?? [])
+      .filter((s) => s.category === "real_economy")
+      .sort((a, b) => b.weight_effective - a.weight_effective),
+  );
+
+  const financialEffWeight = $derived(
+    financialSignals.reduce((sum, s) => sum + s.weight_effective, 0),
+  );
+
+  const realEconEffWeight = $derived(
+    realEconSignals.reduce((sum, s) => sum + s.weight_effective, 0),
+  );
+
   interface TileData {
     region: string;
     compositeScore: number;
-    regime: string;
     dimensions: Array<{ name: string; score: number }>;
   }
 
   const tiles = $derived.by<TileData[]>(() => {
-    if (!scores || !regime) return [];
+    if (!scores) return [];
     return REGION_ORDER.map((key) => {
       const reg = scores!.regions[key];
       if (!reg) return null;
-      const dims = Object.entries(reg.dimensions).map(([name, d]) => ({
-        name,
-        score: d.score,
-      }));
       return {
         region: REGION_LABELS[key] ?? key,
         compositeScore: reg.composite_score,
-        regime: regime!.raw_regime ?? "Unknown",
-        dimensions: dims,
+        dimensions: Object.entries(reg.dimensions).map(([name, d]) => ({
+          name,
+          score: d.score,
+        })),
       };
     }).filter((t): t is TileData => t !== null);
   });
@@ -212,42 +254,14 @@
     }),
   );
 
-  // -- Regime display helpers ------------------------------------------
-
-  const REGIME_DISPLAY: Record<string, string> = {
-    REGIME_NORMAL: "Normal",
-    normal: "Normal",
-    REGIME_RISK_ON: "Risk On",
-    risk_on: "Risk On",
-    REGIME_RISK_OFF: "Risk Off",
-    risk_off: "Risk Off",
-    REGIME_CRISIS: "Crisis",
-    crisis: "Crisis",
-  };
-
-  function sanitizeRegime(raw: string): string {
-    return REGIME_DISPLAY[raw] ?? raw;
-  }
-
-  const globalRegimeLabel = $derived(
-    regime ? sanitizeRegime(regime.raw_regime) : "Unknown",
-  );
-
   const isPinned = $derived(pinnedRegime.current !== null);
 
   function handlePinRegime() {
-    if (!regime || !scores) return;
-
-    // Compute global composite from regional averages
-    const regionKeys = Object.keys(scores.regions);
-    const avgScore = regionKeys.length > 0
-      ? regionKeys.reduce((sum, k) => sum + (scores!.regions[k]?.composite_score ?? 0), 0) / regionKeys.length
-      : 0;
-
+    if (!regime) return;
     pinnedRegime.pin({
-      label: globalRegimeLabel,
+      label: regime.raw_regime,
       region: "GLOBAL",
-      score: Math.round(avgScore),
+      score: Math.round(regime.stress_score ?? 0),
     });
   }
 
@@ -255,18 +269,27 @@
     pinnedRegime.clear();
   }
 
+  function handleProceedToAlloc() {
+    goto("/terminal/allocation");
+  }
+
   // -- Effects ---------------------------------------------------------
 
   $effect(() => {
-    fetchMacroData();
-    fetchSparklines();
+    const ac = new AbortController();
+
+    fetchAllData(ac.signal);
+    fetchSparklines(ac.signal);
 
     const timer = setInterval(() => {
-      fetchMacroData();
-      fetchSparklines();
-    }, 5 * 60 * 1000); // 5 min poll
+      fetchAllData(ac.signal);
+      fetchSparklines(ac.signal);
+    }, 5 * 60 * 1000);
 
-    return () => clearInterval(timer);
+    return () => {
+      ac.abort();
+      clearInterval(timer);
+    };
   });
 </script>
 
@@ -276,59 +299,38 @@
   {:else if fetchError}
     <div class="macro-state macro-state--error">Failed to load macro data. Retrying...</div>
   {:else}
-    <!-- Top row: 4 regime tiles + pin action -->
-    <div class="macro-tiles-row">
-      <div class="macro-tiles">
-        {#each tiles as tile (tile.region)}
-          <RegimeTile
-            region={tile.region}
-            compositeScore={tile.compositeScore}
-            regime={tile.regime}
-            dimensions={tile.dimensions}
-          />
-        {/each}
-      </div>
-      <div class="macro-pin-bar">
-        <span class="macro-global-regime">
-          GLOBAL: <strong>{globalRegimeLabel}</strong>
-          {#if regime?.stress_score != null}
-            <span class="macro-stress-score">STRESS {Math.round(regime.stress_score)}/100</span>
-          {/if}
-        </span>
-        {#if isPinned}
-          <button
-            type="button"
-            class="macro-pin-btn macro-pin-btn--active"
-            onclick={handleUnpinRegime}
-          >
-            UNPIN REGIME
-          </button>
-        {:else}
-          <button
-            type="button"
-            class="macro-pin-btn"
-            onclick={handlePinRegime}
-          >
-            PIN REGIME
-          </button>
-        {/if}
-      </div>
-    </div>
+    <StressHero
+      stressScore={regime?.stress_score ?? 0}
+      regimeLabel={regime?.raw_regime ?? "Unknown"}
+      asOfDate={regime?.as_of_date ?? ""}
+      {financialEffWeight}
+      {realEconEffWeight}
+      {isPinned}
+      onPin={handlePinRegime}
+      onUnpin={handleUnpinRegime}
+      onProceedToAlloc={handleProceedToAlloc}
+    />
 
-    <!-- Signal breakdown -->
-    {#if regime?.signal_details && Object.keys(regime.signal_details).length > 0}
-      <div class="macro-signals">
-        <span class="macro-signals-label">SIGNALS</span>
-        <div class="macro-signals-list">
-          {#each Object.entries(regime.signal_details) as [key, detail] (key)}
-            <span class="macro-signal-chip">{detail}</span>
-          {/each}
-        </div>
-      </div>
-    {/if}
+    <SignalBreakdown signals={regime?.signal_breakdown ?? []} />
 
-    <!-- Bottom row: sparkline wall + committee feed -->
     <div class="macro-bottom">
+      <div class="macro-regions">
+        <Panel>
+          {#snippet header()}
+            <PanelHeader label="REGIONAL ECONOMIC HEALTH" />
+          {/snippet}
+          <div class="region-grid">
+            {#each tiles as tile (tile.region)}
+              <RegionalHealthTile
+                region={tile.region}
+                compositeScore={tile.compositeScore}
+                dimensions={tile.dimensions}
+              />
+            {/each}
+          </div>
+        </Panel>
+      </div>
+
       <div class="macro-sparklines">
         <Panel>
           {#snippet header()}
@@ -360,126 +362,29 @@
     flex-direction: column;
     gap: var(--terminal-space-3);
     width: 100%;
-    height: 100%;
+    height: calc(100vh - 88px);
     font-family: var(--terminal-font-mono);
-    overflow: hidden;
-  }
-
-  .macro-tiles-row {
-    display: flex;
-    flex-direction: column;
-    gap: var(--terminal-space-2);
-    flex-shrink: 0;
-  }
-
-  .macro-tiles {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: var(--terminal-space-3);
-  }
-
-  .macro-pin-bar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 var(--terminal-space-1);
-  }
-
-  .macro-global-regime {
-    font-size: var(--terminal-text-10);
-    letter-spacing: var(--terminal-tracking-caps);
-    text-transform: uppercase;
-    color: var(--terminal-fg-tertiary);
-  }
-
-  .macro-global-regime strong {
-    color: var(--terminal-fg-primary);
-    font-weight: 700;
-  }
-
-  .macro-pin-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--terminal-space-1);
-    padding: 2px var(--terminal-space-2);
-    background: transparent;
-    border: var(--terminal-border-hairline);
-    border-radius: var(--terminal-radius-none);
-    font-family: var(--terminal-font-mono);
-    font-size: var(--terminal-text-10);
-    font-weight: 600;
-    letter-spacing: var(--terminal-tracking-caps);
-    text-transform: uppercase;
-    color: var(--terminal-fg-secondary);
-    cursor: pointer;
-    transition:
-      border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
-      color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
-  }
-
-  .macro-pin-btn:hover {
-    border-color: var(--terminal-accent-amber);
-    color: var(--terminal-accent-amber);
-  }
-
-  .macro-pin-btn--active {
-    border-color: var(--terminal-accent-cyan);
-    color: var(--terminal-accent-cyan);
-  }
-
-  .macro-pin-btn--active:hover {
-    border-color: var(--terminal-status-error);
-    color: var(--terminal-status-error);
-  }
-
-  .macro-stress-score {
-    margin-left: var(--terminal-space-2);
-    font-size: var(--terminal-text-10);
-    font-weight: 600;
-    font-variant-numeric: tabular-nums;
-    color: var(--terminal-accent-amber);
-  }
-
-  .macro-signals {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--terminal-space-2);
-    padding: 0 var(--terminal-space-1);
-    flex-shrink: 0;
-  }
-
-  .macro-signals-label {
-    font-size: var(--terminal-text-10);
-    font-weight: 600;
-    letter-spacing: var(--terminal-tracking-caps);
-    text-transform: uppercase;
-    color: var(--terminal-fg-muted);
-    white-space: nowrap;
-    padding-top: 2px;
-  }
-
-  .macro-signals-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--terminal-space-1);
-  }
-
-  .macro-signal-chip {
-    display: inline-block;
-    padding: 1px var(--terminal-space-2);
-    border: var(--terminal-border-hairline);
-    font-size: var(--terminal-text-10);
-    font-family: var(--terminal-font-mono);
-    color: var(--terminal-fg-secondary);
-    white-space: nowrap;
+    overflow-y: auto;
+    padding: 24px;
   }
 
   .macro-bottom {
     display: grid;
-    grid-template-columns: 1fr 300px;
+    grid-template-columns: 5fr 4fr 3fr;
     gap: var(--terminal-space-3);
     flex: 1;
     min-height: 0;
+  }
+
+  .macro-regions {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .region-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--terminal-space-2);
   }
 
   .macro-sparklines {


### PR DESCRIPTION
## Summary
**Backend (Session A):**
- `RegimeSignalRead` schema with 10 fields (key, label, raw_value, stress, weights, category, fred_series)
- `classify_regime_multi_signal` returns structured signals as 3rd tuple element
- `signal_breakdown` JSONB column on `macro_regime_snapshot` (migration 0110)
- `GlobalRegimeRead` extended with `signal_breakdown: list[RegimeSignalRead]`
- FRED allowlist: added CFNAI, ICSA, TOTBKCR, SAHMREALTIME

**Frontend (Session B):**
- StressHero — score as hero number + 6px bar (green/amber/red at 33/66), weight split, CTA to ALLOC
- SignalBreakdown — 2-column (Financial | Real Economy), stress bars, dynamic weight amplification highlight
- RegionalHealthTile — renamed from RegimeTile, regime badge removed
- Deleted dead code: REGIME_DISPLAY, sanitizeRegime(), old signal chips
- AbortController in $effect, $derived for all computed state

## Test plan
- [ ] Stress score displays as hero with color-coded bar
- [ ] Signal breakdown shows 2 columns with real structured data
- [ ] Dynamic weight amplification highlighted in amber when >1.2x
- [ ] Regional tiles show scores WITHOUT regime badges
- [ ] PIN REGIME pins stress_score (not regional average)
- [ ] PROCEED TO ALLOC navigates correctly
- [ ] No hex colors, no Urbanist, no dead regime code
- [ ] `make test` + `pnpm check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)