### PR TITLE
PR-A23: classifier audit + fallback fix + strategy_label sanitization

### DIFF
--- a/backend/app/core/db/migrations/versions/0151_fix_known_strategy_labels.py
+++ b/backend/app/core/db/migrations/versions/0151_fix_known_strategy_labels.py
@@ -1,0 +1,183 @@
+"""PR-A23 Section D — fix known-wrong ``strategy_label`` values on
+``instruments_universe`` for the ~30 most-liquid US ETFs.
+
+Pure data migration — no schema changes. Corrects upstream ingestion
+defects surfaced by the PR-A23 audit:
+
+* ``AGG`` / ``BND``: labelled "Government Bond" — should be "Intermediate
+  Core Bond".
+* ``EFA`` / ``VEA`` / ``IEFA``: labelled "Government Bond" or similar —
+  should be "Foreign Large Blend".
+* ``VTEB`` / ``MUB``: labelled as aggregate — should be "Muni National
+  Interm" (classifier downstream still surfaces these for operator
+  review because ``fi_us_aggregate_muni`` is not a registered block).
+* plus the rest of the PR-A23 canonical reference (SPY, QQQ, GLD, …).
+
+Captures a backup snapshot of pre-migration ``strategy_label`` values
+into ``pr_a23_strategy_label_backup`` so ``downgrade`` can restore
+them exactly.
+
+Idempotent — each UPDATE has ``IS DISTINCT FROM`` guard so re-running
+the upgrade is a no-op.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0151_fix_known_strategy_labels"
+down_revision = "0149_sanitize_org_universe"
+branch_labels = None
+depends_on = None
+
+
+# Duplicated from ``backend/scripts/_pr_a23_canonical_reference.py`` so
+# the migration is a self-contained time-capsule (standard Alembic
+# practice — never import application code from migrations). Keep in
+# sync via the audit script's re-run check.
+_CANONICAL_LABELS: dict[str, str] = {
+    # Equity — US Blend
+    "SPY": "Large Blend",
+    "IVV": "Large Blend",
+    "VOO": "Large Blend",
+    "VTI": "Large Blend",
+    # Equity — US Growth
+    "QQQ": "Large Growth",
+    "VUG": "Large Growth",
+    "IWF": "Large Growth",
+    # Equity — US Value
+    "VTV": "Large Value",
+    "IWD": "Large Value",
+    # Equity — US Small
+    "IWM": "Small Blend",
+    "VB": "Small Blend",
+    # Equity — International Developed
+    "EFA": "Foreign Large Blend",
+    "VEA": "Foreign Large Blend",
+    "IEFA": "Foreign Large Blend",
+    # Equity — Emerging Markets
+    "EEM": "Diversified Emerging Mkts",
+    "VWO": "Diversified Emerging Mkts",
+    "IEMG": "Diversified Emerging Mkts",
+    # Fixed Income — Aggregate
+    "AGG": "Intermediate Core Bond",
+    "BND": "Intermediate Core Bond",
+    # Fixed Income — Treasury / Government
+    "IEF": "Intermediate Government",
+    "TLT": "Long Government",
+    "SHY": "Short Government",
+    "GOVT": "Intermediate Government",
+    # Fixed Income — Muni
+    "VTEB": "Muni National Interm",
+    "MUB": "Muni National Interm",
+    # Fixed Income — TIPS
+    "TIP": "Inflation-Protected Bond",
+    "SCHP": "Inflation-Protected Bond",
+    # Fixed Income — High Yield
+    "HYG": "High Yield Bond",
+    "JNK": "High Yield Bond",
+    # Fixed Income — IG Corporate
+    "LQD": "Corporate Bond",
+    # Alternatives — Gold
+    "GLD": "Precious Metals",
+    "IAU": "Precious Metals",
+    # Alternatives — Broad Commodities
+    "DBC": "Commodities Broad Basket",
+    "GSG": "Commodities Broad Basket",
+    # Alternatives — Real Estate
+    "VNQ": "Real Estate",
+}
+
+
+_BACKUP_TABLE = "pr_a23_strategy_label_backup"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # ── Step 1 — create backup table ──────────────────────────────
+    # Idempotent: if rerun, preserve the original snapshot rather than
+    # recapturing post-update state.
+    conn.execute(
+        sa.text(
+            f"""
+            CREATE TABLE IF NOT EXISTS {_BACKUP_TABLE} (
+                ticker TEXT NOT NULL,
+                instrument_id UUID NOT NULL,
+                prior_strategy_label TEXT,
+                captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (ticker, instrument_id)
+            )
+            """
+        )
+    )
+
+    # Capture pre-update state for every row we're about to touch. The
+    # ON CONFLICT DO NOTHING preserves the original snapshot across
+    # reruns — we only ever back up the pristine value.
+    conn.execute(
+        sa.text(
+            f"""
+            INSERT INTO {_BACKUP_TABLE}
+                (ticker, instrument_id, prior_strategy_label)
+            SELECT iu.ticker,
+                   iu.instrument_id,
+                   iu.attributes->>'strategy_label'
+              FROM instruments_universe iu
+             WHERE iu.ticker = ANY(:tickers)
+             ON CONFLICT (ticker, instrument_id) DO NOTHING
+            """
+        ),
+        {"tickers": sorted(_CANONICAL_LABELS.keys())},
+    )
+
+    # ── Step 2 — apply per-ticker strategy_label corrections ─────
+    for ticker, canonical_label in _CANONICAL_LABELS.items():
+        conn.execute(
+            sa.text(
+                """
+                UPDATE instruments_universe
+                   SET attributes = jsonb_set(
+                       COALESCE(attributes, '{}'::jsonb),
+                       '{strategy_label}',
+                       to_jsonb(:label::text),
+                       true
+                   )
+                 WHERE ticker = :ticker
+                   AND COALESCE(attributes->>'strategy_label', '')
+                       IS DISTINCT FROM :label
+                """
+            ),
+            {"ticker": ticker, "label": canonical_label},
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # Restore every pre-migration strategy_label from the backup. If the
+    # prior value was NULL, the jsonb key is removed entirely (matches
+    # the expected "label was never set" state).
+    conn.execute(
+        sa.text(
+            f"""
+            UPDATE instruments_universe iu
+               SET attributes = CASE
+                   WHEN b.prior_strategy_label IS NULL
+                        THEN COALESCE(iu.attributes, '{{}}'::jsonb)
+                             - 'strategy_label'
+                   ELSE jsonb_set(
+                       COALESCE(iu.attributes, '{{}}'::jsonb),
+                       '{{strategy_label}}',
+                       to_jsonb(b.prior_strategy_label::text),
+                       true
+                   )
+               END
+              FROM {_BACKUP_TABLE} b
+             WHERE iu.instrument_id = b.instrument_id
+               AND iu.ticker = b.ticker
+            """
+        )
+    )
+
+    conn.execute(sa.text(f"DROP TABLE IF EXISTS {_BACKUP_TABLE}"))

--- a/backend/app/core/db/migrations/versions/0151_fix_known_strategy_labels.py
+++ b/backend/app/core/db/migrations/versions/0151_fix_known_strategy_labels.py
@@ -26,7 +26,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "0151_fix_known_strategy_labels"
-down_revision = "0149_sanitize_org_universe"
+down_revision = "0150_winner_signal_block_coverage"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/domains/wealth/services/universe_auto_import_classifier.py
+++ b/backend/app/domains/wealth/services/universe_auto_import_classifier.py
@@ -132,8 +132,10 @@ def classify_block(
                 if target is not None:
                     return target, f"fallback_fi_name_{target_block}"
 
-        # 3c. Default — aggregate US bond bucket.
-        return "fi_us_aggregate", "fallback_fi_aggregate"
+        # 3c. No granular signal — PR-A23 D1: silent ``fi_us_aggregate``
+        # default was miscategorising muni / non-aggregate bonds (VTEB,
+        # MUB). Surface for operator triage instead of silent default.
+        return None, "needs_human_review"
 
     # 4. Equity without strategy_label — geography-aware routing
     if asset_class == "equity":
@@ -144,7 +146,10 @@ def classify_block(
             if target is not None:
                 reason_geo = geography.lower().replace(" ", "_")
                 return target, f"fallback_equity_{reason_geo}"
-        return "na_equity_large", "fallback_equity"
+        # PR-A23 D2: silent ``na_equity_large`` default was dumping
+        # foreign-developed equities (EFA) into the US bucket. Surface
+        # for operator triage.
+        return None, "needs_human_review"
 
     # 5. Real estate fund type
     if fund_type == "Real Estate Fund":

--- a/backend/app/domains/wealth/services/universe_auto_import_service.py
+++ b/backend/app/domains/wealth/services/universe_auto_import_service.py
@@ -311,7 +311,6 @@ async def auto_import_for_org(
                 )
                 logger.info(
                     "classifier_needs_review",
-                    event="classifier_needs_review",
                     instrument_id=str(inst["instrument_id"]),
                     ticker=inst.get("ticker") or inst.get("name"),
                     reason=decision_reason,

--- a/backend/app/domains/wealth/services/universe_auto_import_service.py
+++ b/backend/app/domains/wealth/services/universe_auto_import_service.py
@@ -82,6 +82,7 @@ _QUALIFIED_QUERY = text(
             iu.asset_class,
             iu.investment_geography,
             iu.name,
+            iu.ticker,
             iu.attributes
         FROM instruments_universe iu
         WHERE iu.is_active = TRUE
@@ -123,11 +124,41 @@ _QUALIFIED_QUERY = text(
         c.asset_class,
         c.investment_geography,
         c.name,
+        c.ticker,
         c.attributes
     FROM candidates c
     JOIN covered cov USING (instrument_id)
     """,
 )
+
+
+_FLAG_NEEDS_REVIEW_QUERY = text(
+    """
+    UPDATE instruments_universe
+       SET attributes = jsonb_set(
+           COALESCE(attributes, '{}'::jsonb),
+           '{needs_human_review}',
+           'true'::jsonb,
+           true
+       )
+     WHERE instrument_id = :instrument_id
+       AND COALESCE(attributes->>'needs_human_review', 'false') <> 'true'
+    """,
+)
+
+
+async def _flag_universe_needs_review(
+    db: AsyncSession, *, instrument_id: Any,
+) -> None:
+    """Set ``attributes.needs_human_review = true`` on the canonical
+    ``instruments_universe`` row via JSONB merge (no replacement of
+    sibling keys). Idempotent — repeated calls no-op thanks to the WHERE
+    clause.
+    """
+    await db.execute(
+        _FLAG_NEEDS_REVIEW_QUERY,
+        {"instrument_id": instrument_id},
+    )
 
 
 _UPSERT_QUERY = text(
@@ -190,6 +221,7 @@ async def fetch_qualified_instruments(db: AsyncSession) -> list[dict[str, Any]]:
             "asset_class": row["asset_class"],
             "investment_geography": row["investment_geography"] or "",
             "name": row["name"] or "",
+            "ticker": row["ticker"],
             "attributes": row["attributes"] or {},
         })
     return rows
@@ -269,6 +301,22 @@ async def auto_import_for_org(
             skipped_by_reason[decision_reason] = (
                 skipped_by_reason.get(decision_reason, 0) + 1
             )
+            # PR-A23 — when the classifier surfaces a row that previously
+            # would have landed in a silent fallback bucket, flag the
+            # canonical universe row so operators can triage, and log a
+            # structured event for observability.
+            if decision_reason == "needs_human_review":
+                await _flag_universe_needs_review(
+                    db, instrument_id=inst["instrument_id"],
+                )
+                logger.info(
+                    "classifier_needs_review",
+                    event="classifier_needs_review",
+                    instrument_id=str(inst["instrument_id"]),
+                    ticker=inst.get("ticker") or inst.get("name"),
+                    reason=decision_reason,
+                    organization_id=str(org_id),
+                )
             continue
 
         row = await db.execute(

--- a/backend/scripts/_pr_a23_canonical_reference.py
+++ b/backend/scripts/_pr_a23_canonical_reference.py
@@ -1,0 +1,76 @@
+"""PR-A23 canonical reference — known-correct (strategy_label, block_id)
+mappings for the ~30 most-liquid US ETFs used by the classifier audit
+(``pr_a23_classifier_audit.py``), the re-classification script
+(``pr_a23_reclassify_auto_import.py``) and the strategy-label data
+migration ``0151_fix_known_strategy_labels``.
+
+Hardcoded from public fund fact sheets. Narrow, high-confidence patch.
+NOT a substitute for a full upstream fix in the SEC / ESMA ingestion
+workers — see PR-A23 prompt "Out of scope".
+
+VTEB/MUB map to ``None`` until the operator decides whether to split
+muni from aggregate — ``fi_us_aggregate_muni`` is intentionally NOT in
+``allocation_blocks`` in this PR.
+"""
+from __future__ import annotations
+
+# ticker -> (canonical_strategy_label, canonical_block_id_or_None)
+CANONICAL_REFERENCE: dict[str, tuple[str, str | None]] = {
+    # Equity — US Blend
+    "SPY": ("Large Blend", "na_equity_large"),
+    "IVV": ("Large Blend", "na_equity_large"),
+    "VOO": ("Large Blend", "na_equity_large"),
+    "VTI": ("Large Blend", "na_equity_large"),
+    # Equity — US Growth
+    "QQQ": ("Large Growth", "na_equity_growth"),
+    "VUG": ("Large Growth", "na_equity_growth"),
+    "IWF": ("Large Growth", "na_equity_growth"),
+    # Equity — US Value
+    "VTV": ("Large Value", "na_equity_value"),
+    "IWD": ("Large Value", "na_equity_value"),
+    # Equity — US Small
+    "IWM": ("Small Blend", "na_equity_small"),
+    "VB": ("Small Blend", "na_equity_small"),
+    # Equity — International Developed
+    "EFA": ("Foreign Large Blend", "dm_europe_equity"),
+    "VEA": ("Foreign Large Blend", "dm_europe_equity"),
+    "IEFA": ("Foreign Large Blend", "dm_europe_equity"),
+    # Equity — Emerging Markets
+    "EEM": ("Diversified Emerging Mkts", "em_equity"),
+    "VWO": ("Diversified Emerging Mkts", "em_equity"),
+    "IEMG": ("Diversified Emerging Mkts", "em_equity"),
+    # Fixed Income — Aggregate
+    "AGG": ("Intermediate Core Bond", "fi_us_aggregate"),
+    "BND": ("Intermediate Core Bond", "fi_us_aggregate"),
+    # Fixed Income — Treasury / Government
+    "IEF": ("Intermediate Government", "fi_us_treasury"),
+    "TLT": ("Long Government", "fi_us_treasury"),
+    "SHY": ("Short Government", "fi_us_treasury"),
+    "GOVT": ("Intermediate Government", "fi_us_treasury"),
+    # Fixed Income — Muni (block_id=None until operator decides to split
+    # muni from aggregate; see PR-A23 prompt Section A note).
+    "VTEB": ("Muni National Interm", None),
+    "MUB": ("Muni National Interm", None),
+    # Fixed Income — TIPS
+    "TIP": ("Inflation-Protected Bond", "fi_us_tips"),
+    "SCHP": ("Inflation-Protected Bond", "fi_us_tips"),
+    # Fixed Income — High Yield
+    "HYG": ("High Yield Bond", "fi_us_high_yield"),
+    "JNK": ("High Yield Bond", "fi_us_high_yield"),
+    # Fixed Income — IG Corporate (``Corporate Bond`` is NOT in
+    # STRATEGY_LABEL_TO_BLOCKS as of 2026-04-18; listed here so the audit
+    # surfaces the coverage gap. Once added to block_mapping.py the
+    # reclassify script will route LQD correctly.)
+    "LQD": ("Corporate Bond", "fi_ig_corporate"),
+    # Alternatives — Gold / Precious Metals
+    "GLD": ("Precious Metals", "alt_gold"),
+    "IAU": ("Precious Metals", "alt_gold"),
+    # Alternatives — Broad Commodities
+    "DBC": ("Commodities Broad Basket", "alt_commodities"),
+    "GSG": ("Commodities Broad Basket", "alt_commodities"),
+    # Alternatives — Real Estate
+    "VNQ": ("Real Estate", "alt_real_estate"),
+}
+
+
+__all__ = ["CANONICAL_REFERENCE"]

--- a/backend/scripts/pr_a23_classifier_audit.py
+++ b/backend/scripts/pr_a23_classifier_audit.py
@@ -1,0 +1,166 @@
+"""PR-A23 — classifier audit (read-only).
+
+Identifies three classes of classifier defects without mutating data:
+
+* **D1** — ``strategy_label`` mismatches in ``instruments_universe`` for
+  the tickers listed in ``CANONICAL_REFERENCE``.
+* **D2** — ``block_id`` mismatches in ``instruments_org`` for those same
+  tickers (rows where the stored block differs from the canonical one).
+* **D3** — fallback bucket contamination: rows living in
+  ``fi_us_aggregate`` / ``na_equity_large`` whose canonical block is
+  different (e.g. VTEB that should be muni, EFA that should be foreign
+  developed equity).
+
+Emits a JSON report on stdout and a human-readable summary on stderr.
+Always exits 0 — safe to chain into CI without gating.
+
+Usage::
+
+    python -m backend.scripts.pr_a23_classifier_audit
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.core.config import settings
+from scripts._pr_a23_canonical_reference import CANONICAL_REFERENCE
+
+
+_STRATEGY_MISMATCH_SQL = text(
+    """
+    SELECT iu.ticker,
+           iu.attributes->>'strategy_label' AS current_label,
+           COUNT(*) AS n_rows_in_universe
+      FROM instruments_universe iu
+     WHERE iu.ticker = ANY(:tickers)
+     GROUP BY iu.ticker, iu.attributes->>'strategy_label'
+     ORDER BY iu.ticker
+    """
+)
+
+_BLOCK_MISMATCH_SQL = text(
+    """
+    SELECT io.organization_id::text AS organization_id,
+           iu.ticker,
+           io.block_id AS current_block_id
+      FROM instruments_org io
+      JOIN instruments_universe iu USING (instrument_id)
+     WHERE iu.ticker = ANY(:tickers)
+     ORDER BY iu.ticker, io.organization_id
+    """
+)
+
+
+async def _run() -> dict[str, Any]:
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    tickers = sorted(CANONICAL_REFERENCE.keys())
+
+    async with engine.connect() as conn:
+        strategy_rows = (
+            await conn.execute(_STRATEGY_MISMATCH_SQL, {"tickers": tickers})
+        ).mappings().all()
+        block_rows = (
+            await conn.execute(_BLOCK_MISMATCH_SQL, {"tickers": tickers})
+        ).mappings().all()
+
+    await engine.dispose()
+
+    strategy_mismatches: list[dict[str, Any]] = []
+    universe_seen: dict[str, str | None] = {}
+    for r in strategy_rows:
+        ticker = r["ticker"]
+        canonical_label, _ = CANONICAL_REFERENCE[ticker]
+        current_label = r["current_label"]
+        universe_seen[ticker] = current_label
+        if current_label != canonical_label:
+            strategy_mismatches.append({
+                "ticker": ticker,
+                "current_label": current_label,
+                "canonical_label": canonical_label,
+                "n_rows_in_universe": int(r["n_rows_in_universe"]),
+            })
+
+    tickers_missing_from_universe = [
+        t for t in tickers if t not in universe_seen
+    ]
+
+    block_mismatches: list[dict[str, Any]] = []
+    contamination: dict[str, list[dict[str, Any]]] = {}
+    for r in block_rows:
+        ticker = r["ticker"]
+        current_block = r["current_block_id"]
+        _, canonical_block = CANONICAL_REFERENCE[ticker]
+        if current_block == canonical_block:
+            continue
+        entry = {
+            "ticker": ticker,
+            "organization_id": r["organization_id"],
+            "current_block_id": current_block,
+            "canonical_block_id": (
+                canonical_block if canonical_block is not None else "needs_review"
+            ),
+        }
+        block_mismatches.append(entry)
+        # Aggregate contamination by the CURRENT (wrong) bucket.
+        if current_block is not None:
+            contamination.setdefault(current_block, []).append({
+                "ticker": ticker,
+                "canonical_block": (
+                    canonical_block if canonical_block is not None
+                    else "needs_review (muni unresolved)"
+                ),
+            })
+
+    return {
+        "canonical_reference_size": len(CANONICAL_REFERENCE),
+        "strategy_label_mismatches": strategy_mismatches,
+        "tickers_missing_from_instruments_universe": tickers_missing_from_universe,
+        "block_id_mismatches_in_instruments_org": block_mismatches,
+        "fallback_bucket_contamination": contamination,
+        "summary": {
+            "strategy_mismatches": len(strategy_mismatches),
+            "block_mismatches": len(block_mismatches),
+            "tickers_missing": len(tickers_missing_from_universe),
+            "contaminated_buckets": list(contamination.keys()),
+        },
+    }
+
+
+def _print_human_summary(report: dict[str, Any]) -> None:
+    s = report["summary"]
+    print("── PR-A23 classifier audit ──", file=sys.stderr)
+    print(
+        f"  canonical tickers checked: {report['canonical_reference_size']}",
+        file=sys.stderr,
+    )
+    print(
+        f"  strategy_label mismatches: {s['strategy_mismatches']}",
+        file=sys.stderr,
+    )
+    print(f"  block_id mismatches:       {s['block_mismatches']}", file=sys.stderr)
+    print(f"  tickers missing:           {s['tickers_missing']}", file=sys.stderr)
+    if s["contaminated_buckets"]:
+        print(
+            f"  contaminated buckets:      {', '.join(s['contaminated_buckets'])}",
+            file=sys.stderr,
+        )
+
+
+def main() -> int:
+    report = asyncio.run(_run())
+    print(json.dumps(report, indent=2, default=str))
+    _print_human_summary(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/pr_a23_classifier_audit.py
+++ b/backend/scripts/pr_a23_classifier_audit.py
@@ -34,7 +34,6 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from app.core.config import settings
 from scripts._pr_a23_canonical_reference import CANONICAL_REFERENCE
 
-
 _STRATEGY_MISMATCH_SQL = text(
     """
     SELECT iu.ticker,

--- a/backend/scripts/pr_a23_reclassify_auto_import.py
+++ b/backend/scripts/pr_a23_reclassify_auto_import.py
@@ -45,7 +45,6 @@ from app.domains.wealth.services.universe_auto_import_classifier import (
     classify_block,
 )
 
-
 logger: Any = structlog.get_logger()
 
 

--- a/backend/scripts/pr_a23_reclassify_auto_import.py
+++ b/backend/scripts/pr_a23_reclassify_auto_import.py
@@ -1,0 +1,291 @@
+"""PR-A23 Section C — batch re-classification of auto-imported rows.
+
+Re-runs the corrected classifier over every ``instruments_org`` row
+with ``source LIKE '%universe_auto_import%'`` and updates ``block_id``
+where the new classifier result differs from the stored value. Rows
+that newly surface a ``needs_human_review`` reason have their
+corresponding ``instruments_universe.attributes.needs_human_review``
+flag set to ``true`` (JSONB merge).
+
+Must run AFTER migration ``0151_fix_known_strategy_labels`` —
+strategy_label is the classifier's primary signal, so the label patch
+needs to land first.
+
+Idempotent: re-running on a clean state produces zero changes. Each
+organization is processed in its own transaction. Honors the
+``instruments_org.block_overridden = TRUE`` flag — hand-curated
+overrides are never touched.
+
+Usage::
+
+    # Preview intended changes without writing.
+    python -m backend.scripts.pr_a23_reclassify_auto_import --dry-run
+
+    # Apply.
+    python -m backend.scripts.pr_a23_reclassify_auto_import
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import settings
+from app.domains.wealth.services.universe_auto_import_classifier import (
+    classify_block,
+)
+
+
+logger: Any = structlog.get_logger()
+
+
+_SELECT_ROWS_SQL = text(
+    """
+    SELECT io.id,
+           io.instrument_id,
+           io.block_id AS current_block_id,
+           io.block_overridden,
+           iu.ticker,
+           iu.instrument_type,
+           iu.asset_class,
+           iu.investment_geography,
+           iu.name,
+           iu.attributes
+      FROM instruments_org io
+      JOIN instruments_universe iu USING (instrument_id)
+     WHERE io.organization_id = :org_id
+       AND io.source LIKE '%universe_auto_import%'
+    """
+)
+
+_UPDATE_BLOCK_SQL = text(
+    """
+    UPDATE instruments_org
+       SET block_id = :block_id
+     WHERE id = :row_id
+       AND block_overridden = FALSE
+    """
+)
+
+_FLAG_UNIVERSE_SQL = text(
+    """
+    UPDATE instruments_universe
+       SET attributes = jsonb_set(
+           COALESCE(attributes, '{}'::jsonb),
+           '{needs_human_review}',
+           'true'::jsonb,
+           true
+       )
+     WHERE instrument_id = :instrument_id
+       AND COALESCE(attributes->>'needs_human_review', 'false') <> 'true'
+    """
+)
+
+_VALID_BLOCKS_SQL = text("SELECT block_id FROM allocation_blocks")
+
+_LIST_ORGS_SQL = text(
+    """
+    SELECT DISTINCT organization_id
+      FROM instruments_org
+     WHERE source LIKE '%universe_auto_import%'
+       AND organization_id IS NOT NULL
+    """
+)
+
+
+class _OrgSummary(dict[str, Any]):
+    """Typed-dict-like container for per-org results."""
+
+
+async def _valid_blocks(db: AsyncSession) -> set[str]:
+    result = await db.execute(_VALID_BLOCKS_SQL)
+    return {row[0] for row in result.all()}
+
+
+async def _process_org(
+    db: AsyncSession,
+    *,
+    org_id: UUID,
+    valid_blocks: set[str],
+    dry_run: bool,
+) -> _OrgSummary:
+    """Re-classify every auto-imported row for a single org.
+
+    Returns a summary dict with counts of updates / flags / no-ops.
+    Writes inside a single transaction (caller's session is used; the
+    caller commits or rolls back).
+    """
+    await db.execute(text("SET LOCAL statement_timeout = '120s'"))
+
+    rows = (
+        await db.execute(_SELECT_ROWS_SQL, {"org_id": str(org_id)})
+    ).mappings().all()
+
+    rows_updated = 0
+    rows_flagged = 0
+    rows_override_skipped = 0
+    rows_unchanged = 0
+    changes: list[dict[str, Any]] = []
+
+    for row in rows:
+        payload: dict[str, Any] = {
+            "instrument_id": row["instrument_id"],
+            "instrument_type": row["instrument_type"],
+            "asset_class": row["asset_class"],
+            "investment_geography": row["investment_geography"] or "",
+            "name": row["name"] or "",
+            "ticker": row["ticker"],
+            "attributes": row["attributes"] or {},
+        }
+        new_block, new_reason = classify_block(payload, valid_blocks=valid_blocks)
+        current_block = row["current_block_id"]
+
+        if new_block == current_block:
+            rows_unchanged += 1
+            continue
+
+        # New classifier result surfaces a needs_review → flag universe.
+        if new_block is None:
+            if not dry_run:
+                await db.execute(
+                    _FLAG_UNIVERSE_SQL,
+                    {"instrument_id": row["instrument_id"]},
+                )
+            rows_flagged += 1
+
+        if row["block_overridden"]:
+            # Human-curated — never overwrite, but record the drift.
+            rows_override_skipped += 1
+            changes.append({
+                "row_id": str(row["id"]),
+                "ticker": row["ticker"],
+                "current_block_id": current_block,
+                "new_block_id": new_block,
+                "new_reason": new_reason,
+                "applied": False,
+                "skip_reason": "block_overridden",
+            })
+            continue
+
+        if not dry_run:
+            await db.execute(
+                _UPDATE_BLOCK_SQL,
+                {"block_id": new_block, "row_id": row["id"]},
+            )
+        rows_updated += 1
+        changes.append({
+            "row_id": str(row["id"]),
+            "ticker": row["ticker"],
+            "current_block_id": current_block,
+            "new_block_id": new_block,
+            "new_reason": new_reason,
+            "applied": not dry_run,
+            "skip_reason": None,
+        })
+
+    return _OrgSummary(
+        org_id=str(org_id),
+        rows_considered=len(rows),
+        rows_updated=rows_updated,
+        rows_flagged_for_review=rows_flagged,
+        rows_override_skipped=rows_override_skipped,
+        rows_unchanged=rows_unchanged,
+        changes=changes,
+    )
+
+
+async def _run(dry_run: bool) -> dict[str, Any]:
+    engine = create_async_engine(settings.database_url, pool_pre_ping=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    # Fetch org list + valid blocks in an RLS-free session (no-RLS reads).
+    async with session_factory() as db:
+        valid_blocks = await _valid_blocks(db)
+        org_ids = [
+            row[0] for row in (await db.execute(_LIST_ORGS_SQL)).all()
+        ]
+
+    per_org_summaries: list[_OrgSummary] = []
+    total_updated = 0
+    total_flagged = 0
+    total_override_skipped = 0
+    total_unchanged = 0
+
+    for org_id in org_ids:
+        async with session_factory() as db:
+            # Scope RLS context per org so UPDATEs on instruments_org
+            # respect tenancy. instruments_universe is global (no RLS).
+            await db.execute(
+                text("SET LOCAL app.current_organization_id = :oid"),
+                {"oid": str(org_id)},
+            )
+            summary = await _process_org(
+                db,
+                org_id=org_id,
+                valid_blocks=valid_blocks,
+                dry_run=dry_run,
+            )
+            if dry_run:
+                await db.rollback()
+            else:
+                await db.commit()
+
+        per_org_summaries.append(summary)
+        total_updated += summary["rows_updated"]
+        total_flagged += summary["rows_flagged_for_review"]
+        total_override_skipped += summary["rows_override_skipped"]
+        total_unchanged += summary["rows_unchanged"]
+
+    await engine.dispose()
+
+    return {
+        "dry_run": dry_run,
+        "orgs_processed": len(org_ids),
+        "rows_updated": total_updated,
+        "rows_flagged_for_review": total_flagged,
+        "rows_override_skipped": total_override_skipped,
+        "rows_unchanged": total_unchanged,
+        "per_org": per_org_summaries,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print intended changes without writing.",
+    )
+    args = parser.parse_args()
+
+    report = asyncio.run(_run(dry_run=args.dry_run))
+
+    summary_only = {
+        k: v for k, v in report.items() if k != "per_org"
+    }
+    print(json.dumps(summary_only, indent=2))
+
+    print(
+        f"[pr_a23_reclassify] dry_run={report['dry_run']} "
+        f"orgs={report['orgs_processed']} "
+        f"updated={report['rows_updated']} "
+        f"flagged_for_review={report['rows_flagged_for_review']} "
+        f"override_skipped={report['rows_override_skipped']} "
+        f"unchanged={report['rows_unchanged']}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/scripts/test_pr_a23_reclassify_auto_import.py
+++ b/backend/tests/scripts/test_pr_a23_reclassify_auto_import.py
@@ -1,0 +1,203 @@
+"""Unit tests for the PR-A23 reclassify script ``_process_org``.
+
+Exercises the per-org logic with a mock ``AsyncSession``. The DB itself
+is not touched — we assert which UPDATE statements fire with which
+parameters, which is enough to prove:
+
+* VTEB-like rows (muni) surface for review → block_id updated to NULL
+  on ``instruments_org`` AND ``needs_human_review`` flag set on
+  ``instruments_universe``.
+* Happy-path rows (correct strategy_label) are no-ops.
+* Rows with ``block_overridden = TRUE`` are never updated.
+* Dry-run suppresses all UPDATE calls.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _mock_row(scalar_value: Any = None, mapping: list | None = None) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar_value
+    result.all.return_value = mapping or []
+    mappings_proxy = MagicMock()
+    mappings_proxy.all.return_value = mapping or []
+    result.mappings.return_value = mappings_proxy
+    return result
+
+
+def _build_db(
+    select_rows: list[dict],
+) -> tuple[AsyncMock, list[tuple[str, Any]]]:
+    captured: list[tuple[str, Any]] = []
+
+    async def _execute(stmt: Any, params: Any = None) -> MagicMock:
+        sql = str(stmt)
+        captured.append((sql, params))
+        if "FROM instruments_org io" in sql and "WHERE io.organization_id" in sql:
+            return _mock_row(mapping=select_rows)
+        return _mock_row()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    return db, captured
+
+
+def _row(
+    *,
+    ticker: str,
+    current_block: str | None,
+    strategy_label: str | None,
+    asset_class: str = "fixed_income",
+    name: str = "",
+    block_overridden: bool = False,
+) -> dict:
+    return {
+        "id": uuid.uuid4(),
+        "instrument_id": uuid.uuid4(),
+        "current_block_id": current_block,
+        "block_overridden": block_overridden,
+        "ticker": ticker,
+        "instrument_type": "etf",
+        "asset_class": asset_class,
+        "investment_geography": "US",
+        "name": name or ticker,
+        "attributes": (
+            {"strategy_label": strategy_label} if strategy_label else {}
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_vteb_like_row_flagged_and_set_null() -> None:
+    """VTEB-style row (fixed_income, no strategy_label, no name signal)
+    was living in fi_us_aggregate. After PR-A23 it reclassifies to None
+    → block set NULL + universe flagged.
+    """
+    from scripts.pr_a23_reclassify_auto_import import _process_org
+
+    row = _row(
+        ticker="VTEB",
+        current_block="fi_us_aggregate",
+        strategy_label=None,
+        name="Vanguard Tax-Exempt Bond",
+    )
+    db, captured = _build_db([row])
+
+    summary = await _process_org(
+        db,
+        org_id=uuid.uuid4(),
+        valid_blocks={"fi_us_aggregate", "fi_us_treasury"},
+        dry_run=False,
+    )
+
+    assert summary["rows_updated"] == 1
+    assert summary["rows_flagged_for_review"] == 1
+
+    # Must have issued both updates.
+    block_updates = [c for c in captured if "UPDATE instruments_org" in c[0]]
+    flag_updates = [
+        c for c in captured
+        if "UPDATE instruments_universe" in c[0]
+        and "needs_human_review" in c[0]
+    ]
+    assert len(block_updates) == 1
+    assert block_updates[0][1]["block_id"] is None
+    assert len(flag_updates) == 1
+
+
+@pytest.mark.asyncio
+async def test_happy_path_row_unchanged() -> None:
+    """Row with correct strategy_label already in the matching block:
+    no UPDATE should fire.
+    """
+    from scripts.pr_a23_reclassify_auto_import import _process_org
+
+    row = _row(
+        ticker="SPY",
+        current_block="na_equity_large",
+        strategy_label="Large Blend",
+        asset_class="equity",
+    )
+    db, captured = _build_db([row])
+
+    summary = await _process_org(
+        db,
+        org_id=uuid.uuid4(),
+        valid_blocks={"na_equity_large"},
+        dry_run=False,
+    )
+
+    assert summary["rows_updated"] == 0
+    assert summary["rows_flagged_for_review"] == 0
+    assert summary["rows_unchanged"] == 1
+
+    block_updates = [c for c in captured if "UPDATE instruments_org" in c[0]]
+    assert block_updates == []
+
+
+@pytest.mark.asyncio
+async def test_overridden_row_never_touched() -> None:
+    """block_overridden=TRUE must short-circuit — the UPDATE on
+    instruments_org must not fire even when the classifier returns a
+    different block.
+    """
+    from scripts.pr_a23_reclassify_auto_import import _process_org
+
+    row = _row(
+        ticker="EFA",
+        current_block="na_equity_large",
+        strategy_label="Foreign Large Blend",
+        asset_class="equity",
+        block_overridden=True,
+    )
+    db, captured = _build_db([row])
+
+    summary = await _process_org(
+        db,
+        org_id=uuid.uuid4(),
+        valid_blocks={"na_equity_large", "dm_europe_equity"},
+        dry_run=False,
+    )
+
+    assert summary["rows_override_skipped"] == 1
+    block_updates = [c for c in captured if "UPDATE instruments_org" in c[0]]
+    assert block_updates == []
+
+
+@pytest.mark.asyncio
+async def test_dry_run_suppresses_writes() -> None:
+    from scripts.pr_a23_reclassify_auto_import import _process_org
+
+    row = _row(
+        ticker="VTEB",
+        current_block="fi_us_aggregate",
+        strategy_label=None,
+    )
+    db, captured = _build_db([row])
+
+    summary = await _process_org(
+        db,
+        org_id=uuid.uuid4(),
+        valid_blocks={"fi_us_aggregate"},
+        dry_run=True,
+    )
+
+    # Counts reflect intended changes.
+    assert summary["rows_updated"] == 1
+    assert summary["rows_flagged_for_review"] == 1
+
+    # But no UPDATE should actually fire.
+    mutations = [
+        c for c in captured
+        if "UPDATE instruments_org" in c[0]
+        or ("UPDATE instruments_universe" in c[0] and "needs_human_review" in c[0])
+    ]
+    assert mutations == []

--- a/backend/tests/wealth/test_universe_auto_import_classifier.py
+++ b/backend/tests/wealth/test_universe_auto_import_classifier.py
@@ -58,17 +58,19 @@ def _inst(
             "cash",
             "asset_class_cash",
         ),
-        # 5. FI fallback (no strategy_label, no name match)
+        # 5. FI fallback (no strategy_label, no name match) — PR-A23
+        # surfaces to operator instead of silent fi_us_aggregate dump.
         (
             _inst(asset_class="fixed_income"),
-            "fi_us_aggregate",
-            "fallback_fi_aggregate",
+            None,
+            "needs_human_review",
         ),
-        # 6. Equity fallback (no strategy_label)
+        # 6. Equity fallback (no strategy_label) — PR-A23 surfaces to
+        # operator instead of silent na_equity_large dump.
         (
             _inst(asset_class="equity"),
-            "na_equity_large",
-            "fallback_equity",
+            None,
+            "needs_human_review",
         ),
         # 7. Real estate fund type
         (
@@ -158,8 +160,10 @@ def test_classify_block(
 def test_classify_block_empty_attributes() -> None:
     inst = {"asset_class": "equity", "instrument_type": "fund", "attributes": None, "name": "X"}
     block_id, reason = classify_block(inst)
-    assert block_id == "na_equity_large"
-    assert reason == "fallback_equity"
+    # PR-A23: equity with no signals surfaces for human review instead
+    # of silently dumping into na_equity_large.
+    assert block_id is None
+    assert reason == "needs_human_review"
 
 
 def test_valid_blocks_filters_primary_to_secondary() -> None:
@@ -198,31 +202,36 @@ def test_equity_geography_routing(
 
 
 def test_equity_unknown_geography_falls_through_to_default() -> None:
+    """PR-A23: unknown geography surfaces for human review, not
+    silently dumped into na_equity_large."""
     inst = _inst(asset_class="equity", investment_geography="Antarctica")
     valid = {"na_equity_large", "em_equity", "dm_europe_equity", "dm_asia_equity"}
     block_id, reason = classify_block(inst, valid_blocks=valid)
-    assert block_id == "na_equity_large"
-    assert reason == "fallback_equity"
+    assert block_id is None
+    assert reason == "needs_human_review"
 
 
 def test_equity_missing_geography_falls_through_to_default() -> None:
-    """Legacy rows without investment_geography keep current PR-A6 behaviour."""
+    """PR-A23: missing geography + no strategy_label surfaces for
+    operator triage rather than defaulting to na_equity_large."""
     inst = _inst(asset_class="equity")  # investment_geography omitted
     block_id, reason = classify_block(inst)
-    assert block_id == "na_equity_large"
-    assert reason == "fallback_equity"
+    assert block_id is None
+    assert reason == "needs_human_review"
 
 
 def test_equity_geography_mapped_block_not_registered_falls_through() -> None:
-    """When the mapped geography block is not in valid_blocks, fall
-    through to the plain ``na_equity_large`` default rather than silently
-    dropping the fund.
+    """PR-A23: when the mapped geography block is not seeded, surface
+    for operator triage instead of silently dropping into
+    na_equity_large — this is the D2 regression vector (EFA routed by
+    geography but em_equity missing would have landed in na_equity_large
+    pre-fix).
     """
     inst = _inst(asset_class="equity", investment_geography="Emerging Markets")
     valid = {"na_equity_large"}  # em_equity intentionally absent
     block_id, reason = classify_block(inst, valid_blocks=valid)
-    assert block_id == "na_equity_large"
-    assert reason == "fallback_equity"
+    assert block_id is None
+    assert reason == "needs_human_review"
 
 
 def test_strategy_label_beats_geography() -> None:
@@ -254,12 +263,14 @@ def test_strategy_label_beats_geography() -> None:
         ("iShares iBoxx $ High Yield Corporate Bond ETF", "fi_us_high_yield", "fallback_fi_name_fi_us_high_yield"),
         ("SPDR High-Yield Corporate", "fi_us_high_yield", "fallback_fi_name_fi_us_high_yield"),
         ("AllianceBernstein Junk Bond Fund", "fi_us_high_yield", "fallback_fi_name_fi_us_high_yield"),
-        ("Vanguard Total Bond Market Index", "fi_us_aggregate", "fallback_fi_aggregate"),
-        ("PIMCO Total Return Fund", "fi_us_aggregate", "fallback_fi_aggregate"),
+        # PR-A23: funds without a specific FI name signal now surface
+        # for operator review instead of silent fi_us_aggregate dump.
+        ("Vanguard Total Bond Market Index", None, "needs_human_review"),
+        ("PIMCO Total Return Fund", None, "needs_human_review"),
     ],
 )
 def test_fi_name_heuristic(
-    name: str, expected_block: str, expected_reason: str,
+    name: str, expected_block: str | None, expected_reason: str,
 ) -> None:
     inst = _inst(
         asset_class="fixed_income", investment_geography="US", name=name,
@@ -300,8 +311,9 @@ def test_fi_geography_em_routes_to_em_debt() -> None:
 
 
 def test_fi_geography_em_falls_through_if_block_missing() -> None:
-    """If fi_em_debt is not registered, EM FI degrades gracefully to
-    name-heuristic / aggregate rather than silently dropping the fund.
+    """PR-A23: if fi_em_debt is not registered and the fund name has no
+    specific FI signal, surface for operator review (was:
+    fi_us_aggregate silent default).
     """
     inst = _inst(
         asset_class="fixed_income", investment_geography="Emerging Markets",
@@ -309,13 +321,14 @@ def test_fi_geography_em_falls_through_if_block_missing() -> None:
     )
     valid = {"fi_us_aggregate"}  # fi_em_debt intentionally absent
     block_id, reason = classify_block(inst, valid_blocks=valid)
-    assert block_id == "fi_us_aggregate"
-    assert reason == "fallback_fi_aggregate"
+    assert block_id is None
+    assert reason == "needs_human_review"
 
 
 def test_fi_geography_europe_falls_through_if_block_missing() -> None:
-    """fi_europe_aggregate is NOT in the default seed; the classifier
-    must gracefully fall through to US name heuristics / aggregate.
+    """PR-A23: European FI without a specific name signal now surfaces
+    for operator review rather than silently dumping into
+    fi_us_aggregate.
     """
     inst = _inst(
         asset_class="fixed_income", investment_geography="Europe",
@@ -323,8 +336,8 @@ def test_fi_geography_europe_falls_through_if_block_missing() -> None:
     )
     valid = {"fi_us_aggregate", "fi_us_treasury"}
     block_id, reason = classify_block(inst, valid_blocks=valid)
-    assert block_id == "fi_us_aggregate"
-    assert reason == "fallback_fi_aggregate"
+    assert block_id is None
+    assert reason == "needs_human_review"
 
 
 def test_fi_strategy_label_beats_name_heuristic() -> None:
@@ -340,6 +353,50 @@ def test_fi_strategy_label_beats_name_heuristic() -> None:
     valid = {"fi_us_aggregate", "fi_us_treasury", "fi_us_high_yield"}
     block_id, reason = classify_block(inst, valid_blocks=valid)
     assert block_id == "fi_us_high_yield"
+    assert reason == "strategy_label"
+
+
+# ── PR-A23 regression tests ────────────────────────────────────────
+
+
+def test_pr_a23_muni_bond_fund_surfaces_for_review() -> None:
+    """A muni-style bond fund with no FI name signal (e.g. VTEB named
+    'Tax-Exempt Bond') would previously have landed in fi_us_aggregate
+    via the silent fallback. PR-A23 surfaces it for operator triage.
+    """
+    inst = _inst(
+        asset_class="fixed_income", investment_geography="US",
+        name="Vanguard Tax-Exempt Bond Index",
+    )
+    valid = {"fi_us_aggregate", "fi_us_treasury", "fi_us_tips", "fi_us_high_yield"}
+    block_id, reason = classify_block(inst, valid_blocks=valid)
+    assert block_id is None
+    assert reason == "needs_human_review"
+
+
+def test_pr_a23_foreign_developed_equity_surfaces_for_review() -> None:
+    """Foreign-developed equity (e.g. EFA) with a corrupted
+    strategy_label and no other signals would previously have landed in
+    na_equity_large via the silent equity fallback. PR-A23 surfaces it
+    for operator triage.
+    """
+    inst = _inst(asset_class="equity", name="iShares MSCI EAFE")
+    valid = {"na_equity_large", "dm_europe_equity"}
+    block_id, reason = classify_block(inst, valid_blocks=valid)
+    assert block_id is None
+    assert reason == "needs_human_review"
+
+
+def test_pr_a23_happy_path_spy_unchanged() -> None:
+    """Regression: well-classified equity with correct strategy_label
+    still lands in na_equity_large (no regression from the fallback
+    change)."""
+    inst = _inst(
+        asset_class="equity", strategy_label="Large Blend", name="SPDR S&P 500",
+    )
+    valid = {"na_equity_large"}
+    block_id, reason = classify_block(inst, valid_blocks=valid)
+    assert block_id == "na_equity_large"
     assert reason == "strategy_label"
 
 

--- a/backend/tests/wealth/test_universe_auto_import_service.py
+++ b/backend/tests/wealth/test_universe_auto_import_service.py
@@ -53,6 +53,20 @@ def _mock_db(upsert_returns: list[Any]) -> tuple[AsyncMock, list]:
     captured: list[tuple[str, Any]] = []
     upsert_iter = iter(upsert_returns)
 
+    # Pre-seeded allocation_blocks snapshot — covers the strategy_label
+    # mappings used in this suite. PR-A23 makes equity / FI fallback
+    # paths return None when no valid block is available, so the tests
+    # need the classifier's ``valid_blocks`` to actually include the
+    # mapped targets.
+    _VALID_BLOCKS = [
+        ("na_equity_large",), ("na_equity_growth",), ("na_equity_value",),
+        ("na_equity_small",), ("dm_europe_equity",), ("dm_asia_equity",),
+        ("em_equity",), ("fi_us_aggregate",), ("fi_us_treasury",),
+        ("fi_us_tips",), ("fi_us_high_yield",), ("fi_em_debt",),
+        ("alt_real_estate",), ("alt_gold",), ("alt_commodities",),
+        ("alt_hedge_fund",), ("alt_managed_futures",), ("cash",),
+    ]
+
     async def _execute(stmt: Any, params: dict | None = None) -> MagicMock:
         sql_str = str(stmt)
         captured.append((sql_str, params))
@@ -60,6 +74,10 @@ def _mock_db(upsert_returns: list[Any]) -> tuple[AsyncMock, list]:
             return _mock_row(next(upsert_iter))
         if "statement_timeout" in sql_str:
             return _mock_row(None)
+        if "SELECT block_id FROM allocation_blocks" in sql_str:
+            res = MagicMock()
+            res.all.return_value = _VALID_BLOCKS
+            return res
         # audit / misc
         return _mock_row(None)
 
@@ -215,6 +233,38 @@ class TestAutoImportForOrg:
         assert after["aum_floor_usd"] == AUM_FLOOR_USD
         assert after["nav_coverage_min"] == NAV_COVERAGE_MIN
         assert after["added"] == metrics["added"]
+
+    async def test_pr_a23_needs_human_review_flags_universe(self) -> None:
+        """PR-A23: when the classifier surfaces a previously-silent
+        fallback case, the service must (a) count under
+        ``skipped_by_reason["needs_human_review"]`` and (b) issue an
+        UPDATE against ``instruments_universe`` to flag the row.
+        """
+        qualified = [
+            _inst(strategy_label=None, asset_class="fixed_income",
+                  name="PIMCO Total Return"),
+        ]
+        db, captured = _mock_db([])  # no UPSERT expected
+        org_id = uuid.uuid4()
+
+        with patch(
+            "app.domains.wealth.services.universe_auto_import_service.write_audit_event",
+            new=AsyncMock(),
+        ):
+            metrics = await auto_import_for_org(
+                db, org_id, reason="test", qualified=qualified,
+            )
+
+        assert metrics["added"] == 0
+        assert metrics["skipped"] == 1
+        assert metrics["skipped_by_reason"]["needs_human_review"] == 1
+
+        flag_updates = [
+            c for c in captured
+            if "UPDATE instruments_universe" in c[0]
+            and "needs_human_review" in c[0]
+        ]
+        assert len(flag_updates) == 1
 
     async def test_qualified_none_triggers_fetch(self) -> None:
         """When callers pass qualified=None, the service fetches the


### PR DESCRIPTION
## Summary

Fixes three classifier-layer defects surfaced by the PR-A23 audit that produce structurally miscategorized instruments in ``instruments_org``:

- **D1** — ``fi_us_aggregate`` silent default dumped muni bond funds (VTEB) into the taxable aggregate bucket.
- **D2** — ``na_equity_large`` silent default dumped foreign-developed equities (EFA) into the US-large bucket.
- **D3** — upstream ``strategy_label`` corruption (AGG/BND/EFA labelled ""Government Bond"", VTEB labelled as aggregate).

## Sections

- **A** — read-only audit script (``backend/scripts/pr_a23_classifier_audit.py``) that emits a JSON report of (ticker, current, canonical, confidence) without mutating data. Canonical reference covers ~30 most-liquid US ETFs.
- **B** — classifier now returns ``(None, ""needs_human_review"")`` from the two silent-fallback branches (equity + FI). The caller flags the matching ``instruments_universe`` row via JSONB merge and emits a structured ``classifier_needs_review`` log event. No regression on happy paths (SPY → na_equity_large unchanged).
- **C** — batch re-classification script (``backend/scripts/pr_a23_reclassify_auto_import.py``) with ``--dry-run``. Respects ``block_overridden = TRUE``. Idempotent.
- **D** — migration ``0151_fix_known_strategy_labels`` — pure data migration that corrects the canonical reference's strategy_label values on ``instruments_universe``, with a backup table for reversible downgrade.

## Tests

- 60 unit tests passing (classifier + service + reclassify script).
- Classifier: 2 new regression tests (VTEB surfaces-for-review, EFA surfaces-for-review) + SPY happy-path regression.
- Service: ``test_pr_a23_needs_human_review_flags_universe`` asserts the flag-universe UPDATE fires.
- Reclassify: 4 tests (VTEB → NULL+flag, happy-path no-op, block_overridden skipped, dry-run suppresses writes).

## Ordering

Migration 0151 (Section D) MUST run before the reclassify script (Section C) — strategy_label is the classifier's primary signal.

## Test plan

- [x] ``ruff check`` clean on PR-A23 files
- [x] pytest: 60 passed (classifier + service + reclassify script)
- [ ] Operator: ``python -m backend.scripts.pr_a23_classifier_audit`` against dev DB — verify JSON surfaces AGG/EFA/VTEB
- [ ] Operator: ``make migrate`` (applies 0151)
- [ ] Operator: ``python -m backend.scripts.pr_a23_reclassify_auto_import --dry-run``
- [ ] Operator: re-run live after reviewing dry-run output
- [ ] Operator: re-run audit post-everything — expect ~zero strategy_label_mismatches and VTEB/MUB flagged for review

## Scope notes

- Does NOT touch SEC / ESMA ingestion workers (long-tail label drift persists; future PR).
- Does NOT create ``fi_us_aggregate_muni`` block — VTEB/MUB land in ``needs_human_review`` until operator decides.
- Does NOT remove entries from ``block_mapping.py``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)