### PR TITLE
feat(wealth): profile-differentiated CVaR defaults (PR-A12.2)

### DIFF
--- a/backend/app/core/db/migrations/versions/0143_cvar_profile_defaults.py
+++ b/backend/app/core/db/migrations/versions/0143_cvar_profile_defaults.py
@@ -1,0 +1,63 @@
+"""PR-A12.2: profile-differentiated CVaR defaults backfill.
+
+Update existing ``portfolio_calibration`` rows to use the institutional
+starting defaults per profile (Conservative 2.5%, Moderate 5%, Growth
+8%, Aggressive 10%). Only rows still at the legacy uniform 5% default
+are touched — operator-customized values (anything other than ``0.0500``)
+are preserved.
+
+No schema change. The migration 0100 server default stays at 0.05 as a
+safe fallback for any insert path that bypasses both
+``create_portfolio`` and ``_ensure_calibration``; the helper in
+``app.domains.wealth.models.model_portfolio.default_cvar_limit_for_profile``
+is now the authoritative default for new rows produced by application
+code.
+
+Revision ID: 0143_cvar_profile_defaults
+Revises: 0142_construction_cascade_telemetry
+Create Date: 2026-04-17
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0143_cvar_profile_defaults"
+down_revision: str | None = "0142_construction_cascade_telemetry"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Backfill cvar_limit by profile, preserving operator customizations."""
+    op.execute(
+        """
+        UPDATE portfolio_calibration pc
+        SET cvar_limit = CASE mp.profile
+            WHEN 'conservative' THEN 0.0250
+            WHEN 'moderate'     THEN 0.0500
+            WHEN 'growth'       THEN 0.0800
+            WHEN 'aggressive'   THEN 0.1000
+            ELSE pc.cvar_limit
+        END
+        FROM model_portfolios mp
+        WHERE pc.portfolio_id = mp.id
+          AND pc.cvar_limit = 0.0500;
+        """,
+    )
+
+
+def downgrade() -> None:
+    """Best-effort reverse — restore uniform 5% on non-moderate profiles.
+
+    Cannot distinguish between "we set it" and "operator set it back to
+    5%"; acceptable for a cosmetic data backfill.
+    """
+    op.execute(
+        """
+        UPDATE portfolio_calibration pc
+        SET cvar_limit = 0.0500
+        FROM model_portfolios mp
+        WHERE pc.portfolio_id = mp.id
+          AND mp.profile IN ('conservative', 'growth', 'aggressive');
+        """,
+    )

--- a/backend/app/domains/wealth/models/model_portfolio.py
+++ b/backend/app/domains/wealth/models/model_portfolio.py
@@ -64,6 +64,33 @@ class ModelPortfolio(OrganizationScopedMixin, Base):
     created_by: Mapped[str | None] = mapped_column(String(128))
 
 
+# ── PR-A12.2 — profile-differentiated CVaR defaults ─────────────────────
+# Institutional starting points for the portfolio-construction CVaR_95
+# budget. Operators override per-portfolio via the Builder slider
+# (PR-A13). Uniform 5% across all profiles defeated the operator's
+# mandate intent — Conservative expects tighter tail-loss containment
+# (~2.5%); Growth accepts more (~8%).
+_CVAR_DEFAULT_BY_PROFILE: dict[str, Decimal] = {
+    "conservative": Decimal("0.0250"),
+    "moderate": Decimal("0.0500"),
+    "growth": Decimal("0.0800"),
+    "aggressive": Decimal("0.1000"),
+}
+
+
+def default_cvar_limit_for_profile(profile: str | None) -> Decimal:
+    """Return the institutional CVaR_95 starting default for ``profile``.
+
+    Falls back to ``Decimal("0.0500")`` (moderate) for None / unknown
+    values so code paths without a resolved profile (legacy fixtures,
+    future profiles not yet calibrated) get a safe value rather than
+    KeyError. Lookup is case-insensitive.
+    """
+    if profile is None:
+        return Decimal("0.0500")
+    return _CVAR_DEFAULT_BY_PROFILE.get(profile.lower(), Decimal("0.0500"))
+
+
 class PortfolioCalibration(OrganizationScopedMixin, Base):
     """Tiered calibration surface for the Builder's CalibrationPanel.
 

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -251,10 +251,16 @@ async def create_model_portfolio(
     # provided so the new draft inherits the calibration discipline
     # of the source model. ``expert_overrides`` is also copied so any
     # JSONB knobs survive the fork.
+    # PR-A12.2 — seed the per-profile institutional CVaR default when
+    # there is no source calibration to clone from.
+    from app.domains.wealth.models.model_portfolio import (
+        default_cvar_limit_for_profile,
+    )
     calibration = PortfolioCalibration(
         organization_id=org_uuid,
         portfolio_id=portfolio.id,
         updated_by=actor.actor_id,
+        cvar_limit=default_cvar_limit_for_profile(portfolio.profile),
     )
     if source_calibration is not None:
         for column in (
@@ -638,7 +644,10 @@ _ADVANCED_FIELDS: tuple[str, ...] = (
 
 
 async def _ensure_calibration(
-    db: AsyncSession, portfolio_id: uuid.UUID, organization_id: uuid.UUID | str,
+    db: AsyncSession,
+    portfolio_id: uuid.UUID,
+    organization_id: uuid.UUID | str,
+    profile: str | None = None,
 ) -> PortfolioCalibration:
     """Fetch-or-create the ``portfolio_calibration`` row for a portfolio.
 
@@ -648,6 +657,11 @@ async def _ensure_calibration(
     Basic tier starts from the org-wide institutional baseline instead
     of an empty form. The frontend never needs to handle the
     ``no calibration`` case.
+
+    PR-A12.2 — when ``profile`` is provided and a new row is created,
+    ``cvar_limit`` is seeded with the institutional default for that
+    profile (Conservative 2.5%, Moderate 5%, Growth 8%, Aggressive 10%).
+    Existing rows are returned unchanged.
     """
     existing = await db.execute(
         select(PortfolioCalibration).where(
@@ -663,9 +677,13 @@ async def _ensure_calibration(
         if isinstance(organization_id, uuid.UUID)
         else uuid.UUID(str(organization_id))
     )
+    from app.domains.wealth.models.model_portfolio import (
+        default_cvar_limit_for_profile,
+    )
     row = PortfolioCalibration(
         organization_id=org_uuid,
         portfolio_id=portfolio_id,
+        cvar_limit=default_cvar_limit_for_profile(profile),
     )
     db.add(row)
     await db.flush()
@@ -700,7 +718,7 @@ async def get_portfolio_calibration(
             detail=f"Model portfolio {portfolio_id} not found",
         )
 
-    row = await _ensure_calibration(db, portfolio_id, org_id)
+    row = await _ensure_calibration(db, portfolio_id, org_id, profile=portfolio.profile)
     return PortfolioCalibrationRead.model_validate(row)
 
 
@@ -739,7 +757,7 @@ async def update_portfolio_calibration(
             detail=f"Model portfolio {portfolio_id} not found",
         )
 
-    row = await _ensure_calibration(db, portfolio_id, org_id)
+    row = await _ensure_calibration(db, portfolio_id, org_id, profile=portfolio.profile)
 
     data = payload.model_dump(exclude_unset=True)
 

--- a/backend/tests/wealth/test_cvar_profile_defaults.py
+++ b/backend/tests/wealth/test_cvar_profile_defaults.py
@@ -1,0 +1,35 @@
+"""PR-A12.2 — profile-differentiated CVaR defaults."""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.domains.wealth.models.model_portfolio import default_cvar_limit_for_profile
+
+
+def test_conservative_default() -> None:
+    assert default_cvar_limit_for_profile("conservative") == Decimal("0.0250")
+
+
+def test_moderate_default() -> None:
+    assert default_cvar_limit_for_profile("moderate") == Decimal("0.0500")
+
+
+def test_growth_default() -> None:
+    assert default_cvar_limit_for_profile("growth") == Decimal("0.0800")
+
+
+def test_aggressive_default() -> None:
+    assert default_cvar_limit_for_profile("aggressive") == Decimal("0.1000")
+
+
+def test_unknown_profile_falls_back_to_moderate() -> None:
+    assert default_cvar_limit_for_profile("custom_profile") == Decimal("0.0500")
+
+
+def test_none_profile_falls_back_to_moderate() -> None:
+    assert default_cvar_limit_for_profile(None) == Decimal("0.0500")
+
+
+def test_case_insensitive() -> None:
+    assert default_cvar_limit_for_profile("CONSERVATIVE") == Decimal("0.0250")
+    assert default_cvar_limit_for_profile("Growth") == Decimal("0.0800")


### PR DESCRIPTION
## Summary
Replace uniform 5% `cvar_limit` with institutional per-profile defaults:

| Profile | Default | Rationale |
|---|---|---|
| `conservative` | **2.5%** | Capital preservation mandate |
| `moderate` | 5.0% | Balanced risk/return (unchanged) |
| `growth` | **8.0%** | Accepts tail risk for return |
| `aggressive` | **10.0%** | Full risk-on |

Pre-A12.2 all 3 canonical portfolios shared 5% — the differentiator was only `strategic_allocation`, not the risk budget. Uniform 5% defeated the operator mandate intent. This PR establishes the institutional starting points the Builder slider (PR-A13) will expose.

## Architecture
Single source of truth: `default_cvar_limit_for_profile()` helper on `model_portfolio.py`. Wired into both calibration creation sites (`create_portfolio` + `_ensure_calibration`). Migration 0143 backfills existing rows **only where cvar_limit=0.0500** — operator customizations preserved.

## Schema
- Migration `0143_cvar_profile_defaults` — data-only UPDATE, no DDL.
- Migration 0100 server-default clause stays at 0.05 as a safe fallback for insert paths that bypass both helpers.

## Live verification (local DB, migration applied)
```
   profile    |       display_name        | cvar_limit
--------------+---------------------------+------------
 conservative | Conservative Preservation |     0.0250
 growth       | Dynamic Growth            |     0.0800
 moderate     | Balanced Income           |     0.0500
```

## Regression smoke (all 3 canonical portfolios, post-migration)
| Portfolio | status | summary | band |
|---|---|---|---|
| Conservative Preservation | succeeded | `phase_1_succeeded` | [9.56%, 30.62%] |
| Balanced Income | succeeded | `phase_1_succeeded` | [10.54%, 31.99%] |
| Dynamic Growth | succeeded | `phase_1_succeeded` | [13.08%, 31.36%] |

Conservative's band_lower drops from 9.84% → 9.56% as expected (tighter 2.5% CVaR constrains the return). No degradation to `phase_3_min_cvar_above_limit` — the 2.5% default is empirically feasible for this universe, so the institutional default holds.

## Tests
- 7 new unit tests in `test_cvar_profile_defaults.py` (all 4 profile values, None/unknown fallback, case-insensitivity)
- **209/209** full wealth+quant+config sweep green

## Test plan
- [x] Unit tests: helper returns correct Decimals
- [x] Migration applied cleanly; SQL verifies backfill applied exactly to the 3 canonical portfolios
- [x] Regression smoke: all 3 still hit `phase_1_succeeded` at their new limits
- [ ] PR-A13 Builder slider consumes `default_cvar_limit_for_profile()` as initial position (follow-up)

## Out of scope
- PR-A13 Builder slider (consumes this default)
- Org-level admin UI to edit the per-profile mapping
- Changing `cvar_level` (0.95 is academic standard)
- μ prior calibration (separate sprint)
- Adding new profiles beyond the current 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)