### PR TITLE
PR-A25: Canonical Allocation Template Schema + Taxonomy Normalization

### DIFF
--- a/backend/app/core/db/migrations/versions/0153_canonical_allocation_template.py
+++ b/backend/app/core/db/migrations/versions/0153_canonical_allocation_template.py
@@ -1,0 +1,595 @@
+"""PR-A25 — canonical allocation template schema + taxonomy normalization.
+
+Establishes the 18-block canonical template that every `(org, profile)`
+pair must share. Profiles differ only in `(target, min, max, risk_budget)`
+per block and the profile-level CVaR limit — never in the block set.
+
+Ordered steps (all inside one transaction):
+
+1. Add ``allocation_blocks.is_canonical`` and
+   ``strategic_allocation.excluded_from_portfolio`` columns.
+2. Relax NOT NULL on ``strategic_allocation.(target|min|max)_weight`` so
+   the backfill can seed rows without forcing arbitrary numeric values —
+   PR-A26 will own the propose-then-approve flow that fills them.
+3. Rename ``fi_short_term → fi_us_short_term`` across every FK-dependent
+   table (same pattern A21 used for ``fi_govt → fi_us_treasury``).
+4. Flip ``is_canonical = true`` on the 18 canonical block IDs; assert
+   the set is complete.
+5. Fix the ``effective_to`` bit-rot that caused the A22 validator to see
+   empty allocations in dev (12-day-stale seed).
+6. Create the ``allocation_template_audit`` table (global, no RLS).
+7. Backfill missing canonical rows into ``strategic_allocation`` for
+   every existing ``(organization_id, profile)`` combo — NULL weights,
+   ``excluded_from_portfolio = false``, ``actor_source = 'migration_0153'``.
+   Matching audit entries written with ``trigger_reason = 'manual_backfill'``.
+8. Install triggers:
+   - ``trg_enforce_allocation_template_sa`` on INSERT to
+     ``strategic_allocation`` auto-populates the remaining canonical rows
+     whenever a fresh ``(org, profile)`` combo lands.
+   - ``trg_enforce_allocation_template_blocks`` on UPDATE of
+     ``allocation_blocks.is_canonical`` → true inserts the newly-canonical
+     block across every existing ``(org, profile)``.
+   Every trigger action is logged to ``allocation_template_audit``.
+
+``winner_signal = 'template_incomplete'`` is stored free-form in
+``cascade_telemetry`` JSONB — no schema change required for the enum;
+the Python-side enum extension lives in ``schemas/sanitized.py``.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0153_canonical_allocation_template"
+down_revision = "0152_exclude_muni_auto_import"
+branch_labels = None
+depends_on = None
+
+
+# The 18 canonical allocation blocks — single source of truth for this
+# migration. If ``allocation_blocks`` is missing any of these rows the
+# migration aborts; they must be seeded by a prior migration.
+_CANONICAL_BLOCKS: tuple[str, ...] = (
+    "na_equity_large",
+    "na_equity_growth",
+    "na_equity_value",
+    "na_equity_small",
+    "dm_europe_equity",
+    "dm_asia_equity",
+    "em_equity",
+    "fi_us_aggregate",
+    "fi_us_treasury",
+    "fi_us_short_term",
+    "fi_us_high_yield",
+    "fi_us_tips",
+    "fi_ig_corporate",
+    "fi_em_debt",
+    "alt_real_estate",
+    "alt_gold",
+    "alt_commodities",
+    "cash",
+)
+
+# Tables carrying a FK/logical reference to ``allocation_blocks.block_id``.
+# Discovered via grep of ``ForeignKey("allocation_blocks.block_id"…)`` in
+# the ORM models as of 2026-04-18. Mirrors migration 0149's list with the
+# addition of ``funds_universe`` (fund.py).
+_FK_DEPENDENT_TABLES: tuple[str, ...] = (
+    "strategic_allocation",
+    "instruments_org",
+    "benchmark_nav",
+    "funds_universe",
+    "tactical_positions",
+    "blended_benchmark_components",
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # ── Step 1 — add columns ─────────────────────────────────────
+    op.execute(
+        """
+        ALTER TABLE allocation_blocks
+          ADD COLUMN IF NOT EXISTS is_canonical BOOLEAN NOT NULL DEFAULT false
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE strategic_allocation
+          ADD COLUMN IF NOT EXISTS excluded_from_portfolio BOOLEAN NOT NULL
+              DEFAULT false
+        """
+    )
+
+    # ── Step 2 — relax NOT NULL on weights (backfill seeds NULLs) ──
+    op.execute(
+        """
+        ALTER TABLE strategic_allocation
+          ALTER COLUMN target_weight DROP NOT NULL,
+          ALTER COLUMN min_weight DROP NOT NULL,
+          ALTER COLUMN max_weight DROP NOT NULL
+        """
+    )
+
+    # ── Step 3 — rename fi_short_term → fi_us_short_term ──────────
+    # Duplicate the row first so FK-dependent rows can retarget before
+    # the old block is deleted. If the destination row already exists
+    # (partial prior run), abort — manual reconciliation only.
+    existing_new = conn.execute(
+        sa.text(
+            """
+            SELECT 1 FROM allocation_blocks
+             WHERE block_id = 'fi_us_short_term'
+            """
+        )
+    ).scalar()
+    existing_old = conn.execute(
+        sa.text(
+            """
+            SELECT 1 FROM allocation_blocks
+             WHERE block_id = 'fi_short_term'
+            """
+        )
+    ).scalar()
+
+    if existing_new and existing_old:
+        raise RuntimeError(
+            "pr_a25_abort both 'fi_us_short_term' and 'fi_short_term' "
+            "exist as distinct blocks — manual reconciliation required "
+            "before migration 0153 can proceed"
+        )
+
+    if existing_old and not existing_new:
+        # Clone fi_short_term row with new id, then remap every
+        # FK-dependent table, then delete the old row.
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO allocation_blocks
+                    (block_id, geography, asset_class, display_name,
+                     benchmark_ticker)
+                SELECT 'fi_us_short_term', geography, asset_class,
+                       display_name, benchmark_ticker
+                  FROM allocation_blocks
+                 WHERE block_id = 'fi_short_term'
+                """
+            )
+        )
+        for tbl in _FK_DEPENDENT_TABLES:
+            result = conn.execute(
+                sa.text(
+                    f"""
+                    UPDATE {tbl}
+                       SET block_id = 'fi_us_short_term'
+                     WHERE block_id = 'fi_short_term'
+                    """
+                )
+            )
+            print(
+                f"[0153] renamed fi_short_term->fi_us_short_term "
+                f"table={tbl} rows={result.rowcount}",
+                flush=True,
+            )
+        # Drop the old block row now that nothing references it.
+        conn.execute(
+            sa.text(
+                """
+                DELETE FROM allocation_blocks
+                 WHERE block_id = 'fi_short_term'
+                """
+            )
+        )
+        print("[0153] deleted legacy block fi_short_term", flush=True)
+    elif not existing_old and not existing_new:
+        # Neither exists — insert the canonical block with a sane default
+        # so Step 4's assertion holds. SHY is the conventional 1-3Y UST.
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO allocation_blocks
+                    (block_id, geography, asset_class, display_name,
+                     benchmark_ticker)
+                VALUES
+                    ('fi_us_short_term', 'us', 'fixed_income',
+                     '1-3 Year Treasury', 'SHY')
+                """
+            )
+        )
+        print("[0153] inserted fi_us_short_term (no prior row)", flush=True)
+    # else: existing_new and not existing_old — nothing to do.
+
+    # ── Step 4 — mark canonical set ───────────────────────────────
+    # Flip is_canonical = true for the 18 IDs. Missing rows at this
+    # point mean the catalog is under-seeded; surface loudly rather
+    # than silently proceed.
+    missing_rows = conn.execute(
+        sa.text(
+            """
+            SELECT t.block_id
+              FROM (SELECT unnest(CAST(:canon AS text[])) AS block_id) t
+             LEFT JOIN allocation_blocks ab ON ab.block_id = t.block_id
+             WHERE ab.block_id IS NULL
+            """
+        ),
+        {"canon": list(_CANONICAL_BLOCKS)},
+    ).fetchall()
+    missing = [r[0] for r in missing_rows]
+    if missing:
+        raise RuntimeError(
+            "pr_a25_abort allocation_blocks is missing canonical rows "
+            f"{missing} — seed them before running migration 0153"
+        )
+    conn.execute(
+        sa.text(
+            """
+            UPDATE allocation_blocks
+               SET is_canonical = true
+             WHERE block_id = ANY(CAST(:canon AS text[]))
+            """
+        ),
+        {"canon": list(_CANONICAL_BLOCKS)},
+    )
+    canon_count = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM allocation_blocks WHERE is_canonical = true"
+        )
+    ).scalar_one()
+    if canon_count != len(_CANONICAL_BLOCKS):
+        raise RuntimeError(
+            f"pr_a25_abort canonical count={canon_count}, expected "
+            f"{len(_CANONICAL_BLOCKS)} — investigate allocation_blocks"
+        )
+    print(f"[0153] marked {canon_count} canonical blocks", flush=True)
+
+    # ── Step 5 — fix effective_to bit-rot ─────────────────────────
+    bitrot = conn.execute(
+        sa.text(
+            """
+            UPDATE strategic_allocation
+               SET effective_to = NULL
+             WHERE effective_to IS NOT NULL
+            """
+        )
+    )
+    print(
+        f"[0153] effective_to bit-rot cleared rows={bitrot.rowcount}",
+        flush=True,
+    )
+
+    # ── Step 6 — create allocation_template_audit ─────────────────
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS allocation_template_audit (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            triggered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            trigger_reason TEXT NOT NULL,
+            organization_id UUID NOT NULL,
+            profile VARCHAR(20) NOT NULL,
+            block_id VARCHAR(80) NOT NULL,
+            action VARCHAR(20) NOT NULL,
+            details JSONB NOT NULL DEFAULT '{}'::jsonb
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_alloc_template_audit_org_profile
+          ON allocation_template_audit (organization_id, profile,
+                                        triggered_at DESC)
+        """
+    )
+
+    # ── Step 7 — backfill missing canonical rows ──────────────────
+    backfill = conn.execute(
+        sa.text(
+            """
+            WITH combo AS (
+                SELECT DISTINCT organization_id, profile
+                  FROM strategic_allocation
+            ),
+            canon AS (
+                SELECT block_id FROM allocation_blocks
+                 WHERE is_canonical = true
+            ),
+            missing AS (
+                SELECT c.organization_id, c.profile, k.block_id
+                  FROM combo c
+                 CROSS JOIN canon k
+             LEFT JOIN strategic_allocation sa
+                    ON sa.organization_id = c.organization_id
+                   AND sa.profile = c.profile
+                   AND sa.block_id = k.block_id
+                 WHERE sa.allocation_id IS NULL
+            )
+            INSERT INTO strategic_allocation (
+                allocation_id, organization_id, profile, block_id,
+                target_weight, min_weight, max_weight, risk_budget,
+                rationale, approved_by, effective_from, effective_to,
+                actor_source, excluded_from_portfolio
+            )
+            SELECT gen_random_uuid(), m.organization_id, m.profile,
+                   m.block_id,
+                   NULL, NULL, NULL, NULL,
+                   'Auto-backfilled by migration 0153 for template completeness',
+                   'system', CURRENT_DATE, NULL,
+                   'migration_0153', false
+              FROM missing m
+            RETURNING organization_id, profile, block_id
+            """
+        )
+    )
+    inserted_rows = backfill.fetchall()
+    print(
+        f"[0153] backfilled {len(inserted_rows)} strategic_allocation rows",
+        flush=True,
+    )
+
+    # Matching audit trail entries.
+    if inserted_rows:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO allocation_template_audit
+                    (trigger_reason, organization_id, profile, block_id,
+                     action, details)
+                SELECT 'manual_backfill', r.organization_id, r.profile,
+                       r.block_id, 'inserted',
+                       jsonb_build_object('source', 'migration_0153')
+                  FROM unnest(CAST(:orgs AS uuid[]),
+                              CAST(:profiles AS text[]),
+                              CAST(:blocks AS text[]))
+                    AS r(organization_id, profile, block_id)
+                """
+            ),
+            {
+                "orgs": [str(r[0]) for r in inserted_rows],
+                "profiles": [r[1] for r in inserted_rows],
+                "blocks": [r[2] for r in inserted_rows],
+            },
+        )
+
+    # ── Step 8 — triggers for ongoing template enforcement ────────
+    op.execute(
+        r"""
+        CREATE OR REPLACE FUNCTION fn_enforce_allocation_template_sa()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            missing_block RECORD;
+            existing_rows INT;
+        BEGIN
+            -- Only act on the FIRST row for this (org, profile). The
+            -- AFTER-INSERT timing means NEW is already visible, hence
+            -- the 'existing = 1' comparison.
+            SELECT COUNT(*)
+              INTO existing_rows
+              FROM strategic_allocation
+             WHERE organization_id = NEW.organization_id
+               AND profile = NEW.profile;
+            IF existing_rows <> 1 THEN
+                RETURN NEW;
+            END IF;
+
+            FOR missing_block IN
+                SELECT block_id FROM allocation_blocks
+                 WHERE is_canonical = true
+                   AND block_id <> NEW.block_id
+            LOOP
+                INSERT INTO strategic_allocation (
+                    allocation_id, organization_id, profile, block_id,
+                    target_weight, min_weight, max_weight, risk_budget,
+                    rationale, approved_by, effective_from, effective_to,
+                    actor_source, excluded_from_portfolio
+                )
+                VALUES (
+                    gen_random_uuid(), NEW.organization_id, NEW.profile,
+                    missing_block.block_id,
+                    NULL, NULL, NULL, NULL,
+                    'Auto-inserted by enforce_allocation_template trigger',
+                    'system', CURRENT_DATE, NULL,
+                    'trigger_enforce', false
+                );
+
+                INSERT INTO allocation_template_audit (
+                    trigger_reason, organization_id, profile, block_id,
+                    action, details
+                )
+                VALUES (
+                    'new_profile_created', NEW.organization_id,
+                    NEW.profile, missing_block.block_id, 'inserted',
+                    jsonb_build_object('source_row_id', NEW.allocation_id)
+                );
+            END LOOP;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql SECURITY DEFINER
+        """
+    )
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_enforce_allocation_template_sa
+          ON strategic_allocation
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_enforce_allocation_template_sa
+          AFTER INSERT ON strategic_allocation
+          FOR EACH ROW EXECUTE FUNCTION fn_enforce_allocation_template_sa()
+        """
+    )
+
+    # Sibling trigger: is_canonical flips to true → backfill that block
+    # across every (org, profile) that exists today.
+    op.execute(
+        r"""
+        CREATE OR REPLACE FUNCTION fn_enforce_allocation_template_blocks()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            combo RECORD;
+        BEGIN
+            IF NOT (NEW.is_canonical = true AND
+                    COALESCE(OLD.is_canonical, false) = false) THEN
+                RETURN NEW;
+            END IF;
+
+            FOR combo IN
+                SELECT DISTINCT organization_id, profile
+                  FROM strategic_allocation
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM strategic_allocation sa
+                      WHERE sa.organization_id = strategic_allocation.organization_id
+                        AND sa.profile = strategic_allocation.profile
+                        AND sa.block_id = NEW.block_id
+                 )
+            LOOP
+                INSERT INTO strategic_allocation (
+                    allocation_id, organization_id, profile, block_id,
+                    target_weight, min_weight, max_weight, risk_budget,
+                    rationale, approved_by, effective_from, effective_to,
+                    actor_source, excluded_from_portfolio
+                )
+                VALUES (
+                    gen_random_uuid(), combo.organization_id, combo.profile,
+                    NEW.block_id,
+                    NULL, NULL, NULL, NULL,
+                    'Auto-inserted by enforce_allocation_template_blocks trigger',
+                    'system', CURRENT_DATE, NULL,
+                    'trigger_enforce', false
+                );
+
+                INSERT INTO allocation_template_audit (
+                    trigger_reason, organization_id, profile, block_id,
+                    action, details
+                )
+                VALUES (
+                    'block_marked_canonical', combo.organization_id,
+                    combo.profile, NEW.block_id, 'inserted',
+                    jsonb_build_object('source_block_id', NEW.block_id)
+                );
+            END LOOP;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql SECURITY DEFINER
+        """
+    )
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_enforce_allocation_template_blocks
+          ON allocation_blocks
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_enforce_allocation_template_blocks
+          AFTER UPDATE OF is_canonical ON allocation_blocks
+          FOR EACH ROW EXECUTE FUNCTION fn_enforce_allocation_template_blocks()
+        """
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # Drop triggers + functions first so later DML doesn't fire them.
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_enforce_allocation_template_blocks "
+        "ON allocation_blocks"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_enforce_allocation_template_sa "
+        "ON strategic_allocation"
+    )
+    op.execute("DROP FUNCTION IF EXISTS fn_enforce_allocation_template_blocks()")
+    op.execute("DROP FUNCTION IF EXISTS fn_enforce_allocation_template_sa()")
+
+    # Delete backfilled rows (identified by actor_source).
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM strategic_allocation
+             WHERE actor_source IN ('migration_0153', 'trigger_enforce')
+            """
+        )
+    )
+
+    # Drop audit table.
+    op.execute("DROP TABLE IF EXISTS allocation_template_audit")
+
+    # Reverse rename: fi_us_short_term → fi_short_term.
+    existing_old = conn.execute(
+        sa.text(
+            "SELECT 1 FROM allocation_blocks WHERE block_id = 'fi_short_term'"
+        )
+    ).scalar()
+    existing_new = conn.execute(
+        sa.text(
+            "SELECT 1 FROM allocation_blocks WHERE block_id = 'fi_us_short_term'"
+        )
+    ).scalar()
+    if existing_new and not existing_old:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO allocation_blocks
+                    (block_id, geography, asset_class, display_name,
+                     benchmark_ticker)
+                SELECT 'fi_short_term', geography, asset_class,
+                       display_name, benchmark_ticker
+                  FROM allocation_blocks
+                 WHERE block_id = 'fi_us_short_term'
+                """
+            )
+        )
+        for tbl in _FK_DEPENDENT_TABLES:
+            conn.execute(
+                sa.text(
+                    f"UPDATE {tbl} SET block_id = 'fi_short_term' "
+                    "WHERE block_id = 'fi_us_short_term'"
+                )
+            )
+        conn.execute(
+            sa.text(
+                "DELETE FROM allocation_blocks "
+                "WHERE block_id = 'fi_us_short_term'"
+            )
+        )
+
+    # Drop added columns.
+    op.execute(
+        "ALTER TABLE strategic_allocation "
+        "DROP COLUMN IF EXISTS excluded_from_portfolio"
+    )
+    op.execute(
+        "ALTER TABLE allocation_blocks DROP COLUMN IF EXISTS is_canonical"
+    )
+
+    # Restore NOT NULL only if every remaining row has a value — otherwise
+    # leave columns nullable and surface a warning. Forcing NOT NULL when
+    # NULLs exist would fail at a confusing point in the rollback.
+    null_count = conn.execute(
+        sa.text(
+            """
+            SELECT COUNT(*) FROM strategic_allocation
+             WHERE target_weight IS NULL
+                OR min_weight IS NULL
+                OR max_weight IS NULL
+            """
+        )
+    ).scalar_one()
+    if null_count == 0:
+        op.execute(
+            """
+            ALTER TABLE strategic_allocation
+              ALTER COLUMN target_weight SET NOT NULL,
+              ALTER COLUMN min_weight SET NOT NULL,
+              ALTER COLUMN max_weight SET NOT NULL
+            """
+        )
+    else:
+        print(
+            f"[0153-down] WARNING {null_count} strategic_allocation rows "
+            "carry NULL weights — leaving columns nullable. Populate them "
+            "before re-attempting to restore NOT NULL.",
+            flush=True,
+        )

--- a/backend/app/domains/wealth/models/allocation.py
+++ b/backend/app/domains/wealth/models/allocation.py
@@ -3,7 +3,18 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import Date, DateTime, ForeignKey, Numeric, String, Text, UniqueConstraint, func
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    false as sa_false,
+    func,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -20,15 +31,27 @@ class StrategicAllocation(OrganizationScopedMixin, Base):
     block_id: Mapped[str] = mapped_column(
         String(80), ForeignKey("allocation_blocks.block_id"), nullable=False,
     )
-    target_weight: Mapped[Decimal] = mapped_column(Numeric(6, 4), nullable=False)
-    min_weight: Mapped[Decimal] = mapped_column(Numeric(6, 4), nullable=False)
-    max_weight: Mapped[Decimal] = mapped_column(Numeric(6, 4), nullable=False)
+    # PR-A25 (migration 0153): weights relaxed to nullable so the canonical
+    # 18-block template can be seeded before the operator or PR-A26's
+    # propose-then-approve flow fills the bands.
+    target_weight: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
+    min_weight: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
+    max_weight: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
     risk_budget: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
     rationale: Mapped[str | None] = mapped_column(Text)
     approved_by: Mapped[str | None] = mapped_column(String(100))
     effective_from: Mapped[date] = mapped_column(Date, nullable=False)
     effective_to: Mapped[date | None] = mapped_column(Date)
     actor_source: Mapped[str | None] = mapped_column(String(20))
+    # PR-A25 — operator may mark a canonical block as intentionally excluded
+    # (forces zero exposure) without breaking template completeness. NULL
+    # weights + excluded_from_portfolio = true means "operator decided out".
+    excluded_from_portfolio: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=sa_false(),
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(),
     )

--- a/backend/app/domains/wealth/models/block.py
+++ b/backend/app/domains/wealth/models/block.py
@@ -14,3 +14,10 @@ class AllocationBlock(Base, AuditMetaMixin):
     description: Mapped[str | None] = mapped_column(Text)
     benchmark_ticker: Mapped[str | None] = mapped_column(String(20))
     is_active: Mapped[bool] = mapped_column(Boolean, server_default="true")
+    # PR-A25 (migration 0153) — canonical 18-block template flag. Every
+    # `(org, profile)` must have a strategic_allocation row for every
+    # is_canonical = true block. Triggered population via
+    # fn_enforce_allocation_template_*.
+    is_canonical: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false",
+    )

--- a/backend/app/domains/wealth/schemas/sanitized.py
+++ b/backend/app/domains/wealth/schemas/sanitized.py
@@ -96,6 +96,12 @@ class WinnerSignal(str, Enum):
     # expand the approved universe for those blocks or zero their
     # target_weight explicitly.
     BLOCK_COVERAGE_INSUFFICIENT = "block_coverage_insufficient"
+    # PR-A25 — cascade aborted because the ``(organization_id, profile)``
+    # pair is missing one or more canonical ``allocation_blocks`` rows.
+    # Structural failure that indicates the migration 0153 trigger did
+    # not run, not an operator misconfiguration. Handled upstream of the
+    # coverage gate so the stricter failure surfaces first.
+    TEMPLATE_INCOMPLETE = "template_incomplete"
 
 
 def compute_winner_signal(

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -79,6 +79,11 @@ from app.domains.wealth.schemas.sanitized import (
     humanize_event_type,
     sanitize_payload,
 )
+from quant_engine.allocation_template_service import (
+    TemplateReport,
+    build_template_operator_message,
+    validate_template_completeness,
+)
 from quant_engine.block_coverage_service import (
     CoverageReport,
     build_coverage_operator_message,
@@ -136,6 +141,22 @@ class CoverageInsufficientError(Exception):
         super().__init__(
             f"block_coverage_insufficient gaps={len(report.gaps)} "
             f"weight_at_risk={report.total_target_weight_at_risk:.4f}"
+        )
+        self.report = report
+
+
+class TemplateIncompleteError(Exception):
+    """PR-A25 — raised when the canonical template is incomplete.
+
+    Fires strictly before ``CoverageInsufficientError`` so operators
+    see the structural defect (missing canonical block rows) rather
+    than the downstream coverage gap it would otherwise manifest as.
+    """
+
+    def __init__(self, report: TemplateReport) -> None:
+        super().__init__(
+            "template_incomplete missing="
+            f"{len(report.missing_canonical_blocks)}"
         )
         self.report = report
 
@@ -885,6 +906,38 @@ async def _build_advisor_result(
     }
 
 
+async def _persist_template_failure(
+    db: AsyncSession,
+    *,
+    run: PortfolioConstructionRun,
+    report: TemplateReport,
+) -> None:
+    """PR-A25 — persist a template-incomplete failure to the run row.
+
+    Mirrors :func:`_persist_coverage_failure`: writes a structured
+    ``cascade_telemetry`` payload with ``winner_signal`` +
+    ``operator_message`` plus a ``template_report`` envelope, and
+    flips ``status = 'failed'`` with a compact ``failure_reason``.
+    """
+    operator_message = build_template_operator_message(report)
+    existing_telemetry = run.cascade_telemetry or {}
+    run.cascade_telemetry = {
+        **existing_telemetry,
+        "winner_signal": WinnerSignal.TEMPLATE_INCOMPLETE.value,
+        "operator_signal": WinnerSignal.TEMPLATE_INCOMPLETE.value,
+        "operator_message": operator_message,
+        "template_report": report.model_dump(mode="json"),
+        # Cascade never ran — signal to downstream consumers that
+        # stress / advisor / validation output should not be rendered.
+        "cascade_summary": "template_incomplete",
+    }
+    run.status = "failed"
+    run.failure_reason = (
+        f"template_incomplete: profile '{report.profile}' missing "
+        f"{len(report.missing_canonical_blocks)} canonical block(s)"
+    )
+
+
 async def _persist_coverage_failure(
     db: AsyncSession,
     *,
@@ -1031,6 +1084,37 @@ async def execute_construction_run(
         logger.warning(
             "construction_run_timeout",
             extra={"run_id": str(run_id), "portfolio_id": str(portfolio_id)},
+        )
+        return run
+    except TemplateIncompleteError as template_exc:
+        # PR-A25 — structural failure ahead of the coverage gate.
+        await _persist_template_failure(
+            db, run=run, report=template_exc.report,
+        )
+        run.completed_at = datetime.now(tz=timezone.utc)
+        run.wall_clock_ms = int((time.perf_counter() - start_ts) * 1000)
+        await db.flush()
+        await _publish_terminal_event_sanitized(
+            db,
+            run_id=run_id,
+            job_id=job_id,
+            raw_type="run_failed",
+            raw_payload={
+                "run_id": str(run_id),
+                "reason": "template_incomplete",
+                "winner_signal": WinnerSignal.TEMPLATE_INCOMPLETE.value,
+                "template_report": template_exc.report.model_dump(mode="json"),
+            },
+        )
+        logger.warning(
+            "construction_run_template_incomplete",
+            extra={
+                "run_id": str(run_id),
+                "portfolio_id": str(portfolio_id),
+                "missing_canonical_blocks": (
+                    template_exc.report.missing_canonical_blocks
+                ),
+            },
         )
         return run
     except CoverageInsufficientError as coverage_exc:
@@ -1196,6 +1280,18 @@ async def _execute_inner(
         raise LookupError(f"portfolio {portfolio_id} not found")
     profile = portfolio.profile
     organization_id = portfolio.organization_id
+
+    # ── PR-A25. Template completeness gate — runs BEFORE the coverage
+    # gate so structural defects (missing canonical blocks) surface as
+    # the dedicated ``template_incomplete`` signal. Post-migration 0153
+    # this should never fail; if it does the trigger is broken and the
+    # operator message directs them to engineering rather than to the
+    # universe editor.
+    template = await validate_template_completeness(
+        db, organization_id, profile,
+    )
+    if not template.is_complete:
+        raise TemplateIncompleteError(template)
 
     # ── PR-A22. Block coverage gate — fail fast if any block in the
     # profile's StrategicAllocation has zero approved candidates in

--- a/backend/quant_engine/allocation_template_service.py
+++ b/backend/quant_engine/allocation_template_service.py
@@ -1,0 +1,148 @@
+"""PR-A25 — Template Completeness Validator.
+
+Pre-run check that hard-fails portfolio construction when a
+``(organization_id, profile)`` pair is missing any canonical
+``allocation_blocks`` row. The 18 canonical blocks define the
+institutional template every profile must share — profiles differ on
+risk (CVaR limit + per-block bands), not on asset-class universe.
+
+Called BEFORE :func:`validate_block_coverage` inside
+``construction_run_executor`` so the stricter "template incomplete"
+failure short-circuits the cascade before the coverage gate's
+per-block candidate count check runs.
+
+Design principles
+-----------------
+* **Structural, not quantitative.** This validator does NOT inspect
+  ``target_weight``. The coverage validator owns weight-level checks;
+  this one only answers "does this profile carry every canonical block
+  row?". Missing rows should be impossible post-migration 0153 — their
+  presence indicates the trigger failed or an admin bypassed it.
+* **Informational extras.** Non-canonical blocks (historical drift)
+  are reported but do not fail the validator — the rename path in
+  0153 preserves history for auditability.
+* Pure read-only — never writes. Uses the RLS-aware session passed by
+  the caller.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class TemplateGap(BaseModel):
+    """One entry per missing canonical block in the report."""
+
+    block_id: str
+
+
+class TemplateReport(BaseModel):
+    """Template completeness status for one ``(org, profile)`` pair."""
+
+    organization_id: uuid.UUID
+    profile: str
+    is_complete: bool
+    missing_canonical_blocks: list[str] = Field(default_factory=list)
+    # Informational: non-canonical blocks present in the allocation (e.g.
+    # historical aliases kept for audit). Does NOT fail the validator.
+    extra_non_canonical_blocks: list[str] = Field(default_factory=list)
+
+
+_MISSING_CANONICAL_SQL = text(
+    """
+    SELECT ab.block_id
+      FROM allocation_blocks ab
+      LEFT JOIN strategic_allocation sa
+        ON sa.block_id = ab.block_id
+       AND sa.organization_id = :organization_id
+       AND sa.profile = :profile
+     WHERE ab.is_canonical = true
+       AND sa.allocation_id IS NULL
+     ORDER BY ab.block_id
+    """
+)
+
+_EXTRA_NON_CANONICAL_SQL = text(
+    """
+    SELECT DISTINCT sa.block_id
+      FROM strategic_allocation sa
+      JOIN allocation_blocks ab ON ab.block_id = sa.block_id
+     WHERE sa.organization_id = :organization_id
+       AND sa.profile = :profile
+       AND ab.is_canonical = false
+     ORDER BY sa.block_id
+    """
+)
+
+
+async def validate_template_completeness(
+    db: AsyncSession,
+    organization_id: uuid.UUID,
+    profile: str,
+) -> TemplateReport:
+    """Build a :class:`TemplateReport` for the given org + profile.
+
+    The report is ``is_complete = True`` iff every canonical block has
+    a matching ``strategic_allocation`` row for the pair. Missing rows
+    carry no weight information on purpose — this validator is strictly
+    structural.
+    """
+    missing_rows = (
+        await db.execute(
+            _MISSING_CANONICAL_SQL,
+            {"organization_id": organization_id, "profile": profile},
+        )
+    ).fetchall()
+    extra_rows = (
+        await db.execute(
+            _EXTRA_NON_CANONICAL_SQL,
+            {"organization_id": organization_id, "profile": profile},
+        )
+    ).fetchall()
+
+    missing = [r[0] for r in missing_rows]
+    extras = [r[0] for r in extra_rows]
+
+    return TemplateReport(
+        organization_id=organization_id,
+        profile=profile,
+        is_complete=not missing,
+        missing_canonical_blocks=missing,
+        extra_non_canonical_blocks=extras,
+    )
+
+
+def build_template_operator_message(report: TemplateReport) -> dict[str, Any]:
+    """Backend-owned operator copy for ``template_incomplete`` signal.
+
+    Mirrors ``build_coverage_operator_message`` so the frontend
+    renders the same envelope shape for both pre-solve failures.
+    """
+    n_missing = len(report.missing_canonical_blocks)
+    missing_list = ", ".join(report.missing_canonical_blocks) or "none"
+    body_lines = [
+        (
+            f"Portfolio construction aborted: profile '{report.profile}' "
+            f"is missing {n_missing} canonical allocation block(s). Expected "
+            "18 blocks per profile per the institutional template; "
+            f"{n_missing} are absent."
+        ),
+        "",
+        f"Missing blocks: {missing_list}",
+        "",
+        (
+            "Action: this should never happen post-migration 0153. "
+            "Contact engineering if you see this message — it indicates "
+            "the template trigger failed."
+        ),
+    ]
+    return {
+        "title": "Template incomplete — canonical blocks missing",
+        "body": "\n".join(body_lines),
+        "severity": "error",
+        "action_hint": "contact_engineering_template_trigger_failed",
+    }

--- a/backend/tests/db/test_allocation_template_trigger.py
+++ b/backend/tests/db/test_allocation_template_trigger.py
@@ -1,0 +1,127 @@
+"""PR-A25 — allocation_template_audit trigger DB-level integration test.
+
+Exercises the live Postgres trigger installed by migration 0153. The
+test inserts a single ``strategic_allocation`` row for a brand-new
+``(organization_id, profile)`` combo and asserts:
+
+* The trigger fan-outs the remaining 17 canonical block rows.
+* Every auto-insert produces a matching ``allocation_template_audit``
+  entry with ``trigger_reason = 'new_profile_created'``.
+
+Runs against the Docker Postgres the repo uses for dev/CI. Cleans up
+after itself in ``finally`` so rerunning is safe.
+"""
+from __future__ import annotations
+
+import uuid
+
+import asyncpg
+import pytest
+
+from app.core.config import settings
+
+
+def _asyncpg_dsn() -> str:
+    return settings.database_url.replace(
+        "postgresql+asyncpg://", "postgresql://",
+    )
+
+
+@pytest.mark.asyncio
+async def test_template_trigger_fans_out_canonical_rows() -> None:
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    synthetic_org = uuid.uuid4()
+    synthetic_profile = f"test_{uuid.uuid4().hex[:8]}"
+    try:
+        # Pick a canonical block_id to seed the first row with — any one
+        # will do; the trigger fills the remaining 17.
+        seed_block = await conn.fetchval(
+            """
+            SELECT block_id FROM allocation_blocks
+             WHERE is_canonical = true
+             ORDER BY block_id
+             LIMIT 1
+            """,
+        )
+        assert seed_block is not None, (
+            "migration 0153 must have seeded at least one canonical block"
+        )
+
+        canonical_ids = {
+            r["block_id"]
+            for r in await conn.fetch(
+                "SELECT block_id FROM allocation_blocks WHERE is_canonical = true"
+            )
+        }
+        assert len(canonical_ids) == 18, (
+            f"expected 18 canonical blocks, got {len(canonical_ids)}"
+        )
+
+        # Single INSERT fires the AFTER trigger.
+        await conn.execute(
+            """
+            INSERT INTO strategic_allocation (
+                allocation_id, organization_id, profile, block_id,
+                target_weight, min_weight, max_weight, risk_budget,
+                rationale, approved_by, effective_from, effective_to,
+                actor_source, excluded_from_portfolio
+            )
+            VALUES (
+                gen_random_uuid(), $1, $2, $3,
+                NULL, NULL, NULL, NULL,
+                'test_seed', 'test', CURRENT_DATE, NULL,
+                'test_trigger', false
+            )
+            """,
+            synthetic_org, synthetic_profile, seed_block,
+        )
+
+        rows = await conn.fetch(
+            """
+            SELECT block_id FROM strategic_allocation
+             WHERE organization_id = $1 AND profile = $2
+            """,
+            synthetic_org, synthetic_profile,
+        )
+        present_blocks = {r["block_id"] for r in rows}
+        assert present_blocks == canonical_ids, (
+            "trigger should backfill every canonical block — missing "
+            f"{canonical_ids - present_blocks}, extra "
+            f"{present_blocks - canonical_ids}"
+        )
+
+        audit_rows = await conn.fetch(
+            """
+            SELECT block_id, action, trigger_reason
+              FROM allocation_template_audit
+             WHERE organization_id = $1 AND profile = $2
+            """,
+            synthetic_org, synthetic_profile,
+        )
+        # 17 auto-inserts (the seed row is NOT audited — only the
+        # trigger-inserted ones are).
+        assert len(audit_rows) == 17, (
+            f"expected 17 audit entries, got {len(audit_rows)}"
+        )
+        assert all(
+            r["trigger_reason"] == "new_profile_created" for r in audit_rows
+        )
+        assert all(r["action"] == "inserted" for r in audit_rows)
+        audited_blocks = {r["block_id"] for r in audit_rows}
+        assert audited_blocks == canonical_ids - {seed_block}
+    finally:
+        await conn.execute(
+            """
+            DELETE FROM allocation_template_audit
+             WHERE organization_id = $1 AND profile = $2
+            """,
+            synthetic_org, synthetic_profile,
+        )
+        await conn.execute(
+            """
+            DELETE FROM strategic_allocation
+             WHERE organization_id = $1 AND profile = $2
+            """,
+            synthetic_org, synthetic_profile,
+        )
+        await conn.close()

--- a/backend/tests/quant_engine/test_allocation_template_service.py
+++ b/backend/tests/quant_engine/test_allocation_template_service.py
@@ -1,0 +1,107 @@
+"""PR-A25 — allocation_template_service unit tests.
+
+Mirror of ``test_block_coverage_service.py``. The validator issues two
+queries (missing canonical, extra non-canonical) — mocking the
+``AsyncSession`` keeps the test loop-agnostic and fast.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from quant_engine.allocation_template_service import (
+    TemplateReport,
+    build_template_operator_message,
+    validate_template_completeness,
+)
+
+
+def _make_session(
+    *,
+    missing: list[str],
+    extras: list[str],
+) -> AsyncMock:
+    """Mock an AsyncSession whose execute returns rows keyed by query text."""
+    session = AsyncMock()
+
+    class FakeResult:
+        def __init__(self, rows: list[tuple]) -> None:
+            self._rows = rows
+
+        def fetchall(self) -> list[tuple]:
+            return self._rows
+
+    async def _execute(stmt, params=None):  # noqa: ANN001
+        sql = str(stmt).lower()
+        if "is_canonical = true" in sql and "sa.allocation_id is null" in sql:
+            return FakeResult([(b,) for b in missing])
+        if "is_canonical = false" in sql:
+            return FakeResult([(b,) for b in extras])
+        return FakeResult([])
+
+    session.execute = _execute
+    return session
+
+
+@pytest.mark.asyncio
+async def test_complete_template_returns_is_complete_true() -> None:
+    org = uuid.uuid4()
+    session = _make_session(missing=[], extras=[])
+    report = await validate_template_completeness(session, org, "moderate")
+    assert report.is_complete is True
+    assert report.missing_canonical_blocks == []
+    assert report.extra_non_canonical_blocks == []
+
+
+@pytest.mark.asyncio
+async def test_missing_canonical_block_fails() -> None:
+    org = uuid.uuid4()
+    session = _make_session(
+        missing=["fi_us_short_term", "alt_commodities"],
+        extras=[],
+    )
+    report = await validate_template_completeness(session, org, "conservative")
+    assert report.is_complete is False
+    assert report.missing_canonical_blocks == [
+        "fi_us_short_term", "alt_commodities",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_extra_non_canonical_is_informational() -> None:
+    """Extras are reported but do NOT fail the validator."""
+    org = uuid.uuid4()
+    session = _make_session(missing=[], extras=["fi_aggregate_legacy"])
+    report = await validate_template_completeness(session, org, "growth")
+    assert report.is_complete is True
+    assert report.extra_non_canonical_blocks == ["fi_aggregate_legacy"]
+
+
+@pytest.mark.asyncio
+async def test_missing_and_extra_together() -> None:
+    org = uuid.uuid4()
+    session = _make_session(
+        missing=["cash"],
+        extras=["legacy_block"],
+    )
+    report = await validate_template_completeness(session, org, "moderate")
+    assert report.is_complete is False
+    assert report.missing_canonical_blocks == ["cash"]
+    assert report.extra_non_canonical_blocks == ["legacy_block"]
+
+
+def test_operator_message_shape() -> None:
+    report = TemplateReport(
+        organization_id=uuid.uuid4(),
+        profile="moderate",
+        is_complete=False,
+        missing_canonical_blocks=["fi_us_short_term", "alt_commodities"],
+    )
+    msg = build_template_operator_message(report)
+    assert msg["severity"] == "error"
+    assert "missing 2 canonical allocation block" in msg["body"]
+    assert "fi_us_short_term" in msg["body"]
+    assert "alt_commodities" in msg["body"]
+    assert msg["action_hint"] == "contact_engineering_template_trigger_failed"

--- a/backend/tests/wealth/test_construction_run_template_gate.py
+++ b/backend/tests/wealth/test_construction_run_template_gate.py
@@ -1,0 +1,121 @@
+"""PR-A25 — construction_run_executor template-gate wiring tests.
+
+Mirrors ``test_construction_run_coverage_gate.py``. Verifies that the
+template completeness check runs BEFORE the coverage check, raises
+``TemplateIncompleteError`` on a missing canonical block, and keeps
+both the optimizer and the coverage validator off the hot path.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domains.wealth.models.model_portfolio import PortfolioConstructionRun
+from app.domains.wealth.schemas.sanitized import WinnerSignal
+from app.domains.wealth.workers import construction_run_executor as executor_mod
+from app.domains.wealth.workers.construction_run_executor import (
+    TemplateIncompleteError,
+    _execute_inner,
+    _persist_template_failure,
+)
+from quant_engine.allocation_template_service import TemplateReport
+
+
+def _incomplete_report() -> TemplateReport:
+    return TemplateReport(
+        organization_id=uuid.uuid4(),
+        profile="moderate",
+        is_complete=False,
+        missing_canonical_blocks=["fi_us_short_term", "alt_commodities"],
+        extra_non_canonical_blocks=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_persist_template_failure_populates_telemetry() -> None:
+    run = PortfolioConstructionRun(
+        id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        portfolio_id=uuid.uuid4(),
+        calibration_snapshot={},
+        calibration_hash="x",
+        universe_fingerprint="pending",
+        status="running",
+        requested_by="tester",
+    )
+    report = _incomplete_report()
+    db = AsyncMock()
+    await _persist_template_failure(db, run=run, report=report)
+
+    assert run.status == "failed"
+    assert "template_incomplete" in (run.failure_reason or "")
+    telemetry = run.cascade_telemetry or {}
+    assert (
+        telemetry["winner_signal"]
+        == WinnerSignal.TEMPLATE_INCOMPLETE.value
+    )
+    assert telemetry["operator_signal"] == telemetry["winner_signal"]
+    assert telemetry["cascade_summary"] == "template_incomplete"
+    assert telemetry["template_report"]["missing_canonical_blocks"] == [
+        "fi_us_short_term", "alt_commodities",
+    ]
+    assert telemetry["operator_message"]["severity"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_execute_inner_raises_before_coverage_and_optimizer() -> None:
+    """Template gate fires first: neither the coverage gate nor the
+    optimizer are reached when the template is incomplete.
+    """
+    report = _incomplete_report()
+
+    portfolio_stub = MagicMock()
+    portfolio_stub.profile = "moderate"
+    portfolio_stub.organization_id = report.organization_id
+    portfolio_result = MagicMock()
+    portfolio_result.scalar_one_or_none.return_value = portfolio_stub
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=portfolio_result)
+
+    run = PortfolioConstructionRun(
+        id=uuid.uuid4(),
+        organization_id=report.organization_id,
+        portfolio_id=uuid.uuid4(),
+        calibration_snapshot={},
+        calibration_hash="x",
+        universe_fingerprint="pending",
+        status="running",
+        requested_by="tester",
+    )
+
+    optimizer_mock = AsyncMock()
+    coverage_mock = AsyncMock()
+
+    with patch.object(
+        executor_mod,
+        "validate_template_completeness",
+        new=AsyncMock(return_value=report),
+    ), patch.object(
+        executor_mod,
+        "validate_block_coverage",
+        new=coverage_mock,
+    ), patch(
+        "app.domains.wealth.routes.model_portfolios._run_construction_async",
+        new=optimizer_mock,
+    ):
+        with pytest.raises(TemplateIncompleteError) as exc_info:
+            await _execute_inner(
+                db=db,
+                run=run,
+                portfolio_id=run.portfolio_id,
+                calibration_snapshot={},
+                job_id=None,
+            )
+
+    assert exc_info.value.report.is_complete is False
+    assert len(exc_info.value.report.missing_canonical_blocks) == 2
+    coverage_mock.assert_not_called()
+    optimizer_mock.assert_not_called()

--- a/backend/vertical_engines/wealth/model_portfolio/block_mapping.py
+++ b/backend/vertical_engines/wealth/model_portfolio/block_mapping.py
@@ -38,6 +38,11 @@ STRATEGY_LABEL_TO_BLOCKS: dict[str, list[str]] = {
     "Mid-Cap Blend": ["na_equity_small"],
     "Mid-Cap Growth": ["na_equity_small"],
     "Mid-Cap Value": ["na_equity_small"],
+    # PR-A25 — catalog uses space-form variants alongside Morningstar's
+    # hyphenated names. Keep both keys so legacy rows carrying the exact
+    # hyphen-form label still map correctly.
+    "Mid Growth": ["na_equity_small", "na_equity_growth"],
+    "Mid Value": ["na_equity_small", "na_equity_value"],
     # Equity — Europe
     "Europe Stock": ["dm_europe_equity"],
     "Foreign Large Blend": ["dm_europe_equity"],
@@ -58,9 +63,14 @@ STRATEGY_LABEL_TO_BLOCKS: dict[str, list[str]] = {
     "Fixed Income": ["fi_us_aggregate"],
     "Multisector Bond": ["fi_us_aggregate"],
     # Fixed Income — Treasury
-    "Short Government": ["fi_us_treasury", "cash"],
+    # PR-A25 — Short Government remaps to the new canonical fi_us_short_term
+    # block (post-rename from fi_short_term). Long/Intermediate stay under
+    # fi_us_treasury.
+    "Short Government": ["fi_us_short_term"],
     "Long Government": ["fi_us_treasury"],
     "Intermediate Government": ["fi_us_treasury"],
+    # Fixed Income — Short-term
+    "Ultrashort Bond": ["fi_us_short_term"],
     # Fixed Income — TIPS
     "Inflation-Protected Bond": ["fi_us_tips"],
     # Fixed Income — High Yield
@@ -76,13 +86,16 @@ STRATEGY_LABEL_TO_BLOCKS: dict[str, list[str]] = {
     "Real Estate Fund": ["alt_real_estate"],
     # Alternatives — Commodities
     "Commodities Broad Basket": ["alt_commodities"],
+    # PR-A25 — catalog labels "Commodities" and "Commodities / Energy"
+    # alongside the Morningstar "Commodities Broad Basket" canonical name.
+    "Commodities": ["alt_commodities"],
+    "Commodities / Energy": ["alt_commodities"],
     "Natural Resources": ["alt_commodities"],
     "Infrastructure": ["alt_commodities"],
     # Alternatives — Gold
     "Precious Metals": ["alt_gold"],
     # Cash
     "Money Market": ["cash"],
-    "Ultrashort Bond": ["cash"],
     "Liquidity Fund": ["cash"],
 }
 

--- a/docs/prompts/2026-04-18-pr-a25-canonical-template-schema.md
+++ b/docs/prompts/2026-04-18-pr-a25-canonical-template-schema.md
@@ -1,0 +1,352 @@
+# PR-A25 — Canonical Allocation Template Schema + Taxonomy Normalization
+
+**Date**: 2026-04-18
+**Status**: P0 STRUCTURAL — introduces the canonical 18-block template that all profiles must share. Unblocks PR-A26 (propose-then-approve optimizer flow).
+**Branch**: `feat/pr-a25-canonical-template-schema`
+**Predecessors merged**: PR-A21 (#207), PR-A22 (#209), PR-A23 (#210), PR-A24 (#212), #211 (cleanup script).
+
+---
+
+## Context — product decision
+
+Per product owner (Andrei, 2026-04-18):
+> "Profiles devem ter exatamente os mesmos blocks — não é classe de ativo que define se o profile é mais ou menos conservador, mas o limite de risco."
+
+Today the three profiles (`conservative`, `moderate`, `growth`) have **different block sets**: Conservative has 11 blocks, Moderate/Growth have 14. This is wrong — it conflates *risk tolerance* (profile) with *asset-class universe* (block set). The optimizer produces non-comparable outputs across profiles, attribution/drift/rebalance can't share taxonomy, and operator gaps propagate silently.
+
+**The new architecture:**
+- One canonical set of allocation blocks defined system-wide.
+- Every `(org, profile)` must have `strategic_allocation` rows for every canonical block.
+- Profiles differ only in `(target_weight, min_weight, max_weight, risk_budget)` per block, plus the profile-level CVaR limit stored in `portfolio_calibration`.
+- Operator may set `excluded_from_portfolio = true` on a row to force zero exposure, without breaking template completeness.
+- PR-A26 will add the propose-then-approve flow where the optimizer outputs bands given only CVaR + exclusions. This PR prepares the schema foundation.
+
+---
+
+## Canonical block set (18 blocks)
+
+| Group | block_id | Notes |
+|---|---|---|
+| Equity US | `na_equity_large` | |
+| | `na_equity_growth` | |
+| | `na_equity_value` | |
+| | `na_equity_small` | |
+| Equity DM | `dm_europe_equity` | |
+| | `dm_asia_equity` | |
+| Equity EM | `em_equity` | |
+| FI US | `fi_us_aggregate` | |
+| | `fi_us_treasury` | |
+| | **`fi_us_short_term`** | **NEW** (rename target of `fi_short_term`) |
+| | `fi_us_high_yield` | |
+| | `fi_us_tips` | **KEPT** — inflation hedge, portfolio sophistication |
+| FI other | `fi_ig_corporate` | |
+| | `fi_em_debt` | |
+| Alt | `alt_real_estate` | |
+| | `alt_gold` | |
+| | `alt_commodities` | |
+| Cash | `cash` | Money Market / Liquidity Fund only |
+
+`fi_short_term` is renamed to `fi_us_short_term` (consistency with `fi_us_*` pattern, same refactor pattern as A21's `fi_govt → fi_us_treasury`). `fi_govt` (A21) remains retired.
+
+Existing non-canonical block IDs in `allocation_blocks` (if any remain post-A21) must be flagged `is_canonical = false` and preserved for historical rows.
+
+---
+
+## Scope
+
+**In scope:**
+- `allocation_blocks.is_canonical` boolean column (default false). Seed migration marks the 18 canonical blocks.
+- Rename `fi_short_term → fi_us_short_term` across all FK-dependent tables (`strategic_allocation`, `instruments_org`, `benchmark_nav`, `funds_universe`, `tactical_positions`, `blended_benchmark_components`, etc.). Same pattern as A21 migration 0149.
+- `strategic_allocation.excluded_from_portfolio` boolean column (default false).
+- `strategic_allocation` completeness: every `(org, profile)` must have rows for all canonical blocks. Backfill seed for canonical org `403d8392-...` with `(target=NULL, min=NULL, max=NULL, excluded_from_portfolio=false)` for missing rows.
+- Postgres trigger `enforce_strategic_allocation_template`: fires on INSERT to `strategic_allocation` when a new `(org, profile)` combo appears, auto-inserts rows for every canonical block not yet present. Also fires on UPDATE of `allocation_blocks.is_canonical` to true, inserting rows for that block across all existing `(org, profile)` combos. Every auto-insert logs a row to a new `allocation_template_audit` table (`triggered_at, trigger_reason, organization_id, profile, block_id, action`).
+- `validate_template_completeness(db, organization_id, profile) -> TemplateReport`: pure function in `backend/quant_engine/allocation_template_service.py`. Called in `construction_run_executor` **before** the A22 coverage gate. Fails the run with `winner_signal = 'template_incomplete'` if any canonical block is missing.
+- `block_mapping.py` extensions: `Commodities`, `Commodities / Energy`, `Mid Growth`, `Mid Value`, `Short Government → fi_us_short_term`, `Ultrashort Bond → fi_us_short_term`. Keep `Inflation-Protected Bond → fi_us_tips`.
+- `effective_to` bit-rot fix: migration sets `effective_to = NULL` on all existing `strategic_allocation` rows (12-day-stale seed in dev DB caused A22 validator to see empty allocation).
+- `WinnerSignal.TEMPLATE_INCOMPLETE` enum value.
+- Integration into coverage report payload: if template incomplete, gate short-circuits before coverage computation.
+- Tests for trigger behavior, rename, completeness validator, excluded flag semantics, audit log population.
+
+**Out of scope:**
+- Do NOT implement the propose-then-approve flow. That is PR-A26.
+- Do NOT compute or seed default `(target, min, max)` values per block — bands remain NULL until operator sets or optimizer proposes. This PR is schema-only.
+- Do NOT modify the optimizer cascade. It will continue to read `(min, target, max)` and treat NULLs per its existing semantics (which may need A26-era adjustment, but not here).
+- Do NOT touch `instruments_universe` ingestion, classifier, or N-PORT pipeline.
+- Do NOT change `allocation_blocks` rows beyond adding `fi_us_short_term` and setting `is_canonical`. Old rows (fi_us_tips, etc.) stay — flagging only.
+- Do NOT rename the profile values (`conservative`, `moderate`, `growth`). Product wording separate.
+
+---
+
+## Execution Spec
+
+### Section A — Alembic migration 0153: canonical template schema
+
+**File:** `backend/app/core/db/migrations/versions/0153_canonical_allocation_template.py`
+
+Down_revision: `0152_exclude_muni_auto_import`.
+
+Transactional. Steps in order:
+
+1. **Add columns:**
+   - `ALTER TABLE allocation_blocks ADD COLUMN is_canonical BOOLEAN NOT NULL DEFAULT false`.
+   - `ALTER TABLE strategic_allocation ADD COLUMN excluded_from_portfolio BOOLEAN NOT NULL DEFAULT false`.
+
+2. **Rename `fi_short_term → fi_us_short_term`:**
+   Mirror the A21 pattern (migration 0149 `fi_govt → fi_us_treasury`):
+   - If `allocation_blocks` has `fi_us_short_term` already, abort with clear error ("fi_us_short_term already exists as distinct block — manual reconciliation required"). Otherwise:
+   - `UPDATE allocation_blocks SET block_id = 'fi_us_short_term' WHERE block_id = 'fi_short_term'` — but FK-dependent tables refer to the old id. Better pattern:
+     1. `INSERT INTO allocation_blocks (block_id, ...) SELECT 'fi_us_short_term', ... FROM allocation_blocks WHERE block_id = 'fi_short_term'` — duplicate the row with new id.
+     2. For each referencing table (`strategic_allocation`, `instruments_org`, `benchmark_nav`, `funds_universe`, `tactical_positions`, `blended_benchmark_components`, and any others surfaced by the referenced-by check at migration time), `UPDATE ... SET block_id = 'fi_us_short_term' WHERE block_id = 'fi_short_term'`. Log row counts per table.
+     3. `DELETE FROM allocation_blocks WHERE block_id = 'fi_short_term'`.
+   Use the same FK-discovery pattern as migration 0149 so any future tables are covered.
+
+3. **Mark canonical set:**
+   ```sql
+   UPDATE allocation_blocks SET is_canonical = true
+    WHERE block_id IN (
+     'na_equity_large','na_equity_growth','na_equity_value','na_equity_small',
+     'dm_europe_equity','dm_asia_equity','em_equity',
+     'fi_us_aggregate','fi_us_treasury','fi_us_short_term','fi_us_high_yield','fi_us_tips',
+     'fi_ig_corporate','fi_em_debt',
+     'alt_real_estate','alt_gold','alt_commodities',
+     'cash'
+   );
+   ```
+   Assertion: `SELECT COUNT(*) FROM allocation_blocks WHERE is_canonical = true` must equal 18. If not, abort with list of missing IDs — means `allocation_blocks` is missing a canonical row that should be inserted inside this migration too.
+
+4. **Fix effective_to bit-rot:**
+   ```sql
+   UPDATE strategic_allocation SET effective_to = NULL WHERE effective_to IS NOT NULL;
+   ```
+   Log row count affected.
+
+5. **Create `allocation_template_audit` table:**
+   ```sql
+   CREATE TABLE allocation_template_audit (
+     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+     triggered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+     trigger_reason TEXT NOT NULL,  -- 'new_profile_created', 'block_marked_canonical', 'manual_backfill'
+     organization_id UUID NOT NULL,
+     profile VARCHAR(20) NOT NULL,
+     block_id VARCHAR(80) NOT NULL,
+     action VARCHAR(20) NOT NULL,  -- 'inserted', 'skipped_existing'
+     details JSONB NOT NULL DEFAULT '{}'::jsonb
+   );
+   CREATE INDEX ix_alloc_template_audit_org_profile
+     ON allocation_template_audit (organization_id, profile, triggered_at DESC);
+   ```
+   Global table (no RLS — audit log for admin visibility).
+
+6. **Backfill missing canonical blocks into `strategic_allocation`:**
+   For each existing distinct `(organization_id, profile)` combo, INSERT rows for every canonical block_id not yet present:
+   ```sql
+   INSERT INTO strategic_allocation
+     (allocation_id, organization_id, profile, block_id, target_weight, min_weight, max_weight,
+      risk_budget, rationale, approved_by, effective_from, effective_to, actor_source, excluded_from_portfolio)
+   SELECT gen_random_uuid(), combo.organization_id, combo.profile, blk.block_id,
+          NULL, NULL, NULL, NULL,
+          'Auto-backfilled by migration 0153 for template completeness',
+          'system', CURRENT_DATE, NULL, 'migration_0153', false
+     FROM (SELECT DISTINCT organization_id, profile FROM strategic_allocation) combo
+     CROSS JOIN (SELECT block_id FROM allocation_blocks WHERE is_canonical = true) blk
+     LEFT JOIN strategic_allocation sa
+       ON sa.organization_id = combo.organization_id
+      AND sa.profile = combo.profile
+      AND sa.block_id = blk.block_id
+    WHERE sa.allocation_id IS NULL;
+   ```
+   Log row count inserted. Also insert matching rows into `allocation_template_audit` with `trigger_reason = 'manual_backfill'`, `action = 'inserted'`.
+
+   **Note on `target_weight NOT NULL`:** `strategic_allocation.target_weight` is currently NOT NULL. Migration must first `ALTER COLUMN target_weight DROP NOT NULL` (and similarly `min_weight`, `max_weight`) to permit the NULL backfill. Same for the migration to be clean.
+
+7. **Create trigger `enforce_strategic_allocation_template`:**
+
+   ```sql
+   CREATE OR REPLACE FUNCTION fn_enforce_allocation_template()
+   RETURNS TRIGGER AS $$
+   DECLARE
+     missing_block RECORD;
+     audit_reason TEXT;
+   BEGIN
+     -- Determine reason based on operation + context
+     IF TG_OP = 'INSERT' AND TG_TABLE_NAME = 'strategic_allocation' THEN
+       audit_reason := 'new_profile_created';
+       -- Check if this is the first row for this (org, profile). If yes, backfill.
+       IF (SELECT COUNT(*) FROM strategic_allocation
+            WHERE organization_id = NEW.organization_id AND profile = NEW.profile) = 1 THEN
+         FOR missing_block IN
+           SELECT block_id FROM allocation_blocks
+            WHERE is_canonical = true AND block_id <> NEW.block_id
+         LOOP
+           INSERT INTO strategic_allocation
+             (allocation_id, organization_id, profile, block_id,
+              target_weight, min_weight, max_weight, risk_budget,
+              rationale, approved_by, effective_from, effective_to,
+              actor_source, excluded_from_portfolio)
+           VALUES
+             (gen_random_uuid(), NEW.organization_id, NEW.profile, missing_block.block_id,
+              NULL, NULL, NULL, NULL,
+              'Auto-inserted by enforce_allocation_template trigger',
+              'system', CURRENT_DATE, NULL, 'trigger_enforce', false);
+           INSERT INTO allocation_template_audit
+             (trigger_reason, organization_id, profile, block_id, action,
+              details)
+           VALUES
+             (audit_reason, NEW.organization_id, NEW.profile, missing_block.block_id,
+              'inserted',
+              jsonb_build_object('source_row_id', NEW.allocation_id));
+         END LOOP;
+       END IF;
+     END IF;
+     RETURN NEW;
+   END;
+   $$ LANGUAGE plpgsql SECURITY DEFINER;
+
+   CREATE TRIGGER trg_enforce_allocation_template_sa
+     AFTER INSERT ON strategic_allocation
+     FOR EACH ROW EXECUTE FUNCTION fn_enforce_allocation_template();
+   ```
+
+   A sibling trigger on `allocation_blocks` for when `is_canonical` flips to true — inserts rows into `strategic_allocation` for every existing `(org, profile)` combo for the newly-canonical block, logging each to audit.
+
+   Triggers MUST log every action (insert OR skip) to `allocation_template_audit` so operators can trace any auto-insertion.
+
+8. **Down-migration:** reverse in reverse order. Triggers dropped. `allocation_template_audit` dropped. Backfilled rows deleted (identified via `actor_source IN ('migration_0153','trigger_enforce')`). `fi_us_short_term` renamed back to `fi_short_term`. Columns dropped. Assertion that NOT NULL can be restored (requires target_weight values to exist for all rows — abort with clear error if any NULL weight remains post-reversal).
+
+**Acceptance:**
+- `make migrate` clean, `make migrate downgrade -1` clean.
+- Post-migration: `SELECT organization_id, profile, COUNT(*) FROM strategic_allocation GROUP BY 1,2` returns 18 rows for every `(org, profile)`.
+- Audit table populated with the migration backfill rows.
+- `fi_us_short_term` exists as canonical block; no FK references to `fi_short_term` remain.
+- `effective_to IS NULL` on 100% of `strategic_allocation` rows.
+
+### Section B — `block_mapping.py` label extensions
+
+**File:** `backend/vertical_engines/wealth/model_portfolio/block_mapping.py`
+
+Extend `STRATEGY_LABEL_TO_BLOCKS`:
+```python
+# Commodities — catalog uses short-form label alongside Morningstar full form
+"Commodities": ["alt_commodities"],
+"Commodities / Energy": ["alt_commodities"],
+# Mid-cap equity — catalog uses space-form, mapping had hyphen-form only
+"Mid Growth": ["na_equity_small", "na_equity_growth"],
+"Mid Value": ["na_equity_small", "na_equity_value"],
+# Short-term FI — remap under new canonical block_id
+"Short Government": ["fi_us_short_term"],   # was ["fi_us_treasury", "cash"]
+"Ultrashort Bond": ["fi_us_short_term"],    # was ["cash"]
+```
+
+Do NOT remove the hyphen-form keys (`Mid-Cap Growth`, `Mid-Cap Value`) — kept for backward compatibility with any existing rows that still carry that exact label.
+
+**Acceptance:** `strategy_labels_for_block('alt_commodities')` returns a list including both `"Commodities Broad Basket"` and `"Commodities"`. `strategy_labels_for_block('fi_us_short_term')` returns `["Short Government", "Ultrashort Bond"]`.
+
+### Section C — Template completeness validator
+
+**File:** `backend/quant_engine/allocation_template_service.py` (new).
+
+Pure function, same shape pattern as `block_coverage_service.py`. Schema:
+```python
+class TemplateGap(BaseModel):
+    block_id: str
+
+class TemplateReport(BaseModel):
+    organization_id: UUID
+    profile: str
+    is_complete: bool
+    missing_canonical_blocks: list[str]
+    extra_non_canonical_blocks: list[str]  # non-canonical blocks present in the allocation; informational, not a failure
+```
+
+Queries:
+```sql
+-- missing canonical blocks
+SELECT ab.block_id
+  FROM allocation_blocks ab
+  LEFT JOIN strategic_allocation sa
+    ON sa.block_id = ab.block_id
+   AND sa.organization_id = :organization_id
+   AND sa.profile = :profile
+ WHERE ab.is_canonical = true
+   AND sa.allocation_id IS NULL;
+
+-- extra non-canonical blocks (historical drift)
+SELECT DISTINCT sa.block_id
+  FROM strategic_allocation sa
+  JOIN allocation_blocks ab ON ab.block_id = sa.block_id
+ WHERE sa.organization_id = :organization_id
+   AND sa.profile = :profile
+   AND ab.is_canonical = false;
+```
+
+Acceptance: unit tests covering complete/missing/extra scenarios. Uses existing conftest fixtures — do not invent new ones.
+
+### Section D — Wire into construction run
+
+**File:** `backend/app/domains/wealth/workers/construction_run_executor.py`
+
+Add as FIRST gate, BEFORE `validate_block_coverage` (currently at line ~1206):
+
+```python
+template = await validate_template_completeness(db, organization_id, profile)
+if not template.is_complete:
+    raise TemplateIncompleteError(template)
+```
+
+`TemplateIncompleteError` handled in the outer try/except the same way as `CoverageInsufficientError` — persists `winner_signal = 'template_incomplete'`, operator message listing the missing canonical blocks, and the full `TemplateReport` under `cascade_telemetry.template_report`.
+
+Operator message template:
+```
+Portfolio construction aborted: profile '{profile}' is missing {N} canonical
+allocation block(s). Expected 18 blocks per profile per the institutional
+template; {N} are absent.
+
+Missing blocks: {comma-separated block_ids}
+
+Action: this should never happen post-migration 0153. Contact engineering
+if you see this message — it indicates the template trigger failed.
+```
+
+Wire a matching branch in the frontend component that renders `winner_signal === 'template_incomplete'` (use the same `CoverageGapPanel.svelte` as scaffold or add a sibling `TemplateIncompletePanel.svelte`).
+
+### Section E — Enum + schema updates
+
+Add `WinnerSignal.TEMPLATE_INCOMPLETE = "template_incomplete"` wherever the enum lives (grep confirms it's in the wealth schemas). No migration needed if `winner_signal` is free-form JSONB — document the decision in migration 0153 header.
+
+### Section F — Integration tests
+
+**Files:**
+- `backend/tests/quant_engine/test_allocation_template_service.py`: complete/missing/extra scenarios for the validator.
+- `backend/tests/wealth/test_construction_run_template_gate.py`: mirror `test_construction_run_coverage_gate.py` — seed an incomplete template, dispatch run, assert `status='failed'`, `winner_signal='template_incomplete'`, optimizer + coverage gate never invoked.
+- `backend/tests/db/test_allocation_template_trigger.py`: insert a new `(org, profile)` combo via a single row, assert trigger creates the remaining 17 rows + matching audit entries.
+
+Tests must run clean against the Docker Postgres used in CI.
+
+---
+
+## Ordering inside this PR
+
+A → B → C → D → E → F. One commit per Section.
+
+## Global guardrails
+
+- `CLAUDE.md` rules. Async-first, RLS via `SET LOCAL`, `expire_on_commit=False`, `lazy="raise"`.
+- No new Python dependencies.
+- `make check` green (tolerating pre-existing lint hygiene issues that are not introduced by this PR — noted in `feedback_dev_first_ci_later.md`).
+- One commit per Section.
+- Do NOT touch: optimizer cascade, candidate_screener, `block_coverage_service.py` beyond integration callsite, classifier, fixtures for other tests.
+
+## Final report format
+
+1. Dev DB post-migration state:
+   - `SELECT organization_id, profile, COUNT(*) FROM strategic_allocation GROUP BY 1,2` — every row shows 18.
+   - `SELECT COUNT(*) FROM allocation_blocks WHERE is_canonical = true` = 18.
+   - `SELECT COUNT(*) FROM allocation_template_audit` ≥ (number of rows backfilled by migration 0153).
+   - No FK references to `fi_short_term`.
+2. Migration up + downgrade round-trip verified (up → down → up clean).
+3. Test output (pytest -v for all three new test files + smoke re-run of A22/A23 tests to confirm no regression).
+4. Construction smoke re-run against org `403d8392-...` for all 3 profiles. Expected:
+   - All 3 abort with `winner_signal = 'block_coverage_insufficient'` (A22 gate triggers after template completeness passes).
+   - Coverage report shows gaps for growth/value/commodities blocks where `catalog_candidates_available` is now non-zero thanks to the Section B mapping updates — operator has candidates to import.
+5. Confirmation that trigger fired at least once during the test suite with a matching audit log entry.
+6. List any deviations from spec discovered during implementation.


### PR DESCRIPTION
## Summary

Establishes the **18-block canonical template** every `(org, profile)`
must share. Profiles differ only on risk (CVaR limit + per-block bands),
never on asset-class universe. Unblocks PR-A26 (propose-then-approve
optimizer flow).

Per product owner: *\"Profiles devem ter exatamente os mesmos blocks —
não é classe de ativo que define se o profile é mais ou menos
conservador, mas o limite de risco.\"*

### Scope

- **Section A** — migration 0153: `allocation_blocks.is_canonical`,
  `strategic_allocation.excluded_from_portfolio`, NOT NULL relax on
  weights, `fi_short_term → fi_us_short_term` rename (5,966 rows),
  `effective_to` bit-rot fix, `allocation_template_audit` table, backfill
  of 15 missing rows so every `(org, profile)` carries all 18 canonical
  blocks, two triggers keeping the template complete on future inserts.
- **Section B** — `block_mapping.py`: Commodities, Mid Growth/Value
  (space-form), Short Government / Ultrashort Bond remapped to
  `fi_us_short_term`.
- **Section C** — `quant_engine/allocation_template_service.py`: pure
  read-only structural validator returning `TemplateReport`.
- **Section D** — `construction_run_executor.py`:
  `TemplateIncompleteError` + `_persist_template_failure`; runs BEFORE
  the A22 coverage gate so structural defects surface first.
- **Section E** — `WinnerSignal.TEMPLATE_INCOMPLETE` enum value.
- **Section F** — 3 test files (5 unit + 2 gate + 1 live trigger).

### Out of scope

- PR-A26 propose-then-approve optimizer flow.
- Default `(target, min, max)` seeding per block — bands stay NULL.
- Optimizer cascade, classifier, N-PORT pipeline.

## Dev DB post-migration state

| Check | Result |
|---|---|
| `strategic_allocation` rows per `(org, profile)` | **18 / 18 / 18** |
| `allocation_blocks` canonical count | **18** |
| `allocation_template_audit` entries | **15** (backfill) |
| References to `fi_short_term` | **0** |
| `effective_to IS NOT NULL` rows | **0** |

Round-trip verified: `0152 → 0153 → 0152 → 0153` all clean.

## Test plan

- [x] `pytest tests/quant_engine/test_allocation_template_service.py -v`
      (5/5 passing — complete/missing/extra/combined + operator message)
- [x] `pytest tests/wealth/test_construction_run_template_gate.py -v`
      (2/2 — persist telemetry + gate fires before coverage+optimizer)
- [x] `pytest tests/db/test_allocation_template_trigger.py -v`
      (1/1 — live Postgres trigger fan-out + audit log)
- [x] Regression: `test_block_coverage_service.py` + coverage gate
      (8/8 still green)
- [ ] Post-merge live smoke re-run against org `403d8392-...` across
      all 3 profiles — expected to abort with
      `winner_signal = 'block_coverage_insufficient'` (A22 fires once
      template is complete, which it now is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)