### PR TITLE
feat(wealth): risk budget slider + achievable return band panel (PR-A13)

### DIFF
--- a/frontends/wealth/src/lib/components/portfolio/AchievableReturnBandChart.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/AchievableReturnBandChart.svelte
@@ -1,0 +1,159 @@
+<!--
+  AchievableReturnBandChart — PR-A13 presentational chart that shows the
+  two-point achievable return band (lower / upper) produced by the RU CVaR
+  cascade (PR-A12). The vertical dashed marker sits at the operator's
+  current CVaR limit; the shaded x-axis area (0 → min_achievable_cvar)
+  marks the universe's infeasible region.
+
+  Institutional UX discipline:
+    - No inline hex literals; colours resolved from @netz/ui CSS
+      custom properties via getComputedStyle (ECharts cannot parse
+      var(--…)).
+    - Fixed pixel height — Layout Cage pattern (feedback_layout_cage_pattern.md).
+      Parent must not rely on ``height: 100%``.
+    - Empty-band fallback renders a placeholder div at the same height so
+      the panel doesn't reflow when a band is not yet available.
+-->
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { formatPercent } from "@investintell/ui";
+	import GenericEChart from "$lib/components/charts/GenericEChart.svelte";
+	import type { AchievableReturnBand } from "$lib/types/cascade-telemetry";
+
+	interface Props {
+		band: AchievableReturnBand | null;
+		cvarLimit: number;
+		minAchievableCvar: number | null;
+		height?: number;
+	}
+
+	let { band, cvarLimit, minAchievableCvar, height = 220 }: Props = $props();
+
+	// Resolve tokens once on mount — ECharts options must receive concrete
+	// colour strings. Re-reading on every $derived would bust the cache.
+	let tokens = $state({ primary: "", warning: "", border: "", muted: "" });
+
+	onMount(() => {
+		const cs = getComputedStyle(document.documentElement);
+		tokens = {
+			primary: cs.getPropertyValue("--terminal-accent-amber").trim() || "#d19a2f",
+			warning: cs.getPropertyValue("--terminal-status-warning").trim() || "#c29840",
+			border: cs.getPropertyValue("--terminal-fg-muted").trim() || "#888888",
+			muted: cs.getPropertyValue("--terminal-fg-secondary").trim() || "#b8b8b8",
+		};
+	});
+
+	const chartOptions = $derived.by(() => {
+		if (!band) return null;
+		const series: unknown[] = [
+			{
+				type: "line",
+				name: "Achievable band",
+				showSymbol: true,
+				symbolSize: 10,
+				data: [
+					[band.lower_at_cvar, band.lower],
+					[band.upper_at_cvar, band.upper],
+				],
+				lineStyle: { color: tokens.primary, width: 2 },
+				itemStyle: { color: tokens.primary },
+			},
+			{
+				type: "line",
+				data: [],
+				markLine: {
+					symbol: "none",
+					silent: true,
+					lineStyle: { color: tokens.warning, type: "dashed", width: 1 },
+					label: {
+						formatter: formatPercent(cvarLimit, 2),
+						color: tokens.warning,
+					},
+					data: [{ xAxis: cvarLimit }],
+				},
+			},
+		];
+		if (minAchievableCvar !== null && minAchievableCvar > 0) {
+			series.push({
+				type: "line",
+				data: [],
+				markArea: {
+					silent: true,
+					itemStyle: { color: tokens.border, opacity: 0.12 },
+					data: [[{ xAxis: 0 }, { xAxis: minAchievableCvar }]],
+				},
+			});
+		}
+		return {
+			grid: { left: 56, right: 16, top: 16, bottom: 36, containLabel: true },
+			xAxis: {
+				type: "value",
+				name: "Tail loss (95% CVaR)",
+				nameLocation: "middle",
+				nameGap: 24,
+				nameTextStyle: { color: tokens.muted, fontSize: 11 },
+				axisLabel: {
+					formatter: (v: number) => formatPercent(v, 1),
+					color: tokens.muted,
+					fontSize: 10,
+				},
+				axisLine: { lineStyle: { color: tokens.border } },
+				splitLine: { show: false },
+			},
+			yAxis: {
+				type: "value",
+				name: "Expected return",
+				nameTextStyle: { color: tokens.muted, fontSize: 11 },
+				axisLabel: {
+					formatter: (v: number) => formatPercent(v, 1),
+					color: tokens.muted,
+					fontSize: 10,
+				},
+				axisLine: { lineStyle: { color: tokens.border } },
+				splitLine: { lineStyle: { color: tokens.border, opacity: 0.25 } },
+			},
+			tooltip: {
+				trigger: "axis",
+				axisPointer: { type: "cross" },
+				formatter: (params: unknown) => {
+					const arr = params as Array<{ value: [number, number] }>;
+					const first = arr?.[0];
+					if (!first) return "";
+					const [x, y] = first.value;
+					return `Tail loss ${formatPercent(x, 2)}<br/>Return ${formatPercent(y, 2)}`;
+				},
+			},
+			series,
+		};
+	});
+</script>
+
+<div class="arbc-root" style:height="{height}px">
+	{#if band && chartOptions}
+		<GenericEChart options={chartOptions} {height} />
+	{:else}
+		<div class="arbc-empty" role="status">
+			<p class="arbc-empty__msg">Run a construction to see the achievable return band.</p>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.arbc-root {
+		width: 100%;
+	}
+	.arbc-empty {
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border: 1px dashed var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel);
+	}
+	.arbc-empty__msg {
+		margin: 0;
+		font-size: 12px;
+		color: var(--terminal-fg-muted);
+		font-family: var(--terminal-font-mono);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/portfolio/CalibrationPanel.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/CalibrationPanel.svelte
@@ -36,6 +36,7 @@
 	import CalibrationSelectField from "./CalibrationSelectField.svelte";
 	import CalibrationToggleField from "./CalibrationToggleField.svelte";
 	import CalibrationScenarioGroup from "./CalibrationScenarioGroup.svelte";
+	import RiskBudgetPanel from "./RiskBudgetPanel.svelte";
 
 	// ── Tier + preview state ─────────────────────────────────────
 	let tier = $state<"basic" | "advanced" | "expert">("basic");
@@ -309,21 +310,14 @@
 						originalValue={snapshot?.mandate as string | undefined}
 					/>
 
-					<CalibrationSliderField
-						id="cp-cvar-limit"
-						label="Tail loss budget"
-						description="Maximum tail loss (95% confidence) the portfolio may carry."
-						value={draft.cvar_limit}
-						onChange={(v) => update({ cvar_limit: v })}
-						min={0.02}
-						max={0.25}
-						step={0.005}
-						displayFormat="percent"
-						digits={2}
-						edgeLabels={["Tighter", "Looser"]}
-						accent="danger"
-						originalValue={snapshot?.cvar_limit as number | undefined}
-					/>
+					{#if workspace.portfolio}
+						<RiskBudgetPanel
+							portfolio={workspace.portfolio}
+							calibration={draft}
+							snapshot={snapshot}
+							onChange={(patch) => update(patch)}
+						/>
+					{/if}
 
 					<CalibrationSliderField
 						id="cp-max-weight"

--- a/frontends/wealth/src/lib/components/portfolio/RiskBudgetPanel.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/RiskBudgetPanel.svelte
@@ -1,0 +1,159 @@
+<!--
+  RiskBudgetPanel — PR-A13 state owner for the Builder risk budget
+  surface. Composes:
+    1. RiskBudgetSlider (operator edits the tail loss limit)
+    2. AchievableReturnBandChart (derived from latest cascade_telemetry)
+    3. Signal banner (operator_signal → copy + tone)
+
+  Two-channel state design is deliberate: ``previewBand`` is reserved for
+  PR-A13.2 (live drag preview via POST /preview-cvar). A13 never writes to
+  it, but the ``previewBand ?? serverBand`` precedence means A13.2 can
+  wire in without rewriting the dependency graph.
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+	import { workspace } from "$lib/state/portfolio-workspace.svelte";
+	import type { ModelPortfolio } from "$lib/types/model-portfolio";
+	import type { PortfolioCalibration } from "$lib/types/portfolio-calibration";
+	import type { AchievableReturnBand } from "$lib/types/cascade-telemetry";
+	import { defaultCvarForProfile } from "$lib/util/profile-defaults";
+	import RiskBudgetSlider from "./RiskBudgetSlider.svelte";
+	import AchievableReturnBandChart from "./AchievableReturnBandChart.svelte";
+
+	interface Props {
+		portfolio: ModelPortfolio;
+		calibration: PortfolioCalibration;
+		snapshot?: Partial<PortfolioCalibration> | null;
+		onChange: (patch: Partial<PortfolioCalibration>) => void;
+	}
+
+	let { portfolio, calibration, snapshot, onChange }: Props = $props();
+
+	const profileDefault = $derived(defaultCvarForProfile(portfolio.profile));
+	const cvarLimit = $derived(calibration.cvar_limit);
+
+	const serverBand = $derived(
+		workspace.constructionRun?.cascade_telemetry?.achievable_return_band ?? null,
+	);
+	const serverSignal = $derived(
+		workspace.constructionRun?.cascade_telemetry?.operator_signal ?? null,
+	);
+	const minAchievableCvar = $derived(
+		workspace.constructionRun?.cascade_telemetry?.min_achievable_cvar ?? null,
+	);
+
+	// PR-A13.2 slot — reserved for live preview. A13 never writes here.
+	let previewBand = $state<AchievableReturnBand | null>(null);
+	const band = $derived(previewBand ?? serverBand);
+
+	const belowFloor = $derived(serverSignal?.kind === "cvar_limit_below_universe_floor");
+	const dataMissing = $derived(serverSignal?.kind === "upstream_data_missing");
+	const polytopeEmpty = $derived(serverSignal?.kind === "constraint_polytope_empty");
+</script>
+
+<div class="rbp-root">
+	<RiskBudgetSlider
+		value={cvarLimit}
+		{profileDefault}
+		profile={portfolio.profile}
+		onChange={(v) => onChange({ cvar_limit: v })}
+		originalValue={snapshot?.cvar_limit as number | undefined}
+	/>
+
+	{#if dataMissing}
+		<div class="rbp-banner rbp-banner--empty" role="status">
+			<p class="rbp-banner__msg">
+				We don't have enough return history for this universe to model an achievable
+				range. Add instruments with at least 36 months of NAV, or check the Universe
+				column.
+			</p>
+		</div>
+	{:else if polytopeEmpty}
+		<div class="rbp-banner rbp-banner--blocking" role="alert">
+			<p class="rbp-banner__msg">
+				The current strategic allocation has no feasible portfolio. Adjust block
+				min/max bounds.
+			</p>
+		</div>
+	{:else}
+		<AchievableReturnBandChart
+			{band}
+			{cvarLimit}
+			{minAchievableCvar}
+			height={220}
+		/>
+		<div class="rbp-stats" data-testid="rbp-stats">
+			{#if band}
+				<div class="rbp-stats__primary">
+					At your tail loss limit: <strong>{formatPercent(band.upper, 2)}</strong> expected
+				</div>
+				<div class="rbp-stats__range">
+					Achievable range across this universe:
+					{formatPercent(band.lower, 2)} – {formatPercent(band.upper, 2)}
+				</div>
+			{:else}
+				<div class="rbp-stats__empty">
+					Run a construction to see the achievable return band.
+				</div>
+			{/if}
+		</div>
+		{#if belowFloor && minAchievableCvar !== null}
+			<div class="rbp-banner rbp-banner--warning" role="status">
+				<p class="rbp-banner__msg">
+					Your tail loss limit ({formatPercent(cvarLimit, 2)}) sits below the lowest
+					tail risk this universe can deliver ({formatPercent(minAchievableCvar, 2)}).
+					We're showing the lowest-tail-risk portfolio achievable. Loosen the limit or
+					expand the universe.
+				</p>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.rbp-root {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+	.rbp-stats {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		font-family: var(--terminal-font-mono);
+	}
+	.rbp-stats__primary {
+		font-size: 12px;
+		color: var(--terminal-fg-primary);
+	}
+	.rbp-stats__range {
+		font-size: 11px;
+		color: var(--terminal-fg-muted);
+	}
+	.rbp-stats__empty {
+		font-size: 11px;
+		color: var(--terminal-fg-muted);
+		font-style: italic;
+	}
+	.rbp-banner {
+		padding: 10px 12px;
+		border-left: 3px solid var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+	.rbp-banner--warning {
+		border-left-color: var(--terminal-status-warning);
+	}
+	.rbp-banner--blocking {
+		border-left-color: var(--terminal-status-error);
+	}
+	.rbp-banner--empty {
+		border-left-color: var(--terminal-fg-muted);
+	}
+	.rbp-banner__msg {
+		margin: 0;
+		font-size: 11px;
+		line-height: 1.45;
+		color: var(--terminal-fg-secondary);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/portfolio/RiskBudgetSlider.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/RiskBudgetSlider.svelte
@@ -1,0 +1,107 @@
+<!--
+  RiskBudgetSlider — PR-A13 wrapper around CalibrationSliderField that
+  adds profile-default affordances: a "Default for {profile}: X.XX%" hint
+  and a conditional "Reset to {profile} default" link when the current
+  value drifts from the profile default.
+
+  Vocabulary discipline (metric-translators.ts convention): the operator
+  surface uses "Tail loss budget", never raw "CVaR 95%". "CVaR" remains
+  reserved for the advanced / result chips.
+
+  No $bindable: callback contract matches CalibrationSliderField so the
+  parent owns the draft.
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+	import CalibrationSliderField from "./CalibrationSliderField.svelte";
+	import { profileLabel } from "$lib/util/profile-defaults";
+
+	interface Props {
+		value: number;
+		profileDefault: number;
+		profile: string | null | undefined;
+		onChange: (v: number) => void;
+		originalValue?: number;
+	}
+
+	let {
+		value,
+		profileDefault,
+		profile,
+		onChange,
+		originalValue,
+	}: Props = $props();
+
+	const label = $derived(profileLabel(profile));
+	const isDrifted = $derived(Math.abs(value - profileDefault) > 1e-6);
+</script>
+
+<div class="rbs-root">
+	<CalibrationSliderField
+		id="cp-cvar-limit"
+		label="Tail loss budget"
+		description="Maximum tail loss (95% confidence) the portfolio may carry."
+		{value}
+		{onChange}
+		min={0.005}
+		max={0.25}
+		step={0.0025}
+		displayFormat="percent"
+		digits={2}
+		edgeLabels={["Tighter", "Looser"]}
+		accent="danger"
+		{originalValue}
+	/>
+
+	<div class="rbs-footer">
+		<span class="rbs-hint" title={`Institutional starting default for the ${label} profile`}>
+			Default for {label}: {formatPercent(profileDefault, 2)}
+		</span>
+		{#if isDrifted}
+			<button type="button" class="rbs-reset" onclick={() => onChange(profileDefault)}>
+				Reset to {label} default
+			</button>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.rbs-root {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	.rbs-footer {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		padding-top: 2px;
+	}
+	.rbs-hint {
+		font-size: 10px;
+		color: var(--terminal-fg-muted);
+		font-family: var(--terminal-font-mono);
+		letter-spacing: 0.02em;
+	}
+	.rbs-reset {
+		font-size: 10px;
+		font-weight: 600;
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-accent-amber);
+		background: transparent;
+		border: none;
+		border-bottom: 1px solid var(--terminal-accent-amber);
+		padding: 0 0 1px 0;
+		cursor: pointer;
+		letter-spacing: 0.02em;
+	}
+	.rbs-reset:hover {
+		color: var(--terminal-fg-primary);
+		border-bottom-color: var(--terminal-fg-primary);
+	}
+	.rbs-reset:focus-visible {
+		outline: 2px solid var(--terminal-accent-amber);
+		outline-offset: 2px;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/builder/WeightsTab.svelte
+++ b/frontends/wealth/src/lib/components/terminal/builder/WeightsTab.svelte
@@ -9,6 +9,7 @@
 	import { formatPercent, formatNumber } from "@investintell/ui";
 	import { BLOCK_GROUPS, blockDisplay, groupDisplay } from "$lib/constants/blocks";
 	import { workspace } from "$lib/state/portfolio-workspace.svelte";
+	import AchievableReturnBandChart from "$lib/components/portfolio/AchievableReturnBandChart.svelte";
 
 	// ── Build 3-level tree (same logic as BuilderTable, DnD stripped) ──
 
@@ -108,6 +109,30 @@
 
 	const hasRun = $derived(workspace.constructionRun !== null);
 
+	// PR-A13 — echo the achievable return band from the completed run so the
+	// operator can see their delivered return against the modeled band.
+	const echoBand = $derived(
+		workspace.constructionRun?.cascade_telemetry?.achievable_return_band ?? null,
+	);
+	const echoMinCvar = $derived(
+		workspace.constructionRun?.cascade_telemetry?.min_achievable_cvar ?? null,
+	);
+	const echoCvarLimit = $derived.by<number>(() => {
+		const snap = workspace.constructionRun?.calibration_snapshot as
+			| { cvar_limit?: number }
+			| null;
+		return typeof snap?.cvar_limit === "number" ? snap.cvar_limit : 0.05;
+	});
+	const realizedReturn = $derived.by<number | null>(() => {
+		const metrics = workspace.constructionRun?.ex_ante_metrics ?? null;
+		const r = metrics?.expected_return ?? metrics?.ann_return ?? null;
+		return typeof r === "number" ? r : null;
+	});
+	const realizedWithinBand = $derived.by<boolean | null>(() => {
+		if (realizedReturn === null || !echoBand) return null;
+		return realizedReturn >= echoBand.lower && realizedReturn <= echoBand.upper;
+	});
+
 	// ── Run diff data for Previous column (Session 3) ──
 	// Fetch diff when a construction run completes
 	$effect(() => {
@@ -157,6 +182,32 @@
 </script>
 
 <div class="wt-root">
+	{#if hasRun && echoBand}
+		<section class="wt-band-echo" aria-label="Achievable return band">
+			<header class="wt-band-echo__header">
+				<h4 class="wt-band-echo__title">Achievable return band</h4>
+				{#if realizedReturn !== null && realizedWithinBand !== null}
+					<span
+						class="wt-band-echo__chip"
+						class:wt-band-echo__chip--within={realizedWithinBand}
+						class:wt-band-echo__chip--below={!realizedWithinBand}
+					>
+						{#if realizedWithinBand}
+							Delivered {formatPercent(realizedReturn, 2)} — within band
+						{:else}
+							Delivered {formatPercent(realizedReturn, 2)} — below modeled band
+						{/if}
+					</span>
+				{/if}
+			</header>
+			<AchievableReturnBandChart
+				band={echoBand}
+				cvarLimit={echoCvarLimit}
+				minAchievableCvar={echoMinCvar}
+				height={180}
+			/>
+		</section>
+	{/if}
 	{#if tree.length === 0}
 		<div class="wt-empty">
 			{#if hasRun}
@@ -256,6 +307,45 @@
 		font-family: var(--terminal-font-mono);
 		font-size: var(--terminal-text-11);
 		color: var(--terminal-fg-secondary);
+	}
+
+	.wt-band-echo {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 12px 0 16px 0;
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		margin-bottom: 12px;
+	}
+	.wt-band-echo__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+	}
+	.wt-band-echo__title {
+		margin: 0;
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--terminal-fg-primary);
+	}
+	.wt-band-echo__chip {
+		font-size: 10px;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		padding: 2px 8px;
+		border: 1px solid var(--terminal-fg-muted);
+		border-radius: 2px;
+	}
+	.wt-band-echo__chip--within {
+		color: var(--terminal-status-success);
+		border-color: var(--terminal-status-success);
+	}
+	.wt-band-echo__chip--below {
+		color: var(--terminal-status-warning);
+		border-color: var(--terminal-status-warning);
 	}
 
 	.wt-empty {

--- a/frontends/wealth/src/lib/state/portfolio-workspace.svelte.ts
+++ b/frontends/wealth/src/lib/state/portfolio-workspace.svelte.ts
@@ -35,6 +35,11 @@ import type {
 	UnifiedAlertInbox,
 } from "$lib/types/alerts";
 import type {
+	CascadeTelemetry,
+	AchievableReturnBand,
+	OperatorSignal,
+} from "$lib/types/cascade-telemetry";
+import type {
 	RegimeBands,
 	TaaHistory,
 	EffectiveAllocationWithRegime,
@@ -71,6 +76,12 @@ export interface ConstructionRunPayload {
 	narrative: ConstructionNarrativeContent | null;
 	rationale_per_weight: Record<string, unknown> | null;
 	weights_proposed: Record<string, number> | null;
+	/**
+	 * PR-A11/A12 — cascade telemetry JSONB column. Drives the PR-A13
+	 * Risk Budget panel: achievable return band, operator signal, and
+	 * per-phase cascade trace.
+	 */
+	cascade_telemetry: CascadeTelemetry | null;
 }
 
 export interface ConstructionStressResult {
@@ -138,6 +149,11 @@ export interface ConstructRunEvent {
 	phase?: string;
 	phase_label?: string;
 	objective_value?: number | null;
+	// PR-A11 cascade_telemetry_completed payload
+	cascade_summary?: string | null;
+	operator_signal?: OperatorSignal | null;
+	min_achievable_cvar?: number | null;
+	achievable_return_band?: AchievableReturnBand | null;
 }
 
 /** Session 3 — NAV history response for Backtest tab. */
@@ -1730,6 +1746,28 @@ export class PortfolioWorkspaceState {
 		} else if (e === "error" || e === "Construction failed" || e === "Construction cancelled") {
 			this.runPhase = "error";
 			this.runError = ev.reason ?? "Construction failed";
+		}
+
+		// PR-A13 — hydrate cascade_telemetry on the dedicated SSE event so the
+		// Risk Budget panel updates before the final REST GET arrives. The
+		// backend only emits the subset needed by the panel
+		// (cascade_summary / achievable_return_band / operator_signal /
+		// min_achievable_cvar). ``phase_attempts`` lands via loadConstructionRun.
+		if (e === "cascade_telemetry_completed" || e === "Cascade telemetry completed") {
+			const run = this.constructionRun;
+			const summary = (ev.cascade_summary ?? null) as
+				| CascadeTelemetry["cascade_summary"]
+				| null;
+			const nextTelemetry: CascadeTelemetry = {
+				phase_attempts: run?.cascade_telemetry?.phase_attempts ?? [],
+				cascade_summary: summary ?? "upstream_heuristic",
+				min_achievable_cvar: ev.min_achievable_cvar ?? null,
+				achievable_return_band: ev.achievable_return_band ?? null,
+				operator_signal: ev.operator_signal ?? null,
+			};
+			this.constructionRun = run
+				? { ...run, cascade_telemetry: nextTelemetry }
+				: run;
 		}
 
 		// Per-phase optimizer cascade events → update timeline pills

--- a/frontends/wealth/src/lib/types/cascade-telemetry.ts
+++ b/frontends/wealth/src/lib/types/cascade-telemetry.ts
@@ -1,0 +1,54 @@
+/**
+ * Cascade telemetry payload — emitted by the construction_run_executor
+ * (PR-A11) and stored on ``portfolio_construction_runs.cascade_telemetry``
+ * (JSONB). The same shape is mirrored on the ``cascade_telemetry_completed``
+ * SSE event, so the panel can hydrate before the final REST GET arrives.
+ *
+ * PR-A13 consumes ``achievable_return_band`` + ``operator_signal`` to drive
+ * the Builder Risk Budget panel. PR-A13.2 will reuse these types for the
+ * live drag-preview branch (``previewBand``).
+ */
+
+export interface AchievableReturnBand {
+	lower: number;
+	upper: number;
+	lower_at_cvar: number;
+	upper_at_cvar: number;
+}
+
+export type OperatorSignalKind =
+	| "feasible"
+	| "cvar_limit_below_universe_floor"
+	| "upstream_data_missing"
+	| "constraint_polytope_empty";
+
+export interface OperatorSignal {
+	kind: OperatorSignalKind;
+	binding: string | null;
+	message_key: string;
+}
+
+export type CascadeSummary =
+	| "phase_1_succeeded"
+	| "phase_2_robust_succeeded"
+	| "phase_3_min_cvar_within_limit"
+	| "phase_3_min_cvar_above_limit"
+	| "upstream_heuristic";
+
+export interface PhaseAttempt {
+	phase: string;
+	status: "succeeded" | "infeasible" | "skipped" | "error";
+	solver?: string;
+	objective_value?: number | null;
+	wall_ms?: number;
+	infeasibility_reason?: string | null;
+	cvar_at_solution?: number | null;
+}
+
+export interface CascadeTelemetry {
+	phase_attempts: PhaseAttempt[];
+	cascade_summary: CascadeSummary;
+	min_achievable_cvar: number | null;
+	achievable_return_band: AchievableReturnBand | null;
+	operator_signal: OperatorSignal | null;
+}

--- a/frontends/wealth/src/lib/util/metric-translators.ts
+++ b/frontends/wealth/src/lib/util/metric-translators.ts
@@ -236,6 +236,11 @@ export function translateCascadeSummary(value: string): TranslatedMetric {
  */
 export function translateOperatorSignalKind(value: string): TranslatedMetric {
 	switch (value) {
+		case "feasible":
+			return {
+				label: "Alocação viável dentro do limite de perda",
+				tone: "success",
+			};
 		case "cvar_limit_below_universe_floor":
 			return {
 				label:

--- a/frontends/wealth/src/lib/util/profile-defaults.ts
+++ b/frontends/wealth/src/lib/util/profile-defaults.ts
@@ -1,0 +1,32 @@
+/**
+ * Profile-differentiated CVaR defaults — mirrors the authoritative backend
+ * helper ``app.domains.wealth.models.model_portfolio.default_cvar_limit_for_profile``
+ * (PR-A12.2). Keep the two in sync; a future PR may expose these via an
+ * admin config endpoint so the frontend stops duplicating the mapping.
+ *
+ * Unknown / null profile → 0.05 (moderate), matching the backend fallback.
+ */
+export function defaultCvarForProfile(profile: string | null | undefined): number {
+	switch ((profile ?? "").toLowerCase()) {
+		case "conservative":
+			return 0.025;
+		case "moderate":
+			return 0.05;
+		case "growth":
+			return 0.08;
+		case "aggressive":
+			return 0.1;
+		default:
+			return 0.05;
+	}
+}
+
+/** Human label for the profile, used in UI copy. */
+export function profileLabel(profile: string | null | undefined): string {
+	const p = (profile ?? "").toLowerCase();
+	if (p === "conservative") return "Conservative";
+	if (p === "moderate") return "Moderate";
+	if (p === "growth") return "Growth";
+	if (p === "aggressive") return "Aggressive";
+	return profile ?? "Moderate";
+}


### PR DESCRIPTION
## Summary

Wires the `cascade_telemetry` JSONB payload (shipped by PR-A11 #190 + PR-A12 #191) into the Builder UI. Operators now see the achievable return band their CVaR limit produces, an edge-case signal banner, and a profile-default reset affordance on the slider.

This is the **static** version — panel reads from the most recent completed run. PR-A13.1 will add `POST /preview-cvar`; PR-A13.2 will wire the live drag preview into the reserved `previewBand` slot.

## Files

**New components** (`frontends/wealth/src/lib/components/portfolio/`):
- `RiskBudgetPanel.svelte` — state owner, composes slider + chart + signal banner
- `RiskBudgetSlider.svelte` — `CalibrationSliderField` wrapper with profile-default hint + conditional "Reset to default" link
- `AchievableReturnBandChart.svelte` — svelte-echarts two-point line with dashed marker at CVaR limit + shaded infeasible region

**New types / utils:**
- `lib/types/cascade-telemetry.ts` — `AchievableReturnBand`, `OperatorSignal`, `CascadeTelemetry`, `PhaseAttempt`
- `lib/util/profile-defaults.ts` — mirror of backend `default_cvar_limit_for_profile` (PR-A12.2)

**Extended:**
- `state/portfolio-workspace.svelte.ts` — `ConstructionRunPayload.cascade_telemetry`, SSE hydration of `cascade_telemetry_completed`
- `util/metric-translators.ts` — `translateOperatorSignalKind` gains the `feasible` case
- `CalibrationPanel.svelte` — replaces the raw `cvar_limit` slider with `RiskBudgetPanel`
- `WeightsTab.svelte` — result-view echo: same chart + delivered-vs-band chip post-build

## Design decisions

- **Two-channel state** (`previewBand ?? serverBand`) — reserves the A13.2 slot without rewriting the dependency graph. A13 never writes to `previewBand`.
- **Vocabulary** — operator surfaces say "Tail loss budget"; "CVaR 95%" remains in advanced / result chips per existing translator convention.
- **Layout cage** — chart containers use fixed pixel height (220 / 180), no `height: 100%`.
- **No hex literals** — colours resolved from CSS custom properties via `getComputedStyle` on mount (ECharts can't parse `var(--…)`).
- **No `$bindable`** — callback contract matches `CalibrationSliderField`.

## Test plan

- [x] `pnpm check` (svelte-check) — 0 errors
- [x] `pnpm build` (SvelteKit adapter-node) — ✓ built in 39.4s
- [x] Lint clean on new files (pre-existing lint debt unchanged)
- [ ] Manual live-DB smoke: open Conservative portfolio builder → verify slider seeds at 2.50%, drift shows Reset link, reset works, chart renders after a construction run, banner variants (below_floor, data_missing) copy correct
- [ ] Playwright e2e (deferred — no config scaffold in repo yet)

## Out of scope (explicit)

- Live drag preview (PR-A13.2)
- `POST /preview-cvar` backend endpoint (PR-A13.1)
- μ prior calibration concern (`memory/project_mu_prior_calibration_concern.md`)
- Admin UI to edit profile defaults (separate config layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)