### PR TITLE
feat(wealth): universe coverage telemetry + secondary operator signal (PR-A14)

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -2077,6 +2077,47 @@ async def _run_construction_async(
             fund_blocks[fid] = f["block_id"]
         fund_instrument_ids.append(uuid.UUID(fid))
 
+    # ── PR-A14: Universe coverage telemetry ──
+    # PR-A7 already renormalises block max_weights when the approved universe
+    # covers a subset of strategic blocks. A14 surfaces the gap to operators
+    # without changing the optimizer math:
+    #   - ``coverage_payload`` is attached to ``result["cascade"]`` below so
+    #     the executor can emit ``cascade_telemetry.coverage`` + a secondary
+    #     ``operator_signal`` when pct_covered < 0.85.
+    #   - Hard-fail at pct_covered < 0.20 (scale factor > 5×) — below that
+    #     floor the renormalisation violates block-max bands and the LP
+    #     result stops being meaningful. Signalled via a sentinel ValueError
+    #     that routes to the ``upstream_heuristic`` fallback below.
+    _coverage_covered_block_ids = sorted({b for b in fund_blocks.values() if b})
+    _coverage_all_block_ids = sorted(strategic_targets.keys())
+    _coverage_missing_block_ids = sorted(
+        bid for bid in _coverage_all_block_ids if bid not in _coverage_covered_block_ids
+    )
+    _coverage_raw_sum = sum(
+        strategic_targets.get(bid, 0.0) for bid in _coverage_covered_block_ids
+    )
+    _coverage_scale = (1.0 / _coverage_raw_sum) if _coverage_raw_sum > 0 else None
+    coverage_payload: dict[str, Any] = {
+        "pct_covered": round(float(_coverage_raw_sum), 4),
+        "n_total_blocks": len(_coverage_all_block_ids),
+        "n_covered_blocks": len(_coverage_covered_block_ids),
+        "covered_blocks": _coverage_covered_block_ids,
+        "missing_blocks": _coverage_missing_block_ids,
+        "renormalization_scale": (
+            round(float(_coverage_scale), 4) if _coverage_scale is not None else None
+        ),
+        "hard_fail": _coverage_raw_sum < 0.20,
+    }
+    logger.info(
+        "universe_coverage_audit",
+        profile=profile,
+        pct_covered=coverage_payload["pct_covered"],
+        n_covered=coverage_payload["n_covered_blocks"],
+        n_total=coverage_payload["n_total_blocks"],
+        missing=coverage_payload["missing_blocks"],
+        hard_fail=coverage_payload["hard_fail"],
+    )
+
     # ── 3+4. Fund-level optimization ──
     composition = None
     # PR-A9 — default conditioning payload for the SHRINKAGE SSE event even
@@ -2168,6 +2209,16 @@ async def _run_construction_async(
         # sum to 1.0 → infeasible.  Rescale proportionally so the optimizer
         # can find a valid fully-invested allocation.
         covered_blocks = set(sub_blocks.values())
+        # PR-A14: hard-fail at pct_covered < 0.20 — the renormalisation below
+        # produces scale factors > 5× which violate block-max invariants and
+        # make the LP result structurally meaningless. Route to the
+        # ``upstream_heuristic`` fallback with the coverage payload intact so
+        # the executor can swap the primary signal kind.
+        if coverage_payload["hard_fail"]:
+            raise ValueError(
+                "universe_coverage_insufficient: "
+                f"pct_covered={coverage_payload['pct_covered']} < 0.20 floor",
+            )
         active_raw = [bc for bc in block_constraints if bc.block_id in covered_blocks]
 
         target_sum = sum(
@@ -2441,6 +2492,10 @@ async def _run_construction_async(
         "winning_phase": cascade_winning,
         "min_achievable_cvar": cascade_min_cvar,
         "achievable_return_band": cascade_band,
+        # PR-A14 — coverage surface consumed by _build_cascade_telemetry to
+        # populate cascade_telemetry.coverage and drive the secondary
+        # operator signal.
+        "coverage": coverage_payload,
     }
 
     # Include TAA provenance for calibration_snapshot enrichment

--- a/backend/app/domains/wealth/schemas/preview.py
+++ b/backend/app/domains/wealth/schemas/preview.py
@@ -42,6 +42,18 @@ class AchievableReturnBandDTO(BaseModel):
     upper_at_cvar: float
 
 
+class OperatorSignalSecondaryDTO(BaseModel):
+    """PR-A14 — non-blocking secondary signal (universe coverage gap)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["universe_coverage_insufficient"]
+    binding: str | None = None
+    message_key: str
+    pct_covered: float | None = None
+    missing_blocks_count: int | None = None
+
+
 class OperatorSignalDTO(BaseModel):
     """Sanitised operator signal — same enum as the persisted telemetry."""
 
@@ -52,9 +64,19 @@ class OperatorSignalDTO(BaseModel):
         "cvar_limit_below_universe_floor",
         "upstream_data_missing",
         "constraint_polytope_empty",
+        # PR-A14 — primary kind only when coverage < 0.20 (hard-fail).
+        "universe_coverage_insufficient",
     ]
     binding: str | None = None
     message_key: str
+    # PR-A14 — additive; None when coverage >= 0.85 or primary is already
+    # the coverage signal itself.
+    secondary: OperatorSignalSecondaryDTO | None = None
+    # PR-A14 — populated only when ``kind == universe_coverage_insufficient``
+    # (hard-fail path); primary carries the coverage numbers so the panel
+    # doesn't need to consult cascade_telemetry.coverage separately.
+    pct_covered: float | None = None
+    missing_blocks_count: int | None = None
 
 
 class PreviewCvarResponse(BaseModel):

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -384,6 +384,12 @@ def _build_cascade_telemetry(
     winning_phase = block.get("winning_phase")
     min_achievable_cvar = block.get("min_achievable_cvar")
     achievable_return_band = block.get("achievable_return_band")
+    # PR-A14 — universe coverage surface (routes/model_portfolios.py
+    # ``coverage_payload``). None on legacy/test paths that didn't emit it.
+    raw_coverage = block.get("coverage")
+    coverage: dict[str, Any] | None = (
+        dict(raw_coverage) if isinstance(raw_coverage, dict) else None
+    )
 
     # Legacy/test path: no cascade info at all → return empty telemetry
     # with a sentinel status so the caller falls back to the solver-string
@@ -471,11 +477,24 @@ def _build_cascade_telemetry(
     elif cascade_summary == "upstream_heuristic":
         # compute_fund_level_inputs raised before cascade ran (e.g.
         # ill-conditioned Σ, too few funds with NAV data).
-        operator_signal = {
-            "kind": "upstream_data_missing",
-            "binding": "returns_quality",
-            "message_key": "statistical_inputs_unavailable",
-        }
+        # PR-A14 — swap primary kind when the heuristic fired because the
+        # approved universe fell below the 20% coverage floor, so operators
+        # see "import funds into the missing blocks" instead of a generic
+        # "statistics unavailable" message.
+        if coverage and bool(coverage.get("hard_fail")):
+            operator_signal = {
+                "kind": "universe_coverage_insufficient",
+                "binding": "universe_coverage",
+                "message_key": "universe_coverage_hard_fail",
+                "pct_covered": coverage.get("pct_covered"),
+                "missing_blocks_count": len(coverage.get("missing_blocks") or []),
+            }
+        else:
+            operator_signal = {
+                "kind": "upstream_data_missing",
+                "binding": "returns_quality",
+                "message_key": "statistical_inputs_unavailable",
+            }
     else:  # constraint_polytope_empty
         operator_signal = {
             "kind": "constraint_polytope_empty",
@@ -483,12 +502,45 @@ def _build_cascade_telemetry(
             "message_key": "block_bands_unsatisfiable",
         }
 
+    # PR-A14 — secondary operator_signal: non-blocking warning when the
+    # approved universe covers < 85% of the profile's strategic allocation
+    # targets. Additive field; primary keeps its existing contract so
+    # frontend callers that only look at ``kind`` continue to work.
+    if (
+        coverage is not None
+        and coverage.get("pct_covered") is not None
+        and float(coverage["pct_covered"]) < 0.85
+        # Hard-fail already surfaces as primary kind — don't duplicate.
+        and not (operator_signal and operator_signal.get("kind") == "universe_coverage_insufficient")
+    ):
+        secondary = {
+            "kind": "universe_coverage_insufficient",
+            "binding": "universe_coverage",
+            "message_key": "expand_universe_recommended",
+            "pct_covered": coverage.get("pct_covered"),
+            "missing_blocks_count": len(coverage.get("missing_blocks") or []),
+        }
+        if operator_signal is None:
+            # Primary was "implicit feasible" (e.g. phase_1_succeeded).
+            # Synthesise a feasible primary so consumers always find the
+            # secondary under operator_signal.secondary.
+            operator_signal = {
+                "kind": "feasible",
+                "binding": None,
+                "message_key": "feasible",
+                "secondary": secondary,
+            }
+        else:
+            operator_signal = {**operator_signal, "secondary": secondary}
+
     telemetry = {
         "phase_attempts": public_attempts,
         "cascade_summary": cascade_summary,
         "min_achievable_cvar": min_achievable_cvar,
         "achievable_return_band": achievable_return_band,
         "operator_signal": operator_signal,
+        # PR-A14 — universe coverage JSONB (nullable for legacy runs).
+        "coverage": coverage,
     }
     return telemetry, run_status
 

--- a/backend/tests/wealth/test_universe_coverage_gate.py
+++ b/backend/tests/wealth/test_universe_coverage_gate.py
@@ -1,0 +1,240 @@
+"""PR-A14 — universe coverage gate + secondary operator signal tests.
+
+Exercises ``_build_cascade_telemetry`` with coverage-bearing cascade blocks
+to lock the three new behaviours:
+
+- Coverage block is surfaced on ``cascade_telemetry.coverage``
+- Secondary ``operator_signal`` fires when pct_covered < 0.85
+- Primary signal kind swaps to ``universe_coverage_insufficient`` on the
+  hard-fail path (coverage < 0.20) routed via ``upstream_heuristic``
+
+Renormalisation itself was shipped in PR-A7 and is covered by the live-DB
+smoke — A14 is observability-only.
+"""
+
+from __future__ import annotations
+
+from app.domains.wealth.workers.construction_run_executor import (
+    _build_cascade_telemetry,
+)
+
+
+def _phase_1_succeeded_block(coverage: dict | None) -> dict:
+    return {
+        "phase_attempts": [
+            {
+                "phase": "phase_1_ru_max_return", "status": "succeeded",
+                "solver": "CLARABEL", "objective_value": 0.11, "wall_ms": 220,
+                "infeasibility_reason": None,
+                "cvar_at_solution": 0.04, "cvar_at_solution_cf": 0.05,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": True,
+            },
+            {
+                "phase": "phase_2_ru_robust", "status": "skipped", "solver": None,
+                "objective_value": None, "wall_ms": 0,
+                "infeasibility_reason": None,
+            },
+            {
+                "phase": "phase_3_min_cvar", "status": "succeeded",
+                "solver": "CLARABEL", "objective_value": 0.03, "wall_ms": 70,
+                "infeasibility_reason": None,
+                "cvar_at_solution": 0.03, "cvar_at_solution_cf": 0.035,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": True,
+            },
+        ],
+        "winning_phase": "phase_1_ru_max_return",
+        "min_achievable_cvar": 0.03,
+        "achievable_return_band": {
+            "lower": 0.09, "upper": 0.11,
+            "lower_at_cvar": 0.03, "upper_at_cvar": 0.04,
+        },
+        "coverage": coverage,
+    }
+
+
+def _full_coverage_payload() -> dict:
+    return {
+        "pct_covered": 1.0,
+        "n_total_blocks": 11,
+        "n_covered_blocks": 11,
+        "covered_blocks": [f"blk_{i}" for i in range(11)],
+        "missing_blocks": [],
+        "renormalization_scale": 1.0,
+        "hard_fail": False,
+    }
+
+
+def _partial_coverage_payload(pct: float, missing: int) -> dict:
+    return {
+        "pct_covered": pct,
+        "n_total_blocks": 11,
+        "n_covered_blocks": 11 - missing,
+        "covered_blocks": [f"blk_{i}" for i in range(11 - missing)],
+        "missing_blocks": [f"blk_{i}" for i in range(11 - missing, 11)],
+        "renormalization_scale": round(1.0 / pct, 4) if pct > 0 else None,
+        "hard_fail": pct < 0.20,
+    }
+
+
+def test_full_coverage_no_secondary_signal() -> None:
+    telemetry, status = _build_cascade_telemetry(
+        cascade_block=_phase_1_succeeded_block(_full_coverage_payload()),
+        optimizer_trace={"status": "optimal"},
+        cvar_limit=0.05,
+    )
+    assert status == "succeeded"
+    assert telemetry["coverage"]["pct_covered"] == 1.0
+    assert telemetry["coverage"]["missing_blocks"] == []
+    # Primary preserved as None (implicit feasible) — no secondary attached.
+    assert telemetry["operator_signal"] is None
+
+
+def test_coverage_below_85_triggers_secondary() -> None:
+    telemetry, status = _build_cascade_telemetry(
+        cascade_block=_phase_1_succeeded_block(
+            _partial_coverage_payload(0.61, missing=5),
+        ),
+        optimizer_trace={"status": "optimal"},
+        cvar_limit=0.05,
+    )
+    assert status == "succeeded"
+    sig = telemetry["operator_signal"]
+    assert sig is not None, "primary must be synthesised so secondary surfaces"
+    assert sig["kind"] == "feasible"
+    assert sig["secondary"] is not None
+    assert sig["secondary"]["kind"] == "universe_coverage_insufficient"
+    assert sig["secondary"]["pct_covered"] == 0.61
+    assert sig["secondary"]["missing_blocks_count"] == 5
+    assert sig["secondary"]["message_key"] == "expand_universe_recommended"
+
+
+def test_coverage_above_85_no_secondary() -> None:
+    telemetry, _ = _build_cascade_telemetry(
+        cascade_block=_phase_1_succeeded_block(
+            _partial_coverage_payload(0.90, missing=1),
+        ),
+        optimizer_trace={"status": "optimal"},
+        cvar_limit=0.05,
+    )
+    # 0.90 >= 0.85 → primary stays None (no secondary attached).
+    assert telemetry["operator_signal"] is None
+    assert telemetry["coverage"]["pct_covered"] == 0.90
+
+
+def test_coverage_at_exactly_85_no_secondary() -> None:
+    telemetry, _ = _build_cascade_telemetry(
+        cascade_block=_phase_1_succeeded_block(
+            _partial_coverage_payload(0.85, missing=2),
+        ),
+        optimizer_trace={"status": "optimal"},
+        cvar_limit=0.05,
+    )
+    # Boundary — 0.85 is NOT below 0.85 (strict inequality), so no secondary.
+    assert telemetry["operator_signal"] is None
+
+
+def test_secondary_coexists_with_primary_below_floor() -> None:
+    """Phase 3 above-limit primary + coverage < 0.85 → both signals present."""
+    cascade_block = {
+        "phase_attempts": [
+            {
+                "phase": "phase_1_ru_max_return", "status": "infeasible",
+                "solver": None, "objective_value": None, "wall_ms": 100,
+                "infeasibility_reason": "PRIMAL_INFEASIBLE",
+            },
+            {
+                "phase": "phase_2_ru_robust", "status": "skipped", "solver": None,
+                "objective_value": None, "wall_ms": 0,
+                "infeasibility_reason": None,
+            },
+            {
+                "phase": "phase_3_min_cvar", "status": "succeeded",
+                "solver": "CLARABEL", "objective_value": 0.06, "wall_ms": 80,
+                "infeasibility_reason": None,
+                "cvar_at_solution": 0.06, "cvar_at_solution_cf": 0.07,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": False,
+            },
+        ],
+        "winning_phase": "phase_3_min_cvar",
+        "min_achievable_cvar": 0.06,
+        "achievable_return_band": {
+            "lower": 0.08, "upper": 0.08,
+            "lower_at_cvar": 0.06, "upper_at_cvar": 0.06,
+        },
+        "coverage": _partial_coverage_payload(0.61, missing=5),
+    }
+    telemetry, status = _build_cascade_telemetry(
+        cascade_block=cascade_block,
+        optimizer_trace={"status": "degraded"},
+        cvar_limit=0.05,
+    )
+    assert status == "degraded"
+    sig = telemetry["operator_signal"]
+    assert sig["kind"] == "cvar_limit_below_universe_floor"
+    assert sig["secondary"] is not None
+    assert sig["secondary"]["kind"] == "universe_coverage_insufficient"
+
+
+def test_hard_fail_swaps_primary_kind_on_upstream_heuristic() -> None:
+    cascade_block = {
+        "phase_attempts": [],
+        "winning_phase": "upstream_heuristic",
+        "coverage": _partial_coverage_payload(0.15, missing=9),
+    }
+    telemetry, status = _build_cascade_telemetry(
+        cascade_block=cascade_block,
+        optimizer_trace={"status": "fallback:insufficient_fund_data"},
+        cvar_limit=0.05,
+    )
+    assert status == "degraded"
+    assert telemetry["cascade_summary"] == "upstream_heuristic"
+    sig = telemetry["operator_signal"]
+    assert sig is not None
+    assert sig["kind"] == "universe_coverage_insufficient"
+    assert sig["pct_covered"] == 0.15
+    assert sig["missing_blocks_count"] == 9
+    # Hard-fail uses primary slot — secondary must NOT duplicate.
+    assert sig.get("secondary") is None
+
+
+def test_upstream_heuristic_without_hard_fail_keeps_data_missing_kind() -> None:
+    cascade_block = {
+        "phase_attempts": [],
+        "winning_phase": "upstream_heuristic",
+        # Coverage fine (full) but upstream failed for a different reason.
+        "coverage": _full_coverage_payload(),
+    }
+    telemetry, _ = _build_cascade_telemetry(
+        cascade_block=cascade_block,
+        optimizer_trace={"status": "fallback:insufficient_fund_data"},
+        cvar_limit=0.05,
+    )
+    sig = telemetry["operator_signal"]
+    assert sig["kind"] == "upstream_data_missing"
+    # No secondary because pct_covered == 1.0 is above the 0.85 threshold.
+    assert sig.get("secondary") is None
+
+
+def test_coverage_absent_is_legacy_compatible() -> None:
+    """Cascade blocks that predate A14 (no ``coverage`` key) must not crash
+    and must not invent a secondary signal."""
+    cascade_block = {
+        "phase_attempts": [
+            {
+                "phase": "phase_1_ru_max_return", "status": "succeeded",
+                "solver": "CLARABEL", "objective_value": 0.10, "wall_ms": 200,
+                "infeasibility_reason": None,
+                "cvar_at_solution": 0.04, "cvar_at_solution_cf": 0.05,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": True,
+            },
+        ],
+        "winning_phase": "phase_1_ru_max_return",
+    }
+    telemetry, status = _build_cascade_telemetry(
+        cascade_block=cascade_block,
+        optimizer_trace={"status": "optimal"},
+        cvar_limit=0.05,
+    )
+    assert status == "succeeded"
+    assert telemetry["operator_signal"] is None
+    assert telemetry["coverage"] is None

--- a/docs/prompts/2026-04-17-pr-a14-universe-coverage-gate.md
+++ b/docs/prompts/2026-04-17-pr-a14-universe-coverage-gate.md
@@ -1,0 +1,274 @@
+# PR-A14 — Universe Coverage Gate & Block Weight Renormalization
+
+**Branch:** `feat/pr-a14-universe-coverage-gate` (cut from `main` post-PR-A12.4 at commit `08ca302a`).
+**Estimated effort:** ~3-4h Opus.
+**Predecessors:** PR-A12.4 #197 (winner-selection correctness).
+**Parallel:** PR-A13.2 (frontend live preview) — zero code overlap.
+
+---
+
+## Section A — Problem statement
+
+Post PR-A12.4, all 3 canonical portfolios degrade with `cascade_summary=phase_3_min_cvar_above_limit` at their institutional default CVaR limits. The A12.4 fix made the signal honest, but revealed a deeper structural issue: **universe narrowness**.
+
+### A.1 Empirical evidence (from `docs/ux/logs.txt`)
+
+```
+Conservative:
+  total_blocks=11, covered_blocks=6  (45% blocks empty)
+  target_sum=0.6103   (optimizer targets only 61% of 1.0)
+  Missing: em_equity, fi_us_treasury, na_equity_value, fi_us_tips, dm_europe_equity
+
+Moderate (Balanced Income):
+  total_blocks=14, covered_blocks=6  (57% blocks empty)
+  target_sum=0.5178
+
+Dynamic Growth:
+  total_blocks=14, covered_blocks=7  (50% blocks empty)
+  target_sum=0.4893
+```
+
+### A.2 Two compounding issues
+
+**Issue 1 — Deployment gap.** LP constraint is `sum(w) = target_sum` where `target_sum = sum(covered_block.target_weight)`. For Conservative, `target_sum=0.6103`, meaning the LP allocates 61% of notional. The remaining 39% sits as uninvested capital with no cash bucket, no fallback — just missing from the portfolio. Operators looking at "weights deployed" see 61%, but there's no current UX signal explaining why.
+
+**Issue 2 — Universe floor elevation.** Phase 3 `min_achievable_cvar` is computed only over the covered blocks and their fund intersection. With half the blocks empty, the remaining universe is heavily skewed (e.g., Conservative's remaining blocks are dominated by equity because the FI diversifiers are missing). The min-CVaR portfolio built from the narrow universe has a higher tail floor than if the universe were complete. That's why Conservative's floor is 6.5% instead of the 2-3% typical for institutional Conservative with broad FI coverage.
+
+Both issues have the same root cause: **the approved universe (`instruments_org`) doesn't have funds for all the strategic allocation blocks.** PR-A14 addresses both with a combined fix: internal renormalization for deployment + explicit coverage signal for operator transparency.
+
+---
+
+## Section B — Design decision: renormalize + signal
+
+Three candidate approaches considered (full memo in `memory/project_a12_3_wiring_learnings.md` follow-up):
+
+- **(A) Renormalize block weights silently** → preserves deployment but hides coverage gap
+- **(B) Block build pre-flight when coverage < threshold** → violates always-solvable principle (`feedback_optimizer_always_solvable.md`)
+- **(C) Renormalize + surface coverage signal** → preserves deployment, surfaces gap transparently
+
+**Lock (C).** Two-part fix:
+
+1. **Backend renormalization:** when a strategic block has no covered funds, redistribute its `target_weight` proportionally to covered blocks (weighted by their existing targets). LP receives `target_sum = 1.0` always. Operators get 100% deployment.
+
+2. **Coverage telemetry:** add `cascade_telemetry.coverage` block with `{pct_covered, missing_blocks[], covered_blocks[]}`. Add secondary `operator_signal.secondary` when coverage < 0.85 with `kind="universe_coverage_insufficient"` + recommendation (expand universe).
+
+Primary signal (`cvar_limit_below_universe_floor`) stays on the `operator_signal` root; secondary is additive. Frontend (future PR-A14.1 or inherited by A13.2 automatically) renders both.
+
+---
+
+## Section C — Implementation
+
+### C.1 Renormalization in `_run_construction_async`
+
+Locate the block-weight assembly in `backend/app/domains/wealth/routes/model_portfolios.py` (search `target_sum` or `active_blocks`). Current logic:
+
+```python
+# Before (simplified)
+target_sum = sum(block.target_weight for block in strategic_allocations if block.id in covered_block_ids)
+active_blocks = [{"id": b.id, "min": b.min_weight, "max": b.max_weight} for b in covered]
+# LP constraint: sum(w) == target_sum
+```
+
+New logic:
+
+```python
+# After — renormalize covered blocks to sum to 1.0
+raw_covered_sum = sum(block.target_weight for block in strategic_allocations if block.id in covered_block_ids)
+if raw_covered_sum <= 0:
+    raise ValueError("Universe has no covered blocks — cannot construct")
+
+scale_factor = 1.0 / raw_covered_sum
+active_blocks = []
+for b in strategic_allocations:
+    if b.id not in covered_block_ids:
+        continue
+    active_blocks.append({
+        "id": b.id,
+        "min": float(b.min_weight) * scale_factor,
+        "max": float(b.max_weight) * scale_factor,
+        "target": float(b.target_weight) * scale_factor,   # scaled target for telemetry; LP doesn't use
+        "renormalized_from": float(b.target_weight),
+    })
+# LP constraint: sum(w) == 1.0 (pass target_sum=1.0 or drop the constraint entirely since blocks sum to 1.0 via their max bounds)
+```
+
+**Verify the LP constraint shape** in `optimizer_service.py` — it might be `sum(w) == target_sum` or `sum(w) == 1.0`. The renormalization must be consistent. If LP currently uses `target_sum`, change to hardcoded `1.0` after renormalization. If LP uses `1.0` already, the `target_sum` was only passed for logging — just update the computation.
+
+**Edge case:** if `raw_covered_sum > 1.0` (unlikely but possible if strategic weights overlap or were defined incorrectly), scale_factor < 1.0 still works — renormalization preserves ratios.
+
+**Edge case:** `covered_block_ids` is empty → no portfolio possible. Return `upstream_heuristic` with `operator_signal.kind="universe_coverage_insufficient"` and empty weights. Do NOT proceed to LP (invariant violation otherwise).
+
+### C.2 Coverage telemetry in cascade_telemetry
+
+Extend the payload per PR-A11 section `cascade_telemetry` JSONB shape. Add a new top-level key:
+
+```python
+coverage = {
+    "pct_covered": round(raw_covered_sum, 4),              # original sum before renormalization
+    "n_total_blocks": len(strategic_allocations),
+    "n_covered_blocks": len(covered_block_ids),
+    "covered_blocks": sorted(covered_block_ids),
+    "missing_blocks": sorted(block.id for block in strategic_allocations if block.id not in covered_block_ids),
+    "renormalization_scale": round(scale_factor, 4),
+}
+```
+
+### C.3 Secondary operator signal
+
+Current `operator_signal` is a single dict with `kind`, `binding`, `message_key`. Extend to support a secondary (non-blocking) signal:
+
+```python
+operator_signal = {
+    "kind": "cvar_limit_below_universe_floor" | "feasible" | ...,  # primary (unchanged)
+    "binding": "risk_budget" | null,
+    "message_key": "...",
+    "secondary": {                                                  # NEW — optional
+        "kind": "universe_coverage_insufficient",
+        "pct_covered": 0.61,
+        "missing_blocks_count": 5,
+        "message_key": "expand_universe_recommended",
+    } if coverage["pct_covered"] < 0.85 else None,
+}
+```
+
+**Threshold:** 0.85 (85% covered). Below that, surface secondary signal. Operators with >95% coverage see nothing (implicit pass). Between 85% and 100% is acceptable — institutional target is 100% but gaps are tolerable.
+
+This is a shape extension to the `OperatorSignal` TypeScript interface (A13 types) — backward compatible (new optional field).
+
+### C.4 Smart-backend / dumb-frontend translation keys
+
+New translation keys required (A13.2 auto-consumes):
+
+| Key | EN | PT |
+|---|---|---|
+| `coverage.insufficient_warning` | Your approved universe covers only {pct}% of this profile's target allocation. {n} blocks have no funds. | Seu universo aprovado cobre apenas {pct}% da alocação-alvo deste perfil. {n} blocos não têm fundos. |
+| `coverage.recommendation_expand` | Import funds into the missing blocks to unlock a deeper universe. | Importe fundos para os blocos ausentes para desbloquear um universo mais amplo. |
+| `coverage.recommendation_open_universe` | Open Universe | Abrir Universo |
+
+---
+
+## Section D — Tests
+
+### D.1 Unit tests
+
+`backend/tests/wealth/test_universe_coverage_gate.py`:
+
+- `test_full_coverage_no_secondary_signal`: seed a universe with funds in all 11 Conservative blocks → `coverage.pct_covered == 1.0`, `operator_signal.secondary is None`
+- `test_61_percent_coverage_renormalizes`: seed Conservative with 6 covered blocks → `coverage.pct_covered == 0.6103`, LP receives renormalized `sum(w) == 1.0`, secondary signal present
+- `test_missing_blocks_enumerated`: assert `coverage.missing_blocks` contains exactly the 5 uncovered block IDs, sorted
+- `test_coverage_below_85_triggers_secondary`: at 0.80 coverage → secondary signal present with `kind="universe_coverage_insufficient"`
+- `test_coverage_above_85_no_secondary`: at 0.90 coverage → secondary signal None
+- `test_empty_universe_signals_upstream_heuristic`: zero covered blocks → no LP call, upstream_heuristic signal, empty weights, status=degraded
+- `test_renormalization_preserves_block_ratios`: verify that if block A had 2× the target weight of block B pre-normalization, it still has 2× post-normalization
+
+### D.2 Integration test (live-DB)
+
+Extend `backend/tests/integration/test_construction_cvar_invariant.py` (added in A12.4):
+
+- `test_conservative_coverage_matches_log`: trigger Conservative build → `cascade_telemetry.coverage.pct_covered == 0.6103 ± 1e-3` (matches logs.txt empirical)
+- `test_growth_coverage_matches_log`: similar, 0.4893
+- `test_moderate_coverage_matches_log`: 0.5178
+- `test_lp_sum_constraint_equals_one_post_renormalization`: assert `sum(weights_proposed.values()) == 1.0 ± 1e-4` (currently delivers 0.61 for Conservative → this test MUST fail pre-fix)
+
+### D.3 Expected smoke result post-fix
+
+| Profile | pre-A14 target_sum | post-A14 weights_sum | coverage.pct | secondary.kind |
+|---|---|---|---|---|
+| Conservative | 0.61 | **1.00** | 0.61 | universe_coverage_insufficient |
+| Moderate | 0.52 | **1.00** | 0.52 | universe_coverage_insufficient |
+| Growth | 0.49 | **1.00** | 0.49 | universe_coverage_insufficient |
+
+**Bonus observable:** Phase 3 `min_achievable_cvar` may DECREASE after renormalization (because covered blocks now carry the full notional, LP has more to work with). If so, that's a secondary win — operator's floor gap narrows. Not required, just observe and log.
+
+### D.4 Regression check — A12.4 invariant
+
+After renormalization, re-run the A12.4 `test_phase_winner_invariant` harness. The winner-selection logic MUST remain correct: Phase 1 with delivered CVaR > limit still falls to Phase 3. No behavior change expected but verify.
+
+---
+
+## Section E — Pass criteria
+
+| # | Criterion | How verified |
+|---|---|---|
+| 1 | `sum(weights_proposed.values()) == 1.0` for all 3 canonical portfolios | integration test |
+| 2 | `cascade_telemetry.coverage` populated with pct_covered, missing_blocks, covered_blocks | unit test + SQL |
+| 3 | `operator_signal.secondary.kind == "universe_coverage_insufficient"` for all 3 (coverage < 0.85) | SQL |
+| 4 | Renormalization preserves block ratios (unit test) | unit |
+| 5 | Empty universe → upstream_heuristic, no LP call | unit |
+| 6 | A12.4 winner-selection invariant still holds | integration regression |
+| 7 | Frontend auto-renders secondary signal (via existing `translateOperatorSignalKind` + new keys) | Playwright screenshot |
+| 8 | Full sweep green | pytest + CI |
+
+Per `feedback_dev_first_ci_later.md`: live-DB smoke is the merge gate.
+
+---
+
+## Section F — Out of scope
+
+- Changing `instruments_org` auto-import logic (PR-A6 already handles; A14 just surfaces the gap)
+- Operator-facing "Import funds to missing blocks" bulk action UI (future)
+- Changing strategic allocation block definitions (those are institutional policy, not engine concern)
+- Fixing `factor_returns_fetch_failed` from `docs/ux/logs.txt:245` (PR-A15, separate)
+- Attribution log spam (PR-A16, separate)
+- Frontend cascade_telemetry coverage panel visualization (may be A14.1 follow-up if rendering gets involved; A13.2's existing signal banner inherits the new secondary key for free)
+- Tightening SCS solver tolerance (A12.4 gate makes it moot)
+- μ prior calibration (separate sprint)
+
+---
+
+## Section G — Open decisions for implementer (flag before locking)
+
+1. **Renormalization floor (scale_factor bound):** if `raw_covered_sum` is extremely small (e.g., 0.05 — only 5% of blocks covered), scale_factor becomes 20×. That can violate individual block max_weight bounds (e.g., a block capped at 25% gets scaled to 500% target). Decision: when `scale_factor > 5.0` (i.e., coverage < 20%), hard-fail with upstream_heuristic — universe too narrow to build a meaningful portfolio. Lock 5.0 threshold unless Andrei objects.
+
+2. **Secondary signal shape — `OperatorSignal.secondary` vs array of signals:** the A13 TypeScript interface has a single primary signal. Extending with optional `secondary` is simpler than refactoring to `signals: OperatorSignal[]`. Lock `secondary: OperatorSignal | null` as a simple optional field.
+
+3. **Coverage threshold (0.85):** institutional rule of thumb. If empirical evidence post-ship shows that most orgs hit 0.80-0.95 naturally, lower threshold to 0.70 to avoid noise. For now, lock 0.85.
+
+All three are pre-locked — do NOT wait for Andrei to confirm. Document the rationale in the PR body so future PRs can re-tune based on operator telemetry.
+
+---
+
+## Section H — Commit & PR
+
+**Branch:** `feat/pr-a14-universe-coverage-gate`
+
+**Commit message:**
+
+```
+feat(wealth): universe coverage gate + block weight renormalization (PR-A14)
+
+Pre-A14: strategic allocations with missing blocks (no funds in approved
+universe) caused the LP to target only sum(covered_block.target_weight),
+leaving up to 39% of operator notional undeployed AND inflating the
+universe tail floor because the LP operated on a narrow asset set.
+
+Fix 1 — Renormalization: covered blocks' weights rescaled by
+1/raw_covered_sum so LP receives sum(w) == 1.0 always. Block ratios
+preserved. If coverage < 20%, hard-fail to upstream_heuristic — universe
+too narrow to meaningfully construct.
+
+Fix 2 — Coverage telemetry: cascade_telemetry.coverage populated with
+pct_covered, n_total_blocks, n_covered_blocks, covered_blocks[],
+missing_blocks[], renormalization_scale.
+
+Fix 3 — Secondary operator signal: operator_signal.secondary emits
+{kind="universe_coverage_insufficient", pct_covered, missing_blocks_count}
+when coverage < 0.85. Primary signal (risk budget / below-floor) unchanged.
+
+Closes the 61%/52%/49% deployment gap on Conservative / Moderate / Growth
+canonical portfolios and surfaces the universe gap to operators without
+blocking the always-solvable cascade.
+
+Frontend (PR-A13.2 or follow-up) auto-inherits via existing
+translateOperatorSignalKind pipeline + new translation keys.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+**PR title:** `feat(wealth): universe coverage gate + renormalization (PR-A14)`
+
+**PR body:** include before/after table for the 3 canonical portfolios, coverage JSONB example, screenshot of rendered secondary signal in Builder.
+
+---
+
+**End of spec. Execute exactly. Renormalization is math, coverage is telemetry, secondary signal is UX — three small changes, one institutional unblock.**

--- a/frontends/wealth/src/lib/types/cascade-telemetry.ts
+++ b/frontends/wealth/src/lib/types/cascade-telemetry.ts
@@ -20,12 +20,48 @@ export type OperatorSignalKind =
 	| "feasible"
 	| "cvar_limit_below_universe_floor"
 	| "upstream_data_missing"
-	| "constraint_polytope_empty";
+	| "constraint_polytope_empty"
+	// PR-A14 — surfaces only when coverage < 0.20 (hard-fail).
+	| "universe_coverage_insufficient";
+
+/**
+ * PR-A14 — non-blocking secondary signal flagged by the executor when the
+ * approved universe covers < 85% of the profile's strategic allocation
+ * targets. Primary signal keeps its existing contract; consumers opt in
+ * to the secondary by reading ``operator_signal.secondary``.
+ */
+export interface OperatorSignalSecondary {
+	kind: "universe_coverage_insufficient";
+	binding: string | null;
+	message_key: string;
+	pct_covered: number | null;
+	missing_blocks_count: number | null;
+}
 
 export interface OperatorSignal {
 	kind: OperatorSignalKind;
 	binding: string | null;
 	message_key: string;
+	// PR-A14 — additive, None outside the coverage-warning window.
+	secondary?: OperatorSignalSecondary | null;
+	// PR-A14 — populated only when ``kind === "universe_coverage_insufficient"``.
+	pct_covered?: number | null;
+	missing_blocks_count?: number | null;
+}
+
+/**
+ * PR-A14 — universe coverage payload. Surfaces the structural fit between
+ * the approved universe (instruments_org) and the profile's strategic
+ * allocation blocks. Nullable for legacy runs that predate the surface.
+ */
+export interface CoverageTelemetry {
+	pct_covered: number;
+	n_total_blocks: number;
+	n_covered_blocks: number;
+	covered_blocks: string[];
+	missing_blocks: string[];
+	renormalization_scale: number | null;
+	hard_fail: boolean;
 }
 
 export type CascadeSummary =
@@ -51,6 +87,8 @@ export interface CascadeTelemetry {
 	min_achievable_cvar: number | null;
 	achievable_return_band: AchievableReturnBand | null;
 	operator_signal: OperatorSignal | null;
+	// PR-A14 — universe coverage surface (nullable for legacy runs).
+	coverage?: CoverageTelemetry | null;
 }
 
 /**

--- a/frontends/wealth/src/lib/util/metric-translators.ts
+++ b/frontends/wealth/src/lib/util/metric-translators.ts
@@ -257,9 +257,37 @@ export function translateOperatorSignalKind(value: string): TranslatedMetric {
 				label: "Soma das bandas por bloco não fecha em 100% — revisar bandas",
 				tone: "danger",
 			};
+		case "universe_coverage_insufficient":
+			return {
+				label:
+					"Universo aprovado não cobre todos os blocos deste perfil — importe fundos nos blocos ausentes",
+				tone: "warning",
+			};
 		default:
 			return { label: value, tone: "neutral" };
 	}
+}
+
+/**
+ * PR-A14 — copy for the non-blocking secondary signal surfaced when the
+ * approved universe covers < 85% of the profile's strategic allocation
+ * blocks. Renders next to (not replacing) the primary signal.
+ */
+export function translateCoverageSecondary(
+	pctCovered: number | null | undefined,
+	missingBlocksCount: number | null | undefined,
+): TranslatedMetric {
+	const pct =
+		typeof pctCovered === "number"
+			? Math.round(pctCovered * 100)
+			: null;
+	const n = typeof missingBlocksCount === "number" ? missingBlocksCount : null;
+	const pctFragment = pct !== null ? ` (${pct}% coberto)` : "";
+	const nFragment = n !== null && n > 0 ? ` — ${n} blocos ausentes` : "";
+	return {
+		label: `Universo aprovado parcial${pctFragment}${nFragment}`,
+		tone: "warning",
+	};
 }
 
 /**


### PR DESCRIPTION
## Summary

Observability-only surface for the universe-coverage gap. The renormalisation that allows partial-universe optimization to converge was already shipped in PR-A7 (`model_portfolios.py:2173-2210`) — A14 exposes the gap to operators without changing any optimizer math.

## What ships

**1. `cascade_telemetry.coverage`** — JSONB block with:
- `pct_covered` (raw sum of covered block `target_weight`s)
- `n_total_blocks`, `n_covered_blocks`
- `covered_blocks[]`, `missing_blocks[]` (sorted)
- `renormalization_scale` (1 / pct_covered, mirrors the PR-A7 scale applied to block max bounds)
- `hard_fail` (true when pct_covered < 0.20)

**2. `operator_signal.secondary`** — non-blocking warning with `kind="universe_coverage_insufficient"` when pct_covered < 0.85. Additive field; primary signal keeps its existing contract. When primary would be `None` (phase_1_succeeded etc.) a minimal `feasible` primary is synthesised so consumers always find the secondary via `operator_signal.secondary`.

**3. Hard-fail primary swap** — at `pct_covered < 0.20` the route raises a sentinel `ValueError` routing to `upstream_heuristic`; the executor detects `coverage.hard_fail` and swaps primary `kind` from `upstream_data_missing` to `universe_coverage_insufficient` so operators see the right remediation (\"import funds into the missing blocks\") instead of a generic \"statistics unavailable\" message.

**4. Translation keys** — `translateOperatorSignalKind` handles the new kind; `translateCoverageSecondary` renders the secondary chip copy (PT-BR, sanitised).

## What does NOT ship — scope note

- **C.1 renormalisation** was already shipped by PR-A7 (`model_portfolios.py:2173-2210`). The LP constraint `cp.sum(w) == 1` (`optimizer_service.py:482`) plus weight re-normalisation at extraction (`w_arr / total`) mean `weights_proposed` already sums to 1.0 on all canonical portfolios. The spec's assertion that `test_lp_sum_constraint_equals_one_post_renormalization` would fail pre-fix was empirically wrong.
- The `target_sum=0.61/0.52/0.49` numbers in `docs/ux/logs.txt` are the *raw* covered-block sum (pre-renormalisation), not LP output. Deployment is already 100%.

## Pre-locked decisions (PR-A14 Section G)

1. **Hard-fail threshold**: `pct_covered < 0.20` (scale factor > 5×). Below that the renormalised max_weights violate block bounds.
2. **Secondary shape**: `operator_signal.secondary : OperatorSignal | null` — simple additive field, not a `signals[]` refactor.
3. **Secondary threshold**: `pct_covered < 0.85` (institutional rule of thumb). Boundary is strict (< 0.85 triggers; == 0.85 does not).

All three pre-locked; no operator telemetry yet to retune.

## Test plan

- [x] `backend/tests/wealth/test_universe_coverage_gate.py` — 8 unit tests on `_build_cascade_telemetry`:
  - full coverage → no secondary
  - 61% coverage → synthesised feasible primary + secondary attached
  - 85% boundary → no secondary (strict)
  - 90% → no secondary
  - primary `cvar_limit_below_universe_floor` + secondary coexist at 61%
  - hard-fail (15%) → primary kind swapped, no secondary duplicate
  - upstream_heuristic without hard-fail → kind stays `upstream_data_missing`
  - legacy cascade block (no coverage key) → no crash, no secondary
- [x] All 161 wealth tests green locally (`pytest backend/tests/wealth/`)
- [x] ruff clean on all 4 backend files
- [x] Pre-existing failures (`test_robust_optimizer`, `test_turnover_penalty`, `test_manifest_freshness`) confirmed unrelated to A14 — ripple from A12.4 `status=\"degraded\"` and worker manifest drift
- [ ] Live-DB smoke post-merge: Conservative / Moderate / Growth must emit `coverage.pct_covered` matching `logs.txt` (0.61 / 0.52 / 0.49) and `operator_signal.secondary.kind == \"universe_coverage_insufficient\"`
- [ ] Frontend Playwright: secondary chip renders next to primary Risk Budget panel warning (inherits from existing `translateOperatorSignalKind` pipeline)

Closes the visibility gap for universes with incomplete block coverage — three small changes, one institutional unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)