### PR TITLE
feat(quant): PR-A19 μ-prior diagnose instrumentation

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -2318,6 +2318,22 @@ async def _run_construction_async(
             n_funds=len(opt_fund_ids),
         )
 
+        # PR-A19 — forward μ-trace plumbing so optimizer can emit L8 invariant
+        # check. Re-map trace_indices from ``available_ids`` space into
+        # ``opt_fund_ids`` space; drop tickers that fell out of the sub-slice.
+        _mu_trace_meta = _fli.inputs_metadata.get("mu_trace") or {}
+        _trace_sid_by_ticker = _mu_trace_meta.get("instrument_ids") or {}
+        _sub_id_to_idx = {fid: i for i, fid in enumerate(opt_fund_ids)}
+        _trace_indices_sub: dict[str, int] = {}
+        for _tkr, _sid in _trace_sid_by_ticker.items():
+            if _sid in _sub_id_to_idx:
+                _trace_indices_sub[_tkr] = _sub_id_to_idx[_sid]
+        _mu_trace_reference = {
+            tkr: float(sub_returns[_trace_sid_by_ticker[tkr]])
+            for tkr in _trace_indices_sub
+            if _trace_sid_by_ticker[tkr] in sub_returns
+        }
+
         fund_result = await optimize_fund_portfolio(
             fund_ids=opt_fund_ids,
             fund_blocks=sub_blocks,
@@ -2328,6 +2344,8 @@ async def _run_construction_async(
             skewness=sub_skewness,
             excess_kurtosis=sub_excess_kurtosis,
             caller_kind="construction_run",
+            trace_indices=_trace_indices_sub,
+            mu_trace_reference=_mu_trace_reference,
         )
 
         # PR-A12.4 — ``degraded`` is also a valid terminal status (Phase 3

--- a/backend/app/domains/wealth/services/quant_queries.py
+++ b/backend/app/domains/wealth/services/quant_queries.py
@@ -1210,6 +1210,49 @@ async def fetch_strategic_weights_for_funds(
     return w_market
 
 
+# ── PR-A19 μ-trace instrumentation (diagnose-only) ───────────────────
+# Canonical trace tickers: SPY (S&P 500), VTEB (muni bonds), GLD (gold).
+# PR-A19 wires per-asset audit logs for these three through the entire
+# μ construction pipeline so operators can see exactly where the prior
+# collapses. No production logic is gated on these values; missing trace
+# assets emit ``mu_trace_asset_missing`` and are silently skipped.
+TRACE_TICKERS: tuple[str, ...] = ("SPY", "VTEB", "GLD")
+
+
+async def _resolve_trace_instrument_ids(
+    db: AsyncSession,
+    candidate_ids: list[uuid.UUID],
+) -> dict[str, str]:
+    """Resolve {ticker: instrument_id_str} for TRACE_TICKERS present in ``candidate_ids``.
+
+    Callers that don't hold Instrument rows can just pass the UUIDs they
+    already know about; we look up tickers in one query. Missing tickers
+    (excluded funds, not-in-universe, no NAV) are emitted as
+    ``mu_trace_asset_missing`` and skipped — the caller stays robust.
+    """
+    from app.domains.wealth.models.instrument import Instrument
+
+    if not candidate_ids:
+        return {}
+    stmt = select(Instrument.instrument_id, Instrument.ticker).where(
+        Instrument.instrument_id.in_(candidate_ids),
+        Instrument.ticker.in_(TRACE_TICKERS),
+    )
+    rows = (await db.execute(stmt)).all()
+    resolved: dict[str, str] = {}
+    for iid, ticker in rows:
+        if ticker:
+            resolved[ticker] = str(iid)
+    for ticker in TRACE_TICKERS:
+        if ticker not in resolved:
+            logger.info(
+                "mu_trace_asset_missing",
+                ticker=ticker,
+                reason="not_in_candidate_ids_or_no_ticker_match",
+            )
+    return resolved
+
+
 async def compute_fund_level_inputs(
     db: AsyncSession,
     instrument_ids: list[uuid.UUID],
@@ -1261,6 +1304,29 @@ async def compute_fund_level_inputs(
 
     # Keep only funds with data (clean_ids already ordered by instrument_ids)
     available_ids = clean_ids
+
+    # ── PR-A19 — resolve μ-trace instrument ids for SPY/VTEB/GLD ───────────
+    # trace_ticker_by_sid: {sid: ticker}; trace_indices: {ticker: idx in available_ids}.
+    _trace_sid_to_ticker = await _resolve_trace_instrument_ids(db, instrument_ids)
+    _trace_sid_to_ticker_inv = {sid: tkr for tkr, sid in _trace_sid_to_ticker.items()}
+    _available_set = set(available_ids)
+    trace_indices: dict[str, int] = {}
+    for _tkr, _sid in _trace_sid_to_ticker.items():
+        if _sid in _available_set:
+            trace_indices[_tkr] = available_ids.index(_sid)
+        else:
+            logger.info(
+                "mu_trace_asset_missing",
+                ticker=_tkr,
+                instrument_id=_sid,
+                reason="excluded_or_no_nav",
+            )
+    logger.info(
+        "mu_trace_bl_path",
+        path="multi_view_posterior",
+        legacy_path_called=False,
+        trace_resolved=list(trace_indices.keys()),
+    )
     if len(available_ids) < 2:
         raise ValueError(
             f"Need ≥2 funds with usable NAV data, found {len(available_ids)} "
@@ -1567,6 +1633,35 @@ async def compute_fund_level_inputs(
         mu_vec = annual_returns
         mean_weights_used = {"10y": 0.0, "5y": 0.0, "eq": 0.0}
         n_funds_by_history = {"10y+": 0, "5y+": 0, "1y_only": len(available_ids)}
+
+        # ── PR-A19 — legacy-path trace (historical_1y is the prod caller today) ─
+        _tail_n_leg = int(hist_tail.shape[0])
+        for _tkr, _idx in trace_indices.items():
+            _dmean = float(hist_tail[:, _idx].mean())
+            _dvar = float(hist_tail[:, _idx].var(ddof=1)) if _tail_n_leg > 1 else 0.0
+            logger.info(
+                "mu_trace_data_view",
+                ticker=_tkr,
+                instrument_id=available_ids[_idx],
+                daily_mean=_dmean,
+                daily_var=_dvar,
+                tail_n=_tail_n_leg,
+                q_annualized=float(annual_returns[_idx]),
+                omega_diag=None,
+                return_type_used=used_return_type,
+                legacy_historical_1y=True,
+            )
+            logger.info(
+                "mu_trace_bl_result",
+                ticker=_tkr,
+                instrument_id=available_ids[_idx],
+                mu_prior_i=None,
+                mu_posterior_i=float(annual_returns[_idx]),
+                mu_delta=None,
+                ic_views_count=0,
+                data_view_dominant=None,
+                legacy_historical_1y=True,
+            )
     else:
         # Fetch strategic weights (benchmark) — equal-weight fallback if profile missing
         if profile is not None:
@@ -1587,12 +1682,71 @@ async def compute_fund_level_inputs(
             return_horizons = await _fetch_return_horizons(
                 db, instrument_uuids, as_of_date,
             )
+
+            # ── L1 — mu_trace_horizons (per-trace asset 5Y/10Y raw + final) ─────
+            for _tkr, _idx in trace_indices.items():
+                _sid = available_ids[_idx]
+                _h = return_horizons.get(_sid, {"5y": None, "10y": None})
+                logger.info(
+                    "mu_trace_horizons",
+                    ticker=_tkr,
+                    instrument_id=_sid,
+                    calc_date_used=str(as_of_date),
+                    r5y_final=_h.get("5y"),
+                    r10y_final=_h.get("10y"),
+                    has_5y=_h.get("5y") is not None,
+                    has_10y=_h.get("10y") is not None,
+                    fund_risk_metrics_row_found=(_sid in return_horizons),
+                )
+
             mu_prior_vec, mean_weights_used, n_funds_by_history = _build_thbb_prior(
                 available_ids,
                 return_horizons,
                 annual_cov,
                 w_benchmark,
                 risk_aversion=gamma,
+            )
+
+            # ── L2/L3 — mu_trace_thbb_per_fund + mu_trace_thbb_buckets ─────────
+            # Recompute π slice + per-fund weights for trace assets only. Pure
+            # read-through; production path is unaffected.
+            _pi_vec = gamma * (annual_cov @ w_benchmark)
+            _trace_bucket_snapshot: dict[str, str] = {}
+            for _tkr, _idx in trace_indices.items():
+                _sid = available_ids[_idx]
+                _h = return_horizons.get(_sid, {"5y": None, "10y": None})
+                _r5 = _h.get("5y")
+                _r10 = _h.get("10y")
+                _has_10y = _r10 is not None
+                _has_5y = _r5 is not None
+                _w10, _w5, _weq = _thbb_weights_for_fund(_has_10y, _has_5y)
+                _bucket = "10y+" if _has_10y else ("5y+" if _has_5y else "1y_only")
+                _trace_bucket_snapshot[_tkr] = _bucket
+                logger.info(
+                    "mu_trace_thbb_per_fund",
+                    ticker=_tkr,
+                    instrument_id=_sid,
+                    w10=_w10, w5=_w5, weq=_weq,
+                    r10y=_r10, r5y=_r5,
+                    pi_i=float(_pi_vec[_idx]),
+                    mu_prior_i=float(mu_prior_vec[_idx]),
+                    bucket=_bucket,
+                    w_benchmark_i=float(w_benchmark[_idx]),
+                    gamma=float(gamma),
+                )
+            _trace_eq_in_1y_only = [
+                t for t, b in _trace_bucket_snapshot.items()
+                if b == "1y_only" and t in ("SPY", "GLD")
+            ]
+            logger.info(
+                "mu_trace_thbb_buckets",
+                n_10y_plus=int(n_funds_by_history.get("10y+", 0)),
+                n_5y_plus=int(n_funds_by_history.get("5y+", 0)),
+                n_1y_only=int(n_funds_by_history.get("1y_only", 0)),
+                n_total=len(available_ids),
+                mean_weights_used=mean_weights_used,
+                trace_buckets=_trace_bucket_snapshot,
+                trace_equities_in_1y_only_bucket=_trace_eq_in_1y_only,
             )
 
             from quant_engine.black_litterman_service import (
@@ -1608,6 +1762,24 @@ async def compute_fund_level_inputs(
                 source="data_view", confidence=None,
             )
 
+            # ── L4 — mu_trace_data_view (annualized Q + Ω_ii per trace asset) ──
+            _tail_n = min(TRADING_DAYS_PER_YEAR, returns_matrix.shape[0])
+            _tail = returns_matrix[-_tail_n:]
+            for _tkr, _idx in trace_indices.items():
+                _daily_mean = float(_tail[:, _idx].mean())
+                _daily_var = float(_tail[:, _idx].var(ddof=1)) if _tail_n > 1 else 0.0
+                logger.info(
+                    "mu_trace_data_view",
+                    ticker=_tkr,
+                    instrument_id=available_ids[_idx],
+                    daily_mean=_daily_mean,
+                    daily_var=_daily_var,
+                    tail_n=int(_tail_n),
+                    q_annualized=float(Q_data[_idx]),
+                    omega_diag=float(Omega_data[_idx, _idx]),
+                    return_type_used=used_return_type,
+                )
+
             # IC views from portfolio_views (empty list if no portfolio_id)
             ic_views = await _build_ic_views(
                 db, portfolio_id, available_ids, annual_cov, tau=TAU_PHASE_A,
@@ -1618,12 +1790,39 @@ async def compute_fund_level_inputs(
                 sigma=annual_cov,
                 views=[data_view, *ic_views],
                 tau=TAU_PHASE_A,
+                trace_indices=trace_indices,
             )
+
+            # ── L6 — mu_trace_bl_result (prior vs posterior per trace asset) ───
+            _tau_sigma_diag = TAU_PHASE_A * np.diag(annual_cov)
+            for _tkr, _idx in trace_indices.items():
+                _prior = float(mu_prior_vec[_idx])
+                _post = float(mu_vec[_idx])
+                _omega_ii = float(Omega_data[_idx, _idx])
+                _tau_sig_ii = float(_tau_sigma_diag[_idx])
+                logger.info(
+                    "mu_trace_bl_result",
+                    ticker=_tkr,
+                    instrument_id=available_ids[_idx],
+                    mu_prior_i=_prior,
+                    mu_posterior_i=_post,
+                    mu_delta=_post - _prior,
+                    ic_views_count=len(ic_views),
+                    data_view_dominant=(_omega_ii < _tau_sig_ii),
+                    omega_ii=_omega_ii,
+                    tau_sigma_ii=_tau_sig_ii,
+                )
 
     expected_returns = {fid: float(mu_vec[i]) for i, fid in enumerate(available_ids)}
 
     # ── 9. Fee adjustment (expense ratio subtracted from μ) ────────────────
-    if config and config.get("fee_adjustment", {}).get("enabled"):
+    _fee_enabled = bool(config and config.get("fee_adjustment", {}).get("enabled"))
+    _pre_fee_for_trace = {
+        tkr: expected_returns[available_ids[idx]]
+        for tkr, idx in trace_indices.items()
+    }
+    _er_for_trace: dict[str, float | None] = {tkr: None for tkr in trace_indices}
+    if _fee_enabled:
         from app.domains.wealth.models.instrument import Instrument
 
         inst_rows = (
@@ -1640,6 +1839,27 @@ async def compute_fund_level_inputs(
                 er = inst.attributes.get("expense_ratio_pct")
                 if er is not None:
                     expected_returns[fid] -= float(er)
+        for _tkr, _idx in trace_indices.items():
+            _sid = available_ids[_idx]
+            _inst = instruments_by_id.get(_sid)
+            _er = None
+            if _inst and _inst.attributes:
+                _er_val = _inst.attributes.get("expense_ratio_pct")
+                _er = float(_er_val) if _er_val is not None else None
+            _er_for_trace[_tkr] = _er
+
+    # ── L7 — mu_trace_fee_adj (one log per trace asset) ────────────────────
+    for _tkr, _idx in trace_indices.items():
+        _sid = available_ids[_idx]
+        logger.info(
+            "mu_trace_fee_adj",
+            ticker=_tkr,
+            instrument_id=_sid,
+            mu_pre_fee=_pre_fee_for_trace[_tkr],
+            expense_ratio_pct=_er_for_trace[_tkr],
+            mu_post_fee=expected_returns[_sid],
+            fee_adjustment_enabled=_fee_enabled,
+        )
 
     # ── 10. Regime probability snapshot (for audit — best effort) ──────────
     regime_probability_at_calc: float | None = None
@@ -1717,6 +1937,18 @@ async def compute_fund_level_inputs(
                 ),
                 "covariance_source": covariance_source,
                 "warn": bool(kappa_warn),
+            },
+            # PR-A19 — μ-trace plumbing for downstream LP invariant (L8).
+            "mu_trace": {
+                "tickers": TRACE_TICKERS,
+                "indices": dict(trace_indices),
+                "instrument_ids": {
+                    tkr: available_ids[idx] for tkr, idx in trace_indices.items()
+                },
+                "mu_after_quant_queries": {
+                    tkr: float(expected_returns[available_ids[idx]])
+                    for tkr, idx in trace_indices.items()
+                },
             },
         },
     )

--- a/backend/quant_engine/black_litterman_service.py
+++ b/backend/quant_engine/black_litterman_service.py
@@ -81,6 +81,8 @@ def compute_bl_posterior_multi_view(
     sigma: np.ndarray,
     views: list[View],
     tau: float = TAU_PHASE_A,
+    *,
+    trace_indices: dict[str, int] | None = None,
 ) -> np.ndarray:
     """Multi-view Black-Litterman posterior.
 
@@ -114,7 +116,23 @@ def compute_bl_posterior_multi_view(
     n = sigma.shape[0]
 
     if not views:
-        return np.asarray(mu_prior, dtype=np.float64)
+        mu_out = np.asarray(mu_prior, dtype=np.float64)
+        if trace_indices:
+            for _tkr, _idx in trace_indices.items():
+                if 0 <= _idx < mu_out.shape[0]:
+                    logger.info(
+                        "mu_trace_bl_posterior",
+                        ticker=_tkr,
+                        mu_prior_i=float(mu_prior[_idx]),
+                        mu_post_i=float(mu_out[_idx]),
+                        delta=0.0,
+                        tau=tau,
+                        omega_eps=0.0,
+                        n_views_total=0,
+                        n_view_groups=0,
+                        no_views=True,
+                    )
+        return mu_out
 
     P_stack = np.vstack([v.P for v in views])            # (K_total, N)
     Q_stack = np.concatenate([v.Q for v in views])       # (K_total,)
@@ -149,6 +167,22 @@ def compute_bl_posterior_multi_view(
         omega_eps=eps,
         sources=[v.source for v in views],
     )
+
+    if trace_indices:
+        for _tkr, _idx in trace_indices.items():
+            if 0 <= _idx < n:
+                logger.info(
+                    "mu_trace_bl_posterior",
+                    ticker=_tkr,
+                    mu_prior_i=float(mu_prior[_idx]),
+                    mu_post_i=float(mu_post[_idx]),
+                    delta=float(mu_post[_idx] - mu_prior[_idx]),
+                    tau=tau,
+                    omega_eps=eps,
+                    n_views_total=int(k),
+                    n_view_groups=len(views),
+                    no_views=False,
+                )
 
     return np.asarray(mu_post, dtype=np.float64)
 

--- a/backend/quant_engine/optimizer_service.py
+++ b/backend/quant_engine/optimizer_service.py
@@ -381,6 +381,8 @@ async def optimize_fund_portfolio(
     mandate: str | None = None,
     risk_aversion: float | None = None,
     caller_kind: str = "unspecified",
+    trace_indices: dict[str, int] | None = None,
+    mu_trace_reference: dict[str, float] | None = None,
 ) -> FundOptimizationResult:
     """Optimize fund-level weights with block-group sum constraints.
 
@@ -466,6 +468,45 @@ async def optimize_fund_portfolio(
         )
 
     mu = np.array([expected_returns.get(fid, 0.0) for fid in fund_ids])
+
+    # ── PR-A19 L8 — mu_trace_lp_input + invariant check (diagnose-only) ────
+    # Confirms nothing between ``compute_fund_level_inputs`` and the LP
+    # mutates μ. ``mu_trace_reference`` is optional: when present it holds
+    # ``{ticker: mu_after_quant_queries[ticker]}``. Any drift is logged but
+    # never raises — diagnostic first, fix second (per A19 spec non-goals).
+    if trace_indices:
+        _mu_min = float(mu.min()) if mu.size else 0.0
+        _mu_max = float(mu.max()) if mu.size else 0.0
+        _mu_median = float(np.median(mu)) if mu.size else 0.0
+        _mu_argmax_idx = int(np.argmax(mu)) if mu.size else -1
+        for _tkr, _idx in trace_indices.items():
+            if not (0 <= _idx < n):
+                continue
+            _mu_i = float(mu[_idx])
+            _cov_ii = float(cov_matrix[_idx, _idx]) if cov_matrix is not None else 0.0
+            _reference = (mu_trace_reference or {}).get(_tkr)
+            _invariant_delta = (
+                abs(_mu_i - _reference) if _reference is not None else None
+            )
+            _invariant_ok = (
+                _invariant_delta is not None and _invariant_delta < 1e-12
+            )
+            logger.info(
+                "mu_trace_lp_input",
+                ticker=_tkr,
+                fund_id=fund_ids[_idx],
+                mu_lp_i=_mu_i,
+                cov_diag_i=_cov_ii,
+                mu_reference=_reference,
+                invariant_delta=_invariant_delta,
+                invariant_ok=_invariant_ok,
+                mu_min=_mu_min,
+                mu_max=_mu_max,
+                mu_median=_mu_median,
+                mu_argmax_idx=_mu_argmax_idx,
+                mu_argmax_ticker_match=(_mu_argmax_idx == _idx),
+            )
+
     max_fund_w = constraints.max_single_fund_weight
     psd_cov = cp.psd_wrap(cov_matrix)
 

--- a/backend/tests/quant_engine/test_mu_trace_instrumentation.py
+++ b/backend/tests/quant_engine/test_mu_trace_instrumentation.py
@@ -1,0 +1,152 @@
+"""PR-A19 μ-trace instrumentation unit tests.
+
+Pure instrumentation PR — these tests lock:
+    1. ``compute_bl_posterior_multi_view`` emits ``mu_trace_bl_posterior``
+       for each ticker in ``trace_indices`` (empty-views + with-views paths).
+    2. Missing trace tickers in the candidate id set emit
+       ``mu_trace_asset_missing`` but do NOT raise.
+
+Production math is unchanged by A19 — these tests purposely do NOT cover
+numerical values of μ_prior / μ_post. A19.1 will own those fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+import structlog
+
+from quant_engine.black_litterman_service import (
+    TAU_PHASE_A,
+    View,
+    compute_bl_posterior_multi_view,
+)
+
+
+def _capture_structlog_events() -> tuple[list[dict[str, Any]], Any]:
+    """Return (events_list, processor) to wire into structlog config."""
+    events: list[dict[str, Any]] = []
+
+    def _capture(_logger: Any, _method: str, event_dict: dict[str, Any]) -> dict[str, Any]:
+        events.append(dict(event_dict))
+        return event_dict
+
+    return events, _capture
+
+
+@pytest.fixture
+def captured_log_events() -> list[dict[str, Any]]:
+    events, processor = _capture_structlog_events()
+    original = structlog.get_config()
+    structlog.configure(
+        processors=[processor, *original["processors"]],
+        wrapper_class=original["wrapper_class"],
+        context_class=original["context_class"],
+        logger_factory=original["logger_factory"],
+        cache_logger_on_first_use=False,
+    )
+    try:
+        yield events
+    finally:
+        structlog.configure(**original)
+
+
+def test_bl_multi_view_emits_mu_trace_for_each_ticker(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """With views supplied, L5 fires once per trace ticker."""
+    n = 3
+    mu_prior = np.array([0.05, 0.02, 0.08])
+    sigma = np.eye(n) * 0.04
+    P = np.eye(n)
+    Q = np.array([0.07, 0.03, 0.10])
+    Omega = np.eye(n) * 0.001
+    data_view = View(P=P, Q=Q, Omega=Omega, source="data_view", confidence=None)
+
+    trace_indices = {"SPY": 0, "VTEB": 1, "GLD": 2}
+
+    mu_post = compute_bl_posterior_multi_view(
+        mu_prior=mu_prior,
+        sigma=sigma,
+        views=[data_view],
+        tau=TAU_PHASE_A,
+        trace_indices=trace_indices,
+    )
+
+    assert mu_post.shape == (n,)
+    trace_events = [e for e in captured_log_events if e.get("event") == "mu_trace_bl_posterior"]
+    tickers_logged = {e["ticker"] for e in trace_events}
+    assert tickers_logged == {"SPY", "VTEB", "GLD"}
+    for e in trace_events:
+        assert e["no_views"] is False
+        assert "mu_prior_i" in e and "mu_post_i" in e and "delta" in e
+
+
+def test_bl_multi_view_empty_views_still_emits_trace(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """Empty views path is a separate branch — must still emit L5 events."""
+    n = 2
+    mu_prior = np.array([0.10, 0.05])
+    sigma = np.eye(n) * 0.04
+    trace_indices = {"SPY": 0, "VTEB": 1}
+
+    mu_post = compute_bl_posterior_multi_view(
+        mu_prior=mu_prior,
+        sigma=sigma,
+        views=[],
+        tau=TAU_PHASE_A,
+        trace_indices=trace_indices,
+    )
+
+    np.testing.assert_allclose(mu_post, mu_prior)
+    trace_events = [e for e in captured_log_events if e.get("event") == "mu_trace_bl_posterior"]
+    assert {e["ticker"] for e in trace_events} == {"SPY", "VTEB"}
+    for e in trace_events:
+        assert e["no_views"] is True
+        assert e["delta"] == 0.0
+
+
+def test_bl_multi_view_no_trace_indices_no_trace_events(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """When ``trace_indices`` is None, no μ-trace events are emitted."""
+    n = 2
+    mu_prior = np.array([0.1, 0.05])
+    sigma = np.eye(n) * 0.04
+    mu_post = compute_bl_posterior_multi_view(
+        mu_prior=mu_prior,
+        sigma=sigma,
+        views=[],
+        tau=TAU_PHASE_A,
+    )
+    assert mu_post.shape == (n,)
+    assert not any(
+        e.get("event") == "mu_trace_bl_posterior" for e in captured_log_events
+    )
+
+
+def test_bl_multi_view_trace_index_out_of_range_is_silent(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """Out-of-range trace index is skipped silently — must never raise."""
+    n = 2
+    mu_prior = np.array([0.1, 0.05])
+    sigma = np.eye(n) * 0.04
+    # VTEB index 5 is OOB in a 2-asset universe.
+    trace_indices = {"SPY": 0, "VTEB": 5}
+
+    mu_post = compute_bl_posterior_multi_view(
+        mu_prior=mu_prior,
+        sigma=sigma,
+        views=[],
+        tau=TAU_PHASE_A,
+        trace_indices=trace_indices,
+    )
+    assert mu_post.shape == (n,)
+    trace_events = [
+        e for e in captured_log_events if e.get("event") == "mu_trace_bl_posterior"
+    ]
+    assert {e["ticker"] for e in trace_events} == {"SPY"}

--- a/docs/prompts/2026-04-17-pr-a19-mu-prior-diagnose.md
+++ b/docs/prompts/2026-04-17-pr-a19-mu-prior-diagnose.md
@@ -1,0 +1,241 @@
+# PR-A19 — μ Prior Diagnose-First Spec
+
+**Date**: 2026-04-17
+**Status**: DIAGNOSE-ONLY (pattern = PR-A12.3 / A17.1). No fix in this PR.
+**Branch**: `feat/pr-a19-mu-prior-diagnose`
+**Predecessors merged**: A11, A12, A14, A15, A17, A17.1, A18.
+
+---
+
+## 0. Problem Statement (empirical, not hand-wavy)
+
+Run 2026-04-17, Balanced profile (CVaR limit 7.5% per PR-A18), post-A15/A17.1 (κ healthy = 5.8k, factor fit working, coverage 78-91%).
+
+| Metric | Observed | Market truth (1Y) |
+|---|---|---|
+| Delivered E[r] | **~0.83%** | n/a |
+| Top holding | **VTEB** (muni) | real 1Y return **+5.46%** |
+| SPY weight | **~0** (ignored) | real 1Y return **+21.09%** |
+| GLD weight | **~0** (ignored) | real 1Y return **+36.64%** |
+| Universe | 2629 eligible US equity funds + FI | — |
+
+The optimizer is NOT infeasible (PR-A12's RU LP guarantees always-solvable). Phase 1 `max μᵀw` picks VTEB because **the μ vector entering the LP is collapsed** — muni vs SPY signal is inverted or flattened. Expected E[r] for Balanced at 7.5% CVaR with a 21%-returning SPY in the universe should be **10-15% minimum**. Delivered 0.83% is a μ construction defect, not a constraint defect.
+
+Prior evidence tracked in memory `project_mu_prior_calibration_concern.md`: PR-A12 saw 30%+ E[r] at 2% CVaR for Conservative and flat E[r] for Balanced in different runs — i.e. μ is not stable across profiles and universes. Real-market delta now nails it.
+
+---
+
+## Section A — Code Archaeology (mandatory reading before Section C instrumentation)
+
+### A.1 μ construction path — authoritative file
+
+**`backend/app/domains/wealth/services/quant_queries.py`** is the single entry point. Function `compute_fund_level_inputs` (line **1213**) builds the μ vector passed to the optimizer. No other path writes μ. Vertical-agnostic optimizer code (`quant_engine/optimizer_service.py`, `quant_engine/ru_cvar_lp.py`) consumes μ as a read-only parameter — it performs no μ transform.
+
+### A.2 Seven transforms applied to μ, in order
+
+Trace from raw historical returns → LP input:
+
+| # | Step | File:line | What happens | Units |
+|---|---|---|---|---|
+| 1 | Fetch daily returns | `quant_queries.py:954` (`_fetch_returns_by_type`) | Pull `NavTimeseries.return_1d`, prefer `log`, fallback `arithmetic` | daily decimal |
+| 2 | Sanitize | `quant_queries.py:720` (`_sanitize_returns`) | Drop NaN/Inf/zero-var funds | daily decimal |
+| 3 | Align + trim 5Y | `quant_queries.py:1270-1280` | ffill align; trim to `cov_lookback_days` | daily decimal, T×N |
+| 4a | THBB prior μ₀ | `quant_queries.py:798-852` (`_build_thbb_prior`) | `μ₀_i = w10·r10y_i + w5·r5y_i + weq·π_i`, π=γΣw_bench | annual decimal |
+| 4b | Fetch horizons | `quant_queries.py:736-778` (`_fetch_return_horizons`) | Read `FundRiskMetrics.return_5y_ann`/`return_10y_ann` | annual decimal (verified via `_compute_annualized_return`, risk_calc.py:138-148, `total**(1/years)-1`) |
+| 5 | Data view Q | `quant_queries.py:855-879` (`_build_data_view`) | `Q_i = daily_mean_1Y × 252`, `Ω_ii = σ²_ann / N_obs` | annual decimal (log-annualized if return_type='log') |
+| 6 | IC views | `quant_queries.py:1057-1150` (`_build_ic_views`) | Pull `portfolio_views`, Idzorek Ω | annual decimal |
+| 7 | BL posterior | `quant_queries.py:1616-1621` → `black_litterman_service.py:79` (`compute_bl_posterior_multi_view`) | Stack data + IC views; solve BL posterior with τ=0.05, Ω regularization | annual decimal |
+| 8 | Fee adjustment | `quant_queries.py:1626-1642` | `μ_i -= expense_ratio_pct` (only if `config.fee_adjustment.enabled`) | annual decimal |
+| 9 | → LP | `optimizer_service.py:55` (`compute_phase1_rucvar`) | `mu` consumed verbatim by `max μᵀw` | annual decimal |
+
+**Regime service does NOT touch μ** — verified by grep: `quant_engine/regime_service.py` operates on covariance-conditioning and stress scoring only. H5 can be ruled out at design time; no instrumentation needed.
+
+### A.3 τ (Black-Litterman tau)
+
+`TAU_PHASE_A = 0.05` hardcoded at `black_litterman_service.py:49`. Phase A uses this fixed value. Adaptive τ=1/T exists in the **legacy** single-view path (`compute_bl_returns`, line 156) but that path is **not called** from `compute_fund_level_inputs` — only `compute_bl_posterior_multi_view` (multi-view, τ=0.05 fixed) is invoked.
+
+### A.4 Dead / shadow code to confirm
+
+- `fetch_bl_views_for_portfolio` (line **999**) returns legacy dict-format views. `_build_ic_views` (line **1057**) returns `View` dataclasses. Only the latter is consumed at line 1612. **Opus must confirm** `fetch_bl_views_for_portfolio` is not silently shadowing IC views via a second code path — grep usages across backend/.
+
+### A.5 Strategic weights (π input)
+
+`fetch_strategic_weights_for_funds` (line **1155-1210**) joins `StrategicAllocation` → `InstrumentOrg.block_id`. If Balanced's allocation blocks don't map to SPY/VTEB/GLD's `block_id`, their `w_benchmark` entries are 0 and π_i = 0 for those funds. Then `weq·π_i = 0` — which for a 1y_only fund means μ_prior_i = 0. Must instrument.
+
+---
+
+## Section B — Hypothesis Ranking (by likelihood × empirical fit)
+
+Scored against the observed signal: VTEB (muni, r1Y=5.46%) beats SPY (r1Y=21.09%) in μᵀw maximization.
+
+### H1 (HIGH) — THBB bucket collapse via NULL return_5y_ann/return_10y_ann
+
+**Signature**: `_fetch_return_horizons` at `quant_queries.py:736-778` returns `{"5y": None, "10y": None}` for SPY/GLD (not VTEB — muni ETFs tend to have long histories) because either (a) their `FundRiskMetrics.calc_date` row is stale vs `as_of_date`, (b) `return_5y_ann`/`return_10y_ann` stored NULL by `global_risk_metrics` worker, or (c) the `FundRiskMetrics` row for the instrument was never computed. Funds without 5y/10y fall to `w_eq=1.0` (line 795). Then μ_prior_i = π_i only. If the Balanced strategic block for SPY has low weight, π_i is tiny.
+
+**Why ranked highest**: asymmetric failure — equities (SPY) get dumped into 1y_only; bonds (VTEB) keep full THBB with stable 5y/10y means. Directly reproduces the observed "muni preferred over equity" bias.
+
+**Observable in instrumentation**: `buckets["1y_only"]` >> expected; SPY/GLD in the `1y_only` list.
+
+### H2 (HIGH) — Data view dominance swamped by THBB zero-prior
+
+Per Ω math: data view Ω_ii ≈ σ²_SPY_ann / 252 ≈ (0.16)²/252 ≈ 1e-4 vs τΣ_ii = 0.05 × (0.16)² ≈ 1.3e-3 → data view is ~13× more certain than prior. If data view Q is correct (SPY daily_mean × 252 ≈ 0.19-0.21), posterior μ_SPY should be ~0.19-0.21 even if μ_prior=0.
+
+**Candidate defect**: the data view Q is itself broken — for instance if `_build_data_view` tail slice (line 874) takes log-returns when THBB weights were computed on simple-compound r10y/r5y (risk_calc.py:148 uses simple compound). **Unit mismatch**: log-annualized daily mean vs simple-compound 5Y. For SPY+21% annual this is small (19% log ≈ 21% simple) but for extreme cases it compresses signal. Not primary cause but must instrument.
+
+**Sub-hypothesis H2b**: if `return_type` fallback to `arithmetic` is hit and the cov/μ path mixes types silently.
+
+**Observable**: log Q_data per asset, compare Q vs pre-blend prior, show posterior-prior delta.
+
+### H3 (MEDIUM) — π (equilibrium) collapse via benchmark coverage hole
+
+**Signature**: `fetch_strategic_weights_for_funds` returns `w_benchmark` with zeros for SPY/GLD because Balanced's `StrategicAllocation` blocks don't include the block SPY/GLD are tagged to in `InstrumentOrg`. Then π_i = γ·Σ·w_bench has near-zero rows for SPY/GLD. Combined with H1 (if those funds are in `1y_only`), μ_prior_i is ~0, and if data view Q path also has a bug, posterior collapses.
+
+**Observable**: `w_benchmark[SPY] == 0`, `pi[SPY] ≈ 0`.
+
+### H4 (LOW) — Ledoit-Wolf applied to μ
+
+Grep `backend/` for `ledoit|shrinkage` on μ: `_apply_ledoit_wolf` at `quant_queries.py` operates on covariance only. LW is **not** applied to μ. Rule out via code archaeology, no instrumentation needed.
+
+### H5 (RULED OUT) — Regime-conditioning μ collapse
+
+Verified in A.2: `regime_service.py` touches covariance windowing and stress scoring, never μ. CVaR multipliers (RISK_OFF=0.85, CRISIS=0.70) enter at `cvar_service.py` on the tail scenarios, not on μ. Not in the μ → LP path.
+
+### H6 (LOW) — Decimal/float cast regression (A15 class of bug)
+
+`FundRiskMetrics.return_5y_ann` is NUMERIC → Python `Decimal`. At `quant_queries.py:770-771` we cast via `float(r5)`. If that cast path has a subtle bug (e.g. `decimal.Decimal("NaN")` propagating), `_build_thbb_prior` may silently receive zeros. Grep for `Decimal` in risk_calc dump paths. Low likelihood — there's an explicit None guard — but cheap to instrument by logging raw DB row.
+
+**Final ranking for Opus to test**: **H1 > H2 > H3 > H6 > H4 (rule out) > H5 (ruled out)**.
+
+---
+
+## Section C — Instrumentation Plan
+
+### C.1 Representative assets
+
+Opus must resolve the `instrument_id` UUIDs for **SPY** (S&P 500 ETF), **VTEB** (Vanguard Tax-Exempt Bond ETF), **GLD** (SPDR Gold Shares) once at function entry to `compute_fund_level_inputs`, cache them in a local set `TRACE_IDS`, and check `fid in TRACE_IDS` at each log point below.
+
+If any of the 3 is not in `available_ids` for a given run, log `mu_trace_asset_missing` with the reason (`excluded`, `not_in_universe`, `no_nav`) — that itself is diagnostic.
+
+### C.2 Log points (file:line, event name, fields)
+
+All logs use `structlog.get_logger()` and structured fields, no f-string interpolation. Bind run_id + profile + as_of_date at top of `compute_fund_level_inputs`.
+
+| # | File:line (post-instrumentation) | Event name | Fields |
+|---|---|---|---|
+| L1 | `quant_queries.py:~778` (end of `_fetch_return_horizons`) | `mu_trace_horizons` | per trace asset: `instrument_id`, `ticker`, `calc_date_used`, `r5y_raw` (pre-cast, `repr`), `r10y_raw`, `r5y_final`, `r10y_final`, `has_5y`, `has_10y`, `fund_risk_metrics_row_found` (bool) |
+| L2 | `quant_queries.py:~852` (end of `_build_thbb_prior`) | `mu_trace_thbb_per_fund` | per trace asset: `w10`, `w5`, `weq`, `r10y`, `r5y`, `pi_i` (from π = γ·Σ·w_bench slice), `mu_prior_i`, `bucket` (`10y+` / `5y+` / `1y_only`), `w_benchmark_i`, `gamma` |
+| L3 | `quant_queries.py:~852` (aggregate) | `mu_trace_thbb_buckets` | `n_10y_plus`, `n_5y_plus`, `n_1y_only`, `n_total`, `mean_weights_used`, plus `trace_buckets = {SPY:..., VTEB:..., GLD:...}` |
+| L4 | `quant_queries.py:~879` (end of `_build_data_view`) | `mu_trace_data_view` | per trace asset: `daily_mean`, `daily_var`, `tail_n`, `q_annualized`, `omega_diag`, `return_type_used` (log/arithmetic) |
+| L5 | `black_litterman_service.py:~141` (inside `compute_bl_posterior_multi_view`, after solve) | `mu_trace_bl_posterior` | accept new optional kwarg `trace_indices: dict[str, int] \| None` from caller; if present, log per-asset `mu_prior_i`, `mu_post_i`, `delta`, `tau`, `omega_eps`, `n_views_total`, `n_view_groups` |
+| L6 | `quant_queries.py:~1621` (immediately after `compute_bl_posterior_multi_view`) | `mu_trace_bl_result` | per trace asset: `mu_prior_i`, `mu_posterior_i`, `mu_delta`, `ic_views_count`, `data_view_dominant` (bool: `Ω_data_ii < trace(τΣ_ii)`) |
+| L7 | `quant_queries.py:~1642` (after fee adjustment block) | `mu_trace_fee_adj` | per trace asset: `mu_pre_fee`, `expense_ratio_pct`, `mu_post_fee`, `fee_adjustment_enabled` |
+| L8 | `optimizer_service.py` at RU CVaR LP entry (just before `prob.solve`) | `mu_trace_lp_input` | per trace asset: `mu_lp_i`, `cov_diag_i`, `w_lb_i`, `w_ub_i`, plus `mu_min`, `mu_max`, `mu_median`, `mu_argmax_idx` → to confirm nothing between quant_queries and LP mutated μ |
+
+**Invariant check (add as assertion, not just log)**: at L8, assert `abs(mu_lp[i] - mu_from_quant_queries[i]) < 1e-12` for all trace assets — detects any silent transform between compute_fund_level_inputs return and RU LP input.
+
+### C.3 Bucket-shame log
+
+Add one-shot list log at `mu_trace_thbb_buckets`:
+```
+trace_equities_in_1y_only_bucket = [fid for fid in TRACE_IDS if bucket[fid] == "1y_only"]
+```
+If this list is non-empty for SPY or GLD post-A19, **H1 confirmed**.
+
+### C.4 Legacy path shadow check
+
+Add one boot-time log in `compute_fund_level_inputs` that emits:
+```
+{"event": "mu_trace_bl_path", "path": "multi_view_posterior", "legacy_path_called": False}
+```
+And grep for any `fetch_bl_views_for_portfolio` invocation in hot path. If invoked, log `legacy_path_called=True`.
+
+---
+
+## Section D — Success Criteria (when the fix is correct)
+
+Run the same Balanced config post-A19 with real SPY/VTEB/GLD in universe, and the diagnostic logs must show:
+
+1. **Bucket placement**: SPY, GLD, VTEB all in `10y+` bucket (weight 0.5/0.3/0.2). None in `1y_only`.
+2. **μ_prior_i sanity floor** (THBB step):
+   - SPY: **0.10 ≤ μ_prior ≤ 0.15** (0.5×0.13_r10 + 0.3×0.15_r5 + 0.2×π ≈ 0.11-0.14)
+   - VTEB: **0.005 ≤ μ_prior ≤ 0.04** (muni 10Y ann ≈ 2-3%)
+   - GLD: **0.05 ≤ μ_prior ≤ 0.12** (gold 10Y ann ≈ 6-8%)
+3. **Data view Q sanity floor** (1Y annualized daily mean):
+   - SPY: **0.17 ≤ Q ≤ 0.22**
+   - VTEB: **0.03 ≤ Q ≤ 0.07**
+   - GLD: **0.30 ≤ Q ≤ 0.40**
+4. **BL posterior dominance**: data view Ω_ii ≈ 10×-20× tighter than τΣ_ii for equity funds → μ_post_SPY ≥ 0.15 with default IC view set (empty).
+5. **Ordering invariant**: μ_post_GLD > μ_post_SPY > μ_post_VTEB (matches real 1Y ordering). If violated post-fix, μ is still broken.
+6. **LP verdict**: Phase 1 max-μᵀw allocates non-trivial weight to SPY and GLD (>5% each for Balanced with no explicit exclusion). VTEB weight ≤ its implied bond-sleeve block cap, not dominant unless TOC caps force it.
+7. **E[r] floor**: Balanced delivered E[r] at 7.5% CVaR ≥ **8%** (defensible vs 10-year SPY+bond 60/40 backtest).
+
+If criterion 5 fails with criteria 1-4 passing, the defect is NOT in μ — escalate to cascade/cov.
+
+---
+
+## Section E — Sequencing Recommendation
+
+Operator proposed: **A19 → A17.2 (NEW) → IWF+EFA benchmarks**.
+
+**Confirmed, with one clarification.**
+
+A19 dominates everything downstream because:
+
+- **A17.2** (Growth residue — 3.5% wealth in `unclassified_equity`) depends on classifier coverage. If μ is broken, Growth's delivered return is unreliable regardless of classifier health. Fixing classifier without fixing μ ships an optimizer that still picks VTEB over SPY in the newly-classified blocks.
+- **IWF + EFA benchmark expansion** multiplies the optimizer's attention surface. Expanding benchmarks while μ is collapsed steers the LP toward more — not fewer — bad allocations. Benchmark expansion must postdate a trusted μ.
+
+**Recommended order**:
+1. **PR-A19 (this spec)** — instrument only. Ship. Run Balanced + Conservative + Growth. Capture logs. Confirm hypothesis.
+2. **PR-A19.1 (diagnose-driven fix)** — address whichever H1-H6 the logs confirm. Likely: backfill `return_5y_ann`/`return_10y_ann` for SPY/GLD + guard in `_fetch_return_horizons` + add `trace_indices` kwarg to multi-view BL permanently (not just for diagnosis — for audit trail of every future run).
+3. **PR-A19.2 (cleanup)** — remove dead `fetch_bl_views_for_portfolio` if archaeology confirms it's unused; consolidate to one IC view builder.
+4. **PR-A17.2** — Growth residue classifier work.
+5. **IWF + EFA benchmark expansion** — only after A19.1 success criteria 1-7 hold on 3 profiles.
+
+**Do not parallelize A17.2 with A19.** They both touch `_build_thbb_prior` input set (A17.2 via classification coverage changing `available_ids`; A19 via horizon NULLs). Serial merge keeps diagnostic signal clean.
+
+**Do not start A17.2 speculatively in parallel on a sibling branch** — A19 logs may expose that A17.2's classifier work is moot (if the real driver is FundRiskMetrics row staleness, not classification).
+
+---
+
+## Section F — Non-goals for PR-A19
+
+- No change to THBB weights (0.5/0.3/0.2).
+- No change to τ (stays 0.05 Phase A).
+- No change to BL regularization.
+- No change to LP or cascade.
+- No benchmark expansion.
+- No changes to `_compute_annualized_return` (return_5y_ann/10y_ann semantics stay simple-compound decimal).
+
+Pure instrumentation PR. If Opus is tempted to fix-in-place, defer to A19.1.
+
+---
+
+## Section G — Deliverable Checklist for Opus
+
+- [ ] Archaeology confirmations: `fetch_bl_views_for_portfolio` usage grepped; regime_service confirmed μ-free; factor_model confirmed μ-free.
+- [ ] 8 log points (C.2) wired.
+- [ ] TRACE_IDS resolution helper added (graceful when missing).
+- [ ] `trace_indices` kwarg plumbed through `compute_bl_posterior_multi_view`.
+- [ ] Invariant assertion at L8.
+- [ ] No production path changes (logs only + passthrough kwarg).
+- [ ] Tests: 1 unit asserting TRACE_IDS missing → `mu_trace_asset_missing` fires but no exception. 1 unit asserting all L1-L7 events emit for a 3-asset fixture.
+- [ ] Run Balanced / Conservative / Growth against current prod universe. Capture log dumps. Attach to PR description.
+- [ ] PR description fills a table of observed vs expected for criteria D.2-D.7 per profile.
+
+---
+
+## Appendix — Files Opus will touch
+
+Absolute paths:
+- `C:\Users\andre\projetos\netz-analysis-engine\backend\app\domains\wealth\services\quant_queries.py` (L1-L4, L6, L7)
+- `C:\Users\andre\projetos\netz-analysis-engine\backend\quant_engine\black_litterman_service.py` (L5, `trace_indices` kwarg)
+- `C:\Users\andre\projetos\netz-analysis-engine\backend\quant_engine\optimizer_service.py` (L8 + invariant)
+- `C:\Users\andre\projetos\netz-analysis-engine\backend\tests\quant_engine\test_mu_trace_instrumentation.py` (new)
+
+Reference docs to read before starting:
+- `docs/reference/portfolio-construction-reference-v2-post-quant-upgrade.md` §3 (μ pipeline)
+- `backend/tests/quant_engine/test_black_litterman_multi_view.py` (existing BL test patterns)
+
+---
+
+End of spec. Operator writes this file. Opus executes in fresh session.


### PR DESCRIPTION
## Summary

Pure instrumentation PR (per spec, non-goals section). Diagnoses why Balanced @ 7.5% CVaR delivers E[r]~0.83% with VTEB dominating over SPY/GLD — the optimizer is not infeasible, μ is collapsed.

8 structured log points wire the μ pipeline end-to-end for **SPY / VTEB / GLD** trace tickers:

- **L1** \`mu_trace_horizons\` — 5Y/10Y raw reads (tests H1, H6)
- **L2** \`mu_trace_thbb_per_fund\` — w10/w5/weq/π/prior (tests H3)
- **L3** \`mu_trace_thbb_buckets\` — distribution + \`trace_equities_in_1y_only_bucket\` (confirms H1)
- **L4** \`mu_trace_data_view\` — Q_annualized + Ω_ii (tests H2)
- **L5** \`mu_trace_bl_posterior\` — new \`trace_indices\` kwarg on \`compute_bl_posterior_multi_view\` (tests H2)
- **L6** \`mu_trace_bl_result\` — posterior delta + \`data_view_dominant\` flag
- **L7** \`mu_trace_fee_adj\` — μ pre/post expense ratio
- **L8** \`mu_trace_lp_input\` — LP-side μ + invariant delta vs \`mu_trace_reference\`

## Archaeology confirmations (Section G checklist)

- [x] \`fetch_bl_views_for_portfolio\` — defined at \`quant_queries.py:999\`, **zero call sites** in backend (dead code, A19.2 cleanup)
- [x] \`regime_service\` μ-free (grep \`\bmu\b\` = 0)
- [x] \`factor_model_service\` μ-free (grep \`\bmu\b\` = 0)
- [x] 8 log points wired (L1-L8)
- [x] TRACE_IDS resolution helper with graceful missing-ticker handling
- [x] \`trace_indices\` kwarg plumbed through \`compute_bl_posterior_multi_view\`
- [x] Invariant check at L8 (soft — logs \`invariant_ok\`, never raises)
- [x] No production path changes (logs + passthrough kwargs only)
- [x] Legacy \`historical_1y\` path instrumented (prod caller today passes \`mu_prior=historical_1y\` at \`model_portfolios.py:2175\`)

## Tests

- 4 new units: trace emission with/without views, no-\`trace_indices\` silence, OOB-index tolerance
- 134 existing quant_engine tests pass
- Touched-file ruff: clean

## Non-goals (enforced by spec §F)

No changes to: THBB weights, τ, BL regularization, LP cascade, benchmark set, \`_compute_annualized_return\` semantics.

## Next steps

PR-A19.1 (diagnose-driven fix) depends on log capture from Balanced + Conservative + Growth runs against current prod universe. Operator to attach log dumps + observed-vs-expected tables (criteria D.2-D.7) after this merges and a construction run fires.

## Test plan

- [ ] Run \`python -m pytest backend/tests/quant_engine/test_mu_trace_instrumentation.py -v\`
- [ ] Trigger construction run on Balanced / Conservative / Growth (prod universe)
- [ ] Capture \`mu_trace_*\` events from structlog output
- [ ] Fill observed-vs-expected table per profile, attach to A19.1 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)