### PR TITLE
fix(quant): raise kappa fallback threshold 5e4->1e5 to unblock cascade (PR-A17.1)

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -2392,6 +2392,33 @@ async def _run_construction_async(
 
     # ── 5. Fallback to block-level heuristic if fund-level failed ──
     if composition is None:
+        # PR-A17.1 C.3 — diagnose the post-A17 regression where every
+        # canonical portfolio lands on upstream_heuristic despite Phase 3
+        # succeeding. Capture fund_result state so we can attribute the
+        # fallback to the right cause (raised exception vs. status/weight
+        # gate miss vs. never-ran).
+        logger.info(
+            "construction_fell_to_heuristic_fallback",
+            portfolio_id=str(portfolio_id) if portfolio_id else None,
+            profile=profile,
+            fund_result_present=(fund_result is not None),
+            fund_result_status=(
+                fund_result.status if fund_result is not None else None
+            ),
+            fund_result_winning_phase=(
+                fund_result.winning_phase if fund_result is not None else None
+            ),
+            fund_result_weight_count=(
+                len(fund_result.weights) if fund_result is not None and fund_result.weights else 0
+            ),
+            fund_result_weight_sum=(
+                float(sum(fund_result.weights.values()))
+                if fund_result is not None and fund_result.weights else None
+            ),
+            fund_result_cvar_95=(
+                fund_result.cvar_95 if fund_result is not None else None
+            ),
+        )
         fallback_meta = OptimizationMeta(
             expected_return=0.0,
             portfolio_volatility=0.0,

--- a/backend/app/domains/wealth/services/quant_queries.py
+++ b/backend/app/domains/wealth/services/quant_queries.py
@@ -149,8 +149,20 @@ RISK_AVERSION_INSTITUTIONAL_DEFAULT = 2.5
 # original 1e4 error threshold fired spuriously on well-behaved institutional
 # universes. The fallback tier hands off to PR-A3 factor covariance (PSD-clamped)
 # when sample Σ is too collinear but not pathologically singular.
-KAPPA_WARN_THRESHOLD = 1e4        # proceed with sample Σ, emit warning
-KAPPA_FALLBACK_THRESHOLD = 5e4    # switch to factor covariance if available
+KAPPA_WARN_THRESHOLD = 1e4        # proceed with sample Sigma, emit warning
+# PR-A17.1 — raised 5e4 -> 1e5. The original 5e4 cutoff was aspirational: it
+# assumed the factor-model fallback would catch kappa in [5e4, 1e6). In
+# practice the factor_returns ingestion has a pre-existing dedup bug
+# ("Index contains duplicate entries", docs/ux/logs.txt:245, pre-A17) so
+# fit_available is False and the fallback path raises every time. Post-A17
+# the expanded universe (135-146 funds / T/N ~= 4.0-4.5) pushes sample kappa
+# into 5e4-1e5 legitimately — Ledoit-Wolf shrinkage + _repair_psd + CLARABEL
+# regularisation handle that band safely, and the empirical RU CVaR verifier
+# (realized_cvar_from_weights) catches downstream violations. Raise to 1e5
+# to unblock production construction until PR-A15 restores factor fallback.
+# ERROR threshold 1e6 intentionally unchanged — truly pathological cases
+# still raise.
+KAPPA_FALLBACK_THRESHOLD = 1e5    # switch to factor covariance if available
 KAPPA_ERROR_THRESHOLD = 1e6       # raise — truly pathological rank deficiency
 # Survivorship bias estimate (bps/year) — see design doc 2026-04-14
 SURVIVORSHIP_BIAS_BPS_RANGE = (50, 150)
@@ -178,7 +190,7 @@ class IllConditionedCovarianceError(Exception):
         self.n_obs = n_obs
         self.worst_eigenvalues = worst_eigenvalues or []
         detail = (
-            f"κ(Σ)={condition_number:.3e} exceeds error threshold ({KAPPA_ERROR_THRESHOLD:.0e}); "
+            f"kappa(Sigma)={condition_number:.3e} exceeds error threshold ({KAPPA_ERROR_THRESHOLD:.0e}); "
             f"N={n_funds}, T={n_obs}"
         )
         if self.worst_eigenvalues:
@@ -614,7 +626,7 @@ def check_covariance_conditioning(
             n_obs=0,
             worst_eigenvalues=worst,
             message=(
-                f"κ(Σ)={kappa:.3e} exceeds pathological threshold "
+                f"kappa(Sigma)={kappa:.3e} exceeds pathological threshold "
                 f"({KAPPA_ERROR_THRESHOLD:.0e}); rank deficient, not recoverable."
             ),
         )
@@ -628,6 +640,19 @@ def check_covariance_conditioning(
         )
 
     if kappa >= KAPPA_WARN_THRESHOLD:
+        # PR-A17.1 — surface the extended warn band [5e4, 1e5) that was
+        # previously routed to factor_fallback. Tracks how often sample
+        # Sigma is pushed into the harder region post-universe-expansion
+        # so we can see if the increase is transient or a new baseline.
+        if kappa >= 5e4:
+            logger.warning(
+                "kappa_in_extended_warn_band",
+                kappa=kappa,
+                min_eigenvalue=min_eig,
+                n_funds=cov_matrix.shape[0],
+                warn_threshold=KAPPA_WARN_THRESHOLD,
+                fallback_threshold=KAPPA_FALLBACK_THRESHOLD,
+            )
         return CovarianceConditioningResult(
             kappa=kappa,
             decision="sample",
@@ -1457,7 +1482,7 @@ async def compute_fund_level_inputs(
                 n_funds=annual_cov.shape[0],
                 n_obs=returns_matrix.shape[0],
                 message=(
-                    f"κ(Σ)={cond_primary.kappa:.3e} in fallback band "
+                    f"kappa(Sigma)={cond_primary.kappa:.3e} in fallback band "
                     f"[{KAPPA_FALLBACK_THRESHOLD:.0e}, {KAPPA_ERROR_THRESHOLD:.0e}) "
                     f"but factor fallback unavailable (source={covariance_source}, "
                     f"fit={'set' if fit is not None else 'none'}, "
@@ -1485,8 +1510,8 @@ async def compute_fund_level_inputs(
                 n_funds=annual_cov.shape[0],
                 n_obs=returns_matrix.shape[0],
                 message=(
-                    f"Both sample (κ={cond_primary.kappa:.3e}) and factor "
-                    f"(κ≥{KAPPA_ERROR_THRESHOLD:.0e}) covariances are "
+                    f"Both sample (kappa={cond_primary.kappa:.3e}) and factor "
+                    f"(kappa>={KAPPA_ERROR_THRESHOLD:.0e}) covariances are "
                     f"ill-conditioned."
                 ),
             ) from factor_exc
@@ -1496,8 +1521,8 @@ async def compute_fund_level_inputs(
                 n_funds=annual_cov.shape[0],
                 n_obs=returns_matrix.shape[0],
                 message=(
-                    f"Both sample (κ={cond_primary.kappa:.3e}) and factor "
-                    f"(κ={cond_factor.kappa:.3e}) covariances are "
+                    f"Both sample (kappa={cond_primary.kappa:.3e}) and factor "
+                    f"(kappa={cond_factor.kappa:.3e}) covariances are "
                     f"ill-conditioned."
                 ),
             )

--- a/backend/quant_engine/optimizer_service.py
+++ b/backend/quant_engine/optimizer_service.py
@@ -924,6 +924,32 @@ async def optimize_fund_portfolio(
     min_achievable_cvar: float | None = None
     if status3 in ("optimal", "optimal_inaccurate"):
         opt_w3 = _extract_weights(w3)
+        # PR-A17.1 C.1 — Phase 3 post-solve inspection. Diagnoses the
+        # "objective_value=0.0 → upstream_heuristic" regression: logs the
+        # extracted weight vector's shape (sum, max, nonzero count) plus
+        # the LP's empirical realized CVaR (daily + annualized) so we can
+        # distinguish genuine near-zero min-CVaR from degenerate solver output.
+        logger.info(
+            "phase_3_post_solve_inspection",
+            prob_status=str(prob3.status),
+            prob_value=float(prob3.value) if prob3.value is not None else None,
+            extracted_is_none=(opt_w3 is None),
+            weights_sum=float(opt_w3.sum()) if opt_w3 is not None else None,
+            weights_max=float(opt_w3.max()) if opt_w3 is not None else None,
+            weights_nonzero_count=int((opt_w3 > 1e-6).sum()) if opt_w3 is not None else None,
+            realized_cvar_daily=(
+                float(realized_cvar_from_weights(opt_w3, returns_scenarios, cvar_alpha))
+                if opt_w3 is not None else None
+            ),
+            realized_cvar_annual=(
+                float(realized_cvar_from_weights(opt_w3, returns_scenarios, cvar_alpha) * SQRT_252)
+                if opt_w3 is not None else None
+            ),
+            n_funds=n,
+            n_scenarios=int(returns_scenarios.shape[0]),
+            cvar_alpha=cvar_alpha,
+            effective_cvar_limit=effective_cvar_limit,
+        )
         if opt_w3 is not None:
             phase3_weights = opt_w3
             # prob3.value is the daily RU-LP objective; annualize to match
@@ -1019,6 +1045,33 @@ async def optimize_fund_portfolio(
             else True
         )
         winner_status = "optimal" if within_limit else "degraded"
+
+    # PR-A17.1 C.2 — winner-selection trace. Captures which phase won,
+    # whether each upstream phase was usable, and the full post-gate state
+    # that feeds _build_result. Pairs with the executor's cascade_summary
+    # mapping so we can see end-to-end how phase_3_min_cvar with
+    # objective_value=0.0 resolves.
+    logger.info(
+        "phase_winner_selection_trace",
+        phase1_usable=bool(_phase1_usable),
+        phase1_weights_valid=(phase1_weights is not None),
+        phase1_within_limit=_phase1_within_limit,
+        phase2_usable=bool(_phase2_usable),
+        phase2_weights_valid=(phase2_weights is not None),
+        phase2_within_limit=_phase2_within_limit,
+        phase3_weights_valid=(phase3_weights is not None),
+        phase3_weights_sum=(
+            float(phase3_weights.sum()) if phase3_weights is not None else None
+        ),
+        phase3_weights_nonzero=(
+            int((phase3_weights > 1e-6).sum()) if phase3_weights is not None else None
+        ),
+        min_achievable_cvar=min_achievable_cvar,
+        effective_cvar_limit=effective_cvar_limit,
+        winning_phase=winner_phase,
+        winner_status=winner_status,
+        winner_return=winner_return,
+    )
 
     assert winner_return is not None
     winner_cvar_ru = _cvar_from_ru(winner_w)

--- a/backend/tests/quant_engine/test_construction_integration.py
+++ b/backend/tests/quant_engine/test_construction_integration.py
@@ -101,21 +101,24 @@ async def test_compute_fund_level_inputs_happy_path_20_fund_synthetic() -> None:
 
 @pytest.mark.asyncio
 async def test_compute_fund_level_inputs_collinear_funds_raises() -> None:
-    """Two exactly-collinear fund series must trip the κ error guard."""
+    """Pathologically rank-deficient series must trip the kappa error guard.
+
+    PR-A17.1 raised KAPPA_FALLBACK_THRESHOLD from 5e4 to 1e5. The previous
+    rank-3-in-R^4 fixture produced kappa post-Ledoit-Wolf that was tolerable
+    on the new ladder (decision='sample', no raise). Strengthen the fixture
+    to rank-1-in-R^4 (all series exact duplicates of series 0) so kappa
+    exceeds the pathological ceiling (1e6) even after shrinkage.
+    """
     rng = np.random.default_rng(11)
     n_days = 1260
-    base = rng.standard_normal(n_days) * 0.01
     ids = [uuid.uuid4() for _ in range(4)]
     start = date(2021, 4, 14)
     dates = [start + timedelta(days=i) for i in range(n_days)]
     returns: dict[str, dict[date, float]] = {}
-    # 3 independent + 1 exact duplicate of fund 0 → rank-3 matrix in R^4
-    for col, iid in enumerate(ids):
-        if col < 3:
-            series = rng.standard_normal(n_days) * 0.01
-        else:
-            series = np.array(list(returns[str(ids[0])].values()))
-        returns[str(iid)] = {d: float(series[i]) for i, d in enumerate(dates)}
+    # Rank-1: every fund is an exact copy of the first series.
+    base_series = rng.standard_normal(n_days) * 0.01
+    for iid in ids:
+        returns[str(iid)] = {d: float(base_series[i]) for i, d in enumerate(dates)}
 
     db = AsyncMock()
     with patch(

--- a/backend/tests/quant_engine/test_covariance_conditioning.py
+++ b/backend/tests/quant_engine/test_covariance_conditioning.py
@@ -75,7 +75,7 @@ def test_warn_band_returns_sample_with_warn_flag() -> None:
 
 
 def test_fallback_band_recommends_factor_fallback() -> None:
-    cov = _diag_cov_with_kappa(1e5)  # inside [5e4, 1e6)
+    cov = _diag_cov_with_kappa(2e5)  # inside [1e5, 1e6)
     result = check_covariance_conditioning(cov)
     assert result.decision == "factor_fallback"
     assert result.warn is True
@@ -167,7 +167,7 @@ def test_fallback_swaps_to_factor_cov_when_sample_in_fallback_band(
     # We call ``check_covariance_conditioning`` ourselves to simulate the
     # branch inside ``compute_fund_level_inputs``. Integration at the route
     # level is covered by ``test_construction_integration.py``.
-    sample_cov = _diag_cov_with_kappa(1e5, n=5)  # fallback band
+    sample_cov = _diag_cov_with_kappa(2e5, n=5)  # fallback band
     cond = check_covariance_conditioning(sample_cov)
     assert cond.decision == "factor_fallback"
 
@@ -186,8 +186,8 @@ def test_both_ill_conditioned_raises_with_dual_kappa_context(
 
     # Sample at 1e5 (fallback band), factor also at 1e5 (still fallback band —
     # not pristine → caller must raise).
-    sample_cov = _diag_cov_with_kappa(1e5, n=5)
-    factor_cov = _diag_cov_with_kappa(1e5, n=5)
+    sample_cov = _diag_cov_with_kappa(2e5, n=5)
+    factor_cov = _diag_cov_with_kappa(2e5, n=5)
     _install_fake_factor_fit(monkeypatch, factor_cov)
 
     # Mirror the guardrail branch manually: sample is "factor_fallback",
@@ -229,7 +229,7 @@ def test_factor_fallback_disabled_when_k_factors_effective_is_zero() -> None:
     assert k_factors_effective == 0
 
     # Sample in fallback band — but no factor help possible.
-    sample_cov = _diag_cov_with_kappa(1e5, n=5)
+    sample_cov = _diag_cov_with_kappa(2e5, n=5)
     sample_cond = check_covariance_conditioning(sample_cov)
     assert sample_cond.decision == "factor_fallback"
 
@@ -249,9 +249,40 @@ def test_factor_fallback_disabled_when_k_factors_effective_is_zero() -> None:
 
 
 def test_warn_threshold_constants_are_recalibrated() -> None:
-    """Sanity gate — PR-A9 constants must match the spec ladder."""
+    """Sanity gate — PR-A17.1 raised FALLBACK from 5e4 to 1e5.
+
+    Rationale: the factor-model fallback that 5e4 assumed is not available
+    in practice (factor_returns has a pre-existing dedup bug — see PR-A15).
+    Post-A17 universe expansion (T/N ~= 4.0-4.5) puts sample kappa in the
+    5e4-1e5 band legitimately, where Ledoit-Wolf + PSD repair + CLARABEL
+    handle it safely. Raising the threshold unblocks production construction
+    without weakening the pathological (1e6) ceiling.
+    """
     assert KAPPA_WARN_THRESHOLD == 1e4
-    assert KAPPA_FALLBACK_THRESHOLD == 5e4
+    assert KAPPA_FALLBACK_THRESHOLD == 1e5  # PR-A17.1: raised from 5e4
     assert KAPPA_ERROR_THRESHOLD == 1e6
     # Ordering invariant: warn < fallback < error
     assert KAPPA_WARN_THRESHOLD < KAPPA_FALLBACK_THRESHOLD < KAPPA_ERROR_THRESHOLD
+
+
+@pytest.mark.parametrize("observed_kappa", [5.7e4, 8.0e4, 8.4e4, 9.9e4])
+def test_pr_a17_1_extended_warn_band_decides_sample(
+    observed_kappa: float,
+) -> None:
+    """PR-A17.1 regression: sample kappa in [5e4, 1e5) must decide 'sample'.
+
+    These are the empirical kappa values observed on the 3 canonical portfolios
+    post-A17 universe expansion (Conservative 5.66e4, Balanced 8.03e4,
+    Growth 8.43e4). Pre-A17.1 they routed to factor_fallback, the fallback
+    was unavailable, and compute_fund_level_inputs raised — every run degraded
+    to upstream_heuristic. This test locks in the raised threshold.
+    """
+    cov = _diag_cov_with_kappa(observed_kappa, n=5)
+    result = check_covariance_conditioning(cov)
+    assert result.decision == "sample", (
+        f"kappa={observed_kappa:.2e} in PR-A17.1 extended warn band must "
+        f"decide 'sample' to avoid routing to upstream_heuristic, "
+        f"got {result.decision}"
+    )
+    assert result.warn is True
+    assert result.kappa == pytest.approx(observed_kappa, rel=1e-6)

--- a/docs/prompts/2026-04-17-pr-a17-1-phase3-objective-zero-diagnose.md
+++ b/docs/prompts/2026-04-17-pr-a17-1-phase3-objective-zero-diagnose.md
@@ -1,0 +1,343 @@
+# PR-A17.1 — Diagnose & Fix: Phase 3 min-CVaR LP Returns objective=0.0 → upstream_heuristic Fallback
+
+**Branch:** `feat/pr-a17-1-phase3-objective-zero-diagnose` (cut from `main` post-PR-A17 at commit `55166f69`).
+**Estimated effort:** ~2-3h Opus (diagnose-first; fix ~30min once root cause confirmed).
+**Predecessor:** PR-A17 #200 (geography + FI classifier).
+**Blocks:** All production construction. Post-A17 ALL 3 canonical portfolios degrade to `upstream_heuristic` — construction pipeline is effectively down.
+
+---
+
+## Section A — Problem statement (empirical evidence)
+
+Post-A17 the coverage improvements landed correctly (Conservative 94%, Balanced 80%, Growth 74%), but a regression surfaced: **every construction run ends in `cascade_summary=upstream_heuristic` with zero weights delivered.**
+
+### A.1 What the event_log shows for all 3 portfolios
+
+```
+seq 4  Optimizer phase completed  phase=phase_2_ru_robust status=skipped
+seq 5  Optimizer phase completed  phase=phase_3_min_cvar  status=succeeded  objective_value=0.0
+seq 6  Optimizer cascade summary  cascade_summary=upstream_heuristic
+                                   operator_signal.kind=upstream_data_missing
+                                   operator_signal.binding=returns_quality
+                                   operator_signal.message_key=statistical_inputs_unavailable
+seq 7  Stress tests started       (runs on empty/invalid weights)
+seq 11 Construction succeeded     status=degraded  wall_ms≈11400
+```
+
+**Contradiction:** Phase 3 LP solver returned `status=succeeded` with `objective_value=0.0`, yet the cascade summary decided the run is `upstream_heuristic` (the pre-flight bailout path — meant for "cascade never ran"). Phase 3 clearly DID run. The routing is broken.
+
+### A.2 Pre-flight state is healthy (ruled-out causes)
+
+| Check | Result |
+|---|---|
+| NAV coverage for all funds | 100% (3,184/3,184 instruments_org rows) |
+| NAV depth ≥ 5Y (1,260 obs) | 100% across every block |
+| Dedup outcome | n_input 380-465 → n_kept 136-147 (healthy — up from 92-95 pre-A17) |
+| Strategic allocation feasibility | sum(min_weight) = 0.50-0.56, sum(max_weight) = 1.51-1.57 — ample slack |
+| Universe coverage | 74-94% (well above A14's 20% hard-fail threshold) |
+
+Data is NOT the problem. The problem is downstream of data loading, inside the optimizer cascade math or its winner-selection gate.
+
+### A.3 Why pre-A17 worked
+
+Pre-A17 the universe was ~90-95 funds post-dedup, concentrated in 7 block_ids (54% na_equity_large). Post-A17 it's 136-147 funds spread across 12-13 block_ids with broader international + FI sub-classification. The LP is solving the SAME mathematical formulation, but on a larger, more diverse universe. Something in the LP construction or its post-solve gate handles the larger universe incorrectly.
+
+---
+
+## Section B — Candidate root causes (ranked)
+
+### B.1 Phase 3 LP returns degenerate solution (HIGH likelihood — Pattern A)
+
+`prob3.value = 0.0` means the min-CVaR LP's objective evaluates to zero at its "optimal" point. Two legitimate reasons:
+
+- **(B.1.a) Degenerate weights.** Solver returned status=optimal but `opt_w3` is all-zeros or sums to ~0. CLARABEL occasionally returns degenerate solutions for tight box-constrained LPs when primal-dual residuals hit the tolerance floor at a near-origin point. Downstream `_extract_weights(w3)` may return `None` or a zero vector that fails usability checks.
+- **(B.1.b) Numerical precision collapse at scale.** The RU LP has (N + T + 1) variables — for N=147 funds and T=937 scenarios, that's 1,085 decision variables plus ~1,100 constraints. CLARABEL in its default tolerance (≈1e-8) may report primal-dual gap < tol but solution quality is still poor.
+
+**If confirmed:** fix is either tighter solver config (eps_abs/eps_rel), explicit degenerate-solution detection (`if opt_w3.sum() < 1e-6: fall through`), or switch to SCS with tighter tolerance for large N.
+
+### B.2 Min-CVaR objective ≈ 0 is genuine — gate is too strict (MEDIUM)
+
+With a 136-fund universe spanning EM equity + DM Europe/Asia + treasury + TIPS + aggregate + HY credit + REITs + gold + cash, min-CVaR can mathematically collapse toward zero via cross-asset hedging (diversification). In that case `objective=0.0` is legitimate — the universe genuinely allows a near-zero-tail-risk portfolio.
+
+If so, the downstream gate `_phase3_usable` (or equivalent A12.4-era check) rejects this as degenerate. Check patterns:
+
+- Does the gate require `min_achievable_cvar > epsilon` for some epsilon?
+- Does it compare `cvar_95` against a positive floor and reject if below?
+- Does `realized_cvar_from_weights(weights, scenarios, alpha)` return exactly 0 (empirical, not LP-reported), confirming weights ARE hedged?
+
+**If confirmed:** fix is relaxing the usability check — a low achievable CVaR is a WIN for the operator, not a failure. Cascade should accept and proceed with Phase 3 weights, reporting `cascade_summary=phase_3_min_cvar_within_limit`.
+
+### B.3 `_run_construction_async` fallback path mis-routing (LOW but verifiable)
+
+A12.3/A12.4 reworked the winning-phase logic. There may be a hold-over branch in `model_portfolios.py` that catches "Phase 3 usable but suspicious" conditions and builds a heuristic composition, then downstream maps that to `upstream_heuristic`. Grep for `solver="heuristic_fallback"` assignments post-Phase-3 success.
+
+### B.4 Block constraints after A17 expansion + PR-A7 renormalization (LOW, already partially ruled out)
+
+Section A.2 showed `sum(min_weight)` is 0.50-0.56 — feasible. But the interaction between PR-A7's `max_weight × 1/target_sum` rescaling and the now-higher `target_sum` (0.94 vs 0.61) compresses the per-block upper bounds. Could make the box-constrained LP region tighter but shouldn't produce `objective=0`.
+
+---
+
+## Section C — Investigation protocol (mandatory — no fix before diagnosis posted)
+
+Same discipline as PR-A12.3 rounds 2-3. STOP before writing any fix. Post the instrumentation output to the PR draft, consultant confirms pattern, THEN proceed to Section D.
+
+### C.1 Instrument Phase 3 post-solve (inside `optimize_fund_portfolio`)
+
+Immediately after `opt_w3 = _extract_weights(w3)` returns, add:
+
+```python
+logger.info(
+    "phase_3_post_solve_inspection",
+    prob_status=str(prob3.status),
+    prob_value=float(prob3.value) if prob3.value is not None else None,
+    extracted_is_none=(opt_w3 is None),
+    weights_sum=float(opt_w3.sum()) if opt_w3 is not None else None,
+    weights_max=float(opt_w3.max()) if opt_w3 is not None else None,
+    weights_nonzero_count=int((opt_w3 > 1e-6).sum()) if opt_w3 is not None else None,
+    realized_cvar_daily=(
+        float(realized_cvar_from_weights(opt_w3, returns_scenarios, cvar_alpha))
+        if opt_w3 is not None else None
+    ),
+    realized_cvar_annual=(
+        float(realized_cvar_from_weights(opt_w3, returns_scenarios, cvar_alpha) * SQRT_252)
+        if opt_w3 is not None else None
+    ),
+)
+```
+
+### C.2 Instrument the usability gate that rejects Phase 3
+
+Locate the winner-selection logic added in PR-A12.4 (in `optimize_fund_portfolio` after all 3 phases solve). The section that computes `_phase1_usable`, `_phase2_usable`, and should also handle Phase 3. Add:
+
+```python
+logger.info(
+    "phase_winner_selection_trace",
+    phase1_usable=_phase1_usable,
+    phase1_weights_valid=(phase1_weights is not None),
+    phase2_usable=_phase2_usable if "phase2_usable" in locals() else None,
+    phase3_weights_valid=(phase3_weights is not None),
+    phase3_realized_annual=(phase3_realized_annual if "phase3_realized_annual" in locals() else None),
+    effective_cvar_limit=effective_cvar_limit,
+    chosen_winning_phase=winning_phase,
+    chosen_cascade_summary=cascade_summary,
+)
+```
+
+### C.3 Instrument the `_run_construction_async` heuristic fallback branch
+
+In `backend/app/domains/wealth/routes/model_portfolios.py`, locate the `except ValueError` / `except IllConditionedCovarianceError` / `composition is None` block that assigns `solver="heuristic_fallback"`. Add:
+
+```python
+logger.info(
+    "construction_fell_to_heuristic_fallback",
+    portfolio_id=str(portfolio_id),
+    reason_type=type(e).__name__ if "e" in locals() else "composition_was_none",
+    reason_msg=str(e) if "e" in locals() else None,
+    fund_result_solver=fund_result.status if "fund_result" in locals() else None,
+    fund_result_weights_count=len(fund_result.weights) if "fund_result" in locals() and hasattr(fund_result, "weights") else None,
+)
+```
+
+### C.4 Run the 3 canonical smokes + attach logs
+
+Trigger Conservative + Balanced + Growth builds (via the existing smoke harness or direct POST). Capture uvicorn stdout for all 3 runs. Identify which of B.1.a / B.1.b / B.2 / B.3 matches the observed data:
+
+| Pattern match | Evidence in logs |
+|---|---|
+| B.1.a degenerate weights | `phase_3_post_solve_inspection.weights_sum ≈ 0` AND `weights_nonzero_count < 2` |
+| B.1.b numerical collapse | `prob_status="optimal_inaccurate"` OR `weights_sum ≈ 1` but `realized_cvar_daily ≈ 0` with 0 meaningful weights |
+| B.2 genuine near-zero CVaR | `weights_sum ≈ 1` AND `weights_nonzero_count >= 10` AND `realized_cvar_annual < 0.005` (legitimate small CVaR from diversification) |
+| B.3 fallback mis-routing | `construction_fell_to_heuristic_fallback` log fires with a specific exception type |
+
+### C.5 Report findings + confirmed pattern
+
+**STOP before fix.** Post to the PR draft:
+- The 3 sets of `phase_3_post_solve_inspection` logs (one per portfolio)
+- The 3 sets of `phase_winner_selection_trace` logs
+- The `construction_fell_to_heuristic_fallback` log if it fired
+- Your pattern identification (B.1.a / B.1.b / B.2 / B.3) with evidence
+
+Consultant confirms before Section D proceeds.
+
+---
+
+## Section D — Implementation (branches by pattern)
+
+### Path D.1 — Pattern B.1.a: degenerate solver output
+
+Detect and reject degenerate weights explicitly in `optimize_fund_portfolio`:
+
+```python
+if opt_w3 is not None and opt_w3.sum() < 1e-4:
+    logger.warning("phase_3_degenerate_solution_rejected",
+                   weights_sum=float(opt_w3.sum()))
+    opt_w3 = None  # treat as infeasible
+```
+
+Upstream fallback then fires correctly. Separately, investigate WHY the LP returned degenerate — may be a missing `sum(w) == 1` constraint or wrong `cp.Variable` bounds.
+
+### Path D.2 — Pattern B.1.b: numerical precision
+
+Tighten solver config:
+
+```python
+prob3.solve(
+    solver=cp.CLARABEL,
+    eps_abs=1e-9,
+    eps_rel=1e-9,
+    max_iter=500,
+)
+```
+
+If CLARABEL still can't converge cleanly, fall back to SCS with tight tolerance. Add a post-solve sanity check (`weights_sum > 0.99` required) and escalate to heuristic if unmet.
+
+### Path D.3 — Pattern B.2: gate too strict
+
+Remove or relax the usability check. The correct semantic is: "Phase 3 succeeds if it returns valid weights (sum ≈ 1, non-trivial), regardless of how low the CVaR is." Near-zero CVaR is a good outcome.
+
+Specifically, the gate should be:
+
+```python
+_phase3_usable = (
+    phase3_weights is not None
+    and abs(phase3_weights.sum() - 1.0) < 1e-3
+    and (phase3_weights > 1e-6).sum() >= 2  # at least 2 non-trivial positions
+)
+# NO min_achievable_cvar > epsilon check — any non-negative CVaR is valid
+```
+
+Post-fix, Phase 3 delivers a diversified near-zero-CVaR portfolio and cascade_summary becomes `phase_3_min_cvar_within_limit`.
+
+### Path D.4 — Pattern B.3: fallback mis-routing
+
+Fix the `_run_construction_async` branch that builds `heuristic_fallback` composition when Phase 3 actually succeeded. Ensure that when `fund_result.status` is successful and weights are valid, the composition is built from the fund_result, NOT from the heuristic path.
+
+### Combined path
+
+If multiple patterns apply, fix all in this PR. Do NOT split — production construction is blocked.
+
+---
+
+## Section E — Tests
+
+### E.1 Regression test (mandatory)
+
+Add to `backend/tests/quant_engine/test_phase_winner_invariant.py` (created in PR-A12.4):
+
+```python
+async def test_phase_3_accepts_near_zero_cvar_when_weights_valid(seeded_portfolio):
+    """PR-A17.1 regression: a diversified universe with natural near-zero min-CVaR
+    must NOT be treated as degenerate. Phase 3 should succeed with
+    cascade_summary=phase_3_min_cvar_within_limit when weights sum ~1 and
+    have >= 2 non-trivial positions, even if min_achievable_cvar is very small."""
+    # Seed a universe with 50+ funds across 10+ blocks so cross-asset hedging is possible
+    portfolio = await seeded_portfolio(profile="conservative", universe_size=50)
+    result = await _run_construction_async(db, "conservative", org_id, portfolio.id)
+    assert result["cascade_telemetry"]["cascade_summary"] in (
+        "phase_1_succeeded",
+        "phase_3_min_cvar_within_limit",
+        "phase_3_min_cvar_above_limit",
+    ), f"Unexpected summary: {result['cascade_telemetry']['cascade_summary']}"
+    assert result["cascade_telemetry"]["cascade_summary"] != "upstream_heuristic", (
+        "Phase 3 valid weights MUST NOT route to upstream_heuristic"
+    )
+    weights_sum = sum(result["weights_proposed"].values())
+    assert abs(weights_sum - 1.0) < 1e-3, f"weights sum {weights_sum} != 1"
+```
+
+Parametrize across the 3 profiles. Test MUST fail on current main and pass post-fix.
+
+### E.2 Integration smoke
+
+Re-run `backend/tests/integration/test_construction_cvar_invariant.py`. Expect:
+- All 3 portfolios: `cascade_summary in ("phase_1_succeeded", "phase_3_min_cvar_within_limit", "phase_3_min_cvar_above_limit")`
+- NONE with `cascade_summary == "upstream_heuristic"`
+- `sum(weights_proposed.values()) ≈ 1.0` for all 3
+
+### E.3 Do NOT weaken existing A12.4 invariants
+
+`test_phase_winner_invariant` from A12.4 already asserts "Phase 1 winner implies delivered cvar ≤ limit". Keep that. The A17.1 fix only affects Phase 3's usability gate, not Phase 1/2.
+
+---
+
+## Section F — Pass criteria
+
+| # | Criterion | Evidence |
+|---|---|---|
+| 1 | Root cause pattern identified + posted to PR draft | manual review by consultant |
+| 2 | Regression test E.1 fails pre-fix, passes post-fix | pytest |
+| 3 | All 3 canonical portfolios live smoke: `cascade_summary != "upstream_heuristic"` | SQL query |
+| 4 | `sum(weights_proposed.values()) ≈ 1.0` for all 3 | live smoke |
+| 5 | `ex_ante_metrics.cvar_95 != null` and is a real number for all 3 | live smoke |
+| 6 | At least one profile (Conservative, likely) flips to `phase_3_min_cvar_within_limit` (universe floor now below 2.5% after universe expansion) | live smoke comparison |
+| 7 | A12.4 existing regression tests still green | pytest |
+| 8 | Full suite 380/380 or better | CI |
+
+Per `feedback_dev_first_ci_later.md`: live-DB smoke is the merge gate.
+
+---
+
+## Section G — Out of scope (explicit)
+
+- Factor equity sub-classification (na_equity_value / na_equity_growth) — PR-A17.2
+- Commodity ETF routing (alt_commodities) — PR-A17.2
+- XBRL / N-CEN richer FI classification — PR-A17.3
+- Factor returns dedup — PR-A15
+- Attribution log spam + taa_bands — PR-A16
+- μ prior calibration — separate sprint
+- Any change to Phase 1 or Phase 2 logic (they're correct post-A12.4)
+- Tightening SCS solver tolerance globally — only apply to Phase 3 if Pattern B.1.b confirmed
+- Changing the RU LP math — only the usability gate or solver config
+
+---
+
+## Section H — Commit & PR
+
+**Branch:** `feat/pr-a17-1-phase3-objective-zero-diagnose`
+
+**Commit message skeleton (fill after pattern confirmed):**
+
+```
+fix(quant): Phase 3 min-CVaR accepts low objective as valid (PR-A17.1)
+
+Post-A17, the richer universe (136-147 funds / 12-13 blocks) pushed
+min-achievable CVaR to near-zero for the 3 canonical portfolios — a
+legitimate outcome of cross-asset hedging over EM equity + DM Europe/Asia
++ treasury + TIPS + aggregate + HY. The winner-selection gate
+(PR-A12.4 pattern) rejected this as degenerate and routed all runs to
+upstream_heuristic, blocking production construction.
+
+Root cause (Pattern <X>): <diagnosis>
+
+Fix: <specific change to gate / solver / LP>
+
+Regression test test_phase_3_accepts_near_zero_cvar_when_weights_valid
+added to catch future gate over-rejection. Asserts Phase 3 with
+sum(w) ≈ 1 and >= 2 non-trivial positions must be accepted regardless
+of min_achievable_cvar magnitude.
+
+Post-fix smoke (3 canonical portfolios):
+  Conservative: cascade_summary=<result>  cvar_95=<value>
+  Balanced:     cascade_summary=<result>  cvar_95=<value>
+  Growth:       cascade_summary=<result>  cvar_95=<value>
+
+Unblocks production construction. All 3 portfolios deliver valid
+weights + ex_ante metrics again.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## Section I — Operating rules
+
+1. **Diagnose before fix.** Post instrumentation logs + confirmed pattern BEFORE modifying any code beyond the logger calls. Consultant blocks fix-merge if diagnosis is incomplete.
+2. **Brutal honesty.** If instrumentation reveals a pattern not in B.1-B.4, STOP and escalate. Do not force-fit a hypothesis.
+3. **One fix per confirmed pattern.** If multiple patterns are true, fix all in this PR — do not split.
+4. **Regression test must fail pre-fix.** If `test_phase_3_accepts_near_zero_cvar` passes without a fix on current main, the test doesn't reproduce the bug — redesign it.
+5. **Integration smoke harness run mandatory.** `tests/integration/test_construction_cvar_invariant.py` must green post-fix. This is the guardrail that would have caught this regression in A17 itself.
+6. **Preserve PR-A14 coverage signal.** Secondary signal still fires for profiles below 85% coverage — that's correct and unchanged.
+
+---
+
+**End of spec. Execute exactly. Production construction pipeline is blocked — this PR is the unblock. No delay for housekeeping; this merges as soon as smoke shows all 3 portfolios delivering valid weights again.**


### PR DESCRIPTION
## Summary

Post-A17 universe expansion (135-146 funds, T/N ~= 4.0-4.5) pushed sample kappa on the 3 canonical portfolios into 5.7e4-8.4e4, which the PR-A9 guard routed to the factor-model fallback. The factor fit path has a pre-existing dedup bug (PR-A15) so `fit_available=False` for every run and `compute_fund_level_inputs` raised before the cascade ran. Every portfolio degraded to `cascade_summary=upstream_heuristic` — production construction was blocked.

**Root-cause note:** the spec's Phase-3-degenerate-objective hypothesis did not reproduce. Diagnostic instrumentation (C.1/C.2/C.3 per Section C) showed zero hits on Phase 3 and 3/3 hits on `construction_covariance_fallback_unavailable` with `k_factors_effective=0`. Scope rewrite approved by @Andreicr1 (Path 2): raise the kappa fallback threshold.

## Changes

- `KAPPA_FALLBACK_THRESHOLD` 5e4 -> 1e5. At T/N ~= 4.0-4.5 with Ledoit-Wolf shrinkage + `_repair_psd` + CLARABEL empirical RU CVaR verifier, kappa in [5e4, 1e5) is numerically safe. Pathological ceiling (1e6) intentionally unchanged.
- New `kappa_in_extended_warn_band` log whenever kappa lands in the raised band — tracks frequency until PR-A15 restores the factor fallback.
- Strip kappa/Sigma/rho unicode chars from exception messages that propagate through `logger.warning` on Windows cp1252 stdout (was masking the real exception with UnicodeEncodeError during diagnosis).
- Diagnostic instrumentation C.1/C.2/C.3 kept as lightweight observability.
- Test updates: new parametrized `test_pr_a17_1_extended_warn_band_decides_sample` over the empirical kappa values (5.7e4, 8.0e4, 8.4e4, 9.9e4); constants assertion bumped to 1e5; collinear-funds test strengthened to rank-1 so pathological ceiling still trips.

## Live-DB smoke (trigger 2026-04-17 20:19 UTC)

| Portfolio | cascade_summary | weights_sum | cvar_95 | limit | floor |
|---|---|---|---|---|---|
| Conservative Preservation | phase_3_min_cvar_above_limit | 1.000001 | -7.33% | 2.5% | 7.36% |
| Balanced Income | phase_3_min_cvar_above_limit | 0.999999 | -7.43% | 5.0% | 7.44% |
| Dynamic Growth | phase_3_min_cvar_above_limit | 1.000001 | -10.07% | 8.0% | 10.08% |

None route to `upstream_heuristic`. All three run the full RU CVaR LP cascade. Phase 3 min-CVaR wins because the expanded universe's achievable-CVaR floor (7-10%) exceeds every operator-set limit — that's an operator-side calibration conversation (preview-cvar from PR-A13.1 already surfaces this), not an engine failure.

## Test plan

- [x] `backend/tests/quant_engine/test_covariance_conditioning.py` — 13/13 pass
- [x] `backend/tests/quant_engine/` suite — 230/230 pass (1 unrelated pre-existing asyncpg-uuid ERROR)
- [x] Live-DB smoke on Conservative/Balanced/Growth — all three cascade summaries off upstream_heuristic, weights sum ~= 1.0, cvar_95 populated

## Follow-ups

- PR-A15 elevated to P0: restore `factor_returns` dedup + fit path so the 1e5-1e6 fallback tier is meaningful again.
- Operator-set CVaR limits vs. universe floor is UX surface (preview-cvar already wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)