### PR TITLE
feat(wealth): recalibrate CVaR defaults 5/7.5/10/12.5 (PR-A18)

### DIFF
--- a/backend/app/core/db/migrations/versions/0145_cvar_profile_defaults_recalibration.py
+++ b/backend/app/core/db/migrations/versions/0145_cvar_profile_defaults_recalibration.py
@@ -1,0 +1,45 @@
+"""PR-A18: recalibrate profile-differentiated CVaR defaults to institutional-realistic values.
+
+Updates existing portfolio_calibration rows where cvar_limit matches an A12.2
+default (0.0250, 0.0500, 0.0800, 0.1000) to the new PR-A18 values
+(0.0500, 0.0750, 0.1000, 0.1250). Operator-customized values (anything
+outside that whitelist) are preserved.
+"""
+from alembic import op
+
+revision = "0145_cvar_profile_defaults_recalibration"
+down_revision = "0144_drop_legacy_allocation_block_aliases"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        UPDATE portfolio_calibration pc
+        SET cvar_limit = CASE mp.profile
+            WHEN 'conservative' THEN 0.0500
+            WHEN 'moderate'     THEN 0.0750
+            WHEN 'growth'       THEN 0.1000
+            WHEN 'aggressive'   THEN 0.1250
+            ELSE pc.cvar_limit
+        END
+        FROM model_portfolios mp
+        WHERE pc.portfolio_id = mp.id
+          AND pc.cvar_limit IN (0.0250, 0.0500, 0.0800, 0.1000);
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        UPDATE portfolio_calibration pc
+        SET cvar_limit = CASE mp.profile
+            WHEN 'conservative' THEN 0.0250
+            WHEN 'moderate'     THEN 0.0500
+            WHEN 'growth'       THEN 0.0800
+            WHEN 'aggressive'   THEN 0.1000
+            ELSE pc.cvar_limit
+        END
+        FROM model_portfolios mp
+        WHERE pc.portfolio_id = mp.id
+          AND pc.cvar_limit IN (0.0500, 0.0750, 0.1000, 0.1250);
+    """)

--- a/backend/app/domains/wealth/models/model_portfolio.py
+++ b/backend/app/domains/wealth/models/model_portfolio.py
@@ -64,31 +64,32 @@ class ModelPortfolio(OrganizationScopedMixin, Base):
     created_by: Mapped[str | None] = mapped_column(String(128))
 
 
-# ── PR-A12.2 — profile-differentiated CVaR defaults ─────────────────────
-# Institutional starting points for the portfolio-construction CVaR_95
-# budget. Operators override per-portfolio via the Builder slider
-# (PR-A13). Uniform 5% across all profiles defeated the operator's
-# mandate intent — Conservative expects tighter tail-loss containment
-# (~2.5%); Growth accepts more (~8%).
+# ── PR-A18 — CVaR defaults recalibrated to institutional-realistic ──────
+# Post-A15 empirical universe floors (7.33/7.44/10.08% for
+# conservative/balanced/growth) showed A12.2's aspirational defaults
+# (2.5/5/8) forced all 3 profiles into phase_3_min_cvar_above_limit
+# permanently. Recalibrated to 5/7.5/10/12.5 to reflect achievable
+# tail-risk band for the current catalog + leave operator headroom
+# to tighten downward once A17.2 NEW (Tiingo catalog) adds bond depth.
 _CVAR_DEFAULT_BY_PROFILE: dict[str, Decimal] = {
-    "conservative": Decimal("0.0250"),
-    "moderate": Decimal("0.0500"),
-    "growth": Decimal("0.0800"),
-    "aggressive": Decimal("0.1000"),
+    "conservative": Decimal("0.0500"),  # PR-A18: was 0.0250 (A12.2)
+    "moderate": Decimal("0.0750"),      # PR-A18: was 0.0500
+    "growth": Decimal("0.1000"),        # PR-A18: was 0.0800
+    "aggressive": Decimal("0.1250"),    # PR-A18: was 0.1000
 }
 
 
 def default_cvar_limit_for_profile(profile: str | None) -> Decimal:
     """Return the institutional CVaR_95 starting default for ``profile``.
 
-    Falls back to ``Decimal("0.0500")`` (moderate) for None / unknown
-    values so code paths without a resolved profile (legacy fixtures,
-    future profiles not yet calibrated) get a safe value rather than
-    KeyError. Lookup is case-insensitive.
+    Falls back to ``Decimal("0.0750")`` (moderate, PR-A18) for None /
+    unknown values so code paths without a resolved profile (legacy
+    fixtures, future profiles not yet calibrated) get a safe value
+    rather than KeyError. Lookup is case-insensitive.
     """
     if profile is None:
-        return Decimal("0.0500")
-    return _CVAR_DEFAULT_BY_PROFILE.get(profile.lower(), Decimal("0.0500"))
+        return Decimal("0.0750")
+    return _CVAR_DEFAULT_BY_PROFILE.get(profile.lower(), Decimal("0.0750"))
 
 
 class PortfolioCalibration(OrganizationScopedMixin, Base):

--- a/backend/tests/wealth/test_cvar_profile_defaults.py
+++ b/backend/tests/wealth/test_cvar_profile_defaults.py
@@ -1,4 +1,4 @@
-"""PR-A12.2 — profile-differentiated CVaR defaults."""
+"""PR-A18 — profile-differentiated CVaR defaults (recalibrated from A12.2)."""
 from __future__ import annotations
 
 from decimal import Decimal
@@ -7,29 +7,29 @@ from app.domains.wealth.models.model_portfolio import default_cvar_limit_for_pro
 
 
 def test_conservative_default() -> None:
-    assert default_cvar_limit_for_profile("conservative") == Decimal("0.0250")
+    assert default_cvar_limit_for_profile("conservative") == Decimal("0.0500")
 
 
 def test_moderate_default() -> None:
-    assert default_cvar_limit_for_profile("moderate") == Decimal("0.0500")
+    assert default_cvar_limit_for_profile("moderate") == Decimal("0.0750")
 
 
 def test_growth_default() -> None:
-    assert default_cvar_limit_for_profile("growth") == Decimal("0.0800")
+    assert default_cvar_limit_for_profile("growth") == Decimal("0.1000")
 
 
 def test_aggressive_default() -> None:
-    assert default_cvar_limit_for_profile("aggressive") == Decimal("0.1000")
+    assert default_cvar_limit_for_profile("aggressive") == Decimal("0.1250")
 
 
 def test_unknown_profile_falls_back_to_moderate() -> None:
-    assert default_cvar_limit_for_profile("custom_profile") == Decimal("0.0500")
+    assert default_cvar_limit_for_profile("custom_profile") == Decimal("0.0750")
 
 
 def test_none_profile_falls_back_to_moderate() -> None:
-    assert default_cvar_limit_for_profile(None) == Decimal("0.0500")
+    assert default_cvar_limit_for_profile(None) == Decimal("0.0750")
 
 
 def test_case_insensitive() -> None:
-    assert default_cvar_limit_for_profile("CONSERVATIVE") == Decimal("0.0250")
-    assert default_cvar_limit_for_profile("Growth") == Decimal("0.0800")
+    assert default_cvar_limit_for_profile("CONSERVATIVE") == Decimal("0.0500")
+    assert default_cvar_limit_for_profile("Growth") == Decimal("0.1000")

--- a/frontends/wealth/src/lib/util/profile-defaults.ts
+++ b/frontends/wealth/src/lib/util/profile-defaults.ts
@@ -1,23 +1,24 @@
 /**
  * Profile-differentiated CVaR defaults — mirrors the authoritative backend
  * helper ``app.domains.wealth.models.model_portfolio.default_cvar_limit_for_profile``
- * (PR-A12.2). Keep the two in sync; a future PR may expose these via an
- * admin config endpoint so the frontend stops duplicating the mapping.
+ * (PR-A18, recalibrated from A12.2). Keep the two in sync; a future PR may
+ * expose these via an admin config endpoint so the frontend stops
+ * duplicating the mapping.
  *
- * Unknown / null profile → 0.05 (moderate), matching the backend fallback.
+ * Unknown / null profile → 0.075 (moderate), matching the backend fallback.
  */
 export function defaultCvarForProfile(profile: string | null | undefined): number {
 	switch ((profile ?? "").toLowerCase()) {
 		case "conservative":
-			return 0.025;
+			return 0.05; // PR-A18: was 0.025
 		case "moderate":
-			return 0.05;
+			return 0.075; // PR-A18: was 0.05
 		case "growth":
-			return 0.08;
+			return 0.1; // PR-A18: was 0.08
 		case "aggressive":
-			return 0.1;
+			return 0.125; // PR-A18: was 0.1
 		default:
-			return 0.05;
+			return 0.075; // moderate fallback (PR-A18)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Recalibrate profile-differentiated CVaR defaults from A12.2's aspirational 2.5/5/8/10 to institutional-realistic 5/7.5/10/12.5, grounded in post-A15 empirical universe floors (7.33%/7.44%/10.08%).
- Update backend helper `default_cvar_limit_for_profile()`, frontend mirror `defaultCvarForProfile()`, and migration `0145` backfills `portfolio_calibration` rows matching A12.2 defaults (operator-customized values preserved by whitelist).

## DB state (post-migration)
```
Conservative Preservation | conservative | 0.0500
Balanced Income           | moderate     | 0.0750
Dynamic Growth            | growth       | 0.1000
```

## Expected smoke behavior
| Profile | New limit | Floor (post-A15) | cascade_summary |
|---|---|---|---|
| Conservative | 5.0% | 7.33% | `phase_3_min_cvar_above_limit` (gap 2.33pp — A17.2 unblocks) |
| Balanced | 7.5% | 7.44% | `phase_1_succeeded` or `within_limit` |
| Growth | 10.0% | 10.08% | Borderline (gap 8bp) |

## Test plan
- [x] `pytest backend/tests/wealth/test_cvar_profile_defaults.py` — 7/7 pass
- [x] `alembic upgrade head` clean → head 0145
- [x] SQL spot-check: 3 canonical portfolios reflect new cvar_limit
- [ ] Live construction smoke for all 3 profiles (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)