### PR TITLE
fix(quant): winner-selection must honour RU-CVaR limit (PR-A12.4)

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -2279,7 +2279,17 @@ async def _run_construction_async(
             caller_kind="construction_run",
         )
 
-        if fund_result.status.startswith("optimal") and fund_result.weights:
+        # PR-A12.4 — ``degraded`` is also a valid terminal status (Phase 3
+        # min-CVaR winner with cvar_above_limit). Treat it as a real result
+        # so the ``phase_3_min_cvar_above_limit`` signal reaches the
+        # executor instead of being swallowed by the upstream_heuristic
+        # fallback. Without this, the A12 always-solvable cascade collapses
+        # to a false "data missing" narrative whenever the universe floor
+        # exceeds the operator's CVaR limit.
+        if (
+            (fund_result.status.startswith("optimal") or fund_result.status == "degraded")
+            and fund_result.weights
+        ):
             opt_meta = OptimizationMeta(
                 expected_return=fund_result.expected_return,
                 portfolio_volatility=fund_result.portfolio_volatility,

--- a/backend/quant_engine/optimizer_service.py
+++ b/backend/quant_engine/optimizer_service.py
@@ -694,6 +694,19 @@ async def optimize_fund_portfolio(
         """Annualized RU-empirical CVaR (matches Phase 1/3 LP objective, √252 scaled)."""
         return realized_cvar_from_weights(w_arr, returns_scenarios, cvar_alpha) * SQRT_252
 
+    # PR-A12.4 — winner-selection must verify realized CVaR against the
+    # operator's limit before promoting Phase 1 / Phase 2. The SCS fallback
+    # (CLARABEL → SCS) can return ``status=optimal`` with realized CVaR
+    # violating the constraint by orders of magnitude at its loose tolerance
+    # (eps=1e-5). Before this PR, the gate was ``phase1_weights is not None``
+    # — any optimal-looking solution was promoted, even when it delivered
+    # 2× the operator's CVaR budget. These flags are hoisted to function
+    # scope so winner selection can read them uniformly.
+    _phase1_within_limit: bool | None = None
+    _phase2_within_limit: bool | None = None
+    _USABLE_TOLERANCE = 1e-4  # annualized; tight enough to reject 2× violations,
+                              # loose enough to accept CLARABEL precision (~1e-6).
+
     phase1_weights: np.ndarray | None = None
     phase1_solver: str | None = None
     phase1_expected_return: float | None = None
@@ -762,10 +775,11 @@ async def optimize_fund_portfolio(
                 sum_weights=float(opt_w1.sum()),
             )
             phase1_within = (
-                phase1_cvar_ru <= effective_cvar_limit
+                phase1_cvar_ru <= effective_cvar_limit + _USABLE_TOLERANCE
                 if effective_cvar_limit is not None
                 else True
             )
+            _phase1_within_limit = phase1_within  # PR-A12.4 winner gate
             attempts.append(PhaseAttempt(
                 phase="phase_1_ru_max_return",
                 status="succeeded",
@@ -849,10 +863,11 @@ async def optimize_fund_portfolio(
                     phase2_cvar_ru = _cvar_from_ru(opt_w2)
                     phase2_cvar_cf = _compute_cvar(opt_w2)
                     phase2_within = (
-                        phase2_cvar_ru <= effective_cvar_limit
+                        phase2_cvar_ru <= effective_cvar_limit + _USABLE_TOLERANCE
                         if effective_cvar_limit is not None
                         else True
                     )
+                    _phase2_within_limit = phase2_within  # PR-A12.4 winner gate
                     attempts.append(PhaseAttempt(
                         phase="phase_2_ru_robust",
                         status="succeeded",
@@ -963,13 +978,31 @@ async def optimize_fund_portfolio(
     phase3_expected_return = float(mu @ phase3_weights)
 
     # ── Winner selection (Phase 1 > Phase 2 > Phase 3) ───────────────────
-    if phase1_weights is not None:
+    # PR-A12.4 — gate Phase 1 / Phase 2 promotion on realized CVaR honouring
+    # the operator's limit. Without this gate, the CLARABEL → SCS fallback
+    # could return ``status=optimal`` with realized CVaR >> limit (SCS's
+    # ``eps=1e-5`` tolerance is loose enough to admit large violations on
+    # heavy-tailed universes). Observed on Growth 2026-04-17 post PR-A12.3:
+    # Phase 1 (SCS) ``status=optimal``, realized 0.1714 vs limit 0.08 —
+    # 2.14× overshoot silently promoted. Phase 3 is always-solvable by
+    # construction (min-CVaR on the base polytope) and does not need
+    # a within-limit gate — its below-floor state is reflected in the
+    # ``phase_3_min_cvar_above_limit`` cascade summary downstream.
+    _phase1_usable = (
+        phase1_weights is not None
+        and (effective_cvar_limit is None or _phase1_within_limit is True)
+    )
+    _phase2_usable = (
+        phase2_weights is not None
+        and (effective_cvar_limit is None or _phase2_within_limit is True)
+    )
+    if _phase1_usable:
         winner_w = phase1_weights
         winner_phase = "phase_1_ru_max_return"
         winner_solver = phase1_solver
         winner_return = phase1_expected_return
         winner_status = "optimal"
-    elif phase2_weights is not None:
+    elif _phase2_usable:
         winner_w = phase2_weights
         winner_phase = "phase_2_ru_robust"
         winner_solver = phase2_solver

--- a/backend/tests/integration/test_construction_cvar_invariant.py
+++ b/backend/tests/integration/test_construction_cvar_invariant.py
@@ -1,0 +1,194 @@
+"""PR-A12.4 — construction-run CVaR invariant (live-DB integration).
+
+Closes the A12.2 class of DB-only tests blind spot. The A12.2 migration
+test validated only that ``portfolio_calibration.cvar_limit`` was updated
+in the column — not that the optimizer actually consumed that value. A
+wiring bug (A12.3 round 1) silently ignored the per-portfolio column and
+applied stale profile-wide defaults; a winner-selection bug (A12.3 round
+2 → A12.4) promoted SCS-fallback constraint-violating solutions to
+cascade_summary=phase_1_succeeded.
+
+This harness exercises the full runtime path for all 3 canonical
+portfolios against a running uvicorn + local Postgres, asserting the
+central invariant:
+
+    |cvar_95_delivered| <= resolved_cvar_limit + tol
+      OR
+    cascade_summary in {phase_3_min_cvar_above_limit, upstream_heuristic,
+                        constraint_polytope_empty}
+
+Any future PR touching ``optimizer_service``, ``model_portfolios``,
+``construction_run_executor``, or ``portfolio_calibration`` MUST keep
+this test green. It is gated behind ``@pytest.mark.integration`` so the
+default ``make test`` lane is unaffected; ``pytest -m integration`` or
+CI-triggered live-db lane runs it.
+
+Preconditions (test is skipped when absent):
+- Backend reachable at ``http://localhost:8000/health``
+- Postgres reachable at the canonical dev DSN
+- The 3 canonical portfolio UUIDs seeded (see ``scripts/seed_canonical_portfolios.py``)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+
+import httpx
+import psycopg
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_CANONICAL_ORG = "403d8392-ebfa-5890-b740-45da49c556eb"
+_BACKEND_URL = "http://localhost:8000"
+_DB_DSN = "postgresql://netz:netz@localhost:5434/netz_engine"
+_WITHIN_TOLERANCE = 1e-3  # annual CVaR tolerance — matches optimizer gate
+
+_PORTFOLIOS = [
+    ("Conservative Preservation", "3945cee6-f85d-4903-a2dd-cf6a51e1c6a5"),
+    ("Balanced Income", "e5892474-7438-4ac5-85da-217abcf99932"),
+    ("Dynamic Growth", "3163d72b-3f8c-427e-9cd2-bead6377b59c"),
+]
+
+_DEV_ACTOR = json.dumps({
+    "actor_id": "cvar-invariant-test",
+    "name": "CVaR Invariant",
+    "email": "ci@netz.capital",
+    "roles": ["ADMIN", "INVESTMENT_TEAM"],
+    "org_id": _CANONICAL_ORG,
+    "org_slug": "ci",
+})
+_HEADERS = {"X-DEV-ACTOR": _DEV_ACTOR, "Content-Type": "application/json"}
+
+_ALLOWED_BELOW_FLOOR_SUMMARIES = {
+    "phase_3_min_cvar_above_limit",
+    "upstream_heuristic",
+    "constraint_polytope_empty",
+}
+
+
+def _backend_reachable() -> bool:
+    try:
+        with httpx.Client(timeout=2.0) as c:
+            return c.get(f"{_BACKEND_URL}/health").status_code == 200
+    except Exception:
+        return False
+
+
+def _db_reachable() -> bool:
+    try:
+        with psycopg.connect(_DB_DSN, connect_timeout=2):
+            return True
+    except Exception:
+        return False
+
+
+def _portfolios_seeded() -> bool:
+    try:
+        with psycopg.connect(_DB_DSN, connect_timeout=2) as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM model_portfolios WHERE id = ANY(%s)",
+                ([pid for _, pid in _PORTFOLIOS],),
+            )
+            return (cur.fetchone() or [0])[0] == len(_PORTFOLIOS)
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not (_backend_reachable() and _db_reachable() and _portfolios_seeded()),
+    reason="Requires local uvicorn + Postgres + seeded canonical portfolios",
+)
+def test_construction_delivered_cvar_within_limit_or_signaled() -> None:
+    """For each of the 3 canonical portfolios, trigger /build and assert that
+    the persisted cascade either honours the operator's CVaR limit
+    (succeeded) or surfaces the below-floor state (degraded with a
+    recognised summary)."""
+    trigger_at = datetime.now(timezone.utc)
+    with httpx.Client(timeout=20.0) as c:
+        for name, pid in _PORTFOLIOS:
+            resp = c.post(
+                f"{_BACKEND_URL}/api/v1/portfolios/{pid}/build",
+                headers=_HEADERS,
+                json={},
+            )
+            assert resp.status_code in (200, 202), (
+                f"{name}: unexpected build response {resp.status_code}"
+            )
+
+    # Poll until all three runs reach a terminal state (≤ 4 min).
+    deadline = time.time() + 240
+    terminal: list[tuple[str, str]] = []
+    while time.time() < deadline:
+        with psycopg.connect(_DB_DSN) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT mp.id::text, pcr.status
+                FROM portfolio_construction_runs pcr
+                JOIN model_portfolios mp ON mp.id = pcr.portfolio_id
+                WHERE pcr.started_at >= %s
+                  AND mp.id = ANY(%s)
+                ORDER BY pcr.started_at DESC
+                """,
+                (trigger_at, [pid for _, pid in _PORTFOLIOS]),
+            )
+            rows = cur.fetchall()
+        terminal = [
+            r for r in rows
+            if r[1] in ("succeeded", "failed", "degraded", "cancelled")
+        ]
+        if len(terminal) >= len(_PORTFOLIOS):
+            break
+        time.sleep(5)
+
+    assert len(terminal) >= len(_PORTFOLIOS), (
+        f"only {len(terminal)}/{len(_PORTFOLIOS)} runs reached a terminal "
+        f"state within the poll window"
+    )
+
+    with psycopg.connect(_DB_DSN) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT mp.display_name,
+                   pcr.status,
+                   pcr.cascade_telemetry->>'cascade_summary' AS summary,
+                   (pcr.calibration_snapshot->>'cvar_limit')::float AS limit_operator,
+                   (pcr.ex_ante_metrics->>'cvar_95')::float AS delivered_cvar95
+            FROM portfolio_construction_runs pcr
+            JOIN model_portfolios mp ON mp.id = pcr.portfolio_id
+            WHERE pcr.started_at >= %s
+              AND mp.id = ANY(%s)
+            ORDER BY pcr.started_at DESC
+            """,
+            (trigger_at, [pid for _, pid in _PORTFOLIOS]),
+        )
+        rows = cur.fetchall()
+
+    # One row per portfolio — each MUST either deliver within limit
+    # or surface the below-floor signal.
+    failures: list[str] = []
+    for name, status, summary, limit, delivered in rows:
+        delivered_abs = abs(delivered) if delivered is not None else None
+        if status == "succeeded" and summary == "phase_1_succeeded":
+            if delivered_abs is None or limit is None:
+                failures.append(
+                    f"{name}: succeeded but missing cvar_95 / calibration limit",
+                )
+            elif delivered_abs > limit + _WITHIN_TOLERANCE:
+                failures.append(
+                    f"{name}: PR-A12.4 invariant violated — "
+                    f"succeeded/phase_1 but delivered {delivered_abs:.4f} > "
+                    f"limit {limit:.4f} (tol {_WITHIN_TOLERANCE})",
+                )
+        elif status == "degraded":
+            if summary not in _ALLOWED_BELOW_FLOOR_SUMMARIES:
+                failures.append(
+                    f"{name}: degraded with unrecognised summary {summary}; "
+                    f"expected one of {_ALLOWED_BELOW_FLOOR_SUMMARIES}",
+                )
+        elif status == "failed":
+            failures.append(f"{name}: unexpected status=failed, summary={summary}")
+
+    assert not failures, "invariant violations:\n  " + "\n  ".join(failures)

--- a/backend/tests/quant_engine/test_phase_winner_invariant.py
+++ b/backend/tests/quant_engine/test_phase_winner_invariant.py
@@ -1,0 +1,224 @@
+"""PR-A12.4 — winner-selection invariant tests.
+
+Central invariant: when ``optimize_fund_portfolio`` returns a result with
+``winning_phase in {phase_1_ru_max_return, phase_2_ru_robust}``, the realized
+CVaR of the returned weights MUST respect the operator's limit (within a
+tolerance of 1e-4 annualized). Otherwise the cascade must fall through to
+Phase 3 and surface the below-floor state via
+``cascade_summary=phase_3_min_cvar_above_limit``.
+
+Before this PR, the gate was ``phase1_weights is not None`` — any optimal-
+looking LP solution was promoted, including CLARABEL → SCS fallback
+solutions where SCS's looser tolerance admitted 2× constraint violations.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from quant_engine.optimizer_service import (
+    BlockConstraint,
+    ProfileConstraints,
+    optimize_fund_portfolio,
+)
+
+
+def _make_inputs(
+    n: int = 5,
+    *,
+    seed: int = 42,
+    mu_scale: float = 0.10,
+    tail_heaviness: float = 1.0,
+) -> tuple[list[str], dict[str, str], dict[str, float], np.ndarray, np.ndarray]:
+    """Build a synthetic universe with tunable tail heaviness.
+
+    Returns (fund_ids, fund_blocks, expected_returns, cov_matrix, returns_scenarios).
+    """
+    rng = np.random.default_rng(seed)
+    fund_ids = [f"f{i}" for i in range(n)]
+    fund_blocks = {fid: "core" for fid in fund_ids}
+    mu = np.linspace(mu_scale * 0.5, mu_scale * 1.5, n)
+    expected_returns = {fid: float(mu[i]) for i, fid in enumerate(fund_ids)}
+    # Draw scenarios from Student-t (fat tails) scaled to daily log-return magnitudes
+    # ``tail_heaviness`` controls df: 3 = very fat, 30 ≈ near-Gaussian.
+    df = max(3.0, 30.0 / tail_heaviness)
+    t_samples = rng.standard_t(df=df, size=(504, n)) * 0.012  # ~2% daily vol scale
+    daily_mu = mu / 252.0
+    returns_scenarios = t_samples + daily_mu
+    # Annualised covariance from scenarios (upper-bound, matches A12.3 convention).
+    cov_daily = np.cov(returns_scenarios.T)
+    cov_matrix = cov_daily * 252.0
+    return fund_ids, fund_blocks, expected_returns, cov_matrix, returns_scenarios
+
+
+@pytest.mark.asyncio
+async def test_phase_1_winner_must_respect_limit() -> None:
+    """Sanity path — Gaussian universe, reasonable limit → Phase 1 wins and delivers within limit."""
+    fund_ids, fund_blocks, er, cov, scenarios = _make_inputs(
+        n=5, tail_heaviness=1.0, mu_scale=0.08,
+    )
+    constraints = ProfileConstraints(
+        blocks=[BlockConstraint(block_id="core", min_weight=0.0, max_weight=1.0)],
+        cvar_limit=0.50,  # generous — Phase 1 should trivially hit this
+        max_single_fund_weight=1.0,
+    )
+    result = await optimize_fund_portfolio(
+        fund_ids=fund_ids,
+        fund_blocks=fund_blocks,
+        expected_returns=er,
+        cov_matrix=cov,
+        returns_scenarios=scenarios,
+        constraints=constraints,
+    )
+    # Either Phase 1 or Phase 2 wins, delivered must respect the limit.
+    if result.winning_phase in ("phase_1_ru_max_return", "phase_2_ru_robust"):
+        assert result.cvar_95 is not None
+        assert abs(result.cvar_95) <= 0.50 + 1e-3, (
+            f"Phase {result.winning_phase} won but delivered CVaR "
+            f"{result.cvar_95} > limit 0.50"
+        )
+
+
+@pytest.mark.asyncio
+async def test_scs_fallback_with_violation_rejected(monkeypatch) -> None:
+    """SCS-fallback scenario: Phase 1 LP reports ``status=optimal`` while the
+    realized RU-CVaR of the returned weights exceeds the operator limit by
+    orders of magnitude. Simulates the Growth 2026-04-17 production pattern
+    where CLARABEL → SCS fallback produced a constraint-violating solution
+    within SCS's loose tolerance (eps=1e-5).
+
+    This is a **pre-fix repro**: before PR-A12.4, the winner-selection gate
+    was ``phase1_weights is not None`` — so any optimal-looking LP solution
+    was promoted, including one with 2× constraint violation. Post-fix, the
+    gate is ``phase1_weights is not None AND phase1_within_limit``, so the
+    cascade falls through to Phase 3 and surfaces the below-floor state.
+
+    We force the exact pathology by patching
+    ``realized_cvar_from_weights`` called inside
+    ``optimize_fund_portfolio`` to inject an out-of-limit realized value
+    after the LP has already solved — identical shape to what SCS would
+    produce.
+    """
+    from quant_engine import ru_cvar_lp
+
+    # Synthetic universe where CLARABEL succeeds with a well-scoped solution.
+    fund_ids, fund_blocks, er, cov, scenarios = _make_inputs(
+        n=4, tail_heaviness=1.0, mu_scale=0.10, seed=7,
+    )
+    constraints = ProfileConstraints(
+        blocks=[BlockConstraint(block_id="core", min_weight=0.0, max_weight=1.0)],
+        # Loose limit so the LP genuinely solves to optimal (otherwise
+        # phase1_weights is None and the gate never fires). The injected
+        # realized value below then simulates SCS's pathology.
+        cvar_limit=0.50,
+        max_single_fund_weight=1.0,
+    )
+
+    # Monkeypatch realized_cvar_from_weights to report the solved weights
+    # as OUT OF LIMIT. _cvar_from_ru multiplies by sqrt(252), so the raw
+    # daily injected value * 15.87 = annualised. Return 0.15 daily → 2.38
+    # annualised, well above the 0.05 limit. Phase 3 needs the true value
+    # to pick a within-limit winner, so we only inject for Phase 1 / 2
+    # signatures (scenarios matrix as 2nd positional arg).
+    orig_realized = ru_cvar_lp.realized_cvar_from_weights
+    call_counter = {"n": 0}
+
+    def _poisoned(w: np.ndarray, scenarios_: np.ndarray, alpha: float) -> float:
+        # First two invocations simulate Phase 1/2 reporting a hugely
+        # violating realized CVaR. Subsequent invocations (Phase 3 audit,
+        # band assembly, _build_result) get the honest value.
+        call_counter["n"] += 1
+        if call_counter["n"] <= 2:
+            return 0.15  # daily → 2.38 annualised → massively over 0.05
+        return orig_realized(w, scenarios_, alpha)
+
+    # Patch both the source definition and the import sites in
+    # optimizer_service, since it does ``from quant_engine.ru_cvar_lp import
+    # realized_cvar_from_weights`` lazily inside the function body.
+    import quant_engine.optimizer_service as opt_mod
+
+    monkeypatch.setattr(ru_cvar_lp, "realized_cvar_from_weights", _poisoned)
+    monkeypatch.setattr(
+        opt_mod, "realized_cvar_from_weights", _poisoned, raising=False,
+    )
+
+    result = await optimize_fund_portfolio(
+        fund_ids=fund_ids,
+        fund_blocks=fund_blocks,
+        expected_returns=er,
+        cov_matrix=cov,
+        returns_scenarios=scenarios,
+        constraints=constraints,
+    )
+
+    # Invariant: phase_1 reporting cvar_within_limit=False must NOT win.
+    p1 = next(
+        (a for a in result.phase_attempts if a.phase == "phase_1_ru_max_return"),
+        None,
+    )
+    assert p1 is not None
+    if p1.status == "succeeded" and p1.cvar_within_limit is False:
+        assert result.winning_phase != "phase_1_ru_max_return", (
+            "PR-A12.4 invariant violated: phase_1 succeeded with "
+            "cvar_within_limit=False was promoted as winner"
+        )
+
+
+@pytest.mark.asyncio
+async def test_phase_1_constraint_violation_forces_phase_3() -> None:
+    """Direct unit test of the gate: inject a phase_1 solution whose realized
+    RU-CVaR exceeds the limit by > tolerance. Assert winner skips Phase 1."""
+    # The easiest way to force this: set the limit far below anything the
+    # universe can satisfy. The LP will still solve (either feasibly under
+    # loose tolerance, or infeasibly — either case tests the gate).
+    fund_ids, fund_blocks, er, cov, scenarios = _make_inputs(
+        n=3, tail_heaviness=2.0, mu_scale=0.15,
+    )
+    constraints = ProfileConstraints(
+        blocks=[BlockConstraint(block_id="core", min_weight=0.0, max_weight=1.0)],
+        cvar_limit=0.001,  # 0.1% — effectively zero
+        max_single_fund_weight=1.0,
+    )
+    result = await optimize_fund_portfolio(
+        fund_ids=fund_ids,
+        fund_blocks=fund_blocks,
+        expected_returns=er,
+        cov_matrix=cov,
+        returns_scenarios=scenarios,
+        constraints=constraints,
+    )
+
+    # Inspect phase_attempts — if phase_1 "succeeded" with within_limit=False,
+    # it must NOT be the winner.
+    p1 = next((a for a in result.phase_attempts if a.phase == "phase_1_ru_max_return"), None)
+    if p1 is not None and p1.status == "succeeded" and p1.cvar_within_limit is False:
+        assert result.winning_phase != "phase_1_ru_max_return", (
+            "PR-A12.4 invariant violated: phase_1 succeeded with "
+            "cvar_within_limit=False but was promoted as winner"
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_cvar_limit_phase_1_wins() -> None:
+    """When the operator passes no CVaR limit, the gate must be a no-op:
+    Phase 1 always wins if it produces weights."""
+    fund_ids, fund_blocks, er, cov, scenarios = _make_inputs(n=4)
+    constraints = ProfileConstraints(
+        blocks=[BlockConstraint(block_id="core", min_weight=0.0, max_weight=1.0)],
+        cvar_limit=None,  # no constraint
+        max_single_fund_weight=1.0,
+    )
+    result = await optimize_fund_portfolio(
+        fund_ids=fund_ids,
+        fund_blocks=fund_blocks,
+        expected_returns=er,
+        cov_matrix=cov,
+        returns_scenarios=scenarios,
+        constraints=constraints,
+    )
+    # With no limit, Phase 1 is unconstrained max-return LP — should succeed.
+    assert result.winning_phase == "phase_1_ru_max_return"
+    assert result.status.startswith("optimal")


### PR DESCRIPTION
## Draft — diagnostic finding posted, awaiting consultant confirmation before Section D fix

## Section A — Pattern identified from existing post-A12.3 telemetry

No new instrumentation needed — the persisted `cascade_telemetry` on the latest Growth run already contains the smoking gun. Query:

```sql
SELECT pcr.cascade_telemetry
FROM portfolio_construction_runs pcr
WHERE pcr.portfolio_id = '3163d72b-3f8c-427e-9cd2-bead6377b59c'
ORDER BY pcr.started_at DESC LIMIT 1;
```

Result (pretty-printed):

```json
{
  "cascade_summary": "phase_1_succeeded",
  "operator_signal": null,
  "min_achievable_cvar": 0.094484,
  "achievable_return_band": {
    "lower": 0.130834, "upper": 0.087382,
    "lower_at_cvar": 0.094484, "upper_at_cvar": 0.171426
  },
  "phase_attempts": [
    {
      "phase": "phase_1_ru_max_return",
      "solver": "SCS",
      "status": "succeeded",
      "objective_value": 0.087382,
      "cvar_at_solution": 0.171426,
      "cvar_within_limit": false,
      "cvar_at_solution_cf": 0.194994,
      "cvar_limit_effective": 0.08,
      "infeasibility_reason": null
    },
    {
      "phase": "phase_2_ru_robust", "status": "skipped"
    },
    {
      "phase": "phase_3_min_cvar",
      "solver": "CLARABEL",
      "status": "succeeded",
      "objective_value": 0.094484,
      "cvar_at_solution": 0.094484,
      "cvar_within_limit": false,
      "cvar_limit_effective": 0.08
    }
  ]
}
```

## Section B — Confirmed pattern: **A + B combined**

### Pattern B (primary — 1-line fix)

Winner-selection accepts Phase 1 even when `cvar_within_limit=False`. Look at `optimizer_service.py` lines ~900-922:

```python
if phase1_weights is not None:
    winner_w = phase1_weights
    winner_phase = "phase_1_ru_max_return"
    winner_status = "optimal"
elif phase2_weights is not None:
    ...
else:
    # phase 3 min-CVaR path — ONLY here does within_limit gate the status
    winner_status = "optimal" if within_limit else "degraded"
```

The gate is `phase1_weights is not None` — but `phase1_weights` is populated whenever the LP returns ANY optimal-status solution, **regardless of whether the realized CVaR respects the constraint**. The within-limit check exists only for Phase 3.

Downstream, `_SUMMARY_BY_WINNING_PHASE["phase_1_ru_max_return"] = "phase_1_succeeded"` unconditionally (construction_run_executor.py:350-354). The executor's within-limit logic at line 438 guards only Phase 3:

```python
if winning_phase == "phase_3_min_cvar":
    ... check cvar_within_limit, pick within/above_limit summary
else:
    cascade_summary = _SUMMARY_BY_WINNING_PHASE.get(winning_phase or "", ...)
```

Growth's phase 3 delivers `min_achievable_cvar = 0.0945` — universe floor is 9.4%, above the operator's 8%. **The cascade should emit `phase_3_min_cvar_above_limit`, not `phase_1_succeeded`.** Instead, the 2.14× overshoot from an SCS-tolerance-violating phase_1 is silently promoted.

### Pattern A (secondary — explains WHY phase_1 returned a constraint-violating solution)

`phase_1.solver = "SCS"` — not CLARABEL. Per `_solve_problem` (optimizer_service.py:493-509), CLARABEL failed (or returned non-optimal status), and SCS fallback solved with looser tolerances (`eps=1e-5, max_iters=10000`). SCS's solution has status `optimal` but a realized RU constraint violation ~100% — SCS returned a feasible-within-its-own-tolerance solution that massively violates the original constraint.

The SCS fallback is the legitimate, A12-intended safety net for solver failures. The bug is not SCS per se — it's that winner-selection does not re-verify the returned solution against the constraint before promoting phase 1 as the winner.

**Ratio forensics:**
- Conservative + Moderate: CLARABEL solved phase_1 to infeasible → phase_1 skipped cleanly → phase_3_min_cvar_above_limit selected. Correct.
- Growth: CLARABEL returned non-optimal (likely `infeasible_inaccurate`) → SCS retried and produced a "feasible" (in SCS's loose tolerance) but constraint-violating solution → winner-selection accepted it. **Asymmetric** because only Growth's universe triggered the CLARABEL→SCS fallback.

## Section C — Proposed fix (Path D.2 confirmed)

One-line gate in winner-selection (`optimizer_service.py:~900`):

```python
# Before:
if phase1_weights is not None:
    winner_phase = "phase_1_ru_max_return"
    ...

# After:
_phase1_usable = (
    phase1_weights is not None
    and (effective_cvar_limit is None or _cvar_from_ru(phase1_weights) <= effective_cvar_limit + 1e-4)
)
if _phase1_usable:
    winner_phase = "phase_1_ru_max_return"
    ...
```

Same tolerance gate applied to phase 2. This keeps the A12 "always-solvable" invariant (phase 3 always wins as fallback) but refuses to promote a solution that violates the constraint by more than numerical tolerance.

Additionally: phase_1 attempt's `status` should be reclassified from `succeeded` to `succeeded_constraint_violated` (or similar) so the telemetry distinguishes "solver found optimum" from "optimum honors user constraint". Otherwise the attempt log is misleading.

## Section D — Stop gate

Per Section I.1 of the spec, posting findings and awaiting consultant confirmation before implementing. Consultant: confirm Pattern A+B and authorize Path D.2 fix, or redirect if the diagnosis is off.