### PR TITLE
feat(wealth): universe pre-filter cascade (PR-A7)

### DIFF
--- a/backend/app/core/db/migrations/versions/0141_portfolio_status_degraded.py
+++ b/backend/app/core/db/migrations/versions/0141_portfolio_status_degraded.py
@@ -1,0 +1,80 @@
+"""portfolio_construction_runs: extend status CHECK with 'degraded'.
+
+PR-A7 §B — when the optimizer cascade exhausts all four CLARABEL phases
+and the run is completed by the proportional heuristic fallback, the
+terminal status is ``degraded`` rather than ``succeeded``. The prior
+constraint allowed only ``{running, succeeded, failed, superseded,
+cancelled}``; this migration adds ``degraded`` as a sixth legal state
+so the executor can persist the new signal.
+
+DROP + ADD inside a single DDL transaction (no table rewrite). Existing
+rows remain valid under the new constraint.
+
+Revision ID: 0141_portfolio_status_degraded
+Revises: 0140_instruments_org_source_override
+Create Date: 2026-04-16
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0141_portfolio_status_degraded"
+down_revision: str | None = "0140_instruments_org_source_override"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        DROP CONSTRAINT portfolio_construction_runs_status_check
+        """,
+    )
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        ADD CONSTRAINT portfolio_construction_runs_status_check
+        CHECK (status = ANY (ARRAY[
+            'running'::text,
+            'succeeded'::text,
+            'failed'::text,
+            'superseded'::text,
+            'cancelled'::text,
+            'degraded'::text
+        ]))
+        """,
+    )
+
+
+def downgrade() -> None:
+    # Roll any 'degraded' rows into 'succeeded' before tightening the
+    # constraint — the downgrade must not fail on existing data. The
+    # optimizer_trace.solver = 'heuristic_fallback' signal on the row
+    # remains, so re-upgrading recovers the distinction deterministically.
+    op.execute(
+        """
+        UPDATE portfolio_construction_runs
+        SET status = 'succeeded'
+        WHERE status = 'degraded'
+        """,
+    )
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        DROP CONSTRAINT portfolio_construction_runs_status_check
+        """,
+    )
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        ADD CONSTRAINT portfolio_construction_runs_status_check
+        CHECK (status = ANY (ARRAY[
+            'running'::text,
+            'succeeded'::text,
+            'failed'::text,
+            'superseded'::text,
+            'cancelled'::text
+        ]))
+        """,
+    )

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -1855,8 +1855,10 @@ async def _run_construction_async(
     _regime_result = await db.execute(_regime_stmt)
     current_regime = _regime_result.scalar_one_or_none() or "RISK_ON"
 
-    # ── 2. Load approved universe (filtered by regime ELITE set) ──
-    universe_funds = await _load_universe_funds(db, org_id, regime=current_regime)
+    # ── 2. Load approved universe, pre-filtered by profile + top-N per block ──
+    universe_funds = await _load_universe_funds(
+        db, org_id, profile=profile, regime=current_regime,
+    )
     if not universe_funds:
         return {"funds": [], "profile": profile, "error": "No approved funds in universe"}
 
@@ -2297,28 +2299,57 @@ async def _compute_factor_exposures(
         return None
 
 
+#: Layer 2 cap — top-N funds per strategic block, ranked by manager_score desc.
+#: 7 populated blocks × 50 ≈ 350 CLARABEL inputs, inside the tractable band [200, 400]
+#: per the quant architect's empirical guidance (PR-A7 spec, 2026-04-16).
+LAYER_2_TOP_N_PER_BLOCK = 50
+
+
 async def _load_universe_funds(
     db: AsyncSession,
     org_id: str,
+    *,
+    profile: str,
     regime: str = "RISK_ON",
 ) -> list[dict[str, Any]]:
-    """Load approved universe instruments with manager_score from risk metrics.
+    """Load org universe funds with a two-layer deterministic pre-filter.
 
-    The optimizer works over the FULL approved universe — not just ELITE.
-    ELITE is a screener UX badge for analyst navigation, not a construction
-    constraint. More candidates = more degrees of freedom = better portfolio.
+    The optimizer works over the approved universe, but the raw cardinality
+    (~3,184 funds post auto-import) drowns ``_align_returns_with_ffill`` in
+    ``compute_fund_level_inputs`` — with heterogeneous NAV histories the
+    common-date intersection collapses and CLARABEL never runs. The two
+    layers below reduce the input to ~320 without losing the "best" funds
+    in any block.
+
+    * **Layer 0 — Strategic block filter.** JOIN against ``strategic_allocation``
+      for the caller's ``profile`` so funds sitting in blocks that aren't in
+      this profile's allocation are excluded at SQL time. The current
+      ``instruments_org`` population puts all imported funds in blocks that
+      all three profiles share, so Layer 0 is a near-no-op today — but it
+      future-proofs for profile-specific block menus.
+    * **Layer 2 — Top-N per block.** ``ROW_NUMBER() OVER (PARTITION BY block_id
+      ORDER BY manager_score DESC, instrument_id ASC)`` keeps at most
+      ``LAYER_2_TOP_N_PER_BLOCK`` rows per block. The ``instrument_id``
+      tiebreak makes the cut reproducible across planner choices.
+
+    ``manager_score`` is read from the same ``latest_risk`` CTE (global
+    rows, ``organization_id IS NULL``) that the JOIN already dedupes — no
+    separate second query.
 
     Liquid funds (registered_us, etf, ucits_eu, money_market) are approved
-    by default when imported to the org. Only private_us and bdc require
-    manual DD-gated approval via UniverseApproval.
+    at import time; private_us and bdc require DD-gated approval before
+    reaching ``instruments_org``. The gate is at IMPORT time, not here.
     """
     from sqlalchemy import func as sa_func
 
+    from app.domains.wealth.models.allocation import StrategicAllocation
     from app.domains.wealth.models.instrument import Instrument
     from app.domains.wealth.models.instrument_org import InstrumentOrg
     from app.domains.wealth.models.risk import FundRiskMetrics
 
-    # Subquery: latest risk metrics row per instrument (for manager_score)
+    today = date.today()
+
+    # Subquery: latest risk metrics row per instrument (global rows only)
     latest_risk = (
         select(
             FundRiskMetrics.instrument_id,
@@ -2329,11 +2360,21 @@ async def _load_universe_funds(
         .subquery("latest_risk")
     )
 
-    stmt = (
+    # Rank funds within each block by manager_score, tie-broken by instrument_id
+    # for deterministic ordering across query planner choices.
+    ranked_cte = (
         select(
-            Instrument.instrument_id,
-            Instrument.name,
-            InstrumentOrg.block_id,
+            Instrument.instrument_id.label("instrument_id"),
+            Instrument.name.label("name"),
+            InstrumentOrg.block_id.label("block_id"),
+            FundRiskMetrics.manager_score.label("manager_score"),
+            sa_func.row_number().over(
+                partition_by=InstrumentOrg.block_id,
+                order_by=(
+                    FundRiskMetrics.manager_score.desc().nulls_last(),
+                    Instrument.instrument_id.asc(),
+                ),
+            ).label("rn"),
         )
         .join(InstrumentOrg, InstrumentOrg.instrument_id == Instrument.instrument_id)
         .join(
@@ -2346,45 +2387,43 @@ async def _load_universe_funds(
             (latest_risk.c.instrument_id == FundRiskMetrics.instrument_id)
             & (latest_risk.c.max_date == FundRiskMetrics.calc_date),
         )
-        .where(
-            Instrument.is_active == True,
-            InstrumentOrg.block_id.isnot(None),
-            # All funds imported to the org (instruments_org with block_id)
-            # are eligible for construction. Liquid funds (MF/ETF/MMF/UCITS)
-            # are approved by default at import time. Private/BDC funds
-            # require DD-gated approval before instruments_org import.
-            # The gate is at IMPORT time, not at construction time.
+        # Layer 0 — only blocks present in this profile's strategic allocation
+        .join(
+            StrategicAllocation,
+            (StrategicAllocation.block_id == InstrumentOrg.block_id)
+            & (StrategicAllocation.profile == profile)
+            & (StrategicAllocation.effective_from <= today)
+            & (
+                StrategicAllocation.effective_to.is_(None)
+                | (StrategicAllocation.effective_to > today)
+            ),
         )
-    )
-    funds_result = await db.execute(stmt)
-    funds_rows = funds_result.all()
+        .where(
+            Instrument.is_active == True,  # noqa: E712 — SQLAlchemy boolean compare
+            InstrumentOrg.block_id.isnot(None),
+        )
+    ).cte("ranked_universe")
 
-    if not funds_rows:
-        return []
+    stmt = select(
+        ranked_cte.c.instrument_id,
+        ranked_cte.c.name,
+        ranked_cte.c.block_id,
+        ranked_cte.c.manager_score,
+    ).where(ranked_cte.c.rn <= LAYER_2_TOP_N_PER_BLOCK)
 
-    fund_ids = [r.instrument_id for r in funds_rows]
-
-    # Latest risk metrics for manager_score
-    risk_stmt = (
-        select(FundRiskMetrics.instrument_id, FundRiskMetrics.manager_score)
-        .where(FundRiskMetrics.instrument_id.in_(fund_ids))
-        .order_by(FundRiskMetrics.instrument_id, FundRiskMetrics.calc_date.desc())
-        .distinct(FundRiskMetrics.instrument_id)
-    )
-    risk_result = await db.execute(risk_stmt)
-    score_map = {
-        r.instrument_id: float(r.manager_score) if r.manager_score else None
-        for r in risk_result.all()
-    }
+    result = await db.execute(stmt)
+    rows = result.all()
 
     return [
         {
             "instrument_id": str(r.instrument_id),
             "fund_name": r.name,
             "block_id": r.block_id,
-            "manager_score": score_map.get(r.instrument_id),
+            "manager_score": (
+                float(r.manager_score) if r.manager_score is not None else None
+            ),
         }
-        for r in funds_rows
+        for r in rows
     ]
 
 

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -735,11 +735,21 @@ async def execute_construction_run(
         )
         return run
 
-    run.status = "succeeded"
+    # Detect heuristic fallback — CLARABEL cascade exhausted, the run was
+    # "rescued" by the proportional heuristic. Per PR-A7 §B.1, this is a
+    # degraded outcome, not a success: the optimizer produced a sensible
+    # portfolio, but none of the formal phases (primary / robust / CVaR /
+    # min-variance) found a feasible solution on the input universe.
+    solver = (run.optimizer_trace or {}).get("solver")
+    run.status = "degraded" if solver == "heuristic_fallback" else "succeeded"
     run.completed_at = datetime.now(tz=timezone.utc)
     run.wall_clock_ms = int((time.perf_counter() - start_ts) * 1000)
     await db.flush()
 
+    # Keep the raw_type as ``run_succeeded`` so the existing frontend
+    # ``phase === "COMPLETED"`` mapping still terminates the builder flow;
+    # the ``status`` field on the payload carries the degraded signal so
+    # downstream UI can render a fallback badge (frontend work lands in PR-A8).
     await _publish_terminal_event_sanitized(
         db,
         run_id=run_id,
@@ -747,7 +757,7 @@ async def execute_construction_run(
         raw_type="run_succeeded",
         raw_payload={
             "run_id": str(run_id),
-            "status": "succeeded",
+            "status": run.status,
             "wall_clock_ms": run.wall_clock_ms,
         },
     )
@@ -757,6 +767,7 @@ async def execute_construction_run(
         extra={
             "run_id": str(run_id),
             "portfolio_id": str(portfolio_id),
+            "status": run.status,
             "wall_clock_ms": run.wall_clock_ms,
         },
     )

--- a/backend/tests/wealth/test_load_universe_funds_prefilter.py
+++ b/backend/tests/wealth/test_load_universe_funds_prefilter.py
@@ -1,0 +1,581 @@
+"""Tests for ``_load_universe_funds`` pre-filter cascade (PR-A7).
+
+Covers the two-layer deterministic reduction from the full
+``instruments_org`` set (~3,184 post auto-import) down to the
+~350-fund tractable band that CLARABEL can actually solve:
+
+* **Layer 0** — JOIN on ``strategic_allocation`` so only blocks in the
+  caller's profile allocation survive.
+* **Layer 2** — ``ROW_NUMBER() OVER (PARTITION BY block_id ORDER BY
+  manager_score DESC, instrument_id ASC)`` caps each block at
+  ``LAYER_2_TOP_N_PER_BLOCK`` rows.
+
+Also covers the ``succeeded → degraded`` status gate introduced in §B:
+when the optimizer result exits the CLARABEL cascade via
+``heuristic_fallback``, the run is persisted as ``degraded`` rather
+than ``succeeded``.
+
+Every seeded test runs inside a single transaction that is **always
+rolled back** at teardown — no commits, no leftover rows, no cross-test
+contamination. Each test uses a unique ``profile`` string (``test_p_<hex>``)
+so the SQL JOIN to ``strategic_allocation`` cannot match pre-existing
+seed rows from other profiles. This is important because the test DB
+connects as a superuser, which bypasses RLS — the profile namespace is
+the deterministic isolation mechanism. The first test hits the real
+local-dev ``403d8392`` org read-only and is marked ``integration`` so
+CI can skip it when the live DB is not reachable.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import text
+
+from app.core.db.engine import async_session_factory
+from app.domains.wealth.routes.model_portfolios import (
+    LAYER_2_TOP_N_PER_BLOCK,
+    _load_universe_funds,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+async def _set_rls(db: Any, org_id: str) -> None:
+    """Apply transaction-scoped RLS context so instruments_org /
+    strategic_allocation policies see the test org.
+    """
+    await db.execute(
+        text("SELECT set_config('app.current_organization_id', :oid, true)"),
+        {"oid": org_id},
+    )
+
+
+async def _seed_allocation_block(db: Any, block_id: str) -> None:
+    """Ensure the allocation_blocks row exists (no-op if already present).
+
+    ``allocation_blocks`` is global (no RLS) — a test block may outlive
+    the test's transactional rollback. Using ``ON CONFLICT DO NOTHING``
+    keeps re-runs safe, and the unique block_id namespace (``test_*``)
+    prevents collision with real seed data.
+    """
+    await db.execute(
+        text(
+            """
+            INSERT INTO allocation_blocks (
+                block_id, geography, asset_class, display_name, is_active
+            )
+            VALUES (:block_id, 'US', 'equity', :block_id, true)
+            ON CONFLICT (block_id) DO NOTHING
+            """,
+        ),
+        {"block_id": block_id},
+    )
+
+
+async def _seed_strategic_allocation(
+    db: Any,
+    *,
+    org_id: str,
+    profile: str,
+    block_id: str,
+) -> None:
+    """Insert a strategic_allocation row mapping (profile, block) for
+    the given org, with an ``effective_from`` of yesterday.
+    """
+    await db.execute(
+        text(
+            """
+            INSERT INTO strategic_allocation (
+                allocation_id, organization_id, profile, block_id,
+                target_weight, min_weight, max_weight, effective_from
+            )
+            VALUES (
+                :allocation_id, :org_id, :profile, :block_id,
+                0.1000, 0.0000, 0.2500, :effective_from
+            )
+            """,
+        ),
+        {
+            "allocation_id": uuid.uuid4(),
+            "org_id": org_id,
+            "profile": profile,
+            "block_id": block_id,
+            "effective_from": date.today() - timedelta(days=1),
+        },
+    )
+
+
+async def _seed_instrument(db: Any, name: str) -> uuid.UUID:
+    """Insert a minimal instruments_universe row. Returns instrument_id.
+
+    ``is_institutional`` is a GENERATED column (migration 0134 — reads
+    ``attributes->>'is_institutional'``), so we drive it via ``attributes``.
+    The ``chk_fund_attrs`` CHECK constraint requires every fund to carry
+    ``aum_usd``, ``manager_name``, and ``inception_date`` in attributes.
+    """
+    instrument_id = uuid.uuid4()
+    attributes = (
+        '{"is_institutional": true, "aum_usd": 1000000000, '
+        '"manager_name": "Test Manager", "inception_date": "2020-01-01"}'
+    )
+    await db.execute(
+        text(
+            """
+            INSERT INTO instruments_universe (
+                instrument_id, instrument_type, name, asset_class,
+                geography, currency, is_active,
+                attributes, created_at, updated_at
+            )
+            VALUES (
+                :instrument_id, 'fund', :name, 'equity',
+                'US', 'USD', true,
+                CAST(:attributes AS jsonb), now(), now()
+            )
+            """,
+        ),
+        {
+            "instrument_id": instrument_id,
+            "name": name,
+            "attributes": attributes,
+        },
+    )
+    return instrument_id
+
+
+async def _seed_instrument_org(
+    db: Any,
+    *,
+    org_id: str,
+    instrument_id: uuid.UUID,
+    block_id: str,
+) -> None:
+    await db.execute(
+        text(
+            """
+            INSERT INTO instruments_org (
+                id, organization_id, instrument_id, block_id,
+                approval_status, source
+            )
+            VALUES (
+                gen_random_uuid(), :org_id, :instrument_id, :block_id,
+                'approved', 'test'
+            )
+            """,
+        ),
+        {
+            "org_id": org_id,
+            "instrument_id": instrument_id,
+            "block_id": block_id,
+        },
+    )
+
+
+async def _seed_risk_metric(
+    db: Any,
+    *,
+    instrument_id: uuid.UUID,
+    manager_score: float | None,
+    calc_date: date | None = None,
+) -> None:
+    """Insert a global (``organization_id IS NULL``) fund_risk_metrics row.
+
+    This is the row the CTE's ``latest_risk`` subquery JOINs against.
+    """
+    await db.execute(
+        text(
+            """
+            INSERT INTO fund_risk_metrics (
+                instrument_id, calc_date, organization_id, manager_score
+            )
+            VALUES (
+                :instrument_id, :calc_date, NULL, :manager_score
+            )
+            ON CONFLICT DO NOTHING
+            """,
+        ),
+        {
+            "instrument_id": instrument_id,
+            "calc_date": calc_date or date.today(),
+            "manager_score": manager_score,
+        },
+    )
+
+
+# ── C.1 — Integration test against live org ──────────────────────────
+
+
+@pytest.mark.integration
+async def test_prefilter_reduces_to_target_cardinality() -> None:
+    """Pre-filter cascade reduces 3,184 → ~300-400 for conservative profile.
+
+    Layer 2 caps 50 per block × 7 populated blocks ≈ 350. Some blocks
+    have <50 funds (cash 44, alt_gold 26) so the actual lands below
+    7×50. The 200-400 band guards against both a runaway (>400 means
+    the cap didn't apply) and a collapse (<200 means Layer 0 dropped
+    too much).
+    """
+    org_id = "403d8392-ebfa-5890-b740-45da49c556eb"
+    async with async_session_factory() as db:
+        await _set_rls(db, org_id)
+        funds = await _load_universe_funds(
+            db, org_id, profile="conservative",
+        )
+    assert 200 <= len(funds) <= 400, (
+        f"Got {len(funds)} funds for conservative profile — "
+        f"expected 200-400 after Layer 0 + Layer 2 pre-filter"
+    )
+    # Every row must have block_id populated — Layer 0 requires the JOIN
+    assert all(f["block_id"] for f in funds), "Some fund returned with null block"
+    # No block should exceed the Layer 2 cap
+    per_block: dict[str, int] = {}
+    for f in funds:
+        per_block[f["block_id"]] = per_block.get(f["block_id"], 0) + 1
+    for block, n in per_block.items():
+        assert n <= LAYER_2_TOP_N_PER_BLOCK, (
+            f"Block {block} has {n} funds, exceeds cap {LAYER_2_TOP_N_PER_BLOCK}"
+        )
+
+
+# ── C.2 — Layer 0 profile filtering ──────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_layer0_filters_blocks_outside_profile() -> None:
+    """Funds in a block NOT present in the profile's strategic allocation
+    must be excluded at SQL time.
+
+    Seeds two ``instruments_org`` rows for a fresh org: one sitting in
+    a block allocated to ``conservative`` and one sitting in a block
+    that is NOT. Layer 0 must keep only the first.
+    """
+    org_id = str(uuid.uuid4())
+    profile = f"test_p_{uuid.uuid4().hex[:10]}"
+    in_profile_block = f"test_l0_in_{uuid.uuid4().hex[:8]}"
+    out_profile_block = f"test_l0_out_{uuid.uuid4().hex[:8]}"
+
+    async with async_session_factory() as db:
+        try:
+            await _set_rls(db, org_id)
+            await _seed_allocation_block(db, in_profile_block)
+            await _seed_allocation_block(db, out_profile_block)
+            # Only the in-profile block gets a strategic_allocation row
+            await _seed_strategic_allocation(
+                db, org_id=org_id, profile=profile,
+                block_id=in_profile_block,
+            )
+
+            in_iid = await _seed_instrument(db, "In-Profile Fund")
+            out_iid = await _seed_instrument(db, "Out-Profile Fund")
+
+            await _seed_instrument_org(
+                db, org_id=org_id, instrument_id=in_iid,
+                block_id=in_profile_block,
+            )
+            await _seed_instrument_org(
+                db, org_id=org_id, instrument_id=out_iid,
+                block_id=out_profile_block,
+            )
+
+            await _seed_risk_metric(db, instrument_id=in_iid, manager_score=0.75)
+            await _seed_risk_metric(db, instrument_id=out_iid, manager_score=0.90)
+            await db.flush()
+
+            funds = await _load_universe_funds(
+                db, org_id, profile=profile,
+            )
+
+            instrument_ids = {f["instrument_id"] for f in funds}
+            assert str(in_iid) in instrument_ids, (
+                "In-profile fund missing from pre-filter output"
+            )
+            assert str(out_iid) not in instrument_ids, (
+                "Out-of-profile fund leaked through Layer 0"
+            )
+        finally:
+            # Roll back the whole test transaction — no committed state
+            # leaks between tests or into the real DB.
+            await db.rollback()
+
+
+# ── C.3 — Layer 2 top-N cap ──────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_layer2_caps_top_n_per_block_by_manager_score() -> None:
+    """Seeds 60 funds in a single block with manager_score 0.01…0.60 and
+    asserts exactly ``LAYER_2_TOP_N_PER_BLOCK=50`` rows are returned,
+    all with the 50 HIGHEST scores, ordered DESC.
+    """
+    org_id = str(uuid.uuid4())
+    profile = f"test_p_{uuid.uuid4().hex[:10]}"
+    block_id = f"test_l2_cap_{uuid.uuid4().hex[:8]}"
+    n_seeded = 60
+
+    async with async_session_factory() as db:
+        try:
+            await _set_rls(db, org_id)
+            await _seed_allocation_block(db, block_id)
+            await _seed_strategic_allocation(
+                db, org_id=org_id, profile=profile, block_id=block_id,
+            )
+            # Seed 60 funds with monotonically increasing manager_score
+            # so the cut is easy to validate: top 50 must be score >= 0.11.
+            for i in range(n_seeded):
+                iid = await _seed_instrument(db, f"Cap Test {i:02d}")
+                await _seed_instrument_org(
+                    db, org_id=org_id, instrument_id=iid, block_id=block_id,
+                )
+                # Score in [0.01, 0.60]
+                await _seed_risk_metric(
+                    db, instrument_id=iid,
+                    manager_score=round((i + 1) / 100.0, 2),
+                )
+            await db.flush()
+
+            funds = await _load_universe_funds(
+                db, org_id, profile=profile,
+            )
+
+            assert len(funds) == LAYER_2_TOP_N_PER_BLOCK, (
+                f"Expected exactly {LAYER_2_TOP_N_PER_BLOCK} rows, got {len(funds)}"
+            )
+            scores = [f["manager_score"] for f in funds]
+            # DESC order — first element is the highest score, last is the
+            # lowest kept
+            assert scores == sorted(scores, reverse=True), (
+                f"manager_score must be DESC, got {scores}"
+            )
+            # Lowest kept score must be 0.11 — the 10 lowest (0.01-0.10)
+            # should have been dropped by the Top-N cap.
+            min_kept = min(s for s in scores if s is not None)
+            assert min_kept >= 0.11 - 1e-9, (
+                f"Lowest kept score {min_kept}, expected >= 0.11 "
+                f"(scores 0.01-0.10 should have been cut)"
+            )
+        finally:
+            await db.rollback()
+
+
+# ── C.4 — Deterministic ordering ─────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_prefilter_ordering_is_deterministic_across_runs() -> None:
+    """Tie-break by instrument_id ASC must survive query planner churn.
+
+    Seeds 10 funds in a block, all with the same manager_score, and
+    runs the pre-filter twice back-to-back. The returned instrument_id
+    sequences must match byte-for-byte.
+    """
+    org_id = str(uuid.uuid4())
+    profile = f"test_p_{uuid.uuid4().hex[:10]}"
+    block_id = f"test_det_{uuid.uuid4().hex[:8]}"
+
+    async with async_session_factory() as db:
+        try:
+            await _set_rls(db, org_id)
+            await _seed_allocation_block(db, block_id)
+            await _seed_strategic_allocation(
+                db, org_id=org_id, profile=profile, block_id=block_id,
+            )
+            for i in range(10):
+                iid = await _seed_instrument(db, f"Determinism {i}")
+                await _seed_instrument_org(
+                    db, org_id=org_id, instrument_id=iid, block_id=block_id,
+                )
+                # Identical score so the instrument_id ASC tie-break is
+                # the only thing making the ordering deterministic.
+                await _seed_risk_metric(db, instrument_id=iid, manager_score=0.5)
+            await db.flush()
+
+            first = await _load_universe_funds(db, org_id, profile=profile)
+            second = await _load_universe_funds(db, org_id, profile=profile)
+
+            first_ids = [f["instrument_id"] for f in first]
+            second_ids = [f["instrument_id"] for f in second]
+            assert first_ids == second_ids, (
+                f"Ordering drifted between runs: "
+                f"first={first_ids} second={second_ids}"
+            )
+            # With the ASC tie-break the ids must be sorted lexicographically
+            assert first_ids == sorted(first_ids), (
+                f"Tie-broken ordering must be instrument_id ASC, got {first_ids}"
+            )
+        finally:
+            await db.rollback()
+
+
+# ── C.5 — succeeded → degraded status gate ───────────────────────────
+
+
+@pytest.mark.integration
+async def test_executor_marks_heuristic_fallback_runs_as_degraded() -> None:
+    """When the optimizer result's ``solver`` is ``heuristic_fallback``
+    the run terminates with ``status='degraded'``, not ``'succeeded'``.
+
+    Patches ``_run_construction_async`` (imported lazily inside
+    ``_execute_inner``) to return a fixed output with ``solver =
+    heuristic_fallback`` and all 4 CLARABEL phases failed/skipped, then
+    calls ``execute_construction_run`` against the real DB and asserts
+    the persisted ``run.status``. Validates both the new CHECK
+    constraint (migration 0141) and the status gate.
+    """
+    from unittest.mock import patch as mock_patch
+
+    from app.domains.wealth.models.model_portfolio import ModelPortfolio
+    from app.domains.wealth.workers.construction_run_executor import (
+        execute_construction_run,
+    )
+
+    org_id = str(uuid.uuid4())
+    portfolio_id = uuid.uuid4()
+
+    fake_base_result: dict[str, Any] = {
+        "funds": [
+            {
+                "instrument_id": str(uuid.uuid4()),
+                "fund_name": "Heuristic Pick",
+                "block_id": "test_deg_block",
+                "weight": 1.0,
+            },
+        ],
+        "profile": "moderate",
+        "optimization": {
+            "solver": "heuristic_fallback",
+            "status": "fallback:insufficient_fund_data",
+            "expected_return": None,
+            "portfolio_volatility": None,
+            "sharpe_ratio": None,
+            "cvar_95": None,
+            "cvar_limit": -0.08,
+        },
+        "taa": None,
+    }
+
+    async def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return fake_base_result
+
+    async with async_session_factory() as db:
+        try:
+            await _set_rls(db, org_id)
+            db.add(
+                ModelPortfolio(
+                    id=portfolio_id,
+                    organization_id=uuid.UUID(org_id),
+                    display_name="Degraded Path Test",
+                    profile="moderate",
+                    state="draft",
+                    state_changed_by="test",
+                    created_by="test",
+                ),
+            )
+            await db.flush()
+
+            with mock_patch(
+                "app.domains.wealth.routes.model_portfolios._run_construction_async",
+                new=_fake,
+            ):
+                run = await execute_construction_run(
+                    db,
+                    portfolio_id=portfolio_id,
+                    organization_id=org_id,
+                    requested_by="test-actor",
+                    job_id=None,
+                    as_of_date=date.today(),
+                )
+
+            assert run.status == "degraded", (
+                f"Expected status='degraded' on heuristic_fallback, "
+                f"got {run.status!r}. optimizer_trace={run.optimizer_trace!r}"
+            )
+            assert (run.optimizer_trace or {}).get("solver") == "heuristic_fallback"
+        finally:
+            await db.rollback()
+
+
+# ── C.5b — Positive control: real solver result still yields succeeded ─
+
+
+@pytest.mark.integration
+async def test_executor_marks_real_solver_runs_as_succeeded() -> None:
+    """Symmetry check — when the optimizer reports a real solver
+    (CLARABEL / SCS), the run must still terminate ``succeeded``.
+
+    Guards against over-matching: a naive implementation might set
+    ``degraded`` any time ``solver is not None`` or any time the
+    trace is non-empty.
+    """
+    from unittest.mock import patch as mock_patch
+
+    from app.domains.wealth.models.model_portfolio import ModelPortfolio
+    from app.domains.wealth.workers.construction_run_executor import (
+        execute_construction_run,
+    )
+
+    org_id = str(uuid.uuid4())
+    portfolio_id = uuid.uuid4()
+
+    fake_base_result: dict[str, Any] = {
+        "funds": [
+            {
+                "instrument_id": str(uuid.uuid4()),
+                "fund_name": "CLARABEL Pick",
+                "block_id": "test_ok_block",
+                "weight": 1.0,
+            },
+        ],
+        "profile": "moderate",
+        "optimization": {
+            "solver": "CLARABEL",
+            "status": "optimal",
+            "expected_return": 0.08,
+            "portfolio_volatility": 0.12,
+            "sharpe_ratio": 0.5,
+            "cvar_95": -0.05,
+            "cvar_limit": -0.08,
+        },
+        "taa": None,
+    }
+
+    async def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return fake_base_result
+
+    async with async_session_factory() as db:
+        try:
+            await _set_rls(db, org_id)
+            db.add(
+                ModelPortfolio(
+                    id=portfolio_id,
+                    organization_id=uuid.UUID(org_id),
+                    display_name="Success Control",
+                    profile="moderate",
+                    state="draft",
+                    state_changed_by="test",
+                    created_by="test",
+                ),
+            )
+            await db.flush()
+
+            with mock_patch(
+                "app.domains.wealth.routes.model_portfolios._run_construction_async",
+                new=_fake,
+            ):
+                run = await execute_construction_run(
+                    db,
+                    portfolio_id=portfolio_id,
+                    organization_id=org_id,
+                    requested_by="test-actor",
+                    job_id=None,
+                    as_of_date=date.today(),
+                )
+            assert run.status == "succeeded", (
+                f"Real solver result must stay 'succeeded', got {run.status!r}"
+            )
+        finally:
+            await db.rollback()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore:The garbage collector is trying to clean up non-checked-in connection:sqlalchemy.exc.SAWarning",
 ]
+markers = [
+    "integration: tests that hit the live docker-compose database (use '-m integration' to select, '-m \"not integration\"' to skip)",
+]
 addopts = "-v --tb=short"
 
 # ── Coverage ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Two-layer deterministic pre-filter at the entry of `_load_universe_funds` reduces the construction universe from ~3,184 auto-imported funds to the ~270-320 tractable band that CLARABEL can operate on.
- Layer 0 JOINs `strategic_allocation` on `(profile, block_id, effective dates)` so funds in blocks not allocated to the caller's profile drop out at SQL time. Layer 2 applies `ROW_NUMBER() OVER (PARTITION BY block_id ORDER BY manager_score DESC NULLS LAST, instrument_id ASC)` with a cap of 50 per block — the `instrument_id` tiebreak keeps the cut reproducible across planner choices.
- Fixes the "succeeded" false-positive when the optimizer exits via heuristic fallback. Migration 0141 extends `portfolio_construction_runs.status` CHECK with `'degraded'`; the status gate in `construction_run_executor` reads `optimizer_trace.solver` and flips to `degraded` only on `heuristic_fallback`.

## Observed cardinality on the live local-dev org (403d8392)

| Profile | After filter |
|---|---|
| Conservative | 50+50+50+50+44+26 = **270** |
| Moderate     | 50+50+50+50+44+26 = **270** |
| Growth       | 50+50+50+50+50+44+26 = **320** |

## Smoke test — 3 portfolios, 2026-04-16 17:46 UTC

- **Before PR-A7** — `_align_returns_with_ffill` collapses to 1 common date, caught by the outer try/except, `optimizer_trace.solver = 'heuristic_fallback'`, 18-21 weights.
- **After PR-A7** — `compute_fund_level_inputs` completes (`N = 269 / 269 / 319`, `T = 930` days), `κ(Σ) ≈ 5e5` exceeds the 1e4 error threshold, run terminates `status=failed` with `IllConditionedCovarianceError`.

The `κ(Σ)` signal is exactly what PR-A8 (Layer 3 correlation dedup) is meant to solve — one level deeper than this PR's scope. Per the spec's D.2 escape clause, the finding is recorded here rather than expanded into scope creep.

## Test plan

- [x] 6 new tests in `backend/tests/wealth/test_load_universe_funds_prefilter.py`
  - C.1 integration — target cardinality on the real `403d8392` universe
  - C.2 — Layer 0 filtering (out-of-profile block excluded)
  - C.3 — Layer 2 Top-N cap (60 seeded → 50 returned, ordered DESC)
  - C.4 — deterministic ordering (two runs byte-identical, tie-broken ASC by `instrument_id`)
  - C.5 — `heuristic_fallback` → `status='degraded'`
  - C.5b — real solver (CLARABEL) → `status='succeeded'` (negative control)
- [x] `make lint` — all checks passed
- [x] Wealth test suite — 104 tests green (6 new + 98 existing)
- [x] `make typecheck` — no new errors introduced (pre-existing repo debt unchanged)
- [x] Migration `0141_portfolio_status_degraded` applied to local dev DB
- [ ] Follow-up PR-A8: Layer 3 correlation dedup + Brinson-style strategy deduplication to tame `κ(Σ)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)