### PR TITLE
PR-A20: universe sync canonical backfill

### DIFF
--- a/backend/app/core/db/migrations/versions/0147_canonical_catalog_backfill.py
+++ b/backend/app/core/db/migrations/versions/0147_canonical_catalog_backfill.py
@@ -1,0 +1,115 @@
+"""PR-A20 Section A — canonical catalog backfill for 4 missing tickers.
+
+PR-A19.1 migration 0146 backfilled only 6 of 10 canonical liquid-beta
+tickers into ``instruments_org`` because the other 4 (IVV, BND, TLT,
+SHY) were absent from the upstream ``instruments_universe`` catalog.
+Universe sync populates the catalog from SEC filings, and these four
+happen to be outside that discovery path (direct issuer ETFs not
+indexed by the current sec_etfs/sec_registered_funds joins).
+
+This migration inserts the 4 missing tickers directly with attribute
+metadata sufficient to satisfy the ``chk_fund_attrs`` CHECK and the
+downstream optimizer pipeline. Source is flagged ``pr_a20_backfill``
+for audit.
+
+NAV history (required by the optimizer) is NOT populated here — the
+``instrument_ingestion`` worker (lock 900_010) pulls OHLC from the
+configured provider for every active ticker in ``instruments_universe``
+on its daily schedule. A one-off trigger script lives at
+``backend/scripts/pr_a20_trigger_canonical_ingestion.py``.
+
+Idempotent: ``WHERE NOT EXISTS`` guards each row, so re-running the
+migration is a no-op.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0147_canonical_catalog_backfill"
+down_revision = "0146_canonical_liquid_beta_backfill"
+branch_labels = None
+depends_on = None
+
+
+# Seed rows for tickers that universe_sync does not reliably discover.
+# inception_date and manager_name are required by chk_fund_attrs on
+# instruments_universe (fund type). aum_usd is seeded at a conservative
+# floor — the next universe_sync run will overwrite these attributes
+# once upstream SEC catalogs index the ticker.
+_CANONICAL_SEED: list[dict[str, str]] = [
+    {
+        "ticker": "IVV",
+        "name": "iShares Core S&P 500 ETF",
+        "asset_class": "equity",
+        "manager_name": "BlackRock Fund Advisors",
+        "inception_date": "2000-05-15",
+    },
+    {
+        "ticker": "BND",
+        "name": "Vanguard Total Bond Market ETF",
+        "asset_class": "fixed_income",
+        "manager_name": "Vanguard Group",
+        "inception_date": "2007-04-03",
+    },
+    {
+        "ticker": "TLT",
+        "name": "iShares 20+ Year Treasury Bond ETF",
+        "asset_class": "fixed_income",
+        "manager_name": "BlackRock Fund Advisors",
+        "inception_date": "2002-07-22",
+    },
+    {
+        "ticker": "SHY",
+        "name": "iShares 1-3 Year Treasury Bond ETF",
+        "asset_class": "fixed_income",
+        "manager_name": "BlackRock Fund Advisors",
+        "inception_date": "2002-07-22",
+    },
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    insert_sql = sa.text(
+        """
+        INSERT INTO instruments_universe (
+            instrument_id, instrument_type, name, ticker,
+            asset_class, geography, currency, is_active, attributes
+        )
+        SELECT
+            gen_random_uuid(),
+            'fund',
+            :name,
+            :ticker,
+            :asset_class,
+            'north_america',
+            'USD',
+            true,
+            jsonb_build_object(
+                'manager_name', :manager_name,
+                'inception_date', :inception_date,
+                'aum_usd', 0,
+                'sec_universe', 'etf',
+                'fund_subtype', 'etf',
+                'source', 'pr_a20_backfill'
+            )
+        WHERE NOT EXISTS (
+            SELECT 1 FROM instruments_universe iu
+            WHERE iu.ticker = :ticker
+        )
+        """
+    )
+
+    for row in _CANONICAL_SEED:
+        conn.execute(insert_sql, row)
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM instruments_universe
+        WHERE attributes->>'source' = 'pr_a20_backfill'
+        """
+    )

--- a/backend/app/core/db/migrations/versions/0148_canonical_org_backfill.py
+++ b/backend/app/core/db/migrations/versions/0148_canonical_org_backfill.py
@@ -1,0 +1,113 @@
+"""PR-A20 Section C — canonical org-scope backfill for 5 new tickers.
+
+After migration 0147 seeded IVV, BND, TLT, SHY into
+``instruments_universe`` and the Section-B trigger populated NAV
+history for those four plus VTI, every wealth org still needs each
+ticker in ``instruments_org`` with ``approval_status='approved'`` to
+enter the optimizer universe.
+
+This migration replays migration 0146's per-org × per-ticker INSERT
+for the 5 tickers the earlier pass could not fully handle:
+
+* VTI — already catalog-present; 0146 backfilled it when the ticker
+  row existed, but this migration is safe to re-run (ON CONFLICT DO
+  NOTHING on UNIQUE (organization_id, instrument_id)).
+* IVV, BND, TLT, SHY — new in 0147.
+
+Source flagged ``pr_a20_backfill`` for audit; downgrade removes only
+rows this migration wrote. Block mapping reuses 0146's
+``CANONICAL_BLOCK_MAP`` semantics.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0148_canonical_org_backfill"
+down_revision = "0147_canonical_catalog_backfill"
+branch_labels = None
+depends_on = None
+
+
+# Reuse 0146's block_id mapping. Scope limited to the 5 tickers that
+# PR-A20 addresses. If an allocation_blocks row is missing, backfill
+# proceeds with NULL block_id (non-blocking — operators remap in UI).
+CANONICAL_BLOCK_MAP: dict[str, str | None] = {
+    "VTI": "na_equity_large",
+    "IVV": "na_equity_large",
+    "BND": "fi_aggregate",
+    "TLT": "fi_govt",
+    "SHY": "fi_short_term",
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    resolved_map: dict[str, str | None] = {}
+    for ticker, block_id in CANONICAL_BLOCK_MAP.items():
+        # Skip tickers still absent from the catalog — 0147 covered the
+        # known-missing ones, but guard against divergence in future
+        # re-runs on partially-migrated clones.
+        present = conn.execute(
+            sa.text(
+                "SELECT 1 FROM instruments_universe WHERE ticker = :t"
+            ),
+            {"t": ticker},
+        ).scalar()
+        if not present:
+            print(
+                f"WARNING pr_a20_catalog_missing ticker={ticker} — "
+                "skipped from org backfill"
+            )
+            continue
+
+        if block_id is None:
+            resolved_map[ticker] = None
+            continue
+        exists = conn.execute(
+            sa.text("SELECT 1 FROM allocation_blocks WHERE block_id = :bid"),
+            {"bid": block_id},
+        ).scalar()
+        if not exists:
+            print(
+                f"WARNING pr_a20_block_missing ticker={ticker} "
+                f"block_id={block_id} — inserting with NULL block_id"
+            )
+            resolved_map[ticker] = None
+        else:
+            resolved_map[ticker] = block_id
+
+    for ticker, block_id in resolved_map.items():
+        block_expr = "NULL" if block_id is None else f"'{block_id}'"
+        op.execute(
+            f"""
+            INSERT INTO instruments_org
+                (organization_id, instrument_id, block_id, approval_status,
+                 source, block_overridden)
+            SELECT
+                o.id,
+                iu.instrument_id,
+                {block_expr},
+                'approved',
+                'pr_a20_backfill',
+                FALSE
+            FROM (
+                SELECT DISTINCT organization_id AS id FROM instruments_org
+                UNION
+                SELECT DISTINCT organization_id AS id FROM model_portfolios
+            ) o
+            CROSS JOIN instruments_universe iu
+            WHERE iu.ticker = '{ticker}'
+            ON CONFLICT (organization_id, instrument_id) DO NOTHING
+            """
+        )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM instruments_org
+        WHERE source = 'pr_a20_backfill'
+        """
+    )

--- a/backend/scripts/pr_a20_trigger_canonical_ingestion.py
+++ b/backend/scripts/pr_a20_trigger_canonical_ingestion.py
@@ -1,0 +1,141 @@
+"""PR-A20 Section B — one-off NAV ingestion for canonical tickers.
+
+Pulls 5y of daily OHLC from the configured instrument provider for
+the 5 tickers that are missing NAV history after migration 0147:
+
+* VTI — in the catalog, 0 nav_timeseries rows (audit evidence
+  2026-04-18 01:15 UTC).
+* IVV, BND, TLT, SHY — freshly inserted by migration 0147.
+
+Scoped to these tickers only so it runs in <30s; the full
+`instrument_ingestion` worker (~9k tickers) is not required. Writes
+into the global `nav_timeseries` hypertable, bypassing the advisory
+lock because this is a narrow manual trigger, not the nightly worker
+path.
+
+Idempotent — `ON CONFLICT (instrument_id, nav_date)` DO UPDATE preserves
+the latest provider value. Safe to re-run.
+"""
+from __future__ import annotations
+
+import asyncio
+import math
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent.parent / ".env")
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import structlog  # noqa: E402
+from sqlalchemy import text  # noqa: E402
+
+from app.core.db.engine import async_session_factory  # noqa: E402
+from app.services.providers import get_instrument_provider  # noqa: E402
+
+logger = structlog.get_logger()
+
+CANONICAL_TICKERS = ["VTI", "IVV", "BND", "TLT", "SHY"]
+LOOKBACK_PERIOD = "5y"  # ≥ 1260 trading days per spec §1.B
+UPSERT_CHUNK = 500
+
+
+async def main() -> None:
+    async with async_session_factory() as db:
+        db.expire_on_commit = False  # type: ignore[attr-defined]
+
+        ticker_map: dict[str, str] = {}
+        for ticker in CANONICAL_TICKERS:
+            row = await db.execute(
+                text(
+                    "SELECT instrument_id::text FROM instruments_universe "
+                    "WHERE ticker = :t AND is_active LIMIT 1"
+                ),
+                {"t": ticker},
+            )
+            instrument_id = row.scalar()
+            if not instrument_id:
+                logger.warning("ticker_not_in_catalog", ticker=ticker)
+                continue
+            ticker_map[ticker] = instrument_id
+
+        if not ticker_map:
+            print("No canonical tickers resolved — aborting.")
+            return
+
+        provider = get_instrument_provider()
+        history = await asyncio.to_thread(
+            provider.fetch_batch_history,
+            list(ticker_map.keys()),
+            LOOKBACK_PERIOD,
+        )
+
+        all_rows: list[dict[str, object]] = []
+        for ticker, instrument_id in ticker_map.items():
+            ticker_data = history.get(ticker) if history else None
+            if ticker_data is None or ticker_data.empty:
+                print(f"{ticker}: provider returned no data")
+                continue
+            if "Close" not in ticker_data.columns:
+                print(f"{ticker}: no Close column")
+                continue
+            ticker_data = ticker_data.dropna(subset=["Close"])
+            prev_close: float | None = None
+            count = 0
+            for idx, row in ticker_data.iterrows():
+                nav_date = idx.date() if hasattr(idx, "date") else idx
+                close_price = float(row["Close"])
+                if close_price <= 0:
+                    prev_close = None
+                    continue
+                return_1d = None
+                if prev_close is not None and prev_close > 0:
+                    return_1d = math.log(close_price / prev_close)
+                prev_close = close_price
+                all_rows.append(
+                    {
+                        "instrument_id": instrument_id,
+                        "nav_date": nav_date,
+                        "nav": round(close_price, 6),
+                        "return_1d": round(return_1d, 8)
+                        if return_1d is not None
+                        else None,
+                        "return_type": "log",
+                        "currency": "USD",
+                        "source": "tiingo",
+                    }
+                )
+                count += 1
+            print(f"{ticker}: {count} rows prepared")
+
+        if not all_rows:
+            print("No rows to upsert.")
+            return
+
+        upsert_sql = text(
+            """
+            INSERT INTO nav_timeseries
+                (instrument_id, nav_date, nav, return_1d, return_type, currency, source)
+            VALUES
+                (:instrument_id, :nav_date, :nav, :return_1d, :return_type, :currency, :source)
+            ON CONFLICT (instrument_id, nav_date)
+            DO UPDATE SET
+                nav = EXCLUDED.nav,
+                return_1d = EXCLUDED.return_1d,
+                return_type = EXCLUDED.return_type,
+                currency = EXCLUDED.currency,
+                source = EXCLUDED.source
+            """
+        )
+        total = 0
+        for i in range(0, len(all_rows), UPSERT_CHUNK):
+            chunk = all_rows[i : i + UPSERT_CHUNK]
+            await db.execute(upsert_sql, chunk)
+            await db.commit()
+            total += len(chunk)
+        print(f"Upserted {total} NAV rows across {len(ticker_map)} tickers.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/wealth/test_canonical_ingestion_coverage.py
+++ b/backend/tests/wealth/test_canonical_ingestion_coverage.py
@@ -1,0 +1,79 @@
+"""PR-A20 — canonical ingestion backfill determinism.
+
+Migration 0147 seeds 4 canonical tickers absent from the upstream
+universe_sync discovery paths; migration 0148 replays the per-org
+backfill for those 4 plus VTI. This test pins:
+
+* the seed ticker set on 0147,
+* the block map on 0148,
+* the attribute keys required by the ``chk_fund_attrs`` CHECK on
+  ``instruments_universe`` (aum_usd, manager_name, inception_date).
+
+Edits that drift from the spec surface in review rather than in
+live smoke.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_migration(filename: str):
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "app" / "core" / "db" / "migrations" / "versions" / filename
+    )
+    spec = importlib.util.spec_from_file_location(filename.split(".")[0], path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── Migration 0147 (catalog backfill) ────────────────────────────────
+
+
+def test_0147_seed_targets_four_missing_tickers() -> None:
+    mod = _load_migration("0147_canonical_catalog_backfill.py")
+    tickers = {row["ticker"] for row in mod._CANONICAL_SEED}
+    assert tickers == {"IVV", "BND", "TLT", "SHY"}
+
+
+def test_0147_equity_vs_fixed_income_asset_class() -> None:
+    mod = _load_migration("0147_canonical_catalog_backfill.py")
+    by_ticker = {row["ticker"]: row["asset_class"] for row in mod._CANONICAL_SEED}
+    assert by_ticker["IVV"] == "equity"
+    assert by_ticker["BND"] == "fixed_income"
+    assert by_ticker["TLT"] == "fixed_income"
+    assert by_ticker["SHY"] == "fixed_income"
+
+
+def test_0147_seed_rows_carry_required_attribute_fields() -> None:
+    # chk_fund_attrs on instruments_universe requires aum_usd +
+    # manager_name + inception_date. The migration injects these via
+    # jsonb_build_object with parameter placeholders; the seed list
+    # must carry manager_name and inception_date (aum_usd is hard-
+    # coded in the SQL literal).
+    mod = _load_migration("0147_canonical_catalog_backfill.py")
+    for row in mod._CANONICAL_SEED:
+        assert row["manager_name"], row
+        assert row["inception_date"], row
+        assert row["name"], row
+
+
+# ── Migration 0148 (org backfill) ────────────────────────────────────
+
+
+def test_0148_scope_covers_five_canonical_tickers() -> None:
+    mod = _load_migration("0148_canonical_org_backfill.py")
+    assert set(mod.CANONICAL_BLOCK_MAP) == {"VTI", "IVV", "BND", "TLT", "SHY"}
+
+
+def test_0148_block_map_matches_0146() -> None:
+    # Prevent drift between the A19.1 and A20 backfill paths — both must
+    # assign the same ticker → block_id mapping so operators see a
+    # single consistent allocation layout.
+    a146 = _load_migration("0146_canonical_liquid_beta_backfill.py")
+    a148 = _load_migration("0148_canonical_org_backfill.py")
+    for ticker, block_id in a148.CANONICAL_BLOCK_MAP.items():
+        assert a146.CANONICAL_BLOCK_MAP[ticker] == block_id, ticker


### PR DESCRIPTION
## Summary
- **Section A (migration 0147):** seed IVV, BND, TLT, SHY into `instruments_universe` (absent from upstream `universe_sync` discovery paths, which caused PR-A19.1 migration 0146 to backfill only 6 of 10 canonical tickers per org).
- **Section B (trigger script):** scoped one-off script `pr_a20_trigger_canonical_ingestion.py` that pulls 5y daily OHLC from Tiingo for VTI (catalog-present, NAV-empty) + the 4 new tickers.
- **Section C (migration 0148):** replay 0146's per-org × per-ticker INSERT for the 5 tickers PR-A20 covers; idempotent via `ON CONFLICT (organization_id, instrument_id) DO NOTHING`.
- **Section D (tests):** `test_canonical_ingestion_coverage.py` pins 0147 seed set, asset-class mapping, required attribute keys, and cross-checks 0148 block map against 0146.

## Spec
`docs/prompts/2026-04-18-pr-a20-universe-sync-canonical-backfill.md`

## Test plan
- [x] New test file passes (`pytest backend/tests/wealth/test_canonical_ingestion_coverage.py` — 5/5).
- [ ] `make migrate` — 0146 → 0147 → 0148 clean on staging DB.
- [ ] Run `python backend/scripts/pr_a20_trigger_canonical_ingestion.py` — ≥245 NAV rows per ticker for trailing 1Y (S.2).
- [ ] Verify `instruments_universe` canonical coverage = 10/10 (S.1).
- [ ] Verify `instruments_org` coverage = 10/10 approved for every wealth org (S.3).
- [ ] Re-run 3 canonical portfolio builds. Conservative `winner_signal` flips `cvar_infeasible_min_var` → `optimal` at CVaR 5% (S.4).
- [ ] Once S.4 verified, convert PR to ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)