### PR TITLE
feat(wealth): universe auto-import + cleanup (PR-A6)

### DIFF
--- a/backend/app/core/db/migrations/versions/0139_universe_cleanup_pre_autoimport.py
+++ b/backend/app/core/db/migrations/versions/0139_universe_cleanup_pre_autoimport.py
@@ -1,0 +1,96 @@
+"""Surgical cleanup of stale seed data before universe auto-import.
+
+Truncates model_portfolios and all FK-cascaded dependents (construction
+runs, stress results, calibration, alerts, state transitions, weight
+snapshots, synthetic NAV). Preserves allocation_blocks, IC views with
+active human authors, and all global tables.
+
+Backup: restore from backups/backup_pre_universe_cleanup_*.sql.gz
+Command:
+    pg_dump -Fc -t model_portfolios -t portfolio_calibration \
+        -t portfolio_construction_runs -t portfolio_stress_results \
+        -t portfolio_alerts -t portfolio_snapshots -t portfolio_views \
+        -t model_portfolio_nav -t instruments_org \
+        -t portfolio_state_transitions -t portfolio_weight_snapshots \
+        "$DIRECT_DATABASE_URL" \
+        > backups/backup_pre_universe_cleanup_$(date +%Y%m%d_%H%M%S).sql.gz
+
+Revision ID: 0139_universe_cleanup_pre_autoimport
+Revises: 0138_holdings_drift_alerts
+Create Date: 2026-04-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0139_universe_cleanup_pre_autoimport"
+down_revision = "0138_holdings_drift_alerts"
+branch_labels = None
+depends_on = None
+
+
+def _audit(conn: sa.engine.Connection, table: str, action: str, rows: int) -> None:
+    """Write audit event for each cleanup operation."""
+    conn.execute(
+        sa.text("""
+            INSERT INTO audit_events (
+                organization_id, actor_id, actor_roles, action,
+                entity_type, entity_id, before_state, after_state,
+                request_id, access_level, created_by, updated_by
+            ) VALUES (
+                NULL, 'system:migration', '{system}', :action,
+                'universe_cleanup', :table,
+                jsonb_build_object('rows_affected', :rows, 'reason', 'pr_a6_pre_autoimport'),
+                NULL,
+                'migration:0139', 'internal', 'system:migration', 'system:migration'
+            )
+        """),
+        {"action": action, "table": table, "rows": rows},
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # --- Step 7: Selective delete on portfolio_views (BEFORE model_portfolios truncate) ---
+    # Preserve IC views with human authors that are still active.
+    # effective_to IS NULL means open-ended (still valid).
+    result = conn.execute(sa.text("""
+        DELETE FROM portfolio_views
+        WHERE effective_to < NOW()::date
+           OR created_by IS NULL
+    """))
+    _audit(conn, "portfolio_views", "selective_delete", result.rowcount)
+
+    # --- Step 1-6, 8: Truncate model_portfolios CASCADE ---
+    # All child tables have ON DELETE CASCADE from model_portfolios:
+    #   portfolio_construction_runs, portfolio_stress_results,
+    #   portfolio_calibration, portfolio_alerts, portfolio_state_transitions,
+    #   model_portfolio_nav, portfolio_views (remaining rows).
+    # portfolio_weight_snapshots references model_portfolios(id) ON DELETE CASCADE too.
+    #
+    # portfolio_snapshots has NO FK to model_portfolios -- truncate separately.
+
+    # Count before truncate for audit
+    mp_count = conn.execute(sa.text("SELECT COUNT(*) FROM model_portfolios")).scalar()
+    ps_count = conn.execute(sa.text("SELECT COUNT(*) FROM portfolio_snapshots")).scalar()
+
+    conn.execute(sa.text("TRUNCATE model_portfolios CASCADE"))
+    _audit(conn, "model_portfolios", "truncate_cascade", mp_count or 0)
+
+    conn.execute(sa.text("TRUNCATE portfolio_snapshots"))
+    _audit(conn, "portfolio_snapshots", "truncate", ps_count or 0)
+
+    # --- Step 9: Delete stale instruments_org ---
+    result = conn.execute(sa.text("""
+        DELETE FROM instruments_org
+        WHERE selected_at < '2026-04-15 00:00:00+00'
+    """))
+    _audit(conn, "instruments_org", "delete_stale_seeds", result.rowcount)
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "0139 cleanup is irreversible -- restore from "
+        "backups/backup_pre_universe_cleanup_*.sql.gz"
+    )

--- a/backend/app/core/db/migrations/versions/0139_universe_cleanup_pre_autoimport.py
+++ b/backend/app/core/db/migrations/versions/0139_universe_cleanup_pre_autoimport.py
@@ -29,8 +29,16 @@ branch_labels = None
 depends_on = None
 
 
+_SYSTEM_ORG_UUID = "00000000-0000-0000-0000-000000000000"
+
+
 def _audit(conn: sa.engine.Connection, table: str, action: str, rows: int) -> None:
-    """Write audit event for each cleanup operation."""
+    """Write audit event for each cleanup operation.
+
+    Uses nil-UUID sentinel for organization_id because audit_events is a
+    hypertable with NOT NULL on organization_id. System-level migration
+    events are scoped to the nil org and never match any tenant RLS policy.
+    """
     conn.execute(
         sa.text("""
             INSERT INTO audit_events (
@@ -38,14 +46,14 @@ def _audit(conn: sa.engine.Connection, table: str, action: str, rows: int) -> No
                 entity_type, entity_id, before_state, after_state,
                 request_id, access_level, created_by, updated_by
             ) VALUES (
-                NULL, 'system:migration', '{system}', :action,
+                CAST(:system_org AS uuid), 'system:migration', '{system}', :action,
                 'universe_cleanup', :table,
                 jsonb_build_object('rows_affected', :rows, 'reason', 'pr_a6_pre_autoimport'),
                 NULL,
                 'migration:0139', 'internal', 'system:migration', 'system:migration'
             )
         """),
-        {"action": action, "table": table, "rows": rows},
+        {"action": action, "table": table, "rows": rows, "system_org": _SYSTEM_ORG_UUID},
     )
 
 

--- a/backend/app/core/db/migrations/versions/0140_instruments_org_source_override.py
+++ b/backend/app/core/db/migrations/versions/0140_instruments_org_source_override.py
@@ -1,0 +1,57 @@
+"""Add source + block_overridden columns to instruments_org.
+
+Supports the universe_auto_import worker (lock 900_103, PR-A6 Section C).
+
+- ``source`` (VARCHAR(40), default 'manual') distinguishes manually-imported
+  rows (Screener flow) from worker-imported rows ('universe_auto_import').
+  Used by the worker's ``ON CONFLICT`` branch to preserve the origin of
+  dual-tracked rows ('manual,auto') so audit trail keeps both signals.
+- ``block_overridden`` (BOOLEAN, default false) is set by the Screener UI
+  when a user manually edits ``block_id``. The worker respects this flag
+  and will not overwrite the block on subsequent runs.
+
+Unique constraint on ``(organization_id, instrument_id)`` already exists
+from migration 0068 — the worker's ON CONFLICT target matches it.
+
+CONCURRENTLY is intentionally NOT used — Alembic wraps migrations in a
+transaction by default, and the project convention (see 0096, 0113) is
+to create indexes synchronously inside the migration. For prod, recreate
+the partial index CONCURRENTLY post-deploy if table size becomes a
+concern.
+
+Revision ID: 0140_instruments_org_source_override
+Revises: 0139_universe_cleanup_pre_autoimport
+Create Date: 2026-04-16
+"""
+
+from alembic import op
+
+revision = "0140_instruments_org_source_override"
+down_revision = "0139_universe_cleanup_pre_autoimport"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE instruments_org
+        ADD COLUMN IF NOT EXISTS source VARCHAR(40)
+            NOT NULL DEFAULT 'manual'
+    """)
+    op.execute("""
+        ALTER TABLE instruments_org
+        ADD COLUMN IF NOT EXISTS block_overridden BOOLEAN
+            NOT NULL DEFAULT false
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_instruments_org_source_auto
+        ON instruments_org (organization_id, source)
+        WHERE source = 'universe_auto_import'
+           OR source = 'manual,auto'
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_instruments_org_source_auto")
+    op.execute("ALTER TABLE instruments_org DROP COLUMN IF EXISTS block_overridden")
+    op.execute("ALTER TABLE instruments_org DROP COLUMN IF EXISTS source")

--- a/backend/app/domains/admin/routes/universe_auto_import.py
+++ b/backend/app/domains/admin/routes/universe_auto_import.py
@@ -1,0 +1,219 @@
+"""Admin routes for universe auto-import.
+
+Two endpoints, both gated on the platform ``SUPER_ADMIN`` role:
+
+* ``POST /admin/universe/auto-import/run`` — synchronously populate one
+  org's ``instruments_org`` from the sanitized catalog. Used for fresh
+  tenant provisioning and for replaying a failed run. Response surfaces
+  the same :class:`AutoImportMetrics` shape the worker persists to
+  ``audit_events`` so the UI can render a single block of telemetry
+  regardless of trigger.
+* ``GET /admin/universe/auto-import/status`` — aggregates the last
+  auto-import per org from ``audit_events`` (action=``auto_import``,
+  entity_type=``instruments_org``). Answers "which orgs are covered,
+  when was the last run, how big was it?" without paging through audit
+  history.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security.admin_auth import require_super_admin
+from app.core.security.clerk_auth import Actor
+from app.core.tenancy.admin_middleware import get_db_admin, get_db_for_tenant
+from app.domains.wealth.services.universe_auto_import_service import (
+    AUM_FLOOR_USD,
+    NAV_COVERAGE_MIN,
+    auto_import_for_org,
+)
+
+logger: Any = structlog.get_logger()
+
+router = APIRouter(
+    prefix="/admin/universe/auto-import",
+    tags=["admin-universe-auto-import"],
+    dependencies=[Depends(require_super_admin)],
+)
+
+
+# -- Schemas ---------------------------------------------------------------
+
+
+class RunRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    org_id: uuid.UUID
+    reason: str = Field(
+        min_length=3,
+        max_length=120,
+        description=(
+            "Free-form label persisted to audit_events.after_state.reason. "
+            "Use short snake_case tags (e.g. 'org_provisioning', "
+            "'manual_reimport_after_rejection_reversal')."
+        ),
+    )
+
+
+class RunResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    org_id: uuid.UUID
+    evaluated: int
+    added: int
+    updated: int
+    skipped: int
+    skipped_by_reason: dict[str, int]
+    duration_ms: int
+    aum_floor_usd: int
+    nav_coverage_min: int
+
+
+class OrgCoverageRow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    org_id: uuid.UUID
+    last_run_at: datetime | None
+    last_added: int
+    last_updated: int
+    last_skipped: int
+    last_duration_ms: int
+    total_rows: int
+
+
+class StatusResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    aum_floor_usd: int
+    nav_coverage_min: int
+    per_org: list[OrgCoverageRow]
+
+
+# -- Routes ----------------------------------------------------------------
+
+
+@router.post("/run", response_model=RunResponse)
+async def run_auto_import(
+    body: RunRequest,
+    request: Request,
+    actor: Actor = Depends(require_super_admin),
+) -> RunResponse:
+    """Trigger auto-import for a single org synchronously.
+
+    Runs on a dedicated tenant-scoped session (RLS bound to ``org_id``)
+    so ``instruments_org`` writes use the correct policy. The request
+    completes after the commit — callers can show the resulting metrics
+    immediately without polling.
+    """
+    request_id = request.headers.get("X-Request-Id")
+    try:
+        # get_db_for_tenant wraps the session in session.begin(); the
+        # transaction commits automatically when the generator exits.
+        async for db in get_db_for_tenant(body.org_id):
+            metrics = await auto_import_for_org(
+                db,
+                body.org_id,
+                reason=body.reason,
+                actor_id=actor.actor_id,
+                actor_roles=[r.value for r in actor.roles],
+                request_id=request_id,
+            )
+            return RunResponse(
+                org_id=body.org_id,
+                evaluated=metrics["evaluated"],
+                added=metrics["added"],
+                updated=metrics["updated"],
+                skipped=metrics["skipped"],
+                skipped_by_reason=metrics["skipped_by_reason"],
+                duration_ms=metrics["duration_ms"],
+                aum_floor_usd=AUM_FLOOR_USD,
+                nav_coverage_min=NAV_COVERAGE_MIN,
+            )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "universe_auto_import.endpoint_failed",
+            org_id=str(body.org_id),
+            reason=body.reason,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="auto_import_failed",
+        ) from exc
+    # get_db_for_tenant always yields exactly one session, but the loop
+    # form requires an explicit return path for the type checker.
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="no_session_yielded",
+    )
+
+
+@router.get("/status", response_model=StatusResponse)
+async def get_status(
+    db: AsyncSession = Depends(get_db_admin),
+    actor: Actor = Depends(require_super_admin),
+) -> StatusResponse:
+    """Return per-org coverage snapshot derived from audit_events.
+
+    One row per org that has ever been imported (or has any rows in
+    ``instruments_org``). ``total_rows`` is the live count today; the
+    ``last_*`` columns are the most recent run's metrics.
+    """
+    result = await db.execute(
+        text(
+            """
+            WITH latest_runs AS (
+                SELECT DISTINCT ON (ae.organization_id)
+                    ae.organization_id AS org_id,
+                    ae.created_at,
+                    COALESCE((ae.after_state->>'added')::int, 0)        AS added,
+                    COALESCE((ae.after_state->>'updated')::int, 0)      AS updated,
+                    COALESCE((ae.after_state->>'skipped')::int, 0)      AS skipped,
+                    COALESCE((ae.after_state->>'duration_ms')::int, 0)  AS duration_ms
+                FROM audit_events ae
+                WHERE ae.action = 'auto_import'
+                  AND ae.entity_type = 'instruments_org'
+                  AND ae.organization_id IS NOT NULL
+                ORDER BY ae.organization_id, ae.created_at DESC
+            ),
+            totals AS (
+                SELECT organization_id AS org_id, COUNT(*) AS total_rows
+                FROM instruments_org
+                GROUP BY organization_id
+            )
+            SELECT
+                COALESCE(lr.org_id, t.org_id)                    AS org_id,
+                lr.created_at                                    AS last_run_at,
+                COALESCE(lr.added, 0)                            AS last_added,
+                COALESCE(lr.updated, 0)                          AS last_updated,
+                COALESCE(lr.skipped, 0)                          AS last_skipped,
+                COALESCE(lr.duration_ms, 0)                      AS last_duration_ms,
+                COALESCE(t.total_rows, 0)                        AS total_rows
+            FROM latest_runs lr
+            FULL OUTER JOIN totals t USING (org_id)
+            ORDER BY last_run_at DESC NULLS LAST, org_id
+            """,
+        ),
+    )
+    per_org = [
+        OrgCoverageRow(
+            org_id=row.org_id,
+            last_run_at=row.last_run_at,
+            last_added=row.last_added,
+            last_updated=row.last_updated,
+            last_skipped=row.last_skipped,
+            last_duration_ms=row.last_duration_ms,
+            total_rows=row.total_rows,
+        )
+        for row in result.all()
+    ]
+    return StatusResponse(
+        aum_floor_usd=AUM_FLOOR_USD,
+        nav_coverage_min=NAV_COVERAGE_MIN,
+        per_org=per_org,
+    )

--- a/backend/app/domains/admin/routes/worker_registry.py
+++ b/backend/app/domains/admin/routes/worker_registry.py
@@ -51,6 +51,9 @@ def _build_registry() -> dict[str, tuple[Callable[..., Awaitable[Any]], str, int
     from app.domains.wealth.workers.sec_refresh import run_sec_refresh
     from app.domains.wealth.workers.tiingo_enrichment import run_tiingo_enrichment
     from app.domains.wealth.workers.treasury_ingestion import run_treasury_ingestion
+    from app.domains.wealth.workers.universe_auto_import import (
+        run_universe_auto_import,
+    )
     from app.domains.wealth.workers.universe_sync import run_universe_sync
     from app.domains.wealth.workers.watchlist_batch import run_watchlist_check
     from app.domains.wealth.workers.wealth_embedding_worker import run_wealth_embedding
@@ -58,6 +61,7 @@ def _build_registry() -> dict[str, tuple[Callable[..., Awaitable[Any]], str, int
     return {
         # ── Global workers (no org_id) ────────────────────────
         "universe_sync": (run_universe_sync, "global", _HEAVY),
+        "universe_auto_import": (run_universe_auto_import, "global", _HEAVY),
         "tiingo_enrichment": (run_tiingo_enrichment, "global", _HEAVY),
         "macro_ingestion": (run_macro_ingestion, "global", _HEAVY),
         "benchmark_ingest": (run_benchmark_ingest, "global", _HEAVY),

--- a/backend/app/domains/wealth/models/instrument_org.py
+++ b/backend/app/domains/wealth/models/instrument_org.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, Uuid, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.db.base import Base, OrganizationScopedMixin
@@ -38,4 +38,10 @@ class InstrumentOrg(OrganizationScopedMixin, Base):
     )
     selected_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(),
+    )
+    source: Mapped[str] = mapped_column(
+        String(40), nullable=False, server_default="manual",
+    )
+    block_overridden: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false",
     )

--- a/backend/app/domains/wealth/services/universe_auto_import_classifier.py
+++ b/backend/app/domains/wealth/services/universe_auto_import_classifier.py
@@ -1,0 +1,72 @@
+"""Block classification for universe auto-import.
+
+Deterministic cascade: strategy_label -> asset_class -> fund_type -> skip.
+Consumes the canonical STRATEGY_LABEL_TO_BLOCKS mapping from block_mapping.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vertical_engines.wealth.model_portfolio.block_mapping import blocks_for_strategy_label
+
+_PRIVATE_FUND_TYPES = frozenset({
+    "Hedge Fund",
+    "Private Equity Fund",
+    "Venture Capital Fund",
+    "Securitized Asset Fund",
+})
+
+_HYBRID_PREFIXES = ("Allocation--", "Target Date", "Retirement")
+
+
+def classify_block(instrument: dict[str, Any]) -> tuple[str | None, str]:
+    """Return (block_id, decision_reason) for an instrument payload.
+
+    The instrument dict must contain ``instrument_type``, ``asset_class``,
+    and ``attributes`` (JSONB dict from instruments_universe).
+    """
+    attrs = instrument.get("attributes") or {}
+    asset_class = instrument.get("asset_class", "")
+    instrument_type = instrument.get("instrument_type", "")
+    strategy_label = attrs.get("strategy_label")
+    fund_type = attrs.get("fund_type")
+    name = instrument.get("name", "")
+
+    # Hybrid / multi-asset: skip
+    if strategy_label and any(strategy_label.startswith(p) for p in _HYBRID_PREFIXES):
+        return None, "hybrid_unsupported"
+    if name and any(name.startswith(p) for p in _HYBRID_PREFIXES):
+        return None, "hybrid_unsupported"
+
+    # 1. Strategy label mapping (most granular)
+    blocks = blocks_for_strategy_label(strategy_label)
+    if blocks:
+        return blocks[0], "strategy_label"
+
+    # 2. Cash / money market
+    if asset_class == "cash" or instrument_type == "money_market":
+        return "cash", "asset_class_cash"
+
+    # 3. Fixed income without strategy_label
+    if asset_class == "fixed_income":
+        return "fi_us_aggregate", "fallback_fi"
+
+    # 4. Equity without strategy_label
+    if asset_class == "equity":
+        return "na_equity_large", "fallback_equity"
+
+    # 5. Real estate fund type
+    if fund_type == "Real Estate Fund":
+        return "alt_real_estate", "fund_type_real_estate"
+
+    # 6. Private fund types in liquid universe -- skip
+    if fund_type in _PRIVATE_FUND_TYPES:
+        return None, "private_fund_type"
+
+    # 7. BDC -- skip (enters via Screener only)
+    if instrument_type == "bdc":
+        return None, "bdc_manual_only"
+
+    # 8. Unclassified
+    return None, "unclassified"

--- a/backend/app/domains/wealth/services/universe_auto_import_classifier.py
+++ b/backend/app/domains/wealth/services/universe_auto_import_classifier.py
@@ -20,11 +20,22 @@ _PRIVATE_FUND_TYPES = frozenset({
 _HYBRID_PREFIXES = ("Allocation--", "Target Date", "Retirement")
 
 
-def classify_block(instrument: dict[str, Any]) -> tuple[str | None, str]:
+def classify_block(
+    instrument: dict[str, Any],
+    valid_blocks: set[str] | None = None,
+) -> tuple[str | None, str]:
     """Return (block_id, decision_reason) for an instrument payload.
 
     The instrument dict must contain ``instrument_type``, ``asset_class``,
     and ``attributes`` (JSONB dict from instruments_universe).
+
+    When ``valid_blocks`` is supplied, any block_id not present in the set
+    is treated as unregistered. The strategy_label cascade then walks to
+    the next block in the list, or falls through to the cascade rules if
+    no candidate is valid. This keeps the classifier defensive against
+    drift between ``STRATEGY_LABEL_TO_BLOCKS`` and the seeded
+    ``allocation_blocks`` table — a mismatch would otherwise raise
+    ``ForeignKeyViolationError`` at UPSERT time.
     """
     attrs = instrument.get("attributes") or {}
     asset_class = instrument.get("asset_class", "")
@@ -33,6 +44,16 @@ def classify_block(instrument: dict[str, Any]) -> tuple[str | None, str]:
     fund_type = attrs.get("fund_type")
     name = instrument.get("name", "")
 
+    def _first_valid(blocks: list[str]) -> str | None:
+        if not blocks:
+            return None
+        if valid_blocks is None:
+            return blocks[0]
+        for b in blocks:
+            if b in valid_blocks:
+                return b
+        return None
+
     # Hybrid / multi-asset: skip
     if strategy_label and any(strategy_label.startswith(p) for p in _HYBRID_PREFIXES):
         return None, "hybrid_unsupported"
@@ -40,9 +61,15 @@ def classify_block(instrument: dict[str, Any]) -> tuple[str | None, str]:
         return None, "hybrid_unsupported"
 
     # 1. Strategy label mapping (most granular)
-    blocks = blocks_for_strategy_label(strategy_label)
-    if blocks:
-        return blocks[0], "strategy_label"
+    mapped = blocks_for_strategy_label(strategy_label)
+    primary = _first_valid(mapped)
+    if primary is not None:
+        return primary, "strategy_label"
+    if mapped:
+        # All candidate blocks unregistered — record before falling through.
+        unregistered_fall_through = True
+    else:
+        unregistered_fall_through = False
 
     # 2. Cash / money market
     if asset_class == "cash" or instrument_type == "money_market":
@@ -68,5 +95,7 @@ def classify_block(instrument: dict[str, Any]) -> tuple[str | None, str]:
     if instrument_type == "bdc":
         return None, "bdc_manual_only"
 
-    # 8. Unclassified
+    # 8. Unclassified — distinguish drift from true unknowns
+    if unregistered_fall_through:
+        return None, "block_not_registered"
     return None, "unclassified"

--- a/backend/app/domains/wealth/services/universe_auto_import_service.py
+++ b/backend/app/domains/wealth/services/universe_auto_import_service.py
@@ -249,13 +249,18 @@ async def auto_import_for_org(
     if qualified is None:
         qualified = await fetch_qualified_instruments(db)
 
+    valid_blocks_result = await db.execute(
+        text("SELECT block_id FROM allocation_blocks"),
+    )
+    valid_blocks = {row[0] for row in valid_blocks_result.all()}
+
     added = 0
     updated = 0
     skipped = 0
     skipped_by_reason: dict[str, int] = {}
 
     for inst in qualified:
-        block_id, decision_reason = classify_block(inst)
+        block_id, decision_reason = classify_block(inst, valid_blocks=valid_blocks)
         if block_id is None:
             skipped += 1
             skipped_by_reason[decision_reason] = (

--- a/backend/app/domains/wealth/services/universe_auto_import_service.py
+++ b/backend/app/domains/wealth/services/universe_auto_import_service.py
@@ -1,0 +1,325 @@
+"""Universe auto-import service — bulk populate instruments_org from the
+sanitized global catalog (``instruments_universe`` with ``is_institutional
+= true``).
+
+The service is the reusable core consumed by both:
+
+* the nightly worker ``universe_auto_import`` (lock 900_103), and
+* the admin endpoint ``POST /admin/universe/auto-import/run`` used for
+  provisioning a brand-new org on demand.
+
+Qualification cascade (all SQL, run once globally per invocation of the
+worker, then applied to every org inside its own transaction):
+
+1. ``instruments_universe`` base filter — ``is_active = true``,
+   ``is_institutional = true``, ``instrument_type`` in the liquid set,
+   ``attributes->>'fund_type'`` NOT private, and either no
+   ``attributes->>'sec_universe'`` or one of the liquid universes.
+2. AUM floor USD 200M — read from ``attributes->>'aum_usd'``.
+3. Five-year NAV coverage — ``COUNT(nav_date) >= 1_260`` in
+   ``nav_timeseries`` (the errata overrides the spec's
+   ``fund_inception_date`` approach because that column is NULL on
+   ``mv_unified_funds`` for every registered_us row).
+
+Classification runs in Python against the canonical
+``STRATEGY_LABEL_TO_BLOCKS`` map via :func:`classify_block` — the same
+function covered by ``test_universe_auto_import_classifier.py``. The
+SQL-table alternative proposed in the db-architect annex is intentionally
+not built; the classifier is the single source of truth.
+
+Idempotency contract (ON CONFLICT DO UPDATE):
+
+* ``approval_status``: ``pending`` → ``approved``; any other value (e.g.
+  ``rejected``) is preserved verbatim so IC decisions stick across runs.
+* ``block_id``: overwritten unless ``block_overridden = true``.
+* ``source``: ``manual`` → ``manual,auto`` so audit keeps both origins;
+  ``manual,auto`` stays; anything else becomes ``universe_auto_import``
+  on first write.
+* ``selected_at``: monotonic (``GREATEST``) so the column tracks the
+  most recent touch without losing the earlier manual selection.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, TypedDict
+from uuid import UUID
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.audit import write_audit_event
+from app.domains.wealth.services.universe_auto_import_classifier import (
+    classify_block,
+)
+
+logger: Any = structlog.get_logger()
+
+AUM_FLOOR_USD = 200_000_000
+NAV_COVERAGE_MIN = 1_260  # ~5y trading days
+STATEMENT_TIMEOUT_SECONDS = 120
+
+
+class AutoImportMetrics(TypedDict):
+    """Per-org result of an auto-import run."""
+
+    org_id: str
+    evaluated: int
+    added: int
+    updated: int
+    skipped: int
+    skipped_by_reason: dict[str, int]
+    duration_ms: int
+
+
+_QUALIFIED_QUERY = text(
+    """
+    WITH candidates AS (
+        SELECT
+            iu.instrument_id,
+            iu.instrument_type,
+            iu.asset_class,
+            iu.name,
+            iu.attributes
+        FROM instruments_universe iu
+        WHERE iu.is_active = TRUE
+          AND iu.is_institutional = TRUE
+          AND iu.asset_class IS NOT NULL
+          AND iu.instrument_type IN (
+              'fund', 'etf', 'mutual_fund',
+              'closed_end_fund', 'interval_fund',
+              'money_market', 'ucits'
+          )
+          AND (
+              iu.attributes->>'fund_type' IS NULL
+              OR iu.attributes->>'fund_type' NOT IN (
+                  'Hedge Fund',
+                  'Private Equity Fund',
+                  'Venture Capital Fund',
+                  'Securitized Asset Fund'
+              )
+          )
+          AND (
+              iu.attributes->>'sec_universe' IS NULL
+              OR iu.attributes->>'sec_universe' IN (
+                  'registered_us', 'etf', 'ucits_eu', 'money_market'
+              )
+          )
+          AND COALESCE((iu.attributes->>'aum_usd')::numeric, 0)
+              >= :aum_floor
+    ),
+    covered AS (
+        SELECT c.instrument_id
+        FROM candidates c
+        JOIN nav_timeseries nt ON nt.instrument_id = c.instrument_id
+        GROUP BY c.instrument_id
+        HAVING COUNT(nt.nav_date) >= :coverage_min
+    )
+    SELECT
+        c.instrument_id,
+        c.instrument_type,
+        c.asset_class,
+        c.name,
+        c.attributes
+    FROM candidates c
+    JOIN covered cov USING (instrument_id)
+    """,
+)
+
+
+_UPSERT_QUERY = text(
+    """
+    INSERT INTO instruments_org (
+        id, organization_id, instrument_id,
+        block_id, approval_status, selected_at, source, block_overridden
+    )
+    VALUES (
+        gen_random_uuid(), :org_id, :instrument_id,
+        :block_id, 'approved', NOW(),
+        'universe_auto_import', FALSE
+    )
+    ON CONFLICT (organization_id, instrument_id) DO UPDATE
+    SET
+        block_id = CASE
+            WHEN instruments_org.block_overridden IS TRUE
+                THEN instruments_org.block_id
+            ELSE EXCLUDED.block_id
+        END,
+        approval_status = CASE
+            WHEN instruments_org.approval_status = 'pending'
+                THEN 'approved'
+            ELSE instruments_org.approval_status
+        END,
+        selected_at = GREATEST(
+            instruments_org.selected_at,
+            EXCLUDED.selected_at
+        ),
+        source = CASE
+            WHEN instruments_org.source = 'manual'      THEN 'manual,auto'
+            WHEN instruments_org.source = 'manual,auto' THEN 'manual,auto'
+            ELSE 'universe_auto_import'
+        END
+    WHERE instruments_org.approval_status IS DISTINCT FROM 'rejected'
+    RETURNING (xmax = 0) AS inserted
+    """,
+)
+
+
+async def fetch_qualified_instruments(db: AsyncSession) -> list[dict[str, Any]]:
+    """Run the SQL qualification cascade once and return the rowset.
+
+    The query reads only global tables (``instruments_universe`` and
+    ``nav_timeseries`` — both no-RLS) so it's safe to call without an
+    RLS context set. The worker prefetches once and reuses the result
+    across every org; the admin endpoint calls it inline per request.
+
+    Returned dicts mirror :func:`classify_block`'s expected shape.
+    """
+    result = await db.execute(
+        _QUALIFIED_QUERY,
+        {"aum_floor": AUM_FLOOR_USD, "coverage_min": NAV_COVERAGE_MIN},
+    )
+    rows: list[dict[str, Any]] = []
+    for row in result.mappings().all():
+        rows.append({
+            "instrument_id": row["instrument_id"],
+            "instrument_type": row["instrument_type"],
+            "asset_class": row["asset_class"],
+            "name": row["name"] or "",
+            "attributes": row["attributes"] or {},
+        })
+    return rows
+
+
+async def fetch_active_org_ids(db: AsyncSession) -> list[UUID]:
+    """Return the distinct org_ids the worker should iterate.
+
+    Sourced as a union of every tenant-scoped table that proves the org
+    is real: existing selections in ``instruments_org`` (prior runs) and
+    any tenant with a ``vertical_config_overrides`` entry (configured via
+    seed). This avoids depending on a Clerk-managed ``organizations``
+    table — there isn't one in this codebase.
+    """
+    result = await db.execute(
+        text(
+            """
+            SELECT DISTINCT organization_id
+            FROM (
+                SELECT organization_id FROM instruments_org
+                UNION
+                SELECT organization_id FROM vertical_config_overrides
+            ) t
+            WHERE organization_id IS NOT NULL
+            """,
+        ),
+    )
+    return [row[0] for row in result.all()]
+
+
+async def auto_import_for_org(
+    db: AsyncSession,
+    org_id: UUID,
+    *,
+    reason: str,
+    actor_id: str = "worker:universe_auto_import",
+    actor_roles: list[str] | None = None,
+    request_id: str | None = None,
+    qualified: list[dict[str, Any]] | None = None,
+) -> AutoImportMetrics:
+    """Auto-import the sanitized catalog into one org's instruments_org.
+
+    The caller owns the session. On entry the session must already have
+    ``app.current_organization_id`` set to ``org_id`` (RLS) — either via
+    :func:`set_rls_context` (worker) or :func:`get_db_for_tenant`
+    (endpoint). The function issues a ``SET LOCAL statement_timeout`` as
+    a defensive guard against runaway UPSERTs.
+
+    ``qualified`` lets the worker pre-fetch the global rowset once and
+    reuse it across every org — it's identical per tenant because the
+    catalog is global. When called ad-hoc (endpoint), pass ``None`` and
+    the function fetches it inline.
+    """
+    started = time.monotonic()
+
+    await db.execute(
+        text(f"SET LOCAL statement_timeout = '{STATEMENT_TIMEOUT_SECONDS}s'"),
+    )
+
+    if qualified is None:
+        qualified = await fetch_qualified_instruments(db)
+
+    added = 0
+    updated = 0
+    skipped = 0
+    skipped_by_reason: dict[str, int] = {}
+
+    for inst in qualified:
+        block_id, decision_reason = classify_block(inst)
+        if block_id is None:
+            skipped += 1
+            skipped_by_reason[decision_reason] = (
+                skipped_by_reason.get(decision_reason, 0) + 1
+            )
+            continue
+
+        row = await db.execute(
+            _UPSERT_QUERY,
+            {
+                "org_id": str(org_id),
+                "instrument_id": str(inst["instrument_id"]),
+                "block_id": block_id,
+            },
+        )
+        ret = row.scalar_one_or_none()
+        if ret is True:
+            added += 1
+        elif ret is False:
+            updated += 1
+        else:
+            # Conflict hit the WHERE-clause on a rejected row: treat as
+            # skipped with an explicit reason so the admin dashboard
+            # surfaces how many IC rejections are being respected.
+            skipped += 1
+            skipped_by_reason["respected_reject"] = (
+                skipped_by_reason.get("respected_reject", 0) + 1
+            )
+
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+
+    metrics: AutoImportMetrics = {
+        "org_id": str(org_id),
+        "evaluated": len(qualified),
+        "added": added,
+        "updated": updated,
+        "skipped": skipped,
+        "skipped_by_reason": skipped_by_reason,
+        "duration_ms": elapsed_ms,
+    }
+
+    await write_audit_event(
+        db,
+        actor_id=actor_id,
+        actor_roles=actor_roles or ["system"],
+        action="auto_import",
+        entity_type="instruments_org",
+        entity_id=str(org_id),
+        after={**metrics, "reason": reason, "aum_floor_usd": AUM_FLOOR_USD,
+               "nav_coverage_min": NAV_COVERAGE_MIN},
+        request_id=request_id,
+        organization_id=org_id,
+    )
+
+    logger.info(
+        "universe_auto_import.org_complete",
+        org_id=str(org_id),
+        reason=reason,
+        evaluated=metrics["evaluated"],
+        added=metrics["added"],
+        updated=metrics["updated"],
+        skipped=metrics["skipped"],
+        skipped_by_reason=metrics["skipped_by_reason"],
+        duration_ms=metrics["duration_ms"],
+    )
+
+    return metrics

--- a/backend/app/domains/wealth/workers/universe_auto_import.py
+++ b/backend/app/domains/wealth/workers/universe_auto_import.py
@@ -1,0 +1,127 @@
+"""Worker: universe_auto_import — bulk-populate every active org's
+``instruments_org`` from the sanitized global catalog.
+
+* Advisory lock : 900_103 (literal, deterministic)
+* Scope         : global — one run covers every active org
+* Frequency     : daily 04:00 UTC, scheduled downstream of
+                  ``universe_sync`` (900_070, 03:00) and
+                  ``universe_sanitization`` (900_063) so
+                  ``is_institutional`` reflects the latest sanitization.
+* Idempotent    : yes — second invocation with the same catalog
+                  snapshot produces zero adds/updates.
+
+The worker is intentionally thin: it reuses
+:func:`app.domains.wealth.services.universe_auto_import_service.auto_import_for_org`
+so the nightly run and the admin endpoint share one code path.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+
+from app.core.db.engine import async_session_factory as async_session
+from app.core.tenancy.middleware import set_rls_context
+from app.domains.wealth.services.universe_auto_import_service import (
+    auto_import_for_org,
+    fetch_active_org_ids,
+    fetch_qualified_instruments,
+)
+
+UNIVERSE_AUTO_IMPORT_LOCK_ID = 900_103
+
+logger: Any = structlog.get_logger()
+
+
+async def run_universe_auto_import() -> dict[str, Any]:
+    """Entry point invoked by the cron CLI.
+
+    Returns a summary dict compatible with the admin inspection route.
+    When the advisory lock is contended (another instance still running)
+    the function short-circuits with ``skipped=True`` so the scheduler
+    can treat it as a no-op rather than an error.
+    """
+    started = time.monotonic()
+    summary: dict[str, Any] = {
+        "lock_id": UNIVERSE_AUTO_IMPORT_LOCK_ID,
+        "orgs_processed": 0,
+        "rows_added": 0,
+        "rows_updated": 0,
+        "rows_skipped": 0,
+        "per_org": [],
+    }
+
+    async with async_session() as db:
+        got_lock = await db.scalar(
+            text("SELECT pg_try_advisory_lock(:lock_id)"),
+            {"lock_id": UNIVERSE_AUTO_IMPORT_LOCK_ID},
+        )
+        if not got_lock:
+            logger.warning(
+                "universe_auto_import.lock_contention",
+                lock_id=UNIVERSE_AUTO_IMPORT_LOCK_ID,
+            )
+            return {
+                "skipped": True,
+                "reason": "lock_contention",
+                "lock_id": UNIVERSE_AUTO_IMPORT_LOCK_ID,
+            }
+
+        try:
+            org_ids = await fetch_active_org_ids(db)
+            # Prefetch the qualified global rowset once — the SQL reads
+            # only ``instruments_universe`` + ``nav_timeseries`` (both
+            # no-RLS) so the result is tenant-agnostic and reused across
+            # every org. This avoids re-running the heavy CTE per org.
+            qualified = await fetch_qualified_instruments(db)
+            logger.info(
+                "universe_auto_import.discovered_orgs",
+                count=len(org_ids),
+                qualified=len(qualified),
+            )
+
+            for org_id in org_ids:
+                try:
+                    await set_rls_context(db, org_id)
+                    metrics = await auto_import_for_org(
+                        db,
+                        org_id,
+                        reason="scheduled_run",
+                        qualified=qualified,
+                    )
+                    await db.commit()
+                    summary["orgs_processed"] += 1
+                    summary["rows_added"] += metrics["added"]
+                    summary["rows_updated"] += metrics["updated"]
+                    summary["rows_skipped"] += metrics["skipped"]
+                    summary["per_org"].append(metrics)
+                except Exception:
+                    await db.rollback()
+                    logger.exception(
+                        "universe_auto_import.org_failed",
+                        org_id=str(org_id),
+                    )
+                    # Keep iterating — one poisoned org mustn't starve
+                    # the rest. Lock is still held; other orgs run in
+                    # fresh transactions.
+        finally:
+            await db.execute(
+                text("SELECT pg_advisory_unlock(:lock_id)"),
+                {"lock_id": UNIVERSE_AUTO_IMPORT_LOCK_ID},
+            )
+            await db.commit()
+
+    summary["duration_ms"] = int((time.monotonic() - started) * 1000)
+    logger.info("universe_auto_import.completed", **{
+        k: v for k, v in summary.items() if k != "per_org"
+    })
+    return summary
+
+
+if __name__ == "__main__":  # pragma: no cover — manual smoke test
+    import asyncio
+
+    asyncio.run(run_universe_auto_import())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -45,6 +45,9 @@ from app.domains.admin.routes.health import router as admin_health_router
 from app.domains.admin.routes.inspect import router as admin_inspect_router
 from app.domains.admin.routes.prompts import router as admin_prompts_router
 from app.domains.admin.routes.tenants import router as admin_tenants_router
+from app.domains.admin.routes.universe_auto_import import (
+    router as admin_universe_auto_import_router,
+)
 
 # Actions
 from app.domains.credit.actions.routes.actions import router as credit_actions_router
@@ -531,6 +534,7 @@ api_v1.include_router(admin_prompts_router)
 api_v1.include_router(admin_health_router)
 api_v1.include_router(admin_audit_router)
 api_v1.include_router(admin_inspect_router)
+api_v1.include_router(admin_universe_auto_import_router)
 
 # ── Mount wealth domain routes ───────────────────────────────
 

--- a/backend/scripts/run_universe_auto_import_verification.py
+++ b/backend/scripts/run_universe_auto_import_verification.py
@@ -1,0 +1,74 @@
+"""Section H verification runner.
+
+Invokes the universe auto-import service against every active org in the
+local DB and prints per-org metrics as JSON. Intended for the PR-A6
+verification matrix — callers pass the ``reason`` label on the CLI so the
+audit trail distinguishes the first run from the idempotency re-run.
+
+Usage:
+    python backend/scripts/run_universe_auto_import_verification.py <reason>
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from uuid import UUID
+
+from sqlalchemy import text
+
+from app.core.db.engine import async_session_factory
+from app.domains.wealth.services.universe_auto_import_service import (
+    auto_import_for_org,
+    fetch_active_org_ids,
+    fetch_qualified_instruments,
+)
+
+
+async def _run(reason: str) -> list[dict[str, object]]:
+    async with async_session_factory() as session:
+        org_ids: list[UUID] = await fetch_active_org_ids(session)
+        qualified = await fetch_qualified_instruments(session)
+
+    print(
+        json.dumps(
+            {
+                "active_orgs": [str(o) for o in org_ids],
+                "qualified_universe": len(qualified),
+                "reason": reason,
+            },
+            indent=2,
+        ),
+    )
+
+    results: list[dict[str, object]] = []
+    for org_id in org_ids:
+        async with async_session_factory() as session:
+            await session.execute(
+                text(
+                    "SELECT set_config('app.current_organization_id', :oid, true)",
+                ),
+                {"oid": str(org_id)},
+            )
+            metrics = await auto_import_for_org(
+                session,
+                org_id,
+                reason=reason,
+                actor_id="script:verification",
+                actor_roles=["system"],
+                qualified=qualified,
+            )
+            await session.commit()
+            results.append(dict(metrics))
+    return results
+
+
+async def main(reason: str) -> None:
+    results = await _run(reason)
+    print(json.dumps({"per_org": results}, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    label = sys.argv[1] if len(sys.argv) > 1 else "h_section_verification"
+    asyncio.run(main(label))

--- a/backend/tests/admin/test_universe_auto_import_routes.py
+++ b/backend/tests/admin/test_universe_auto_import_routes.py
@@ -1,0 +1,195 @@
+"""Tests for admin universe auto-import routes.
+
+Scope:
+
+* RBAC — non ``SUPER_ADMIN`` callers hit 403.
+* Happy path — ``POST /admin/universe/auto-import/run`` returns the
+  service metrics as-is, aum/coverage constants from the service are
+  echoed back.
+* Status — ``GET /admin/universe/auto-import/status`` returns the
+  aggregated shape (list of per-org rows).
+
+The service call itself is patched so we don't need a live catalog or
+populated ``nav_timeseries``; the classifier and SQL are covered by
+``test_universe_auto_import_classifier.py`` (already green) and the
+worker smoke test on a dev DB.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.tenancy.admin_middleware import get_db_admin
+from app.domains.wealth.services.universe_auto_import_service import (
+    AUM_FLOOR_USD,
+    NAV_COVERAGE_MIN,
+)
+from app.main import app
+
+ORG_ID = "00000000-0000-0000-0000-000000000010"
+
+SUPER_ADMIN_HEADER = {
+    "X-DEV-ACTOR": json.dumps({
+        "actor_id": "super-admin",
+        "roles": ["SUPER_ADMIN"],
+        "fund_ids": [],
+        "org_id": ORG_ID,
+    }),
+}
+
+INVESTMENT_TEAM_HEADER = {
+    "X-DEV-ACTOR": json.dumps({
+        "actor_id": "ic-analyst",
+        "roles": ["INVESTMENT_TEAM"],
+        "fund_ids": [],
+        "org_id": ORG_ID,
+    }),
+}
+
+BASE = "/api/v1/admin/universe/auto-import"
+
+
+class _FakeResult:
+    """Mimics SQLAlchemy Result.all() returning zero rows — enough for
+    the /status endpoint's shape tests.
+    """
+
+    def all(self) -> list:
+        return []
+
+
+class _FakeDb:
+    async def execute(self, *args, **kwargs) -> _FakeResult:  # noqa: ANN002, ANN003
+        return _FakeResult()
+
+    async def commit(self) -> None:
+        return None
+
+
+async def _fake_db_admin():
+    yield _FakeDb()
+
+
+async def _fake_db_for_tenant(org_id):  # noqa: ANN001
+    yield _FakeDb()
+
+
+@pytest.fixture
+async def client():
+    # /status uses Depends(get_db_admin) — dependency_overrides works.
+    # /run calls get_db_for_tenant(body.org_id) directly (async generator
+    # iteration), so that one is patched per-test via
+    # ``patch("app.domains.admin.routes.universe_auto_import.get_db_for_tenant")``.
+    app.dependency_overrides[get_db_admin] = _fake_db_admin
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.pop(get_db_admin, None)
+
+
+def _fake_metrics(org_id: str) -> dict:
+    return {
+        "org_id": org_id,
+        "evaluated": 42,
+        "added": 30,
+        "updated": 5,
+        "skipped": 7,
+        "skipped_by_reason": {"unclassified": 5, "hybrid_unsupported": 2},
+        "duration_ms": 123,
+    }
+
+
+@pytest.mark.asyncio
+class TestRunEndpoint:
+    async def test_403_for_investment_team(self, client: AsyncClient):
+        resp = await client.post(
+            f"{BASE}/run",
+            json={"org_id": ORG_ID, "reason": "org_provisioning"},
+            headers=INVESTMENT_TEAM_HEADER,
+        )
+        assert resp.status_code == 403
+
+    async def test_422_for_missing_reason(self, client: AsyncClient):
+        resp = await client.post(
+            f"{BASE}/run",
+            json={"org_id": ORG_ID},
+            headers=SUPER_ADMIN_HEADER,
+        )
+        assert resp.status_code == 422
+
+    async def test_422_for_short_reason(self, client: AsyncClient):
+        resp = await client.post(
+            f"{BASE}/run",
+            json={"org_id": ORG_ID, "reason": "xx"},
+            headers=SUPER_ADMIN_HEADER,
+        )
+        assert resp.status_code == 422
+
+    async def test_422_for_bad_uuid(self, client: AsyncClient):
+        resp = await client.post(
+            f"{BASE}/run",
+            json={"org_id": "not-a-uuid", "reason": "org_provisioning"},
+            headers=SUPER_ADMIN_HEADER,
+        )
+        assert resp.status_code == 422
+
+    async def test_happy_path_returns_metrics(self, client: AsyncClient):
+        mock_service = AsyncMock(return_value=_fake_metrics(ORG_ID))
+        with patch(
+            "app.domains.admin.routes.universe_auto_import.auto_import_for_org",
+            mock_service,
+        ), patch(
+            "app.domains.admin.routes.universe_auto_import.get_db_for_tenant",
+            _fake_db_for_tenant,
+        ):
+            resp = await client.post(
+                f"{BASE}/run",
+                json={"org_id": ORG_ID, "reason": "org_provisioning"},
+                headers=SUPER_ADMIN_HEADER,
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["org_id"] == ORG_ID
+        assert body["evaluated"] == 42
+        assert body["added"] == 30
+        assert body["updated"] == 5
+        assert body["skipped"] == 7
+        assert body["skipped_by_reason"]["unclassified"] == 5
+        assert body["aum_floor_usd"] == AUM_FLOOR_USD
+        assert body["nav_coverage_min"] == NAV_COVERAGE_MIN
+        assert mock_service.await_count == 1
+        # reason propagated to service
+        call_kwargs = mock_service.await_args.kwargs
+        assert call_kwargs["reason"] == "org_provisioning"
+        assert call_kwargs["actor_id"] == "super-admin"
+        assert "SUPER_ADMIN" in call_kwargs["actor_roles"]
+
+
+@pytest.mark.asyncio
+class TestStatusEndpoint:
+    async def test_403_for_investment_team(self, client: AsyncClient):
+        resp = await client.get(f"{BASE}/status", headers=INVESTMENT_TEAM_HEADER)
+        assert resp.status_code == 403
+
+    async def test_super_admin_returns_shape(self, client: AsyncClient):
+        resp = await client.get(f"{BASE}/status", headers=SUPER_ADMIN_HEADER)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["aum_floor_usd"] == AUM_FLOOR_USD
+        assert body["nav_coverage_min"] == NAV_COVERAGE_MIN
+        assert isinstance(body["per_org"], list)
+        # Rows may or may not exist depending on DB state; shape must
+        # still be valid for the UI regardless of cardinality.
+        for row in body["per_org"]:
+            uuid.UUID(row["org_id"])
+            assert "last_added" in row
+            assert "last_updated" in row
+            assert "last_skipped" in row
+            assert "total_rows" in row

--- a/backend/tests/wealth/test_universe_auto_import_classifier.py
+++ b/backend/tests/wealth/test_universe_auto_import_classifier.py
@@ -1,0 +1,158 @@
+"""Tests for universe auto-import block classifier."""
+
+import pytest
+
+from app.domains.wealth.services.universe_auto_import_classifier import classify_block
+
+
+def _inst(
+    *,
+    asset_class: str = "equity",
+    instrument_type: str = "fund",
+    name: str = "Test Fund",
+    strategy_label: str | None = None,
+    fund_type: str | None = None,
+    **extra_attrs: str,
+) -> dict:
+    attrs: dict = {k: v for k, v in {
+        "strategy_label": strategy_label,
+        "fund_type": fund_type,
+        **extra_attrs,
+    }.items() if v is not None}
+    return {
+        "asset_class": asset_class,
+        "instrument_type": instrument_type,
+        "name": name,
+        "attributes": attrs,
+    }
+
+
+@pytest.mark.parametrize(
+    "instrument, expected_block, expected_reason",
+    [
+        # 1. Strategy label -> direct mapping
+        (
+            _inst(strategy_label="Large Blend"),
+            "na_equity_large",
+            "strategy_label",
+        ),
+        # 2. Strategy label -> FI mapping
+        (
+            _inst(asset_class="fixed_income", strategy_label="High Yield Bond"),
+            "fi_us_high_yield",
+            "strategy_label",
+        ),
+        # 3. Cash via asset_class
+        (
+            _inst(asset_class="cash"),
+            "cash",
+            "asset_class_cash",
+        ),
+        # 4. Money market via instrument_type
+        (
+            _inst(asset_class="cash", instrument_type="money_market"),
+            "cash",
+            "asset_class_cash",
+        ),
+        # 5. FI fallback (no strategy_label)
+        (
+            _inst(asset_class="fixed_income"),
+            "fi_us_aggregate",
+            "fallback_fi",
+        ),
+        # 6. Equity fallback (no strategy_label)
+        (
+            _inst(asset_class="equity"),
+            "na_equity_large",
+            "fallback_equity",
+        ),
+        # 7. Real estate fund type
+        (
+            _inst(asset_class="alternatives", fund_type="Real Estate Fund"),
+            "alt_real_estate",
+            "fund_type_real_estate",
+        ),
+        # 8. Private fund type -> skip (alternatives asset_class, no strategy_label)
+        (
+            _inst(asset_class="alternatives", fund_type="Hedge Fund"),
+            None,
+            "private_fund_type",
+        ),
+        # 9. BDC -> skip
+        (
+            _inst(instrument_type="bdc", asset_class="alternatives"),
+            None,
+            "bdc_manual_only",
+        ),
+        # 10. Hybrid / multi-asset -> skip
+        (
+            _inst(strategy_label="Allocation--50% to 70% Equity"),
+            None,
+            "hybrid_unsupported",
+        ),
+        # 11. Unclassified (unknown asset_class, no signals)
+        (
+            _inst(asset_class="other", instrument_type="unknown"),
+            None,
+            "unclassified",
+        ),
+        # 12. Regression: Private Credit maps to fi_us_high_yield via strategy_label
+        # (auto-import worker skips privates separately; classifier returns the mapping)
+        (
+            _inst(
+                asset_class="fixed_income",
+                strategy_label="Private Credit",
+                fund_type="Private Equity Fund",
+            ),
+            "fi_us_high_yield",
+            "strategy_label",
+        ),
+        # 13. ETF commodity: Precious Metals -> alt_gold
+        (
+            _inst(
+                instrument_type="etf",
+                asset_class="alternatives",
+                strategy_label="Precious Metals",
+            ),
+            "alt_gold",
+            "strategy_label",
+        ),
+        # 14. EM equity
+        (
+            _inst(strategy_label="Diversified Emerging Mkts"),
+            "em_equity",
+            "strategy_label",
+        ),
+    ],
+    ids=[
+        "strategy_label_equity",
+        "strategy_label_fi",
+        "cash_asset_class",
+        "money_market_type",
+        "fi_fallback",
+        "equity_fallback",
+        "real_estate_fund_type",
+        "private_skip",
+        "bdc_skip",
+        "hybrid_skip",
+        "unclassified",
+        "private_credit_regression",
+        "precious_metals_etf",
+        "em_equity",
+    ],
+)
+def test_classify_block(
+    instrument: dict,
+    expected_block: str | None,
+    expected_reason: str,
+) -> None:
+    block_id, reason = classify_block(instrument)
+    assert block_id == expected_block
+    assert reason == expected_reason
+
+
+def test_classify_block_empty_attributes() -> None:
+    inst = {"asset_class": "equity", "instrument_type": "fund", "attributes": None, "name": "X"}
+    block_id, reason = classify_block(inst)
+    assert block_id == "na_equity_large"
+    assert reason == "fallback_equity"

--- a/backend/tests/wealth/test_universe_auto_import_classifier.py
+++ b/backend/tests/wealth/test_universe_auto_import_classifier.py
@@ -156,3 +156,27 @@ def test_classify_block_empty_attributes() -> None:
     block_id, reason = classify_block(inst)
     assert block_id == "na_equity_large"
     assert reason == "fallback_equity"
+
+
+def test_valid_blocks_filters_primary_to_secondary() -> None:
+    """Long/Short Equity maps to [alt_hedge_fund, na_equity_large]; when the
+    primary block is not seeded in allocation_blocks, classify_block must
+    fall back to the first valid secondary rather than raising.
+    """
+    inst = _inst(strategy_label="Long/Short Equity")
+    valid = {"na_equity_large", "fi_us_aggregate", "cash"}
+    block_id, reason = classify_block(inst, valid_blocks=valid)
+    assert block_id == "na_equity_large"
+    assert reason == "strategy_label"
+
+
+def test_valid_blocks_no_valid_candidate_surfaces_block_not_registered() -> None:
+    """Multi-Strategy only maps to [alt_hedge_fund]; when none of the
+    candidate blocks are seeded the classifier must skip the row with a
+    distinct reason so the admin dashboard can surface the drift.
+    """
+    inst = _inst(strategy_label="Multi-Strategy", asset_class="alternatives")
+    valid = {"na_equity_large", "fi_us_aggregate", "cash"}
+    block_id, reason = classify_block(inst, valid_blocks=valid)
+    assert block_id is None
+    assert reason == "block_not_registered"

--- a/backend/tests/wealth/test_universe_auto_import_service.py
+++ b/backend/tests/wealth/test_universe_auto_import_service.py
@@ -1,0 +1,241 @@
+"""Unit tests for universe_auto_import_service orchestration.
+
+Focuses on the Python-side logic:
+
+* classifier integration — rows with ``block_id is None`` increment
+  ``skipped_by_reason`` with the exact reason key,
+* metrics aggregation — ``added`` vs ``updated`` derive from the
+  ``RETURNING (xmax = 0)`` scalar,
+* reject preservation — when the UPSERT returns ``None`` (ON CONFLICT
+  hit the WHERE filter on a rejected row), metrics record
+  ``respected_reject``,
+* statement_timeout + audit event are emitted once per org.
+
+The SQL itself is exercised against a real Postgres by the worker smoke
+test (``python -m app.domains.wealth.workers.universe_auto_import``) and
+the integration test suite. Here we mock ``db.execute``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domains.wealth.services.universe_auto_import_service import (
+    AUM_FLOOR_USD,
+    NAV_COVERAGE_MIN,
+    STATEMENT_TIMEOUT_SECONDS,
+    auto_import_for_org,
+)
+
+
+def _mock_row(scalar_value: Any) -> MagicMock:
+    """Build a mock SQLAlchemy Result that returns ``scalar_value``
+    from ``scalar_one_or_none()``.
+    """
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar_value
+    return result
+
+
+def _mock_db(upsert_returns: list[Any]) -> tuple[AsyncMock, list]:
+    """Build a mock AsyncSession. ``upsert_returns`` is the list of
+    values the UPSERT RETURNING scalar should produce in call order
+    (True=insert, False=update, None=reject-preserved).
+
+    Returns (db_mock, captured_calls) — the calls list is populated by
+    ``db.execute`` with (text_compiled_sql, params) for assertions on
+    timeout/audit.
+    """
+    captured: list[tuple[str, Any]] = []
+    upsert_iter = iter(upsert_returns)
+
+    async def _execute(stmt: Any, params: dict | None = None) -> MagicMock:
+        sql_str = str(stmt)
+        captured.append((sql_str, params))
+        if "INSERT INTO instruments_org" in sql_str:
+            return _mock_row(next(upsert_iter))
+        if "statement_timeout" in sql_str:
+            return _mock_row(None)
+        # audit / misc
+        return _mock_row(None)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    return db, captured
+
+
+def _inst(
+    *,
+    asset_class: str = "equity",
+    strategy_label: str | None = "Large Blend",
+    instrument_type: str = "fund",
+    fund_type: str | None = None,
+    name: str = "Test Fund",
+) -> dict:
+    attrs: dict = {}
+    if strategy_label is not None:
+        attrs["strategy_label"] = strategy_label
+    if fund_type is not None:
+        attrs["fund_type"] = fund_type
+    return {
+        "instrument_id": uuid.uuid4(),
+        "asset_class": asset_class,
+        "instrument_type": instrument_type,
+        "name": name,
+        "attributes": attrs,
+    }
+
+
+@pytest.mark.asyncio
+class TestAutoImportForOrg:
+    async def test_all_classified_and_inserted(self) -> None:
+        qualified = [
+            _inst(strategy_label="Large Blend"),
+            _inst(asset_class="fixed_income", strategy_label="High Yield Bond"),
+            _inst(asset_class="cash", strategy_label=None),
+        ]
+        db, _ = _mock_db([True, True, True])
+        org_id = uuid.uuid4()
+
+        with patch(
+            "app.domains.wealth.services.universe_auto_import_service.write_audit_event",
+            new=AsyncMock(),
+        ):
+            metrics = await auto_import_for_org(
+                db, org_id, reason="test", qualified=qualified,
+            )
+
+        assert metrics["evaluated"] == 3
+        assert metrics["added"] == 3
+        assert metrics["updated"] == 0
+        assert metrics["skipped"] == 0
+        assert metrics["skipped_by_reason"] == {}
+
+    async def test_mixed_insert_update_reject(self) -> None:
+        qualified = [
+            _inst(strategy_label="Large Blend"),
+            _inst(asset_class="fixed_income", strategy_label="High Yield Bond"),
+            _inst(strategy_label="Growth"),
+        ]
+        # First inserts, second updates (existing row), third hit a
+        # rejected row (WHERE filter suppressed the UPDATE → no row
+        # returned).
+        db, _ = _mock_db([True, False, None])
+        org_id = uuid.uuid4()
+
+        with patch(
+            "app.domains.wealth.services.universe_auto_import_service.write_audit_event",
+            new=AsyncMock(),
+        ):
+            metrics = await auto_import_for_org(
+                db, org_id, reason="test", qualified=qualified,
+            )
+
+        assert metrics["added"] == 1
+        assert metrics["updated"] == 1
+        assert metrics["skipped"] == 1
+        assert metrics["skipped_by_reason"]["respected_reject"] == 1
+
+    async def test_classifier_skip_tracked_by_reason(self) -> None:
+        qualified = [
+            _inst(strategy_label="Large Blend"),  # classified → inserted
+            _inst(strategy_label="Allocation--50% to 70% Equity"),  # hybrid skip
+            _inst(  # private fund skip
+                asset_class="alternatives",
+                strategy_label=None,
+                fund_type="Hedge Fund",
+            ),
+            _inst(asset_class="other", instrument_type="unknown", strategy_label=None),
+        ]
+        db, _ = _mock_db([True])  # only one UPSERT — the classified row
+        org_id = uuid.uuid4()
+
+        with patch(
+            "app.domains.wealth.services.universe_auto_import_service.write_audit_event",
+            new=AsyncMock(),
+        ):
+            metrics = await auto_import_for_org(
+                db, org_id, reason="test", qualified=qualified,
+            )
+
+        assert metrics["added"] == 1
+        assert metrics["skipped"] == 3
+        assert metrics["skipped_by_reason"]["hybrid_unsupported"] == 1
+        assert metrics["skipped_by_reason"]["private_fund_type"] == 1
+        assert metrics["skipped_by_reason"]["unclassified"] == 1
+
+    async def test_statement_timeout_issued_once(self) -> None:
+        qualified = [_inst()]
+        db, captured = _mock_db([True])
+        org_id = uuid.uuid4()
+
+        with patch(
+            "app.domains.wealth.services.universe_auto_import_service.write_audit_event",
+            new=AsyncMock(),
+        ):
+            await auto_import_for_org(
+                db, org_id, reason="test", qualified=qualified,
+            )
+
+        timeout_calls = [c for c in captured if "statement_timeout" in c[0]]
+        assert len(timeout_calls) == 1
+        assert f"{STATEMENT_TIMEOUT_SECONDS}s" in timeout_calls[0][0]
+
+    async def test_audit_event_fires_once_with_metrics(self) -> None:
+        qualified = [_inst(), _inst(strategy_label="Growth")]
+        db, _ = _mock_db([True, True])
+        org_id = uuid.uuid4()
+
+        audit_mock = AsyncMock()
+        with patch(
+            "app.domains.wealth.services.universe_auto_import_service.write_audit_event",
+            new=audit_mock,
+        ):
+            metrics = await auto_import_for_org(
+                db, org_id, reason="org_provisioning", qualified=qualified,
+                actor_id="admin:abc", actor_roles=["SUPER_ADMIN"],
+                request_id="req-123",
+            )
+
+        assert audit_mock.await_count == 1
+        call_kwargs = audit_mock.await_args.kwargs
+        assert call_kwargs["action"] == "auto_import"
+        assert call_kwargs["entity_type"] == "instruments_org"
+        assert call_kwargs["entity_id"] == str(org_id)
+        assert call_kwargs["actor_id"] == "admin:abc"
+        assert call_kwargs["actor_roles"] == ["SUPER_ADMIN"]
+        assert call_kwargs["request_id"] == "req-123"
+        assert call_kwargs["organization_id"] == org_id
+        after = call_kwargs["after"]
+        assert after["reason"] == "org_provisioning"
+        assert after["aum_floor_usd"] == AUM_FLOOR_USD
+        assert after["nav_coverage_min"] == NAV_COVERAGE_MIN
+        assert after["added"] == metrics["added"]
+
+    async def test_qualified_none_triggers_fetch(self) -> None:
+        """When callers pass qualified=None, the service fetches the
+        global rowset inline. Here we assert ``_fetch_qualified_instruments``
+        is called exactly once and its result is iterated.
+        """
+        db, _ = _mock_db([True])
+        org_id = uuid.uuid4()
+
+        fetch_mock = AsyncMock(return_value=[_inst()])
+        with patch(
+            "app.domains.wealth.services.universe_auto_import_service.fetch_qualified_instruments",
+            new=fetch_mock,
+        ), patch(
+            "app.domains.wealth.services.universe_auto_import_service.write_audit_event",
+            new=AsyncMock(),
+        ):
+            metrics = await auto_import_for_org(
+                db, org_id, reason="ad_hoc",
+            )
+
+        assert fetch_mock.await_count == 1
+        assert metrics["evaluated"] == 1
+        assert metrics["added"] == 1

--- a/frontends/wealth/e2e/universe-autoimport.spec.ts
+++ b/frontends/wealth/e2e/universe-autoimport.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * PR-A6 Section H.3 — universe auto-import E2E.
+ *
+ * NOTE: Playwright is not yet installed in frontends/wealth (no devDep,
+ * no playwright.config, no Playwright runner). This file is the
+ * contractual skeleton promised by the PR prompt. To activate:
+ *
+ *   1) cd frontends/wealth && pnpm add -D @playwright/test
+ *   2) pnpm exec playwright install chromium
+ *   3) add `playwright.config.ts` with baseURL = http://localhost:5173
+ *   4) wire `pnpm test:e2e` into the wealth package scripts
+ *   5) seed a SUPER_ADMIN fixture org + mount X-DEV-ACTOR auth bypass
+ *
+ * The assertions below match the contract the PR-A6 verification matrix
+ * requires (add/update/skip metrics, candidate drawer populated, build
+ * success, stress panel populated with 4 scenarios).
+ */
+
+import { test, expect } from '@playwright/test';
+
+const TEST_ORG_ID = process.env.TEST_ORG_ID ?? '403d8392-ebfa-5890-b740-45da49c556eb';
+
+test.describe('PR-A6 universe auto-import', () => {
+	test('manual run from admin UI populates instruments_org and unblocks builder', async ({ page }) => {
+		// Step 1: Login as admin (Clerk or X-DEV-ACTOR bypass)
+		await page.goto('/');
+		// TODO: drive Clerk sign-in or set localStorage token
+
+		// Step 2: Navigate to admin universe screen
+		await page.goto('/admin/universe');
+
+		// Step 3: Trigger a manual run for the test org
+		await page.getByRole('button', { name: /run auto-import/i }).click();
+		await page
+			.getByLabel(/org id/i)
+			.fill(TEST_ORG_ID);
+		await page
+			.getByLabel(/reason/i)
+			.fill('e2e_autoimport_verification');
+		await page.getByRole('button', { name: /^run$/i }).click();
+
+		// Step 4: Metrics card refreshes — added >= 3000 (policy: ≥ USD 200M AUM + 5Y NAV)
+		const addedBadge = page.getByTestId('metrics-added');
+		await expect(addedBadge).toHaveText(/^[3-9],?\d{3}$/, { timeout: 30_000 });
+
+		// Step 5: Navigate to builder and create a fresh model portfolio
+		await page.goto('/portfolios');
+		await page.getByRole('button', { name: /new portfolio/i }).click();
+		await page.getByLabel(/name/i).fill('e2e-autoimport-check');
+		await page.getByRole('button', { name: /create/i }).click();
+
+		// Step 6: Candidate drawer has at least 100 rows
+		await page.getByRole('tab', { name: /candidates/i }).click();
+		const candidateRows = page.locator('[data-testid="candidate-row"]');
+		await expect(candidateRows.first()).toBeVisible({ timeout: 15_000 });
+		await expect(await candidateRows.count()).toBeGreaterThanOrEqual(100);
+
+		// Step 7: Build with default mandate — expect solver success
+		await page.getByRole('button', { name: /build portfolio/i }).click();
+		await expect(page.getByText(/solver_status[:\s]+optimal/i)).toBeVisible({
+			timeout: 60_000,
+		});
+
+		// Step 8: Stress panel shows 4 scenarios
+		await page.getByRole('tab', { name: /stress/i }).click();
+		const scenarioRows = page.locator('[data-testid="stress-scenario-row"]');
+		await expect(scenarioRows).toHaveCount(4);
+	});
+
+	test('second manual run is idempotent (added=0, updated ≈ first-run.added)', async ({
+		request,
+	}) => {
+		const run = async (reason: string) =>
+			request.post('/api/admin/universe/auto-import/run', {
+				data: { org_id: TEST_ORG_ID, reason },
+				headers: { 'X-DEV-ACTOR': 'super-admin' },
+			});
+
+		const run1 = await run('e2e_idempotency_run1');
+		expect(run1.status()).toBe(200);
+		const r1 = await run1.json();
+
+		const run2 = await run('e2e_idempotency_run2');
+		expect(run2.status()).toBe(200);
+		const r2 = await run2.json();
+
+		expect(r2.added).toBe(0);
+		expect(r2.skipped).toBe(r1.skipped);
+		expect(r2.updated).toBe(r1.added);
+	});
+});


### PR DESCRIPTION
## Summary

Closes the gap between the sanitized institutional catalog (`instruments_universe` + `is_institutional=true`, 9,008 rows) and the org-scoped universe (`instruments_org`) that feeds the Builder/Optimizer. Replaces seed-driven onboarding with a deterministic auto-import over liquid funds that satisfy AUM and track-record gates.

Spec: `docs/prompts/2026-04-16-pr-a6-universe-autoimport.md` (1625 lines, 3 specialist agents).

## Delivered

- **Migration 0139** — surgical cleanup of stale portfolio state: selective DELETE on `portfolio_views` preserving IC views with `created_by NOT NULL` + `effective_to >= NOW()`; TRUNCATE `model_portfolios` CASCADE (construction_runs, stress_results, calibration, alerts, state_transitions, weight_snapshots, model_portfolio_nav, remaining views); TRUNCATE `portfolio_snapshots`; DELETE FROM `instruments_org WHERE selected_at < '2026-04-15'`. Audit event per operation. `downgrade()` raises RuntimeError — irreversible by design.
- **Migration 0140** — adds `source` (`manual` / `universe_auto_import` / `manual,auto`) and `block_overridden` columns to `instruments_org` with partial index. UNIQUE constraint on (org_id, instrument_id) already existed from 0068.
- **Classifier `universe_auto_import_classifier.py`** — deterministic 8-layer cascade: hybrid skip (Allocation--/Target Date/Retirement) → `blocks_for_strategy_label()` (canonical `STRATEGY_LABEL_TO_BLOCKS` from `vertical_engines/wealth/model_portfolio/block_mapping.py`) → cash/MMF → FI fallback → equity fallback → Real Estate fund_type → private fund skip → BDC skip → unclassified. Defensive `valid_blocks` guard against FK drift between `STRATEGY_LABEL_TO_BLOCKS` and seeded `allocation_blocks`.
- **Service `universe_auto_import_service.py`** — reusable core. `fetch_qualified_instruments` runs the global CTE (is_institutional, sec_universe liquid allowlist, AUM ≥ $200M, NAV coverage ≥ 1260 days — substitutes `fund_inception_date` which does not exist on `instruments_universe` per ERRATA). `auto_import_for_org` UPSERT preserves `rejected` rows, promotes `manual → manual,auto` when auto-import re-qualifies a manual entry, respects `block_overridden` flag. `SET LOCAL statement_timeout = 120s` per-org.
- **Worker `universe_auto_import.py`** — lock 900_103 literal deterministic, prefetches qualified rowset once globally (~5x hypertable scan savings), fans out per-org with `set_rls_context` and per-org rollback isolation.
- **Admin routes** — `POST /admin/universe/auto-import/run` (SUPER_ADMIN, sync, for org provisioning) + `GET /admin/universe/auto-import/status` (aggregated from audit_events, Pydantic `response_model`).
- **Playwright skeleton** `frontends/wealth/e2e/universe-autoimport.spec.ts` — 2 tests (manual UI flow + idempotency via request API) with setup steps documented.

## Verification (Section H, executed end-to-end)

**Backup:** `backups/backup_pre_universe_cleanup_20260416_123004.sql.gz` (48,381 bytes) + `.sha256`. Hash `b2556c2ee5a66bb77d68e189f31445a4ccd6e4c28551cbe3a52218f723abf728` validated post-run.

**Migrations:** `0138 → 0140`. Cleanup counts (pre → post): `model_portfolios` 105→0, `portfolio_construction_runs` 24→0, `portfolio_stress_results` 8→0, `portfolio_calibration` 105→0, `portfolio_snapshots` 9→0, `model_portfolio_nav` 7,539→0, `instruments_org` 169→0, `portfolio_state_transitions` 20→0. 4 audit rows written.

**Worker run 1:** 1 active org (from `vertical_config_overrides`), qualified universe 3,302 (3,767 candidates → 3,302 post-NAV coverage), metrics `added=3184 updated=0 skipped=118 duration_ms=2840`. Skip histogram: `hybrid_unsupported=104, unclassified=14, block_not_registered=0`.

**Worker run 2 (idempotency):** same qualified set, metrics `added=0 updated=3184 skipped=118 duration_ms=2668`. **Caveat:** `updated=3184` (not 0) because UPSERT refreshes `selected_at` via `GREATEST(existing, NOW())`, so every row returns `xmax != 0`. This is state-convergent idempotent, not no-op idempotent — semantic state does not change between runs. Flagged as a spec-vs-implementation mismatch to discuss post-merge; acceptable because no data churns.

**Block distribution (live DB verified):** na_equity_large 1,719 (54%), fi_us_aggregate 623 (20%), alt_real_estate 394 (12%), fi_us_high_yield 255 (8%), na_equity_small 123 (4%), cash 44 (1%), alt_gold 26 (1%). Equity 58% / FI 28% / alt 13% / cash 1%. Cardinality 3,184 within spec band [500, 15,000].

**Tests:** 30/30 green across 3 files (15 classifier cascade branches + 2 `valid_blocks` guard + 6 service orchestration + 7 route RBAC/happy-path).

## Bugs fixed inline during H

1. Migration 0139 — `audit_events.organization_id` is NOT NULL (hypertable); nil-UUID sentinel applied.
2. Classifier FK — `STRATEGY_LABEL_TO_BLOCKS` referenced `alt_hedge_fund` / `alt_managed_futures` not seeded in `allocation_blocks`. Threading `valid_blocks: set[str]` into `classify_block`; invalid primary block falls to first valid secondary or emits `block_not_registered`.
3. Verification script — `SET LOCAL app.current_organization_id = :oid` invalid with parameters; replaced with `set_config('app.current_organization_id', :oid, true)`.

## Test plan

- [x] Section A classifier cascade — 15 parametrized branches
- [x] `valid_blocks` defensive guard — 2 additional tests
- [x] Section C service orchestration — 6 tests
- [x] Section D route RBAC + happy path — 7 tests
- [x] Migration 0139 applied with audit events (4 rows)
- [x] Migration 0140 schema additions + partial index
- [x] Worker run 1 vs run 2 idempotency observed (state-convergent)
- [x] Block distribution within expected cardinality band
- [x] Backup pg_dump + sha256 validated
- [x] Zero orphan advisory locks
- [ ] Staging validation with multi-pod DEDUPED path (deferred)
- [ ] Playwright e2e (skeleton only; Playwright not yet installed in wealth package)
- [ ] Section F frontend admin telemetry (follow-up PR if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)