### PR TITLE
chore(wealth): cleanup deferred items from PR-A12 (PR-A12.1)

### DIFF
--- a/backend/app/core/config/registry.py
+++ b/backend/app/core/config/registry.py
@@ -131,7 +131,7 @@ _REGISTRY: tuple[ConfigDomain, ...] = (
         config_type="optimizer",
         ownership="config_service",
         client_visible=False,
-        description="Wealth construction-engine optimizer tunables (cf_relaxation_factor, etc.)",
+        description="Wealth construction-engine optimizer tunables (reserved for future per-tenant overrides)",
         required=False,
     ),
 )

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -2194,12 +2194,6 @@ async def _run_construction_async(
             max_single_fund=active_constraints.max_single_fund_weight,
         )
 
-        from app.core.config.config_service import ConfigService
-        config_svc = ConfigService(db)
-        optimizer_result = await config_svc.get("wealth", "optimizer", str(org_id))
-        optimizer_config = optimizer_result.value if optimizer_result else {}
-        cf_factor = float(optimizer_config.get("cf_relaxation_factor", 1.3))
-
         fund_result = await optimize_fund_portfolio(
             fund_ids=opt_fund_ids,
             fund_blocks=sub_blocks,
@@ -2209,7 +2203,7 @@ async def _run_construction_async(
             constraints=active_constraints,
             skewness=sub_skewness,
             excess_kurtosis=sub_excess_kurtosis,
-            cf_relaxation_factor=cf_factor,  # PR-A12: retained for one release, ignored
+            caller_kind="construction_run",
         )
 
         if fund_result.status.startswith("optimal") and fund_result.weights:

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -928,20 +928,30 @@ async def execute_construction_run(
         )
         return run
 
-    # Detect heuristic fallback + PR-A11 Phase 3 min-variance fallback. Both
-    # outcomes produced weights but fail to honor the CVaR objective, so
-    # persist as ``degraded``. ``run.cascade_telemetry`` (set in the inner
-    # executor) drives the decision; the legacy solver-string check remains
-    # as a defensive fallback for pre-A11 code paths (empty telemetry).
+    # PR-A12 cascade summary enum drives run.status. Post-A12 there is no
+    # cvar-blind fallback that produced weights — Phase 3 always runs
+    # CVaR-aware, so ``phase_3_min_cvar_above_limit`` and ``upstream_heuristic``
+    # are the only ``degraded`` outcomes; ``constraint_polytope_empty`` is the
+    # only remaining terminal failure. The legacy solver-string check stays
+    # as a defensive fallback for empty cascade_telemetry (pre-A11 mocks).
     telemetry_summary = (run.cascade_telemetry or {}).get("cascade_summary")
     solver = (run.optimizer_trace or {}).get("solver")
-    if telemetry_summary in ("phase_3_fallback", "heuristic_fallback"):
+    if telemetry_summary in (
+        "phase_3_min_cvar_above_limit",
+        "upstream_heuristic",
+    ):
         run.status = "degraded"
-    elif telemetry_summary == "cascade_exhausted":
+    elif telemetry_summary == "constraint_polytope_empty":
         run.status = "failed"
-    elif telemetry_summary in ("phase_1_succeeded", "phase_1_5_robust_succeeded", "phase_2_succeeded"):
+    elif telemetry_summary in (
+        "phase_1_succeeded",
+        "phase_2_robust_succeeded",
+        "phase_3_min_cvar_within_limit",
+    ):
         run.status = "succeeded"
     elif solver == "heuristic_fallback":
+        # Defensive: legacy path where cascade_telemetry is empty but the
+        # upstream-bailout composition was built (solver tag set by the route).
         run.status = "degraded"
     else:
         run.status = "succeeded"

--- a/backend/quant_engine/optimizer_service.py
+++ b/backend/quant_engine/optimizer_service.py
@@ -193,7 +193,6 @@ async def optimize_portfolio(
     objective: str = "max_sharpe",
     mandate: str | None = None,
     risk_aversion: float | None = None,
-    cf_relaxation_factor: float = 1.3,
 ) -> OptimizationResult:
     """Optimize portfolio weights using cvxpy.
 
@@ -381,7 +380,7 @@ async def optimize_fund_portfolio(
     cvar_alpha: float = 0.95,
     mandate: str | None = None,
     risk_aversion: float | None = None,
-    cf_relaxation_factor: float = 1.3,
+    caller_kind: str = "unspecified",
 ) -> FundOptimizationResult:
     """Optimize fund-level weights with block-group sum constraints.
 
@@ -404,8 +403,11 @@ async def optimize_fund_portfolio(
     feasibility reasons — only for upstream data failures (no funds, PSD
     violation, empty polytope).
 
-    ``cf_relaxation_factor`` is retained in the signature for one release
-    of backwards compatibility; PR-A12 ignores it (dead param).
+    ``caller_kind`` tags the call site so the auto-synthesis warning
+    ("returns_scenarios_missing_using_covariance_synth") can be filtered
+    by dashboard. Production construction runs should always pass
+    ``caller_kind="construction_run"`` AND ``returns_scenarios`` — if
+    the warning fires with that tag it is a P1 bug.
 
     Constraints:
         sum(w) == 1                          (fully invested)
@@ -414,7 +416,6 @@ async def optimize_fund_portfolio(
         sum(w[funds_in_block]) >= block_min  (block floor)
         sum(w[funds_in_block]) <= block_max  (block ceiling)
     """
-    del cf_relaxation_factor  # PR-A12: dead param, kept for compat
     n = len(fund_ids)
     cvar_limit = constraints.cvar_limit
 
@@ -617,6 +618,7 @@ async def optimize_fund_portfolio(
         logger.warning(
             "returns_scenarios_missing_using_covariance_synth",
             n_funds=n,
+            caller_kind=caller_kind,
         )
         # Deterministic seed derived from fund_ids so repeated calls match.
         seed = int(abs(hash(tuple(fund_ids))) % (2**32 - 1))

--- a/backend/tests/quant_engine/test_always_solvable_cascade.py
+++ b/backend/tests/quant_engine/test_always_solvable_cascade.py
@@ -273,3 +273,41 @@ def test_polytope_empty_returns_constraint_polytope_empty() -> None:
 
     assert result.status == "constraint_polytope_empty"
     assert result.weights == {}
+
+
+# ── PR-A12.1 — caller_kind propagates to synthesis warning ──────────
+
+
+def test_caller_kind_tag_flows_to_scenarios_synth_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When ``returns_scenarios=None`` the synthesizer fires a warning.
+    The ``caller_kind`` kwarg must appear on the structured record so a
+    dashboard alert can filter production-path invocations vs intentional
+    screener / block-pareto calls."""
+    fund_ids = ["X", "Y"]
+    fund_blocks = {"X": "b", "Y": "b"}
+    expected_returns = {"X": 0.08, "Y": 0.10}
+    cov = np.array([[0.04, 0.01], [0.01, 0.03]])
+    constraints = ProfileConstraints(
+        blocks=[BlockConstraint("b", 0.0, 1.0)],
+        cvar_limit=0.10, max_single_fund_weight=1.0,
+    )
+
+    asyncio.run(
+        optimize_fund_portfolio(
+            fund_ids=fund_ids, fund_blocks=fund_blocks,
+            expected_returns=expected_returns, cov_matrix=cov,
+            returns_scenarios=None,
+            constraints=constraints,
+            caller_kind="screener_preview",
+        ),
+    )
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "returns_scenarios_missing_using_covariance_synth" in combined, (
+        "synth warning must fire when returns_scenarios is None"
+    )
+    assert "caller_kind=screener_preview" in combined, (
+        "caller_kind tag missing from synth warning output"
+    )

--- a/backend/tests/test_config_registry.py
+++ b/backend/tests/test_config_registry.py
@@ -82,9 +82,12 @@ class TestRegistryLookup:
         assert "wealth" in verticals
 
     def test_wealth_optimizer_registered_as_optional(self):
-        """PR-A9.1: wealth/optimizer must be registered (otherwise construction
-        runs raise ConfigMissError). It must be required=False so that absence
-        of seed/override falls through to in-code default cf_relaxation_factor=1.3.
+        """PR-A9.1: wealth/optimizer must be registered (otherwise any future
+        ``config_svc.get("wealth", "optimizer", ...)`` call would raise
+        ConfigMissError). Currently there is no production reader, but the
+        domain is reserved for future per-tenant overrides. required=False
+        so absence of seed/override returns an empty ConfigResult instead
+        of raising.
         """
         domain = ConfigRegistry.get("wealth", "optimizer")
         assert domain is not None, "wealth/optimizer must be registered"


### PR DESCRIPTION
## Summary
Non-functional cleanup closing 3 items deferred from PR-A12 (#191).

1. **Remove dead `cf_relaxation_factor`** — param was retained in `optimize_portfolio` + `optimize_fund_portfolio` signatures for one release after PR-A12 deleted the variance-cap phase that consumed it. Now dropped everywhere: optimizer, route call site, config-service read block, registry description, test docstring.
2. **Tighten `cascade_summary` → `run.status` mapping** in the outer executor wrapper. Legacy A11 values (`phase_3_fallback`, `heuristic_fallback`, `cascade_exhausted`, etc.) are no longer produced by the A12 cascade — remove them from the dispatch table. Keeps the defensive `solver=="heuristic_fallback"` branch for empty telemetry (pre-A11 mocks).
3. **Add `caller_kind: str` kwarg** to `optimize_fund_portfolio` so the `returns_scenarios_missing_using_covariance_synth` warning is tagged by call site. Construction runs pass `"construction_run"`; any dashboard alert filtering on that tag + the warning key will flag a P1 production bug (synthetic scenarios lose skew/kurtosis).

## Schema
No migration. `("wealth","optimizer")` ConfigDomain stays registered (`required=False`) so any future per-tenant override still works without raising `ConfigMissError`; only the description line is updated.

## Tests
- 89/89 cascade + config tests green, including new caller_kind regression
- 282/283 full quant+wealth sweep (1 pre-existing collinear test failing on main, unrelated)
- `grep -rn cf_relaxation_factor backend/ frontends/` empty

## Test plan
- [x] Full quant_engine + wealth test sweep
- [x] `grep` verification empty outside docs/
- [x] No behavior change on happy path — 3 canonical portfolios still hit `phase_1_succeeded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)