### PR TITLE
feat(wealth): apply gate flags — legacy-to-canonical + source filter + restore SAVEPOINT

### DIFF
--- a/backend/scripts/apply_strategy_reclassification.py
+++ b/backend/scripts/apply_strategy_reclassification.py
@@ -50,7 +50,10 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.engine import async_session_factory as async_session
-from app.domains.wealth.services.classification_family import classify_severity
+from app.domains.wealth.services.classification_family import (
+    classify_severity,
+    family_of,
+)
 
 logger = logging.getLogger("apply_strategy_reclassification")
 
@@ -205,27 +208,57 @@ async def _emit_audit(
     """
     from app.core.db.audit import write_audit_event
 
+    # SAVEPOINT isolates the audit insert. ``audit_events`` requires
+    # ``organization_id`` NOT NULL; a CLI invocation has no RLS context
+    # so the insert raises NotNullViolationError at flush time. Without
+    # ``begin_nested`` that error poisons the outer transaction and
+    # rolls back the production UPDATEs we just applied.
     try:
-        await write_audit_event(
-            db,
-            actor_id=actor,
-            action="apply_batch",
-            entity_type="strategy_reclassification",
-            entity_id=str(batch_id),
-            after={
-                "run_id": str(run_id),
-                "batch_id": str(batch_id),
-                "severities": severities,
-                "counts": counts,
-                "justification": justification,
-                "applied_at": datetime.now(timezone.utc).isoformat(),
-            },
-        )
+        async with db.begin_nested():
+            await write_audit_event(
+                db,
+                actor_id=actor,
+                action="apply_batch",
+                entity_type="strategy_reclassification",
+                entity_id=str(batch_id),
+                after={
+                    "run_id": str(run_id),
+                    "batch_id": str(batch_id),
+                    "severities": severities,
+                    "counts": counts,
+                    "justification": justification,
+                    "applied_at": datetime.now(timezone.utc).isoformat(),
+                    "legacy_taxonomy_migration": counts.get(
+                        "legacy_to_canonical", 0,
+                    ) > 0,
+                },
+            )
     except Exception as exc:
         logger.warning(
             "audit_event_skipped batch_id=%s reason=%s",
             batch_id, exc,
         )
+
+
+def _is_legacy_to_canonical(
+    current: str | None, proposed: str | None,
+) -> bool:
+    """A legacy → canonical migration is a P2 row where the current label
+    is non-canonical (no family entry) and the proposed label is canonical.
+
+    These ~21k rows were swept into ``asset_class_change`` by the original
+    severity matrix only because ``unknown != equity`` (etc). They are
+    vocabulary upgrades, not real cross-family reclassifications, and
+    carry no information loss — the previous label was already off-taxonomy.
+    """
+    # ``current is not None`` excludes NULL→canonical (which is P0
+    # safe_auto_apply, gated separately and never blocked by --force).
+    return (
+        current is not None
+        and family_of(current) is None
+        and proposed is not None
+        and family_of(proposed) is not None
+    )
 
 
 async def apply_batch(
@@ -235,17 +268,39 @@ async def apply_batch(
     dry_run: bool,
     actor: str,
     justification: str | None,
+    legacy_only: bool = False,
+    source_filter: str | None = None,
 ) -> dict[str, int]:
     """Walk the stage table once; apply rows whose severity is selected.
 
     Idempotency guarantee: ``WHERE applied_at IS NULL`` filters out any
     row from a previous batch. Severity is computed *fresh* per row so a
     label that changed between report and apply is still gated correctly.
+
+    Two narrowing filters can be combined with ``severities``:
+
+    ``legacy_only``
+        Only applies rows where ``current_family is None`` (current label
+        not in canonical taxonomy) AND ``proposed_family is not None``.
+        Use with ``--severity asset_class`` to migrate the legacy 37-label
+        vocabulary into the canonical 51-label taxonomy without touching
+        true cross-family changes. Counted as ``legacy_to_canonical``
+        rather than under the underlying severity tag.
+
+    ``source_filter``
+        Only applies rows whose ``classification_source`` matches the
+        given value (``fallback``, ``tiingo_description``, ``name_regex``,
+        or ``adv_brochure``). Useful with ``--severity lost`` to apply
+        only fallback-driven NULL transitions where the cascade had no
+        signal to work with.
     """
     batch_id = uuid4()
     counts: dict[str, int] = dict.fromkeys(severities, 0)
+    counts["legacy_to_canonical"] = 0
     counts["unchanged_skipped"] = 0
     counts["other_severity_skipped"] = 0
+    counts["filtered_legacy"] = 0
+    counts["filtered_source"] = 0
     counts["errors"] = 0
 
     async with async_session() as db:
@@ -275,14 +330,36 @@ async def apply_batch(
             if severity not in severities:
                 counts["other_severity_skipped"] += 1
                 continue
+
+            # ── Optional narrowing filters ───────────────────────────
+            is_legacy = _is_legacy_to_canonical(
+                row.current_strategy_label,
+                row.proposed_strategy_label,
+            )
+            if legacy_only and not is_legacy:
+                counts["filtered_legacy"] += 1
+                continue
+            if source_filter and row.classification_source != source_filter:
+                counts["filtered_source"] += 1
+                continue
+
+            # Counter bucket: legacy_to_canonical takes precedence over
+            # the raw severity tag so the operator sees the migration
+            # signal in the result summary.
+            counter_key = (
+                "legacy_to_canonical"
+                if (legacy_only and is_legacy)
+                else severity
+            )
+
             if dry_run:
-                counts[severity] += 1
+                counts[counter_key] += 1
                 continue
             try:
                 await _apply_one(
                     db, row=row, batch_id=batch_id, actor=actor,
                 )
-                counts[severity] += 1
+                counts[counter_key] += 1
             except Exception as exc:
                 logger.exception(
                     "apply_failed stage_id=%s source=%s pk=%s err=%s",
@@ -290,7 +367,10 @@ async def apply_batch(
                 )
                 counts["errors"] += 1
 
-        applied_total = sum(counts[s] for s in severities)
+        applied_total = (
+            sum(counts[s] for s in severities)
+            + counts["legacy_to_canonical"]
+        )
         if not dry_run and applied_total > 0:
             await db.execute(
                 text(
@@ -353,6 +433,29 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip the interactive 'APPLY' confirmation prompt (CI use)",
     )
+    parser.add_argument(
+        "--legacy-to-canonical-only",
+        action="store_true",
+        help=(
+            "Only apply rows where the CURRENT label is non-canonical "
+            "(unknown family) and the PROPOSED label is canonical. "
+            "Treats them as a vocabulary migration: --force is NOT "
+            "required even when severity is asset_class. Combine with "
+            "--severity asset_class to migrate the legacy 37-label "
+            "vocabulary into the 51-label canonical taxonomy."
+        ),
+    )
+    parser.add_argument(
+        "--source-filter",
+        default=None,
+        choices=("fallback", "tiingo_description", "name_regex", "adv_brochure"),
+        help=(
+            "Only apply rows whose classification_source matches. "
+            "Most useful with '--severity lost --source-filter fallback' "
+            "to apply only NULL transitions where the cascade had no "
+            "signal at any layer."
+        ),
+    )
     return parser
 
 
@@ -362,10 +465,18 @@ async def main() -> None:
 
     severities = _resolve_severities(args.severity)
 
-    needs_force = bool(set(severities) & SEVERITIES_REQUIRING_FORCE)
+    # ``--legacy-to-canonical-only`` waives the --force gate for P2
+    # because the operation is a vocabulary migration, not a real
+    # asset-class reclassification (current label is off-taxonomy, no
+    # information can be lost). lost_class still needs justification.
+    needs_force = bool(
+        set(severities) & SEVERITIES_REQUIRING_FORCE,
+    ) and not args.legacy_to_canonical_only
     if needs_force and not args.force:
         parser.error(
-            "--force is required when applying asset_class_change or lost_class",
+            "--force is required when applying asset_class_change or "
+            "lost_class. (Pass --legacy-to-canonical-only to waive "
+            "--force for vocabulary migrations only.)",
         )
     needs_justification = bool(
         set(severities) & SEVERITIES_REQUIRING_JUSTIFICATION,
@@ -374,18 +485,30 @@ async def main() -> None:
         parser.error(
             "--justification is required when applying lost_class",
         )
+    if (
+        args.legacy_to_canonical_only
+        and "asset_class_change" not in severities
+    ):
+        parser.error(
+            "--legacy-to-canonical-only only makes sense with "
+            "--severity asset_class (or all)",
+        )
 
     actor = args.actor or getpass.getuser()
     run_id = UUID(args.run_id)
     dry_run = not args.confirm
 
     print("apply_strategy_reclassification")
-    print(f"  run_id       : {run_id}")
-    print(f"  severities   : {', '.join(severities)}")
-    print(f"  dry_run      : {dry_run}")
-    print(f"  actor        : {actor}")
+    print(f"  run_id            : {run_id}")
+    print(f"  severities        : {', '.join(severities)}")
+    print(f"  dry_run           : {dry_run}")
+    print(f"  actor             : {actor}")
+    if args.legacy_to_canonical_only:
+        print("  legacy_only       : True (vocabulary migration mode)")
+    if args.source_filter:
+        print(f"  source_filter     : {args.source_filter}")
     if args.justification:
-        print(f"  justification: {args.justification}")
+        print(f"  justification     : {args.justification}")
     print()
 
     if not dry_run and not args.yes:
@@ -399,6 +522,8 @@ async def main() -> None:
         dry_run=dry_run,
         actor=actor,
         justification=args.justification,
+        legacy_only=args.legacy_to_canonical_only,
+        source_filter=args.source_filter,
     )
 
     print("\n=== RESULT ===")

--- a/backend/tests/test_apply_strategy_reclassification_cli.py
+++ b/backend/tests/test_apply_strategy_reclassification_cli.py
@@ -92,6 +92,75 @@ class TestSeverityRequirements:
         assert frozenset({"lost_class"}) == apply_mod.SEVERITIES_REQUIRING_JUSTIFICATION  # noqa: SIM300
 
 
+class TestLegacyToCanonical:
+    """The ``--legacy-to-canonical-only`` filter must isolate vocabulary
+    migrations from real cross-family changes.
+    """
+
+    def test_unknown_to_canonical_is_legacy(self) -> None:
+        # "Hedge Fund" (legacy 37-cat) → "Multi-Strategy" (canonical)
+        assert apply_mod._is_legacy_to_canonical(
+            "Hedge Fund", "Multi-Strategy",
+        ) is True
+
+    def test_unknown_to_unknown_is_not_legacy(self) -> None:
+        # Both off-taxonomy → not a legacy → canonical migration
+        assert apply_mod._is_legacy_to_canonical(
+            "Hedge Fund", "Some Other Legacy",
+        ) is False
+
+    def test_canonical_to_canonical_is_not_legacy(self) -> None:
+        # True cross-family change — must NOT be misclassified as legacy
+        assert apply_mod._is_legacy_to_canonical(
+            "Large Blend", "High Yield Bond",
+        ) is False
+
+    def test_null_current_is_not_legacy(self) -> None:
+        # NULL current is P0 safe_auto_apply, not a legacy migration
+        assert apply_mod._is_legacy_to_canonical(
+            None, "Large Blend",
+        ) is False
+
+    def test_canonical_to_null_is_not_legacy(self) -> None:
+        # Canonical → NULL is P3 lost_class, not legacy
+        assert apply_mod._is_legacy_to_canonical(
+            "Large Blend", None,
+        ) is False
+
+
+class TestParserNewFlags:
+    def test_legacy_only_flag(self, parser) -> None:
+        args = parser.parse_args(
+            [
+                "--run-id", str(uuid4()),
+                "--severity", "asset_class",
+                "--legacy-to-canonical-only",
+            ],
+        )
+        assert args.legacy_to_canonical_only is True
+
+    def test_source_filter_choices_enforced(self, parser) -> None:
+        # Bogus source value must fail at parse time
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                [
+                    "--run-id", str(uuid4()),
+                    "--severity", "lost",
+                    "--source-filter", "invented_source",
+                ],
+            )
+
+    def test_source_filter_fallback_accepted(self, parser) -> None:
+        args = parser.parse_args(
+            [
+                "--run-id", str(uuid4()),
+                "--severity", "lost",
+                "--source-filter", "fallback",
+            ],
+        )
+        assert args.source_filter == "fallback"
+
+
 class TestUpdateStmtCoverage:
     """Each source_table the worker writes must have an UPDATE statement."""
 

--- a/docs/reference/classification-apply-runbook.md
+++ b/docs/reference/classification-apply-runbook.md
@@ -69,31 +69,64 @@ python backend/scripts/apply_strategy_reclassification.py \
   --run-id <uuid> --severity style --confirm
 ```
 
-## Phase 4 — Apply P2 (asset class changes, ~13,000 rows)
+## Phase 4 — Apply P2 (asset class changes)
 
-Medium risk: fund moves family. Allocation blocks, peer groups, and
-scoring weights may shift.
+Empirically, P2 splits into two very different sub-buckets that should
+be applied separately:
+
+### 4a. Legacy → Canonical vocabulary migration (low risk, large volume)
+
+Rows where the *current* `strategy_label` is from the old 37-category
+vocabulary (no entry in `STRATEGY_FAMILY`) and the *proposed* label is
+canonical. These were swept into "asset_class_change" only because
+`unknown != equity` (etc), but they carry no information loss — the
+previous label was already off-taxonomy. Use the dedicated flag:
+
+```bash
+python backend/scripts/apply_strategy_reclassification.py \
+  --run-id <uuid> --severity asset_class \
+  --legacy-to-canonical-only --confirm
+```
+
+`--legacy-to-canonical-only` waives the `--force` requirement because
+the operation is a vocabulary upgrade, not a real reclassification.
+Counted in the result summary under `legacy_to_canonical`.
+
+### 4b. True cross-family changes (medium risk, smaller volume)
+
+Rows where both labels are canonical but in different families
+(e.g. `Large Blend` → `High Yield Bond`). These need real review —
+sample 20+ rows per `source_table` from the CSV first; reject the run
+if the cascade is misclassifying a recognisable cohort.
 
 ```bash
 python backend/scripts/apply_strategy_reclassification.py \
   --run-id <uuid> --severity asset_class --confirm --force
 ```
 
-Per source table, sample 20+ rows from the CSV before applying. Reject
-the run if the cascade is misclassifying a recognisable cohort
-(e.g. all "Income" funds going to Fixed Income when half are equity
-income).
+Without `--legacy-to-canonical-only`, the script will apply BOTH
+sub-buckets — only do this after Phase 4a has completed and the true
+cross-family residual is small enough to inspect manually.
 
-## Phase 5 — Apply P3 (lost class, ~9,600 rows)
+## Phase 5 — Apply P3 (lost class)
 
-High risk: label becomes NULL. Requires IC sign-off and a written
-justification recorded in the audit event.
+High risk: label becomes NULL. Use `--source-filter fallback` to
+restrict the apply to rows where the cascade had no signal at any
+layer (Tiingo description, name regex, ADV brochure all came up empty).
+For those, NULL is genuinely better than a stale legacy label:
 
 ```bash
 python backend/scripts/apply_strategy_reclassification.py \
-  --run-id <uuid> --severity lost --confirm --force \
-  --justification "IC 2026-04-14: ESMA residuals approved for null-out"
+  --run-id <uuid> --severity lost --source-filter fallback \
+  --confirm --force \
+  --justification "Cascade fallback: no canonical label found, NULL preferable to non-canonical legacy"
 ```
+
+For rows where `classification_source` is `tiingo_description` or
+`name_regex` and the proposed label is NULL, treat as suspect — Layer
+1/2 fired but didn't reach a canonical label, which usually indicates
+a classifier bug rather than a genuine "this fund has no strategy"
+case. Inspect manually before applying.
 
 ## Combined batches
 


### PR DESCRIPTION
## Why
Empirical analysis after applying P0+P1 from run \`b5623a5b\` showed the 24,178 P2 rows are not homogeneous:

| Bucket | Rows | What it is |
|---|---|---|
| **A: Legacy → Canonical** | **21,559 (89%)** | Current label is from the legacy 37-category vocabulary (no entry in STRATEGY_FAMILY). Proposed is canonical. Pure vocabulary upgrade — no information loss. |
| **B: True cross-family** | **2,619 (11%)** | Both labels canonical, different families. Real reclassification, needs review. |

The original severity matrix swept Bucket A into \`asset_class_change\` only because \`unknown != equity\`. Mixing them under one \`--force\` gate either blocks the safe migration or waves through risky cross-family changes.

Sample of Bucket B exposed 3 specific bugs in the cascade classifier (\`name:international\` over-firing on bonds, \`desc:mbs\` firing on non-MBS funds, \`name:general_bond\` swallowing HY/IG). Round 2.5 patches will follow in a separate PR — this PR delivers the apply-side controls.

## Changes
- \`--legacy-to-canonical-only\` — applies only Bucket A. Waives \`--force\` (vocabulary upgrade, not reclassification). Counted as \`legacy_to_canonical\` in result summary.
- \`--source-filter {fallback,tiingo_description,name_regex,adv_brochure}\` — narrows to rows with matching \`classification_source\`. Designed for \`--severity lost --source-filter fallback\` (NULL transitions where the cascade had no signal anywhere).
- **Restores SAVEPOINT around \`_emit_audit\`** — lost in the squash merge of #174. Without \`db.begin_nested()\`, the audit's NotNullViolationError on \`organization_id\` poisons the outer transaction and rolls back the production UPDATEs.
- Audit metadata now includes \`legacy_taxonomy_migration\` flag.
- Updated runbook with Phase 4a (legacy migration) / 4b (true cross-family) split and Phase 5 fallback-only guidance.

## Verification
- [x] \`make lint\` passes
- [x] 46/46 apply + family tests pass (10 new)
- [x] Local dry-run: \`--severity asset_class --legacy-to-canonical-only\` → 21,559 candidates, 2,619 filtered out
- [x] Local dry-run: \`--severity lost --source-filter fallback --force\` → 9,612 candidates (100% of P3 are fallback by construction)
- [x] Local dry-run: \`--severity asset_class\` (no flag) → 24,178 unchanged baseline

## Test plan
- [ ] After merge: \`python backend/scripts/apply_strategy_reclassification.py --run-id b5623a5b-9f2d-4df7-b02f-0726a9703ea8 --severity asset_class --legacy-to-canonical-only --confirm\` applies ~21,559 rows
- [ ] Re-run is no-op (idempotency)
- [ ] \`--legacy-to-canonical-only\` without \`--severity asset_class\` errors out
- [ ] \`--source-filter foo\` rejects unknown source

🤖 Generated with [Claude Code](https://claude.com/claude-code)