### PR TITLE
fix(config): register wealth/optimizer domain as optional (PR-A9.1)

### DIFF
--- a/backend/app/core/config/registry.py
+++ b/backend/app/core/config/registry.py
@@ -125,6 +125,15 @@ _REGISTRY: tuple[ConfigDomain, ...] = (
         description="Tenant branding: logos, colors, display name",
         required=False,
     ),
+    # ── wealth: ConfigService-managed ────────────────────────────────────
+    ConfigDomain(
+        vertical="wealth",
+        config_type="optimizer",
+        ownership="config_service",
+        client_visible=False,
+        description="Wealth construction-engine optimizer tunables (cf_relaxation_factor, etc.)",
+        required=False,
+    ),
 )
 
 

--- a/backend/tests/test_config_registry.py
+++ b/backend/tests/test_config_registry.py
@@ -79,6 +79,18 @@ class TestRegistryLookup:
         verticals = ConfigRegistry.verticals()
         assert "liquid_funds" in verticals
         assert "private_credit" in verticals
+        assert "wealth" in verticals
+
+    def test_wealth_optimizer_registered_as_optional(self):
+        """PR-A9.1: wealth/optimizer must be registered (otherwise construction
+        runs raise ConfigMissError). It must be required=False so that absence
+        of seed/override falls through to in-code default cf_relaxation_factor=1.3.
+        """
+        domain = ConfigRegistry.get("wealth", "optimizer")
+        assert domain is not None, "wealth/optimizer must be registered"
+        assert domain.required is False, "must be optional — no seed data exists"
+        assert domain.client_visible is False, "optimizer internals are IP-protected"
+        assert domain.ownership == "config_service"
 
     def test_config_service_domains_excludes_prompt_service(self):
         for d in ConfigRegistry.config_service_domains():


### PR DESCRIPTION
## Summary
- Register ("wealth", "optimizer") in ConfigRegistry as required=False
- Add test_wealth_optimizer_registered_as_optional
- Unblocks PR-A9 (κ calibration) smoke F.2 and any production tenant attempting portfolio construction

## Root cause
Commit 809b56d1 added `config_svc.get("wealth", "optimizer", ...)` without registering the domain. CFG-01 default is required=True → every construction run raises ConfigMissError before reaching the optimizer. Pre-existing bug, not introduced by PR-A9.

## Fix shape
Single ConfigDomain entry, required=False. Call site at model_portfolios.py:2190-2192 already handles MISSING_OPTIONAL correctly (defaults cf_relaxation_factor to 1.3 from the in-code literal). No migration, no seed, no CHECK constraint changes.

## Test plan
- [x] pytest backend/tests/test_config_registry.py green (incl. new test_wealth_optimizer_registered_as_optional) — 22/22
- [x] pytest backend/tests/test_config_service.py green
- [x] pytest backend/tests/test_cfg01_config_result.py green — 55/55 combined
- [x] ruff clean on touched files
- [x] mypy clean on registry.py
- [ ] Live DB smoke: deferred (Docker not running in this session; will run after merge when rebasing PR-A9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)