### PR TITLE
PR-A22: block coverage validator (operator-facing pre-run check)

### DIFF
--- a/backend/app/core/db/migrations/versions/0150_winner_signal_block_coverage.py
+++ b/backend/app/core/db/migrations/versions/0150_winner_signal_block_coverage.py
@@ -1,0 +1,30 @@
+"""PR-A22 — document ``block_coverage_insufficient`` winner signal.
+
+No schema change is required. ``portfolio_construction_runs.cascade_telemetry``
+is a free-form JSONB column (see migration ``0142_construction_cascade_telemetry``);
+``winner_signal`` is a JSON key inside that column and has no CHECK
+constraint or Postgres ENUM backing. The Python ``WinnerSignal`` enum
+in ``app/domains/wealth/schemas/sanitized.py`` is the single source
+of truth for allowed values — PR-A22 extends it with
+``BLOCK_COVERAGE_INSUFFICIENT = 'block_coverage_insufficient'``.
+
+This migration exists only as an audit marker so the decision is
+traceable in ``alembic history``. ``upgrade`` and ``downgrade`` are
+both no-ops.
+"""
+from __future__ import annotations
+
+revision = "0150_winner_signal_block_coverage"
+down_revision = "0149_sanitize_org_universe"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # No schema change — see module docstring.
+    pass
+
+
+def downgrade() -> None:
+    # No schema change — see module docstring.
+    pass

--- a/backend/app/domains/wealth/schemas/sanitized.py
+++ b/backend/app/domains/wealth/schemas/sanitized.py
@@ -90,6 +90,12 @@ class WinnerSignal(str, Enum):
     DEGRADED_OTHER = "degraded_other"
     # No winner at all: empty universe, PSD violation, polytope empty.
     PRE_SOLVE_FAILURE = "pre_solve_failure"
+    # PR-A22 — cascade aborted before the optimizer ran because one or
+    # more blocks in the profile's StrategicAllocation have zero
+    # approved candidates in ``instruments_org``. Operator remedy:
+    # expand the approved universe for those blocks or zero their
+    # target_weight explicitly.
+    BLOCK_COVERAGE_INSUFFICIENT = "block_coverage_insufficient"
 
 
 def compute_winner_signal(

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -73,10 +73,16 @@ from app.domains.wealth.models.model_portfolio import (
     PortfolioStressResult,
 )
 from app.domains.wealth.schemas.sanitized import (
+    WinnerSignal,
     build_operator_message,
     compute_winner_signal,
     humanize_event_type,
     sanitize_payload,
+)
+from quant_engine.block_coverage_service import (
+    CoverageReport,
+    build_coverage_operator_message,
+    validate_block_coverage,
 )
 from vertical_engines.wealth.model_portfolio.narrative_templater import (
     render_narrative,
@@ -116,6 +122,22 @@ class RunCancelledError(Exception):
     def __init__(self, phase: str) -> None:
         super().__init__(f"construction cancelled at phase {phase}")
         self.phase = phase
+
+
+class CoverageInsufficientError(Exception):
+    """PR-A22 — raised when block coverage validation fails pre-optimizer.
+
+    Carries the full :class:`CoverageReport` so the top-level handler
+    can persist it into ``cascade_telemetry`` and emit a structured SSE
+    event. The optimizer is never invoked when this exception bubbles.
+    """
+
+    def __init__(self, report: CoverageReport) -> None:
+        super().__init__(
+            f"block_coverage_insufficient gaps={len(report.gaps)} "
+            f"weight_at_risk={report.total_target_weight_at_risk:.4f}"
+        )
+        self.report = report
 
 
 # ── Helpers ────────────────────────────────────────────────────
@@ -863,6 +885,39 @@ async def _build_advisor_result(
     }
 
 
+async def _persist_coverage_failure(
+    db: AsyncSession,
+    *,
+    run: PortfolioConstructionRun,
+    report: CoverageReport,
+) -> None:
+    """PR-A22 — persist the block-coverage failure to the run row.
+
+    Writes a structured ``cascade_telemetry`` payload that mirrors the
+    shape of the normal cascade (``winner_signal`` +
+    ``operator_message``) plus a ``coverage_report`` envelope with the
+    per-block gap detail. Frontend consumers branch on
+    ``winner_signal = 'block_coverage_insufficient'``.
+    """
+    operator_message = build_coverage_operator_message(report)
+    existing_telemetry = run.cascade_telemetry or {}
+    run.cascade_telemetry = {
+        **existing_telemetry,
+        "winner_signal": WinnerSignal.BLOCK_COVERAGE_INSUFFICIENT.value,
+        "operator_signal": WinnerSignal.BLOCK_COVERAGE_INSUFFICIENT.value,
+        "operator_message": operator_message,
+        "coverage_report": report.model_dump(mode="json"),
+        # cascade never ran — flag it so downstream readers know to
+        # skip stress/advisor/validation rendering.
+        "cascade_summary": "block_coverage_insufficient",
+    }
+    run.status = "failed"
+    run.failure_reason = (
+        f"block_coverage_insufficient: {len(report.gaps)} gap(s), "
+        f"{report.total_target_weight_at_risk:.1%} of mandate uncovered"
+    )
+
+
 # ── Main entry point ──────────────────────────────────────────
 
 
@@ -976,6 +1031,36 @@ async def execute_construction_run(
         logger.warning(
             "construction_run_timeout",
             extra={"run_id": str(run_id), "portfolio_id": str(portfolio_id)},
+        )
+        return run
+    except CoverageInsufficientError as coverage_exc:
+        # PR-A22 — pre-solve failure with structured gap report.
+        await _persist_coverage_failure(
+            db, run=run, report=coverage_exc.report,
+        )
+        run.completed_at = datetime.now(tz=timezone.utc)
+        run.wall_clock_ms = int((time.perf_counter() - start_ts) * 1000)
+        await db.flush()
+        await _publish_terminal_event_sanitized(
+            db,
+            run_id=run_id,
+            job_id=job_id,
+            raw_type="run_failed",
+            raw_payload={
+                "run_id": str(run_id),
+                "reason": "block_coverage_insufficient",
+                "winner_signal": WinnerSignal.BLOCK_COVERAGE_INSUFFICIENT.value,
+                "coverage_report": coverage_exc.report.model_dump(mode="json"),
+            },
+        )
+        logger.info(
+            "construction_run_block_coverage_insufficient",
+            extra={
+                "run_id": str(run_id),
+                "portfolio_id": str(portfolio_id),
+                "gaps": [g.block_id for g in coverage_exc.report.gaps],
+                "weight_at_risk": coverage_exc.report.total_target_weight_at_risk,
+            },
         )
         return run
     except RunCancelledError as cancel_exc:
@@ -1111,6 +1196,16 @@ async def _execute_inner(
         raise LookupError(f"portfolio {portfolio_id} not found")
     profile = portfolio.profile
     organization_id = portfolio.organization_id
+
+    # ── PR-A22. Block coverage gate — fail fast if any block in the
+    # profile's StrategicAllocation has zero approved candidates in
+    # the org's universe. Runs BEFORE the optimizer so the cascade is
+    # never invoked against an ill-specified mandate. The operator
+    # sees a structured gap report instead of a silently redistributed
+    # portfolio.
+    coverage = await validate_block_coverage(db, organization_id, profile)
+    if not coverage.is_sufficient:
+        raise CoverageInsufficientError(coverage)
 
     await _check_cancellation(job_id, "pre_optimizer")
     await _publish_event_sanitized(

--- a/backend/quant_engine/block_coverage_service.py
+++ b/backend/quant_engine/block_coverage_service.py
@@ -1,0 +1,235 @@
+"""PR-A22 — Block Coverage Validator.
+
+Pre-run check that hard-fails portfolio construction when any block in
+the profile's ``StrategicAllocation`` has zero approved candidates in
+the org's universe. Replaces the silent fallback where the optimizer
+would redistribute missing-block weight across blocks that DO have
+candidates, producing a portfolio that violates the declared mandate
+without any operator signal.
+
+Called as the first step of ``construction_run_executor`` — before
+universe loading, before statistical inputs, before the solver. If the
+report ``is_sufficient = False`` the run is marked ``failed`` with
+``winner_signal = 'block_coverage_insufficient'`` and a structured
+gap report is persisted to ``cascade_telemetry.coverage_report``.
+
+Design principles
+-----------------
+* **No threshold.** Any block with ``target_weight > 0`` and
+  ``n_candidates = 0`` fails the validator. If the operator wants to
+  run with a gap they must explicitly set the block's
+  ``target_weight`` to zero in their ``StrategicAllocation`` — an
+  explicit mandate decision, not a silent substitution.
+* **Deduplicate strategic_allocation rows.** The profile may
+  transiently have more than one row per block (historical defect).
+  The validator reduces to one row per ``block_id`` by keeping the
+  max ``target_weight`` so a true coverage picture surfaces.
+* **Catalog suggestions are best-effort.** Operator sees counts plus
+  the top-5 tickers by AUM so they can go to the universe editor and
+  import candidates — the validator never auto-imports.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from vertical_engines.wealth.model_portfolio.block_mapping import (
+    strategy_labels_for_block,
+)
+
+
+class BlockCoverageGap(BaseModel):
+    """One entry per uncovered block in the report."""
+
+    block_id: str
+    target_weight: float
+    suggested_strategy_labels: list[str] = Field(default_factory=list)
+    catalog_candidates_available: int = 0
+    example_tickers: list[str] = Field(default_factory=list)
+
+
+class CoverageReport(BaseModel):
+    """Coverage status for one ``(organization_id, profile)`` pair."""
+
+    organization_id: uuid.UUID
+    profile: str
+    is_sufficient: bool
+    total_target_weight_at_risk: float = 0.0
+    gaps: list[BlockCoverageGap] = Field(default_factory=list)
+
+
+_STRATEGIC_ALLOCATION_SQL = text(
+    """
+    SELECT block_id, MAX(target_weight) AS target_weight
+      FROM strategic_allocation
+     WHERE profile = :profile
+       AND organization_id = :organization_id
+       AND target_weight > 0
+       AND (effective_to IS NULL OR effective_to > CURRENT_DATE)
+     GROUP BY block_id
+    """
+)
+
+_APPROVED_COUNT_SQL = text(
+    """
+    SELECT COUNT(*)
+      FROM instruments_org
+     WHERE organization_id = :organization_id
+       AND block_id = :block_id
+       AND approval_status = 'approved'
+    """
+)
+
+_CATALOG_CANDIDATES_SQL = text(
+    """
+    SELECT ticker
+      FROM instruments_universe
+     WHERE is_active = TRUE
+       AND is_institutional = TRUE
+       AND attributes->>'strategy_label' = ANY(CAST(:labels AS text[]))
+     ORDER BY
+        COALESCE(NULLIF(attributes->>'aum_usd', '')::numeric, 0) DESC
+          NULLS LAST
+     LIMIT 5
+    """
+)
+
+_CATALOG_COUNT_SQL = text(
+    """
+    SELECT COUNT(*)
+      FROM instruments_universe
+     WHERE is_active = TRUE
+       AND is_institutional = TRUE
+       AND attributes->>'strategy_label' = ANY(CAST(:labels AS text[]))
+    """
+)
+
+
+async def _count_approved(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    block_id: str,
+) -> int:
+    row = await db.execute(
+        _APPROVED_COUNT_SQL,
+        {"organization_id": organization_id, "block_id": block_id},
+    )
+    return int(row.scalar_one() or 0)
+
+
+async def _catalog_snapshot(
+    db: AsyncSession,
+    *,
+    labels: list[str],
+) -> tuple[int, list[str]]:
+    """Return ``(count, top5_tickers)`` for a given set of strategy labels.
+
+    Gracefully degrades to ``(0, [])`` when ``labels`` is empty so the
+    caller never has to special-case an unmapped block.
+    """
+    if not labels:
+        return 0, []
+    count_row = await db.execute(_CATALOG_COUNT_SQL, {"labels": labels})
+    count = int(count_row.scalar_one() or 0)
+    if count == 0:
+        return 0, []
+    tickers_row = await db.execute(_CATALOG_CANDIDATES_SQL, {"labels": labels})
+    tickers = [r[0] for r in tickers_row.fetchall() if r[0]]
+    return count, tickers
+
+
+async def validate_block_coverage(
+    db: AsyncSession,
+    organization_id: uuid.UUID,
+    profile: str,
+) -> CoverageReport:
+    """Build a :class:`CoverageReport` for the given org + profile.
+
+    Pure read-only — never writes. Uses the RLS-aware session passed
+    by the caller (``construction_run_executor``). Does not raise on
+    empty allocations — an empty allocation simply returns
+    ``is_sufficient=True`` with no gaps (semantically "nothing to
+    cover", which is a different defect surfaced elsewhere).
+    """
+    rows = (
+        await db.execute(
+            _STRATEGIC_ALLOCATION_SQL,
+            {"profile": profile, "organization_id": organization_id},
+        )
+    ).fetchall()
+
+    gaps: list[BlockCoverageGap] = []
+    weight_at_risk = 0.0
+    for block_id, target_weight in rows:
+        n_candidates = await _count_approved(
+            db,
+            organization_id=organization_id,
+            block_id=block_id,
+        )
+        if n_candidates > 0:
+            continue
+        labels = strategy_labels_for_block(block_id)
+        catalog_count, example_tickers = await _catalog_snapshot(
+            db, labels=labels,
+        )
+        tw = float(target_weight or 0.0)
+        weight_at_risk += tw
+        gaps.append(
+            BlockCoverageGap(
+                block_id=block_id,
+                target_weight=tw,
+                suggested_strategy_labels=labels,
+                catalog_candidates_available=catalog_count,
+                example_tickers=example_tickers,
+            )
+        )
+
+    return CoverageReport(
+        organization_id=organization_id,
+        profile=profile,
+        is_sufficient=not gaps,
+        total_target_weight_at_risk=weight_at_risk,
+        gaps=gaps,
+    )
+
+
+def build_coverage_operator_message(report: CoverageReport) -> dict[str, Any]:
+    """Backend-owned copy for the ``block_coverage_insufficient`` signal.
+
+    Mirrors ``build_operator_message`` in ``schemas/sanitized.py`` —
+    frontend renders verbatim (smart-backend / dumb-frontend).
+    """
+    pct = report.total_target_weight_at_risk * 100
+    lines = [
+        (
+            f"Portfolio construction aborted: {pct:.1f}% of the declared "
+            "mandate is uncovered. The following blocks have zero approved "
+            "candidates in your universe:"
+        ),
+        "",
+    ]
+    for gap in report.gaps:
+        gap_pct = gap.target_weight * 100
+        tickers = ", ".join(gap.example_tickers) if gap.example_tickers else "none"
+        lines.append(
+            f"  • {gap.block_id} (target {gap_pct:.1f}%): "
+            f"{gap.catalog_candidates_available} candidates available in "
+            f"the global catalog. Examples: {tickers}."
+        )
+    lines.append("")
+    lines.append(
+        "Action: review your approved universe and either import "
+        "candidates for the uncovered blocks or adjust the "
+        "StrategicAllocation to set their target_weight to zero."
+    )
+    return {
+        "title": "Coverage insufficient — mandate cannot be honoured",
+        "body": "\n".join(lines),
+        "severity": "error",
+        "action_hint": "expand_universe_or_zero_weight",
+    }

--- a/backend/tests/quant_engine/test_block_coverage_service.py
+++ b/backend/tests/quant_engine/test_block_coverage_service.py
@@ -1,0 +1,210 @@
+"""PR-A22 — block_coverage_service unit tests.
+
+Pure unit coverage using an AsyncMock session. The validator's SQL is
+simple enough that mocking the four query shapes is more maintainable
+than seeding a real DB — and it isolates the test from the shared
+``app.core.db.engine`` event loop contract.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from quant_engine.block_coverage_service import (
+    BlockCoverageGap,
+    CoverageReport,
+    build_coverage_operator_message,
+    validate_block_coverage,
+)
+
+
+def _make_session(
+    *,
+    allocations: list[tuple[str, float]],
+    approved_counts: dict[str, int],
+    catalog_counts: dict[str, int],
+    catalog_tickers: dict[str, list[str]],
+) -> AsyncMock:
+    """Mock an ``AsyncSession`` whose ``execute`` matches the validator's
+    four query shapes by inspecting bind parameters.
+    """
+    session = AsyncMock()
+
+    class FakeResult:
+        def __init__(
+            self,
+            *,
+            rows: list[tuple] | None = None,
+            scalar: int | None = None,
+        ) -> None:
+            self._rows = rows or []
+            self._scalar = scalar
+
+        def fetchall(self) -> list[tuple]:
+            return self._rows
+
+        def scalar_one(self) -> int:
+            return self._scalar if self._scalar is not None else 0
+
+    async def _execute(stmt, params=None):  # noqa: ANN001
+        sql = str(stmt).lower()
+        params = params or {}
+        if "from strategic_allocation" in sql:
+            return FakeResult(rows=list(allocations))
+        if "from instruments_org" in sql and "count(" in sql:
+            block_id = params.get("block_id")
+            return FakeResult(scalar=approved_counts.get(block_id, 0))
+        if (
+            "from instruments_universe" in sql
+            and "count(" in sql
+        ):
+            # Use a stable key — the labels list passed in. Tests key
+            # counts by the first label in the list.
+            labels = params.get("labels") or []
+            key = labels[0] if labels else None
+            return FakeResult(scalar=catalog_counts.get(key, 0))
+        if "from instruments_universe" in sql:
+            labels = params.get("labels") or []
+            key = labels[0] if labels else None
+            tickers = catalog_tickers.get(key, [])
+            return FakeResult(rows=[(t,) for t in tickers])
+        return FakeResult()
+
+    session.execute = _execute
+    return session
+
+
+@pytest.mark.asyncio
+async def test_all_blocks_covered_returns_sufficient() -> None:
+    org_id = uuid.uuid4()
+    session = _make_session(
+        allocations=[("na_equity_large", 1.0)],
+        approved_counts={"na_equity_large": 3},
+        catalog_counts={},
+        catalog_tickers={},
+    )
+
+    report = await validate_block_coverage(session, org_id, "moderate")
+    assert report.is_sufficient is True
+    assert report.gaps == []
+    assert report.total_target_weight_at_risk == 0.0
+
+
+@pytest.mark.asyncio
+async def test_uncovered_block_with_catalog_candidates() -> None:
+    org_id = uuid.uuid4()
+    # na_equity_large maps (via block_mapping) to strategy labels
+    # including "Large Blend" — that is the first label the validator
+    # passes to the catalog queries.
+    first_label = "Large Blend"
+    session = _make_session(
+        allocations=[("na_equity_large", 0.5)],
+        approved_counts={"na_equity_large": 0},
+        catalog_counts={first_label: 50},
+        catalog_tickers={first_label: ["VOO", "IVV", "SPY", "VTI", "SCHX"]},
+    )
+
+    report = await validate_block_coverage(session, org_id, "moderate")
+    assert report.is_sufficient is False
+    assert len(report.gaps) == 1
+    gap = report.gaps[0]
+    assert gap.block_id == "na_equity_large"
+    assert gap.target_weight == pytest.approx(0.5)
+    assert gap.catalog_candidates_available == 50
+    assert gap.example_tickers == ["VOO", "IVV", "SPY", "VTI", "SCHX"]
+    assert first_label in gap.suggested_strategy_labels
+    assert report.total_target_weight_at_risk == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_uncovered_block_with_no_catalog_candidates() -> None:
+    org_id = uuid.uuid4()
+    # Synthetic block not present in block_mapping — the validator
+    # sees an empty suggested_strategy_labels list and skips the
+    # catalog queries entirely.
+    session = _make_session(
+        allocations=[("synthetic_block", 0.3)],
+        approved_counts={"synthetic_block": 0},
+        catalog_counts={},
+        catalog_tickers={},
+    )
+
+    report = await validate_block_coverage(session, org_id, "aggressive")
+    assert report.is_sufficient is False
+    assert len(report.gaps) == 1
+    gap = report.gaps[0]
+    assert gap.suggested_strategy_labels == []
+    assert gap.catalog_candidates_available == 0
+    assert gap.example_tickers == []
+    assert report.total_target_weight_at_risk == pytest.approx(0.3)
+
+
+@pytest.mark.asyncio
+async def test_multiple_blocks_mixed_coverage() -> None:
+    org_id = uuid.uuid4()
+    first_label = "Large Blend"
+    session = _make_session(
+        allocations=[
+            ("na_equity_large", 0.4),
+            ("fi_us_treasury", 0.3),
+            ("alt_gold", 0.1),
+        ],
+        approved_counts={
+            "na_equity_large": 0,
+            "fi_us_treasury": 5,
+            "alt_gold": 0,
+        },
+        catalog_counts={first_label: 10, "Precious Metals": 3},
+        catalog_tickers={
+            first_label: ["A", "B"],
+            "Precious Metals": ["GLD", "IAU", "SGOL"],
+        },
+    )
+    report = await validate_block_coverage(session, org_id, "balanced")
+    assert report.is_sufficient is False
+    # fi_us_treasury has 5 approved → not a gap. Two gaps expected.
+    assert [g.block_id for g in report.gaps] == [
+        "na_equity_large", "alt_gold",
+    ]
+    assert report.total_target_weight_at_risk == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_empty_strategic_allocation_is_sufficient() -> None:
+    """Edge case: no allocation rows at all → nothing to validate."""
+    org_id = uuid.uuid4()
+    session = _make_session(
+        allocations=[],
+        approved_counts={},
+        catalog_counts={},
+        catalog_tickers={},
+    )
+    report = await validate_block_coverage(session, org_id, "moderate")
+    assert report.is_sufficient is True
+    assert report.gaps == []
+
+
+def test_build_coverage_operator_message_shape() -> None:
+    report = CoverageReport(
+        organization_id=uuid.uuid4(),
+        profile="moderate",
+        is_sufficient=False,
+        total_target_weight_at_risk=0.1979,
+        gaps=[
+            BlockCoverageGap(
+                block_id="na_equity_growth",
+                target_weight=0.0897,
+                suggested_strategy_labels=["Growth"],
+                catalog_candidates_available=42,
+                example_tickers=["VUG", "IWF"],
+            ),
+        ],
+    )
+    msg = build_coverage_operator_message(report)
+    assert msg["severity"] == "error"
+    assert "19.8%" in msg["body"]
+    assert "na_equity_growth" in msg["body"]
+    assert "VUG" in msg["body"]
+    assert msg["action_hint"] == "expand_universe_or_zero_weight"

--- a/backend/tests/wealth/test_construction_run_coverage_gate.py
+++ b/backend/tests/wealth/test_construction_run_coverage_gate.py
@@ -1,0 +1,136 @@
+"""PR-A22 — construction_run_executor coverage-gate wiring tests.
+
+Verifies the pre-optimizer block-coverage check:
+
+* ``_execute_inner`` raises ``CoverageInsufficientError`` when the
+  validator returns an insufficient report — the optimizer
+  (``_run_construction_async``) is never invoked.
+* ``_persist_coverage_failure`` writes the expected
+  ``cascade_telemetry`` envelope and marks the run ``failed`` with a
+  structured ``failure_reason``.
+* The top-level ``execute_construction_run`` catches the exception,
+  persists the failure, and emits a terminal SSE event whose payload
+  carries ``winner_signal = 'block_coverage_insufficient'`` and the
+  full coverage report.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domains.wealth.models.model_portfolio import PortfolioConstructionRun
+from app.domains.wealth.schemas.sanitized import WinnerSignal
+from app.domains.wealth.workers import construction_run_executor as executor_mod
+from app.domains.wealth.workers.construction_run_executor import (
+    CoverageInsufficientError,
+    _execute_inner,
+    _persist_coverage_failure,
+)
+from quant_engine.block_coverage_service import (
+    BlockCoverageGap,
+    CoverageReport,
+)
+
+
+def _insufficient_report() -> CoverageReport:
+    return CoverageReport(
+        organization_id=uuid.uuid4(),
+        profile="moderate",
+        is_sufficient=False,
+        total_target_weight_at_risk=0.1979,
+        gaps=[
+            BlockCoverageGap(
+                block_id="na_equity_growth",
+                target_weight=0.0897,
+                suggested_strategy_labels=["Growth"],
+                catalog_candidates_available=42,
+                example_tickers=["VUG", "IWF", "QQQG", "MGK", "SCHG"],
+            ),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_persist_coverage_failure_populates_telemetry() -> None:
+    run = PortfolioConstructionRun(
+        id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        portfolio_id=uuid.uuid4(),
+        calibration_snapshot={},
+        calibration_hash="x",
+        universe_fingerprint="pending",
+        status="running",
+        requested_by="tester",
+    )
+    report = _insufficient_report()
+    db = AsyncMock()
+    await _persist_coverage_failure(db, run=run, report=report)
+    assert run.status == "failed"
+    assert "block_coverage_insufficient" in (run.failure_reason or "")
+    telemetry = run.cascade_telemetry or {}
+    assert (
+        telemetry["winner_signal"]
+        == WinnerSignal.BLOCK_COVERAGE_INSUFFICIENT.value
+    )
+    assert telemetry["operator_signal"] == telemetry["winner_signal"]
+    assert telemetry["cascade_summary"] == "block_coverage_insufficient"
+    assert telemetry["coverage_report"]["gaps"][0]["block_id"] == (
+        "na_equity_growth"
+    )
+    assert telemetry["operator_message"]["severity"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_execute_inner_raises_and_optimizer_never_invoked() -> None:
+    """Validator returns insufficient → CoverageInsufficientError and the
+    optimizer entry point is never reached.
+    """
+    report = _insufficient_report()
+
+    # Fake portfolio fetch: one ORM query returning a stub portfolio.
+    portfolio_stub = MagicMock()
+    portfolio_stub.profile = "moderate"
+    portfolio_stub.organization_id = report.organization_id
+    portfolio_result = MagicMock()
+    portfolio_result.scalar_one_or_none.return_value = portfolio_stub
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=portfolio_result)
+
+    run = PortfolioConstructionRun(
+        id=uuid.uuid4(),
+        organization_id=report.organization_id,
+        portfolio_id=uuid.uuid4(),
+        calibration_snapshot={},
+        calibration_hash="x",
+        universe_fingerprint="pending",
+        status="running",
+        requested_by="tester",
+    )
+
+    optimizer_mock = AsyncMock()
+
+    # Patch _run_construction_async where _execute_inner imports it
+    # lazily to avoid circular imports.
+    with patch.object(
+        executor_mod,
+        "validate_block_coverage",
+        new=AsyncMock(return_value=report),
+    ), patch(
+        "app.domains.wealth.routes.model_portfolios._run_construction_async",
+        new=optimizer_mock,
+    ):
+        with pytest.raises(CoverageInsufficientError) as exc_info:
+            await _execute_inner(
+                db=db,
+                run=run,
+                portfolio_id=run.portfolio_id,
+                calibration_snapshot={},
+                job_id=None,
+            )
+
+    assert exc_info.value.report.is_sufficient is False
+    assert len(exc_info.value.report.gaps) == 1
+    optimizer_mock.assert_not_called()

--- a/docs/plans/2026-04-18-netz-terminal-parity.md
+++ b/docs/plans/2026-04-18-netz-terminal-parity.md
@@ -1,0 +1,533 @@
+# Netz Terminal Parity — `/portfolio/live`
+
+**Date:** 2026-04-18
+**Owner:** Andrei
+**Scope decision locked:** Terminal.html parity for `(terminal)/portfolio/live` ONLY. Macro / Builder / Screener are follow-up sprints.
+**Execution model:** 3–5 independently-mergeable sub-PRs sized for a single Opus session each (Andrei runs parallel Gemini + Opus sessions; do not cross-touch).
+
+---
+
+## 0. Ground truth & assumptions
+
+- Figma bundle (`Terminal.html`, `terminal.css`, `terminal-app.jsx`, `terminal-chart.jsx`, `terminal-panels.jsx`, `terminal-data.jsx`) is NOT checked into this repo. Opus must treat the Figma file as the visual oracle; tokens listed in §B are the canonical extraction. If the bundle is later committed under `docs/design/terminal-bundle/`, Opus should diff against it at visual-QA time only.
+- Existing infra to KEEP: `TerminalShell` + `TerminalTopNav` + `TerminalContextRail` + `TerminalStatusBar` + `LayoutCage` + `CommandPalette` in `packages/investintell-ui`-adjacent `frontends/wealth/src/lib/components/terminal/shell/`. `MarketDataStore` (`market-data.svelte.ts`) already wires Tiingo WS via `/api/v1/market-data/live/ws`. **Do not rewrite the shell.**
+- Existing token file `packages/investintell-ui/src/lib/tokens/terminal.css` uses the `--terminal-*` namespace. The Figma bundle uses `--term-void`, `--fg-primary`, etc. **Decision:** keep the `--terminal-*` namespace as canonical; add `--term-*` as aliases ONLY if the Figma bundle's JS touches them at runtime (it doesn't — tokens are CSS-only). No aliases needed.
+- Tweaks panel state = **in-memory `$state` only, session-scoped**. No localStorage, no URL param (keeps shell clean). Andrei to confirm at PR-1 review. If he pushes back, switch to `?density=compact&accent=cyan&theme=light` URL param (still zero storage).
+- `terminal-screener` is canonical; `(app)/research` and `(terminal)/research` flagged for deprecation in a later sprint — **out of scope here**.
+
+---
+
+## A. Diff-style audit per existing file
+
+Each row: **Current** → **Gap** → **Patch**.
+
+### A.1 `frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte`
+
+| # | Current | Gap vs Figma | Patch |
+|---|---|---|---|
+| 1 | Line 495: `(absDrift * 100).toFixed(1)` for drift alert title. | Violates frontend formatter discipline. | Replace with `formatPpDrift(drift)` from new `@netz/ui` formatter (signed, "+2.3pp" / "−1.1pp", tabular). |
+| 2 | Hard-coded grid `grid-template-columns: 280px 1fr 280px` + `flex: 60/25/15` rails. | Figma widths are 280/1fr/320 with denser typography at density=compact. | Widths stay; rail sizes must react to `[data-density="compact"]` (row heights shrink 22px→18px, fonts 11px→10px). Expose via data-attrs set by Tweaks panel. |
+| 3 | `lw-shell { height: calc(100vh - 88px); }` inline. | Should consume `var(--terminal-shell-cage-height)` already defined. | Replace literal calc with token. |
+| 4 | `data-live-root` attribute is only used by `:global(.lc-cage--standard:has([data-live-root])) { padding: 0 !important; }`. | OK but brittle `:has()`. | Leave — this is a known pattern from `feedback_layout_cage_pattern.md`; do NOT replace with flex/grid. |
+| 5 | Portfolio dropdown is re-implemented inline (lw-portfolio-trigger). | Figma uses same control on Builder + Macro (need reuse). | Extract `<PortfolioPicker />` into `frontends/wealth/src/lib/components/terminal/live/` (keep wealth-local for now; promote to `@netz/ui` only when second consumer appears — see `feedback_tokens_vs_components.md`). |
+| 6 | No Tweaks panel mount. | Figma has a floating gear (bottom-right) + side drawer with density/accent/theme toggles. | Mount `<TerminalTweaksPanel />` at page root, trigger via `Shift+T` + floating button. |
+| 7 | Right rail: `NewsFeed` (55) + `MacroRegimePanel` (45). | Figma right rail has News + Alert Stream (not Macro). Macro lives in center drift panel. | **DECISION:** keep current layout — Andrei locked this in Phase 5 (`feedback_live_workbench_vision.md`). Figma → reality delta is acceptable. Flag in §H. |
+| 8 | Regime matrix pin drag UX. | Not present — `MacroRegimePanel` currently read-only. | Add drag-drop on regime cells → fires `$state` `simulatedRegime`, propagates to chart overlay + summary only. **No backend write.** Call out in UI "SIMULATION" banner. |
+| 9 | Timeframe prop: `"1Y"` coerced to `"3M"` for chart (`timeframe={chartTimeframe === "1Y" ? "3M" : chartTimeframe}`). | Chart should render 1Y properly. | Bug: delete the coercion, fix `TerminalPriceChart` to accept `1Y`. Flag as scope creep — if it requires new REST aggregation, defer to follow-up. |
+
+### A.2 `frontends/wealth/src/lib/components/terminal/shell/TerminalStatusBar.svelte`
+
+| # | Current | Gap | Patch |
+|---|---|---|---|
+| 1 | Line 91: `new Date().toISOString().substring(11, 19) + " UTC"` | Not using shared formatter. Duplicated logic vs Figma mono clock. | Replace with `formatMonoTime(new Date(), "utc")` from new `@netz/ui/formatters/mono`. Keep the 1s `setInterval` (correct `$effect` cleanup already in place). |
+| 2 | `connectionStatus` hardcoded `"connecting"` upstream in `TerminalShell.svelte:81`. | No live aggregation from `MarketDataStore`. | In PR-3, pass `marketStore.status` through context to the shell (map `connected`→`open`, `reconnecting`→`degraded`, etc.). |
+
+### A.3 `frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte`
+
+| # | Current | Gap | Patch |
+|---|---|---|---|
+| 1 | `setInterval(fetchDDQueueCount, 60_000)` in $effect. | Fine — cleanup present. | No-op. |
+| 2 | `orgName = "NETZ"`, `userInitials = "AR"` hardcoded. | OK per plan notes — Phase 2+. | No-op for this sprint. |
+
+### A.4 `frontends/wealth/src/lib/components/terminal/shell/TerminalTopNav.svelte`
+
+| # | Current | Gap | Patch |
+|---|---|---|---|
+| 1 | `setInterval(fetchRegime, 5 * 60 * 1000)` — macro regime poll. | OK. | No-op. |
+| 2 | No breadcrumb rendering. | Figma has persistent `Screener → Terminal → Macro → Builder` breadcrumb row. | Mount `<TerminalBreadcrumb />` as a new 28px row BELOW TopNav but ABOVE LayoutCage. Requires updating `TerminalShell` grid from `32px 1fr 28px` to `32px 28px 1fr 28px`. Adjust `--terminal-shell-topbar-height` → 60px OR add `--terminal-shell-breadcrumb-height: 28px` and `--terminal-shell-cage-height: calc(100vh - 116px)`. |
+
+### A.5 `frontends/wealth/src/routes/(terminal)/+layout.svelte`
+
+| # | Current | Gap | Patch |
+|---|---|---|---|
+| 1 | Plain `TerminalShell` wrapper, sets `MarketDataStore` context. | Needs to also set `TerminalTweaksContext` (density/accent/theme). | Create `terminal-tweaks.svelte.ts` store, instantiate in layout, `setContext(TERMINAL_TWEAKS_KEY, ...)`. Bind `data-density` / `data-accent` / `data-theme` on `<TerminalShell>` root element. |
+
+### A.6 `frontends/wealth/src/lib/components/terminal/live/*.svelte` (scan)
+
+- **No** `.toFixed` / `toLocaleString` / `toLocaleTimeString` found in the `live/` directory per grep. Good.
+- **No** localStorage / postMessage found. Good.
+- **No** `EventSource` found. Good.
+- `MacroRegimePanel.svelte` — read-only; needs drag-drop simulation overlay (§A.1 #8). New prop `onSimulate?: (regime) => void` or emit via `$bindable`.
+- `TradeLog`, `AlertStreamPanel`, `NewsFeed` — verify keyed `{#each (item.id)}` (likely OK but must enforce in PR-4 QA sweep).
+
+### A.7 `frontends/wealth/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte`
+
+| # | Current | Gap | Patch |
+|---|---|---|---|
+| 1 | Uses `lightweight-charts`, accepts `lastTick` from MarketDataStore. | Confirms Tiingo WS live. | No `setInterval` sim to delete — grep confirmed clean. Just verify visual parity of candle vs line fallback. |
+| 2 | Single series type (line today). | Figma chart-type selector exposes Candle + Line in the toolbar. | Widen `TerminalPriceChart` to a dual-series component — see §A.9. Scope-locked in PR-4 (moved out of Open Risks). |
+
+### A.9 `TerminalPriceChart` — dual-mode (Candle / Line) spec
+
+**Prop contract (separate series props, single `mode` driver — avoids union narrowing pain):**
+
+```ts
+export interface OHLCPoint {
+    time: UTCTimestamp; // lightweight-charts time (s epoch or business day)
+    open: number;
+    high: number;
+    low: number;
+    close: number;
+}
+export interface LinePoint {
+    time: UTCTimestamp;
+    value: number; // typically close
+}
+
+export interface TerminalPriceChartProps {
+    mode: "candle" | "line";          // default "candle"
+    candleData: OHLCPoint[];          // required when mode==="candle"
+    lineData: LinePoint[];            // required when mode==="line"
+    lastTick?: { time: UTCTimestamp; open?: number; high?: number; low?: number; close: number };
+    timeframe: "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
+    ticker: string;
+    height?: number;
+}
+```
+
+**Rendering contract:**
+- Internally maintains ONE `IChartApi` instance (never recreated on `mode` flip).
+- On `mode` change: call `chart.removeSeries(currentSeries)`, then `chart.addCandlestickSeries(...)` OR `chart.addLineSeries(...)`, then `series.setData(candleData | lineData)`.
+- **Before swap**, capture `chart.timeScale().getVisibleRange()` and `chart.subscribeCrosshairMove` snapshot; **after swap**, restore via `setVisibleRange(...)` and re-subscribe. Prevents viewport reset on toggle.
+- Live tick handling:
+  - Candle mode: if `lastTick` arrives for current bar's `time`, call `series.update({ time, open, high, low, close })` where high/low are rolled from existing bar. If `lastTick` lacks OHLC (ticks-only backend), synthesize locally: see §D note.
+  - Line mode: `series.update({ time, value: lastTick.close })`.
+- No flicker: the swap path must NOT unmount the `<div>` container. Do NOT use `{#if mode === "candle"}` on the series layer — bind series lifecycle inside `$effect` that depends on `mode`.
+
+### A.8 `MarketDataStore` (`market-data.svelte.ts`)
+
+- Already Tiingo WS + REST fallback. No `setInterval` simulation. No changes needed for parity. **Confirmed clean** — Andrei's instruction "delete bundle's setInterval sim" is a non-op in our codebase (the sim only ever existed in the Figma bundle's `terminal-data.jsx`; it was never ported).
+
+---
+
+## B. New `@netz/ui` additions
+
+All paths relative to `packages/investintell-ui/src/lib/`.
+
+### B.1 `tokens/terminal.css` — **EXTEND** (existing file; do not replace)
+
+Existing file is the canonical `--terminal-*` namespace. Add:
+
+```css
+/* ── Runtime tweak surfaces ─────────────────────────────── */
+/* Density: standard (default) vs compact (Bloomberg-tight).
+   Switched via [data-density="compact"] on terminal-root.    */
+:root[data-density="compact"],
+[data-surface="terminal"][data-density="compact"] {
+	--terminal-space-1: 2px;
+	--terminal-space-2: 6px;
+	--terminal-space-3: 10px;
+	--terminal-space-4: 12px;
+	--terminal-text-10: 9px;
+	--terminal-text-11: 10px;
+	--terminal-text-12: 11px;
+	--terminal-text-14: 12px;
+	--terminal-shell-topbar-height: 28px;
+	--terminal-shell-breadcrumb-height: 24px;
+	--terminal-shell-cage-height: calc(100vh - 80px);
+	--t-row-height: 18px;
+}
+
+:root,
+[data-surface="terminal"] {
+	--t-row-height: 22px;
+	--t-size-hero: var(--terminal-text-24);
+	--t-size-kpi: var(--terminal-text-20);
+	--t-size-label: var(--terminal-text-10);
+}
+
+/* Accent: user-selectable. Default amber (institutional). */
+[data-accent="cyan"] {
+	--terminal-accent-amber: var(--terminal-accent-cyan);
+	--terminal-accent-amber-dim: var(--terminal-accent-cyan-dim);
+}
+[data-accent="violet"] {
+	--terminal-accent-amber: var(--terminal-accent-violet);
+	--terminal-accent-amber-dim: var(--terminal-accent-violet-dim);
+}
+
+/* Severity scale for alerts (used by AlertStreamPanel + ticker). */
+:root,
+[data-surface="terminal"] {
+	--sev-info: var(--terminal-accent-cyan);
+	--sev-warn: var(--terminal-status-warn);
+	--sev-critical: var(--terminal-status-error);
+	--up: var(--terminal-status-success);
+	--down: var(--terminal-status-error);
+}
+
+/* Light theme — institutional white, still mono-first. */
+[data-theme="light"],
+[data-theme="light"][data-surface="terminal"] {
+	--terminal-bg-void: #f5f5f0;
+	--terminal-bg-panel: #ffffff;
+	--terminal-bg-panel-raised: #fafaf6;
+	--terminal-bg-panel-sunken: #ededed;
+	--terminal-bg-overlay: #ffffff;
+	--terminal-bg-scrim: rgba(245, 245, 240, 0.72);
+	--terminal-fg-primary: #0a0a0a;
+	--terminal-fg-secondary: #3d3d38;
+	--terminal-fg-tertiary: #6b6b63;
+	--terminal-fg-muted: #b8b8b0;
+	--terminal-fg-disabled: #d8d8d0;
+	--terminal-fg-inverted: #ffffff;
+}
+```
+
+Hex values added here are **the only permitted location** per existing file comment.
+
+### B.2 `formatters/mono.ts` — **NEW**
+
+```ts
+// packages/investintell-ui/src/lib/formatters/mono.ts
+//
+// Mono-friendly formatters for terminal surfaces. All outputs are
+// tabular-safe (stable column widths) and locale-independent.
+
+/**
+ * UTC clock string "HH:MM:SS UTC" (ISO extraction). Zero allocation
+ * beyond the Date itself. `kind` = "utc" (default) or "local".
+ */
+export function formatMonoTime(d: Date, kind: "utc" | "local" = "utc"): string;
+
+/**
+ * Compact currency: $1.23B / $987M / $12.3K. Negative prefix "−".
+ * Pass `digits` (default 2). Returns "—" for null/undefined.
+ */
+export function formatCompactCurrency(
+	value: number | null | undefined,
+	opts?: { digits?: number; currency?: "USD" | "EUR" | "BRL" }
+): string;
+
+/**
+ * Percentage-point drift: "+2.3pp", "−1.1pp", "0.0pp". Input is a
+ * fraction (0.023 → "+2.3pp"). Uses `digits` (default 1). "—" for
+ * null. Sign uses the Unicode minus (U+2212) for column alignment.
+ */
+export function formatPpDrift(
+	fractionDelta: number | null | undefined,
+	digits?: number
+): string;
+
+/**
+ * Terminal percent: "12.34%", "-0.05%". Input is a fraction.
+ * Tabular-nums. Digits default 2.
+ */
+export function formatMonoPercent(
+	fraction: number | null | undefined,
+	digits?: number
+): string;
+```
+
+All four re-exported from `packages/investintell-ui/src/lib/index.ts`. No ESLint rule changes needed — existing rule forbids `.toFixed`/`Intl` in frontend code, which steers callers to these.
+
+### B.3 `components/terminal/` primitives — **NEW**
+
+Directory: `packages/investintell-ui/src/lib/components/terminal/`.
+
+Each component has a **single-purpose, read-only** props contract (no `$bindable` unless noted). All are tokenized — **zero hex inline**.
+
+#### `Pill.svelte`
+```ts
+interface PillProps {
+	label: string;
+	tone?: "neutral" | "accent" | "success" | "warn" | "error";
+	size?: "xs" | "sm";
+	as?: "button" | "span"; // default span; button emits onclick
+	onclick?: () => void;
+}
+```
+
+#### `Kbd.svelte`
+```ts
+interface KbdProps {
+	keys: string[]; // e.g. ["Shift", "T"] rendered as [Shift]+[T]
+}
+```
+
+#### `KpiCard.svelte`
+```ts
+interface KpiCardProps {
+	label: string;             // uppercase caps auto-applied
+	value: string;             // pre-formatted (call formatters before pass)
+	delta?: string;            // pre-formatted +/- delta (e.g. "+1.2pp")
+	deltaTone?: "up" | "down" | "neutral";
+	size?: "sm" | "md" | "lg"; // drives --t-size-*
+	mono?: boolean;            // default true
+	loading?: boolean;
+}
+```
+
+#### `DensityToggle.svelte`
+```ts
+interface DensityToggleProps {
+	value: "standard" | "compact";
+	onChange: (v: "standard" | "compact") => void;
+}
+```
+
+#### `AccentPicker.svelte`
+```ts
+interface AccentPickerProps {
+	value: "amber" | "cyan" | "violet";
+	onChange: (v: "amber" | "cyan" | "violet") => void;
+}
+```
+
+#### `ThemeToggle.svelte`
+```ts
+interface ThemeToggleProps {
+	value: "dark" | "light";
+	onChange: (v: "dark" | "light") => void;
+}
+```
+
+All primitives exported from `packages/investintell-ui/src/lib/index.ts` under subpath `/terminal`.
+
+### B.4 Fonts — `styles/typography.css` additions
+
+```css
+/* Scoped terminal fonts — do NOT leak into (app). */
+[data-surface="terminal"] {
+	font-family: var(--terminal-font-mono);
+}
+[data-surface="terminal"] [data-font="sans"] {
+	font-family: "IBM Plex Sans", Inter, Urbanist, system-ui, sans-serif;
+}
+```
+
+Load via `@fontsource-variable/ibm-plex-mono` + `@fontsource-variable/ibm-plex-sans` (pnpm add in `packages/investintell-ui/package.json`). Imported once from the wealth root `+layout.svelte` already; just add the two new font packages.
+
+Urbanist remains the default OUTSIDE `[data-surface="terminal"]` per `feedback_design_direction.md`.
+
+---
+
+## C. Terminal-scoped wiring
+
+### C.1 `TerminalBreadcrumb.svelte` (new, in `frontends/wealth/src/lib/components/terminal/shell/`)
+
+- 28px persistent row mounted by `TerminalShell` BETWEEN `TerminalTopNav` and `LayoutCage`.
+- Content: `Screener → Terminal → Macro → Builder`, each a `<a>` with `data-sveltekit-preload-data`, href mapped:
+  - Screener → `/terminal-screener`
+  - Terminal → `/portfolio/live`
+  - Macro → `/macro`
+  - Builder → `/portfolio/builder`
+- Active segment: matches current `page.route.id`; styled with `color: var(--terminal-accent-amber)` + underline.
+- Keyboard: `Alt+1..4` jumps to each. Ignored when focus is inside an input/textarea/contenteditable (reuse existing detection from `TerminalShell`).
+- Shell grid update: `grid-template-rows: var(--terminal-shell-topbar-height) var(--terminal-shell-breadcrumb-height) 1fr var(--terminal-shell-statusbar-height)`. Update `--terminal-shell-cage-height` to `calc(100vh - 116px)` (32 + 28 + 28 + padding residue absorbed by LayoutCage). Verify `lw-shell` height literal removed per §A.1 #3.
+
+### C.2 `TerminalTweaksPanel.svelte` (new, `frontends/wealth/src/lib/components/terminal/shell/`)
+
+- Floating gear button (bottom-right, `z: var(--terminal-z-toast)`).
+- Opens as a right-side drawer (320px, full cage height).
+- Contents: `<DensityToggle>`, `<AccentPicker>`, `<ThemeToggle>`, `<Pill label="LIVE SIM OFF" tone="neutral">` (no-op placeholder; Andrei gated Live Sim as always-off per scope decision).
+- State: reads/writes `terminal-tweaks.svelte.ts` store (see C.4). **Zero storage.** Resets on full page reload — confirmed-and-accepted trade-off per Andrei's scope-decision #3.
+- Shortcut: `Shift+T` toggles. Ignores inputs.
+
+### C.3 `TerminalStatusBar` clock
+
+- Replace `new Date().toISOString().substring(11, 19) + " UTC"` with `formatMonoTime(new Date(), "utc")`.
+- Keep the `setInterval(tick, 1000)` + cleanup. Do NOT switch to `requestAnimationFrame` — 1Hz is correct.
+
+### C.4 `terminal-tweaks.svelte.ts` (new, `frontends/wealth/src/lib/stores/`)
+
+```ts
+export const TERMINAL_TWEAKS_KEY = Symbol("netz:terminal-tweaks");
+
+export interface TerminalTweaks {
+	density: "standard" | "compact";
+	accent: "amber" | "cyan" | "violet";
+	theme: "dark" | "light";
+	setDensity(v: "standard" | "compact"): void;
+	setAccent(v: "amber" | "cyan" | "violet"): void;
+	setTheme(v: "dark" | "light"): void;
+}
+
+export function createTerminalTweaks(): TerminalTweaks {
+	let density = $state<"standard" | "compact">("standard");
+	let accent = $state<"amber" | "cyan" | "violet">("amber");
+	let theme = $state<"dark" | "light">("dark");
+	return {
+		get density() { return density; },
+		get accent() { return accent; },
+		get theme() { return theme; },
+		setDensity(v) { density = v; },
+		setAccent(v) { accent = v; },
+		setTheme(v) { theme = v; },
+	};
+}
+```
+
+Layout wires `data-density`, `data-accent`, `data-theme` attributes on the `TerminalShell` root.
+
+### C.5 Live data confirmation
+
+- `MarketDataStore` → `TerminalPriceChart` (via `lastTick`) — **verified wired**.
+- `MarketDataStore` → `Watchlist` (via `marketStore.priceMap`) — verify in PR-1 smoke (likely OK — `handleWatchlistSelect` already consumes).
+- `MarketDataStore` → `PortfolioSummary` (`marketStore.totalAum`, `marketStore.totalReturnPct`) — **verified wired**.
+- No `setInterval` simulation to delete in-repo. If Opus greps `setInterval` in live components, they may touch only cleanup-safe timers in shell (already audited, keep).
+
+---
+
+## D. Data contracts per panel
+
+| Panel | Component | Endpoint / Stream | Status | Notes |
+|---|---|---|---|---|
+| Portfolio picker | inline dropdown | `data.portfolios` (load function) | OK | Move to server load only (already done). |
+| Watchlist | `Watchlist.svelte` | REST `/instruments` + WS `/api/v1/market-data/live/ws` (via MarketDataStore) | OK | Tiingo-backed. |
+| Chart | `TerminalPriceChart.svelte` | REST `/market-data/historical/:ticker` + WS tick | **VERIFY OHLC** | Drop the 1Y→3M coercion (§A.1 #9). **Dual-mode (candle/line) spec §A.9.** Verify in PR-4: `/market-data/historical/:ticker` MUST return `{time, open, high, low, close}` rows — if it returns `{time, value}` only, backend gap. WS `lastTick` from Tiingo delivers last price only (no OHLC per tick); client aggregates ticks into the current bar (roll high = max(high, px), low = min(low, px), close = px) as interim until a dedicated 1m-bars stream is wired. Flag as backend follow-up if candle fidelity insufficient. |
+| Portfolio summary | `PortfolioSummary.svelte` | MarketDataStore derived + `/model-portfolios/:id/actual-holdings` | OK | |
+| Holdings table | `HoldingsTable.svelte` | `/model-portfolios/:id/actual-holdings` | OK | |
+| Trade log | `TradeLog.svelte` | `/model-portfolios/:id/trades` (assume — verify in PR-2) | **VERIFY** | If the endpoint doesn't exist, flag as backend dependency. Likely exists — Phase 5 completed. |
+| Alert stream | `AlertStreamPanel.svelte` | `/alerts/stream` SSE? REST poll? | **VERIFY** | Currently fed by `driftAlerts` synthetic in-page + `injectedAlerts` prop. Real live feed may be missing. **Flag as backend gap if not found.** |
+| News feed | `NewsFeed.svelte` | `/market-data/news?tickers=` | OK | Poll-based. |
+| Macro regime panel | `MacroRegimePanel.svelte` | `/macro/regime/latest` (used by TopNav already) | OK | Add drag-drop simulation client-only. |
+| Rebalance focus mode | `RebalanceFocusMode.svelte` | `/model-portfolios/:id/rebalance/*` | OK | |
+
+**Flagged backend gaps** (handoff to backend consultant, NOT this frontend sprint):
+- **AlertStream live feed** — confirm SSE endpoint exists with `X-DEV-ACTOR` / Clerk JWT + single-flight.
+- **Trade log endpoint** — confirm shape matches `TradeLog.svelte` props.
+
+If either is missing, PR-4 (QA) flags + blocks, and we ship without a real stream (in-page synthesis only for alerts, fine per existing code).
+
+---
+
+## E. Violations cleanup checklist
+
+Grep targets. Each must return 0 matches in `frontends/wealth/src/routes/(terminal)/**` + `frontends/wealth/src/lib/components/terminal/**` (excluding shell clock `formatMonoTime` callsite).
+
+1. `.toFixed(` — current: **1 hit** (`+page.svelte:495`). Fix: `formatPpDrift`.
+2. `.toLocaleString(` — current: 0. Hold line.
+3. `.toLocaleTimeString(` — current: 0 (shell uses `toISOString().substring(...)` — still a violation, replace per §C.3).
+4. `toISOString().substring` — current: 1 (`TerminalStatusBar.svelte:91`). Fix: `formatMonoTime`.
+5. `localStorage` / `sessionStorage` — current: 0. Hold line.
+6. `postMessage(` inside terminal namespace — current: 0. Hold line.
+7. `new EventSource` — current: 0 in terminal. Hold line.
+8. Hex literals (`#[0-9a-fA-F]{3,6}`) in `.svelte` / `.ts` under `frontends/wealth/src/lib/components/terminal/` and `(terminal)/` — must be 0. Audit: ESLint rule (add if missing — see ESLint §E.9).
+9. `{#each ... as item}` without `(item.id)` key — 0 in live panels (verify at QA).
+10. Emojis — 0. (Andrei has `feedback_no_emojis.md`.)
+11. `new Intl.NumberFormat` / `new Intl.DateTimeFormat` — 0 inline. Hold line.
+
+### E.9 ESLint rule
+
+Verify `frontends/eslint.config.js` forbids hex in `.svelte` files under terminal paths. If not present, add in PR-1:
+- Rule: `no-restricted-syntax` targeting `Literal[value=/#[0-9a-fA-F]{3,6}/]` scoped to `**/terminal/**` + `**/(terminal)/**`.
+
+---
+
+## F. Acceptance criteria
+
+### F.1 Visual
+- Screenshot parity with Figma at 1440×900 dark default, `data-density="standard"`.
+- Density toggle → compact: every row shrinks to `--t-row-height: 18px`, fonts drop 1px, no reflow overflow.
+- Accent picker → cyan → all amber surfaces (portfolio name, active breadcrumb, focus borders) switch in ≤1 frame.
+- Theme toggle → light → full palette inversion without hex leaks.
+
+### F.2 Lint
+- `pnpm -F wealth lint` exits 0.
+- `pnpm -F wealth check` exits 0 (type check).
+- Grep checklist §E returns 0 matches (CI job `scripts/check-terminal-tokens-sync.mjs` extended with these patterns).
+
+### F.3 Runtime
+- Tiingo WS connects on live page mount (network tab: `wss://` upgrade with 101 Switching Protocols within 2s).
+- First live tick propagates to chart + watchlist row ≤ 300ms after arrival.
+- Theme / density / accent toggles work in-session, revert on hard reload (expected — no persistence).
+- Zero console errors / warnings on clean mount.
+- `Alt+1..4` breadcrumb nav works; `Shift+T` opens Tweaks; `C`/`L` flip chart type when chart is focused; none fire when typing in an input.
+- **Chart type toggle:** clicking CANDLE / LINE (or pressing C / L) swaps the series instantly with no chart flicker, no container remount; visible time range is preserved across the swap; crosshair position is preserved if it was active. Default on mount is `candle`. Hard reload reverts to `candle` (no persistence, by design).
+
+### F.4 Tests
+- `packages/investintell-ui` unit tests for `formatMonoTime`, `formatCompactCurrency`, `formatPpDrift`, `formatMonoPercent` (edge cases: null, 0, ±sign, very large, very small).
+- Svelte component tests (vitest + `@testing-library/svelte`) for:
+  - `TerminalTweaksPanel` — shortcut toggles, callbacks fire, no DOM side effects outside drawer.
+  - `TerminalBreadcrumb` — active segment derived from `page.route.id`, keyboard nav.
+  - `KpiCard` — loading state, delta tone classes, size variants.
+  - **ChartToolbar chart-type toggle** — default `candle`; click LINE → callback fires with `"line"` and `aria-pressed` flips; `C` key → `"candle"`, `L` key → `"line"`; keys ignored when a text input is focused; toggle is a `role="radiogroup"` with two `aria-pressed` buttons.
+- Integration: `(terminal)/portfolio/live/+page.svelte` renders with empty `data.portfolios` → shows empty state; with 1 portfolio → shows full shell.
+
+---
+
+## G. Sequencing — 4 sub-PRs
+
+Each PR is **independently mergeable** (no stacked deps). Each sized for one Opus session.
+
+### PR-1 — **feat/terminal-ui-formatters-and-tokens**
+Scope:
+- `packages/investintell-ui/src/lib/formatters/mono.ts` + exports + tests.
+- `packages/investintell-ui/src/lib/tokens/terminal.css` extensions (density / accent / theme / severity).
+- Fonts: IBM Plex Mono + Sans package additions.
+- ESLint rule for hex-in-terminal (§E.9).
+Size: ~4 files new, 2 files edited. ~150 LoC + tests.
+
+### PR-2 — **feat/terminal-ui-primitives**
+Scope:
+- `packages/investintell-ui/src/lib/components/terminal/{Pill,Kbd,KpiCard,DensityToggle,AccentPicker,ThemeToggle}.svelte`.
+- Exports from `index.ts`.
+- Vitest component tests for `KpiCard` + 2 snapshot tests.
+Size: 6 components + index edit + tests. Depends on PR-1 tokens — **merge PR-1 first** but PR-2 can be opened in parallel once PR-1 is in review.
+
+### PR-3 — **feat/terminal-shell-tweaks-and-breadcrumb**
+Scope:
+- `terminal-tweaks.svelte.ts` store.
+- `TerminalTweaksPanel.svelte` + `Shift+T` shortcut.
+- `TerminalBreadcrumb.svelte` + `Alt+1..4` shortcuts.
+- `TerminalShell.svelte` grid update (+28px breadcrumb row, cage height recalc).
+- `TerminalStatusBar.svelte` clock → `formatMonoTime`.
+- `(terminal)/+layout.svelte` wires tweaks context + data attributes.
+Size: 3 new components + 4 edits. ~400 LoC + tests.
+
+### PR-4 — **feat/terminal-live-parity-and-cleanup**
+Scope:
+- `(terminal)/portfolio/live/+page.svelte`: `.toFixed` → `formatPpDrift`, `calc(100vh-88px)` → token, 1Y→3M coercion removal.
+- `MacroRegimePanel.svelte` drag-drop simulation (client-only).
+- `MarketDataStore` status → shell connection status wiring.
+- **TerminalPriceChart dual-mode (Candle/Line)** per §A.9 — widen props, in-place series swap with visible-range + crosshair preservation, local tick aggregation for candle mode until bars stream ships.
+- **ChartToolbar chart-type toggle (Candle | Line)** — segmented control rendered via the `Pill`/segmented primitive from PR-2 (use the `as="button"` variant, `aria-pressed`, grouped with `role="radiogroup"` and `aria-label="Chart type"`). Default `candle`. Parent page owns state as `let chartType = $state<"candle" | "line">("candle")` — **in-memory only, no localStorage, no URL param** (matches Tweaks panel policy). Keyboard shortcuts `C` / `L` when the chart container has focus (guard: ignore when a text input, textarea, or contenteditable has focus; reuse existing detection util). Visible label text `CANDLE` / `LINE` in mono caps, matching Figma chart-type selector.
+- Visual QA against Figma at 1440×900 + 1920×1080.
+- Playwright smoke (`test-browser` skill) for shortcut + WS handshake + density toggle + chart-type toggle.
+Size: 5 files edited. ~280 LoC + smoke test + component test.
+
+**Optional PR-5 (if scope bleeds)** — Hard-deprecate `(terminal)/research` (add `<meta http-equiv="refresh">` to `/terminal-screener` + banner). Separate sprint per Andrei's decision #6.
+
+---
+
+## H. Open risks
+
+1. **RebalanceFocusMode already diverges from Figma.** It's a FocusMode overlay, Figma has it inline in the center column. Phase 5 decision (Andrei) was overlay. **Do NOT "fix" in this sprint** — if Opus reads Figma and flags it, point at `project_phase5_live_workbench_complete.md` and `feedback_live_workbench_vision.md`.
+2. ~~`lightweight-charts` candle data shape mismatch.~~ **RESOLVED — scoped into PR-4 §A.9.** Dual-mode (Candle + Line) with in-place series swap is a confirmed feature, not a risk. Residual sub-risk: if `/market-data/historical/:ticker` does not return full OHLC (only close series), backend must add an OHLC response shape OR the client must aggregate raw ticks into 1m bars — flagged in §D as `VERIFY OHLC`.
+3. **Font loading flicker.** IBM Plex additions may trigger FOUT on first cold load. Mitigate: `font-display: optional` on the Plex faces so the system mono renders immediately, Plex swaps in on next reload. Verify in PR-1.
+4. **Tweaks drawer + LayoutCage `:has()` selector.** The `:global(.lc-cage--standard:has([data-live-root])) { padding: 0 !important; }` may conflict with the drawer if the drawer is mounted INSIDE the cage. Mount the drawer at the shell root (outside LayoutCage), NOT inside the page component. Andrei flagged this pattern in `feedback_layout_cage_pattern.md`.
+5. **AlertStreamPanel has no real live feed today** (the in-page `driftAlerts` is synthetic). If backend SSE isn't ready, PR-4 flags it; we do NOT ship a fake live stream. Escalate to backend consultant.
+6. **Breadcrumb collision with existing CommandPalette `g + s/l/r/m/a/p/n/d`** — `Alt+1..4` uses Alt namespace; no conflict. Confirmed.
+7. **`--terminal-*` vs Figma `--term-*` naming.** If Opus tries to "harmonize" to `--term-*`, block it. The `--terminal-*` namespace is the established contract (already consumed by 40+ files per git log on `terminal-unification` branches).
+
+---
+
+## Appendix — Post-merge follow-up backlog (not this sprint)
+
+- Terminal Macro parity (separate plan).
+- Terminal Builder parity (separate plan).
+- `terminal-screener` vs `(app)/research` consolidation + deprecation redirect.
+- Rebalance FocusMode — decide if Figma's inline layout is worth returning to (requires re-litigating Phase 5 decision).
+- AlertStream SSE backend contract (if flagged in D).
+- Dedicated 1m-bars stream (if client-side tick aggregation in candle mode proves insufficient for fidelity).

--- a/docs/prompts/2026-04-18-pr-a22-block-coverage-validator.md
+++ b/docs/prompts/2026-04-18-pr-a22-block-coverage-validator.md
@@ -1,0 +1,180 @@
+# PR-A22 — Block Coverage Validator (Operator-Facing Pre-Run Check)
+
+**Date**: 2026-04-18
+**Status**: P0 STRUCTURAL — replaces the silent fallback that hid 19.79% uncovered allocation weight in the moderate profile of org `403d8392-...`.
+**Branch**: `feat/pr-a22-block-coverage-validator`
+**Predecessors merged**: PR-A21 (org universe sanitization).
+
+---
+
+## Context — what this PR fixes
+
+Post-A19.1 + A20 empirical finding (dev DB, org `403d8392-...`, profile `moderate`, 2026-04-18):
+
+| block_id | target_weight | n_candidates in `instruments_org` (approved) |
+|---|---|---|
+| na_equity_large | 22.08% | 1553 |
+| fi_us_aggregate | 14.04% | 558 |
+| na_equity_growth | **8.97%** | **0** |
+| dm_europe_equity | 7.68% | 44 |
+| na_equity_value | **7.68%** | **0** |
+| fi_us_treasury | 7.23% | 13 (post-A21 consolidation) |
+| em_equity | 5.46% | 93 |
+| alt_real_estate | 5.14% | 394 |
+| fi_us_high_yield | 4.43% | 284 |
+| fi_us_tips | 4.43% | 3 |
+| alt_gold | 4.09% | 26 |
+| dm_asia_equity | 3.64% | 38 |
+| **alt_commodities** | **3.14%** | **0** |
+| cash | 2.00% | 44 |
+
+Three blocks with zero candidates total **19.79%** of the mandate. Construction runs currently succeed anyway — the cascade silently redistributes that weight across blocks with candidates. This is the bug: the optimizer returns a portfolio that violates the declared mandate, and the operator has no signal.
+
+The fix is a **pre-run validator** that hard-fails the cascade with a structured `block_coverage_insufficient` signal **before** the optimizer ever receives data. The operator sees exactly which blocks are uncovered, how much weight is at risk, and which catalog candidates they could import. No silent substitution. No automatic backfill.
+
+---
+
+## Scope
+
+**In scope:**
+- New validator function `validate_block_coverage(db, organization_id, profile) -> CoverageReport` in `backend/quant_engine/block_coverage_service.py`.
+- Pydantic schema `CoverageReport` with per-block gap detail and suggested catalog candidates.
+- Wire the validator into `backend/app/domains/wealth/workers/construction_run_executor.py` as the first step of the run, before any quant code executes.
+- New `WinnerSignal` enum value `block_coverage_insufficient` and update to `cascade_telemetry.operator_message` templating.
+- Unit + integration tests.
+- Minimal frontend surface: extend the existing run-result rendering to display the coverage report when `winner_signal = 'block_coverage_insufficient'`. **Do not build a new import flow** — the frontend only displays the report and a link to the existing approved-universe editor. Operator action is out of this PR's scope.
+
+**Out of scope:**
+- Do NOT implement "import from catalog" button. Operator goes to the existing universe editor manually. A future PR can automate if needed.
+- Do NOT modify the optimizer cascade, candidate screener, or block_mapping.
+- Do NOT re-classify any instruments. Coverage is computed from current state.
+- Do NOT add a threshold for "minor gaps" — any block with `target_weight > 0` and `n_candidates = 0` fails the validator. If operator wants to run with a gap, they must set the block's target_weight to 0 in their StrategicAllocation (explicit mandate decision).
+
+---
+
+## Execution Spec
+
+### Section A — `block_coverage_service.py`
+
+**File:** `backend/quant_engine/block_coverage_service.py` (new).
+
+Pure function, no side effects, receives `AsyncSession` + `organization_id` + `profile` and returns a `CoverageReport`.
+
+Algorithm:
+1. Load all rows from `strategic_allocation` where `profile = <profile>` and `target_weight > 0`.
+2. For each block, count approved candidates:
+   ```sql
+   SELECT COUNT(*) FROM instruments_org io
+   WHERE io.organization_id = :org_id
+     AND io.block_id = :block_id
+     AND io.approval_status = 'approved'
+   ```
+3. For each block with `n_candidates = 0`, compute suggested catalog candidates:
+   - Look up `strategy_labels_for_block(block_id)` from `vertical_engines.wealth.model_portfolio.block_mapping`.
+   - Query `instruments_universe` for count of instruments whose `attributes->>'strategy_label'` matches any of those labels.
+   - Return top-5 tickers by AUM (`attributes->>'aum_usd'::numeric DESC NULLS LAST`) as examples. Use `is_active = true` and `is_institutional = true` filters.
+
+Return shape:
+```python
+class BlockCoverageGap(BaseModel):
+    block_id: str
+    target_weight: float
+    suggested_strategy_labels: list[str]
+    catalog_candidates_available: int
+    example_tickers: list[str]  # top-5 by AUM
+
+class CoverageReport(BaseModel):
+    organization_id: UUID
+    profile: str
+    is_sufficient: bool  # True iff all blocks have >= 1 candidate
+    total_target_weight_at_risk: float  # sum of target_weight for uncovered blocks
+    gaps: list[BlockCoverageGap]
+```
+
+**Acceptance:** unit test in `backend/tests/quant_engine/test_block_coverage_service.py` covers:
+- All blocks have candidates → `is_sufficient=True`, empty `gaps`.
+- One block has zero candidates, catalog has 50 candidates for it → `gaps` has one entry, `catalog_candidates_available=50`, `example_tickers` has 5 entries.
+- One block has zero candidates, catalog also has zero for its strategy labels → `gaps` entry with `catalog_candidates_available=0`, `example_tickers=[]`.
+- Profile has duplicate rows in `strategic_allocation` (current bug — one row per block is what validator should see; DISTINCT on block_id with max target_weight) — validator does NOT crash and counts distinct blocks.
+
+### Section B — Integration into `construction_run_executor.py`
+
+**File:** `backend/app/domains/wealth/workers/construction_run_executor.py`
+
+First step of the run body (after acquiring advisory lock, before loading universe stats):
+
+```python
+coverage = await validate_block_coverage(db, organization_id, profile)
+if not coverage.is_sufficient:
+    await _persist_coverage_failure(db, run_id, coverage)
+    await _emit_sse_event(run_id, "block_coverage_insufficient", coverage.model_dump())
+    return  # do not proceed to optimizer
+```
+
+`_persist_coverage_failure` writes to `portfolio_construction_runs`:
+- `status = 'failed'`
+- `cascade_telemetry.winner_signal = 'block_coverage_insufficient'`
+- `cascade_telemetry.operator_message` = human-readable summary using the coverage report (template below)
+- `cascade_telemetry.coverage_report = <full CoverageReport JSON>`
+
+Operator message template:
+```
+Portfolio construction aborted: {total_target_weight_at_risk:.1%} of the
+declared mandate is uncovered. The following blocks have zero approved
+candidates in your universe:
+
+{for each gap}
+  • {block_id} (target {target_weight:.1%}): {catalog_candidates_available}
+    candidates available in the global catalog. Examples: {example_tickers}.
+{endfor}
+
+Action: review your approved universe and either import candidates for
+the uncovered blocks or adjust the StrategicAllocation to set their
+target_weight to zero.
+```
+
+Lock release, SSE completion event emission, idempotency: follow the existing patterns in the file — do not invent new ones.
+
+**Acceptance:**
+- Integration test in `backend/tests/wealth/test_construction_run_coverage_gate.py`: seed an org with an allocation that has one uncovered block, dispatch a run, assert `status='failed'`, `winner_signal='block_coverage_insufficient'`, SSE event emitted with correct payload, optimizer never invoked (assert via mock that optimizer_service entry point is not called).
+
+### Section C — Enum + schema updates
+
+**Files:**
+- `backend/app/domains/wealth/schemas/construction.py` (or wherever `WinnerSignal` lives — grep for existing enum): add `BLOCK_COVERAGE_INSUFFICIENT = "block_coverage_insufficient"`.
+- `backend/app/core/db/migrations/versions/0150_winner_signal_block_coverage.py`: if `winner_signal` is stored as a CHECK-constrained string or Postgres ENUM, extend the allowed values. If it's a free-form string, no migration needed — document the decision in the migration file header.
+
+**Acceptance:** `make check` passes. Existing `WinnerSignal`-consuming code (frontend types, other services) accepts the new value without runtime errors.
+
+### Section D — Frontend surface (minimal)
+
+**File:** `frontends/wealth/src/lib/components/portfolio/ConstructionRunResult.svelte` (or wherever the run result is rendered — grep for existing `winner_signal` rendering).
+
+Add a conditional render branch for `winner_signal === 'block_coverage_insufficient'`:
+- Headline: "Coverage insufficient — {total_target_weight_at_risk} of mandate uncovered"
+- Table of gaps: block name (humanize block_id), target weight, count of catalog candidates, example tickers
+- CTA: link to the existing approved-universe page with `?highlight=<block_id>` query param (the target page can ignore the param for now — PR-A22 only emits the link).
+
+Use existing `@netz/ui` components and formatters (`formatPercent`, `formatNumber`). No new styling primitives.
+
+**Acceptance:**
+- Manual: run the dev server, dispatch a construction run with an uncovered block, verify the result page renders the gap table and CTA link.
+- Type check: `make check-all` green.
+- No new npm dependencies.
+
+---
+
+## Global guardrails
+
+- Respect `CLAUDE.md`. Async-first, `expire_on_commit=False`, `lazy="raise"`, RLS via `SET LOCAL`.
+- Do not touch optimizer, candidate_screener, classifier, or any existing migration.
+- `make check` and `make check-all` before declaring done.
+- One commit per Section (A/B/C/D).
+
+## Final report format
+
+1. Unit + integration test output (pytest -v).
+2. End-to-end dev smoke: run the validator against org `403d8392-...` profile `moderate` (post-A21 state) and paste the resulting `CoverageReport` JSON — should show 3 gaps (`na_equity_growth`, `na_equity_value`, `alt_commodities`) totaling ~19.79%.
+3. Construction run dispatch against same org/profile: confirm it fails with `block_coverage_insufficient` and does not invoke the optimizer.
+4. Screenshot of the frontend gap view.
+5. List of any unexpected behaviors or follow-ups.

--- a/docs/prompts/2026-04-18-pr-a23-classifier-audit-fix.md
+++ b/docs/prompts/2026-04-18-pr-a23-classifier-audit-fix.md
@@ -1,0 +1,218 @@
+# PR-A23 — Classifier Audit + Fallback Fix + Strategy Label Sanitization
+
+**Date**: 2026-04-18
+**Status**: P1 — depends on PR-A21 (sanitized `instruments_org`). Can run in parallel with or after PR-A22.
+**Branch**: `feat/pr-a23-classifier-audit-fix`
+**Predecessors merged**: PR-A21. Ideally also PR-A22, but not strictly required.
+
+---
+
+## Context — what this PR fixes
+
+Diagnostic (dev DB, 2026-04-18) surfaced three distinct classifier-layer defects that cause structurally miscategorized instruments in `instruments_org`:
+
+### Defect D1 — `fallback_fi_aggregate` at `universe_auto_import_classifier.py:136`
+
+Concrete example: VTEB (Vanguard Tax-Exempt Bond ETF — municipal bonds) is classified into `fi_us_aggregate`. Taxable aggregate bond funds (AGG, BND) and muni bonds have fundamentally different risk/return/tax profiles. The current fallback code path silently buckets anything unclassified-but-bond-like into `fi_us_aggregate`, producing false candidates for the cascade.
+
+### Defect D2 — equity classifier dumps foreign-developed into `na_equity_large`
+
+Concrete example: EFA (iShares MSCI EAFE, 100% developed markets ex-US) is classified into `na_equity_large`. This is an equity-side analog of D1 — the classifier has insufficient geography signal and defaults to the most common US-equity block.
+
+### Defect D3 — upstream `strategy_label` corruption
+
+Concrete examples: AGG and EFA both have `attributes->>'strategy_label' = 'Government Bond'` in `instruments_universe`. AGG is an aggregate bond fund, not government-only. EFA is an equity fund. These are errors in the upstream data ingestion (likely SEC/ESMA parsing in `data_providers/sec/` or the ESMA ingestion worker) OR in the `backfill_strategy_label.py` script. The classifier downstream cannot be correct if its input is wrong.
+
+---
+
+## Scope
+
+**In scope:**
+- Audit-only script `backend/scripts/pr_a23_classifier_audit.py` that produces a report of suspected misclassifications with (current, inferred, confidence) per instrument, WITHOUT mutating any data.
+- Fix the `fallback_fi_aggregate` branch at `backend/app/domains/wealth/services/universe_auto_import_classifier.py:136` and any sibling equity fallback: replace silent mis-bucketing with `block_id = NULL` + `attributes.needs_human_review = true`.
+- Batch re-classification script `backend/scripts/pr_a23_reclassify_auto_import.py` that re-runs the corrected classifier over existing `source='universe_auto_import'` rows and updates `block_id` where the new classifier result differs from the stored value. Writes an audit log row per change.
+- Strategy-label patch migration: for a narrow, verified set of universally-wrong labels (AGG, BND, EFA, EEM, VEA, VWO, VTEB, MUB, and any others surfaced by the audit script with high confidence), correct `instruments_universe.attributes->'strategy_label'` via a data migration.
+- Unit tests for the classifier changes.
+
+**Out of scope:**
+- Do NOT rewrite the classifier algorithm. Keep the existing three-layer structure (rules → cosine similarity → LLM fallback). Only replace the *silent fallback bucket* with an explicit NULL+flag.
+- Do NOT add ML or LLM passes to identify misclassifications. The audit uses deterministic ticker/ISIN → canonical strategy_label mappings hardcoded from public fund fact sheets for the ~30 most-liquid ETFs. This is a narrow, high-confidence patch, not a full re-labeling.
+- Do NOT change `block_mapping.py` (strategy_label → block_id) except additions; do not remove entries.
+- Do NOT touch SEC ingestion workers or ESMA ingestion worker. The upstream `strategy_label` corruption will persist for long-tail tickers; this PR fixes the top-30 by liquidity only. A future PR can address upstream.
+- Do NOT run the re-classification against prod. This PR ships the script; operator runs it manually after review.
+
+---
+
+## Execution Spec
+
+### Section A — Audit script
+
+**File:** `backend/scripts/pr_a23_classifier_audit.py`
+
+Reads (never writes). Identifies suspected misclassifications via a **canonical reference table** hardcoded in the script — the ~30 most-liquid ETFs with their known-correct `strategy_label` and `block_id`:
+
+```python
+CANONICAL_REFERENCE = {
+    # Equity - US
+    "SPY": ("Large Blend", "na_equity_large"),
+    "IVV": ("Large Blend", "na_equity_large"),
+    "VOO": ("Large Blend", "na_equity_large"),
+    "VTI": ("Large Blend", "na_equity_large"),
+    "QQQ": ("Large Growth", "na_equity_growth"),
+    "VUG": ("Large Growth", "na_equity_growth"),
+    "IWF": ("Large Growth", "na_equity_growth"),
+    "VTV": ("Large Value", "na_equity_value"),
+    "IWD": ("Large Value", "na_equity_value"),
+    "IWM": ("Small Blend", "na_equity_small"),
+    "VB": ("Small Blend", "na_equity_small"),
+    # Equity - International
+    "EFA": ("Foreign Large Blend", "dm_europe_equity"),
+    "VEA": ("Foreign Large Blend", "dm_europe_equity"),
+    "IEFA": ("Foreign Large Blend", "dm_europe_equity"),
+    "EEM": ("Diversified Emerging Mkts", "em_equity"),
+    "VWO": ("Diversified Emerging Mkts", "em_equity"),
+    "IEMG": ("Diversified Emerging Mkts", "em_equity"),
+    # Fixed Income - Treasury / Aggregate
+    "AGG": ("Intermediate Core Bond", "fi_us_aggregate"),
+    "BND": ("Intermediate Core Bond", "fi_us_aggregate"),
+    "IEF": ("Intermediate Government", "fi_us_treasury"),
+    "TLT": ("Long Government", "fi_us_treasury"),
+    "SHY": ("Short Government", "fi_us_treasury"),
+    "GOVT": ("Intermediate Government", "fi_us_treasury"),
+    # Fixed Income - Muni (NOT fi_us_aggregate)
+    "VTEB": ("Muni National Interm", "fi_us_aggregate_muni"),  # see note
+    "MUB": ("Muni National Interm", "fi_us_aggregate_muni"),
+    # Fixed Income - TIPS / HY / IG
+    "TIP": ("Inflation-Protected Bond", "fi_us_tips"),
+    "SCHP": ("Inflation-Protected Bond", "fi_us_tips"),
+    "HYG": ("High Yield Bond", "fi_us_high_yield"),
+    "JNK": ("High Yield Bond", "fi_us_high_yield"),
+    "LQD": ("Corporate Bond", "fi_ig_corporate"),
+    # Alts
+    "GLD": ("Precious Metals", "alt_gold"),
+    "IAU": ("Precious Metals", "alt_gold"),
+    "DBC": ("Commodities Broad Basket", "alt_commodities"),
+    "GSG": ("Commodities Broad Basket", "alt_commodities"),
+    "VNQ": ("Real Estate", "alt_real_estate"),
+}
+```
+
+**Note on `fi_us_aggregate_muni`:** if `allocation_blocks` does not have this block, report it as a gap for operator decision; do not create it in this PR. For now VTEB/MUB should classify to `None` with `needs_human_review=true` until the operator decides whether to split muni from aggregate.
+
+Audit output (JSON + human summary):
+```json
+{
+  "strategy_label_mismatches": [
+    {"ticker": "AGG", "current_label": "Government Bond",
+     "canonical_label": "Intermediate Core Bond",
+     "n_rows_in_universe": 1}
+  ],
+  "block_id_mismatches_in_instruments_org": [
+    {"ticker": "EFA", "organization_id": "...",
+     "current_block_id": "na_equity_large",
+     "canonical_block_id": "dm_europe_equity"}
+  ],
+  "fallback_bucket_contamination": {
+    "fi_us_aggregate_contaminated_by": [
+      {"ticker": "VTEB", "canonical_block": "muni (unresolved)"}
+    ]
+  }
+}
+```
+
+**Acceptance:** script runs against dev DB, produces JSON that matches the defects observed (AGG/EFA strategy_label mismatches, VTEB in `fi_us_aggregate`, EFA in `na_equity_large`).
+
+### Section B — Classifier fallback fix
+
+**File:** `backend/app/domains/wealth/services/universe_auto_import_classifier.py` (around line 136 and any sibling fallback).
+
+Current behavior (roughly):
+```python
+# line ~136
+return "fi_us_aggregate", "fallback_fi_aggregate"
+```
+
+New behavior:
+```python
+return None, "needs_human_review"
+```
+
+And the caller (wherever `universe_auto_import_service.py` consumes this) must handle `None` by:
+- Setting `instruments_org.block_id = NULL`
+- Setting `attributes.needs_human_review = True` (via JSONB merge, not replace)
+- Logging a structured event `{"event": "classifier_needs_review", "ticker": ..., "reason": "fallback_..."}`
+
+Do the same for any equity-side fallback bucket (audit the file — there may be a `fallback_equity_large` or similar). If uncertain, add a comment and flag in the audit report rather than guessing.
+
+**Acceptance:**
+- Unit test: mock a "muni-like" input (bond with muni in name, no other signals) — classifier returns `(None, "needs_human_review")`, not `("fi_us_aggregate", "fallback_fi_aggregate")`.
+- Unit test: mock a well-known equity input (SPY metadata) — classifier still returns `("na_equity_large", ...)` correctly. No regression on happy path.
+
+### Section C — Batch re-classification script
+
+**File:** `backend/scripts/pr_a23_reclassify_auto_import.py`
+
+For every row in `instruments_org` with `source = 'universe_auto_import'`:
+1. Re-run the classifier using current metadata from `instruments_universe`.
+2. If new `block_id` differs from stored `block_id`, update the row. Record a before/after audit entry.
+3. If classifier returns `None`, set `block_id = NULL` and `attributes.needs_human_review = True` on the corresponding `instruments_universe` row (NOT on `instruments_org` — universe is the canonical place for human-review flags).
+
+Script MUST:
+- Be idempotent (re-running produces zero changes on second run).
+- Run in a single transaction per organization_id for safety.
+- Emit a summary at the end: `{"orgs_processed": N, "rows_updated": M, "rows_flagged_for_review": K}`.
+- Support a `--dry-run` flag that only prints intended changes.
+
+**Acceptance:**
+- Dry-run against dev DB: output plausible change counts (at minimum, VTEB → NULL+flag, EFA → dm_europe_equity if strategy_label is corrected first via Section D).
+- Live run against dev DB: changes applied, re-run dry-run shows zero pending changes.
+- Unit test: seed a minimal fixture with a VTEB-like row, run script (not dry), assert block_id = NULL and needs_human_review flag set.
+
+### Section D — Strategy label data migration
+
+**File:** `backend/app/core/db/migrations/versions/0151_fix_known_strategy_labels.py`
+
+Pure data migration — no schema changes. Uses the `CANONICAL_REFERENCE` list from Section A (import it, don't duplicate). For each ticker in that dict, update `instruments_universe.attributes->'strategy_label'` to the canonical value IF the current value differs.
+
+Use JSONB update semantics:
+```sql
+UPDATE instruments_universe
+SET attributes = jsonb_set(attributes, '{strategy_label}', '"Intermediate Core Bond"'::jsonb)
+WHERE ticker = 'AGG'
+  AND attributes->>'strategy_label' IS DISTINCT FROM 'Intermediate Core Bond';
+```
+
+Down-migration: write the inverse update (restore the prior value). Since we can't recover the *exact* prior strings without a snapshot table, capture pre-migration state into a one-off `pr_a23_strategy_label_backup` table within the migration, so down can restore.
+
+**Acceptance:**
+- `make migrate` clean.
+- Post-migration: AGG has `strategy_label = 'Intermediate Core Bond'`, EFA has `'Foreign Large Blend'`, VTEB has `'Muni National Interm'`, and so on for the canonical reference list.
+- `make migrate downgrade -1`: values restored to pre-migration state.
+
+---
+
+## Ordering + dependencies
+
+- Section A (audit) ships first and can run before B/C/D — it is read-only.
+- Section D (strategy label fix) must run BEFORE Section C (re-classification), because the classifier reads strategy_label as a primary signal.
+- Section B (classifier fallback fix) must ship before Section C (otherwise re-classification would re-bucket VTEB to fi_us_aggregate again).
+- Order inside this PR: A → B → D → C.
+
+---
+
+## Global guardrails
+
+- `CLAUDE.md` rules.
+- No new dependencies.
+- `make check` green.
+- One commit per Section.
+- Do not touch `optimizer_service.py`, `construction_run_executor.py`, `candidate_screener.py`, `block_coverage_service.py`.
+
+## Final report format
+
+1. Audit script output (JSON) against dev DB pre-migration.
+2. Migration execution log.
+3. Classifier unit test output.
+4. Re-classification dry-run output + live run summary.
+5. Audit script re-run post-everything — expect ~zero `strategy_label_mismatches` for tickers in the canonical reference, and VTEB/MUB flagged for review.
+6. List of tickers that landed in `needs_human_review` state for operator triage.

--- a/frontends/wealth/src/lib/components/portfolio/ConstructionResultsOverlay.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/ConstructionResultsOverlay.svelte
@@ -21,6 +21,7 @@
 	import { portfolioDisplayName } from "$lib/constants/blocks";
 	import { blockLabel } from "$lib/constants/blocks";
 	import { chartTokens } from "$lib/components/charts/chart-tokens";
+	import CoverageGapPanel from "./CoverageGapPanel.svelte";
 
 	interface Props {
 		onClose: () => void;
@@ -40,6 +41,17 @@
 	const metrics = $derived(run?.ex_ante_metrics ?? null);
 	const narrative = $derived(run?.narrative ?? null);
 	const stressResults = $derived(run?.stress_results ?? []);
+	// PR-A22 — pre-solve block-coverage failure. Takes priority over
+	// the normal KPI/allocation rendering: the cascade never ran, so
+	// there are no metrics to display — only the gap report.
+	const coverageReport = $derived(
+		run?.cascade_telemetry?.coverage_report ?? null,
+	);
+	const coverageMessage = $derived(run?.cascade_telemetry?.operator_message ?? null);
+	const coverageInsufficient = $derived(
+		run?.cascade_telemetry?.winner_signal === "block_coverage_insufficient"
+			&& coverageReport !== null,
+	);
 
 	const portfolioName = $derived(
 		workspace.portfolio
@@ -296,10 +308,14 @@
 	<header class="cro-header">
 		<div class="cro-header-left">
 			<h1 class="cro-title">{portfolioName}</h1>
-			<span class="cro-badge">
-				<CheckCircle size={14} />
-				Construction Successful
-			</span>
+			{#if coverageInsufficient}
+				<span class="cro-badge cro-badge--error">Construction Aborted</span>
+			{:else}
+				<span class="cro-badge">
+					<CheckCircle size={14} />
+					Construction Successful
+				</span>
+			{/if}
 		</div>
 		<button type="button" class="cro-close" onclick={onClose}>
 			<X size={18} />
@@ -309,6 +325,12 @@
 
 	<!-- ── Content ─────────────────────────────────────────── -->
 	<div class="cro-body">
+		{#if coverageInsufficient && coverageReport}
+			<CoverageGapPanel
+				report={coverageReport}
+				message={coverageMessage}
+			/>
+		{:else}
 		<!-- Row 1: KPI Strip -->
 		<div class="cro-kpi-strip">
 			<div class="cro-kpi">
@@ -382,6 +404,7 @@
 				{/if}
 			</div>
 		{/if}
+		{/if}
 	</div>
 </div>
 
@@ -450,6 +473,10 @@
 		font-weight: 600;
 		font-family: "Urbanist", sans-serif;
 		white-space: nowrap;
+	}
+	.cro-badge--error {
+		background: rgba(239, 68, 68, 0.12);
+		color: #ef4444;
 	}
 
 	.cro-close {

--- a/frontends/wealth/src/lib/components/portfolio/CoverageGapPanel.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/CoverageGapPanel.svelte
@@ -1,0 +1,180 @@
+<!--
+  CoverageGapPanel — PR-A22. Surfaced when a construction run aborts
+  pre-solve with ``winner_signal === "block_coverage_insufficient"``.
+
+  Smart-backend / dumb-frontend: the backend owns the prose
+  (``operator_message``) and the per-block gap list
+  (``coverage_report``). This component just tables the data and
+  emits a CTA link to the approved-universe editor with a
+  ``?highlight=<block_id>`` hint the target page may consume later
+  (PR-A22 only emits the link).
+-->
+<script lang="ts">
+	import { formatPercent, formatNumber } from "@investintell/ui";
+	import { blockLabel } from "$lib/constants/blocks";
+	import type {
+		CoverageReport,
+		OperatorMessage,
+	} from "$lib/types/cascade-telemetry";
+
+	interface Props {
+		report: CoverageReport;
+		message: OperatorMessage | null;
+		universeHref?: string;
+	}
+
+	let {
+		report,
+		message,
+		universeHref = "/portfolio",
+	}: Props = $props();
+
+	function gapHref(blockId: string): string {
+		const separator = universeHref.includes("?") ? "&" : "?";
+		return `${universeHref}${separator}highlight=${encodeURIComponent(blockId)}`;
+	}
+</script>
+
+<section class="cgp-root" data-testid="coverage-gap-panel">
+	<header class="cgp-header">
+		<h2 class="cgp-title">
+			Coverage insufficient — {formatPercent(
+				report.total_target_weight_at_risk,
+				1,
+			)} of mandate uncovered
+		</h2>
+		{#if message}
+			<p class="cgp-subtitle">{message.title}</p>
+		{/if}
+	</header>
+
+	<table class="cgp-table">
+		<thead>
+			<tr>
+				<th scope="col">Block</th>
+				<th scope="col" class="cgp-num">Target weight</th>
+				<th scope="col" class="cgp-num">Catalog candidates</th>
+				<th scope="col">Examples</th>
+				<th scope="col" class="cgp-cta-col">Action</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each report.gaps as gap (gap.block_id)}
+				<tr>
+					<td>
+						<span class="cgp-block-name">{blockLabel(gap.block_id) || gap.block_id}</span>
+						<span class="cgp-block-id">{gap.block_id}</span>
+					</td>
+					<td class="cgp-num">{formatPercent(gap.target_weight, 1)}</td>
+					<td class="cgp-num">{formatNumber(gap.catalog_candidates_available, 0)}</td>
+					<td>
+						{#if gap.example_tickers.length > 0}
+							<span class="cgp-tickers">{gap.example_tickers.join(", ")}</span>
+						{:else}
+							<span class="cgp-empty">no catalog suggestions</span>
+						{/if}
+					</td>
+					<td>
+						<a
+							class="cgp-cta"
+							href={gapHref(gap.block_id)}
+							data-block-id={gap.block_id}
+						>
+							Review universe
+						</a>
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+
+	{#if message}
+		<p class="cgp-body">{message.body}</p>
+	{/if}
+</section>
+
+<style>
+	.cgp-root {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		padding: 24px;
+		border-left: 3px solid var(--terminal-status-error);
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+	.cgp-header {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	.cgp-title {
+		margin: 0;
+		font-size: 14px;
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+	.cgp-subtitle {
+		margin: 0;
+		font-size: 12px;
+		color: var(--terminal-fg-secondary);
+	}
+	.cgp-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 12px;
+	}
+	.cgp-table th,
+	.cgp-table td {
+		padding: 8px 12px;
+		text-align: left;
+		border-bottom: 1px solid var(--terminal-border-subtle);
+		vertical-align: middle;
+	}
+	.cgp-table thead th {
+		color: var(--terminal-fg-muted);
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-weight: 600;
+	}
+	.cgp-num {
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+	}
+	.cgp-cta-col {
+		text-align: right;
+	}
+	.cgp-block-name {
+		display: block;
+		color: var(--terminal-fg-primary);
+	}
+	.cgp-block-id {
+		display: block;
+		font-size: 10px;
+		color: var(--terminal-fg-muted);
+	}
+	.cgp-tickers {
+		color: var(--terminal-fg-secondary);
+	}
+	.cgp-empty {
+		color: var(--terminal-fg-muted);
+		font-style: italic;
+	}
+	.cgp-cta {
+		color: var(--terminal-status-info, var(--terminal-fg-primary));
+		text-decoration: underline;
+		font-size: 12px;
+	}
+	.cgp-cta:hover,
+	.cgp-cta:focus-visible {
+		text-decoration: none;
+	}
+	.cgp-body {
+		margin: 0;
+		white-space: pre-wrap;
+		font-size: 11px;
+		line-height: 1.5;
+		color: var(--terminal-fg-secondary);
+	}
+</style>

--- a/frontends/wealth/src/lib/types/cascade-telemetry.ts
+++ b/frontends/wealth/src/lib/types/cascade-telemetry.ts
@@ -93,7 +93,29 @@ export type WinnerSignal =
 	| "cvar_infeasible_min_var"
 	| "robustness_fallback"
 	| "degraded_other"
-	| "pre_solve_failure";
+	| "pre_solve_failure"
+	// PR-A22 — block coverage gate aborted the run before the optimizer.
+	| "block_coverage_insufficient";
+
+/**
+ * PR-A22 — per-block gap in the profile's StrategicAllocation. Surfaced
+ * when ``winner_signal === "block_coverage_insufficient"``.
+ */
+export interface BlockCoverageGap {
+	block_id: string;
+	target_weight: number;
+	suggested_strategy_labels: string[];
+	catalog_candidates_available: number;
+	example_tickers: string[];
+}
+
+export interface CoverageReport {
+	organization_id: string;
+	profile: string;
+	is_sufficient: boolean;
+	total_target_weight_at_risk: number;
+	gaps: BlockCoverageGap[];
+}
 
 export type OperatorMessageSeverity = "info" | "warning" | "error";
 
@@ -115,6 +137,8 @@ export interface CascadeTelemetry {
 	// PR-A19.1 — cascade-aware signal + backend-owned copy.
 	winner_signal?: WinnerSignal | null;
 	operator_message?: OperatorMessage | null;
+	// PR-A22 — populated only when ``winner_signal === "block_coverage_insufficient"``.
+	coverage_report?: CoverageReport | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- New pure function validate_block_coverage in backend/quant_engine/block_coverage_service.py - counts approved candidates per block, flags any block with target_weight > 0 and zero approved candidates as a gap, suggests top-5 catalog tickers by AUM.
- Wired as the **first step** of _execute_inner. Raises CoverageInsufficientError; top-level handler persists cascade_telemetry.winner_signal='block_coverage_insufficient' + full coverage report, emits terminal SSE event, returns. **Optimizer never invoked.**
- WinnerSignal.BLOCK_COVERAGE_INSUFFICIENT added (Python + TypeScript). Migration 0150 documents the no-schema-change decision.
- New CoverageGapPanel.svelte renders per-block gap table (name, weight, catalog count, example tickers, CTA to /portfolio?highlight=<block_id>). ConstructionResultsOverlay branches on winner_signal.
- No threshold - any block with target_weight > 0 and zero approved candidates fails. Operator must explicitly zero target_weight to opt out.

## Tests
- test_block_coverage_service.py: 6/6 (all-covered, with-catalog, no-catalog, mixed, empty, message shape)
- test_construction_run_coverage_gate.py: 2/2 (_persist_coverage_failure telemetry, optimizer never invoked)

## Test plan
- [x] pytest 8/8 pass
- [x] pnpm check clean (no new errors)
- [x] ruff clean
- [ ] Manual dev smoke against org 403d8392/moderate -> expect abort covering na_equity_growth, na_equity_value, alt_commodities (~19.79%)