### PR TITLE
feat(wealth): universe sanitization — is_institutional flag + worker (Session A)

### DIFF
--- a/backend/app/core/db/migrations/versions/0134_universe_sanitization_flags.py
+++ b/backend/app/core/db/migrations/versions/0134_universe_sanitization_flags.py
@@ -1,0 +1,99 @@
+"""Add is_institutional + exclusion_reason for universe sanitization.
+
+Adds a three-column triplet (``is_institutional``, ``exclusion_reason``,
+``sanitized_at``) to the six fund source tables plus a generated
+``is_institutional`` column on ``instruments_universe`` that reads from
+the JSONB ``attributes`` payload.
+
+Default is TRUE on every existing row: the sanitization worker
+(``universe_sanitization``, lock 900_063) re-runs to compute the flag.
+Partial indexes on ``is_institutional = true`` keep downstream filtered
+queries fast; the sanitized subset is ~65% of the universe.
+
+Revision ID: 0134_universe_sanitization_flags
+Revises: 0133_strategy_reclassification_stage
+Create Date: 2026-04-14
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0134_universe_sanitization_flags"
+down_revision = "0133_strategy_reclassification_stage"
+branch_labels = None
+depends_on = None
+
+
+TABLES = (
+    "sec_manager_funds",
+    "sec_registered_funds",
+    "sec_etfs",
+    "sec_bdcs",
+    "sec_money_market_funds",
+    "esma_funds",
+)
+
+
+def upgrade() -> None:
+    for table in TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "is_institutional",
+                sa.Boolean,
+                nullable=False,
+                server_default=sa.text("true"),
+            ),
+        )
+        op.add_column(
+            table,
+            sa.Column("exclusion_reason", sa.Text, nullable=True),
+        )
+        op.add_column(
+            table,
+            sa.Column(
+                "sanitized_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+        )
+        op.create_index(
+            f"idx_{table}_institutional",
+            table,
+            ["is_institutional"],
+            postgresql_where=sa.text("is_institutional = true"),
+        )
+
+    # instruments_universe stores the flag inline via a generated column
+    # reading from the JSONB ``attributes`` payload so propagation from
+    # source tables is a single JSONB merge.
+    op.execute(
+        """
+        ALTER TABLE instruments_universe
+        ADD COLUMN is_institutional BOOLEAN
+        GENERATED ALWAYS AS (
+            COALESCE((attributes->>'is_institutional')::boolean, true)
+        ) STORED
+        """,
+    )
+    op.create_index(
+        "idx_instruments_universe_institutional",
+        "instruments_universe",
+        ["is_institutional"],
+        postgresql_where=sa.text("is_institutional = true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_instruments_universe_institutional",
+        table_name="instruments_universe",
+    )
+    op.execute(
+        "ALTER TABLE instruments_universe DROP COLUMN is_institutional",
+    )
+    for table in TABLES:
+        op.drop_index(f"idx_{table}_institutional", table_name=table)
+        op.drop_column(table, "sanitized_at")
+        op.drop_column(table, "exclusion_reason")
+        op.drop_column(table, "is_institutional")

--- a/backend/app/domains/wealth/workers/universe_sanitization.py
+++ b/backend/app/domains/wealth/workers/universe_sanitization.py
@@ -1,0 +1,639 @@
+"""Worker: universe_sanitization — flag non-institutional vehicles so
+downstream consumers (strategy_reclassification, candidate_screener,
+catalog_sql, mv_unified_funds) stop polluting peer groups and scoring
+percentiles with retirement, CIT, education, SMA, and sub-scale funds.
+
+Advisory lock : 900_063 (deterministic literal)
+Frequency     : on-demand. Run AFTER sec_adv_ingestion, sec_bulk_ingestion,
+                esma_ingestion; BEFORE strategy_reclassification.
+Idempotent    : yes — every invocation first resets flags to TRUE on all
+                rows, then re-applies the rule cascade. A second run with
+                the same source data produces the same per-reason counts.
+
+Design notes
+------------
+* **Stored column, not a view.** Gives a permanent audit trail
+  (``exclusion_reason``) and keeps downstream queries cheap.
+* **First match wins.** ``exclusion_reason IS NULL`` is the gate; once a
+  row is flagged with e.g. ``retirement`` it will not be re-flagged as
+  ``cit`` in a later rule. The ordering of rules matters for reporting
+  but not for the final institutional/non-institutional bit.
+* **No external fetches.** Everything reads from already-ingested tables.
+* **Per-rule commit.** Each rule commits on its own so a crash mid-run
+  preserves partial progress and the idempotent reset on the next run
+  cleans it up.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.engine import async_session_factory as async_session
+
+SANITIZATION_LOCK_ID = 900_063
+GAV_FLOOR_USD = 3_000_000_000  # $3B manager GAV floor
+
+logger: Any = structlog.get_logger()
+
+
+# ── Exclusion keyword patterns (PostgreSQL POSIX regex, case-insensitive) ──
+
+PATTERN_RETIREMENT = (
+    r"(\m401\(?k\)?|\m403\(?b\)?|\m457\M|"
+    r"\mIRA\M|\mSEP\s+IRA|\mSIMPLE\s+IRA|"
+    r"ERISA|retirement|pension\s+plan|"
+    r"\mESOP\M|employee\s+stock\s+ownership|"
+    r"\mtarget\s+(date|retirement)\M)"
+)
+
+PATTERN_CIT = (
+    r"(collective\s+(investment\s+)?trust|"
+    r"\mCIT\M\s+fund|"  # avoid false positives on bank abbreviations
+    r"common\s+(investment\s+)?fund|"
+    r"bank\s+collective)"
+)
+
+PATTERN_EDUCATION = (
+    r"(\m529\s*(plan|portfolio)|"
+    r"coverdell|"
+    r"education\s+savings)"
+)
+
+PATTERN_INSURANCE = (
+    r"(stable\s+value|"
+    r"guaranteed\s+(income|interest|annuity)|"
+    r"insurance.{0,10}wrap|"
+    r"\mGIC\M|guaranteed\s+investment\s+contract|"
+    r"fixed\s+annuity)"
+)
+
+PATTERN_SMA_WRAP = (
+    r"(\mSMA\M\s+(program|platform)|"
+    r"separately\s+managed|"
+    r"wrap\s+(account|program|fee)|"
+    r"managed\s+account\s+program|"
+    r"\mUMA\M)"  # unified managed account
+)
+
+_SOURCE_TABLES: tuple[str, ...] = (
+    "sec_manager_funds",
+    "sec_registered_funds",
+    "sec_etfs",
+    "sec_bdcs",
+    "sec_money_market_funds",
+    "esma_funds",
+)
+
+
+# ───────────────────────────────────────────────────────────────────
+# Public entry point
+# ───────────────────────────────────────────────────────────────────
+
+
+async def run_universe_sanitization() -> dict[str, Any]:
+    """Apply sanitization rules across all fund tables.
+
+    Returns a dict with ``per_table`` mapping to per-reason counters
+    plus an ``institutional`` / ``excluded`` / ``total`` summary block.
+    """
+    started = datetime.now(timezone.utc)
+    result: dict[str, Any] = {
+        "started_at": started.isoformat(),
+        "per_table": {},
+    }
+
+    async with async_session() as db:
+        lock_row = await db.execute(
+            text("SELECT pg_try_advisory_lock(:lock_id)"),
+            {"lock_id": SANITIZATION_LOCK_ID},
+        )
+        if not lock_row.scalar():
+            logger.warning("sanitization_skipped", reason="lock_contention")
+            return {"skipped": True, "reason": "lock_contention"}
+
+        try:
+            await _reset_flags(db)
+            await db.commit()
+
+            result["per_table"]["sec_manager_funds"] = (
+                await _sanitize_sec_manager_funds(db)
+            )
+            await db.commit()
+
+            result["per_table"]["sec_registered_funds"] = (
+                await _sanitize_sec_registered_funds(db)
+            )
+            await db.commit()
+
+            result["per_table"]["sec_etfs"] = await _sanitize_sec_etfs(db)
+            await db.commit()
+
+            # sec_bdcs: no rules today (all public BDCs are institutional).
+            # Still report the summary for the audit trail.
+            result["per_table"]["sec_bdcs"] = await _summary(db, "sec_bdcs")
+
+            result["per_table"]["sec_money_market_funds"] = (
+                await _sanitize_sec_mmfs(db)
+            )
+            await db.commit()
+
+            result["per_table"]["esma_funds"] = await _sanitize_esma_funds(db)
+            await db.commit()
+
+            await _propagate_to_instruments_universe(db)
+            await db.commit()
+
+            finished = datetime.now(timezone.utc)
+            result["completed_at"] = finished.isoformat()
+            result["duration_seconds"] = (finished - started).total_seconds()
+
+        finally:
+            await db.execute(
+                text("SELECT pg_advisory_unlock(:lock_id)"),
+                {"lock_id": SANITIZATION_LOCK_ID},
+            )
+            await db.commit()
+
+    return result
+
+
+# ───────────────────────────────────────────────────────────────────
+# Helpers
+# ───────────────────────────────────────────────────────────────────
+
+
+async def _reset_flags(db: AsyncSession) -> None:
+    """Reset every row to institutional=true so the run is idempotent."""
+    for table in _SOURCE_TABLES:
+        await db.execute(
+            text(
+                f"UPDATE {table} "
+                f"SET is_institutional = true, "
+                f"    exclusion_reason = NULL, "
+                f"    sanitized_at = NOW()",
+            ),
+        )
+    logger.info("sanitization_flags_reset")
+
+
+async def _summary(db: AsyncSession, table: str) -> dict[str, int]:
+    """Return institutional / excluded / total counts for a table."""
+    row = (
+        await db.execute(
+            text(
+                f"SELECT "
+                f"  COUNT(*) FILTER (WHERE is_institutional) AS institutional, "
+                f"  COUNT(*) FILTER (WHERE NOT is_institutional) AS excluded, "
+                f"  COUNT(*) AS total "
+                f"FROM {table}",
+            ),
+        )
+    ).one()
+    return dict(row._mapping)
+
+
+# ───────────────────────────────────────────────────────────────────
+# sec_manager_funds — highest-risk table, 62k rows
+# ───────────────────────────────────────────────────────────────────
+
+
+async def _sanitize_sec_manager_funds(db: AsyncSession) -> dict[str, int]:
+    """Rules:
+      1. retirement / ERISA (name regex)
+      2. CIT (name regex)
+      3. education (name regex)
+      4. insurance-wrapped (name regex)
+      5. SMA / wrap (name regex)
+      6. GAV floor $3B at manager level
+      7. retail adviser (client_types JSONB)
+      8. duplicate multi-adviser filings (keep largest adviser)
+    """
+    counts: dict[str, int] = {}
+
+    for reason, pattern in (
+        ("retirement", PATTERN_RETIREMENT),
+        ("cit", PATTERN_CIT),
+        ("education", PATTERN_EDUCATION),
+        ("insurance_wrapped", PATTERN_INSURANCE),
+        ("sma_wrap", PATTERN_SMA_WRAP),
+    ):
+        r = await db.execute(
+            text(
+                "UPDATE sec_manager_funds "
+                "SET is_institutional = false, "
+                "    exclusion_reason = :reason, "
+                "    sanitized_at = NOW() "
+                "WHERE is_institutional = true "
+                "  AND exclusion_reason IS NULL "
+                "  AND fund_name ~* :pattern",
+            ),
+            {"reason": reason, "pattern": pattern},
+        )
+        counts[reason] = r.rowcount or 0
+
+    # Rule 6 — GAV floor at the manager level
+    r = await db.execute(
+        text(
+            "UPDATE sec_manager_funds f "
+            "SET is_institutional = false, "
+            "    exclusion_reason = 'gav_below_3b', "
+            "    sanitized_at = NOW() "
+            "FROM sec_managers m "
+            "WHERE f.crd_number = m.crd_number "
+            "  AND f.is_institutional = true "
+            "  AND f.exclusion_reason IS NULL "
+            "  AND COALESCE(m.total_private_fund_assets, 0) < :floor",
+        ),
+        {"floor": GAV_FLOOR_USD},
+    )
+    counts["gav_below_3b"] = r.rowcount or 0
+
+    # Rule 7 — retail adviser heuristic (>500 individual clients OR
+    # fewer than 2 pooled vehicles: the firm is not a pure institutional
+    # allocator).
+    r = await db.execute(
+        text(
+            "UPDATE sec_manager_funds f "
+            "SET is_institutional = false, "
+            "    exclusion_reason = 'retail_adviser', "
+            "    sanitized_at = NOW() "
+            "FROM sec_managers m "
+            "WHERE f.crd_number = m.crd_number "
+            "  AND f.is_institutional = true "
+            "  AND f.exclusion_reason IS NULL "
+            "  AND ( "
+            "    COALESCE((m.client_types->'individuals'->>'count')::int, 0) > 500 "
+            "    OR COALESCE((m.client_types->'pooled_vehicles'->>'count')::int, 0) < 2 "
+            "  )",
+        ),
+    )
+    counts["retail_adviser"] = r.rowcount or 0
+
+    # Rule 8 — duplicate multi-adviser filings. For a fund reported by
+    # multiple CRDs with the same (fund_name, GAV), keep the adviser with
+    # the largest AUM. Ties fall to the lexicographically smaller CRD.
+    r = await db.execute(
+        text(
+            """
+            WITH dupes AS (
+                SELECT
+                    f.id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY f.fund_name, f.gross_asset_value
+                        ORDER BY m.aum_total DESC NULLS LAST, f.crd_number
+                    ) AS rn
+                FROM sec_manager_funds f
+                JOIN sec_managers m ON f.crd_number = m.crd_number
+                WHERE f.is_institutional = true
+                  AND f.exclusion_reason IS NULL
+                  AND f.fund_name IS NOT NULL
+                  AND f.gross_asset_value IS NOT NULL
+            )
+            UPDATE sec_manager_funds f
+            SET is_institutional = false,
+                exclusion_reason = 'duplicate_filing',
+                sanitized_at = NOW()
+            FROM dupes d
+            WHERE f.id = d.id
+              AND d.rn > 1
+            """,
+        ),
+    )
+    counts["duplicate_filing"] = r.rowcount or 0
+
+    counts.update(await _summary(db, "sec_manager_funds"))
+    logger.info("sec_manager_funds_sanitized", **counts)
+    return counts
+
+
+# ───────────────────────────────────────────────────────────────────
+# sec_registered_funds — mutual funds, closed-end, interval
+# ───────────────────────────────────────────────────────────────────
+
+
+async def _sanitize_sec_registered_funds(db: AsyncSession) -> dict[str, int]:
+    """Rules:
+      1. retirement keywords in name
+      2. is_target_date flag from N-CEN
+      3. sub-scale (< $100M aggregate net assets across share classes)
+    """
+    counts: dict[str, int] = {}
+
+    r = await db.execute(
+        text(
+            "UPDATE sec_registered_funds "
+            "SET is_institutional = false, "
+            "    exclusion_reason = 'retirement', "
+            "    sanitized_at = NOW() "
+            "WHERE is_institutional = true "
+            "  AND exclusion_reason IS NULL "
+            "  AND fund_name ~* :pattern",
+        ),
+        {"pattern": PATTERN_RETIREMENT},
+    )
+    counts["retirement"] = r.rowcount or 0
+
+    r = await db.execute(
+        text(
+            "UPDATE sec_registered_funds "
+            "SET is_institutional = false, "
+            "    exclusion_reason = 'target_date', "
+            "    sanitized_at = NOW() "
+            "WHERE is_institutional = true "
+            "  AND exclusion_reason IS NULL "
+            "  AND COALESCE(is_target_date, false) = true",
+        ),
+    )
+    counts["target_date"] = r.rowcount or 0
+
+    # Aggregate share-class net_assets (XBRL-enriched column on
+    # sec_fund_classes) and exclude sub-$100M funds. The fund table PK
+    # is ``cik``; so is the share-class table.
+    r = await db.execute(
+        text(
+            """
+            UPDATE sec_registered_funds f
+            SET is_institutional = false,
+                exclusion_reason = 'sub_scale',
+                sanitized_at = NOW()
+            FROM (
+                SELECT cik, SUM(net_assets) AS total_aum
+                FROM sec_fund_classes
+                WHERE net_assets IS NOT NULL
+                GROUP BY cik
+            ) agg
+            WHERE f.cik = agg.cik
+              AND f.is_institutional = true
+              AND f.exclusion_reason IS NULL
+              AND agg.total_aum < 100000000
+            """,
+        ),
+    )
+    counts["sub_scale"] = r.rowcount or 0
+
+    counts.update(await _summary(db, "sec_registered_funds"))
+    logger.info("sec_registered_funds_sanitized", **counts)
+    return counts
+
+
+# ───────────────────────────────────────────────────────────────────
+# sec_etfs
+# ───────────────────────────────────────────────────────────────────
+
+
+async def _sanitize_sec_etfs(db: AsyncSession) -> dict[str, int]:
+    """Rules:
+      1. retirement-focused ETFs (target date)
+      2. leveraged / inverse retail exotics below $100M AUM
+    """
+    counts: dict[str, int] = {}
+
+    r = await db.execute(
+        text(
+            "UPDATE sec_etfs "
+            "SET is_institutional = false, "
+            "    exclusion_reason = 'retirement', "
+            "    sanitized_at = NOW() "
+            "WHERE is_institutional = true "
+            "  AND exclusion_reason IS NULL "
+            "  AND fund_name ~* :pattern",
+        ),
+        {"pattern": PATTERN_RETIREMENT},
+    )
+    counts["retirement"] = r.rowcount or 0
+
+    # ETF model exposes monthly_avg_net_assets (no raw net_assets column).
+    r = await db.execute(
+        text(
+            r"""
+            UPDATE sec_etfs
+            SET is_institutional = false,
+                exclusion_reason = 'leveraged_retail',
+                sanitized_at = NOW()
+            WHERE is_institutional = true
+              AND exclusion_reason IS NULL
+              AND fund_name ~* '(\m(2x|3x|-?1x|-?2x|-?3x)\M|leveraged|inverse|ultra)'
+              AND COALESCE(monthly_avg_net_assets, 0) < 100000000
+            """,
+        ),
+    )
+    counts["leveraged_retail"] = r.rowcount or 0
+
+    counts.update(await _summary(db, "sec_etfs"))
+    logger.info("sec_etfs_sanitized", **counts)
+    return counts
+
+
+# ───────────────────────────────────────────────────────────────────
+# sec_money_market_funds
+# ───────────────────────────────────────────────────────────────────
+
+
+async def _sanitize_sec_mmfs(db: AsyncSession) -> dict[str, int]:
+    """Rules:
+      1. retirement / insurance-wrapped MMFs (name regex)
+      2. retail-only MMFs (mmf_category)
+    """
+    counts: dict[str, int] = {}
+
+    r = await db.execute(
+        text(
+            "UPDATE sec_money_market_funds "
+            "SET is_institutional = false, "
+            "    exclusion_reason = 'retirement_or_insurance', "
+            "    sanitized_at = NOW() "
+            "WHERE is_institutional = true "
+            "  AND exclusion_reason IS NULL "
+            "  AND (fund_name ~* :pattern_retirement "
+            "       OR fund_name ~* :pattern_insurance)",
+        ),
+        {
+            "pattern_retirement": PATTERN_RETIREMENT,
+            "pattern_insurance": PATTERN_INSURANCE,
+        },
+    )
+    counts["retirement_or_insurance"] = r.rowcount or 0
+
+    r = await db.execute(
+        text(
+            r"""
+            UPDATE sec_money_market_funds
+            SET is_institutional = false,
+                exclusion_reason = 'retail_mmf_category',
+                sanitized_at = NOW()
+            WHERE is_institutional = true
+              AND exclusion_reason IS NULL
+              AND mmf_category ~* '(retail|\mgovernment\s+retail\M)'
+            """,
+        ),
+    )
+    counts["retail_mmf_category"] = r.rowcount or 0
+
+    counts.update(await _summary(db, "sec_money_market_funds"))
+    logger.info("sec_money_market_funds_sanitized", **counts)
+    return counts
+
+
+# ───────────────────────────────────────────────────────────────────
+# esma_funds
+# ───────────────────────────────────────────────────────────────────
+
+
+async def _sanitize_esma_funds(db: AsyncSession) -> dict[str, int]:
+    """Rules:
+      1. retirement / pension focused UCITS (name regex)
+      2. EU-specific pension wrappers (PEPP, IORP)
+
+    Note: sub-scale AUM filtering is intentionally skipped — the
+    ``esma_funds`` table has no AUM column today.
+    """
+    counts: dict[str, int] = {}
+
+    r = await db.execute(
+        text(
+            "UPDATE esma_funds "
+            "SET is_institutional = false, "
+            "    exclusion_reason = 'retirement', "
+            "    sanitized_at = NOW() "
+            "WHERE is_institutional = true "
+            "  AND exclusion_reason IS NULL "
+            "  AND fund_name ~* :pattern",
+        ),
+        {"pattern": PATTERN_RETIREMENT},
+    )
+    counts["retirement"] = r.rowcount or 0
+
+    r = await db.execute(
+        text(
+            r"""
+            UPDATE esma_funds
+            SET is_institutional = false,
+                exclusion_reason = 'eu_pension',
+                sanitized_at = NOW()
+            WHERE is_institutional = true
+              AND exclusion_reason IS NULL
+              AND fund_name ~* '(\mPEPP\M|pan.?european\s+pension|\mIORP\M|occupational\s+pension)'
+            """,
+        ),
+    )
+    counts["eu_pension"] = r.rowcount or 0
+
+    counts.update(await _summary(db, "esma_funds"))
+    logger.info("esma_funds_sanitized", **counts)
+    return counts
+
+
+# ───────────────────────────────────────────────────────────────────
+# Propagate to instruments_universe via JSONB attributes
+# ───────────────────────────────────────────────────────────────────
+
+
+async def _propagate_to_instruments_universe(db: AsyncSession) -> None:
+    """Fold is_institutional + exclusion_reason into instruments_universe.
+
+    The ``is_institutional`` column on ``instruments_universe`` is GENERATED
+    from ``attributes->>'is_institutional'``; writing to the JSONB
+    attributes is enough to update the column.
+    """
+    # sec_manager_funds — joined via sec_crd + fund_name
+    await db.execute(
+        text(
+            """
+            UPDATE instruments_universe iu
+            SET attributes = COALESCE(iu.attributes, '{}'::jsonb)
+                || jsonb_build_object(
+                    'is_institutional', f.is_institutional,
+                    'exclusion_reason', f.exclusion_reason
+                )
+            FROM sec_manager_funds f
+            WHERE iu.attributes->>'sec_crd' = f.crd_number
+              AND iu.attributes->>'fund_name' = f.fund_name
+            """,
+        ),
+    )
+
+    # sec_registered_funds — joined via sec_cik
+    await db.execute(
+        text(
+            """
+            UPDATE instruments_universe iu
+            SET attributes = COALESCE(iu.attributes, '{}'::jsonb)
+                || jsonb_build_object(
+                    'is_institutional', f.is_institutional,
+                    'exclusion_reason', f.exclusion_reason
+                )
+            FROM sec_registered_funds f
+            WHERE iu.attributes->>'sec_cik' = f.cik::text
+            """,
+        ),
+    )
+
+    # sec_etfs — joined via series_id
+    await db.execute(
+        text(
+            """
+            UPDATE instruments_universe iu
+            SET attributes = COALESCE(iu.attributes, '{}'::jsonb)
+                || jsonb_build_object(
+                    'is_institutional', f.is_institutional,
+                    'exclusion_reason', f.exclusion_reason
+                )
+            FROM sec_etfs f
+            WHERE iu.attributes->>'series_id' = f.series_id
+            """,
+        ),
+    )
+
+    # sec_bdcs — joined via series_id
+    await db.execute(
+        text(
+            """
+            UPDATE instruments_universe iu
+            SET attributes = COALESCE(iu.attributes, '{}'::jsonb)
+                || jsonb_build_object(
+                    'is_institutional', f.is_institutional,
+                    'exclusion_reason', f.exclusion_reason
+                )
+            FROM sec_bdcs f
+            WHERE iu.attributes->>'series_id' = f.series_id
+            """,
+        ),
+    )
+
+    # sec_money_market_funds — joined via series_id
+    await db.execute(
+        text(
+            """
+            UPDATE instruments_universe iu
+            SET attributes = COALESCE(iu.attributes, '{}'::jsonb)
+                || jsonb_build_object(
+                    'is_institutional', f.is_institutional,
+                    'exclusion_reason', f.exclusion_reason
+                )
+            FROM sec_money_market_funds f
+            WHERE iu.attributes->>'series_id' = f.series_id
+            """,
+        ),
+    )
+
+    # esma_funds — joined via isin
+    await db.execute(
+        text(
+            """
+            UPDATE instruments_universe iu
+            SET attributes = COALESCE(iu.attributes, '{}'::jsonb)
+                || jsonb_build_object(
+                    'is_institutional', f.is_institutional,
+                    'exclusion_reason', f.exclusion_reason
+                )
+            FROM esma_funds f
+            WHERE iu.attributes->>'isin' = f.isin
+            """,
+        ),
+    )
+
+    logger.info("instruments_universe_flag_propagated")

--- a/backend/app/domains/wealth/workers/universe_sanitization.py
+++ b/backend/app/domains/wealth/workers/universe_sanitization.py
@@ -252,26 +252,22 @@ async def _sanitize_sec_manager_funds(db: AsyncSession) -> dict[str, int]:
     )
     counts["gav_below_3b"] = r.rowcount or 0
 
-    # Rule 7 — retail adviser heuristic (>500 individual clients OR
-    # fewer than 2 pooled vehicles: the firm is not a pure institutional
-    # allocator).
-    r = await db.execute(
-        text(
-            "UPDATE sec_manager_funds f "
-            "SET is_institutional = false, "
-            "    exclusion_reason = 'retail_adviser', "
-            "    sanitized_at = NOW() "
-            "FROM sec_managers m "
-            "WHERE f.crd_number = m.crd_number "
-            "  AND f.is_institutional = true "
-            "  AND f.exclusion_reason IS NULL "
-            "  AND ( "
-            "    COALESCE((m.client_types->'individuals'->>'count')::int, 0) > 500 "
-            "    OR COALESCE((m.client_types->'pooled_vehicles'->>'count')::int, 0) < 2 "
-            "  )",
-        ),
-    )
-    counts["retail_adviser"] = r.rowcount or 0
+    # Rule 7 — retail adviser heuristic: REMOVED.
+    #
+    # Original design: flag managers with >500 individual clients OR <2
+    # pooled vehicles. Empirical validation against the 2026-04-14 DB
+    # snapshot showed this catches foundational institutional managers
+    # (PIMCO, Neuberger Berman, Lazard, Western Asset, Franklin, UBS AM)
+    # because top-tier firms run both wealth platforms (thousands of
+    # individual clients) and institutional private fund books. 1,185
+    # funds from the top of the league table were false-flagged.
+    #
+    # ``client_types`` alone cannot separate "institutional manager with
+    # wealth platform" from "retail RIA". The $3B GAV floor above
+    # already filters the genuinely small RIAs, and ``duplicate_filing``
+    # cleans multi-adviser noise. If later data shows residual retail
+    # pollution, revisit with a stricter signal such as
+    # ``individuals_pct_aum > 90%`` once that granularity is populated.
 
     # Rule 8 — duplicate multi-adviser filings. For a fund reported by
     # multiple CRDs with the same (fund_name, GAV), keep the adviser with
@@ -458,20 +454,23 @@ async def _sanitize_sec_mmfs(db: AsyncSession) -> dict[str, int]:
     )
     counts["retirement_or_insurance"] = r.rowcount or 0
 
+    # Retail MMFs expose a boolean ``is_retail`` flag populated from
+    # N-MFP (``mmf_category`` is the investment style — Government,
+    # Prime, Tax Exempt — not the retail/institutional split).
     r = await db.execute(
         text(
-            r"""
+            """
             UPDATE sec_money_market_funds
             SET is_institutional = false,
-                exclusion_reason = 'retail_mmf_category',
+                exclusion_reason = 'retail_mmf',
                 sanitized_at = NOW()
             WHERE is_institutional = true
               AND exclusion_reason IS NULL
-              AND mmf_category ~* '(retail|\mgovernment\s+retail\M)'
+              AND is_retail IS TRUE
             """,
         ),
     )
-    counts["retail_mmf_category"] = r.rowcount or 0
+    counts["retail_mmf"] = r.rowcount or 0
 
     counts.update(await _summary(db, "sec_money_market_funds"))
     logger.info("sec_money_market_funds_sanitized", **counts)

--- a/backend/scripts/refresh_local_reclassification.py
+++ b/backend/scripts/refresh_local_reclassification.py
@@ -1,0 +1,386 @@
+"""Refresh local fund reclassification without re-running ingestion.
+
+Usage
+-----
+    python backend/scripts/refresh_local_reclassification.py
+
+Prerequisites
+-------------
+- PR #169 (classifier patches round 1) merged.
+- Local DB populated (no SEC/ESMA/Tiingo ingestion required).
+- Tiingo enrichment already run (``instruments_universe.attributes
+  ->> 'tiingo_description'`` populated).
+
+Output
+------
+- New ``run_id`` written to ``strategy_reclassification_stage``.
+- Structured stdout report: per-source counts, cascade layer
+  distribution, diff-severity distribution, PR #169 patch validation
+  counts, top 20 proposed labels, and random samples of ``lost_class``
+  and ``fallback`` rows for manual review.
+
+Writes are staging-only — production ``strategy_label`` columns are
+never touched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+
+from app.core.db.engine import async_session_factory as async_session
+from app.domains.wealth.workers import strategy_reclassification
+
+log = logging.getLogger(__name__)
+
+# Reference only — reported in commentary. Comes from a Cloud run that
+# predates the local DB refresh, so numbers are not directly comparable.
+PREVIOUS_CLOUD_RUN_ID = UUID("3a966438-5b32-42f7-8556-f4b8d119ef11")
+
+SOURCE_TABLES: tuple[str, ...] = (
+    "instruments_universe",
+    "sec_manager_funds",
+    "sec_registered_funds",
+    "sec_etfs",
+    "esma_funds",
+)
+
+
+async def _count_table(db: Any, table: str) -> int:
+    # Table name is validated against SOURCE_TABLES whitelist, safe to inline.
+    r = await db.execute(text(f"SELECT COUNT(*) FROM {table}"))  # noqa: S608
+    return int(r.scalar() or 0)
+
+
+async def _layer_distribution(db: Any, run_id: UUID) -> list[dict[str, Any]]:
+    stmt = text(
+        """
+        SELECT source_table,
+               classification_source,
+               confidence,
+               COUNT(*) AS n
+          FROM strategy_reclassification_stage
+         WHERE run_id = :run_id
+      GROUP BY source_table, classification_source, confidence
+      ORDER BY source_table, classification_source, confidence
+        """
+    )
+    r = await db.execute(stmt, {"run_id": run_id})
+    return [dict(row._mapping) for row in r]
+
+
+async def _severity_distribution(db: Any, run_id: UUID) -> list[dict[str, Any]]:
+    stmt = text(
+        """
+        SELECT source_table,
+               COUNT(*) FILTER (
+                   WHERE current_strategy_label IS NOT DISTINCT FROM proposed_strategy_label
+               ) AS unchanged,
+               COUNT(*) FILTER (
+                   WHERE current_strategy_label IS NULL
+                     AND proposed_strategy_label IS NOT NULL
+               ) AS new_classification,
+               COUNT(*) FILTER (
+                   WHERE current_strategy_label IS NOT NULL
+                     AND proposed_strategy_label IS NULL
+               ) AS lost_class,
+               COUNT(*) FILTER (
+                   WHERE current_strategy_label IS NOT NULL
+                     AND proposed_strategy_label IS NOT NULL
+                     AND current_strategy_label <> proposed_strategy_label
+               ) AS changed,
+               COUNT(*) AS total
+          FROM strategy_reclassification_stage
+         WHERE run_id = :run_id
+      GROUP BY source_table
+      ORDER BY source_table
+        """
+    )
+    r = await db.execute(stmt, {"run_id": run_id})
+    return [dict(row._mapping) for row in r]
+
+
+async def _top_proposed_labels(
+    db: Any, run_id: UUID, limit: int = 20,
+) -> list[dict[str, Any]]:
+    stmt = text(
+        """
+        SELECT proposed_strategy_label,
+               COUNT(*) AS n
+          FROM strategy_reclassification_stage
+         WHERE run_id = :run_id
+           AND proposed_strategy_label IS NOT NULL
+      GROUP BY proposed_strategy_label
+      ORDER BY n DESC
+         LIMIT :limit
+        """
+    )
+    r = await db.execute(stmt, {"run_id": run_id, "limit": limit})
+    return [dict(row._mapping) for row in r]
+
+
+async def _patch_specific_counts(db: Any, run_id: UUID) -> dict[str, int]:
+    stmt = text(
+        """
+        SELECT COUNT(*) FILTER (WHERE proposed_strategy_label = 'Municipal Bond')
+                 AS municipal,
+               COUNT(*) FILTER (WHERE proposed_strategy_label = 'Government Bond')
+                 AS government,
+               COUNT(*) FILTER (WHERE proposed_strategy_label = 'Structured Credit')
+                 AS structured_credit,
+               COUNT(*) FILTER (WHERE proposed_strategy_label = 'Infrastructure')
+                 AS infrastructure,
+               COUNT(*) FILTER (WHERE matched_pattern LIKE '%pe_secondaries%')
+                 AS pe_secondaries,
+               COUNT(*) FILTER (WHERE matched_pattern LIKE '%pe_coinvest%')
+                 AS pe_coinvest,
+               COUNT(*) FILTER (WHERE matched_pattern LIKE '%pe_growth%')
+                 AS pe_growth,
+               COUNT(*) FILTER (WHERE matched_pattern LIKE '%pe_infra%')
+                 AS pe_infra,
+               COUNT(*) FILTER (WHERE matched_pattern LIKE '%style_only%')
+                 AS style_only_defaults,
+               COUNT(*) FILTER (WHERE matched_pattern = 'name:hedge_generic')
+                 AS hedge_generic,
+               COUNT(*) FILTER (WHERE proposed_strategy_label IS NOT NULL)
+                 AS total_classified
+          FROM strategy_reclassification_stage
+         WHERE run_id = :run_id
+        """
+    )
+    r = await db.execute(stmt, {"run_id": run_id})
+    row = r.one()
+    return {k: int(v or 0) for k, v in row._mapping.items()}
+
+
+async def _lost_class_samples(
+    db: Any, run_id: UUID, limit: int = 30,
+) -> list[dict[str, Any]]:
+    stmt = text(
+        """
+        SELECT source_table,
+               source_pk,
+               fund_name,
+               current_strategy_label,
+               classification_source
+          FROM strategy_reclassification_stage
+         WHERE run_id = :run_id
+           AND current_strategy_label IS NOT NULL
+           AND proposed_strategy_label IS NULL
+      ORDER BY RANDOM()
+         LIMIT :limit
+        """
+    )
+    r = await db.execute(stmt, {"run_id": run_id, "limit": limit})
+    return [dict(row._mapping) for row in r]
+
+
+async def _fallback_samples(
+    db: Any, run_id: UUID, limit: int = 30,
+) -> list[dict[str, Any]]:
+    stmt = text(
+        """
+        SELECT s.source_table,
+               s.source_pk,
+               s.fund_name,
+               s.fund_type,
+               LEFT(
+                   COALESCE(
+                       (
+                           SELECT iu.attributes ->> 'tiingo_description'
+                             FROM instruments_universe iu
+                            WHERE iu.instrument_id::text = s.source_pk
+                            LIMIT 1
+                       ),
+                       ''
+                   ),
+                   200
+               ) AS tiingo_desc_sample
+          FROM strategy_reclassification_stage s
+         WHERE s.run_id = :run_id
+           AND s.classification_source = 'fallback'
+      ORDER BY RANDOM()
+         LIMIT :limit
+        """
+    )
+    r = await db.execute(stmt, {"run_id": run_id, "limit": limit})
+    return [dict(row._mapping) for row in r]
+
+
+async def _most_recent_run_id(db: Any) -> UUID | None:
+    stmt = text(
+        """
+        SELECT run_id
+          FROM strategy_reclassification_stage
+      GROUP BY run_id
+      ORDER BY MAX(classified_at) DESC
+         LIMIT 1
+        """
+    )
+    r = await db.execute(stmt)
+    row = r.first()
+    return row[0] if row else None
+
+
+async def main() -> None:
+    started = datetime.now(UTC)
+    print(f"\n=== LOCAL RECLASSIFICATION REFRESH ({started.isoformat()}) ===\n")
+
+    # Step 1 — baseline source counts.
+    print("STEP 1 — Baseline source table counts")
+    async with async_session() as db:
+        baseline = {t: await _count_table(db, t) for t in SOURCE_TABLES}
+    for t, n in baseline.items():
+        print(f"  {t:<25} {n:>10,}")
+    print(f"  {'TOTAL':<25} {sum(baseline.values()):>10,}\n")
+
+    # Step 2 — run the classifier worker.
+    print("STEP 2 — Running strategy_reclassification worker")
+    result = await strategy_reclassification.run_strategy_reclassification()
+    totals = result.get("totals", {})
+    print(
+        f"  candidates={totals.get('candidates', 0):,}  "
+        f"staged={totals.get('staged', 0):,}  "
+        f"fallback={totals.get('fallback', 0):,}"
+    )
+    print(f"  run_id={result.get('run_id')}\n")
+
+    # Step 3 — confirm run_id via stage table.
+    async with async_session() as db:
+        new_run_id = await _most_recent_run_id(db)
+    if new_run_id is None:
+        print("ERROR: no run_id found in stage table after worker run")
+        sys.exit(1)
+    print(f"STEP 3 — Authoritative run_id: {new_run_id}")
+    print(f"         Previous Cloud run_id (reference): {PREVIOUS_CLOUD_RUN_ID}\n")
+
+    # Step 4 — cascade layer distribution.
+    print("STEP 4 — Cascade layer distribution per source")
+    async with async_session() as db:
+        layers = await _layer_distribution(db, new_run_id)
+    print(
+        f"  {'source_table':<25} {'classification_source':<22} "
+        f"{'confidence':<10} {'n':>10}"
+    )
+    for row in layers:
+        print(
+            f"  {row['source_table']:<25} "
+            f"{row['classification_source']:<22} "
+            f"{row['confidence']:<10} "
+            f"{row['n']:>10,}"
+        )
+    print()
+
+    # Step 5 — diff severity distribution.
+    print("STEP 5 — Diff severity distribution per source")
+    print(
+        f"  {'source_table':<25} {'unchanged':>10} {'new':>10} "
+        f"{'lost':>10} {'changed':>10} {'total':>10}"
+    )
+    async with async_session() as db:
+        severities = await _severity_distribution(db, new_run_id)
+    total_lost = total_new = total_changed = total_unchanged = total_rows = 0
+    for row in severities:
+        print(
+            f"  {row['source_table']:<25} "
+            f"{row['unchanged']:>10,} "
+            f"{row['new_classification']:>10,} "
+            f"{row['lost_class']:>10,} "
+            f"{row['changed']:>10,} "
+            f"{row['total']:>10,}"
+        )
+        total_unchanged += row["unchanged"]
+        total_new += row["new_classification"]
+        total_lost += row["lost_class"]
+        total_changed += row["changed"]
+        total_rows += row["total"]
+    print(
+        f"  {'TOTAL':<25} "
+        f"{total_unchanged:>10,} "
+        f"{total_new:>10,} "
+        f"{total_lost:>10,} "
+        f"{total_changed:>10,} "
+        f"{total_rows:>10,}"
+    )
+    print(
+        "  (Cloud baseline lost_class was 14,178 — reference only, "
+        "different DB snapshot.)\n"
+    )
+
+    # Step 6 — PR #169 patch validation.
+    print("STEP 6 — PR #169 patch validation")
+    async with async_session() as db:
+        patches = await _patch_specific_counts(db, new_run_id)
+    for k, v in patches.items():
+        print(f"  {k:<22} {v:>10,}")
+    print()
+
+    # Step 7 — top proposed labels.
+    print("STEP 7 — Top 20 proposed labels")
+    async with async_session() as db:
+        tops = await _top_proposed_labels(db, new_run_id)
+    for row in tops:
+        print(f"  {row['proposed_strategy_label']:<30} {row['n']:>10,}")
+    print()
+
+    # Step 8 — lost_class samples.
+    print("STEP 8 — Random sample of lost_class funds (current → NULL)")
+    async with async_session() as db:
+        lost = await _lost_class_samples(db, new_run_id)
+    for row in lost[:15]:
+        name = (row.get("fund_name") or "?")[:60]
+        print(
+            f"  [{row['source_table']:<22}] {name:<60} "
+            f"was: {row['current_strategy_label']}"
+        )
+    if len(lost) > 15:
+        print(f"  (... {len(lost) - 15} more samples available)\n")
+    else:
+        print()
+
+    # Step 9 — fallback samples.
+    print("STEP 9 — Random sample of fallback funds (round 2 / Phase 4 candidates)")
+    async with async_session() as db:
+        fallback = await _fallback_samples(db, new_run_id)
+    for row in fallback[:15]:
+        name = (row.get("fund_name") or "?")[:50]
+        desc = (row.get("tiingo_desc_sample") or "").strip()
+        desc_hint = f" | desc: {desc[:80]}" if desc else ""
+        print(
+            f"  [{row['source_table']:<22}] {name:<50} "
+            f"type: {row.get('fund_type') or '?'}{desc_hint}"
+        )
+    if len(fallback) > 15:
+        print(f"  (... {len(fallback) - 15} more samples available)\n")
+    else:
+        print()
+
+    elapsed = (datetime.now(UTC) - started).total_seconds()
+    print(f"=== REFRESH COMPLETE in {elapsed:.1f}s ===\n")
+    print("Next steps:")
+    print(
+        "  1. Inspect stage table: "
+        f"SELECT * FROM strategy_reclassification_stage "
+        f"WHERE run_id = '{new_run_id}' LIMIT 100;"
+    )
+    print("  2. If numbers calibrated, proceed to Session B (apply gate).")
+    print("  3. If regressions remain, identify patterns → round 2 patches.")
+
+
+if __name__ == "__main__":
+    # Windows consoles default to cp1252 which cannot encode em-dashes or
+    # arrows used in the report headers. Force UTF-8 on stdout/stderr.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8")
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    asyncio.run(main())

--- a/backend/tests/domains/wealth/workers/test_universe_sanitization.py
+++ b/backend/tests/domains/wealth/workers/test_universe_sanitization.py
@@ -1,0 +1,208 @@
+"""Tests for universe sanitization worker.
+
+Only the regex classification patterns are covered as unit tests —
+integration coverage lives in the audit report script, which runs
+post-migration against the real DB and samples excluded funds per
+reason.
+
+The sanitization module uses PostgreSQL POSIX regex word-boundary
+markers (``\\m`` / ``\\M``) that Python's ``re`` module does not
+understand natively. ``_to_python_re`` rewrites them so the intent of
+the pattern can be validated in isolation.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from app.domains.wealth.workers.universe_sanitization import (
+    GAV_FLOOR_USD,
+    PATTERN_CIT,
+    PATTERN_EDUCATION,
+    PATTERN_INSURANCE,
+    PATTERN_RETIREMENT,
+    PATTERN_SMA_WRAP,
+    SANITIZATION_LOCK_ID,
+)
+
+
+def _to_python_re(pg_pattern: str) -> re.Pattern[str]:
+    """Translate PostgreSQL ``\\m`` / ``\\M`` word boundaries to ``\\b``."""
+    translated = pg_pattern.replace(r"\m", r"\b").replace(r"\M", r"\b")
+    return re.compile(translated, re.IGNORECASE)
+
+
+# ── Module-level constants ────────────────────────────────────────────
+
+
+class TestModuleConstants:
+    def test_lock_id_is_deterministic_literal(self) -> None:
+        assert SANITIZATION_LOCK_ID == 900_063
+
+    def test_gav_floor_is_three_billion(self) -> None:
+        assert GAV_FLOOR_USD == 3_000_000_000
+
+
+# ── Retirement pattern ────────────────────────────────────────────────
+
+
+class TestRetirementPattern:
+    PATTERN = _to_python_re(PATTERN_RETIREMENT)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Vanguard Target Retirement 2045",
+            "Fidelity 401(k) Plan Fund",
+            "Fidelity 401k Growth",
+            "JPMorgan 403(b) Stable Value",
+            "Morgan Stanley IRA Portfolio",
+            "American Funds SEP IRA",
+            "Vanguard SIMPLE IRA",
+            "ESOP Shares Trust",
+            "Employee Stock Ownership Plan Fund",
+            "ERISA Stable Value Fund",
+            "State Street Target Date 2050",
+            "BlackRock LifePath Retirement Fund",
+            "Prudential Pension Plan Trust",
+        ],
+    )
+    def test_matches_retirement_vehicle(self, name: str) -> None:
+        assert self.PATTERN.search(name), f"expected match: {name}"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Goldman Sachs Large Cap Growth",
+            "KKR Private Credit Fund",
+            "Apollo European Equity",
+            "Citadel Global Macro",
+            "Blackstone Real Estate Income Trust",
+            "Bridgewater All Weather",
+        ],
+    )
+    def test_does_not_match_institutional(self, name: str) -> None:
+        assert not self.PATTERN.search(name), f"unexpected match: {name}"
+
+
+# ── CIT pattern ───────────────────────────────────────────────────────
+
+
+class TestCitPattern:
+    PATTERN = _to_python_re(PATTERN_CIT)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "JPMorgan Collective Investment Trust",
+            "Wells Fargo Collective Trust",
+            "Bank Collective Fund Series A",
+            "T. Rowe Price Common Investment Fund",
+            "Fidelity Collective Trust Growth",
+        ],
+    )
+    def test_matches_cit(self, name: str) -> None:
+        assert self.PATTERN.search(name), f"expected match: {name}"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Citadel Global Equities",
+            "Private Credit Opportunities",
+            "Ares Credit Strategies",
+            "PIMCO Income Fund",
+        ],
+    )
+    def test_does_not_match_non_cit(self, name: str) -> None:
+        assert not self.PATTERN.search(name), f"unexpected match: {name}"
+
+
+# ── Education pattern ─────────────────────────────────────────────────
+
+
+class TestEducationPattern:
+    PATTERN = _to_python_re(PATTERN_EDUCATION)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Vanguard 529 Plan Moderate Portfolio",
+            "Utah 529 Portfolio",
+            "Coverdell ESA Fund",
+            "Nuveen Education Savings Account",
+        ],
+    )
+    def test_matches_education(self, name: str) -> None:
+        assert self.PATTERN.search(name), f"expected match: {name}"
+
+    @pytest.mark.parametrize(
+        "name",
+        ["Vanguard Value Index 529 Fund Holdings"],
+    )
+    def test_matches_529_even_without_plan_word(self, name: str) -> None:
+        # 529 alone requires (plan|portfolio) adjacent — keep precision.
+        assert not self.PATTERN.search(name)
+
+
+# ── Insurance pattern ─────────────────────────────────────────────────
+
+
+class TestInsurancePattern:
+    PATTERN = _to_python_re(PATTERN_INSURANCE)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Prudential Stable Value Fund",
+            "MetLife Guaranteed Income Annuity",
+            "Insurance-wrapped Income Strategy",
+            "AIG GIC Portfolio",
+            "Fixed Annuity Series Fund",
+            "New York Life Guaranteed Interest Account",
+        ],
+    )
+    def test_matches_insurance_wrapper(self, name: str) -> None:
+        assert self.PATTERN.search(name), f"expected match: {name}"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Oaktree Value Opportunities",
+            "Apollo Credit Strategies",
+        ],
+    )
+    def test_does_not_match_generic_fund(self, name: str) -> None:
+        assert not self.PATTERN.search(name), f"unexpected match: {name}"
+
+
+# ── SMA / wrap pattern ────────────────────────────────────────────────
+
+
+class TestSmaWrapPattern:
+    PATTERN = _to_python_re(PATTERN_SMA_WRAP)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Morgan Stanley SMA Program",
+            "UBS Separately Managed Portfolio",
+            "Merrill Wrap Account Series",
+            "Fidelity Managed Account Program",
+            "Schwab UMA Platform",
+            "Wells Fargo Wrap Fee Account",
+        ],
+    )
+    def test_matches_wrap_vehicle(self, name: str) -> None:
+        assert self.PATTERN.search(name), f"expected match: {name}"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "KKR Credit Opportunities",
+            "Citadel Tactical Trading",
+            "Bridgewater Pure Alpha",
+        ],
+    )
+    def test_does_not_match_institutional_fund(self, name: str) -> None:
+        assert not self.PATTERN.search(name), f"unexpected match: {name}"

--- a/docs/prompts/2026-04-14-local-reclassification-refresh.md
+++ b/docs/prompts/2026-04-14-local-reclassification-refresh.md
@@ -1,0 +1,435 @@
+# Local Fund Reclassification Refresh — Opcao C (no external ingestion)
+
+**Date:** 2026-04-14
+**Branch:** `fix/local-reclassification-refresh`
+**Sessions:** 1
+**Depends on:** PR #169 merged (classifier patches round 1)
+
+---
+
+## Context
+
+The previous staging run_id (`3a966438-5b32-42f7-8556-f4b8d119ef11`) came from Timescale Cloud which is outdated vs the local dev DB. That run showed `lost_class = 14,178` against a stale snapshot. Local DB is currently well-populated and is the authoritative snapshot for iterating on classifier quality.
+
+We do NOT want to run the external-facing workers now (sec_bulk_ingestion, sec_adv_ingestion, esma_ingestion) — they depend on SEC/ESMA APIs and take 1-1.5h combined. Local DB already has the data needed.
+
+We do NOT need to re-run tiingo_enrichment — it already completed (99.96% coverage in `instruments_universe.attributes.tiingo_description`).
+
+The only action needed is re-running `run_strategy_reclassification()` with the PR #169 patches applied. This writes a new run_id to the staging table and becomes the authoritative "local baseline" for Session B.
+
+---
+
+## OBJECTIVE
+
+1. Run `run_strategy_reclassification()` against the local DB with PR #169 patches applied.
+2. Generate a validation report comparing the new run_id against the previous Cloud-based run_id, isolating patch impact vs data-source differences.
+3. Produce a concrete severity distribution to calibrate Session B's apply gate.
+
+---
+
+## CONSTRAINTS
+
+- **No ingestion workers run.** No SEC, ESMA, Tiingo, or other external-facing fetches.
+- **Read-only on production columns.** Worker writes to `strategy_reclassification_stage` only; zero writes to `strategy_label` on source tables.
+- **Preserve historical run_ids.** The old Cloud run_id stays in the staging table as a reference. New run_id is created fresh.
+- **Pure validation.** No schema changes, no new tables, no new workers.
+
+---
+
+## DELIVERABLES
+
+### 1. Create `backend/scripts/refresh_local_reclassification.py`
+
+A script that:
+1. Captures baseline counts from all 5 source tables
+2. Runs `run_strategy_reclassification()` to generate new run_id
+3. Queries the stage table for per-source layer distribution
+4. Queries the stage table for severity distribution
+5. Compares against the old Cloud run_id (`3a966438-5b32-42f7-8556-f4b8d119ef11`) where possible
+6. Emits a structured report to stdout
+
+```python
+"""Refresh local fund reclassification without re-running ingestion.
+
+Usage:
+    python backend/scripts/refresh_local_reclassification.py
+
+Prerequisites:
+    - PR #169 (classifier patches round 1) merged
+    - Local DB populated (no ingestion needed)
+    - Tiingo enrichment already run (tiingo_description populated)
+
+Output:
+    - New run_id written to strategy_reclassification_stage
+    - Structured report: layer distribution, severity distribution, 
+      comparison to previous Cloud run_id.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+
+from app.core.db import async_session
+from app.domains.wealth.workers import strategy_reclassification
+
+log = logging.getLogger(__name__)
+
+PREVIOUS_CLOUD_RUN_ID = UUID("3a966438-5b32-42f7-8556-f4b8d119ef11")
+
+SOURCE_TABLES = [
+    "instruments_universe",
+    "sec_manager_funds",
+    "sec_registered_funds",
+    "sec_etfs",
+    "esma_funds",
+]
+
+
+async def _count_table(db, table: str) -> int:
+    r = await db.execute(text(f"SELECT COUNT(*) FROM {table}"))
+    return r.scalar() or 0
+
+
+async def _layer_distribution(db, run_id: UUID) -> list[dict[str, Any]]:
+    """Per-source cascade layer hit rates."""
+    stmt = text("""
+        SELECT 
+            source_table,
+            classification_source,
+            confidence,
+            COUNT(*) AS n
+        FROM strategy_reclassification_stage
+        WHERE run_id = :run_id
+        GROUP BY source_table, classification_source, confidence
+        ORDER BY source_table, classification_source
+    """)
+    r = await db.execute(stmt, {"run_id": run_id})
+    return [dict(row._mapping) for row in r]
+
+
+async def _severity_distribution(db, run_id: UUID) -> list[dict[str, Any]]:
+    """Diff severity per source.
+
+    Categories:
+      - unchanged: current == proposed (or both NULL)
+      - new_classification: current IS NULL, proposed IS NOT NULL
+      - lost_class: current IS NOT NULL, proposed IS NULL
+      - changed: both non-null, different
+    """
+    stmt = text("""
+        SELECT
+            source_table,
+            COUNT(*) FILTER (WHERE 
+                current_strategy_label IS NOT DISTINCT FROM proposed_strategy_label
+            ) AS unchanged,
+            COUNT(*) FILTER (WHERE 
+                current_strategy_label IS NULL AND proposed_strategy_label IS NOT NULL
+            ) AS new_classification,
+            COUNT(*) FILTER (WHERE 
+                current_strategy_label IS NOT NULL AND proposed_strategy_label IS NULL
+            ) AS lost_class,
+            COUNT(*) FILTER (WHERE 
+                current_strategy_label IS NOT NULL 
+                AND proposed_strategy_label IS NOT NULL
+                AND current_strategy_label != proposed_strategy_label
+            ) AS changed,
+            COUNT(*) AS total
+        FROM strategy_reclassification_stage
+        WHERE run_id = :run_id
+        GROUP BY source_table
+        ORDER BY source_table
+    """)
+    r = await db.execute(stmt, {"run_id": run_id})
+    return [dict(row._mapping) for row in r]
+
+
+async def _top_proposed_labels(db, run_id: UUID, limit: int = 20) -> list[dict[str, Any]]:
+    stmt = text("""
+        SELECT 
+            proposed_strategy_label, 
+            COUNT(*) AS n
+        FROM strategy_reclassification_stage
+        WHERE run_id = :run_id
+          AND proposed_strategy_label IS NOT NULL
+        GROUP BY proposed_strategy_label
+        ORDER BY n DESC
+        LIMIT :limit
+    """)
+    r = await db.execute(stmt, {"run_id": run_id, "limit": limit})
+    return [dict(row._mapping) for row in r]
+
+
+async def _patch_specific_counts(db, run_id: UUID) -> dict[str, int]:
+    """Counts that validate PR #169 patches.
+
+    - Municipal Bond (should increase with tax-free pattern)
+    - Government Bond (should increase with expanded pattern)
+    - Structured Credit (new label, expect > 0)
+    - PE with lineage pe_secondaries/pe_coinvest/pe_growth/pe_infra
+    """
+    stmt = text("""
+        SELECT 
+            COUNT(*) FILTER (WHERE proposed_strategy_label = 'Municipal Bond') AS municipal,
+            COUNT(*) FILTER (WHERE proposed_strategy_label = 'Government Bond') AS government,
+            COUNT(*) FILTER (WHERE proposed_strategy_label = 'Structured Credit') AS structured_credit,
+            COUNT(*) FILTER (WHERE matched_pattern LIKE '%pe_secondaries%') AS pe_secondaries,
+            COUNT(*) FILTER (WHERE matched_pattern LIKE '%pe_coinvest%') AS pe_coinvest,
+            COUNT(*) FILTER (WHERE matched_pattern LIKE '%pe_growth%') AS pe_growth,
+            COUNT(*) FILTER (WHERE matched_pattern LIKE '%pe_infra%') AS pe_infra,
+            COUNT(*) FILTER (WHERE matched_pattern LIKE '%style_only%') AS style_only_defaults,
+            COUNT(*) FILTER (WHERE proposed_strategy_label IS NOT NULL) AS total_classified
+        FROM strategy_reclassification_stage
+        WHERE run_id = :run_id
+    """)
+    r = await db.execute(stmt, {"run_id": run_id})
+    row = r.one()
+    return dict(row._mapping)
+
+
+async def _lost_class_samples(db, run_id: UUID, limit: int = 30) -> list[dict[str, Any]]:
+    """Sample funds that LOST their label (current non-null → proposed NULL).
+
+    These are the highest-severity diffs and need manual review.
+    """
+    stmt = text("""
+        SELECT 
+            source_table,
+            source_pk,
+            fund_name,
+            current_strategy_label,
+            classification_source
+        FROM strategy_reclassification_stage
+        WHERE run_id = :run_id
+          AND current_strategy_label IS NOT NULL
+          AND proposed_strategy_label IS NULL
+        ORDER BY RANDOM()
+        LIMIT :limit
+    """)
+    r = await db.execute(stmt, {"run_id": run_id, "limit": limit})
+    return [dict(row._mapping) for row in r]
+
+
+async def _fallback_samples(db, run_id: UUID, limit: int = 30) -> list[dict[str, Any]]:
+    """Sample funds still in fallback (classification_source = 'fallback').
+
+    Candidates for round 2 patches or Phase 4 N-PORT holdings classifier.
+    """
+    stmt = text("""
+        SELECT 
+            source_table,
+            source_pk,
+            fund_name,
+            fund_type,
+            LEFT(
+                COALESCE(
+                    (SELECT attributes->>'tiingo_description' 
+                     FROM instruments_universe 
+                     WHERE instrument_id::text = source_pk 
+                     LIMIT 1), 
+                    ''
+                ), 
+                200
+            ) AS tiingo_desc_sample
+        FROM strategy_reclassification_stage
+        WHERE run_id = :run_id
+          AND classification_source = 'fallback'
+        ORDER BY RANDOM()
+        LIMIT :limit
+    """)
+    r = await db.execute(stmt, {"run_id": run_id, "limit": limit})
+    return [dict(row._mapping) for row in r]
+
+
+async def main() -> None:
+    started = datetime.now(timezone.utc)
+    print(f"\n=== LOCAL RECLASSIFICATION REFRESH ({started.isoformat()}) ===\n")
+
+    # Step 1: Baseline counts
+    print("STEP 1 — Baseline source table counts")
+    async with async_session() as db:
+        baseline = {t: await _count_table(db, t) for t in SOURCE_TABLES}
+    for t, n in baseline.items():
+        print(f"  {t}: {n:,}")
+    total = sum(baseline.values())
+    print(f"  TOTAL: {total:,}\n")
+
+    # Step 2: Run reclassification (generates new run_id)
+    print("STEP 2 — Running strategy_reclassification worker")
+    result = await strategy_reclassification.run_strategy_reclassification()
+    print(f"  Result: {result}\n")
+
+    # Step 3: Find the new run_id (most recent)
+    async with async_session() as db:
+        stmt = text("""
+            SELECT run_id, MAX(classified_at) AS latest
+            FROM strategy_reclassification_stage
+            GROUP BY run_id
+            ORDER BY latest DESC
+            LIMIT 2
+        """)
+        r = await db.execute(stmt)
+        runs = list(r)
+    if not runs:
+        print("ERROR: No run_id found in stage table after worker run")
+        sys.exit(1)
+    new_run_id = runs[0][0]
+    print(f"STEP 3 — New run_id: {new_run_id}\n")
+
+    # Step 4: Layer distribution
+    print("STEP 4 — Cascade layer distribution per source")
+    async with async_session() as db:
+        layers = await _layer_distribution(db, new_run_id)
+    for row in layers:
+        print(f"  {row['source_table']:<25} {row['classification_source']:<25} "
+              f"{row['confidence']:<10} {row['n']:>8,}")
+    print()
+
+    # Step 5: Severity distribution
+    print("STEP 5 — Diff severity distribution per source")
+    print(f"  {'source_table':<25} {'unchanged':>10} {'new':>10} {'lost':>10} "
+          f"{'changed':>10} {'total':>10}")
+    async with async_session() as db:
+        severities = await _severity_distribution(db, new_run_id)
+    total_lost = 0
+    total_new = 0
+    total_changed = 0
+    for row in severities:
+        print(f"  {row['source_table']:<25} {row['unchanged']:>10,} "
+              f"{row['new_classification']:>10,} {row['lost_class']:>10,} "
+              f"{row['changed']:>10,} {row['total']:>10,}")
+        total_lost += row["lost_class"]
+        total_new += row["new_classification"]
+        total_changed += row["changed"]
+    print(f"\n  TOTAL lost_class:         {total_lost:,}")
+    print(f"  TOTAL new_classification: {total_new:,}")
+    print(f"  TOTAL changed:            {total_changed:,}")
+    print(f"  (Previous Cloud baseline lost_class: 14,178 — for reference, not comparable)\n")
+
+    # Step 6: Patch-specific counts
+    print("STEP 6 — PR #169 patch validation")
+    async with async_session() as db:
+        patches = await _patch_specific_counts(db, new_run_id)
+    for k, v in patches.items():
+        print(f"  {k}: {v:,}")
+    print()
+
+    # Step 7: Top proposed labels
+    print("STEP 7 — Top 20 proposed labels (sanity check)")
+    async with async_session() as db:
+        tops = await _top_proposed_labels(db, new_run_id)
+    for row in tops:
+        print(f"  {row['proposed_strategy_label']:<30} {row['n']:>8,}")
+    print()
+
+    # Step 8: Lost-class samples
+    print("STEP 8 — Random sample of lost_class funds (current → NULL)")
+    async with async_session() as db:
+        lost = await _lost_class_samples(db, new_run_id)
+    for row in lost[:15]:  # Show 15 for readability
+        print(f"  [{row['source_table']}] {row['fund_name'][:60]:<60} "
+              f"was: {row['current_strategy_label']}")
+    print(f"  (... {len(lost)-15} more in DB)\n" if len(lost) > 15 else "")
+
+    # Step 9: Fallback samples
+    print("STEP 9 — Random sample of fallback funds (candidates for round 2)")
+    async with async_session() as db:
+        fallback = await _fallback_samples(db, new_run_id)
+    for row in fallback[:15]:
+        desc = (row.get("tiingo_desc_sample") or "").strip()
+        desc_hint = f" | desc: {desc[:80]}" if desc else ""
+        print(f"  [{row['source_table']}] {(row['fund_name'] or '?')[:50]:<50} "
+              f"type: {row.get('fund_type') or '?'}{desc_hint}")
+    print(f"  (... {len(fallback)-15} more in DB)\n" if len(fallback) > 15 else "")
+
+    elapsed = (datetime.now(timezone.utc) - started).total_seconds()
+    print(f"\n=== REFRESH COMPLETE in {elapsed:.1f}s ===")
+    print(f"\nNext steps:")
+    print(f"  1. Inspect the full stage table with:")
+    print(f"     SELECT * FROM strategy_reclassification_stage WHERE run_id = '{new_run_id}' LIMIT 100;")
+    print(f"  2. If numbers look calibrated, proceed to Session B (diff gate + apply script)")
+    print(f"  3. If regressions remain, identify patterns and do round 2 patches")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+    asyncio.run(main())
+```
+
+### 2. Add entry to `backend/Makefile` or document the invocation
+
+Optional: add a Make target for repeatability:
+
+```makefile
+# Refresh local reclassification stage (no external ingestion)
+.PHONY: refresh-reclass
+refresh-reclass:
+	cd backend && python scripts/refresh_local_reclassification.py
+```
+
+---
+
+## VERIFICATION
+
+1. `make lint` passes.
+2. `make typecheck` passes.
+3. Script runs to completion with no exceptions.
+4. New run_id exists in `strategy_reclassification_stage`.
+5. Old Cloud run_id (`3a966438-5b32-42f7-8556-f4b8d119ef11`) preserved.
+6. Structured Credit count > 0 (validates Patch 7).
+7. Municipal Bond count increased vs baseline (validates Patch 2 — tax-free).
+8. Government Bond count increased vs baseline (validates Patch 3).
+9. `lost_class` count decreased vs 14,178 Cloud baseline (validates Patch 5 — hedge fallback).
+10. `style_only_defaults` > 0 (validates Patch 6).
+
+---
+
+## INTERPRETING THE OUTPUT
+
+**If `lost_class` is still > 5,000:**
+- Investigate fallback samples to find common patterns
+- Likely candidates for round 2: sector equity, ESG fixed income, more international variations
+
+**If Structured Credit count is 0:**
+- Check if local DB has CLO funds (query `sec_manager_funds` for `fund_name ILIKE '%clo%'`)
+- If yes but classifier missed them, debug the pattern
+
+**If Municipal Bond count did NOT increase vs baseline:**
+- Check if tax-free funds exist in DB (query `WHERE fund_name ILIKE '%tax-free%'`)
+- Possible explanation: local DB does not have as many tax-free funds as Cloud
+
+**If `new_classification` (NULL → specific) dominates:**
+- Great outcome. These are safe to auto-apply in Session B with no review.
+- Define the auto-apply filter in Session B: `severity = 'new_classification' AND confidence IN ('high', 'medium')`.
+
+**If `changed` (x → y) dominates:**
+- Session B severity matrix becomes critical
+- `asset_class_change` subset requires manual review per fund
+- `style_refinement` subset (same family, e.g., Large Blend → Large Growth) can be auto-applied
+
+---
+
+## OUT OF SCOPE
+
+- Running any external-facing ingestion worker (sec_bulk, sec_adv, esma, tiingo, benchmark, etc.)
+- Modifying `strategy_classifier.py` (patches already in PR #169)
+- Writing Session B apply script (that's the next sprint after this validation)
+- Touching any production `strategy_label` column
+- Schema changes
+
+---
+
+## AFTER THIS RUNS
+
+The output of this script directly feeds into Session B's design:
+- **Severity matrix calibration:** counts of new_classification vs lost_class vs changed inform the default `--severity` filter
+- **Auto-apply threshold:** if high-confidence new_classification is safe and large, it becomes the default apply target
+- **Round 2 patches:** fallback samples reveal the next iteration priorities
+- **Taxonomy additions:** if many specific labels are missing (e.g., Structured Credit was added in this round), similar gaps may emerge
+
+Report back with the script's output and we calibrate Session B's apply gate accordingly.

--- a/docs/prompts/2026-04-14-universe-sanitization-sprint.md
+++ b/docs/prompts/2026-04-14-universe-sanitization-sprint.md
@@ -1,0 +1,941 @@
+# Universe Sanitization Sprint — Filter Non-Institutional Vehicles
+
+**Date:** 2026-04-14
+**Branch:** `feat/universe-sanitization`
+**Sessions:** 2 (Session A: Migration + sanitization worker, Session B: Downstream consumers + report)
+**Priority:** CRITICAL — blocks Session B (apply gate) and Round 2 classifier patches
+**Depends on:** PR #169 merged (classifier patches round 1)
+
+---
+
+## Context
+
+The fund universe contains 62,728 rows in `sec_manager_funds`, 4,617 in `sec_registered_funds`, and 10,436 in `esma_funds`. Empirical analysis shows these counts include entities that are NOT appropriate for an institutional wealth management engine:
+
+- **Retirement vehicles** (401k, 403b, IRA, ERISA, ESOP, pension plans)
+- **Collective Investment Trusts** (CIT, bank-sponsored, retirement-focused)
+- **Education plans** (529, Coverdell)
+- **Insurance-wrapped products** (stable value, GICs, guaranteed income)
+- **SMA/wrap programs** (separately managed accounts disguised as "funds")
+- **Small retail-adviser-sponsored funds** (advisers with <$3B GAV or retail-heavy client base)
+- **Duplicate multi-adviser filings** (same private fund reported by primary + sub-adviser)
+
+Classifying these funds pollutes:
+1. **Peer groups** — institutional funds compared against retirement vehicles
+2. **Scoring percentiles** — inflated/deflated by non-comparable entities
+3. **Candidate screener** — proposes unsuitable vehicles to IC
+4. **Allocation blocks** — mis-routed by incorrect classification
+5. **DD report context** — LLM receives retail context for institutional analysis
+
+Classification fixes (Round 2) and apply gate (Session B) must wait for a clean universe.
+
+---
+
+## OBJECTIVE
+
+Add `is_institutional` boolean flag to 6 fund tables + `instruments_universe`. Compute the flag via a new sanitization worker (lock `900_063`) using layered exclusion rules. Update downstream consumers to respect the flag. Produce an audit report of exclusions.
+
+**Targets (estimated post-sanitization):**
+
+| Table | Current | Expected after filter | Exclusions |
+|---|---|---|---|
+| sec_manager_funds | 62,728 | ~40,000 | ~22k (retirement, CIT, small-RIA, duplicates) |
+| sec_registered_funds | 4,617 | ~3,500 | ~1.1k (target-date retirement, non-institutional share) |
+| sec_etfs | 985 | ~950 | ~35 (target-date ETFs, exotic leveraged retail) |
+| sec_bdcs | 196 | 196 | 0 (all public BDCs are institutional-appropriate) |
+| sec_money_market_funds | 373 | ~320 | ~53 (retail-only MMFs) |
+| esma_funds | 10,436 | ~8,000 | ~2.4k (retirement-focused UCITS, sub-scale) |
+| **TOTAL** | **79,335** | **~53,000** | **~26k excluded (33%)** |
+
+---
+
+## CONSTRAINTS
+
+- **Stored column, not computed view.** Performance + audit trail.
+- **Default TRUE on migration.** Existing data stays institutional until sanitization runs.
+- **GAV floor: $3B at manager level** (not $1B from embedding worker, not $5B).
+- **Reversible.** Every exclusion has `exclusion_reason` for manual override.
+- **Idempotent.** Re-run resets flags and re-applies rules.
+- **No external fetches.** All data already in DB.
+- **Don't break ESMA.** UCITS structure is the institutional filter; apply name/GAV-based rules only.
+
+---
+
+## Session A — Migration + Sanitization Worker
+
+### DELIVERABLES
+
+#### 1. Migration `0134_universe_sanitization_flags.py`
+
+Add to 6 fund tables plus `instruments_universe`:
+
+```python
+"""Add is_institutional + exclusion_reason for universe sanitization.
+
+Revision ID: 0134_universe_sanitization_flags
+Revises: 0133_strategy_reclassification_stage
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0134_universe_sanitization_flags"
+down_revision = "0133_strategy_reclassification_stage"
+branch_labels = None
+depends_on = None
+
+
+TABLES = [
+    "sec_manager_funds",
+    "sec_registered_funds",
+    "sec_etfs",
+    "sec_bdcs",
+    "sec_money_market_funds",
+    "esma_funds",
+]
+
+
+def upgrade() -> None:
+    for table in TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "is_institutional", sa.Boolean,
+                nullable=False, server_default=sa.text("true"),
+            ),
+        )
+        op.add_column(
+            table,
+            sa.Column("exclusion_reason", sa.Text, nullable=True),
+        )
+        op.add_column(
+            table,
+            sa.Column(
+                "sanitized_at", sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+        )
+        # Partial index: institutional rows (most queries filter for these)
+        op.create_index(
+            f"idx_{table}_institutional",
+            table,
+            ["is_institutional"],
+            postgresql_where=sa.text("is_institutional = true"),
+        )
+
+    # instruments_universe is JSONB-attributes-based, store flag inline
+    # Use a generated column that reads from attributes for consistency
+    op.execute("""
+        ALTER TABLE instruments_universe
+        ADD COLUMN is_institutional BOOLEAN
+        GENERATED ALWAYS AS (
+            COALESCE((attributes->>'is_institutional')::boolean, true)
+        ) STORED;
+    """)
+    op.create_index(
+        "idx_instruments_universe_institutional",
+        "instruments_universe",
+        ["is_institutional"],
+        postgresql_where=sa.text("is_institutional = true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_instruments_universe_institutional", "instruments_universe")
+    op.execute("ALTER TABLE instruments_universe DROP COLUMN is_institutional")
+    for table in TABLES:
+        op.drop_index(f"idx_{table}_institutional", table)
+        op.drop_column(table, "sanitized_at")
+        op.drop_column(table, "exclusion_reason")
+        op.drop_column(table, "is_institutional")
+```
+
+#### 2. Sanitization worker: `backend/app/domains/wealth/workers/universe_sanitization.py`
+
+```python
+"""Universe sanitization worker.
+
+Layered exclusion rules applied in sequence. First match wins
+(exclusion_reason records the triggering rule). Idempotent — resets
+flags at start of each run.
+
+Advisory lock: 900_063
+Frequency: on-demand. Should run after sec_adv_ingestion,
+sec_bulk_ingestion, esma_ingestion, and BEFORE strategy_reclassification.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import async_session
+
+SANITIZATION_LOCK_ID = 900_063
+GAV_FLOOR_USD = 3_000_000_000  # $3B manager GAV floor
+
+logger = logging.getLogger(__name__)
+
+
+# ── Exclusion keyword patterns (PostgreSQL regex, case-insensitive) ──
+
+PATTERN_RETIREMENT = (
+    r"(\m401\(?k\)?|\m403\(?b\)?|\m457\b|"
+    r"\bIRA\b|\bSEP\s+IRA|\bSIMPLE\s+IRA|"
+    r"ERISA|retirement|pension\s+plan|"
+    r"\bESOP\b|employee\s+stock\s+ownership|"
+    r"\btarget\s+(?:date|retirement)\b)"
+)
+
+PATTERN_CIT = (
+    r"(collective\s+(?:investment\s+)?trust|"
+    r"\bCIT\b\s+fund|"  # Avoid false positives on bank abbreviations
+    r"common\s+(?:investment\s+)?fund|"
+    r"bank\s+collective)"
+)
+
+PATTERN_EDUCATION = (
+    r"(\b529\s*(?:plan|portfolio)|"
+    r"coverdell|"
+    r"education\s+savings)"
+)
+
+PATTERN_INSURANCE = (
+    r"(stable\s+value|"
+    r"guaranteed\s+(?:income|interest|annuity)|"
+    r"insurance.{0,10}wrap|"
+    r"\bGIC\b|guaranteed\s+investment\s+contract|"
+    r"fixed\s+annuity)"
+)
+
+PATTERN_SMA_WRAP = (
+    r"(\bSMA\b\s+(?:program|platform)|"
+    r"separately\s+managed|"
+    r"wrap\s+(?:account|program|fee)|"
+    r"managed\s+account\s+program|"
+    r"\bUMA\b)"  # Unified managed account
+)
+
+
+async def run_universe_sanitization() -> dict[str, Any]:
+    """Apply sanitization rules across all fund tables.
+
+    Returns:
+        dict with per-table, per-reason exclusion counts.
+    """
+    started = datetime.now(timezone.utc)
+    result: dict[str, Any] = {
+        "started_at": started.isoformat(),
+        "per_table": {},
+    }
+
+    async with async_session() as db:
+        # Acquire advisory lock
+        lock_result = await db.execute(
+            text(f"SELECT pg_try_advisory_lock({SANITIZATION_LOCK_ID})")
+        )
+        if not lock_result.scalar():
+            logger.warning("sanitization_skipped: another instance running")
+            return {"skipped": True, "reason": "lock_contention"}
+
+        try:
+            # Reset all flags to institutional=true first (idempotency)
+            await _reset_flags(db)
+            await db.commit()
+
+            # Apply sanitization rules per table
+            result["per_table"]["sec_manager_funds"] = \
+                await _sanitize_sec_manager_funds(db)
+            await db.commit()
+
+            result["per_table"]["sec_registered_funds"] = \
+                await _sanitize_sec_registered_funds(db)
+            await db.commit()
+
+            result["per_table"]["sec_etfs"] = await _sanitize_sec_etfs(db)
+            await db.commit()
+
+            result["per_table"]["sec_money_market_funds"] = \
+                await _sanitize_sec_mmfs(db)
+            await db.commit()
+
+            result["per_table"]["esma_funds"] = await _sanitize_esma_funds(db)
+            await db.commit()
+
+            # Propagate to instruments_universe via JSONB attributes
+            await _propagate_to_instruments_universe(db)
+            await db.commit()
+
+            result["completed_at"] = datetime.now(timezone.utc).isoformat()
+            result["duration_seconds"] = (
+                datetime.now(timezone.utc) - started
+            ).total_seconds()
+
+        finally:
+            await db.execute(
+                text(f"SELECT pg_advisory_unlock({SANITIZATION_LOCK_ID})")
+            )
+
+    return result
+
+
+async def _reset_flags(db: AsyncSession) -> None:
+    """Reset all sanitization flags. Ensures idempotency."""
+    for table in [
+        "sec_manager_funds", "sec_registered_funds", "sec_etfs",
+        "sec_bdcs", "sec_money_market_funds", "esma_funds",
+    ]:
+        await db.execute(text(f"""
+            UPDATE {table}
+            SET is_institutional = true,
+                exclusion_reason = NULL,
+                sanitized_at = NOW()
+        """))
+    logger.info("sanitization_flags_reset")
+
+
+async def _sanitize_sec_manager_funds(db: AsyncSession) -> dict[str, int]:
+    """Sanitize sec_manager_funds (62k rows, highest-risk table).
+
+    Rules in order:
+      1. Retirement/ERISA (name regex)
+      2. CIT (name regex)
+      3. Education (name regex)
+      4. Insurance-wrapped (name regex)
+      5. SMA/Wrap (name regex)
+      6. GAV floor $3B at manager level (JOIN sec_managers)
+      7. Retail-adviser (client_types JSONB check)
+      8. Duplicate multi-adviser filings (keep primary, exclude secondaries)
+    """
+    counts: dict[str, int] = {}
+
+    for reason, pattern in [
+        ("retirement", PATTERN_RETIREMENT),
+        ("cit", PATTERN_CIT),
+        ("education", PATTERN_EDUCATION),
+        ("insurance_wrapped", PATTERN_INSURANCE),
+        ("sma_wrap", PATTERN_SMA_WRAP),
+    ]:
+        r = await db.execute(text(f"""
+            UPDATE sec_manager_funds
+            SET is_institutional = false,
+                exclusion_reason = :reason,
+                sanitized_at = NOW()
+            WHERE is_institutional = true
+              AND exclusion_reason IS NULL
+              AND fund_name ~* :pattern
+        """), {"reason": reason, "pattern": pattern})
+        counts[reason] = r.rowcount
+
+    # Rule 6: GAV floor at manager level
+    r = await db.execute(text(f"""
+        UPDATE sec_manager_funds f
+        SET is_institutional = false,
+            exclusion_reason = 'gav_below_3b',
+            sanitized_at = NOW()
+        FROM sec_managers m
+        WHERE f.crd_number = m.crd_number
+          AND f.is_institutional = true
+          AND f.exclusion_reason IS NULL
+          AND COALESCE(m.total_private_fund_assets, 0) < {GAV_FLOOR_USD}
+    """))
+    counts["gav_below_3b"] = r.rowcount
+
+    # Rule 7: Retail adviser (heavy individual clients, few pooled vehicles)
+    # client_types JSONB structure: {"individuals": {"count": N, "pct_aum": X}, ...}
+    r = await db.execute(text("""
+        UPDATE sec_manager_funds f
+        SET is_institutional = false,
+            exclusion_reason = 'retail_adviser',
+            sanitized_at = NOW()
+        FROM sec_managers m
+        WHERE f.crd_number = m.crd_number
+          AND f.is_institutional = true
+          AND f.exclusion_reason IS NULL
+          AND (
+              COALESCE((m.client_types->'individuals'->>'count')::int, 0) > 500
+              OR COALESCE((m.client_types->'pooled_vehicles'->>'count')::int, 0) < 2
+          )
+    """))
+    counts["retail_adviser"] = r.rowcount
+
+    # Rule 8: Duplicate multi-adviser filings
+    # Strategy: for funds with same (fund_name, gross_asset_value) across
+    # multiple crd_numbers, keep the one with the largest adviser (AUM),
+    # mark others as duplicates.
+    r = await db.execute(text("""
+        WITH dupes AS (
+            SELECT 
+                f.fund_name,
+                f.gross_asset_value,
+                f.crd_number,
+                m.aum_total,
+                ROW_NUMBER() OVER (
+                    PARTITION BY f.fund_name, f.gross_asset_value
+                    ORDER BY m.aum_total DESC NULLS LAST, f.crd_number
+                ) AS rn
+            FROM sec_manager_funds f
+            JOIN sec_managers m ON f.crd_number = m.crd_number
+            WHERE f.is_institutional = true
+              AND f.exclusion_reason IS NULL
+              AND f.fund_name IS NOT NULL
+              AND f.gross_asset_value IS NOT NULL
+        )
+        UPDATE sec_manager_funds f
+        SET is_institutional = false,
+            exclusion_reason = 'duplicate_filing',
+            sanitized_at = NOW()
+        FROM dupes d
+        WHERE f.fund_name = d.fund_name
+          AND COALESCE(f.gross_asset_value, -1) = COALESCE(d.gross_asset_value, -1)
+          AND f.crd_number = d.crd_number
+          AND d.rn > 1
+    """))
+    counts["duplicate_filing"] = r.rowcount
+
+    # Total institutional remaining
+    r = await db.execute(text("""
+        SELECT 
+            COUNT(*) FILTER (WHERE is_institutional) AS institutional,
+            COUNT(*) FILTER (WHERE NOT is_institutional) AS excluded,
+            COUNT(*) AS total
+        FROM sec_manager_funds
+    """))
+    summary = dict(r.one()._mapping)
+    counts.update(summary)
+
+    logger.info("sec_manager_funds_sanitized", extra=counts)
+    return counts
+
+
+async def _sanitize_sec_registered_funds(db: AsyncSession) -> dict[str, int]:
+    """Sanitize sec_registered_funds (mutual funds, interval, closed-end).
+
+    Rules:
+      1. Retirement/ERISA keywords in name
+      2. Target date fund series (even if not in retirement keywords)
+      3. Very low AUM (< $100M — sub-scale)
+    """
+    counts: dict[str, int] = {}
+
+    # Rule 1: Retirement keywords
+    r = await db.execute(text("""
+        UPDATE sec_registered_funds
+        SET is_institutional = false,
+            exclusion_reason = 'retirement',
+            sanitized_at = NOW()
+        WHERE is_institutional = true
+          AND exclusion_reason IS NULL
+          AND fund_name ~* :pattern
+    """), {"pattern": PATTERN_RETIREMENT})
+    counts["retirement"] = r.rowcount
+
+    # Rule 2: Explicit target date column if exists (N-CEN enrichment)
+    r = await db.execute(text("""
+        UPDATE sec_registered_funds
+        SET is_institutional = false,
+            exclusion_reason = 'target_date',
+            sanitized_at = NOW()
+        WHERE is_institutional = true
+          AND exclusion_reason IS NULL
+          AND COALESCE(is_target_date, false) = true
+    """))
+    counts["target_date"] = r.rowcount
+
+    # Rule 3: Very low AUM (sub-scale)
+    # Use sec_fund_classes.net_assets aggregated if available,
+    # otherwise skip this rule
+    r = await db.execute(text("""
+        UPDATE sec_registered_funds f
+        SET is_institutional = false,
+            exclusion_reason = 'sub_scale',
+            sanitized_at = NOW()
+        FROM (
+            SELECT cik_number, SUM(net_assets) AS total_aum
+            FROM sec_fund_classes
+            GROUP BY cik_number
+        ) agg
+        WHERE f.cik_number = agg.cik_number
+          AND f.is_institutional = true
+          AND f.exclusion_reason IS NULL
+          AND agg.total_aum < 100_000_000
+    """))
+    counts["sub_scale"] = r.rowcount
+
+    r = await db.execute(text("""
+        SELECT 
+            COUNT(*) FILTER (WHERE is_institutional) AS institutional,
+            COUNT(*) FILTER (WHERE NOT is_institutional) AS excluded,
+            COUNT(*) AS total
+        FROM sec_registered_funds
+    """))
+    counts.update(dict(r.one()._mapping))
+
+    logger.info("sec_registered_funds_sanitized", extra=counts)
+    return counts
+
+
+async def _sanitize_sec_etfs(db: AsyncSession) -> dict[str, int]:
+    """Sanitize sec_etfs.
+
+    Most ETFs are institutional-appropriate by structure. Exclude:
+      1. Retirement-focused ETFs (target date)
+      2. Leveraged/inverse with low AUM (retail exotic)
+    """
+    counts: dict[str, int] = {}
+
+    r = await db.execute(text("""
+        UPDATE sec_etfs
+        SET is_institutional = false,
+            exclusion_reason = 'retirement',
+            sanitized_at = NOW()
+        WHERE is_institutional = true
+          AND exclusion_reason IS NULL
+          AND fund_name ~* :pattern
+    """), {"pattern": PATTERN_RETIREMENT})
+    counts["retirement"] = r.rowcount
+
+    # Leveraged/inverse ETFs below $100M AUM are typically retail-focused
+    r = await db.execute(text("""
+        UPDATE sec_etfs
+        SET is_institutional = false,
+            exclusion_reason = 'leveraged_retail',
+            sanitized_at = NOW()
+        WHERE is_institutional = true
+          AND exclusion_reason IS NULL
+          AND fund_name ~* '(\\b(?:2x|3x|-?1x|-?2x|-?3x)\\b|leveraged|inverse|ultra)'
+          AND COALESCE(net_assets, 0) < 100_000_000
+    """))
+    counts["leveraged_retail"] = r.rowcount
+
+    r = await db.execute(text("""
+        SELECT 
+            COUNT(*) FILTER (WHERE is_institutional) AS institutional,
+            COUNT(*) FILTER (WHERE NOT is_institutional) AS excluded,
+            COUNT(*) AS total
+        FROM sec_etfs
+    """))
+    counts.update(dict(r.one()._mapping))
+
+    logger.info("sec_etfs_sanitized", extra=counts)
+    return counts
+
+
+async def _sanitize_sec_mmfs(db: AsyncSession) -> dict[str, int]:
+    """Sanitize sec_money_market_funds.
+
+    Rules:
+      1. Retirement-focused MMFs (stable value wrappers, ERISA)
+      2. Retail-only share class (if mmf_category indicates)
+    """
+    counts: dict[str, int] = {}
+
+    r = await db.execute(text("""
+        UPDATE sec_money_market_funds
+        SET is_institutional = false,
+            exclusion_reason = 'retirement',
+            sanitized_at = NOW()
+        WHERE is_institutional = true
+          AND exclusion_reason IS NULL
+          AND (
+              fund_name ~* :pattern_retirement
+              OR fund_name ~* :pattern_insurance
+          )
+    """), {
+        "pattern_retirement": PATTERN_RETIREMENT,
+        "pattern_insurance": PATTERN_INSURANCE,
+    })
+    counts["retirement_or_insurance"] = r.rowcount
+
+    # MMF category check (if column exists and indicates retail)
+    r = await db.execute(text("""
+        UPDATE sec_money_market_funds
+        SET is_institutional = false,
+            exclusion_reason = 'retail_mmf_category',
+            sanitized_at = NOW()
+        WHERE is_institutional = true
+          AND exclusion_reason IS NULL
+          AND mmf_category ~* '(retail|\\bgovernment\\s+retail\\b)'
+    """))
+    counts["retail_mmf_category"] = r.rowcount
+
+    r = await db.execute(text("""
+        SELECT 
+            COUNT(*) FILTER (WHERE is_institutional) AS institutional,
+            COUNT(*) FILTER (WHERE NOT is_institutional) AS excluded,
+            COUNT(*) AS total
+        FROM sec_money_market_funds
+    """))
+    counts.update(dict(r.one()._mapping))
+
+    logger.info("sec_money_market_funds_sanitized", extra=counts)
+    return counts
+
+
+async def _sanitize_esma_funds(db: AsyncSession) -> dict[str, int]:
+    """Sanitize esma_funds (UCITS).
+
+    UCITS structure is already institutional by design (cross-border,
+    regulated). Apply lighter filters:
+      1. Retirement/pension-focused UCITS
+      2. Education/529-equivalent EU products
+      3. Very small AUM (< €50M sub-scale)
+    """
+    counts: dict[str, int] = {}
+
+    r = await db.execute(text("""
+        UPDATE esma_funds
+        SET is_institutional = false,
+            exclusion_reason = 'retirement',
+            sanitized_at = NOW()
+        WHERE is_institutional = true
+          AND exclusion_reason IS NULL
+          AND fund_name ~* :pattern
+    """), {"pattern": PATTERN_RETIREMENT})
+    counts["retirement"] = r.rowcount
+
+    # EU pension products (PEPP, IORP-covered)
+    r = await db.execute(text("""
+        UPDATE esma_funds
+        SET is_institutional = false,
+            exclusion_reason = 'eu_pension',
+            sanitized_at = NOW()
+        WHERE is_institutional = true
+          AND exclusion_reason IS NULL
+          AND fund_name ~* '(\\bPEPP\\b|pan.?european\\s+pension|IORP|occupational\\s+pension)'
+    """))
+    counts["eu_pension"] = r.rowcount
+
+    # Sub-scale UCITS (if AUM column available)
+    # Note: adjust column name based on actual esma_funds schema
+    r = await db.execute(text("""
+        UPDATE esma_funds
+        SET is_institutional = false,
+            exclusion_reason = 'sub_scale',
+            sanitized_at = NOW()
+        WHERE is_institutional = true
+          AND exclusion_reason IS NULL
+          AND COALESCE(total_assets_eur, 0) < 50_000_000
+          AND total_assets_eur IS NOT NULL
+    """))
+    counts["sub_scale"] = r.rowcount
+
+    r = await db.execute(text("""
+        SELECT 
+            COUNT(*) FILTER (WHERE is_institutional) AS institutional,
+            COUNT(*) FILTER (WHERE NOT is_institutional) AS excluded,
+            COUNT(*) AS total
+        FROM esma_funds
+    """))
+    counts.update(dict(r.one()._mapping))
+
+    logger.info("esma_funds_sanitized", extra=counts)
+    return counts
+
+
+async def _propagate_to_instruments_universe(db: AsyncSession) -> None:
+    """Propagate is_institutional from source tables to instruments_universe.
+
+    The column is GENERATED from attributes->>'is_institutional', so we
+    write to JSONB attributes.
+    """
+    # sec_manager_funds
+    await db.execute(text("""
+        UPDATE instruments_universe iu
+        SET attributes = COALESCE(attributes, '{}'::jsonb) || jsonb_build_object(
+            'is_institutional', f.is_institutional,
+            'exclusion_reason', f.exclusion_reason
+        )
+        FROM sec_manager_funds f
+        WHERE iu.attributes->>'sec_crd' = f.crd_number
+          AND iu.attributes->>'fund_name' = f.fund_name
+    """))
+
+    # sec_registered_funds via CIK
+    await db.execute(text("""
+        UPDATE instruments_universe iu
+        SET attributes = COALESCE(attributes, '{}'::jsonb) || jsonb_build_object(
+            'is_institutional', f.is_institutional,
+            'exclusion_reason', f.exclusion_reason
+        )
+        FROM sec_registered_funds f
+        WHERE iu.attributes->>'sec_cik' = f.cik_number::text
+    """))
+
+    # sec_etfs via series_id
+    await db.execute(text("""
+        UPDATE instruments_universe iu
+        SET attributes = COALESCE(attributes, '{}'::jsonb) || jsonb_build_object(
+            'is_institutional', f.is_institutional,
+            'exclusion_reason', f.exclusion_reason
+        )
+        FROM sec_etfs f
+        WHERE iu.attributes->>'series_id' = f.series_id
+    """))
+
+    # esma_funds via ISIN
+    await db.execute(text("""
+        UPDATE instruments_universe iu
+        SET attributes = COALESCE(attributes, '{}'::jsonb) || jsonb_build_object(
+            'is_institutional', f.is_institutional,
+            'exclusion_reason', f.exclusion_reason
+        )
+        FROM esma_funds f
+        WHERE iu.attributes->>'isin' = f.isin
+    """))
+
+    logger.info("instruments_universe_flag_propagated")
+```
+
+#### 3. Tests: `backend/tests/domains/wealth/workers/test_universe_sanitization.py`
+
+```python
+"""Tests for universe sanitization worker."""
+import pytest
+from uuid import uuid4
+
+from app.domains.wealth.workers.universe_sanitization import (
+    run_universe_sanitization,
+    GAV_FLOOR_USD,
+    PATTERN_RETIREMENT,
+    PATTERN_CIT,
+)
+
+
+class TestExclusionPatterns:
+    """Regex pattern validation (independent of DB)."""
+
+    @pytest.mark.parametrize("name,should_match", [
+        ("Vanguard Target Retirement 2045", True),
+        ("Fidelity 401(k) Plan Fund", True),
+        ("Morgan Stanley IRA Portfolio", True),
+        ("ESOP Shares Trust", True),
+        ("ERISA Stable Value Fund", True),
+        # Should NOT match
+        ("Goldman Sachs Large Cap Growth", False),
+        ("KKR Private Credit Fund", False),
+        ("Apollo European Equity", False),
+    ])
+    def test_retirement_pattern(self, name, should_match):
+        import re
+        match = re.search(PATTERN_RETIREMENT, name, re.IGNORECASE)
+        assert bool(match) == should_match
+
+    @pytest.mark.parametrize("name,should_match", [
+        ("JPMorgan Collective Investment Trust", True),
+        ("Wells Fargo Collective Trust", True),
+        ("Bank Collective Fund Series A", True),
+        # Should NOT match
+        ("Citadel Global Equities", False),
+        ("Private Credit Opportunities", False),
+    ])
+    def test_cit_pattern(self, name, should_match):
+        import re
+        match = re.search(PATTERN_CIT, name, re.IGNORECASE)
+        assert bool(match) == should_match
+
+
+@pytest.mark.asyncio
+class TestSanitizationWorker:
+    async def test_worker_completes_without_error(self, db):
+        """Integration: worker runs end-to-end against test DB."""
+        result = await run_universe_sanitization()
+        assert "per_table" in result
+        assert "sec_manager_funds" in result["per_table"]
+
+    async def test_idempotent_re_run(self, db):
+        """Running twice produces same state."""
+        r1 = await run_universe_sanitization()
+        r2 = await run_universe_sanitization()
+        # Per-reason counts should match exactly (idempotent)
+        assert r1["per_table"] == r2["per_table"]
+```
+
+---
+
+## Session B — Downstream Consumers + Report
+
+### DELIVERABLES
+
+#### 1. Update `strategy_reclassification.py` to filter institutional
+
+Add `WHERE is_institutional = true` clause to every source table query.
+
+#### 2. Update `candidate_screener.py`
+
+File: `backend/app/domains/wealth/services/candidate_screener.py`
+
+Add filter to the `discover_candidates()` query — `WHERE (attributes->>'is_institutional')::boolean = true`.
+
+#### 3. Update `catalog_sql.py`
+
+File: `backend/app/domains/wealth/queries/catalog_sql.py`
+
+Add institutional filter to `build_catalog_query()`. Default `TRUE` (filter out non-institutional), with optional param `include_non_institutional: bool = False` for admin screens.
+
+#### 4. Update materialized view `mv_unified_funds`
+
+The view joins multiple source tables. Add `is_institutional` column to the SELECT list and a filter clause. Refresh after sanitization worker completes.
+
+Create migration `0135_mv_unified_funds_institutional.py` with a `REFRESH MATERIALIZED VIEW CONCURRENTLY` after the view is redefined.
+
+#### 5. Audit report script: `backend/scripts/universe_sanitization_report.py`
+
+```python
+"""Generate audit report of universe sanitization exclusions.
+
+Usage:
+    python backend/scripts/universe_sanitization_report.py [--samples=20]
+
+Output:
+    - Per-table, per-reason exclusion counts
+    - Random samples of excluded funds per reason
+    - Remaining institutional totals
+    - Diff vs previous sanitization run (if any)
+"""
+import asyncio
+import sys
+
+from sqlalchemy import text
+from app.core.db import async_session
+
+
+TABLES = [
+    "sec_manager_funds", "sec_registered_funds", "sec_etfs",
+    "sec_bdcs", "sec_money_market_funds", "esma_funds",
+]
+
+
+async def main(samples: int = 20):
+    print("\n=== UNIVERSE SANITIZATION AUDIT REPORT ===\n")
+
+    async with async_session() as db:
+        for table in TABLES:
+            print(f"\n--- {table} ---")
+            r = await db.execute(text(f"""
+                SELECT 
+                    exclusion_reason,
+                    COUNT(*) AS n
+                FROM {table}
+                WHERE NOT is_institutional
+                GROUP BY exclusion_reason
+                ORDER BY n DESC
+            """))
+            rows = list(r)
+            if not rows:
+                print("  (no exclusions)")
+                continue
+            total_excluded = sum(row[1] for row in rows)
+            for reason, n in rows:
+                print(f"  {reason:<30} {n:>8,}")
+            print(f"  {'TOTAL EXCLUDED':<30} {total_excluded:>8,}")
+
+            # Total institutional
+            r = await db.execute(text(f"""
+                SELECT COUNT(*) FROM {table} WHERE is_institutional
+            """))
+            inst = r.scalar()
+            print(f"  {'INSTITUTIONAL':<30} {inst:>8,}")
+
+        # Samples per reason for sec_manager_funds (largest table)
+        print(f"\n\n=== SAMPLE EXCLUSIONS (sec_manager_funds, {samples} per reason) ===")
+        reasons_r = await db.execute(text("""
+            SELECT DISTINCT exclusion_reason FROM sec_manager_funds
+            WHERE NOT is_institutional AND exclusion_reason IS NOT NULL
+        """))
+        for (reason,) in reasons_r:
+            print(f"\n--- {reason} ---")
+            r = await db.execute(text(f"""
+                SELECT fund_name, crd_number, gross_asset_value
+                FROM sec_manager_funds
+                WHERE exclusion_reason = :reason
+                ORDER BY RANDOM()
+                LIMIT :limit
+            """), {"reason": reason, "limit": samples})
+            for row in r:
+                name, crd, gav = row
+                gav_str = f"${gav/1e9:.1f}B" if gav else "--"
+                print(f"  [{crd}] {(name or '?')[:70]:<70} {gav_str}")
+
+
+if __name__ == "__main__":
+    samples = 20
+    for arg in sys.argv[1:]:
+        if arg.startswith("--samples="):
+            samples = int(arg.split("=")[1])
+    asyncio.run(main(samples=samples))
+```
+
+### VERIFICATION
+
+1. `make test` passes.
+2. `make lint` and `make typecheck` pass.
+3. Migration 0134 applies cleanly.
+4. Worker runs to completion against local DB. Report exclusion counts.
+5. `sec_manager_funds` institutional count: **expected ~40k** (from 62.7k).
+6. `esma_funds` institutional count: **expected ~8k** (from 10.4k).
+7. `instruments_universe.attributes->>'is_institutional'` propagated correctly.
+8. Downstream queries filter by `is_institutional = true` by default.
+9. Audit report script runs and emits exclusion samples.
+
+---
+
+## Interpreting the Output
+
+**Expected per-reason distribution in sec_manager_funds:**
+
+| Reason | Expected count | Rationale |
+|---|---|---|
+| gav_below_3b | 12,000-16,000 | Most sub-$3B advisers |
+| retirement | 500-1,500 | 401k/IRA/ERISA products |
+| retail_adviser | 2,000-4,000 | RIAs with >500 individual clients |
+| duplicate_filing | 2,000-3,000 | Multi-adviser sub-advisory |
+| cit | 500-1,000 | Collective trusts |
+| sma_wrap | 500-1,500 | SMA/wrap programs |
+| insurance_wrapped | 200-500 | Stable value, GICs |
+| education | 50-200 | 529 plans (rare in ADV) |
+
+**If numbers deviate significantly:**
+- **`gav_below_3b` > 25,000:** threshold too high — consider dropping to $2B
+- **`duplicate_filing` > 5,000:** may indicate broken matching — review samples
+- **`retail_adviser` > 10,000:** client_types thresholds too aggressive — tune
+
+**Samples review:**
+
+The audit report produces random samples per exclusion reason. Before proceeding to Round 2 classifier patches + Session B, manually review 10-20 samples per reason. Flag any **false positives** (institutional funds wrongly excluded) for rule tuning.
+
+---
+
+## OUT OF SCOPE
+
+- **Fund-level GAV filtering** — deferred. Would require `sec_manager_funds.gross_asset_value` validation; Schedule D ingestion is incomplete (agent noted fund_id PFIDs missing).
+- **Jurisdictional filtering** — deferred. Would require `jurisdiction` column from Schedule D (not populated).
+- **`is_section_3c7` / `is_section_3c1`** — deferred. Same reason.
+- **Adding `fund_id` (PFID) to dedup** — deferred. Schedule D ingestion backlog item.
+- **Share class-level exclusion for sec_registered_funds** — deferred. Current filter at fund level; share class granularity is Phase 1.5+ sprint.
+- **Re-running sec_adv_ingestion** — explicitly out of scope. User confirmed external-facing workers not needed.
+
+---
+
+## Order of Execution
+
+1. **Migration 0134 applied** → adds columns with default TRUE (no rows excluded yet).
+2. **Worker `run_universe_sanitization()` executed** → flags computed, ~26k rows marked non-institutional.
+3. **Audit report reviewed** → sample check for false positives.
+4. **Downstream consumers updated** (Session B of this sprint) → queries filter by `is_institutional`.
+5. **Session B of classification sprint** can now proceed with a clean universe.
+6. **Round 2 classifier patches** run next, with new numbers that reflect the institutional subset only.
+
+---
+
+## After This Sprint
+
+The classifier Session B (apply gate) and Round 2 patches can proceed with confidence that:
+- Peer groups reflect institutional reality
+- Scoring percentiles are comparable
+- Candidate screener proposes only institutional-appropriate funds
+- `lost_class` diffs in reclassification will be smaller (non-institutional vehicles no longer pollute the stage)
+
+The `is_institutional = false` rows stay in the DB (reversible, auditable) but are invisible to product queries.


### PR DESCRIPTION
## Summary
- Migration 0134 adds `is_institutional`, `exclusion_reason`, `sanitized_at` to 6 fund tables + partial indexes
- `instruments_universe` gets generated column reading from JSONB attributes
- Worker (lock 900_063) applies cascade exclusion rules:
  - sec_manager_funds: 8 rules (retirement, CIT, education, insurance, SMA/wrap, GAV $3B floor, retail adviser, duplicate filings)
  - sec_registered_funds: 3 rules (retirement, target_date, sub_scale)
  - sec_etfs: 2 rules (retirement, leveraged_retail)
  - sec_money_market_funds: 2 rules (retirement/insurance, retail_mmf_category)
  - esma_funds: 2 rules (retirement, EU pension)
- Idempotent reset + first-match-wins lineage
- JSONB propagation to instruments_universe
- 52 parametrized pattern tests (all pass)

## Empirical bug fixes during execution
1. `sec_registered_funds.cik_number` → `cik` (actual column name)
2. `sec_fund_classes.cik_number` → `cik`
3. `sec_etfs.net_assets` → `monthly_avg_net_assets`
4. Dropped ESMA sub_scale rule (no AUM column on esma_funds)
5. `f.cik_number::text` → `f.cik::text` in propagation
6. Import: `async_session_factory as async_session` (match sibling workers)

## Safety upgrade
Dedup CTE uses PK `id` instead of composite `(fund_name, gross_asset_value, crd_number)` — `sec_manager_funds` has IdMixin, composite not guaranteed unique.

## Out of scope (Session B)
- Downstream consumer filters (strategy_reclassification, candidate_screener, catalog_sql)
- mv_unified_funds rewrite + migration 0135
- Audit report script

## Test plan
- [x] 52 pattern tests pass
- [ ] Migration applies cleanly: `make migrate`
- [ ] Worker runs against local DB: `python -c "import asyncio; from app.domains.wealth.workers.universe_sanitization import run_universe_sanitization; print(asyncio.run(run_universe_sanitization()))"`
- [ ] Expected exclusion counts:
  - sec_manager_funds: ~22k excluded (from 62.7k → ~40k)
  - sec_registered_funds: ~1.1k excluded (from 4.6k → ~3.5k)
  - esma_funds: ~2.4k excluded (from 10.4k → ~8k)

🤖 Generated with [Claude Code](https://claude.com/claude-code)