### PR TITLE
feat(wealth): live drag preview on risk budget slider (PR-A13.2)

### DIFF
--- a/frontends/wealth/src/lib/components/portfolio/RiskBudgetPanel.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/RiskBudgetPanel.svelte
@@ -1,21 +1,26 @@
 <!--
-  RiskBudgetPanel — PR-A13 state owner for the Builder risk budget
-  surface. Composes:
+  RiskBudgetPanel — Builder risk budget surface. Composes:
     1. RiskBudgetSlider (operator edits the tail loss limit)
-    2. AchievableReturnBandChart (derived from latest cascade_telemetry)
+    2. AchievableReturnBandChart (derived from live preview ?? latest
+       cascade_telemetry)
     3. Signal banner (operator_signal → copy + tone)
 
-  Two-channel state design is deliberate: ``previewBand`` is reserved for
-  PR-A13.2 (live drag preview via POST /preview-cvar). A13 never writes to
-  it, but the ``previewBand ?? serverBand`` precedence means A13.2 can
-  wire in without rewriting the dependency graph.
+  PR-A13 shipped the static form; PR-A13.2 wires the live drag preview
+  via POST /preview-cvar. ``previewBand ?? serverBand`` precedence lets
+  the drag-derived band override the last completed run's band, while
+  clearing ``previewBand`` on ``runPhase === "done"`` re-grants authority
+  to the fresh server band (closes the two-channel state gap from
+  PR-A13 Section B.2).
 -->
 <script lang="ts">
 	import { formatPercent } from "@investintell/ui";
 	import { workspace } from "$lib/state/portfolio-workspace.svelte";
 	import type { ModelPortfolio } from "$lib/types/model-portfolio";
 	import type { PortfolioCalibration } from "$lib/types/portfolio-calibration";
-	import type { AchievableReturnBand } from "$lib/types/cascade-telemetry";
+	import type {
+		AchievableReturnBand,
+		OperatorSignal,
+	} from "$lib/types/cascade-telemetry";
 	import { defaultCvarForProfile } from "$lib/util/profile-defaults";
 	import RiskBudgetSlider from "./RiskBudgetSlider.svelte";
 	import AchievableReturnBandChart from "./AchievableReturnBandChart.svelte";
@@ -32,23 +37,96 @@
 	const profileDefault = $derived(defaultCvarForProfile(portfolio.profile));
 	const cvarLimit = $derived(calibration.cvar_limit);
 
+	// ── Server-channel state (authoritative when no live preview) ──
 	const serverBand = $derived(
 		workspace.constructionRun?.cascade_telemetry?.achievable_return_band ?? null,
 	);
 	const serverSignal = $derived(
 		workspace.constructionRun?.cascade_telemetry?.operator_signal ?? null,
 	);
-	const minAchievableCvar = $derived(
+	const serverMinCvar = $derived(
 		workspace.constructionRun?.cascade_telemetry?.min_achievable_cvar ?? null,
 	);
 
-	// PR-A13.2 slot — reserved for live preview. A13 never writes here.
+	// ── Preview-channel state (PR-A13.2 live drag) ─────────────────
 	let previewBand = $state<AchievableReturnBand | null>(null);
-	const band = $derived(previewBand ?? serverBand);
+	let previewSignal = $state<OperatorSignal | null>(null);
+	let previewMinCvar = $state<number | null>(null);
+	let previewing = $state(false);
+	let previewError = $state<string | null>(null);
 
-	const belowFloor = $derived(serverSignal?.kind === "cvar_limit_below_universe_floor");
-	const dataMissing = $derived(serverSignal?.kind === "upstream_data_missing");
-	const polytopeEmpty = $derived(serverSignal?.kind === "constraint_polytope_empty");
+	const band = $derived(previewBand ?? serverBand);
+	const signal = $derived(previewSignal ?? serverSignal);
+	const minAchievableCvar = $derived(previewMinCvar ?? serverMinCvar);
+
+	const belowFloor = $derived(signal?.kind === "cvar_limit_below_universe_floor");
+	const dataMissing = $derived(signal?.kind === "upstream_data_missing");
+	const polytopeEmpty = $derived(signal?.kind === "constraint_polytope_empty");
+
+	// ── Debounced preview fetch ────────────────────────────────────
+	// 250ms debounce on slider mutations. AbortController cancels stale
+	// in-flight requests so rapid drags don't produce a late response that
+	// overwrites a newer one.
+	let previewTimer: ReturnType<typeof setTimeout> | null = null;
+	let previewAbort: AbortController | null = null;
+	let lastPreviewedCvar: number | null = null;
+
+	$effect(() => {
+		const cv = cvarLimit;
+		// Skip when the operator hasn't moved from the current calibration
+		// value — server band is already authoritative in that case.
+		if (cv === null || cv === undefined) return;
+		if (cv === lastPreviewedCvar) return;
+		if (previewTimer) clearTimeout(previewTimer);
+		previewTimer = setTimeout(() => {
+			void runPreview(cv);
+		}, 250);
+		return () => {
+			if (previewTimer) {
+				clearTimeout(previewTimer);
+				previewTimer = null;
+			}
+		};
+	});
+
+	// Clear the preview channel once a new construction completes so the
+	// freshly-authoritative server band wins. Without this, a stale drag
+	// preview would continue masking the real completed-run band.
+	$effect(() => {
+		if (workspace.runPhase === "done") {
+			previewBand = null;
+			previewSignal = null;
+			previewMinCvar = null;
+			previewError = null;
+			lastPreviewedCvar = null;
+		}
+	});
+
+	async function runPreview(cv: number): Promise<void> {
+		previewAbort?.abort();
+		const ac = new AbortController();
+		previewAbort = ac;
+		previewing = true;
+		previewError = null;
+		try {
+			const res = await workspace.previewCvar(cv, ac.signal);
+			if (ac.signal.aborted) return;
+			if (res === null) return;
+			previewBand = res.achievable_return_band;
+			previewSignal = res.operator_signal;
+			previewMinCvar = res.min_achievable_cvar;
+			lastPreviewedCvar = cv;
+		} catch (err) {
+			if (ac.signal.aborted) return;
+			if (err instanceof DOMException && err.name === "AbortError") return;
+			// Preserve last good preview; surface a non-blocking chip.
+			previewError =
+				err instanceof Error ? err.message : "Live preview unavailable";
+		} finally {
+			if (previewAbort === ac) previewAbort = null;
+			previewing = false;
+		}
+	}
 </script>
 
 <div class="rbp-root">
@@ -76,12 +154,25 @@
 			</p>
 		</div>
 	{:else}
-		<AchievableReturnBandChart
-			{band}
-			{cvarLimit}
-			{minAchievableCvar}
-			height={220}
-		/>
+		<div class="rbp-chart-frame" class:rbp-chart-frame--previewing={previewing}>
+			<AchievableReturnBandChart
+				{band}
+				{cvarLimit}
+				{minAchievableCvar}
+				height={220}
+			/>
+			{#if previewing}
+				<div class="rbp-preview-pulse" aria-label="Updating preview" data-testid="rbp-preview-spinner"></div>
+			{/if}
+		</div>
+		{#if previewError}
+			<div class="rbp-banner rbp-banner--preview-error" role="status" data-testid="rbp-preview-error">
+				<p class="rbp-banner__msg">
+					Live preview unavailable — showing the last completed run's band. Adjust
+					the slider or trigger a full build.
+				</p>
+			</div>
+		{/if}
 		<div class="rbp-stats" data-testid="rbp-stats">
 			{#if band}
 				<div class="rbp-stats__primary">
@@ -155,5 +246,29 @@
 		font-size: 11px;
 		line-height: 1.45;
 		color: var(--terminal-fg-secondary);
+	}
+	.rbp-banner--preview-error {
+		border-left-color: var(--terminal-status-warning);
+	}
+	.rbp-chart-frame {
+		position: relative;
+	}
+	.rbp-chart-frame--previewing {
+		opacity: 0.85;
+	}
+	.rbp-preview-pulse {
+		position: absolute;
+		top: 8px;
+		right: 8px;
+		width: 10px;
+		height: 10px;
+		border-radius: 50%;
+		background: var(--terminal-status-info, var(--terminal-fg-muted));
+		animation: rbp-preview-pulse 1.2s ease-in-out infinite;
+		pointer-events: none;
+	}
+	@keyframes rbp-preview-pulse {
+		0%, 100% { opacity: 0.3; transform: scale(0.85); }
+		50%      { opacity: 1;   transform: scale(1);    }
 	}
 </style>

--- a/frontends/wealth/src/lib/components/portfolio/__tests__/RiskBudgetPanel.test.ts
+++ b/frontends/wealth/src/lib/components/portfolio/__tests__/RiskBudgetPanel.test.ts
@@ -1,0 +1,83 @@
+/**
+ * PR-A13.2 — RiskBudgetPanel unit test contract.
+ *
+ * NOTE: Vitest is not yet installed in `frontends/wealth` (no devDep,
+ * no vitest.config, no test runner). This file is the contractual
+ * skeleton matching the spec in
+ * `docs/prompts/2026-04-17-pr-a13-2-live-drag-preview.md`. It mirrors the
+ * same "contract skeleton" precedent established by
+ * `frontends/wealth/e2e/universe-autoimport.spec.ts` (PR-A6).
+ *
+ * To activate:
+ *   1) cd frontends/wealth && pnpm add -D vitest @testing-library/svelte jsdom
+ *   2) add `vitest.config.ts` with svelte + jsdom environment
+ *   3) wire `pnpm test` into the package scripts
+ *   4) seed `portfolio-workspace.svelte.ts` with a test harness that
+ *      allows injecting a mocked `previewCvar` method.
+ *
+ * Live smoke is exercised against the running dev server (port 5174)
+ * against the backend `POST /preview-cvar` endpoint (PR-A13.1) — see
+ * PR body for screenshots.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { PreviewCvarResponse } from "$lib/types/cascade-telemetry";
+
+const MOCK_BAND: PreviewCvarResponse = {
+	achievable_return_band: {
+		lower: 0.095,
+		upper: 0.306,
+		lower_at_cvar: 0.004,
+		upper_at_cvar: 0.025,
+	},
+	min_achievable_cvar: 0.004,
+	operator_signal: { kind: "feasible", binding: null, message_key: "feasible" },
+	cached: false,
+	wall_ms: 42,
+};
+
+describe("RiskBudgetPanel — PR-A13.2 live drag preview", () => {
+	it("test_drag_triggers_debounced_preview", () => {
+		// Drive cvarLimit mutations at 100ms intervals across a 260ms window;
+		// assert workspace.previewCvar called exactly once with the final value.
+		expect(MOCK_BAND).toBeDefined();
+	});
+
+	it("test_preview_updates_band_derived", () => {
+		// Stub preview response; assert `band` derived reflects preview value
+		// even when workspace.constructionRun.cascade_telemetry.achievable_return_band
+		// differs.
+		expect(MOCK_BAND.achievable_return_band.upper).toBe(0.306);
+	});
+
+	it("test_preview_cleared_on_run_completion", () => {
+		// Seed a preview band; mutate workspace.runPhase = "done"; assert
+		// previewBand / previewSignal / previewMinCvar all reset to null so
+		// the server band regains authority.
+		expect(true).toBe(true);
+	});
+
+	it("test_preview_abort_on_rapid_drag", () => {
+		// Start preview; mutate cvarLimit mid-fetch; assert previous
+		// AbortController.signal.aborted === true and only the newest fetch
+		// resolves into state.
+		expect(true).toBe(true);
+	});
+
+	it("test_preview_error_preserves_last_good_band", () => {
+		// Mock workspace.previewCvar to throw; assert previewBand is
+		// unchanged and previewError is populated with the error message.
+		expect(true).toBe(true);
+	});
+
+	it("test_preview_below_floor_signal_renders_warning", () => {
+		// Mock preview returning operator_signal.kind =
+		// "cvar_limit_below_universe_floor"; assert the amber warning banner
+		// is visible via data-testid="rbp-banner-below-floor".
+		expect(true).toBe(true);
+	});
+});
+
+// Placeholder to silence lint warnings for the mocked imports above
+void vi;

--- a/frontends/wealth/src/lib/state/portfolio-workspace.svelte.ts
+++ b/frontends/wealth/src/lib/state/portfolio-workspace.svelte.ts
@@ -38,6 +38,7 @@ import type {
 	CascadeTelemetry,
 	AchievableReturnBand,
 	OperatorSignal,
+	PreviewCvarResponse,
 } from "$lib/types/cascade-telemetry";
 import type {
 	RegimeBands,
@@ -1048,6 +1049,34 @@ export class PortfolioWorkspaceState {
 		} finally {
 			this.isApplyingCalibration = false;
 		}
+	}
+
+	/**
+	 * PR-A13.2 — Live drag preview for the Builder risk budget slider.
+	 *
+	 * Calls ``POST /portfolios/{id}/preview-cvar`` to compute the
+	 * achievable_return_band for a probed cvar_limit without persisting
+	 * to portfolio_calibration. Backed by a 5-min Redis cache; cold wall
+	 * is ~4s on a typical universe, hot is ~12ms. The caller is
+	 * responsible for debouncing and for threading an AbortController
+	 * signal to cancel stale in-flight requests when the operator drags
+	 * past the quantized value.
+	 *
+	 * Returns ``null`` when no portfolio is selected or the token
+	 * provider isn't configured (matches the rest of the workspace loader
+	 * contract).
+	 */
+	async previewCvar(
+		cvarLimit: number,
+		signal?: AbortSignal,
+	): Promise<PreviewCvarResponse | null> {
+		if (!this._getToken || !this.portfolioId) return null;
+		const api = this.api();
+		return await api.post<PreviewCvarResponse>(
+			`/portfolios/${this.portfolioId}/preview-cvar`,
+			{ cvar_limit: cvarLimit },
+			{ signal, timeoutMs: 20_000 },
+		);
 	}
 
 	// ── TAA Sprint 4 — Regime visualization loaders ─────────────────

--- a/frontends/wealth/src/lib/types/cascade-telemetry.ts
+++ b/frontends/wealth/src/lib/types/cascade-telemetry.ts
@@ -52,3 +52,17 @@ export interface CascadeTelemetry {
 	achievable_return_band: AchievableReturnBand | null;
 	operator_signal: OperatorSignal | null;
 }
+
+/**
+ * PR-A13.2 — POST /preview-cvar response. Mirrors
+ * ``backend/app/domains/wealth/schemas/preview.py``. Used by the Builder
+ * RiskBudgetPanel to populate the ``previewBand ?? serverBand`` channel
+ * while the operator drags the slider.
+ */
+export interface PreviewCvarResponse {
+	achievable_return_band: AchievableReturnBand;
+	min_achievable_cvar: number;
+	operator_signal: OperatorSignal;
+	cached: boolean;
+	wall_ms: number;
+}

--- a/packages/investintell-ui/src/lib/utils/api-client.ts
+++ b/packages/investintell-ui/src/lib/utils/api-client.ts
@@ -190,18 +190,22 @@ export class NetzApiClient {
 	async post<T>(
 		path: string,
 		body?: unknown,
-		options?: { timeoutMs?: number; headers?: Record<string, string> },
+		options?: { timeoutMs?: number; headers?: Record<string, string>; signal?: AbortSignal },
 	): Promise<T> {
 		const timeout = options?.timeoutMs ?? this.timeoutMs;
 		const baseHeaders = await this.headers();
 		const headers = options?.headers
 			? { ...baseHeaders, ...options.headers }
 			: baseHeaders;
+		// Caller-supplied AbortSignal wins over the default timeout. Required
+		// for debounced drag-preview patterns that need to cancel in-flight
+		// requests when a newer request supersedes (PR-A13.2).
+		const signal = options?.signal ?? AbortSignal.timeout(timeout);
 		const res = await fetch(buildUrl(this.baseUrl, path), {
 			method: "POST",
 			headers,
 			body: body !== undefined ? JSON.stringify(body) : undefined,
-			signal: AbortSignal.timeout(timeout),
+			signal,
 		});
 		return handleResponse<T>(res);
 	}


### PR DESCRIPTION
Wires POST /preview-cvar into RiskBudgetPanel with 250ms debounce + AbortController. Three-channel state (band / min_cvar / signal) with previewBand ?? serverBand precedence. Clear-on-done effect closes the two-channel gap from PR-A13 Section B.2. UX: pulse indicator while previewing, amber chip on error preserving last-good band. Plumbing: api-client.post accepts AbortSignal; new workspace.previewCvar() method; PreviewCvarResponse type. svelte-check 0 errors. Live smoke against post-A12.4 backend: Conservative @ 3% collapses to [9.56%, 9.56%] with below-floor signal populated live. Vitest not installed in wealth; contract skeleton added per PR-A6 precedent.