### PR TITLE
feat(wealth): always-solvable RU CVaR cascade (PR-A12)

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -2105,6 +2105,8 @@ async def _run_construction_async(
         available_ids = _fli.available_ids
         fund_skewness = _fli.skewness
         fund_excess_kurtosis = _fli.excess_kurtosis
+        # PR-A12 — raw scenario matrix driving the RU CVaR LP cascade.
+        returns_scenarios_full = _fli.returns_scenarios
         # PR-A9 — surface the three-tier conditioning decision so the run
         # executor can persist + emit it on the SHRINKAGE SSE phase.
         shrinkage_metrics = dict(_fli.inputs_metadata.get("conditioning") or {})
@@ -2122,6 +2124,8 @@ async def _run_construction_async(
         sub_blocks = {fid: fund_blocks[fid] for fid in opt_fund_ids}
         sub_skewness = fund_skewness[indices]
         sub_excess_kurtosis = fund_excess_kurtosis[indices]
+        # PR-A12 — slice scenario matrix to the same funds ordered as sub_cov.
+        sub_returns_scenarios = returns_scenarios_full[:, indices]
 
         # Filter and rescale constraints to covered blocks only.
         # When universe covers a subset of blocks, original min/max don't
@@ -2201,10 +2205,11 @@ async def _run_construction_async(
             fund_blocks=sub_blocks,
             expected_returns=sub_returns,
             cov_matrix=sub_cov,
+            returns_scenarios=sub_returns_scenarios,
             constraints=active_constraints,
             skewness=sub_skewness,
             excess_kurtosis=sub_excess_kurtosis,
-            cf_relaxation_factor=cf_factor,
+            cf_relaxation_factor=cf_factor,  # PR-A12: retained for one release, ignored
         )
 
         if fund_result.status.startswith("optimal") and fund_result.weights:
@@ -2294,7 +2299,12 @@ async def _run_construction_async(
     # fund-level optimizer produced the composition or the heuristic fallback
     # fired. The executor reads this block to build ``cascade_telemetry``.
     from dataclasses import asdict as _asdict
-    _cascade_phase_order = ("primary", "robust", "variance_capped", "min_variance")
+    # PR-A12 — 3-phase RU cascade. Heuristic/variance-capped/min-variance retired.
+    _cascade_phase_order = (
+        "phase_1_ru_max_return",
+        "phase_2_ru_robust",
+        "phase_3_min_cvar",
+    )
 
     def _skipped_attempts_all() -> list[dict[str, Any]]:
         return [
@@ -2302,11 +2312,9 @@ async def _run_construction_async(
                 "phase": p, "status": "skipped", "solver": None,
                 "objective_value": None, "wall_ms": 0,
                 "infeasibility_reason": None,
-                "cvar_at_solution": None, "cvar_limit_effective": None,
-                "cvar_within_limit": None, "max_var": None,
-                "max_vol_target": None, "cvar_coeff": None,
-                "cf_normal_ratio": None, "phase2_limit": None,
-                "min_achievable_variance": None, "min_achievable_vol": None,
+                "cvar_at_solution": None, "cvar_at_solution_cf": None,
+                "cvar_limit_effective": None,
+                "cvar_within_limit": None,
                 "kappa_used": None,
             }
             for p in _cascade_phase_order
@@ -2319,6 +2327,12 @@ async def _run_construction_async(
         cascade_attempts = _skipped_attempts_all()
         cascade_winning = None
 
+    # PR-A12 — the optimizer always produces RU/min-CVaR weights. The legacy
+    # "heuristic" fallback path (surfaced via composition.optimization.solver
+    # == "heuristic_fallback") is now exclusively an upstream/data failure
+    # marker — it means compute_fund_level_inputs raised before the cascade
+    # ever ran. Emit it as a distinct attempt so the executor can flag
+    # ``operator_signal.kind = "upstream_data_missing"`` downstream.
     used_heuristic = (
         composition is not None
         and composition.optimization is not None
@@ -2327,22 +2341,29 @@ async def _run_construction_async(
     )
     if used_heuristic:
         cascade_attempts.append({
-            "phase": "heuristic", "status": "succeeded",
+            "phase": "upstream_heuristic", "status": "succeeded",
             "solver": "heuristic_fallback",
             "objective_value": None, "wall_ms": 0,
             "infeasibility_reason": None,
-            "cvar_at_solution": None, "cvar_limit_effective": None,
-            "cvar_within_limit": None, "max_var": None,
-            "max_vol_target": None, "cvar_coeff": None,
-            "cf_normal_ratio": None, "phase2_limit": None,
-            "min_achievable_variance": None, "min_achievable_vol": None,
+            "cvar_at_solution": None, "cvar_at_solution_cf": None,
+            "cvar_limit_effective": None,
+            "cvar_within_limit": None,
             "kappa_used": None,
         })
-        cascade_winning = "heuristic"
+        cascade_winning = "upstream_heuristic"
+
+    # PR-A12 — achievable-return band + min-CVaR surface directly from optimizer.
+    cascade_min_cvar: float | None = None
+    cascade_band: dict[str, float] | None = None
+    if fund_result is not None:
+        cascade_min_cvar = fund_result.min_achievable_cvar
+        cascade_band = fund_result.achievable_return_band
 
     result["cascade"] = {
         "phase_attempts": cascade_attempts,
         "winning_phase": cascade_winning,
+        "min_achievable_cvar": cascade_min_cvar,
+        "achievable_return_band": cascade_band,
     }
 
     # Include TAA provenance for calibration_snapshot enrichment

--- a/backend/app/domains/wealth/services/quant_queries.py
+++ b/backend/app/domains/wealth/services/quant_queries.py
@@ -197,6 +197,12 @@ class FundLevelInputs:
     cov_matrix: npt.NDArray[np.float64]
     expected_returns: dict[str, float]
     available_ids: list[str]
+    # PR-A12 — raw scenario matrix (T, N) driving the Rockafellar-Uryasev
+    # CVaR LP. Same window + forward-fill used for Σ, trimmed to
+    # ``cov_lookback_days``. Trading-day rows where every fund is NaN are
+    # dropped upstream. T_effective >= 252 is enforced; 252 <= T < 504
+    # emits a warning (short-history universe).
+    returns_scenarios: npt.NDArray[np.float64]
     skewness: npt.NDArray[np.float64]
     excess_kurtosis: npt.NDArray[np.float64]
     condition_number: float
@@ -1653,10 +1659,24 @@ async def compute_fund_level_inputs(
         excluded_count=len(excluded),
     )
 
+    # PR-A12 — warn on short history (T < 504 = 2Y daily). The RU LP still
+    # works but CVaR tail is estimated from <2 full credit cycles. Hard
+    # floor MIN_OBSERVATIONS (252 = 1Y) is enforced earlier in this
+    # function; anything below that has already raised ValueError.
+    T_effective = int(returns_matrix.shape[0])
+    if T_effective < 504:
+        logger.warning(
+            "fund_level_inputs_short_history",
+            t_effective=T_effective,
+            recommended_min=504,
+            hard_floor=MIN_OBSERVATIONS,
+        )
+
     return FundLevelInputs(
         cov_matrix=annual_cov,
         expected_returns=expected_returns,
         available_ids=available_ids,
+        returns_scenarios=np.ascontiguousarray(returns_matrix, dtype=np.float64),
         skewness=np.asarray(skewness, dtype=np.float64),
         excess_kurtosis=np.asarray(excess_kurtosis, dtype=np.float64),
         condition_number=condition_number,

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -290,64 +290,67 @@ async def _publish_terminal_event_sanitized(
 
 # ── Per-phase cascade events ─────────────────────────────────────
 
-# Ordered cascade phases with sanitized labels per Appendix D.
+# PR-A12 — RU LP cascade. Three phases only; variance-capped + min-variance
+# + heuristic-fallback paths retired. Labels stay operator-vocabulary.
 _CASCADE_PHASES: list[tuple[str, str]] = [
-    ("primary", "Primary Objective"),
-    ("robust", "Robust Optimization"),
-    ("variance_capped", "Variance-Capped"),
-    ("min_variance", "Minimum Variance"),
-    ("heuristic", "Heuristic Recovery"),
+    ("phase_1_ru_max_return", "Max Return (CVaR-bounded)"),
+    ("phase_2_ru_robust", "Robust Max Return"),
+    ("phase_3_min_cvar", "Min Tail Risk"),
 ]
 
 # Map optimizer result status → index of the winning phase (0-based).
-# Phases before the winner failed; phases after were skipped.
+# PR-A12: "optimal" covers Phase 1/2/3 success; "degraded" = Phase 3 above
+# limit (universe floor binds); "constraint_polytope_empty" = upstream
+# configuration error (block bands unsatisfiable).
 _STATUS_TO_WINNING_PHASE: dict[str, int] = {
-    "optimal": 0,                          # Phase 1 succeeded
-    "optimal:robust": 1,                   # Phase 1.5 succeeded
-    "optimal:cvar_constrained": 2,         # Phase 2 succeeded
-    "optimal:min_variance_fallback": 3,    # Phase 3 succeeded
-    "optimal:cvar_violated": 4,            # All formal phases failed → heuristic
+    "optimal": 2,                           # winner index resolved from winning_phase below
+    "degraded": 2,                          # Phase 3 above-limit
+    "constraint_polytope_empty": 2,         # no feasible polytope
 }
 
 
-# ── PR-A11 — cascade telemetry builder ──────────────────────────
+# ── PR-A11/A12 — cascade telemetry builder ──────────────────────────
 
-# Normalized public phase keys written to the persisted column. Internal
-# optimizer keys map into these via ``_PHASE_PUBLIC_KEY``. Skipped phases
-# are padded in the same order so consumers can rely on a uniform shape.
+# Normalized public phase keys — match the optimizer's internal keys 1:1
+# (PR-A12 renames the optimizer so the remap is a no-op). Kept as a dict
+# for forward-compat if we ever want to decouple internal from external
+# naming again.
 _CASCADE_PHASE_ORDER_PUBLIC: tuple[str, ...] = (
-    "phase_1",
-    "phase_1_5_robust",
-    "phase_2_variance_capped",
-    "phase_3_min_variance",
+    "phase_1_ru_max_return",
+    "phase_2_ru_robust",
+    "phase_3_min_cvar",
 )
 
 _PHASE_PUBLIC_KEY: dict[str, str] = {
-    "primary": "phase_1",
-    "robust": "phase_1_5_robust",
-    "variance_capped": "phase_2_variance_capped",
-    "min_variance": "phase_3_min_variance",
-    "heuristic": "heuristic",
+    "phase_1_ru_max_return": "phase_1_ru_max_return",
+    "phase_2_ru_robust": "phase_2_ru_robust",
+    "phase_3_min_cvar": "phase_3_min_cvar",
+    "upstream_heuristic": "upstream_heuristic",
 }
 
-# run.status derived from cascade outcome. Phase 3 fallback and heuristic
-# fallback both produce weights but fail to honor the CVaR objective —
-# persist them as ``degraded`` so operators can gate activation.
+# run.status derived from cascade outcome.
+# - Phase 1/2 win → succeeded
+# - Phase 3 winner WITHIN cvar_limit → succeeded (rare — Phase 1 usually
+#   wins whenever the universe supports it)
+# - Phase 3 winner ABOVE cvar_limit → degraded (universe floor binds)
+# - Upstream heuristic (compute_fund_level_inputs failed before cascade) → degraded
+# - Constraint polytope empty (block bands sum > 1) → failed
 _STATUS_BY_SUMMARY: dict[str, str] = {
     "phase_1_succeeded": "succeeded",
-    "phase_1_5_robust_succeeded": "succeeded",
-    "phase_2_succeeded": "succeeded",
-    "phase_3_fallback": "degraded",
-    "heuristic_fallback": "degraded",
-    "cascade_exhausted": "failed",
+    "phase_2_robust_succeeded": "succeeded",
+    "phase_3_min_cvar_within_limit": "succeeded",
+    "phase_3_min_cvar_above_limit": "degraded",
+    "upstream_heuristic": "degraded",
+    "constraint_polytope_empty": "failed",
 }
 
+# NOTE: final summary also depends on cvar_within_limit when winning_phase
+# is phase_3_min_cvar — resolved inside ``_build_cascade_telemetry``. This
+# table handles the non-conditional cases.
 _SUMMARY_BY_WINNING_PHASE: dict[str, str] = {
-    "primary": "phase_1_succeeded",
-    "robust": "phase_1_5_robust_succeeded",
-    "variance_capped": "phase_2_succeeded",
-    "min_variance": "phase_3_fallback",
-    "heuristic": "heuristic_fallback",
+    "phase_1_ru_max_return": "phase_1_succeeded",
+    "phase_2_ru_robust": "phase_2_robust_succeeded",
+    "upstream_heuristic": "upstream_heuristic",
 }
 
 
@@ -379,6 +382,8 @@ def _build_cascade_telemetry(
     block = cascade_block or {}
     raw_attempts: list[dict[str, Any]] = list(block.get("phase_attempts") or [])
     winning_phase = block.get("winning_phase")
+    min_achievable_cvar = block.get("min_achievable_cvar")
+    achievable_return_band = block.get("achievable_return_band")
 
     # Legacy/test path: no cascade info at all → return empty telemetry
     # with a sentinel status so the caller falls back to the solver-string
@@ -388,7 +393,7 @@ def _build_cascade_telemetry(
         return {}, "unknown"
 
     # Normalize each attempt's phase key to the public naming, pad missing
-    # cascade slots with ``skipped`` so ``len(phase_attempts) >= 4`` always.
+    # cascade slots with ``skipped`` so ``len(phase_attempts) >= 3`` always.
     public_attempts: list[dict[str, Any]] = []
     seen_public: set[str] = set()
     for att in raw_attempts:
@@ -402,15 +407,9 @@ def _build_cascade_telemetry(
             "wall_ms": att.get("wall_ms") or 0,
             "infeasibility_reason": att.get("infeasibility_reason"),
             "cvar_at_solution": att.get("cvar_at_solution"),
+            "cvar_at_solution_cf": att.get("cvar_at_solution_cf"),
             "cvar_limit_effective": att.get("cvar_limit_effective"),
             "cvar_within_limit": att.get("cvar_within_limit"),
-            "max_var": att.get("max_var"),
-            "max_vol_target": att.get("max_vol_target"),
-            "cvar_coeff": att.get("cvar_coeff"),
-            "cf_normal_ratio": att.get("cf_normal_ratio"),
-            "phase2_limit": att.get("phase2_limit"),
-            "min_achievable_variance": att.get("min_achievable_variance"),
-            "min_achievable_vol": att.get("min_achievable_vol"),
             "kappa_used": att.get("kappa_used"),
         })
         seen_public.add(phase_public)
@@ -420,15 +419,13 @@ def _build_cascade_telemetry(
                 "phase": phase_public, "status": "skipped", "solver": None,
                 "objective_value": None, "wall_ms": 0,
                 "infeasibility_reason": None,
-                "cvar_at_solution": None, "cvar_limit_effective": None,
-                "cvar_within_limit": None, "max_var": None,
-                "max_vol_target": None, "cvar_coeff": None,
-                "cf_normal_ratio": None, "phase2_limit": None,
-                "min_achievable_variance": None, "min_achievable_vol": None,
+                "cvar_at_solution": None, "cvar_at_solution_cf": None,
+                "cvar_limit_effective": None,
+                "cvar_within_limit": None,
                 "kappa_used": None,
             })
 
-    # Order attempts canonically (standard 4 + heuristic last)
+    # Order attempts canonically (3 RU phases + optional upstream_heuristic last)
     order_lookup = {
         p: i for i, p in enumerate(_CASCADE_PHASE_ORDER_PUBLIC)
     }
@@ -436,62 +433,61 @@ def _build_cascade_telemetry(
         key=lambda a: order_lookup.get(a["phase"], len(_CASCADE_PHASE_ORDER_PUBLIC)),
     )
 
-    cascade_summary = _SUMMARY_BY_WINNING_PHASE.get(
-        winning_phase or "", "cascade_exhausted",
-    )
+    # Resolve cascade_summary. Phase 3 needs within-limit check to pick
+    # the right enum; Phase 1/2/upstream use the direct mapping.
+    if winning_phase == "phase_3_min_cvar":
+        phase3_attempt = next(
+            (a for a in public_attempts if a["phase"] == "phase_3_min_cvar"),
+            None,
+        )
+        within_limit = bool(phase3_attempt and phase3_attempt.get("cvar_within_limit"))
+        cascade_summary = (
+            "phase_3_min_cvar_within_limit" if within_limit
+            else "phase_3_min_cvar_above_limit"
+        )
+    else:
+        cascade_summary = _SUMMARY_BY_WINNING_PHASE.get(
+            winning_phase or "", "constraint_polytope_empty",
+        )
     run_status = _STATUS_BY_SUMMARY.get(cascade_summary, "failed")
 
-    # Phase 2 variance ceiling + universe min-variance (when relevant)
-    phase2_max_var: float | None = None
-    min_achievable_variance: float | None = None
-    for att in public_attempts:
-        if att["phase"] == "phase_2_variance_capped" and att.get("max_var") is not None:
-            phase2_max_var = float(att["max_var"])
-        if att["phase"] == "phase_3_min_variance" and att.get("min_achievable_variance") is not None:
-            min_achievable_variance = float(att["min_achievable_variance"])
-
-    # Feasibility gap only meaningful when Phase 3 actually fired. Guard
-    # against divide-by-zero for a degenerate universe.
-    feasibility_gap_pct: float | None = None
-    if (
-        cascade_summary == "phase_3_fallback"
-        and phase2_max_var is not None
-        and min_achievable_variance is not None
-        and min_achievable_variance > 0
-    ):
-        feasibility_gap_pct = round(
-            (1.0 - phase2_max_var / min_achievable_variance) * 100.0, 2,
-        )
-
-    # Operator signal — sanitized, translated by PR-A10 frontend copy.
+    # Operator signal — sanitized, translated by PR-A10/A13 frontend copy.
     operator_signal: dict[str, Any] | None
-    if cascade_summary in ("phase_1_succeeded", "phase_1_5_robust_succeeded", "phase_2_succeeded"):
+    if cascade_summary in (
+        "phase_1_succeeded",
+        "phase_2_robust_succeeded",
+        "phase_3_min_cvar_within_limit",
+    ):
         operator_signal = None
-    elif cascade_summary == "phase_3_fallback":
+    elif cascade_summary == "phase_3_min_cvar_above_limit":
+        # Tail-risk floor binds — universe cannot hit operator's CVaR limit.
         operator_signal = {
-            "kind": "constraint_binding",
-            "binding": "risk_budget",
+            "kind": "cvar_limit_below_universe_floor",
+            "binding": "tail_risk_floor",
             "message_key": "cvar_limit_below_universe_floor",
+            "min_achievable_cvar": min_achievable_cvar,
+            "user_cvar_limit": cvar_limit,
         }
-    elif cascade_summary == "heuristic_fallback":
+    elif cascade_summary == "upstream_heuristic":
+        # compute_fund_level_inputs raised before cascade ran (e.g.
+        # ill-conditioned Σ, too few funds with NAV data).
         operator_signal = {
-            "kind": "constraint_binding",
-            "binding": "solver",
-            "message_key": "convex_phases_exhausted",
+            "kind": "upstream_data_missing",
+            "binding": "returns_quality",
+            "message_key": "statistical_inputs_unavailable",
         }
-    else:  # cascade_exhausted
+    else:  # constraint_polytope_empty
         operator_signal = {
-            "kind": "cascade_failure",
-            "binding": "solver",
-            "message_key": "no_feasible_allocation",
+            "kind": "constraint_polytope_empty",
+            "binding": "block_bands",
+            "message_key": "block_bands_unsatisfiable",
         }
 
     telemetry = {
         "phase_attempts": public_attempts,
         "cascade_summary": cascade_summary,
-        "phase2_max_var": phase2_max_var,
-        "min_achievable_variance": min_achievable_variance,
-        "feasibility_gap_pct": feasibility_gap_pct,
+        "min_achievable_cvar": min_achievable_cvar,
+        "achievable_return_band": achievable_return_band,
         "operator_signal": operator_signal,
     }
     return telemetry, run_status
@@ -502,32 +498,42 @@ async def _emit_cascade_phase_events(
     *,
     run_id: uuid.UUID,
     job_id: str | None,
-    optimizer_status: str,
+    winning_phase: str | None,
     objective_value: float | None,
 ) -> None:
     """Emit retrospective per-phase optimizer events for the cascade timeline.
 
-    The optimizer runs as a single synchronous call (~200ms), so we infer
-    the cascade path from the result ``status`` and emit a burst of events
-    that the frontend CascadeTimeline can animate in sequence.
+    PR-A12 — uses the cascade's ``winning_phase`` directly (set by the RU
+    cascade) instead of inferring from solver status strings. Phase 3
+    ALWAYS runs (for the achievable band) so it is always ``succeeded``;
+    earlier phases that weren't the winner are ``failed`` or ``skipped``
+    depending on position.
     """
-    winning_idx = _STATUS_TO_WINNING_PHASE.get(optimizer_status)
-    # If status is unrecognised (e.g. "empty", "solver_failed"),
-    # treat as total failure — all phases failed, no winner.
-    total_failure = winning_idx is None
+    winning_idx: int | None = None
+    for i, (pk, _) in enumerate(_CASCADE_PHASES):
+        if pk == winning_phase:
+            winning_idx = i
+            break
+
+    total_failure = winning_idx is None and winning_phase is None
+    # Phase 3 always runs → always succeeded unless the whole cascade
+    # failed upstream (polytope empty etc).
+    phase_3_idx = next(
+        (i for i, (pk, _) in enumerate(_CASCADE_PHASES) if pk == "phase_3_min_cvar"),
+        len(_CASCADE_PHASES) - 1,
+    )
 
     for idx, (phase_key, phase_label) in enumerate(_CASCADE_PHASES):
-        # Determine phase outcome
-        if total_failure or idx < (winning_idx or 0):
+        if total_failure:
             status = "failed"
         elif idx == winning_idx:
             status = "succeeded"
+        elif idx == phase_3_idx:
+            # Always-run telemetry phase.
+            status = "succeeded"
+        elif winning_idx is not None and idx < winning_idx:
+            status = "failed"
         else:
-            status = "skipped"
-
-        # Phase 1.5 (robust) is currently not enabled — mark as skipped
-        # unless it was the actual winner (future-proofing).
-        if phase_key == "robust" and winning_idx != 1:
             status = "skipped"
 
         await _publish_event_sanitized(
@@ -1097,11 +1103,11 @@ async def _execute_inner(
         db,
         run_id=run.id,
         job_id=job_id,
-        optimizer_status=optimizer_trace.get("status") or "",
+        winning_phase=(base_result.get("cascade") or {}).get("winning_phase"),
         objective_value=optimization.get("expected_return"),
     )
 
-    # ── 4c. PR-A11 cascade telemetry (structured + sanitized) ──
+    # ── 4c. PR-A11/A12 cascade telemetry (structured + sanitized) ──
     cascade_telemetry, derived_run_status = _build_cascade_telemetry(
         cascade_block=base_result.get("cascade") or {},
         optimizer_trace=optimizer_trace,
@@ -1116,7 +1122,9 @@ async def _execute_inner(
             raw_payload={
                 "cascade_summary": cascade_telemetry.get("cascade_summary"),
                 "operator_signal": cascade_telemetry.get("operator_signal"),
-                "feasibility_gap_pct": cascade_telemetry.get("feasibility_gap_pct"),
+                # PR-A12 — Builder slider inputs. Sanitized numeric values only.
+                "min_achievable_cvar": cascade_telemetry.get("min_achievable_cvar"),
+                "achievable_return_band": cascade_telemetry.get("achievable_return_band"),
             },
         )
 

--- a/backend/quant_engine/optimizer_service.py
+++ b/backend/quant_engine/optimizer_service.py
@@ -318,7 +318,11 @@ class PhaseAttempt:
     failed.
     """
 
-    phase: str                         # "primary"|"robust"|"variance_capped"|"min_variance"|"heuristic"
+    # PR-A12 phase keys: "phase_1_ru_max_return" | "phase_2_ru_robust"
+    # | "phase_3_min_cvar". Legacy keys (primary/robust/variance_capped/
+    # min_variance/heuristic) are retired. Kept as ``str`` to preserve A11
+    # dataclass discipline.
+    phase: str
     status: str                        # "succeeded"|"infeasible"|"solver_failed"|"skipped"
     solver: str | None
     objective_value: float | None
@@ -328,14 +332,10 @@ class PhaseAttempt:
     cvar_at_solution: float | None = None
     cvar_limit_effective: float | None = None
     cvar_within_limit: bool | None = None
-    max_var: float | None = None
-    max_vol_target: float | None = None
-    cvar_coeff: float | None = None
-    cf_normal_ratio: float | None = None
-    phase2_limit: float | None = None
-    min_achievable_variance: float | None = None
-    min_achievable_vol: float | None = None
     kappa_used: float | None = None
+    # PR-A12 — CF CVaR kept as legacy comparator alongside RU-empirical
+    # ``cvar_at_solution``. Populated only on succeeded phases.
+    cvar_at_solution_cf: float | None = None
 
 
 @dataclass
@@ -352,12 +352,15 @@ class FundOptimizationResult:
     cvar_within_limit: bool
     status: str
     solver_info: str | None = None
-    # PR-A11 — cascade audit trail. ``phase_attempts`` contains one entry
-    # per cascade phase including skipped ones (>= 4 for the standard
-    # 4-phase cascade). ``winning_phase`` is one of:
-    # "primary"|"robust"|"variance_capped"|"min_variance"|"heuristic"|None.
+    # PR-A11 — cascade audit trail. Post-PR-A12 the cascade has 3 phases:
+    # "phase_1_ru_max_return" | "phase_2_ru_robust" | "phase_3_min_cvar".
+    # ``winning_phase`` is one of those keys or None (pre-solve failure).
     phase_attempts: list[PhaseAttempt] = field(default_factory=list)
     winning_phase: str | None = None
+    # PR-A12 — Phase 3 (min-CVaR) ALWAYS runs for telemetry. These fields
+    # populate the achievable-return band the Builder slider uses.
+    min_achievable_cvar: float | None = None
+    achievable_return_band: dict[str, float] | None = None
 
 
 async def optimize_fund_portfolio(
@@ -366,6 +369,7 @@ async def optimize_fund_portfolio(
     expected_returns: dict[str, float],
     constraints: ProfileConstraints,
     cov_matrix: np.ndarray,
+    returns_scenarios: np.ndarray | None = None,
     risk_free_rate: float = 0.04,
     skewness: np.ndarray | None = None,
     excess_kurtosis: np.ndarray | None = None,
@@ -374,22 +378,34 @@ async def optimize_fund_portfolio(
     robust: bool = False,
     uncertainty_level: float | None = None,
     regime_cvar_multiplier: float = 1.0,
+    cvar_alpha: float = 0.95,
     mandate: str | None = None,
     risk_aversion: float | None = None,
     cf_relaxation_factor: float = 1.3,
 ) -> FundOptimizationResult:
     """Optimize fund-level weights with block-group sum constraints.
 
-    Unlike optimize_portfolio() which works at block level, this optimizes
-    individual fund weights while enforcing block-level allocation bands
-    from StrategicAllocation.
+    PR-A12 — always-solvable Rockafellar-Uryasev cascade:
 
-    CVaR enforcement cascade:
-    1. Solve max risk-adjusted return (primary)
-    2. If CVaR violates limit → re-solve with variance ceiling derived from
-       cvar_limit (max return subject to σ² ≤ σ²_max)
-    3. If variance-capped solve infeasible → solve min_variance (safest
-       allocation within block constraints)
+    1. **Phase 1 (RU max-return LP)**: maximize μᵀw s.t. empirical
+       CVaR_α(w) ≤ limit via the RU auxiliary-variable linearization.
+       Pure LP, no variance proxy, no Cornish-Fisher approximation.
+    2. **Phase 2 (robust RU, opt-in)**: adds PR-A3 ellipsoidal uncertainty
+       penalty ``κ·‖Lᵀw‖₂`` to Phase 1's objective. SOCP.
+    3. **Phase 3 (min-CVaR LP, ALWAYS runs)**: minimizes empirical CVaR
+       on the base polytope. Feasible for any non-empty polytope;
+       populates ``achievable_return_band`` for the Builder slider.
+
+    When ``cvar_limit`` is None, Phase 1 becomes unconstrained max-return;
+    Phase 3 still runs for the band. When Phase 1/2 both fail (the
+    polytope is non-empty but the CVaR band is binding), Phase 3 wins
+    with ``status=degraded`` and ``operator_signal`` flags the universe
+    floor. The cascade never produces ``status=failed`` for solver /
+    feasibility reasons — only for upstream data failures (no funds, PSD
+    violation, empty polytope).
+
+    ``cf_relaxation_factor`` is retained in the signature for one release
+    of backwards compatibility; PR-A12 ignores it (dead param).
 
     Constraints:
         sum(w) == 1                          (fully invested)
@@ -398,6 +414,7 @@ async def optimize_fund_portfolio(
         sum(w[funds_in_block]) >= block_min  (block floor)
         sum(w[funds_in_block]) <= block_max  (block ceiling)
     """
+    del cf_relaxation_factor  # PR-A12: dead param, kept for compat
     n = len(fund_ids)
     cvar_limit = constraints.cvar_limit
 
@@ -412,7 +429,7 @@ async def optimize_fund_portfolio(
                     phase=p, status="skipped", solver=None,
                     objective_value=None, wall_ms=0, infeasibility_reason=None,
                 )
-                for p in ("primary", "robust", "variance_capped", "min_variance")
+                for p in ("phase_1_ru_max_return", "phase_2_ru_robust", "phase_3_min_cvar")
             ],
             winning_phase=None,
         )
@@ -442,7 +459,7 @@ async def optimize_fund_portfolio(
                     phase=p, status="skipped", solver=None,
                     objective_value=None, wall_ms=0, infeasibility_reason="psd_violation",
                 )
-                for p in ("primary", "robust", "variance_capped", "min_variance")
+                for p in ("phase_1_ru_max_return", "phase_2_ru_robust", "phase_3_min_cvar")
             ],
             winning_phase=None,
         )
@@ -513,7 +530,11 @@ async def optimize_fund_portfolio(
     # completes (or is skipped); ``_pad_skipped`` backfills the remaining
     # cascade slots at every return site so the shape is uniform.
     attempts: list[PhaseAttempt] = []
-    _CASCADE_PHASE_ORDER = ("primary", "robust", "variance_capped", "min_variance")
+    _CASCADE_PHASE_ORDER = (
+        "phase_1_ru_max_return",
+        "phase_2_ru_robust",
+        "phase_3_min_cvar",
+    )
 
     def _pad_skipped() -> list[PhaseAttempt]:
         seen = {a.phase for a in attempts}
@@ -534,6 +555,8 @@ async def optimize_fund_portfolio(
     def _build_result(
         w_arr: np.ndarray, solver: str | None, status: str,
         winning_phase: str | None = None,
+        min_achievable_cvar: float | None = None,
+        achievable_return_band: dict[str, float] | None = None,
     ) -> FundOptimizationResult:
         """Build FundOptimizationResult from optimized weights."""
         ret = float(mu @ w_arr)
@@ -561,6 +584,8 @@ async def optimize_fund_portfolio(
             solver_info=solver,
             phase_attempts=_pad_skipped(),
             winning_phase=winning_phase,
+            min_achievable_cvar=min_achievable_cvar,
+            achievable_return_band=achievable_return_band,
         )
 
     def _empty_result(
@@ -576,413 +601,348 @@ async def optimize_fund_portfolio(
             winning_phase=winning_phase,
         )
 
-    # ── Phase 1: Max risk-adjusted return (with optional turnover penalty) ──
-    w1 = cp.Variable(n, nonneg=True)
-    # S2-C: λ must be mandate-sensitive. Historical hardcoded λ=2 treated every
-    # client identically regardless of risk tolerance — a fiduciary bug.
-    lambda_risk = resolve_risk_aversion(risk_aversion, mandate)
-    objective_expr = mu @ w1 - lambda_risk * cp.quad_form(w1, psd_cov)
-    phase1_constraints = _build_base_constraints(w1)
+    # ── PR-A12 cascade bootstrap ──────────────────────────────────────────
+    # The Rockafellar-Uryasev LP needs a raw scenario matrix. The legacy
+    # entry points for ``optimize_fund_portfolio`` (screener drill-downs,
+    # block-level allocations) never supplied one; synthesize it from the
+    # covariance when absent so those callers still work while
+    # construction runs pass the real series.
+    from quant_engine.ru_cvar_lp import (
+        build_ru_cvar_constraints,
+        build_ru_cvar_objective,
+        realized_cvar_from_weights,
+    )
 
-    if current_weights is not None and turnover_cost > 0:
-        t1 = cp.Variable(n, nonneg=True)  # slack for |w - w_current|
-        phase1_constraints += [
-            t1 >= w1 - current_weights,
-            t1 >= current_weights - w1,
-        ]
-        objective_expr = objective_expr - turnover_cost * cp.sum(t1)
+    if returns_scenarios is None or returns_scenarios.size == 0:
+        logger.warning(
+            "returns_scenarios_missing_using_covariance_synth",
+            n_funds=n,
+        )
+        # Deterministic seed derived from fund_ids so repeated calls match.
+        seed = int(abs(hash(tuple(fund_ids))) % (2**32 - 1))
+        rng = np.random.default_rng(seed)
+        try:
+            L_synth = np.linalg.cholesky(cov_matrix / 252.0)
+        except np.linalg.LinAlgError:
+            eig_v, eig_vec = np.linalg.eigh(cov_matrix / 252.0)
+            eig_v = np.maximum(eig_v, 1e-10)
+            L_synth = eig_vec @ np.diag(np.sqrt(eig_v))
+        returns_scenarios = (rng.standard_normal((504, n)) @ L_synth.T) + (mu / 252.0)
 
-    prob1 = cp.Problem(cp.Maximize(objective_expr), phase1_constraints)
+    if returns_scenarios.shape[1] != n:
+        raise ValueError(
+            f"returns_scenarios has {returns_scenarios.shape[1]} columns, expected {n}",
+        )
+    T = int(returns_scenarios.shape[0])
+    if T < 252:
+        logger.error(
+            "returns_scenarios_below_minimum_observations",
+            t=T, min_required=252,
+        )
+        return _empty_result("insufficient_scenarios")
 
-    _t_p1 = time.perf_counter()
-    status1 = await _solve_problem(prob1)
-    _wall_p1 = int((time.perf_counter() - _t_p1) * 1000)
-    if status1 in (None, "solver_error"):
-        attempts.append(PhaseAttempt(
-            phase="primary", status="solver_failed", solver=None,
-            objective_value=None, wall_ms=_wall_p1,
-            infeasibility_reason="Both CLARABEL and SCS failed",
-        ))
-        return _empty_result("solver_failed", "Both CLARABEL and SCS failed")
-    if status1 not in ("optimal", "optimal_inaccurate"):
-        # If turnover penalty caused infeasibility, retry without it
-        if current_weights is not None and turnover_cost > 0:
-            logger.warning("turnover_penalty_infeasible_retrying_without")
-            w1_retry = cp.Variable(n, nonneg=True)
-            prob1_retry = cp.Problem(
-                cp.Maximize(mu @ w1_retry - lambda_risk * cp.quad_form(w1_retry, psd_cov)),
-                _build_base_constraints(w1_retry),
-            )
-            status1 = await _solve_problem(prob1_retry)
-            if status1 in ("optimal", "optimal_inaccurate"):
-                w1 = w1_retry
-                prob1 = prob1_retry
-            else:
-                attempts.append(PhaseAttempt(
-                    phase="primary", status="infeasible", solver=None,
-                    objective_value=None, wall_ms=_wall_p1,
-                    infeasibility_reason=str(status1),
-                ))
-                return _empty_result(f"infeasible: {status1}")
-        else:
-            attempts.append(PhaseAttempt(
-                phase="primary", status="infeasible", solver=None,
-                objective_value=None, wall_ms=_wall_p1,
-                infeasibility_reason=str(status1),
-            ))
-            return _empty_result(f"infeasible: {status1}")
-
-    opt_w = _extract_weights(w1)
-    if opt_w is None:
-        attempts.append(PhaseAttempt(
-            phase="primary", status="infeasible", solver=None,
-            objective_value=None, wall_ms=_wall_p1,
-            infeasibility_reason="zero weights after clipping",
-        ))
-        return _empty_result("infeasible: zero weights")
-
-    solver_name = prob1.solver_stats.solver_name if prob1.solver_stats else None
-
-    # Check CVaR against limit
-    cvar_neg = _compute_cvar(opt_w)
-    cvar_ok = cvar_neg >= cvar_limit if cvar_limit is not None else True
-
-    # Apply regime CVaR multiplier (tighter limit in adverse regimes)
-    effective_cvar_limit = cvar_limit
+    # Regime-adjusted effective CVaR limit — same semantics as the legacy
+    # cascade so downstream telemetry keeps its meaning.
+    effective_cvar_limit: float | None = cvar_limit
     if cvar_limit is not None and regime_cvar_multiplier != 1.0:
-        effective_cvar_limit = cvar_limit * regime_cvar_multiplier
+        effective_cvar_limit = float(abs(cvar_limit)) * regime_cvar_multiplier
         logger.info(
             "regime_cvar_multiplier_applied",
             original_limit=cvar_limit,
             effective_limit=effective_cvar_limit,
             multiplier=regime_cvar_multiplier,
         )
-        # Re-check with effective limit
-        cvar_ok = cvar_neg >= effective_cvar_limit
+    elif cvar_limit is not None:
+        effective_cvar_limit = float(abs(cvar_limit))
 
-    # PR-A11 — record Phase 1 attempt now that CVaR check has run so we can
-    # capture ``cvar_at_solution`` / ``cvar_within_limit`` on the attempt.
-    attempts.append(PhaseAttempt(
-        phase="primary",
-        status="succeeded",
-        solver=solver_name,
-        objective_value=(float(prob1.value) if prob1.value is not None else None),
-        wall_ms=_wall_p1,
-        infeasibility_reason=None,
-        cvar_at_solution=round(cvar_neg, 6),
-        cvar_limit_effective=effective_cvar_limit,
-        cvar_within_limit=cvar_ok,
-    ))
+    lambda_risk = resolve_risk_aversion(risk_aversion, mandate)  # Phase 2 only
 
-    if cvar_ok or effective_cvar_limit is None:
-        result = _build_result(opt_w, solver_name, "optimal", winning_phase="primary")
-        logger.info(
-            "fund_portfolio_optimized",
-            n_funds=n, sharpe=result.sharpe_ratio,
-            cvar_95=result.cvar_95, cvar_limit=effective_cvar_limit,
-            solver=solver_name, status="optimal",
+    def _cvar_from_ru(w_arr: np.ndarray) -> float:
+        """RU-empirical CVaR (matches Phase 1/3 LP objective)."""
+        return realized_cvar_from_weights(w_arr, returns_scenarios, cvar_alpha)
+
+    phase1_weights: np.ndarray | None = None
+    phase1_solver: str | None = None
+    phase1_expected_return: float | None = None
+    phase2_weights: np.ndarray | None = None
+    phase2_solver: str | None = None
+    phase2_expected_return: float | None = None
+
+    # ── Phase 1 — RU CVaR-constrained max return ──────────────────────────
+    w1 = cp.Variable(n, nonneg=True)
+    phase1_constraints = _build_base_constraints(w1)
+    if effective_cvar_limit is not None:
+        ru_cs, _, _ = build_ru_cvar_constraints(
+            w_var=w1,
+            returns_scenarios=returns_scenarios,
+            alpha=cvar_alpha,
+            cvar_limit=effective_cvar_limit,
         )
-        return result
+        phase1_constraints.extend(ru_cs)
 
-    # ── Phase 1.5: Robust optimization (ellipsoidal uncertainty set) ──
+    objective_expr1 = mu @ w1
+    if current_weights is not None and turnover_cost > 0:
+        t1 = cp.Variable(n, nonneg=True)
+        phase1_constraints += [t1 >= w1 - current_weights, t1 >= current_weights - w1]
+        objective_expr1 = objective_expr1 - turnover_cost * cp.sum(t1)
+
+    prob1 = cp.Problem(cp.Maximize(objective_expr1), phase1_constraints)
+    _t_p1 = time.perf_counter()
+    status1 = await _solve_problem(prob1)
+    _wall_p1 = int((time.perf_counter() - _t_p1) * 1000)
+
+    if status1 in ("optimal", "optimal_inaccurate"):
+        opt_w1 = _extract_weights(w1)
+        if opt_w1 is not None:
+            phase1_weights = opt_w1
+            phase1_solver = prob1.solver_stats.solver_name if prob1.solver_stats else "CLARABEL"
+            phase1_expected_return = float(mu @ opt_w1)
+            phase1_cvar_ru = _cvar_from_ru(opt_w1)
+            phase1_cvar_cf = _compute_cvar(opt_w1)  # legacy comparator (positive = loss)
+            phase1_within = (
+                phase1_cvar_ru <= effective_cvar_limit
+                if effective_cvar_limit is not None
+                else True
+            )
+            attempts.append(PhaseAttempt(
+                phase="phase_1_ru_max_return",
+                status="succeeded",
+                solver=phase1_solver,
+                objective_value=round(phase1_expected_return, 6),
+                wall_ms=_wall_p1,
+                infeasibility_reason=None,
+                cvar_at_solution=round(phase1_cvar_ru, 6),
+                cvar_at_solution_cf=round(abs(phase1_cvar_cf), 6),
+                cvar_limit_effective=effective_cvar_limit,
+                cvar_within_limit=phase1_within,
+            ))
+        else:
+            attempts.append(PhaseAttempt(
+                phase="phase_1_ru_max_return", status="infeasible",
+                solver=None, objective_value=None, wall_ms=_wall_p1,
+                infeasibility_reason="zero weights after clipping",
+                cvar_limit_effective=effective_cvar_limit,
+            ))
+    elif status1 in (None, "solver_error"):
+        attempts.append(PhaseAttempt(
+            phase="phase_1_ru_max_return", status="solver_failed", solver=None,
+            objective_value=None, wall_ms=_wall_p1,
+            infeasibility_reason="Both CLARABEL and SCS failed",
+            cvar_limit_effective=effective_cvar_limit,
+        ))
+    else:
+        attempts.append(PhaseAttempt(
+            phase="phase_1_ru_max_return", status="infeasible", solver=None,
+            objective_value=None, wall_ms=_wall_p1,
+            infeasibility_reason=str(status1),
+            cvar_limit_effective=effective_cvar_limit,
+        ))
+
+    # ── Phase 2 — Robust RU (ellipsoidal uncertainty on μ) ────────────────
     if not robust:
         attempts.append(PhaseAttempt(
-            phase="robust", status="skipped", solver=None,
+            phase="phase_2_ru_robust", status="skipped", solver=None,
             objective_value=None, wall_ms=0, infeasibility_reason=None,
         ))
-    if robust:
+    else:
         try:
-            # S2-E: Ben-Tal & Nemirovski's robust counterpart for a Gaussian
-            # uncertainty set at confidence (1-α) uses
-            #       κ = √χ²_{1-α, n}
-            # where n is the dimensionality of the uncertain mean vector.
-            # This guarantees the true mean lies inside the ellipsoid with
-            # probability 1-α under multivariate normal assumptions. The
-            # previous formulation (κ = c·√n with c=0.5) was dimensionally
-            # correct but miscalibrated — at n=4 it gave κ=1.0 which only
-            # covers ≈39% of the uncertainty set, far below the 95% target.
-            #
-            # We preserve the ``uncertainty_level`` hook as a confidence
-            # *override* multiplier: None → 95% (institutional default);
-            # otherwise κ is rescaled proportionally so callers who already
-            # tuned uncertainty_level in production keep their behaviour.
             from scipy.stats import chi2 as sp_chi2
             kappa_95 = float(np.sqrt(sp_chi2.ppf(0.95, df=max(n, 1))))
-            if uncertainty_level is None:
-                kappa = kappa_95
-                _kappa_source = "chi2_95"
-            else:
-                # Legacy callers: uncertainty_level=0.5 was the old default,
-                # so we rescale against that to avoid silent behaviour drift
-                # while still routing through the statistically-sound base.
-                kappa = float(uncertainty_level) * (kappa_95 / 0.5) * 0.5
-                _kappa_source = f"legacy({uncertainty_level})"
-            # Cholesky of PSD-wrapped covariance for SOCP norm
-            try:
-                L = np.linalg.cholesky(cov_matrix)
-            except np.linalg.LinAlgError:
-                # Fallback: eigenvalue clipping for near-PSD matrices
-                eigvals, eigvecs = np.linalg.eigh(cov_matrix)
-                eigvals = np.maximum(eigvals, 1e-8)
-                L = eigvecs @ np.diag(np.sqrt(eigvals))
-
-            w_robust = cp.Variable(n, nonneg=True)
-            robust_penalty = kappa * cp.norm(L.T @ w_robust, 2)
-            robust_obj = cp.Maximize(
-                mu @ w_robust - robust_penalty - lambda_risk * cp.quad_form(w_robust, psd_cov)
+            kappa = kappa_95 if uncertainty_level is None else (
+                float(uncertainty_level) * (kappa_95 / 0.5) * 0.5
             )
-            robust_constraints = _build_base_constraints(w_robust)
-            prob_robust = cp.Problem(robust_obj, robust_constraints)
+            try:
+                L_chol = np.linalg.cholesky(cov_matrix)
+            except np.linalg.LinAlgError:
+                eig_v, eig_vec = np.linalg.eigh(cov_matrix)
+                eig_v = np.maximum(eig_v, 1e-8)
+                L_chol = eig_vec @ np.diag(np.sqrt(eig_v))
 
-            _t_pr = time.perf_counter()
-            status_robust = await _solve_problem(prob_robust)
-            _wall_pr = int((time.perf_counter() - _t_pr) * 1000)
-            if status_robust in ("optimal", "optimal_inaccurate"):
-                opt_w_robust = _extract_weights(w_robust)
-                if opt_w_robust is not None:
-                    cvar_robust = _compute_cvar(opt_w_robust)
-                    cvar_ok_robust = (
-                        cvar_robust >= effective_cvar_limit
+            w2 = cp.Variable(n, nonneg=True)
+            constraints2 = _build_base_constraints(w2)
+            if effective_cvar_limit is not None:
+                ru_cs2, _, _ = build_ru_cvar_constraints(
+                    w_var=w2,
+                    returns_scenarios=returns_scenarios,
+                    alpha=cvar_alpha,
+                    cvar_limit=effective_cvar_limit,
+                )
+                constraints2.extend(ru_cs2)
+
+            robust_obj = cp.Maximize(
+                mu @ w2 - kappa * cp.norm(L_chol.T @ w2, 2)
+            )
+            prob2 = cp.Problem(robust_obj, constraints2)
+
+            _t_p2 = time.perf_counter()
+            status2 = await _solve_problem(prob2)
+            _wall_p2 = int((time.perf_counter() - _t_p2) * 1000)
+
+            if status2 in ("optimal", "optimal_inaccurate"):
+                opt_w2 = _extract_weights(w2)
+                if opt_w2 is not None:
+                    phase2_weights = opt_w2
+                    phase2_solver = prob2.solver_stats.solver_name if prob2.solver_stats else "CLARABEL"
+                    phase2_expected_return = float(mu @ opt_w2)
+                    phase2_cvar_ru = _cvar_from_ru(opt_w2)
+                    phase2_cvar_cf = _compute_cvar(opt_w2)
+                    phase2_within = (
+                        phase2_cvar_ru <= effective_cvar_limit
                         if effective_cvar_limit is not None
                         else True
                     )
-                    if cvar_ok_robust:
-                        attempts.append(PhaseAttempt(
-                            phase="robust", status="succeeded",
-                            solver="CLARABEL:robust",
-                            objective_value=(float(prob_robust.value) if prob_robust.value is not None else None),
-                            wall_ms=_wall_pr,
-                            infeasibility_reason=None,
-                            cvar_at_solution=round(cvar_robust, 6),
-                            cvar_limit_effective=effective_cvar_limit,
-                            cvar_within_limit=True,
-                            kappa_used=round(kappa, 6),
-                        ))
-                        result = _build_result(opt_w_robust, "CLARABEL:robust", "optimal:robust", winning_phase="robust")
-                        logger.info(
-                            "robust_optimization_succeeded",
-                            sharpe=result.sharpe_ratio,
-                            cvar_95=result.cvar_95,
-                            kappa=round(kappa, 4),
-                            kappa_source=_kappa_source,
-                        )
-                        return result
-                    else:
-                        attempts.append(PhaseAttempt(
-                            phase="robust", status="infeasible",
-                            solver="CLARABEL:robust",
-                            objective_value=(float(prob_robust.value) if prob_robust.value is not None else None),
-                            wall_ms=_wall_pr,
-                            infeasibility_reason="cvar_still_violated",
-                            cvar_at_solution=round(cvar_robust, 6),
-                            cvar_limit_effective=effective_cvar_limit,
-                            cvar_within_limit=False,
-                            kappa_used=round(kappa, 6),
-                        ))
-                        logger.warning(
-                            "robust_cvar_still_violated",
-                            cvar_95=round(cvar_robust, 6),
-                            limit=effective_cvar_limit,
-                        )
+                    attempts.append(PhaseAttempt(
+                        phase="phase_2_ru_robust",
+                        status="succeeded",
+                        solver=phase2_solver,
+                        objective_value=round(phase2_expected_return, 6),
+                        wall_ms=_wall_p2,
+                        infeasibility_reason=None,
+                        cvar_at_solution=round(phase2_cvar_ru, 6),
+                        cvar_at_solution_cf=round(abs(phase2_cvar_cf), 6),
+                        cvar_limit_effective=effective_cvar_limit,
+                        cvar_within_limit=phase2_within,
+                        kappa_used=round(kappa, 6),
+                    ))
                 else:
                     attempts.append(PhaseAttempt(
-                        phase="robust", status="infeasible",
-                        solver="CLARABEL:robust",
-                        objective_value=None, wall_ms=_wall_pr,
+                        phase="phase_2_ru_robust", status="infeasible",
+                        solver=phase2_solver, objective_value=None, wall_ms=_wall_p2,
                         infeasibility_reason="zero weights after clipping",
                         kappa_used=round(kappa, 6),
+                        cvar_limit_effective=effective_cvar_limit,
                     ))
             else:
                 attempts.append(PhaseAttempt(
-                    phase="robust", status="infeasible",
-                    solver="CLARABEL:robust",
-                    objective_value=None, wall_ms=_wall_pr,
-                    infeasibility_reason=str(status_robust),
+                    phase="phase_2_ru_robust", status="infeasible",
+                    solver=None, objective_value=None, wall_ms=_wall_p2,
+                    infeasibility_reason=str(status2),
                     kappa_used=round(kappa, 6),
+                    cvar_limit_effective=effective_cvar_limit,
                 ))
-                logger.warning("robust_optimization_infeasible", status=status_robust)
         except Exception as e:
             attempts.append(PhaseAttempt(
-                phase="robust", status="solver_failed",
+                phase="phase_2_ru_robust", status="solver_failed",
                 solver=None, objective_value=None, wall_ms=0,
                 infeasibility_reason=str(e),
-            ))
-            logger.warning("robust_optimization_failed", error=str(e))
-
-    # ── Phase 2: CVaR violated — re-solve with variance ceiling ──
-    # Derive σ_max from the CVaR limit under a parametric approximation:
-    # CVaR_95 ≈ σ · c − μ   →   σ_max ≈ |limit| / c
-    #
-    # S2-G: the limit MUST be the regime-adjusted ``effective_cvar_limit``.
-    # The previous code fell back to the *relaxed* ``cvar_limit`` after Phase 1
-    # had tightened it for stress regimes — silently defeating the whole
-    # purpose of ``regime_cvar_multiplier``. We now anchor every derivation
-    # to ``phase2_limit`` and keep ``cvar_limit`` only for the result payload.
-    #
-    # S2-D: Phase 1 measures CVaR with Cornish-Fisher (accommodates skew and
-    # kurtosis). Deriving σ_max with the pure Normal coefficient
-    # ``c_N = −z_α + φ(z_α)/α ≈ 3.71`` introduces a calibration mismatch: at
-    # realistic equity kurtosis the CF CVaR is ≈1.3× the Normal CVaR for the
-    # same σ, so using c_N over-restricts (it assumes a thinner tail than
-    # Phase 1 uses to verify). We apply a conservative CF relaxation factor
-    # so Phase 2 produces feasible, tail-aware candidates instead of
-    # collapsing to min-variance. The exact factor is taken from the
-    # expected CF/Normal ratio for the portfolio moments; we fall back to
-    # the injected `cf_relaxation_factor` (default 1.3) when moments are zero.
-    from scipy.stats import norm as sp_norm
-
-    assert cvar_limit is not None  # Phase 2 only reached when cvar_limit was set
-    phase2_limit = effective_cvar_limit if effective_cvar_limit is not None else cvar_limit
-
-    z_alpha = sp_norm.ppf(0.05)  # -1.645
-    phi_z = sp_norm.pdf(z_alpha)
-    cvar_coeff_normal = -z_alpha + phi_z / 0.05  # ≈ 3.71 (pure Normal)
-
-    # Estimate the portfolio-level CF/Normal ratio using the Phase-1 weights
-    # (opt_w), which is the best feasible proxy available at this point. If
-    # the moment arrays are zero, fall back to the conservative parameter
-    # `cf_relaxation_factor`.
-    _port_skew = float(opt_w @ _skew)
-    _port_kurt = float(opt_w @ _kurt)
-    _z_cf = (
-        z_alpha
-        + (z_alpha**2 - 1) * _port_skew / 6
-        + (z_alpha**3 - 3 * z_alpha) * _port_kurt / 24
-        - (2 * z_alpha**3 - 5 * z_alpha) * _port_skew**2 / 36
-    )
-    _cvar_coeff_cf = -_z_cf + sp_norm.pdf(_z_cf) / 0.05
-    _cf_normal_ratio = _cvar_coeff_cf / cvar_coeff_normal
-    if not np.isfinite(_cf_normal_ratio) or _cf_normal_ratio < 1.05:
-        _cf_normal_ratio = cf_relaxation_factor
-
-    # Relax the Normal coefficient so σ_max reflects the CF-measured tail.
-    cvar_coeff = cvar_coeff_normal / _cf_normal_ratio
-    max_var = (abs(phase2_limit) / cvar_coeff) ** 2
-
-    logger.warning(
-        "cvar_violation_re_optimizing",
-        cvar_95=round(cvar_neg, 6),
-        cvar_limit=cvar_limit,
-        phase2_limit=round(phase2_limit, 6),
-        cf_normal_ratio=round(_cf_normal_ratio, 4),
-        max_vol_target=round(abs(phase2_limit) / cvar_coeff, 6),
-    )
-
-    w2 = cp.Variable(n, nonneg=True)
-    constraints2 = _build_base_constraints(w2)
-    constraints2.append(cp.quad_form(w2, psd_cov) <= max_var)
-
-    prob2 = cp.Problem(cp.Maximize(mu @ w2), constraints2)
-    _t_p2 = time.perf_counter()
-    status2 = await _solve_problem(prob2)
-    _wall_p2 = int((time.perf_counter() - _t_p2) * 1000)
-
-    _max_vol_target = float(abs(phase2_limit) / cvar_coeff)
-
-    if status2 in ("optimal", "optimal_inaccurate"):
-        opt_w2 = _extract_weights(w2)
-        if opt_w2 is not None:
-            solver2 = prob2.solver_stats.solver_name if prob2.solver_stats else solver_name
-            _cvar_p2 = _compute_cvar(opt_w2)
-            attempts.append(PhaseAttempt(
-                phase="variance_capped", status="succeeded",
-                solver=solver2,
-                objective_value=(float(prob2.value) if prob2.value is not None else None),
-                wall_ms=_wall_p2,
-                infeasibility_reason=None,
-                cvar_at_solution=round(_cvar_p2, 6),
                 cvar_limit_effective=effective_cvar_limit,
-                cvar_within_limit=(_cvar_p2 >= effective_cvar_limit if effective_cvar_limit is not None else True),
-                max_var=round(max_var, 9),
-                max_vol_target=round(_max_vol_target, 6),
-                cvar_coeff=round(float(cvar_coeff), 6),
-                cf_normal_ratio=round(float(_cf_normal_ratio), 4),
-                phase2_limit=round(float(phase2_limit), 6),
             ))
-            result = _build_result(opt_w2, solver2, "optimal:cvar_constrained", winning_phase="variance_capped")
-            logger.info(
-                "cvar_constrained_re_optimization_succeeded",
-                cvar_95=result.cvar_95, cvar_limit=cvar_limit,
-                cvar_within_limit=result.cvar_within_limit,
-                sharpe=result.sharpe_ratio,
-            )
-            return result
-        else:
-            attempts.append(PhaseAttempt(
-                phase="variance_capped", status="infeasible",
-                solver=None, objective_value=None, wall_ms=_wall_p2,
-                infeasibility_reason="zero weights after clipping",
-                max_var=round(max_var, 9),
-                max_vol_target=round(_max_vol_target, 6),
-                cvar_coeff=round(float(cvar_coeff), 6),
-                cf_normal_ratio=round(float(_cf_normal_ratio), 4),
-                phase2_limit=round(float(phase2_limit), 6),
-            ))
-    else:
-        attempts.append(PhaseAttempt(
-            phase="variance_capped", status="infeasible",
-            solver="CLARABEL",
-            objective_value=None, wall_ms=_wall_p2,
-            infeasibility_reason=str(status2),
-            max_var=round(max_var, 9),
-            max_vol_target=round(_max_vol_target, 6),
-            cvar_coeff=round(float(cvar_coeff), 6),
-            cf_normal_ratio=round(float(_cf_normal_ratio), 4),
-            phase2_limit=round(float(phase2_limit), 6),
-        ))
+            logger.warning("phase_2_ru_robust_failed", error=str(e))
 
-    # ── Phase 3: Variance-capped infeasible — fall back to min_variance ──
-    logger.warning("cvar_capped_infeasible_falling_back_to_min_variance")
-
+    # ── Phase 3 — Min-CVaR LP (ALWAYS runs for telemetry band) ────────────
     w3 = cp.Variable(n, nonneg=True)
-    prob3 = cp.Problem(
-        cp.Minimize(cp.quad_form(w3, psd_cov)),
-        _build_base_constraints(w3),
+    cvar_expr3, slack_cs3, _zeta3, _u3 = build_ru_cvar_objective(
+        w_var=w3,
+        returns_scenarios=returns_scenarios,
+        alpha=cvar_alpha,
     )
+    constraints3 = _build_base_constraints(w3) + slack_cs3
+    prob3 = cp.Problem(cp.Minimize(cvar_expr3), constraints3)
+
     _t_p3 = time.perf_counter()
     status3 = await _solve_problem(prob3)
     _wall_p3 = int((time.perf_counter() - _t_p3) * 1000)
 
+    phase3_weights: np.ndarray | None = None
+    min_achievable_cvar: float | None = None
     if status3 in ("optimal", "optimal_inaccurate"):
         opt_w3 = _extract_weights(w3)
         if opt_w3 is not None:
-            _min_var = float(prob3.value) if prob3.value is not None else float(opt_w3 @ cov_matrix @ opt_w3)
+            phase3_weights = opt_w3
+            min_achievable_cvar = float(prob3.value) if prob3.value is not None else _cvar_from_ru(opt_w3)
+            phase3_cvar_cf = _compute_cvar(opt_w3)
+            phase3_within = (
+                min_achievable_cvar <= effective_cvar_limit
+                if effective_cvar_limit is not None
+                else True
+            )
             attempts.append(PhaseAttempt(
-                phase="min_variance", status="succeeded",
+                phase="phase_3_min_cvar",
+                status="succeeded",
                 solver="CLARABEL",
-                objective_value=round(_min_var, 9),
+                objective_value=round(min_achievable_cvar, 6),
                 wall_ms=_wall_p3,
                 infeasibility_reason=None,
-                min_achievable_variance=round(_min_var, 9),
-                min_achievable_vol=round(float(np.sqrt(max(_min_var, 0.0))), 6),
+                cvar_at_solution=round(min_achievable_cvar, 6),
+                cvar_at_solution_cf=round(abs(phase3_cvar_cf), 6),
+                cvar_limit_effective=effective_cvar_limit,
+                cvar_within_limit=phase3_within,
             ))
-            result = _build_result(opt_w3, "min_variance_fallback", "optimal:min_variance_fallback", winning_phase="min_variance")
-            logger.warning(
-                "min_variance_fallback_used",
-                cvar_95=result.cvar_95, cvar_limit=cvar_limit,
-                cvar_within_limit=result.cvar_within_limit,
-            )
-            return result
         else:
             attempts.append(PhaseAttempt(
-                phase="min_variance", status="infeasible",
-                solver="CLARABEL",
-                objective_value=None, wall_ms=_wall_p3,
+                phase="phase_3_min_cvar", status="infeasible",
+                solver="CLARABEL", objective_value=None, wall_ms=_wall_p3,
                 infeasibility_reason="zero weights after clipping",
+                cvar_limit_effective=effective_cvar_limit,
             ))
     else:
         attempts.append(PhaseAttempt(
-            phase="min_variance", status="solver_failed",
-            solver="CLARABEL",
-            objective_value=None, wall_ms=_wall_p3,
+            phase="phase_3_min_cvar", status="solver_failed",
+            solver="CLARABEL", objective_value=None, wall_ms=_wall_p3,
             infeasibility_reason=str(status3),
+            cvar_limit_effective=effective_cvar_limit,
         ))
 
-    # All three phases failed — return original Phase 1 result with violation flag
-    result = _build_result(opt_w, solver_name, "optimal:cvar_violated", winning_phase="heuristic")
-    logger.error(
-        "all_cvar_enforcement_phases_failed",
-        cvar_95=result.cvar_95, cvar_limit=cvar_limit,
+    # If Phase 3 failed, the constraint polytope is malformed (block bands
+    # sum > 1 etc.). This is the ONLY failure mode in PR-A12.
+    if phase3_weights is None:
+        logger.error(
+            "constraint_polytope_empty",
+            n_funds=n,
+        )
+        return _empty_result("constraint_polytope_empty", "CLARABEL")
+    assert min_achievable_cvar is not None  # non-None whenever phase3_weights is set
+    phase3_expected_return = float(mu @ phase3_weights)
+
+    # ── Winner selection (Phase 1 > Phase 2 > Phase 3) ───────────────────
+    if phase1_weights is not None:
+        winner_w = phase1_weights
+        winner_phase = "phase_1_ru_max_return"
+        winner_solver = phase1_solver
+        winner_return = phase1_expected_return
+        winner_status = "optimal"
+    elif phase2_weights is not None:
+        winner_w = phase2_weights
+        winner_phase = "phase_2_ru_robust"
+        winner_solver = phase2_solver
+        winner_return = phase2_expected_return
+        winner_status = "optimal"
+    else:
+        winner_w = phase3_weights
+        winner_phase = "phase_3_min_cvar"
+        winner_solver = "CLARABEL"
+        winner_return = phase3_expected_return
+        within_limit = (
+            min_achievable_cvar <= effective_cvar_limit
+            if effective_cvar_limit is not None
+            else True
+        )
+        winner_status = "optimal" if within_limit else "degraded"
+
+    assert winner_return is not None
+    winner_cvar_ru = _cvar_from_ru(winner_w)
+    band: dict[str, float] = {
+        "lower": round(phase3_expected_return, 6),
+        "upper": round(float(winner_return), 6),
+        "lower_at_cvar": round(min_achievable_cvar, 6),
+        "upper_at_cvar": round(winner_cvar_ru, 6),
+    }
+
+    result = _build_result(
+        winner_w, winner_solver, winner_status,
+        winning_phase=winner_phase,
+        min_achievable_cvar=round(min_achievable_cvar, 6),
+        achievable_return_band=band,
+    )
+
+    logger.info(
+        "fund_portfolio_optimized",
+        n_funds=n, sharpe=result.sharpe_ratio,
+        cvar_95=result.cvar_95, cvar_limit=effective_cvar_limit,
+        solver=winner_solver, status=winner_status,
+        winning_phase=winner_phase,
+        min_achievable_cvar=round(min_achievable_cvar, 6),
+        band_upper=band["upper"], band_lower=band["lower"],
     )
     return result
 

--- a/backend/quant_engine/ru_cvar_lp.py
+++ b/backend/quant_engine/ru_cvar_lp.py
@@ -1,0 +1,118 @@
+"""Rockafellar-Uryasev CVaR LP formulation helpers (PR-A12).
+
+Implements the auxiliary-variable linearization from Uryasev (2000):
+    CVaR_alpha(L) = min_zeta { zeta + (1/(1-alpha)) E[(L - zeta)+] }
+
+where L is the loss random variable. For a portfolio with weights w and
+historical scenarios ``returns_scenarios`` (shape (T, N)), the loss in
+scenario i is L_i = -returns_scenarios[i, :] @ w. The expectation is
+replaced by the empirical mean (1/T) sum_i max(L_i - zeta, 0), and the
+max is linearized via slack variables u_i >= 0, u_i >= L_i - zeta.
+
+Two entry points:
+
+- :func:`build_ru_cvar_constraints` — CVaR as a constraint (Phase 1 / 2).
+- :func:`build_ru_cvar_objective` — CVaR as the minimization objective
+  (Phase 3 min-CVaR LP, always feasible on a non-empty constraint
+  polytope).
+
+Both return the auxiliary ``zeta`` / ``u`` variables so callers can
+introspect the realized CVaR post-solve via
+``float(zeta.value + u.value.sum() / ((1 - alpha) * T))``.
+"""
+
+from __future__ import annotations
+
+import cvxpy as cp
+import numpy as np
+
+
+def build_ru_cvar_constraints(
+    w_var: cp.Variable,
+    returns_scenarios: np.ndarray,
+    alpha: float,
+    cvar_limit: float,
+) -> tuple[list[cp.constraints.Constraint], cp.Variable, cp.Variable]:
+    """Return ``(constraints, zeta, u)`` enforcing CVaR_alpha(w) <= cvar_limit.
+
+    Loss-distribution convention: ``cvar_limit > 0`` is the maximum tail
+    loss the operator tolerates (e.g. ``0.05`` = 5% loss).
+
+    Internally::
+
+        L_i  = -returns_scenarios[i, :] @ w_var       (loss = -return)
+        CVaR = zeta + (1 / ((1 - alpha) * T)) * sum(u) <= cvar_limit
+        u_i >= L_i - zeta,   u_i >= 0
+    """
+    T, N = returns_scenarios.shape
+    if w_var.shape != (N,):
+        raise ValueError(f"w_var shape {w_var.shape} != ({N},)")
+    if not (0.0 < alpha < 1.0):
+        raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+    if cvar_limit <= 0.0:
+        raise ValueError(f"cvar_limit must be > 0, got {cvar_limit}")
+
+    zeta = cp.Variable()
+    u = cp.Variable(T, nonneg=True)
+    losses = -returns_scenarios @ w_var
+
+    cvar_expr = zeta + (1.0 / ((1.0 - alpha) * T)) * cp.sum(u)
+    constraints: list[cp.constraints.Constraint] = [
+        u >= losses - zeta,
+        cvar_expr <= cvar_limit,
+    ]
+    return constraints, zeta, u
+
+
+def build_ru_cvar_objective(
+    w_var: cp.Variable,
+    returns_scenarios: np.ndarray,
+    alpha: float,
+) -> tuple[cp.Expression, list[cp.constraints.Constraint], cp.Variable, cp.Variable]:
+    """Return ``(cvar_expr, slack_constraints, zeta, u)`` for min-CVaR.
+
+    Usage::
+
+        cvar_expr, slack_cs, zeta, u = build_ru_cvar_objective(w, R, 0.95)
+        prob = cp.Problem(cp.Minimize(cvar_expr), slack_cs + base_constraints)
+
+    Phase 3 min-CVaR LP is feasible for any non-empty constraint polytope
+    (RU slacks ``u_i`` are unbounded above), so this path is the
+    always-solvable floor of the PR-A12 cascade.
+    """
+    T, N = returns_scenarios.shape
+    if w_var.shape != (N,):
+        raise ValueError(f"w_var shape {w_var.shape} != ({N},)")
+    if not (0.0 < alpha < 1.0):
+        raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+
+    zeta = cp.Variable()
+    u = cp.Variable(T, nonneg=True)
+    losses = -returns_scenarios @ w_var
+    cvar_expr = zeta + (1.0 / ((1.0 - alpha) * T)) * cp.sum(u)
+    slack_constraints: list[cp.constraints.Constraint] = [u >= losses - zeta]
+    return cvar_expr, slack_constraints, zeta, u
+
+
+def realized_cvar_from_weights(
+    weights: np.ndarray,
+    returns_scenarios: np.ndarray,
+    alpha: float,
+) -> float:
+    """Empirical CVaR_alpha of a realized weight vector (post-solve check).
+
+    Used for telemetry and tests — computes CVaR directly from the
+    scenario matrix without re-solving an LP. Equivalent to the LP
+    objective value at optimality.
+    """
+    T, _ = returns_scenarios.shape
+    losses = -returns_scenarios @ weights
+    # Empirical VaR at level alpha = (1-alpha)-quantile of losses from above.
+    # For CVaR: average of losses exceeding VaR.
+    var_threshold = float(np.quantile(losses, alpha))
+    tail = losses[losses >= var_threshold]
+    if tail.size == 0:
+        return float(var_threshold)
+    # RU definition equivalent: CVaR = zeta + mean(max(L - zeta, 0)) / (1 - alpha)
+    # At zeta = VaR, this reduces to mean of tail losses when tail mass = (1-alpha).
+    return float(tail.mean())

--- a/backend/scripts/pr_a12_smoke.py
+++ b/backend/scripts/pr_a12_smoke.py
@@ -1,0 +1,131 @@
+"""PR-A12 F.1 live-DB smoke.
+
+Executes construction runs for the 3 canonical model portfolios against
+the local Timescale container. Emits the verification table required by
+Section F of the prompt.
+
+Usage::
+
+    cd backend && PYTHONPATH=. python scripts/pr_a12_smoke.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import date
+
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://netz:password@127.0.0.1:5434/netz_engine",
+)
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+
+ORG_ID = uuid.UUID("403d8392-ebfa-5890-b740-45da49c556eb")
+PORTFOLIOS = [
+    ("Conservative Preservation", uuid.UUID("3945cee6-f85d-4903-a2dd-cf6a51e1c6a5")),
+    ("Balanced Income",           uuid.UUID("e5892474-7438-4ac5-85da-217abcf99932")),
+    ("Dynamic Growth",            uuid.UUID("3163d72b-3f8c-427e-9cd2-bead6377b59c")),
+]
+
+
+async def _with_rls(session: AsyncSession, org_id: uuid.UUID) -> None:
+    """Set RLS context for the session."""
+    await session.execute(
+        text("SELECT set_config('app.current_organization_id', :oid, true)"),
+        {"oid": str(org_id)},
+    )
+
+
+async def main() -> None:
+    from app.domains.wealth.workers.construction_run_executor import (
+        execute_construction_run,
+    )
+
+    engine = create_async_engine(os.environ["DATABASE_URL"], echo=False)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    results: list[dict] = []
+    for name, pid in PORTFOLIOS:
+        print(f"\n=== Running {name} ({pid}) ===", flush=True)
+        async with Session() as db:
+            await _with_rls(db, ORG_ID)
+            try:
+                run = await execute_construction_run(
+                    db,
+                    portfolio_id=pid,
+                    organization_id=ORG_ID,
+                    requested_by="pr_a12_smoke",
+                    job_id=None,
+                    as_of_date=date.today(),
+                )
+                await db.commit()
+                print(
+                    f"  status={run.status} winning_phase={(run.cascade_telemetry or {}).get('cascade_summary')}",
+                    flush=True,
+                )
+                results.append({
+                    "name": name, "portfolio_id": pid, "run_id": run.id,
+                    "status": run.status,
+                })
+            except Exception as e:
+                print(f"  FAILED: {type(e).__name__}: {e}", flush=True)
+                await db.rollback()
+                results.append({
+                    "name": name, "portfolio_id": pid, "run_id": None,
+                    "status": f"error:{type(e).__name__}",
+                    "error": str(e),
+                })
+
+    # F.1 verification query — pull the runs we just created
+    print("\n=== F.1 verification ===", flush=True)
+    async with Session() as db:
+        await _with_rls(db, ORG_ID)
+        rows = await db.execute(
+            text(
+                """
+                SELECT mp.display_name AS name,
+                       pcr.status,
+                       pcr.cascade_telemetry->>'cascade_summary' AS summary,
+                       (pcr.cascade_telemetry->>'min_achievable_cvar')::float AS min_cvar,
+                       (pcr.cascade_telemetry->'achievable_return_band'->>'lower')::float AS band_lower,
+                       (pcr.cascade_telemetry->'achievable_return_band'->>'upper')::float AS band_upper,
+                       pcr.cascade_telemetry->'operator_signal'->>'kind' AS sig_kind,
+                       (SELECT COUNT(*) FROM jsonb_object_keys(pcr.weights_proposed)) AS n_w,
+                       pcr.wall_clock_ms
+                FROM portfolio_construction_runs pcr
+                JOIN model_portfolios mp ON mp.id = pcr.portfolio_id
+                WHERE pcr.portfolio_id IN (
+                    '3945cee6-f85d-4903-a2dd-cf6a51e1c6a5',
+                    'e5892474-7438-4ac5-85da-217abcf99932',
+                    '3163d72b-3f8c-427e-9cd2-bead6377b59c'
+                )
+                  AND pcr.requested_at > NOW() - INTERVAL '30 minutes'
+                ORDER BY mp.display_name, pcr.requested_at DESC
+                LIMIT 3
+                """,
+            ),
+        )
+        print(f"{'name':28} {'status':10} {'summary':38} {'min_cvar':>10} "
+              f"{'band_lo':>8} {'band_hi':>8} {'sig_kind':28} {'n_w':>4} {'ms':>5}", flush=True)
+        for r in rows.mappings():
+            min_cvar = f"{r['min_cvar']:.5f}" if r["min_cvar"] is not None else "None"
+            band_lo = f"{r['band_lower']:.4f}" if r["band_lower"] is not None else "None"
+            band_hi = f"{r['band_upper']:.4f}" if r["band_upper"] is not None else "None"
+            sig = r["sig_kind"] or "null"
+            print(
+                f"{(r['name'] or '')[:28]:28} {r['status']:10} "
+                f"{(r['summary'] or '')[:38]:38} {min_cvar:>10} "
+                f"{band_lo:>8} {band_hi:>8} {sig[:28]:28} "
+                f"{r['n_w']:>4} {r['wall_clock_ms'] or 0:>5}",
+                flush=True,
+            )
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/quant_engine/test_always_solvable_cascade.py
+++ b/backend/tests/quant_engine/test_always_solvable_cascade.py
@@ -1,0 +1,275 @@
+"""PR-A12 — always-solvable Rockafellar-Uryasev cascade tests.
+
+Covers Section E of ``docs/prompts/2026-04-16-pr-a12-always-solvable-cascade.md``:
+
+E.1 — Phase 1 succeeds within CVaR limit.
+E.2 — Impossibly tight limit: Phase 3 wins with status=degraded.
+E.3 — Always-solvable invariant across random configs.
+E.4 — Band monotonicity across tightening limits.
+E.5 — Phase 3 runs even on Phase 1 success.
+E.6 — RU constraint matches empirical CVaR modulo solver tolerance.
+E.7 — Empty constraint polytope produces ``constraint_polytope_empty``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from quant_engine.optimizer_service import (
+    BlockConstraint,
+    FundOptimizationResult,
+    ProfileConstraints,
+    optimize_fund_portfolio,
+)
+from quant_engine.ru_cvar_lp import realized_cvar_from_weights
+
+
+def _build_universe(
+    n: int,
+    seed: int,
+    T: int = 1260,
+    annual_mu_range: tuple[float, float] = (0.04, 0.12),
+    vol_range: tuple[float, float] = (0.10, 0.25),
+) -> tuple[list[str], dict[str, str], dict[str, float], np.ndarray, np.ndarray]:
+    """Return (fund_ids, fund_blocks, expected_returns, cov_matrix, scenarios)."""
+    rng = np.random.default_rng(seed)
+    fund_ids = [f"F{i}" for i in range(n)]
+    fund_blocks = {fid: "eq" for fid in fund_ids}
+    annual_mu = rng.uniform(*annual_mu_range, size=n)
+    annual_vol = rng.uniform(*vol_range, size=n)
+    # Random correlation matrix via factor model structure.
+    F = rng.standard_normal((n, 3))
+    corr = F @ F.T
+    D = np.sqrt(np.diag(corr))
+    corr = corr / np.outer(D, D)
+    annual_cov = np.outer(annual_vol, annual_vol) * corr
+    # Repair PSD
+    eigvals, eigvecs = np.linalg.eigh(annual_cov)
+    eigvals = np.maximum(eigvals, 1e-8)
+    annual_cov = eigvecs @ np.diag(eigvals) @ eigvecs.T
+    daily_cov = annual_cov / 252.0
+    daily_mu = annual_mu / 252.0
+    L = np.linalg.cholesky(daily_cov)
+    scenarios = (rng.standard_normal((T, n)) @ L.T) + daily_mu
+    expected_returns = {fid: float(annual_mu[i]) for i, fid in enumerate(fund_ids)}
+    return fund_ids, fund_blocks, expected_returns, annual_cov, scenarios
+
+
+def _run(
+    cvar_limit: float | None,
+    *,
+    n: int = 5,
+    seed: int = 42,
+    max_single: float = 0.50,
+    robust: bool = False,
+    block_bounds: tuple[float, float] = (0.0, 1.0),
+) -> FundOptimizationResult:
+    fund_ids, fund_blocks, er, cov, R = _build_universe(n=n, seed=seed)
+    constraints = ProfileConstraints(
+        blocks=[BlockConstraint("eq", block_bounds[0], block_bounds[1])],
+        cvar_limit=cvar_limit,
+        max_single_fund_weight=max_single,
+    )
+    return asyncio.run(
+        optimize_fund_portfolio(
+            fund_ids=fund_ids,
+            fund_blocks=fund_blocks,
+            expected_returns=er,
+            constraints=constraints,
+            cov_matrix=cov,
+            returns_scenarios=R,
+            robust=robust,
+        ),
+    )
+
+
+# ── E.1 — Phase 1 succeeds within CVaR limit ─────────────────────────
+
+
+def test_phase_1_succeeds_within_cvar_limit() -> None:
+    result = _run(cvar_limit=0.10, n=3, max_single=1.0)
+
+    assert result.status == "optimal"
+    assert result.winning_phase == "phase_1_ru_max_return"
+    assert result.min_achievable_cvar is not None
+    assert result.min_achievable_cvar <= 0.10
+    band = result.achievable_return_band
+    assert band is not None
+    assert band["upper"] >= band["lower"]
+
+
+# ── E.2 — Impossibly tight limit: Phase 3 wins with degraded ─────────
+
+
+def test_phase_3_above_limit_returns_min_cvar() -> None:
+    # cvar_limit=0.0005 is well below any achievable CVaR_95 on a 5Y daily
+    # universe with vol >= 10% — guaranteed Phase 3 winner.
+    result = _run(cvar_limit=0.0005, n=3, max_single=1.0)
+
+    assert result.status == "degraded"
+    assert result.winning_phase == "phase_3_min_cvar"
+    assert len(result.weights) > 0  # always-solvable invariant
+    assert result.min_achievable_cvar is not None
+    assert result.min_achievable_cvar > 0.0005
+    band = result.achievable_return_band
+    assert band is not None
+    # Band collapses at the floor.
+    assert band["lower"] == band["upper"]
+
+
+# ── E.3 — Always-solvable invariant across random configs ────────────
+
+
+def _invariant_params() -> list[tuple[int, float, int, float]]:
+    rng = np.random.default_rng(99)
+    out: list[tuple[int, float, int, float]] = []
+    for s in range(50):
+        n = int(rng.choice([3, 4, 5, 6, 8]))
+        max_single = float(rng.choice([0.30, 0.40, 0.50, 0.60, 1.0]))
+        # Ensure polytope non-empty: n * max_single must exceed 1.
+        while n * max_single < 1.05:
+            max_single = min(1.0, max_single + 0.10)
+        lim = float(rng.choice([0.02, 0.05, 0.08, 0.12, 0.30]))
+        out.append((s, lim, n, max_single))
+    return out
+
+
+@pytest.mark.parametrize("seed, cvar_limit, n, max_single", _invariant_params())
+def test_always_solvable_invariant(
+    seed: int, cvar_limit: float, n: int, max_single: float,
+) -> None:
+    result = _run(
+        cvar_limit=float(cvar_limit),
+        n=int(n),
+        seed=int(seed),
+        max_single=float(max_single),
+    )
+    # Cascade NEVER fails for solver / feasibility reasons.
+    assert result.status in ("optimal", "degraded"), (
+        f"seed={seed} cvar={cvar_limit} n={n}: status={result.status}"
+    )
+    assert len(result.weights) > 0
+    total = sum(result.weights.values())
+    assert abs(total - 1.0) < 1e-4
+    assert result.min_achievable_cvar is not None
+
+
+# ── E.4 — Band monotonicity across tightening limits ─────────────────
+
+
+def test_achievable_band_monotonic() -> None:
+    # Include a value well below any plausible universe floor (0.0005)
+    # so the sweep guarantees at least one band collapse.
+    limits = [0.10, 0.07, 0.05, 0.03, 0.01, 0.0005]
+    bands: list[tuple[float, float]] = []
+    for lim in limits:
+        r = _run(cvar_limit=lim, n=4, max_single=0.50, seed=3)
+        assert r.achievable_return_band is not None
+        bands.append(
+            (r.achievable_return_band["lower"], r.achievable_return_band["upper"]),
+        )
+
+    # Upper bound is non-increasing as we tighten the limit.
+    uppers = [b[1] for b in bands]
+    for prev, cur in zip(uppers, uppers[1:]):
+        assert cur <= prev + 1e-6, f"band.upper not monotonic: {uppers}"
+
+    # When the limit drops below the universe floor the band collapses.
+    collapsed = [abs(b[0] - b[1]) < 1e-6 for b in bands]
+    assert any(collapsed), "no limit was below universe floor in the sweep"
+
+
+# ── E.5 — Phase 3 runs even on Phase 1 success ───────────────────────
+
+
+def test_phase_3_runs_even_on_phase_1_success() -> None:
+    result = _run(cvar_limit=0.20, n=3, max_single=1.0)
+
+    assert result.winning_phase == "phase_1_ru_max_return"
+    p3 = next(
+        (a for a in result.phase_attempts if a.phase == "phase_3_min_cvar"),
+        None,
+    )
+    assert p3 is not None
+    assert p3.status == "succeeded"
+    assert p3.wall_ms > 0
+    assert p3.objective_value is not None and p3.objective_value > 0
+
+
+# ── E.6 — RU constraint matches empirical CVaR ───────────────────────
+
+
+def test_ru_cvar_constraint_matches_empirical() -> None:
+    # Deterministic small fixture: T=500, N=2 with one low-risk + one
+    # high-risk fund so the LP has something to trade off.
+    rng = np.random.default_rng(123)
+    T = 500
+    R_low = rng.normal(0.0003, 0.005, size=T)
+    R_high = rng.normal(0.0008, 0.020, size=T)
+    R = np.column_stack([R_low, R_high])
+
+    cvar_limit = 0.04
+    fund_ids = ["LOW", "HIGH"]
+    fund_blocks = {"LOW": "x", "HIGH": "x"}
+    annual_mu = np.array([R_low.mean() * 252, R_high.mean() * 252])
+    expected_returns = {fid: float(annual_mu[i]) for i, fid in enumerate(fund_ids)}
+    annual_cov = np.cov(R, rowvar=False) * 252.0
+
+    constraints = ProfileConstraints(
+        blocks=[BlockConstraint("x", 0.0, 1.0)],
+        cvar_limit=cvar_limit,
+        max_single_fund_weight=1.0,
+    )
+    result = asyncio.run(
+        optimize_fund_portfolio(
+            fund_ids=fund_ids, fund_blocks=fund_blocks,
+            expected_returns=expected_returns, cov_matrix=annual_cov,
+            returns_scenarios=R, constraints=constraints,
+        ),
+    )
+
+    assert result.status == "optimal"
+    weights = np.array([result.weights[fid] for fid in fund_ids])
+    realized = realized_cvar_from_weights(weights, R, alpha=0.95)
+    # LP enforces empirical CVaR <= limit; allow a small solver tolerance.
+    assert realized <= cvar_limit + 1e-3, (
+        f"realized CVaR {realized:.4f} breaches limit {cvar_limit}"
+    )
+
+
+# ── E.7 — Empty constraint polytope ──────────────────────────────────
+
+
+def test_polytope_empty_returns_constraint_polytope_empty() -> None:
+    # Block min sums > 1 — no feasible point.
+    fund_ids = ["A", "B", "C"]
+    fund_blocks = {"A": "X", "B": "Y", "C": "Z"}
+    annual_mu = np.array([0.08, 0.09, 0.07])
+    expected_returns = {fid: float(annual_mu[i]) for i, fid in enumerate(fund_ids)}
+    annual_cov = np.eye(3) * 0.02
+    rng = np.random.default_rng(7)
+    R = rng.normal(0.0003, 0.01, size=(500, 3))
+
+    # Each block must hold >=0.5, sum of mins = 1.5 > 1 → infeasible polytope.
+    constraints = ProfileConstraints(
+        blocks=[
+            BlockConstraint("X", 0.5, 1.0),
+            BlockConstraint("Y", 0.5, 1.0),
+            BlockConstraint("Z", 0.5, 1.0),
+        ],
+        cvar_limit=0.10,
+        max_single_fund_weight=1.0,
+    )
+    result = asyncio.run(
+        optimize_fund_portfolio(
+            fund_ids=fund_ids, fund_blocks=fund_blocks,
+            expected_returns=expected_returns, cov_matrix=annual_cov,
+            returns_scenarios=R, constraints=constraints,
+        ),
+    )
+
+    assert result.status == "constraint_polytope_empty"
+    assert result.weights == {}

--- a/backend/tests/quant_engine/test_cascade_telemetry.py
+++ b/backend/tests/quant_engine/test_cascade_telemetry.py
@@ -1,12 +1,16 @@
-"""PR-A11 — optimizer cascade telemetry unit tests.
+"""PR-A11/A12 — optimizer cascade telemetry unit tests.
 
-Covers Section E of ``docs/prompts/2026-04-16-pr-a11-validation-gate-review.md``:
+A12 reshaped the cascade from the legacy 4-phase variance-proxy
+sequence into a 3-phase Rockafellar-Uryasev sequence
+(``phase_1_ru_max_return`` → ``phase_2_ru_robust`` →
+``phase_3_min_cvar``). The PR-A11 invariants preserved here:
 
-- E.1 Phase 1 success: 1 succeeded + 3 skipped attempts.
-- E.2 Phase 2 success: primary recorded, variance_capped succeeded.
-- E.3 Phase 3 fallback: infeasibility_reason + max_vol_target captured.
-
-All tests synchronous against a well-conditioned 3-fund universe.
+- ``phase_attempts`` is a dense list with one entry per cascade phase
+  (including skipped ones). Skipped phases have ``status="skipped"``
+  and ``wall_ms=0``.
+- ``winning_phase`` is one of the three phase keys or None (pre-solve
+  failure).
+- Empty universe produces all-skipped attempts with ``status="empty"``.
 """
 
 from __future__ import annotations
@@ -27,7 +31,10 @@ from quant_engine.optimizer_service import (
 
 def _make_inputs(
     cvar_limit: float | None = None,
-) -> tuple[list[str], dict[str, str], dict[str, float], ProfileConstraints, np.ndarray]:
+) -> tuple[
+    list[str], dict[str, str], dict[str, float], ProfileConstraints,
+    np.ndarray, np.ndarray,
+]:
     fund_ids = ["A", "B", "C"]
     fund_blocks = {"A": "eq", "B": "eq", "C": "fi"}
     expected_returns = {"A": 0.10, "B": 0.08, "C": 0.04}
@@ -44,11 +51,20 @@ def _make_inputs(
         cvar_limit=cvar_limit,
         max_single_fund_weight=1.0,
     )
-    return fund_ids, fund_blocks, expected_returns, constraints, cov
+    # Synth 5Y daily scenarios from cov; reproducible seed.
+    rng = np.random.default_rng(11)
+    daily_cov = cov / 252.0
+    L = np.linalg.cholesky(daily_cov)
+    daily_mu = np.array([expected_returns[fid] / 252.0 for fid in fund_ids])
+    scenarios = (rng.standard_normal((1260, 3)) @ L.T) + daily_mu
+    return fund_ids, fund_blocks, expected_returns, constraints, cov, scenarios
 
 
-def _run(cvar_limit: float | None = None) -> FundOptimizationResult:
-    fund_ids, fund_blocks, er, constraints, cov = _make_inputs(cvar_limit)
+def _run(
+    cvar_limit: float | None = None,
+    robust: bool = False,
+) -> FundOptimizationResult:
+    fund_ids, fund_blocks, er, constraints, cov, R = _make_inputs(cvar_limit)
     return asyncio.run(
         optimize_fund_portfolio(
             fund_ids=fund_ids,
@@ -56,6 +72,8 @@ def _run(cvar_limit: float | None = None) -> FundOptimizationResult:
             expected_returns=er,
             constraints=constraints,
             cov_matrix=cov,
+            returns_scenarios=R,
+            robust=robust,
         ),
     )
 
@@ -67,72 +85,79 @@ def _get_attempt(attempts: list[PhaseAttempt], phase: str) -> PhaseAttempt:
     raise AssertionError(f"phase {phase!r} not found in attempts")
 
 
-# ── E.1 — Phase 1 success ─────────────────────────────────────────────
+# ── E.1 — Phase 1 success ────────────────────────────────────────────
 
 
 def test_phase_attempts_recorded_for_phase1_success() -> None:
     result = _run(cvar_limit=None)
 
     assert result.status == "optimal"
-    assert result.winning_phase == "primary"
-    assert len(result.phase_attempts) >= 4
-    primary = _get_attempt(result.phase_attempts, "primary")
-    assert primary.status == "succeeded"
-    # Skipped phases must have status="skipped" and zero walltime
-    for ph in ("robust", "variance_capped", "min_variance"):
-        att = _get_attempt(result.phase_attempts, ph)
-        assert att.status == "skipped"
-        assert att.wall_ms == 0
-        assert att.infeasibility_reason is None
+    assert result.winning_phase == "phase_1_ru_max_return"
+    # Cascade has 3 phases; Phase 2 skipped (robust=False), Phase 3 always runs.
+    assert len(result.phase_attempts) == 3
+    p1 = _get_attempt(result.phase_attempts, "phase_1_ru_max_return")
+    assert p1.status == "succeeded"
+    p2 = _get_attempt(result.phase_attempts, "phase_2_ru_robust")
+    assert p2.status == "skipped"
+    assert p2.wall_ms == 0
+    # Phase 3 ALWAYS runs for the achievable-return band
+    p3 = _get_attempt(result.phase_attempts, "phase_3_min_cvar")
+    assert p3.status == "succeeded"
+    assert p3.wall_ms > 0
 
 
-# ── E.2 — Phase 2 success ─────────────────────────────────────────────
+# ── E.2 — Phase 2 robust success ─────────────────────────────────────
 
 
-def test_phase_attempts_records_phase2_success() -> None:
-    # Tight-but-feasible CVaR limit so Phase 1 violates, Phase 2 solves.
-    result = _run(cvar_limit=-0.20)
+def test_phase_attempts_records_phase2_robust_success() -> None:
+    # Run with robust=True and no cvar_limit so both Phase 1 (no CVaR
+    # constraint, max μᵀw) and Phase 2 robust can solve. Phase 1 wins
+    # because the robust penalty is strictly worse than the pure
+    # max-return objective; Phase 2 is recorded as ``succeeded`` but
+    # not selected. The invariant we care about: Phase 2 logged a real
+    # attempt (not ``skipped``) when robust=True.
+    result = _run(cvar_limit=None, robust=True)
 
-    # Either Phase 1 already satisfies or Phase 2 wins — accept both, but the
-    # attempt trail MUST contain ``primary`` recorded (not skipped).
-    primary = _get_attempt(result.phase_attempts, "primary")
-    assert primary.status == "succeeded"
-    assert primary.cvar_limit_effective == pytest.approx(-0.20)
+    p1 = _get_attempt(result.phase_attempts, "phase_1_ru_max_return")
+    assert p1.status == "succeeded"
 
-    if result.winning_phase == "variance_capped":
-        vc = _get_attempt(result.phase_attempts, "variance_capped")
-        assert vc.status == "succeeded"
-        assert vc.max_var is not None and vc.max_var > 0
-        assert vc.cvar_coeff is not None and vc.cvar_coeff > 0
-        assert vc.phase2_limit is not None
-
-
-# ── E.3 — Phase 3 fallback ────────────────────────────────────────────
+    p2 = _get_attempt(result.phase_attempts, "phase_2_ru_robust")
+    assert p2.status in ("succeeded", "infeasible")
+    assert p2.wall_ms > 0
+    if p2.status == "succeeded":
+        assert p2.kappa_used is not None and p2.kappa_used > 0
 
 
-def test_phase_attempts_records_phase3_fallback() -> None:
-    # Impossibly tight CVaR (≥ 0.5% cushion) — Phase 2 ceiling ~0 → infeasible
-    result = _run(cvar_limit=-0.005)
+# ── E.3 — Phase 3 winner (tight CVaR limit, degraded) ────────────────
 
-    assert result.winning_phase == "min_variance", (
+
+def test_phase_attempts_records_phase3_winner_degraded() -> None:
+    # Impossibly tight CVaR (0.1%) — Phase 1 infeasible, Phase 3 wins
+    # with status=degraded (universe floor binds).
+    result = _run(cvar_limit=0.001)
+
+    assert result.winning_phase == "phase_3_min_cvar", (
         f"expected Phase 3 winner, got {result.winning_phase!r} "
         f"(status={result.status})"
     )
+    assert result.status == "degraded"
+    assert result.min_achievable_cvar is not None
+    assert result.min_achievable_cvar > 0.001, (
+        "min-CVaR must exceed the impossible limit"
+    )
+    assert result.achievable_return_band is not None
+    band = result.achievable_return_band
+    # Band collapses when limit < floor.
+    assert band["lower"] == band["upper"]
 
-    vc = _get_attempt(result.phase_attempts, "variance_capped")
-    assert vc.status == "infeasible"
-    assert vc.infeasibility_reason is not None
-    assert vc.max_vol_target is not None and vc.max_vol_target > 0
-
-    mv = _get_attempt(result.phase_attempts, "min_variance")
-    assert mv.status == "succeeded"
-    assert mv.min_achievable_variance is not None
-    assert mv.min_achievable_vol is not None
-    # Feasibility gap: min-var floor > Phase 2 ceiling
-    assert mv.min_achievable_vol > vc.max_vol_target
+    p1 = _get_attempt(result.phase_attempts, "phase_1_ru_max_return")
+    assert p1.status == "infeasible"
+    p3 = _get_attempt(result.phase_attempts, "phase_3_min_cvar")
+    assert p3.status == "succeeded"
+    assert p3.objective_value is not None and p3.objective_value > 0
 
 
-# ── E.1b — Defensive: skipped-phase padding on trivial empty input ───
+# ── E.1b — Defensive: empty universe produces all-skipped attempts ───
 
 
 def test_empty_universe_produces_all_skipped_attempts() -> None:
@@ -144,6 +169,14 @@ def test_empty_universe_produces_all_skipped_attempts() -> None:
         ),
     )
     assert result.status == "empty"
-    assert len(result.phase_attempts) == 4
+    # PR-A12 cascade has 3 phases
+    assert len(result.phase_attempts) == 3
     assert all(a.status == "skipped" for a in result.phase_attempts)
     assert result.winning_phase is None
+    # Skipped phases carry the A12 phase keys
+    phase_keys = [a.phase for a in result.phase_attempts]
+    assert phase_keys == [
+        "phase_1_ru_max_return",
+        "phase_2_ru_robust",
+        "phase_3_min_cvar",
+    ]

--- a/backend/tests/quant_engine/test_construction_adversarial.py
+++ b/backend/tests/quant_engine/test_construction_adversarial.py
@@ -364,6 +364,7 @@ def test_fund_level_inputs_is_frozen() -> None:
         cov_matrix=np.eye(2),
         expected_returns={"a": 0.05, "b": 0.07},
         available_ids=["a", "b"],
+        returns_scenarios=np.zeros((252, 2)),
         skewness=np.zeros(2),
         excess_kurtosis=np.zeros(2),
         condition_number=1.0,

--- a/backend/tests/wealth/test_construction_run_executor_cascade.py
+++ b/backend/tests/wealth/test_construction_run_executor_cascade.py
@@ -1,13 +1,17 @@
-"""PR-A11 — executor-side cascade telemetry builder tests.
+"""PR-A11/A12 — executor-side cascade telemetry builder tests.
 
 These exercise ``_build_cascade_telemetry`` (pure function) without a DB
-so they can run offline. End-to-end persistence is validated by the F.1
+so they run offline. End-to-end persistence is validated by the F.1
 live-DB smoke in the prompt.
 
+PR-A12 reshaped the cascade into 3 RU phases; tests updated in lockstep.
 Covers:
-- E.4 Phase 3 fallback → degraded + risk_budget operator_signal
-- E.5 Phase 2 winner → succeeded + null operator_signal
-- E.6 Sanitization: SSE-bound payload contains only the public subset
+
+- Phase 3 winner ABOVE limit → degraded + cvar_limit_below_universe_floor
+- Phase 1 winner → succeeded + null operator_signal
+- Upstream heuristic (compute_fund_level_inputs failed) → degraded
+- Constraint polytope empty → failed
+- SSE vocabulary sanitization regression guard
 """
 
 from __future__ import annotations
@@ -19,136 +23,143 @@ from app.domains.wealth.workers.construction_run_executor import (
 )
 
 
-def _phase_3_fallback_block() -> dict:
+def _phase_3_above_limit_block() -> dict:
+    """Canonical Conservative-like block: Phase 1 infeasible, Phase 3 above limit."""
     return {
         "phase_attempts": [
             {
-                "phase": "primary", "status": "succeeded", "solver": "CLARABEL",
-                "objective_value": 0.131991, "wall_ms": 4321,
-                "infeasibility_reason": None,
-                "cvar_at_solution": -0.15, "cvar_limit_effective": -0.05,
-                "cvar_within_limit": False,
+                "phase": "phase_1_ru_max_return", "status": "infeasible",
+                "solver": None, "objective_value": None, "wall_ms": 312,
+                "infeasibility_reason": "PRIMAL_INFEASIBLE",
+                "cvar_at_solution": None, "cvar_at_solution_cf": None,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": None,
             },
             {
-                "phase": "robust", "status": "skipped", "solver": None,
+                "phase": "phase_2_ru_robust", "status": "skipped", "solver": None,
                 "objective_value": None, "wall_ms": 0,
                 "infeasibility_reason": None,
             },
             {
-                "phase": "variance_capped", "status": "infeasible",
-                "solver": "CLARABEL", "objective_value": None, "wall_ms": 217,
-                "infeasibility_reason": "infeasible",
-                "max_var": 0.000071, "max_vol_target": 0.0084,
-                "cvar_coeff": 2.85, "cf_normal_ratio": 1.3,
-                "phase2_limit": -0.05,
-            },
-            {
-                "phase": "min_variance", "status": "succeeded",
-                "solver": "CLARABEL", "objective_value": 0.000868,
+                "phase": "phase_3_min_cvar", "status": "succeeded",
+                "solver": "CLARABEL", "objective_value": 0.0635,
                 "wall_ms": 89, "infeasibility_reason": None,
-                "min_achievable_variance": 0.000868,
-                "min_achievable_vol": 0.02946,
+                "cvar_at_solution": 0.0635, "cvar_at_solution_cf": 0.071,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": False,
             },
         ],
-        "winning_phase": "min_variance",
+        "winning_phase": "phase_3_min_cvar",
+        "min_achievable_cvar": 0.0635,
+        "achievable_return_band": {
+            "lower": 0.0998, "upper": 0.0998,
+            "lower_at_cvar": 0.0635, "upper_at_cvar": 0.0635,
+        },
     }
 
 
-def test_phase_3_fallback_yields_degraded_and_risk_budget_signal() -> None:
+def test_phase_3_above_limit_yields_degraded_and_floor_signal() -> None:
     telemetry, status = _build_cascade_telemetry(
-        cascade_block=_phase_3_fallback_block(),
-        optimizer_trace={"status": "optimal:min_variance_fallback"},
-        cvar_limit=-0.05,
+        cascade_block=_phase_3_above_limit_block(),
+        optimizer_trace={"status": "degraded"},
+        cvar_limit=0.05,
     )
     assert status == "degraded"
-    assert telemetry["cascade_summary"] == "phase_3_fallback"
-    assert telemetry["phase2_max_var"] == 0.000071
-    assert telemetry["min_achievable_variance"] == 0.000868
-    assert telemetry["feasibility_gap_pct"] is not None
-    assert telemetry["feasibility_gap_pct"] > 80
+    assert telemetry["cascade_summary"] == "phase_3_min_cvar_above_limit"
+    assert telemetry["min_achievable_cvar"] == 0.0635
+    band = telemetry["achievable_return_band"]
+    assert band["lower"] == band["upper"] == 0.0998
     sig = telemetry["operator_signal"]
     assert sig is not None
-    assert sig["kind"] == "constraint_binding"
-    assert sig["binding"] == "risk_budget"
-    assert sig["message_key"] == "cvar_limit_below_universe_floor"
-    # Phase keys normalized to public names + at least 4 attempts
+    assert sig["kind"] == "cvar_limit_below_universe_floor"
+    assert sig["binding"] == "tail_risk_floor"
+    assert sig["min_achievable_cvar"] == 0.0635
+    assert sig["user_cvar_limit"] == 0.05
+    # All 3 phases present
     phases = [a["phase"] for a in telemetry["phase_attempts"]]
-    assert "phase_1" in phases
-    assert "phase_2_variance_capped" in phases
-    assert "phase_3_min_variance" in phases
-    assert len(telemetry["phase_attempts"]) >= 4
+    assert phases == [
+        "phase_1_ru_max_return",
+        "phase_2_ru_robust",
+        "phase_3_min_cvar",
+    ]
 
 
-def test_phase_2_winner_yields_clean_telemetry() -> None:
+def test_phase_1_winner_yields_clean_telemetry() -> None:
     cascade_block = {
         "phase_attempts": [
             {
-                "phase": "primary", "status": "succeeded", "solver": "CLARABEL",
-                "objective_value": 0.1, "wall_ms": 100,
+                "phase": "phase_1_ru_max_return", "status": "succeeded",
+                "solver": "CLARABEL", "objective_value": 0.1085, "wall_ms": 287,
                 "infeasibility_reason": None,
-                "cvar_at_solution": -0.10, "cvar_limit_effective": -0.08,
-                "cvar_within_limit": False,
+                "cvar_at_solution": 0.047, "cvar_at_solution_cf": 0.053,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": True,
             },
-            {"phase": "robust", "status": "skipped", "solver": None,
-             "objective_value": None, "wall_ms": 0, "infeasibility_reason": None},
             {
-                "phase": "variance_capped", "status": "succeeded",
-                "solver": "CLARABEL", "objective_value": 0.09,
-                "wall_ms": 150, "infeasibility_reason": None,
-                "max_var": 0.002, "max_vol_target": 0.045,
-                "cvar_coeff": 2.85, "cf_normal_ratio": 1.3,
-                "phase2_limit": -0.08,
+                "phase": "phase_2_ru_robust", "status": "skipped", "solver": None,
+                "objective_value": None, "wall_ms": 0,
+                "infeasibility_reason": None,
+            },
+            {
+                "phase": "phase_3_min_cvar", "status": "succeeded",
+                "solver": "CLARABEL", "objective_value": 0.0352, "wall_ms": 91,
+                "infeasibility_reason": None,
+                "cvar_at_solution": 0.0352, "cvar_at_solution_cf": 0.040,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": True,
             },
         ],
-        "winning_phase": "variance_capped",
+        "winning_phase": "phase_1_ru_max_return",
+        "min_achievable_cvar": 0.0352,
+        "achievable_return_band": {
+            "lower": 0.0975, "upper": 0.1085,
+            "lower_at_cvar": 0.0352, "upper_at_cvar": 0.047,
+        },
     }
     telemetry, status = _build_cascade_telemetry(
         cascade_block=cascade_block,
-        optimizer_trace={"status": "optimal:cvar_constrained"},
-        cvar_limit=-0.08,
+        optimizer_trace={"status": "optimal"},
+        cvar_limit=0.05,
     )
     assert status == "succeeded"
-    assert telemetry["cascade_summary"] == "phase_2_succeeded"
+    assert telemetry["cascade_summary"] == "phase_1_succeeded"
     assert telemetry["operator_signal"] is None
-    assert telemetry["feasibility_gap_pct"] is None
+    assert telemetry["min_achievable_cvar"] == 0.0352
 
 
-def test_heuristic_fallback_yields_degraded_and_solver_signal() -> None:
+def test_upstream_heuristic_yields_degraded_and_data_signal() -> None:
     cascade_block = {
         "phase_attempts": [],
-        "winning_phase": "heuristic",
+        "winning_phase": "upstream_heuristic",
     }
     telemetry, status = _build_cascade_telemetry(
         cascade_block=cascade_block,
         optimizer_trace={"status": "fallback:insufficient_fund_data"},
-        cvar_limit=-0.05,
+        cvar_limit=0.05,
     )
     assert status == "degraded"
-    assert telemetry["cascade_summary"] == "heuristic_fallback"
+    assert telemetry["cascade_summary"] == "upstream_heuristic"
     sig = telemetry["operator_signal"]
     assert sig is not None
-    assert sig["binding"] == "solver"
-    assert sig["message_key"] == "convex_phases_exhausted"
+    assert sig["kind"] == "upstream_data_missing"
+    assert sig["binding"] == "returns_quality"
 
 
-def test_cascade_exhausted_yields_failed_status() -> None:
-    # At least one recorded attempt (in failed state) distinguishes a
-    # genuine cascade exhaustion from the legacy/empty sentinel path.
+def test_constraint_polytope_empty_yields_failed_status() -> None:
     telemetry, status = _build_cascade_telemetry(
         cascade_block={
             "phase_attempts": [
-                {"phase": "primary", "status": "solver_failed", "solver": None,
-                 "objective_value": None, "wall_ms": 10,
-                 "infeasibility_reason": "Both CLARABEL and SCS failed"},
+                {
+                    "phase": "phase_3_min_cvar", "status": "solver_failed",
+                    "solver": "CLARABEL", "objective_value": None, "wall_ms": 10,
+                    "infeasibility_reason": "infeasible",
+                    "cvar_limit_effective": 0.05,
+                },
             ],
             "winning_phase": None,
         },
-        optimizer_trace={"status": "solver_failed"},
-        cvar_limit=None,
+        optimizer_trace={"status": "constraint_polytope_empty"},
+        cvar_limit=0.05,
     )
     assert status == "failed"
-    assert telemetry["cascade_summary"] == "cascade_exhausted"
-    assert telemetry["operator_signal"]["kind"] == "cascade_failure"
+    assert telemetry["cascade_summary"] == "constraint_polytope_empty"
+    assert telemetry["operator_signal"]["kind"] == "constraint_polytope_empty"
 
 
 def test_empty_block_returns_legacy_sentinel() -> None:
@@ -165,24 +176,24 @@ def test_empty_block_returns_legacy_sentinel() -> None:
 
 
 def test_sse_payload_is_sanitized() -> None:
-    """The SSE-bound subset ({cascade_summary, operator_signal,
-    feasibility_gap_pct}) must not leak solver names, internal phase keys,
-    or math jargon. Regression guard for the vocabulary allowlist."""
+    """The SSE-bound subset must not leak solver names, internal phase keys,
+    or math jargon. Regression guard for the PR-A12 vocabulary allowlist."""
     telemetry, _ = _build_cascade_telemetry(
-        cascade_block=_phase_3_fallback_block(),
-        optimizer_trace={"status": "optimal:min_variance_fallback"},
-        cvar_limit=-0.05,
+        cascade_block=_phase_3_above_limit_block(),
+        optimizer_trace={"status": "degraded"},
+        cvar_limit=0.05,
     )
     sse_payload = {
         "cascade_summary": telemetry["cascade_summary"],
         "operator_signal": telemetry["operator_signal"],
-        "feasibility_gap_pct": telemetry["feasibility_gap_pct"],
+        "min_achievable_cvar": telemetry["min_achievable_cvar"],
+        "achievable_return_band": telemetry["achievable_return_band"],
     }
     payload_json = json.dumps(sse_payload)
-    assert "CLARABEL" not in payload_json
-    assert "SCS" not in payload_json
-    assert "phase_attempts" not in payload_json
-    assert "phase_2_variance_capped" not in payload_json
-    assert "min_variance_fallback" not in payload_json
-    assert "cvar_coeff" not in payload_json
-    assert "κ" not in payload_json
+    forbidden = [
+        "CLARABEL", "SCS", "phase_attempts", "cvar_coeff",
+        "Rockafellar-Uryasev", "Cornish-Fisher", "zeta", "u_i",
+        "min_variance_fallback", "heuristic_fallback",
+    ]
+    for tok in forbidden:
+        assert tok not in payload_json, f"forbidden token {tok!r} leaked"

--- a/frontends/wealth/src/lib/util/metric-translators.ts
+++ b/frontends/wealth/src/lib/util/metric-translators.ts
@@ -154,11 +154,22 @@ export function translateRSquaredMedian(value: number): TranslatedMetric {
 
 /**
  * ``phase_used`` — which optimiser cascade phase produced the final
- * weights. Falling through to the heuristic is a visible signal that
- * the convex solvers could not land a feasible point.
+ * weights. PR-A12 reshaped the cascade into three Rockafellar-Uryasev
+ * phases; legacy keys are aliased for one release so stale runs still
+ * render a sensible label.
  */
 export function translateOptimizerPhase(value: string): TranslatedMetric {
 	switch (value) {
+		// PR-A12 canonical keys
+		case "phase_1_ru_max_return":
+			return { label: "Máximo retorno (risco limitado)", tone: "success" };
+		case "phase_2_ru_robust":
+			return { label: "Máximo retorno (robusto)", tone: "success" };
+		case "phase_3_min_cvar":
+			return { label: "Mínimo risco de cauda", tone: "neutral" };
+		case "upstream_heuristic":
+			return { label: "Fallback por dados insuficientes", tone: "warning" };
+		// Legacy aliases — drop after one release cycle
 		case "primary":
 			return { label: "Otimizador principal", tone: "success" };
 		case "robust":
@@ -171,6 +182,78 @@ export function translateOptimizerPhase(value: string): TranslatedMetric {
 			return { label: "Fallback heurístico", tone: "warning" };
 		default:
 			return { label: `Otimizador: ${value}`, tone: "neutral" };
+	}
+}
+
+/**
+ * ``cascade_summary`` (PR-A11/A12) — operator-vocabulary headline for the
+ * construction run's cascade outcome. Drives the Builder's cascade chip
+ * colour + top-line message. Allowed vocabulary only; never shows solver
+ * names, phase keys or math jargon.
+ */
+export function translateCascadeSummary(value: string): TranslatedMetric {
+	switch (value) {
+		case "phase_1_succeeded":
+			return {
+				label: "Otimizado para máximo retorno dentro do limite de risco",
+				tone: "success",
+			};
+		case "phase_2_robust_succeeded":
+			return {
+				label: "Otimizado com ajuste robusto conservador",
+				tone: "success",
+			};
+		case "phase_3_min_cvar_within_limit":
+			return {
+				label: "Alocação de mínimo risco de cauda dentro do limite",
+				tone: "success",
+			};
+		case "phase_3_min_cvar_above_limit":
+			return {
+				label:
+					"Limite de perda está abaixo do piso do universo — exibindo alocação de mínimo risco",
+				tone: "warning",
+			};
+		case "upstream_heuristic":
+			return {
+				label: "Dados insuficientes para otimização — alocação provisória",
+				tone: "warning",
+			};
+		case "constraint_polytope_empty":
+			return {
+				label: "Bandas por bloco incompatíveis — revisar estrutura de alocação",
+				tone: "danger",
+			};
+		default:
+			return { label: value, tone: "neutral" };
+	}
+}
+
+/**
+ * ``operator_signal.kind`` (PR-A11/A12) — structured signal driving the
+ * feedback panel next to the CVaR slider. Emits the copy the Builder
+ * surfaces; numeric values travel alongside in the signal payload.
+ */
+export function translateOperatorSignalKind(value: string): TranslatedMetric {
+	switch (value) {
+		case "cvar_limit_below_universe_floor":
+			return {
+				label:
+					"Seu limite de perda está abaixo do menor risco de cauda que o universo entrega",
+				tone: "warning",
+			};
+		case "upstream_data_missing":
+			return {
+				label: "Estatísticas de retorno indisponíveis para o universo atual",
+				tone: "warning",
+			};
+		case "constraint_polytope_empty":
+			return {
+				label: "Soma das bandas por bloco não fecha em 100% — revisar bandas",
+				tone: "danger",
+			};
+		default:
+			return { label: value, tone: "neutral" };
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace variance-proxy CVaR enforcement with **Rockafellar-Uryasev LP** — Phase 1 maximizes return s.t. exact empirical CVaR ≤ limit, no more false infeasibility from the CF approximation
- Replace min-variance fallback with **min-CVaR LP** (Phase 3) that **ALWAYS runs**, populating `achievable_return_band` for the upcoming Builder slider feedback (PR-A13)
- Cascade **never** returns `failed` for solver / feasibility reasons — the only terminal failure is `constraint_polytope_empty` (block bands sum > 1, a config error)
- Drop `heuristic_fallback` and `min_variance_fallback` paths — both lost the operator's CVaR intent

## New cascade shape
| Phase | Objective | When |
|---|---|---|
| `phase_1_ru_max_return` | max μᵀw s.t. RU CVaR ≤ limit | always first |
| `phase_2_ru_robust` | + PR-A3 ellipsoidal κ‖Lᵀw‖₂ | opt-in (`robust=True`) |
| `phase_3_min_cvar` | min RU CVaR | **always runs** (band telemetry) |

## Schema
- **No new column, no migration.** PR-A11's `cascade_telemetry JSONB` (migration 0142) extended additively with `min_achievable_cvar` and `achievable_return_band`.
- `cascade_summary` enum updated: `phase_1_succeeded | phase_2_robust_succeeded | phase_3_min_cvar_within_limit | phase_3_min_cvar_above_limit | upstream_heuristic | constraint_polytope_empty`. Old values (`variance_capped`, `phase_3_fallback`, `heuristic_fallback`, `cascade_exhausted`) retired.
- `operator_signal.kind` enum updated: `cvar_limit_below_universe_floor`, `upstream_data_missing`, `constraint_polytope_empty`.

## Empirical smoke (live local DB, org `403d8392-...`)

| Portfolio | status | summary | min_cvar | band_lower | band_upper | n_w | ms |
|---|---|---|---:|---:|---:|---:|---:|
| **Conservative Preservation** | succeeded | `phase_1_succeeded` | 0.00415 | 9.84% | 30.62% | 9 | 5109 |
| **Balanced Income** | succeeded | `phase_1_succeeded` | 0.00435 | 10.54% | 31.99% | 7 | 2463 |
| **Dynamic Growth** | succeeded | `phase_1_succeeded` | 0.00595 | 13.08% | 31.36% | 8 | 2482 |

**The big result:** Pre-A12, Conservative + Balanced silently degraded to `min_variance_fallback` (CVaR-blind) because `σ_max ≈ 1.75-2.27%` falsely rejected feasible CVaR-compliant portfolios with higher σ. Post-A12 the RU LP measures empirical CVaR directly — Conservative's universe floor is **0.42%**, well below the 5% limit, so Phase 1 wins cleanly. The variance proxy was the bug, not the universe.

**Always-solvable invariant** verified via property test (E.3): 50 random configurations, `status ∈ {succeeded, degraded}`, never `failed`.

## Tests
- **7 new unit tests** (`test_always_solvable_cascade.py`, E.1-E.7) covering Phase 1/2/3 paths, monotonic band, empirical CVaR match, empty polytope. E.3 parametrized over 50 random configs → 56 test cases total.
- PR-A11's `test_cascade_telemetry.py` updated in lockstep for new enum values
- Executor-side `test_construction_run_executor_cascade.py` rewritten for A12 summary/signal enums
- `test_construction_adversarial.py::test_fund_level_inputs_is_frozen` extended with `returns_scenarios` arg
- **66/66 cascade tests green**; **119/119 wealth suite green**; **162/163 quant_engine** (1 pre-existing failure on main, unrelated)

## Test plan
- [x] Unit tests green (66 cascade + 119 wealth)
- [x] F.1 live-DB smoke on 3 canonical portfolios — all 3 `succeeded` with `phase_1_succeeded`
- [x] SSE payload sanitization regression guard green
- [x] Frontend translator updated in lockstep with new enum values
- [ ] PR-A11 `cascade_telemetry_completed` consumers in `frontends/wealth/` verified rendering new operator_signal.kind values (delegated to PR-A13)
- [ ] Railway deploy smoke (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)