### PR TITLE
feat(wealth): POST /preview-cvar endpoint (PR-A13.1)

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -1838,6 +1838,7 @@ async def _run_construction_async(
     profile: str,
     org_id: str,
     portfolio_id: uuid.UUID | None = None,
+    cvar_limit_override: float | None = None,
 ) -> dict[str, Any]:
     """Run optimizer-driven portfolio construction (fully async).
 
@@ -1848,6 +1849,11 @@ async def _run_construction_async(
     4. Invoke CLARABEL fund-level optimizer with block-group constraints
     5. Build PortfolioComposition from optimizer output
     6. Fallback to block-level heuristic if fund-level optimization fails
+
+    PR-A13.1 — ``cvar_limit_override`` bypasses the calibration-resolved
+    CVaR limit for a single run. The POST ``/preview-cvar`` endpoint uses
+    this to render the Builder's live drag-preview without persisting the
+    operator's probe value into ``portfolio_calibration``.
     """
     from app.domains.wealth.models.allocation import TaaRegimeState as _TaaRS
     from app.domains.wealth.services.quant_queries import (
@@ -1964,7 +1970,12 @@ async def _run_construction_async(
     strategic_targets = {a.block_id: float(a.target_weight) for a in allocations}
 
     # ── Resolve CVaR limit from profile config ──
-    cvar_limit = await _resolve_cvar_limit(db, profile)
+    # PR-A13.1 — honour the preview override when supplied so the drag-band
+    # endpoint can probe arbitrary operator CVaR limits without persisting.
+    if cvar_limit_override is not None:
+        cvar_limit = float(cvar_limit_override)
+    else:
+        cvar_limit = await _resolve_cvar_limit(db, profile)
 
     # ── TAA: Resolve dynamic regime bands (or fallback to static IPS) ──
     from app.domains.wealth.models.allocation import TaaRegimeState

--- a/backend/app/domains/wealth/routes/portfolios/builder.py
+++ b/backend/app/domains/wealth/routes/portfolios/builder.py
@@ -374,3 +374,318 @@ async def build_portfolio(
 def _accepted_response(payload: dict[str, Any]) -> JSONResponse:
     """Helper for callers wishing to wrap the dict into an explicit 202."""
     return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=payload)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PR-A13.1 — POST /{id}/preview-cvar (synchronous band preview)
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Lightweight sibling of ``/build``. Returns only the
+# ``achievable_return_band + min_achievable_cvar + operator_signal`` for a
+# proposed ``cvar_limit`` — no stress tests, advisor, validation, narrative,
+# or persistence. Reuses the full ``_run_construction_async`` path so Phase 1
+# + Phase 3 math stays single-source-of-truth; the optimizer's
+# ``robust=False`` default already skips Phase 2 and composition work is
+# microseconds. Redis-cached on ``(org, portfolio, cvar_limit)`` with a
+# 5min TTL.
+#
+# Budget: 3s hard timeout (asyncio.wait_for). Target wall_ms < 500ms on a
+# typical Conservative/Balanced/Growth universe.
+
+# Cold-call wall time is dominated by `compute_fund_level_inputs` (NAV query
+# + Ledoit-Wolf + scenarios) — measured ~4.7s on Conservative Preservation's
+# universe during the local-DB smoke. Hot-call (Redis cache hit) is ~7ms.
+# The original 3s budget from the spec assumed Phase 1/3 extraction would
+# skip the input assembly; we reuse the full path to keep single-source-
+# of-truth with `_run_construction_async`. 15s leaves headroom for the
+# cold call on larger universes without masking a true pathology.
+#
+# PR-A13.2 can add a separate `FundLevelInputs` Redis cache layer if the
+# cold-call UX needs to be sub-500ms on first drag.
+_PREVIEW_TIMEOUT_S = 15
+_PREVIEW_CACHE_TTL_S = 300
+_preview_inflight: SingleFlightLock[str, dict[str, Any]] = SingleFlightLock()
+
+
+def _preview_cache_key(
+    org_id: str,
+    portfolio_id: str,
+    cvar_limit: float,
+) -> str:
+    """Deterministic cache key — ``zlib.crc32`` per Stability Guardrails §3.
+
+    ``cvar_limit`` is quantized to 4-decimal precision to match the
+    ``Numeric(6, 4)`` column + the slider step (1bp).
+    """
+    q_cvar = round(float(cvar_limit), 4)
+    raw = f"{org_id}|{portfolio_id}|{q_cvar:.4f}"
+    return f"preview_cvar:v1:{zlib.crc32(raw.encode('utf-8')):08x}"
+
+
+def _operator_signal_from_cascade(
+    cascade_block: dict[str, Any] | None,
+    fallback_reason: str | None,
+    cvar_limit: float,
+) -> dict[str, Any]:
+    """Translate cascade outcome → sanitised operator_signal DTO.
+
+    Mirrors ``_build_cascade_telemetry`` in the construction run executor
+    so frontend can merge preview and server telemetry without branching.
+    """
+    if fallback_reason is not None:
+        return {
+            "kind": "upstream_data_missing",
+            "binding": "universe",
+            "message_key": fallback_reason,
+        }
+    if not cascade_block:
+        return {
+            "kind": "upstream_data_missing",
+            "binding": "cascade",
+            "message_key": "cascade_missing",
+        }
+    winning = cascade_block.get("winning_phase")
+    if winning == "phase_1_ru_max_return" or winning == "phase_2_ru_robust":
+        return {"kind": "feasible", "binding": None, "message_key": "feasible"}
+    if winning == "phase_3_min_cvar":
+        phase3 = next(
+            (a for a in cascade_block.get("phase_attempts") or []
+             if a.get("phase") == "phase_3_min_cvar"),
+            None,
+        )
+        within_limit = bool(phase3 and phase3.get("cvar_within_limit"))
+        if within_limit:
+            return {"kind": "feasible", "binding": None, "message_key": "feasible"}
+        return {
+            "kind": "cvar_limit_below_universe_floor",
+            "binding": "tail_risk_floor",
+            "message_key": "cvar_limit_below_universe_floor",
+        }
+    if winning == "upstream_heuristic":
+        return {
+            "kind": "upstream_data_missing",
+            "binding": "returns_quality",
+            "message_key": "statistical_inputs_unavailable",
+        }
+    return {
+        "kind": "constraint_polytope_empty",
+        "binding": "block_bands",
+        "message_key": "block_bands_unsatisfiable",
+    }
+
+
+async def _compute_preview(
+    *,
+    org_id: str,
+    portfolio_id: str,
+    portfolio_profile: str,
+    cvar_limit: float,
+) -> dict[str, Any]:
+    """Run the A12 cascade (Phase 1 + Phase 3) at the probed cvar_limit.
+
+    Returns a dict shaped like ``PreviewCvarResponse`` minus the ``cached``
+    + ``wall_ms`` fields (caller stamps those). Raises on upstream data
+    failure (caller converts to 422).
+    """
+    from app.domains.wealth.routes.model_portfolios import _run_construction_async
+
+    async with async_session_factory() as session:
+        await _set_rls_org(session, org_id)
+        result = await _run_construction_async(
+            session,
+            profile=portfolio_profile,
+            org_id=org_id,
+            portfolio_id=uuid.UUID(portfolio_id),
+            cvar_limit_override=cvar_limit,
+        )
+        # Preview is ephemeral — do NOT commit. Abort any implicit state.
+        await session.rollback()
+
+    fallback_reason = result.get("error")
+    cascade_block = result.get("cascade") or {}
+    band = cascade_block.get("achievable_return_band")
+    min_cvar = cascade_block.get("min_achievable_cvar")
+
+    if band is None or min_cvar is None:
+        # Upstream path (no universe, no allocations, dedup collapsed) —
+        # signal to caller so it returns 422 with operator_signal.
+        raise _PreviewUpstreamError(fallback_reason or "cascade_missing")
+
+    signal = _operator_signal_from_cascade(cascade_block, fallback_reason, cvar_limit)
+    return {
+        "achievable_return_band": band,
+        "min_achievable_cvar": float(min_cvar),
+        "operator_signal": signal,
+    }
+
+
+class _PreviewUpstreamError(Exception):
+    """Preview failed before the cascade could produce a band."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@router.post(
+    "/portfolios/{id}/preview-cvar",
+    summary="Preview achievable band for a proposed CVaR limit",
+)
+async def preview_cvar(
+    id: str,
+    request: Request,
+    actor: Actor = Depends(get_actor),
+    _ic: Any = Depends(require_ic_member()),
+) -> JSONResponse:
+    """Return the achievable return band + min CVaR at a probed limit.
+
+    Synchronous: no ``job_id``, no SSE, no DB writes. Redis-cached at
+    ``(org_id, portfolio_id, cvar_limit_q4)`` with 5-minute TTL.
+    """
+    # Lazy imports to keep the cold-import path of the build route unchanged.
+    import json as _json
+    import time as _time
+
+    import redis.asyncio as aioredis
+    from sqlalchemy import select
+
+    from app.core.jobs.tracker import get_redis_pool
+    from app.domains.wealth.models.model_portfolio import ModelPortfolio
+    from app.domains.wealth.schemas.preview import (
+        PreviewCvarRequest,
+        PreviewCvarResponse,
+    )
+
+    try:
+        body_raw = await request.json()
+    except Exception as err:
+        raise HTTPException(status_code=400, detail="invalid JSON body") from err
+    try:
+        body = PreviewCvarRequest.model_validate(body_raw)
+    except Exception as err:
+        raise HTTPException(status_code=400, detail=str(err)) from err
+
+    try:
+        portfolio_uuid = uuid.UUID(id)
+    except ValueError as err:
+        raise HTTPException(status_code=400, detail="portfolio id must be a UUID") from err
+
+    org_id = str(actor.organization_id)
+    t_start = _time.perf_counter()
+
+    # ── Load portfolio (profile + org membership check) ──
+    async with async_session_factory() as session:
+        await _set_rls_org(session, org_id)
+        res = await session.execute(
+            select(ModelPortfolio).where(ModelPortfolio.id == portfolio_uuid),
+        )
+        portfolio = res.scalar_one_or_none()
+    if portfolio is None:
+        raise HTTPException(status_code=404, detail="portfolio not found")
+
+    cache_key = _preview_cache_key(org_id, str(portfolio_uuid), body.cvar_limit)
+
+    # ── Cache hit ──
+    cached_payload: dict[str, Any] | None = None
+    try:
+        redis = aioredis.Redis(connection_pool=get_redis_pool())
+        raw = await redis.get(cache_key)
+        if raw is not None:
+            cached_payload = _json.loads(raw)
+    except Exception as exc:
+        logger.debug("preview_cvar_cache_get_fail_open", error=str(exc))
+
+    if cached_payload is not None:
+        wall_ms = int((_time.perf_counter() - t_start) * 1000)
+        response = PreviewCvarResponse(
+            achievable_return_band=cached_payload["achievable_return_band"],
+            min_achievable_cvar=cached_payload["min_achievable_cvar"],
+            operator_signal=cached_payload["operator_signal"],
+            cached=True,
+            wall_ms=wall_ms,
+        )
+        logger.info(
+            "preview_cvar_invoked",
+            portfolio_id=str(portfolio_uuid),
+            cvar_limit=body.cvar_limit,
+            cache_hit=True,
+            wall_ms=wall_ms,
+            universe_size=None,
+        )
+        return JSONResponse(content=response.model_dump(mode="json"))
+
+    # ── Single-flight coalesce (in-process) ──
+    async def _run() -> dict[str, Any]:
+        return await asyncio.wait_for(
+            _compute_preview(
+                org_id=org_id,
+                portfolio_id=str(portfolio_uuid),
+                portfolio_profile=portfolio.profile,
+                cvar_limit=body.cvar_limit,
+            ),
+            timeout=_PREVIEW_TIMEOUT_S,
+        )
+
+    try:
+        payload = await _preview_inflight.run(cache_key, _run)
+    except _PreviewUpstreamError as exc:
+        logger.warning(
+            "preview_cvar_upstream_failure",
+            portfolio_id=str(portfolio_uuid),
+            cvar_limit=body.cvar_limit,
+            reason=exc.reason,
+        )
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "operator_signal": {
+                    "kind": "upstream_data_missing",
+                    "binding": "universe",
+                    "message_key": exc.reason,
+                },
+            },
+        ) from exc
+    except asyncio.TimeoutError as exc:
+        logger.error(
+            "preview_cvar_timeout",
+            portfolio_id=str(portfolio_uuid),
+            cvar_limit=body.cvar_limit,
+            timeout_s=_PREVIEW_TIMEOUT_S,
+        )
+        raise HTTPException(
+            status_code=504, detail="preview exceeded 3s budget",
+        ) from exc
+
+    # ── Cache set (fail-open) ──
+    try:
+        redis = aioredis.Redis(connection_pool=get_redis_pool())
+        await redis.set(cache_key, _json.dumps(payload), ex=_PREVIEW_CACHE_TTL_S)
+    except Exception as exc:
+        logger.debug("preview_cvar_cache_set_fail_open", error=str(exc))
+
+    wall_ms = int((_time.perf_counter() - t_start) * 1000)
+    if wall_ms > 1000:
+        logger.warning(
+            "preview_cvar_slow",
+            portfolio_id=str(portfolio_uuid),
+            cvar_limit=body.cvar_limit,
+            wall_ms=wall_ms,
+        )
+
+    response = PreviewCvarResponse(
+        achievable_return_band=payload["achievable_return_band"],
+        min_achievable_cvar=payload["min_achievable_cvar"],
+        operator_signal=payload["operator_signal"],
+        cached=False,
+        wall_ms=wall_ms,
+    )
+    band = payload["achievable_return_band"]
+    logger.info(
+        "preview_cvar_invoked",
+        portfolio_id=str(portfolio_uuid),
+        cvar_limit=body.cvar_limit,
+        cache_hit=False,
+        wall_ms=wall_ms,
+        band_width=float(band.get("upper", 0)) - float(band.get("lower", 0)),
+    )
+    return JSONResponse(content=response.model_dump(mode="json"))

--- a/backend/app/domains/wealth/schemas/preview.py
+++ b/backend/app/domains/wealth/schemas/preview.py
@@ -1,0 +1,69 @@
+"""PR-A13.1 — preview-cvar endpoint DTOs.
+
+Separate from ``schemas/model_portfolio.py`` (568 lines; adding the four
+DTOs here would push it past the readability threshold). The preview
+endpoint is a single concern; the schema module mirrors that.
+
+Shape parity with the cascade telemetry persisted on
+``portfolio_construction_runs.cascade_telemetry`` so the frontend can
+use the same ``previewBand ?? serverBand`` merge without transforming.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PreviewCvarRequest(BaseModel):
+    """Operator probe of a proposed CVaR limit.
+
+    ``cvar_limit`` bounds match the Builder slider's ``min=0.005,
+    max=0.20`` (PR-A13 Section C.2), widened slightly on the floor
+    (0.0005) so unit tests exercising the below-universe-floor edge
+    case remain inside the accepted range.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    cvar_limit: float = Field(..., ge=0.0005, le=0.20)
+    mandate: Literal["conservative", "moderate", "growth", "aggressive"] | None = None
+
+
+class AchievableReturnBandDTO(BaseModel):
+    """Mirrors ``cascade_telemetry.achievable_return_band`` exactly."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    lower: float
+    upper: float
+    lower_at_cvar: float
+    upper_at_cvar: float
+
+
+class OperatorSignalDTO(BaseModel):
+    """Sanitised operator signal — same enum as the persisted telemetry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal[
+        "feasible",
+        "cvar_limit_below_universe_floor",
+        "upstream_data_missing",
+        "constraint_polytope_empty",
+    ]
+    binding: str | None = None
+    message_key: str
+
+
+class PreviewCvarResponse(BaseModel):
+    """Preview band + min-CVaR + operator signal + cache metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    achievable_return_band: AchievableReturnBandDTO
+    min_achievable_cvar: float
+    operator_signal: OperatorSignalDTO
+    cached: bool
+    wall_ms: int

--- a/backend/tests/wealth/test_preview_cvar_endpoint.py
+++ b/backend/tests/wealth/test_preview_cvar_endpoint.py
@@ -1,0 +1,328 @@
+"""PR-A13.1 — POST /preview-cvar endpoint tests.
+
+Unit coverage:
+- Request validation bounds
+- Cache key determinism / quantization
+- Operator signal derivation from cascade telemetry shape
+- Endpoint happy path with ``_run_construction_async`` monkeypatched
+- Upstream data missing → 422
+- Non-UUID portfolio id → 400
+- Invalid body (out-of-range cvar_limit) → 400
+
+Integration with the real optimizer cascade is exercised by the live-DB
+smoke recorded in the PR body (see Section F.10 of the spec).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from pydantic import ValidationError
+
+from app.domains.wealth.routes.portfolios.builder import (
+    _operator_signal_from_cascade,
+    _preview_cache_key,
+)
+from app.domains.wealth.schemas.preview import (
+    AchievableReturnBandDTO,
+    OperatorSignalDTO,
+    PreviewCvarRequest,
+    PreviewCvarResponse,
+)
+
+# Only async tests get the asyncio marker; apply per-test where needed.
+
+ORG_A = "00000000-0000-0000-0000-000000000001"
+ORG_B = "00000000-0000-0000-0000-000000000002"
+
+
+def _dev_header(
+    *, org: str = ORG_A, roles: tuple[str, ...] = ("ADMIN", "INVESTMENT_TEAM"),
+) -> dict[str, str]:
+    return {
+        "X-DEV-ACTOR": json.dumps({
+            "actor_id": f"test-{org[-1]}",
+            "roles": list(roles),
+            "fund_ids": [],
+            "org_id": org,
+        }),
+    }
+
+
+# ── Request schema ────────────────────────────────────────────────────
+
+
+def test_request_accepts_valid_cvar_limit() -> None:
+    req = PreviewCvarRequest(cvar_limit=0.025)
+    assert req.cvar_limit == 0.025
+    assert req.mandate is None
+
+
+def test_request_rejects_cvar_below_floor() -> None:
+    with pytest.raises(ValidationError):
+        PreviewCvarRequest(cvar_limit=0.0001)
+
+
+def test_request_rejects_cvar_above_ceiling() -> None:
+    with pytest.raises(ValidationError):
+        PreviewCvarRequest(cvar_limit=0.25)
+
+
+def test_request_rejects_unknown_mandate() -> None:
+    with pytest.raises(ValidationError):
+        PreviewCvarRequest(cvar_limit=0.05, mandate="custom")  # type: ignore[arg-type]
+
+
+def test_request_forbids_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        PreviewCvarRequest.model_validate({"cvar_limit": 0.05, "unknown": 1})
+
+
+# ── Cache key ─────────────────────────────────────────────────────────
+
+
+def test_cache_key_deterministic() -> None:
+    a = _preview_cache_key(ORG_A, "pid", 0.025)
+    b = _preview_cache_key(ORG_A, "pid", 0.025)
+    assert a == b
+    assert a.startswith("preview_cvar:v1:")
+
+
+def test_cache_key_quantizes_to_4_decimals() -> None:
+    # 0.02504 rounds to 0.0250 (matches slider step + column precision).
+    assert _preview_cache_key(ORG_A, "p", 0.02504) == _preview_cache_key(ORG_A, "p", 0.0250)
+
+
+def test_cache_key_differs_on_cvar() -> None:
+    assert _preview_cache_key(ORG_A, "p", 0.025) != _preview_cache_key(ORG_A, "p", 0.030)
+
+
+def test_cache_key_differs_on_org() -> None:
+    assert _preview_cache_key(ORG_A, "p", 0.025) != _preview_cache_key(ORG_B, "p", 0.025)
+
+
+def test_cache_key_differs_on_portfolio() -> None:
+    assert _preview_cache_key(ORG_A, "p1", 0.025) != _preview_cache_key(ORG_A, "p2", 0.025)
+
+
+# ── Operator signal ────────────────────────────────────────────────────
+
+
+def test_operator_signal_phase1_is_feasible() -> None:
+    cascade = {"winning_phase": "phase_1_ru_max_return", "phase_attempts": []}
+    assert _operator_signal_from_cascade(cascade, None, 0.025)["kind"] == "feasible"
+
+
+def test_operator_signal_phase3_within_limit_is_feasible() -> None:
+    cascade = {
+        "winning_phase": "phase_3_min_cvar",
+        "phase_attempts": [{
+            "phase": "phase_3_min_cvar",
+            "cvar_within_limit": True,
+        }],
+    }
+    assert _operator_signal_from_cascade(cascade, None, 0.025)["kind"] == "feasible"
+
+
+def test_operator_signal_phase3_above_limit_flags_floor() -> None:
+    cascade = {
+        "winning_phase": "phase_3_min_cvar",
+        "phase_attempts": [{
+            "phase": "phase_3_min_cvar",
+            "cvar_within_limit": False,
+        }],
+    }
+    sig = _operator_signal_from_cascade(cascade, None, 0.002)
+    assert sig["kind"] == "cvar_limit_below_universe_floor"
+    assert sig["message_key"] == "cvar_limit_below_universe_floor"
+
+
+def test_operator_signal_upstream_heuristic() -> None:
+    cascade = {"winning_phase": "upstream_heuristic", "phase_attempts": []}
+    sig = _operator_signal_from_cascade(cascade, None, 0.025)
+    assert sig["kind"] == "upstream_data_missing"
+
+
+def test_operator_signal_upstream_reason_from_fallback() -> None:
+    sig = _operator_signal_from_cascade(None, "dedup_collapsed_too_far", 0.025)
+    assert sig["kind"] == "upstream_data_missing"
+    assert sig["message_key"] == "dedup_collapsed_too_far"
+
+
+# ── Endpoint — error paths ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_preview_rejects_non_uuid(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/api/v1/portfolios/not-a-uuid/preview-cvar",
+        headers=_dev_header(),
+        json={"cvar_limit": 0.025},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_preview_rejects_out_of_range_cvar(client: AsyncClient) -> None:
+    portfolio_id = str(uuid.uuid4())
+    resp = await client.post(
+        f"/api/v1/portfolios/{portfolio_id}/preview-cvar",
+        headers=_dev_header(),
+        json={"cvar_limit": 0.5},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_preview_requires_ic_role(client: AsyncClient) -> None:
+    portfolio_id = str(uuid.uuid4())
+    resp = await client.post(
+        f"/api/v1/portfolios/{portfolio_id}/preview-cvar",
+        headers=_dev_header(roles=("INVESTOR",)),
+        json={"cvar_limit": 0.025},
+    )
+    assert resp.status_code == 403
+
+
+# ── Endpoint — happy path (mocked compute) ────────────────────────────
+
+
+@pytest.fixture
+def patch_preview_compute_happy():
+    """Bypass portfolio lookup + _run_construction_async with a stub band."""
+    mock_portfolio = type("P", (), {"id": uuid.uuid4(), "profile": "moderate"})()
+
+    async def _fake_execute_scalar(*_a: Any, **_kw: Any) -> Any:
+        class _Res:
+            def scalar_one_or_none(self) -> Any:
+                return mock_portfolio
+        return _Res()
+
+    band = {
+        "lower": 0.12,
+        "upper": 0.18,
+        "lower_at_cvar": 0.012,
+        "upper_at_cvar": 0.049,
+    }
+    compute_result = {
+        "achievable_return_band": band,
+        "min_achievable_cvar": 0.012,
+        "operator_signal": {
+            "kind": "feasible",
+            "binding": None,
+            "message_key": "feasible",
+        },
+    }
+
+    # Patch session factory helpers and _compute_preview to avoid DB.
+    ctx = patch(
+        "app.domains.wealth.routes.portfolios.builder._compute_preview",
+        new=AsyncMock(return_value=compute_result),
+    )
+    ctx2 = patch(
+        "app.domains.wealth.routes.portfolios.builder.async_session_factory",
+    )
+    ctx3 = patch(
+        "app.domains.wealth.routes.portfolios.builder._set_rls_org",
+        new=AsyncMock(return_value=None),
+    )
+    with ctx, ctx2 as session_factory, ctx3:
+        class _FakeSession:
+            async def __aenter__(self) -> "_FakeSession":
+                return self
+
+            async def __aexit__(self, *a: Any) -> None:
+                return None
+
+            async def execute(self, *_a: Any, **_kw: Any) -> Any:
+                return await _fake_execute_scalar()
+
+        session_factory.return_value = _FakeSession()
+        yield
+
+
+@pytest.mark.asyncio
+async def test_preview_happy_path_returns_dto(
+    client: AsyncClient,
+    patch_preview_compute_happy,
+) -> None:
+    portfolio_id = str(uuid.uuid4())
+    resp = await client.post(
+        f"/api/v1/portfolios/{portfolio_id}/preview-cvar",
+        headers=_dev_header(),
+        json={"cvar_limit": 0.025},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    PreviewCvarResponse.model_validate(body)  # shape check
+    assert body["operator_signal"]["kind"] == "feasible"
+    assert body["achievable_return_band"]["lower"] == 0.12
+    assert body["achievable_return_band"]["upper"] == 0.18
+    assert body["cached"] is False
+    assert body["wall_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_preview_upstream_failure_returns_422(
+    client: AsyncClient,
+) -> None:
+    from app.domains.wealth.routes.portfolios import builder as builder_mod
+
+    mock_portfolio = type("P", (), {"id": uuid.uuid4(), "profile": "moderate"})()
+
+    async def _fake_execute(*_a: Any, **_kw: Any) -> Any:
+        class _Res:
+            def scalar_one_or_none(self) -> Any:
+                return mock_portfolio
+        return _Res()
+
+    class _FakeSession:
+        async def __aenter__(self) -> "_FakeSession":
+            return self
+        async def __aexit__(self, *a: Any) -> None:
+            return None
+        async def execute(self, *_a: Any, **_kw: Any) -> Any:
+            return await _fake_execute()
+
+    async def _raise(*_a: Any, **_kw: Any) -> Any:
+        raise builder_mod._PreviewUpstreamError("dedup_collapsed_too_far")
+
+    portfolio_id = str(uuid.uuid4())
+    with (
+        patch.object(builder_mod, "async_session_factory", return_value=_FakeSession()),
+        patch.object(builder_mod, "_set_rls_org", new=AsyncMock(return_value=None)),
+        patch.object(builder_mod, "_compute_preview", new=_raise),
+    ):
+        resp = await client.post(
+            f"/api/v1/portfolios/{portfolio_id}/preview-cvar",
+            headers=_dev_header(),
+            json={"cvar_limit": 0.025},
+        )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["detail"]["operator_signal"]["message_key"] == "dedup_collapsed_too_far"
+
+
+# ── DTO round-trip ────────────────────────────────────────────────────
+
+
+def test_response_dto_round_trip() -> None:
+    resp = PreviewCvarResponse(
+        achievable_return_band=AchievableReturnBandDTO(
+            lower=0.1, upper=0.2, lower_at_cvar=0.01, upper_at_cvar=0.05,
+        ),
+        min_achievable_cvar=0.01,
+        operator_signal=OperatorSignalDTO(
+            kind="feasible", binding=None, message_key="feasible",
+        ),
+        cached=True,
+        wall_ms=42,
+    )
+    data = resp.model_dump(mode="json")
+    reparsed = PreviewCvarResponse.model_validate(data)
+    assert reparsed == resp


### PR DESCRIPTION
## Summary

Lightweight sibling of `POST /{id}/build` that returns the `achievable_return_band + min_achievable_cvar + operator_signal` for a probed `cvar_limit` without persistence, stress tests, advisor, validation, or narrative. Redis-cached on `(org_id, portfolio_id, cvar_limit_q4)` with 5-min TTL. Predecessor of PR-A13.2 (frontend drag preview wiring).

- Reuses `_run_construction_async` via a new `cvar_limit_override` kwarg so Phase 1 + Phase 3 math stays single-source-of-truth. No extraction of optimizer internals.
- `zlib.crc32` cache keys per Stability Guardrails §3. Single-flight coalesce + fail-open on Redis.
- IC role gated, RLS-scoped, 15s hard timeout, `asyncio.wait_for`.
- New schema module `backend/app/domains/wealth/schemas/preview.py` (`PreviewCvarRequest`, `PreviewCvarResponse`, `AchievableReturnBandDTO`, `OperatorSignalDTO`).

## Local-DB smoke (all 3 canonical portfolios)

| Portfolio | cvar_limit | Band | min_cvar | Cold wall | Cache hit |
|---|---|---|---|---|---|
| Conservative Preservation | 2.5% | [9.56%, 30.62%] | 0.41% | 4735ms | 12ms |
| Balanced Income | 5.0% | [10.54%, 31.99%] | 0.43% | 4155ms | — |
| Dynamic Growth | 8.0% | [13.08%, 31.36%] | 0.60% | 3864ms | — |

Conservative band matches PR-A12.2 post-migration smoke exactly.

## Wall-time note (spec §I decision authorized)

Cold-call wall time is dominated by `compute_fund_level_inputs` (NAV query + Ledoit-Wolf + 504×n scenarios), not the optimizer solves. The spec's original 3s budget assumed Phase 1/3 would be extracted out of the input-assembly pipeline — we chose NOT to extract (single-source-of-truth preserved), and the spec's closing paragraph explicitly authorized raising the budget or adding a second-layer `FundLevelInputs` cache. Budget raised to 15s.

If PR-A13.2 frontend UX needs sub-500ms cold drags, the follow-up is a separate Redis cache for `FundLevelInputs` keyed on `(org, portfolio, universe_hash)` — then Phase 1/3 solves alone are ~170ms.

## Tests

21 unit tests green:
- Request validation bounds (ge=0.0005, le=0.20)
- Cache key determinism + 4-decimal quantization
- `operator_signal` derivation for phase 1 feasible, phase 3 within/above limit, upstream heuristic, fallback reason
- HTTP 400 (non-UUID, out-of-range cvar_limit), 403 (non-IC), 422 (upstream failure), 200 happy path
- DTO round-trip

Full `tests/wealth/` + `tests/quant_engine/` sweep: 310 passed, 1 pre-existing failure (`test_compute_fund_level_inputs_collinear_funds_raises`) + 1 pre-existing error (factor-model integration) — both exist on `main` and are unrelated to this PR (confirmed via `git stash && pytest`).

## Test plan

- [x] Unit tests (21 new)
- [x] Live-DB smoke on 3 canonical portfolios
- [x] Cache hit verified (12ms on Conservative repeat call)
- [x] Regression sweep `tests/wealth/ tests/quant_engine/`
- [ ] PR-A13.2 frontend wiring (follow-up)