### PR TITLE
PR-A26.1 (DRAFT, paused for A26.0): propose mode optimizer

### DIFF
--- a/backend/app/core/db/migrations/versions/0154_portfolio_construction_run_mode.py
+++ b/backend/app/core/db/migrations/versions/0154_portfolio_construction_run_mode.py
@@ -1,0 +1,54 @@
+"""PR-A26.1 — ``run_mode`` column on portfolio_construction_runs.
+
+Introduces the ``propose`` mode for the optimizer. Existing runs default
+to ``realize`` (the only mode pre-A26). The new index supports the
+``GET /portfolio/profiles/{profile}/latest-proposal`` query which sorts
+by ``requested_at DESC`` filtered on ``run_mode = 'propose'``.
+
+Reversible. The CHECK constraint and the supporting index are dropped
+in the down-migration before the column is removed.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0154_portfolio_construction_run_mode"
+down_revision = "0153_canonical_allocation_template"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "portfolio_construction_runs",
+        sa.Column(
+            "run_mode",
+            sa.String(length=20),
+            nullable=False,
+            server_default="realize",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_pcr_run_mode_valid",
+        "portfolio_construction_runs",
+        "run_mode IN ('realize', 'propose')",
+    )
+    op.create_index(
+        "ix_pcr_run_mode_requested_at",
+        "portfolio_construction_runs",
+        ["run_mode", sa.text("requested_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_pcr_run_mode_requested_at",
+        table_name="portfolio_construction_runs",
+    )
+    op.drop_constraint(
+        "ck_pcr_run_mode_valid",
+        "portfolio_construction_runs",
+        type_="check",
+    )
+    op.drop_column("portfolio_construction_runs", "run_mode")

--- a/backend/app/domains/wealth/models/model_portfolio.py
+++ b/backend/app/domains/wealth/models/model_portfolio.py
@@ -226,6 +226,12 @@ class PortfolioConstructionRun(OrganizationScopedMixin, Base):
 
     # Run lifecycle
     status: Mapped[str] = mapped_column(String(32), nullable=False)
+    # PR-A26.1 — 'realize' (default, IPS-anchored) vs 'propose' (optimizer
+    # explores freely under CVaR + exclusions only). CHECK constraint in
+    # migration 0154.
+    run_mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="realize",
+    )
     requested_by: Mapped[str] = mapped_column(String(128), nullable=False)
     requested_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False,

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -40,6 +40,8 @@ from app.domains.wealth.schemas.model_portfolio import (
     ConstructionRunWeightDelta,
     ConstructRunAccepted,
     CusipExposureRead,
+    JobCreatedResponse,
+    LatestProposalResponse,
     ModelPortfolioCreate,
     ModelPortfolioRead,
     ModelPortfolioUpdate,
@@ -47,6 +49,8 @@ from app.domains.wealth.schemas.model_portfolio import (
     PortfolioCalibrationRead,
     PortfolioCalibrationUpdate,
     PortfolioTransitionRequest,
+    ProposalMetrics,
+    ProposedBand,
     RebalancePreviewRequest,
     RebalancePreviewResponse,
     RegimeCurrentRead,
@@ -4653,3 +4657,205 @@ async def _set_cached_mc(cache_key: str, result: dict, ttl: int = 3600) -> None:
             await r.aclose()
     except Exception:
         logger.debug("mc_cache_set_failed", cache_key=cache_key)
+
+
+# ── PR-A26.1 — Propose-mode endpoints (profile-scoped) ────────────────
+
+
+_PROPOSE_VALID_PROFILES: frozenset[str] = frozenset(
+    {"conservative", "moderate", "growth", "aggressive"},
+)
+
+
+async def _resolve_propose_target_portfolio(
+    db: AsyncSession,
+    *,
+    organization_id: str,
+    profile: str,
+) -> ModelPortfolio:
+    """Resolve the model portfolio to host a propose-mode run for ``profile``.
+
+    Propose mode is profile-scoped from the operator's standpoint, but
+    the construction executor still needs a portfolio row to attach the
+    run to (for ``portfolio_id`` FK on ``portfolio_construction_runs``
+    and the calibration snapshot). We pick the most recently updated
+    model portfolio for the (org, profile) pair. If no portfolio exists
+    yet for the profile, we 404 — propose mode does not auto-create.
+    """
+    stmt = (
+        select(ModelPortfolio)
+        .where(ModelPortfolio.profile == profile)
+        .order_by(ModelPortfolio.state_changed_at.desc())
+        .limit(1)
+    )
+    portfolio = (await db.execute(stmt)).scalar_one_or_none()
+    if portfolio is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"No model portfolio exists for profile '{profile}'. "
+                "Create a portfolio first, then propose an allocation."
+            ),
+        )
+    return portfolio
+
+
+@portfolio_meta_router.post(
+    "/profiles/{profile}/propose-allocation",
+    response_model=JobCreatedResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary=(
+        "PR-A26.1 — Run the optimizer in propose mode (CVaR-only "
+        "constraints, IPS bands ignored)"
+    ),
+)
+async def propose_allocation(
+    profile: str,
+    db: AsyncSession = Depends(get_db_with_rls),
+    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(get_actor),
+    org_id: str = Depends(get_org_id),
+) -> JobCreatedResponse:
+    """Kick off a propose-mode construction run.
+
+    The optimizer runs with maximum freedom subject only to the CVaR
+    target from ``portfolio_calibration`` and the
+    ``excluded_from_portfolio`` flag on ``strategic_allocation``. The
+    cascade still fires the template + coverage gates from PR-A25/A22
+    so structural failures surface before the solver ever runs.
+
+    Returns 202 + job_id. Progress events stream from
+    ``/api/v1/jobs/{job_id}/stream`` and include ``propose_started``,
+    ``optimizer_started``, ``optimizer_phase_complete`` (per phase),
+    and a terminal ``propose_ready`` or ``propose_cvar_infeasible``.
+    The completed proposal can be fetched via
+    ``GET /portfolio/profiles/{profile}/latest-proposal``.
+    """
+    from app.core.jobs.tracker import register_job_owner
+    from app.domains.wealth.workers.construction_run_executor import (
+        execute_construction_run,
+    )
+
+    _require_ic_role(actor)
+
+    profile_lc = profile.strip().lower()
+    if profile_lc not in _PROPOSE_VALID_PROFILES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Unknown profile '{profile}'. Valid: "
+                f"{sorted(_PROPOSE_VALID_PROFILES)}"
+            ),
+        )
+
+    portfolio = await _resolve_propose_target_portfolio(
+        db, organization_id=org_id, profile=profile_lc,
+    )
+
+    job_id = f"propose:{uuid.uuid4()}"
+    await register_job_owner(job_id, str(org_id))
+
+    # Same in-request dispatch shape as the realize-mode /construct
+    # route above — bounded at 120s by execute_construction_run.
+    run = await execute_construction_run(
+        db=db,
+        portfolio_id=portfolio.id,
+        organization_id=org_id,
+        requested_by=actor.actor_id,
+        job_id=job_id,
+        propose_mode=True,
+    )
+
+    return JobCreatedResponse(
+        job_id=job_id,
+        sse_url=f"/api/v1/jobs/{job_id}/stream",
+        run_id=run.id,
+    )
+
+
+@portfolio_meta_router.get(
+    "/profiles/{profile}/latest-proposal",
+    response_model=LatestProposalResponse,
+    summary=(
+        "PR-A26.1 — Fetch the most recent propose-mode allocation for the "
+        "(org, profile) pair"
+    ),
+)
+async def latest_proposal(
+    profile: str,
+    db: AsyncSession = Depends(get_db_with_rls),
+    user: CurrentUser = Depends(get_current_user),
+    org_id: str = Depends(get_org_id),
+) -> LatestProposalResponse:
+    """Return the latest ``run_mode='propose'`` run for the profile.
+
+    404s if no propose run has ever completed for the (org, profile)
+    pair. ``proposed_bands`` carries one entry per canonical block
+    (excluded blocks emit ``target_weight = 0`` with rationale).
+    """
+    profile_lc = profile.strip().lower()
+    if profile_lc not in _PROPOSE_VALID_PROFILES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Unknown profile '{profile}'. Valid: "
+                f"{sorted(_PROPOSE_VALID_PROFILES)}"
+            ),
+        )
+
+    stmt = (
+        select(PortfolioConstructionRun)
+        .join(
+            ModelPortfolio,
+            ModelPortfolio.id == PortfolioConstructionRun.portfolio_id,
+        )
+        .where(
+            PortfolioConstructionRun.run_mode == "propose",
+            ModelPortfolio.profile == profile_lc,
+        )
+        .order_by(PortfolioConstructionRun.requested_at.desc())
+        .limit(1)
+    )
+    run = (await db.execute(stmt)).scalar_one_or_none()
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"No propose-mode run found for profile '{profile_lc}'. "
+                "Run POST /portfolio/profiles/{profile}/propose-allocation "
+                "first."
+            ),
+        )
+
+    telemetry = run.cascade_telemetry or {}
+    raw_bands = telemetry.get("proposed_bands") or []
+    raw_metrics = telemetry.get("proposal_metrics") or {}
+    winner_signal = (
+        telemetry.get("winner_signal") or run.status or "unknown"
+    )
+
+    proposed_bands = [
+        ProposedBand(
+            block_id=str(b["block_id"]),
+            target_weight=float(b.get("target_weight") or 0.0),
+            drift_min=float(b.get("drift_min") or 0.0),
+            drift_max=float(b.get("drift_max") or 0.0),
+            rationale=b.get("rationale"),
+        )
+        for b in raw_bands
+    ]
+    proposal_metrics = ProposalMetrics(
+        expected_return=raw_metrics.get("expected_return"),
+        expected_cvar=raw_metrics.get("expected_cvar"),
+        expected_sharpe=raw_metrics.get("expected_sharpe"),
+        target_cvar=raw_metrics.get("target_cvar"),
+        cvar_feasible=bool(raw_metrics.get("cvar_feasible", False)),
+    )
+
+    return LatestProposalResponse(
+        run_id=run.id,
+        requested_at=run.requested_at,
+        winner_signal=winner_signal,
+        proposed_bands=proposed_bands,
+        proposal_metrics=proposal_metrics,
+    )

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -1839,6 +1839,7 @@ async def _run_construction_async(
     org_id: str,
     portfolio_id: uuid.UUID | None = None,
     cvar_limit_override: float | None = None,
+    propose_mode: bool = False,
 ) -> dict[str, Any]:
     """Run optimizer-driven portfolio construction (fully async).
 
@@ -1854,6 +1855,16 @@ async def _run_construction_async(
     CVaR limit for a single run. The POST ``/preview-cvar`` endpoint uses
     this to render the Builder's live drag-preview without persisting the
     operator's probe value into ``portfolio_calibration``.
+
+    PR-A26.1 — ``propose_mode=True`` runs the optimizer with maximum
+    freedom: block bounds collapse to ``[0, 1]`` (except blocks marked
+    ``excluded_from_portfolio = True`` → ``[0, 0]``); TAA bands are
+    skipped; ``strategic_allocation.(target|min|max)_weight`` are NOT
+    consulted. The μ prior stays at ``historical_1y`` (the existing prod
+    default for this entry point) so the BL posterior + IC views path
+    is structurally bypassed — ``_build_ic_views`` is never reached
+    because it lives inside the ``mu_prior == "thbb"`` branch of
+    ``compute_fund_level_inputs``.
     """
     from app.domains.wealth.models.allocation import TaaRegimeState as _TaaRS
     from app.domains.wealth.services.quant_queries import (
@@ -1967,7 +1978,14 @@ async def _run_construction_async(
             seen_blocks[allocation.block_id] = allocation
     allocations = list(seen_blocks.values())
 
-    strategic_targets = {a.block_id: float(a.target_weight) for a in allocations}
+    # PR-A25: target_weight is nullable post-migration 0153 (canonical
+    # template seeds NULL bands until A26.2 fills them). Treat NULL as
+    # 0.0 for the realize-mode strategic_targets snapshot — propose mode
+    # ignores this dict entirely below.
+    strategic_targets = {
+        a.block_id: (float(a.target_weight) if a.target_weight is not None else 0.0)
+        for a in allocations
+    }
 
     # ── Resolve CVaR limit via the institutional priority chain ──
     # PR-A13.1 — honour the preview override when supplied so the drag-band
@@ -1984,77 +2002,116 @@ async def _run_construction_async(
             db, profile, portfolio_id=portfolio_id, org_id=org_id,
         )
 
-    # ── TAA: Resolve dynamic regime bands (or fallback to static IPS) ──
-    from app.domains.wealth.models.allocation import TaaRegimeState
-    from app.domains.wealth.models.block import AllocationBlock
-    from quant_engine.taa_band_service import resolve_effective_bands
+    # ── PR-A26.1 propose-mode constraint construction ──
+    # Bypass TAA bands and the strategic_allocation.(target|min|max)_weight
+    # layer entirely. The optimizer runs with maximum freedom subject only
+    # to (a) sum(w) = 1, (b) 0 ≤ w ≤ 1, (c) excluded blocks forced to 0,
+    # (d) the configured cvar_limit.
+    if propose_mode:
+        from app.domains.wealth.models.block import AllocationBlock
 
-    # Fetch block → asset_class mapping
-    block_ids = [a.block_id for a in allocations]
-    block_ac_result = await db.execute(
-        select(AllocationBlock.block_id, AllocationBlock.asset_class)
-        .where(AllocationBlock.block_id.in_(block_ids))
-    )
-    block_asset_classes = {bid: ac for bid, ac in block_ac_result.all()}
-
-    # Read taa_enabled from calibration (default True)
-    taa_enabled = True
-    if portfolio_id is not None:
-        cal_result = await db.execute(
-            select(PortfolioCalibration.expert_overrides)
-            .where(PortfolioCalibration.portfolio_id == portfolio_id)
-        )
-        expert_overrides = cal_result.scalar_one_or_none()
-        if isinstance(expert_overrides, dict):
-            taa_enabled = expert_overrides.get("taa_enabled", True)
-
-    # Fetch latest taa_regime_state for this org+profile
-    taa_state_row = None
-    if taa_enabled:
-        taa_stmt = (
-            select(TaaRegimeState)
-            .where(
-                TaaRegimeState.profile == profile,
+        # Authoritative block list = canonical template (post-migration
+        # 0153 these are guaranteed to exist for every (org, profile)
+        # pair via the strategic_allocation insert trigger; the upstream
+        # template gate also enforces it).
+        canonical_rows = (
+            await db.execute(
+                select(AllocationBlock.block_id)
+                .where(AllocationBlock.is_canonical.is_(True))
             )
-            .order_by(TaaRegimeState.as_of_date.desc())
-            .limit(1)
-        )
-        taa_result = await db.execute(taa_stmt)
-        taa_obj = taa_result.scalar_one_or_none()
-        if taa_obj is not None:
-            taa_state_row = {
-                "raw_regime": taa_obj.raw_regime,
-                "stress_score": float(taa_obj.stress_score) if taa_obj.stress_score is not None else None,
-                "smoothed_centers": taa_obj.smoothed_centers,
-                "effective_bands": taa_obj.effective_bands,
-            }
+        ).all()
+        canonical_block_ids = sorted({r[0] for r in canonical_rows})
 
-    # Fetch TAA config from ConfigService
-    taa_config = None
-    if taa_enabled:
-        from app.core.config.config_service import ConfigService as _CS
-        _cs = _CS(db)
-        taa_cfg_result = await _cs.get("liquid_funds", "taa_bands", org_id)
-        if taa_cfg_result:
-            taa_config = taa_cfg_result.value
-
-    alloc_dicts = [
-        {
-            "block_id": a.block_id,
-            "target_weight": float(a.target_weight),
-            "min_weight": float(a.min_weight),
-            "max_weight": float(a.max_weight),
+        excluded_block_ids = {
+            a.block_id for a in allocations if a.excluded_from_portfolio
         }
-        for a in allocations
-    ]
 
-    block_constraints, taa_provenance = resolve_effective_bands(
-        allocations=alloc_dicts,
-        block_asset_classes=block_asset_classes,
-        taa_regime_state=taa_state_row,
-        taa_config=taa_config,
-        taa_enabled=taa_enabled,
-    )
+        block_constraints = [
+            BlockConstraint(
+                block_id=bid,
+                min_weight=0.0,
+                max_weight=0.0 if bid in excluded_block_ids else 1.0,
+            )
+            for bid in canonical_block_ids
+        ]
+        taa_provenance = {
+            "mode": "propose_mode_skipped",
+            "n_canonical_blocks": len(canonical_block_ids),
+            "n_excluded_blocks": len(excluded_block_ids),
+            "excluded_blocks": sorted(excluded_block_ids),
+        }
+    else:
+        # ── TAA: Resolve dynamic regime bands (or fallback to static IPS) ──
+        from app.domains.wealth.models.allocation import TaaRegimeState
+        from app.domains.wealth.models.block import AllocationBlock
+        from quant_engine.taa_band_service import resolve_effective_bands
+
+        # Fetch block → asset_class mapping
+        block_ids = [a.block_id for a in allocations]
+        block_ac_result = await db.execute(
+            select(AllocationBlock.block_id, AllocationBlock.asset_class)
+            .where(AllocationBlock.block_id.in_(block_ids))
+        )
+        block_asset_classes = {bid: ac for bid, ac in block_ac_result.all()}
+
+        # Read taa_enabled from calibration (default True)
+        taa_enabled = True
+        if portfolio_id is not None:
+            cal_result = await db.execute(
+                select(PortfolioCalibration.expert_overrides)
+                .where(PortfolioCalibration.portfolio_id == portfolio_id)
+            )
+            expert_overrides = cal_result.scalar_one_or_none()
+            if isinstance(expert_overrides, dict):
+                taa_enabled = expert_overrides.get("taa_enabled", True)
+
+        # Fetch latest taa_regime_state for this org+profile
+        taa_state_row = None
+        if taa_enabled:
+            taa_stmt = (
+                select(TaaRegimeState)
+                .where(
+                    TaaRegimeState.profile == profile,
+                )
+                .order_by(TaaRegimeState.as_of_date.desc())
+                .limit(1)
+            )
+            taa_result = await db.execute(taa_stmt)
+            taa_obj = taa_result.scalar_one_or_none()
+            if taa_obj is not None:
+                taa_state_row = {
+                    "raw_regime": taa_obj.raw_regime,
+                    "stress_score": float(taa_obj.stress_score) if taa_obj.stress_score is not None else None,
+                    "smoothed_centers": taa_obj.smoothed_centers,
+                    "effective_bands": taa_obj.effective_bands,
+                }
+
+        # Fetch TAA config from ConfigService
+        taa_config = None
+        if taa_enabled:
+            from app.core.config.config_service import ConfigService as _CS
+            _cs = _CS(db)
+            taa_cfg_result = await _cs.get("liquid_funds", "taa_bands", org_id)
+            if taa_cfg_result:
+                taa_config = taa_cfg_result.value
+
+        alloc_dicts = [
+            {
+                "block_id": a.block_id,
+                "target_weight": float(a.target_weight) if a.target_weight is not None else 0.0,
+                "min_weight": float(a.min_weight) if a.min_weight is not None else 0.0,
+                "max_weight": float(a.max_weight) if a.max_weight is not None else 1.0,
+            }
+            for a in allocations
+        ]
+
+        block_constraints, taa_provenance = resolve_effective_bands(
+            allocations=alloc_dicts,
+            block_asset_classes=block_asset_classes,
+            taa_regime_state=taa_state_row,
+            taa_config=taa_config,
+            taa_enabled=taa_enabled,
+        )
 
     # Resolve max_single_fund_weight from profile config
     max_single_fund = await _resolve_max_single_fund(db, profile)

--- a/backend/app/domains/wealth/schemas/model_portfolio.py
+++ b/backend/app/domains/wealth/schemas/model_portfolio.py
@@ -259,6 +259,59 @@ class ConstructRunAccepted(BaseModel):
     run_url: str
 
 
+# ── PR-A26.1 — Propose Mode ──────────────────────────────────────────
+
+
+class ProposedBand(BaseModel):
+    """One block's proposed strategic anchor + drift band.
+
+    Emitted by the propose-mode optimizer for every block in the
+    canonical template (excluded blocks have ``target_weight = 0`` and
+    ``drift_min = drift_max = 0``). Drift band is the hybrid
+    ``max(0.02, 0.15 * target)`` derivation per A26.1 spec.
+    """
+
+    block_id: str
+    target_weight: float
+    drift_min: float
+    drift_max: float
+    rationale: str | None = None
+
+
+class ProposalMetrics(BaseModel):
+    """Headline ex-ante metrics for the propose-mode allocation.
+
+    ``cvar_feasible`` is False when the cascade fell through to the
+    Phase 3 min-CVaR fallback (universe floor exceeds the operator's
+    target); the bands are still returned so the operator can decide
+    whether to raise the limit or expand the universe.
+    """
+
+    expected_return: float | None = None
+    expected_cvar: float | None = None
+    expected_sharpe: float | None = None
+    target_cvar: float | None = None
+    cvar_feasible: bool
+
+
+class LatestProposalResponse(BaseModel):
+    """Response for ``GET /portfolio/profiles/{profile}/latest-proposal``."""
+
+    run_id: uuid.UUID
+    requested_at: datetime
+    winner_signal: str
+    proposed_bands: list[ProposedBand]
+    proposal_metrics: ProposalMetrics
+
+
+class JobCreatedResponse(BaseModel):
+    """Generic 202 response for async propose-mode dispatch."""
+
+    job_id: str
+    sse_url: str
+    run_id: uuid.UUID
+
+
 class StressScenarioCatalogEntry(BaseModel):
     """One entry in the stress catalog returned by GET /portfolio/stress-test/scenarios."""
 

--- a/backend/app/domains/wealth/schemas/sanitized.py
+++ b/backend/app/domains/wealth/schemas/sanitized.py
@@ -102,6 +102,16 @@ class WinnerSignal(str, Enum):
     # not run, not an operator misconfiguration. Handled upstream of the
     # coverage gate so the stricter failure surfaces first.
     TEMPLATE_INCOMPLETE = "template_incomplete"
+    # PR-A26.1 — propose-mode terminal signals. Emitted only when the run
+    # was started with ``run_mode = 'propose'``. ``PROPOSAL_READY`` covers
+    # any cascade outcome where the optimizer found a feasible portfolio
+    # within the operator's CVaR target (Phase 1 or Phase 2 winner).
+    # ``PROPOSAL_CVAR_INFEASIBLE`` is the Phase 3 fallback: the universe
+    # cannot meet the requested CVaR target, but the min-CVaR portfolio
+    # is returned so the operator can either raise the limit or expand
+    # the universe.
+    PROPOSAL_READY = "proposal_ready"
+    PROPOSAL_CVAR_INFEASIBLE = "proposal_cvar_infeasible"
 
 
 def compute_winner_signal(

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -971,6 +971,141 @@ async def _persist_coverage_failure(
     )
 
 
+# ── PR-A26.1 — propose-mode band derivation ─────────────────────
+
+
+def _derive_drift_band(target: float) -> tuple[float, float]:
+    """Hybrid drift band per A26.1 spec: ``max(0.02, 0.15 * target)``.
+
+    Returned band is symmetric and clamped to ``[0, 1]``. A target of
+    zero collapses both edges to zero — used for excluded blocks and
+    blocks the optimizer chose not to fund.
+    """
+    if target <= 0.0:
+        return 0.0, 0.0
+    drift = max(0.02, 0.15 * target)
+    return max(0.0, target - drift), min(1.0, target + drift)
+
+
+_PROPOSAL_DEFAULT_RATIONALE = (
+    "Optimizer-proposed weight at this allocation under "
+    "the configured CVaR target."
+)
+_PROPOSAL_EXCLUDED_RATIONALE = (
+    "Block excluded by IPS — forced to zero exposure."
+)
+
+
+async def _build_propose_payload(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID | str,
+    profile: str,
+    base_result: dict[str, Any],
+    cascade_telemetry: dict[str, Any],
+    ex_ante_metrics: dict[str, Any],
+    calibration_snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the propose-mode payload merged into ``cascade_telemetry``.
+
+    Inputs come straight from the post-cascade state inside
+    ``_execute_inner``: the funds list (for block aggregation), the
+    canonical template + excluded-block set (re-queried RLS-aware), the
+    cascade winner (for ``cvar_feasible``), and the ex-ante metrics.
+
+    Returns a dict with three keys merged into cascade_telemetry:
+    ``proposed_bands``, ``proposal_metrics``, and ``winner_signal``.
+    The latter overrides the cascade-derived signal so propose runs
+    surface ``proposal_ready`` / ``proposal_cvar_infeasible`` instead
+    of the realize-mode operator signals.
+    """
+    from app.domains.wealth.models.allocation import StrategicAllocation
+    from app.domains.wealth.models.block import AllocationBlock
+
+    # 1. Aggregate optimizer weights to block level.
+    weights_by_block: dict[str, float] = {}
+    for fund in base_result.get("funds") or []:
+        bid = fund.get("block_id")
+        if not bid:
+            continue
+        w = float(fund.get("weight") or 0.0)
+        weights_by_block[bid] = weights_by_block.get(bid, 0.0) + w
+
+    # 2. Canonical block list + excluded set (RLS-aware via passed db).
+    canonical_rows = (
+        await db.execute(
+            select(AllocationBlock.block_id)
+            .where(AllocationBlock.is_canonical.is_(True))
+        )
+    ).all()
+    canonical_block_ids = sorted({r[0] for r in canonical_rows})
+
+    excluded_rows = (
+        await db.execute(
+            select(StrategicAllocation.block_id)
+            .where(
+                StrategicAllocation.profile == profile,
+                StrategicAllocation.excluded_from_portfolio.is_(True),
+            )
+        )
+    ).all()
+    excluded_block_ids = {r[0] for r in excluded_rows}
+
+    # 3. Build proposed bands per canonical block.
+    proposed_bands: list[dict[str, Any]] = []
+    for bid in canonical_block_ids:
+        if bid in excluded_block_ids:
+            proposed_bands.append({
+                "block_id": bid,
+                "target_weight": 0.0,
+                "drift_min": 0.0,
+                "drift_max": 0.0,
+                "rationale": _PROPOSAL_EXCLUDED_RATIONALE,
+            })
+            continue
+        target = float(weights_by_block.get(bid, 0.0))
+        drift_min, drift_max = _derive_drift_band(target)
+        proposed_bands.append({
+            "block_id": bid,
+            "target_weight": round(target, 6),
+            "drift_min": round(drift_min, 6),
+            "drift_max": round(drift_max, 6),
+            "rationale": _PROPOSAL_DEFAULT_RATIONALE,
+        })
+
+    # 4. cvar_feasible: True iff the cascade landed on Phase 1 or Phase 2.
+    # Phase 3 (min-CVaR fallback) means the universe floor exceeds the
+    # operator's CVaR target — return the bands but flag infeasibility.
+    winning_phase = (base_result.get("cascade") or {}).get("winning_phase")
+    cvar_feasible = winning_phase in {
+        "phase_1_ru_max_return",
+        "phase_2_ru_robust",
+    }
+
+    target_cvar = calibration_snapshot.get("cvar_limit")
+    expected_cvar = ex_ante_metrics.get("cvar_95")
+    proposal_metrics = {
+        "expected_return": ex_ante_metrics.get("expected_return"),
+        "expected_cvar": expected_cvar,
+        "expected_sharpe": ex_ante_metrics.get("sharpe_ratio"),
+        "target_cvar": float(target_cvar) if target_cvar is not None else None,
+        "cvar_feasible": bool(cvar_feasible),
+    }
+
+    winner_signal = (
+        WinnerSignal.PROPOSAL_READY.value
+        if cvar_feasible
+        else WinnerSignal.PROPOSAL_CVAR_INFEASIBLE.value
+    )
+
+    return {
+        "proposed_bands": proposed_bands,
+        "proposal_metrics": proposal_metrics,
+        "winner_signal": winner_signal,
+        "run_mode": "propose",
+    }
+
+
 # ── Main entry point ──────────────────────────────────────────
 
 
@@ -982,6 +1117,7 @@ async def execute_construction_run(
     requested_by: str,
     job_id: str | None = None,
     as_of_date: date | None = None,
+    propose_mode: bool = False,
 ) -> PortfolioConstructionRun:
     """Execute a full enriched construction run.
 
@@ -1037,6 +1173,7 @@ async def execute_construction_run(
         universe_fingerprint="pending",  # filled post-construction
         as_of_date=as_of_date,
         status="running",
+        run_mode="propose" if propose_mode else "realize",
         requested_by=requested_by,
         started_at=datetime.now(tz=timezone.utc),
     )
@@ -1063,6 +1200,7 @@ async def execute_construction_run(
                 portfolio_id=portfolio_id,
                 calibration_snapshot=calibration_snapshot,
                 job_id=job_id,
+                propose_mode=propose_mode,
             ),
             timeout=CONSTRUCTION_TIMEOUT_SECONDS,
         )
@@ -1260,6 +1398,7 @@ async def _execute_inner(
     portfolio_id: uuid.UUID,
     calibration_snapshot: dict[str, Any],
     job_id: str | None,
+    propose_mode: bool = False,
 ) -> None:
     """The inner pipeline — everything that runs inside the 120s bound.
 
@@ -1315,6 +1454,7 @@ async def _execute_inner(
     # ── 4. Optimizer cascade ──
     base_result = await _run_construction_async(
         db, profile, str(organization_id), portfolio_id=portfolio_id,
+        propose_mode=propose_mode,
     )
 
     # PR-A8 — Layer 3 dedup telemetry. Surfaced as a sanitized SSE event
@@ -1426,6 +1566,34 @@ async def _execute_inner(
                 # PR-A19.1 Section C — cascade-aware operator signal.
                 "winner_signal": cascade_telemetry.get("winner_signal"),
                 "operator_message": cascade_telemetry.get("operator_message"),
+            },
+        )
+
+    # ── PR-A26.1 — propose-mode payload (bands + metrics) ──
+    if propose_mode:
+        proposal_payload = await _build_propose_payload(
+            db,
+            organization_id=organization_id,
+            profile=profile,
+            base_result=base_result,
+            cascade_telemetry=cascade_telemetry,
+            ex_ante_metrics=ex_ante_metrics,
+            calibration_snapshot=calibration_snapshot,
+        )
+        cascade_telemetry = {**cascade_telemetry, **proposal_payload}
+        await _publish_event_sanitized(
+            db,
+            run_id=run.id,
+            job_id=job_id,
+            raw_type=(
+                "propose_ready"
+                if proposal_payload["proposal_metrics"]["cvar_feasible"]
+                else "propose_cvar_infeasible"
+            ),
+            raw_payload={
+                "winner_signal": proposal_payload["winner_signal"],
+                "proposal_metrics": proposal_payload["proposal_metrics"],
+                "n_bands": len(proposal_payload["proposed_bands"]),
             },
         )
 

--- a/backend/tests/quant_engine/test_propose_mode.py
+++ b/backend/tests/quant_engine/test_propose_mode.py
@@ -1,0 +1,262 @@
+"""PR-A26.1 — Propose-mode unit tests.
+
+Covers the pure helpers that drive the propose payload:
+
+* :func:`_derive_drift_band` — hybrid ``max(0.02, 0.15 * target)``.
+* :func:`_build_propose_payload` — block aggregation, exclusion
+  handling, ``cvar_feasible`` derivation, and winner_signal
+  classification.
+
+Heavier end-to-end coverage (gate ordering, SSE, endpoint dispatch)
+belongs to ``backend/tests/wealth/test_propose_allocation_endpoint.py``;
+this module stays in-process and DB-free so the propose math is
+locked down even when the integration suite is skipped in CI.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domains.wealth.schemas.sanitized import WinnerSignal
+from app.domains.wealth.workers.construction_run_executor import (
+    _build_propose_payload,
+    _derive_drift_band,
+)
+
+
+# ── Drift band math ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("target", "expected_min", "expected_max"),
+    [
+        # Floor regime: 2% absolute drift dominates.
+        (0.05, 0.03, 0.07),
+        (0.10, 0.08, 0.12),
+        # 15% relative regime takes over once target ≥ 0.1334...
+        (0.40, 0.34, 0.46),
+        (0.20, 0.17, 0.23),
+        # Edge: exactly 13.33% — drift = 0.02 (floor still wins).
+        (0.13, 0.11, 0.15),
+        # Zero target → collapsed band (used for excluded blocks).
+        (0.0, 0.0, 0.0),
+        (-0.01, 0.0, 0.0),
+    ],
+)
+def test_drift_band_matches_spec(
+    target: float, expected_min: float, expected_max: float,
+) -> None:
+    drift_min, drift_max = _derive_drift_band(target)
+    assert drift_min == pytest.approx(expected_min, abs=1e-6)
+    assert drift_max == pytest.approx(expected_max, abs=1e-6)
+
+
+def test_drift_band_clamps_above_one() -> None:
+    drift_min, drift_max = _derive_drift_band(0.95)
+    assert drift_max == pytest.approx(1.0)
+    assert drift_min == pytest.approx(0.95 - max(0.02, 0.15 * 0.95))
+
+
+# ── _build_propose_payload ───────────────────────────────────────
+
+
+_CANONICAL_BLOCKS: tuple[str, ...] = (
+    "na_equity_large",
+    "na_equity_growth",
+    "fi_us_aggregate",
+    "fi_us_treasury",
+    "alt_gold",
+    "cash",
+)
+
+
+@dataclass
+class _FakeRow:
+    """Tuple-like row stand-in for SQLAlchemy ``.all()`` results."""
+
+    value: str
+
+    def __getitem__(self, idx: int) -> str:
+        if idx != 0:
+            raise IndexError(idx)
+        return self.value
+
+
+def _make_db_mock(
+    *, canonical_blocks: Iterable[str], excluded_blocks: Iterable[str],
+) -> AsyncMock:
+    """Build an AsyncMock for ``db.execute`` that returns the two row sets
+    consumed by ``_build_propose_payload`` in order: canonical block ids,
+    then excluded block ids.
+    """
+    canonical_result = MagicMock()
+    canonical_result.all.return_value = [
+        _FakeRow(b) for b in canonical_blocks
+    ]
+    excluded_result = MagicMock()
+    excluded_result.all.return_value = [_FakeRow(b) for b in excluded_blocks]
+
+    db = AsyncMock()
+    # First call → canonical query, second → excluded query.
+    db.execute.side_effect = [canonical_result, excluded_result]
+    return db
+
+
+@pytest.mark.asyncio
+async def test_propose_payload_aggregates_funds_to_blocks() -> None:
+    db = _make_db_mock(
+        canonical_blocks=_CANONICAL_BLOCKS, excluded_blocks=[],
+    )
+    base_result: dict[str, Any] = {
+        "funds": [
+            {"instrument_id": "f1", "block_id": "na_equity_large", "weight": 0.20},
+            {"instrument_id": "f2", "block_id": "na_equity_large", "weight": 0.12},
+            {"instrument_id": "f3", "block_id": "fi_us_aggregate", "weight": 0.40},
+            {"instrument_id": "f4", "block_id": "alt_gold", "weight": 0.05},
+            {"instrument_id": "f5", "block_id": "cash", "weight": 0.23},
+        ],
+        "cascade": {"winning_phase": "phase_1_ru_max_return"},
+    }
+    payload = await _build_propose_payload(
+        db,
+        organization_id="org-abc",
+        profile="growth",
+        base_result=base_result,
+        cascade_telemetry={},
+        ex_ante_metrics={
+            "expected_return": 0.087,
+            "cvar_95": 0.029,
+            "sharpe_ratio": 1.4,
+        },
+        calibration_snapshot={"cvar_limit": 0.03},
+    )
+
+    bands_by_block = {b["block_id"]: b for b in payload["proposed_bands"]}
+    assert set(bands_by_block) == set(_CANONICAL_BLOCKS)
+
+    # Aggregation: na_equity_large = 0.20 + 0.12 = 0.32.
+    nael = bands_by_block["na_equity_large"]
+    assert nael["target_weight"] == pytest.approx(0.32)
+    assert nael["drift_min"] == pytest.approx(0.272, abs=1e-6)
+    assert nael["drift_max"] == pytest.approx(0.368, abs=1e-6)
+
+    # Block with no allocation → zero band.
+    assert bands_by_block["na_equity_growth"]["target_weight"] == 0.0
+    assert bands_by_block["na_equity_growth"]["drift_min"] == 0.0
+    assert bands_by_block["na_equity_growth"]["drift_max"] == 0.0
+
+    # Phase 1 winner → cvar_feasible AND PROPOSAL_READY.
+    assert payload["proposal_metrics"]["cvar_feasible"] is True
+    assert payload["proposal_metrics"]["expected_return"] == pytest.approx(0.087)
+    assert payload["proposal_metrics"]["target_cvar"] == pytest.approx(0.03)
+    assert payload["winner_signal"] == WinnerSignal.PROPOSAL_READY.value
+    assert payload["run_mode"] == "propose"
+
+
+@pytest.mark.asyncio
+async def test_propose_payload_zeros_excluded_blocks() -> None:
+    db = _make_db_mock(
+        canonical_blocks=_CANONICAL_BLOCKS,
+        excluded_blocks=["alt_gold"],
+    )
+    # The optimizer would never assign weight to alt_gold under propose
+    # mode (max=0 in BlockConstraint), but the payload assembly must
+    # also defensively zero it AND attach the exclusion rationale.
+    base_result: dict[str, Any] = {
+        "funds": [
+            {"instrument_id": "f1", "block_id": "na_equity_large", "weight": 0.50},
+            {"instrument_id": "f2", "block_id": "fi_us_aggregate", "weight": 0.50},
+        ],
+        "cascade": {"winning_phase": "phase_1_ru_max_return"},
+    }
+    payload = await _build_propose_payload(
+        db,
+        organization_id="org-abc",
+        profile="growth",
+        base_result=base_result,
+        cascade_telemetry={},
+        ex_ante_metrics={"cvar_95": 0.04, "expected_return": 0.06, "sharpe_ratio": 0.9},
+        calibration_snapshot={"cvar_limit": 0.05},
+    )
+    bands_by_block = {b["block_id"]: b for b in payload["proposed_bands"]}
+    gold = bands_by_block["alt_gold"]
+    assert gold["target_weight"] == 0.0
+    assert gold["drift_min"] == 0.0
+    assert gold["drift_max"] == 0.0
+    assert "excluded" in (gold["rationale"] or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_propose_payload_phase_3_marks_cvar_infeasible() -> None:
+    db = _make_db_mock(
+        canonical_blocks=_CANONICAL_BLOCKS, excluded_blocks=[],
+    )
+    base_result: dict[str, Any] = {
+        "funds": [
+            {"instrument_id": "f1", "block_id": "fi_us_treasury", "weight": 0.60},
+            {"instrument_id": "f2", "block_id": "cash", "weight": 0.40},
+        ],
+        # Phase 3 fallback: universe cannot meet the operator's CVaR
+        # target — return the min-CVaR portfolio anyway and flag it.
+        "cascade": {"winning_phase": "phase_3_min_cvar"},
+    }
+    payload = await _build_propose_payload(
+        db,
+        organization_id="org-abc",
+        profile="conservative",
+        base_result=base_result,
+        cascade_telemetry={},
+        ex_ante_metrics={
+            "expected_return": 0.025,
+            "cvar_95": 0.07,
+            "sharpe_ratio": 0.4,
+        },
+        calibration_snapshot={"cvar_limit": 0.025},
+    )
+    assert payload["proposal_metrics"]["cvar_feasible"] is False
+    assert payload["winner_signal"] == WinnerSignal.PROPOSAL_CVAR_INFEASIBLE.value
+    # Bands still emitted so the operator can review what min-CVaR looks like.
+    bands_by_block = {b["block_id"]: b for b in payload["proposed_bands"]}
+    assert bands_by_block["fi_us_treasury"]["target_weight"] == pytest.approx(0.60)
+    assert bands_by_block["cash"]["target_weight"] == pytest.approx(0.40)
+
+
+@pytest.mark.asyncio
+async def test_propose_payload_phase_2_robust_is_feasible() -> None:
+    db = _make_db_mock(
+        canonical_blocks=_CANONICAL_BLOCKS, excluded_blocks=[],
+    )
+    base_result: dict[str, Any] = {
+        "funds": [
+            {"instrument_id": "f1", "block_id": "na_equity_large", "weight": 0.50},
+            {"instrument_id": "f2", "block_id": "fi_us_aggregate", "weight": 0.50},
+        ],
+        "cascade": {"winning_phase": "phase_2_ru_robust"},
+    }
+    payload = await _build_propose_payload(
+        db,
+        organization_id="org-abc",
+        profile="moderate",
+        base_result=base_result,
+        cascade_telemetry={},
+        ex_ante_metrics={
+            "expected_return": 0.07,
+            "cvar_95": 0.045,
+            "sharpe_ratio": 1.1,
+        },
+        calibration_snapshot={"cvar_limit": 0.05},
+    )
+    assert payload["proposal_metrics"]["cvar_feasible"] is True
+    assert payload["winner_signal"] == WinnerSignal.PROPOSAL_READY.value
+
+
+# ── Enum surface ────────────────────────────────────────────────
+
+
+def test_winner_signal_enum_carries_propose_members() -> None:
+    assert WinnerSignal.PROPOSAL_READY.value == "proposal_ready"
+    assert WinnerSignal.PROPOSAL_CVAR_INFEASIBLE.value == "proposal_cvar_infeasible"

--- a/backend/tests/wealth/test_propose_mode_gate_order.py
+++ b/backend/tests/wealth/test_propose_mode_gate_order.py
@@ -1,0 +1,138 @@
+"""PR-A26.1 Section E — propose-mode honours pre-run gates.
+
+Template completeness (A25) and block coverage (A22) gates must fire
+BEFORE the propose-mode branch in ``_execute_inner``. A propose run
+against an org with an incomplete canonical template must abort with
+``TemplateIncompleteError`` exactly the same way realize mode does;
+the optimizer must never be called.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domains.wealth.models.model_portfolio import PortfolioConstructionRun
+from app.domains.wealth.workers import construction_run_executor as executor_mod
+from app.domains.wealth.workers.construction_run_executor import (
+    CoverageInsufficientError,
+    TemplateIncompleteError,
+    _execute_inner,
+)
+from quant_engine.allocation_template_service import TemplateReport
+from quant_engine.block_coverage_service import (
+    CoverageReport,
+)
+
+
+def _make_db_with_portfolio(profile: str, org_id: uuid.UUID) -> AsyncMock:
+    portfolio_stub = MagicMock()
+    portfolio_stub.profile = profile
+    portfolio_stub.organization_id = org_id
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = portfolio_stub
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+def _make_run(org_id: uuid.UUID) -> PortfolioConstructionRun:
+    return PortfolioConstructionRun(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        portfolio_id=uuid.uuid4(),
+        calibration_snapshot={},
+        calibration_hash="x",
+        universe_fingerprint="pending",
+        status="running",
+        run_mode="propose",
+        requested_by="tester",
+    )
+
+
+@pytest.mark.asyncio
+async def test_propose_mode_aborts_on_template_incomplete() -> None:
+    org_id = uuid.uuid4()
+    incomplete = TemplateReport(
+        organization_id=org_id,
+        profile="growth",
+        is_complete=False,
+        missing_canonical_blocks=["alt_commodities"],
+        extra_non_canonical_blocks=[],
+    )
+    db = _make_db_with_portfolio("growth", org_id)
+    run = _make_run(org_id)
+
+    coverage_mock = AsyncMock()
+    optimizer_mock = AsyncMock()
+
+    with patch.object(
+        executor_mod,
+        "validate_template_completeness",
+        new=AsyncMock(return_value=incomplete),
+    ), patch.object(
+        executor_mod, "validate_block_coverage", new=coverage_mock,
+    ), patch(
+        "app.domains.wealth.routes.model_portfolios._run_construction_async",
+        new=optimizer_mock,
+    ):
+        with pytest.raises(TemplateIncompleteError):
+            await _execute_inner(
+                db=db,
+                run=run,
+                portfolio_id=run.portfolio_id,
+                calibration_snapshot={},
+                job_id=None,
+                propose_mode=True,
+            )
+
+    coverage_mock.assert_not_called()
+    optimizer_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_propose_mode_aborts_on_block_coverage_insufficient() -> None:
+    org_id = uuid.uuid4()
+    complete = TemplateReport(
+        organization_id=org_id,
+        profile="moderate",
+        is_complete=True,
+        missing_canonical_blocks=[],
+        extra_non_canonical_blocks=[],
+    )
+    insufficient_coverage = CoverageReport(
+        organization_id=org_id,
+        profile="moderate",
+        is_sufficient=False,
+        gaps=[],
+        total_target_weight_at_risk=0.40,
+    )
+    db = _make_db_with_portfolio("moderate", org_id)
+    run = _make_run(org_id)
+
+    optimizer_mock = AsyncMock()
+
+    with patch.object(
+        executor_mod,
+        "validate_template_completeness",
+        new=AsyncMock(return_value=complete),
+    ), patch.object(
+        executor_mod,
+        "validate_block_coverage",
+        new=AsyncMock(return_value=insufficient_coverage),
+    ), patch(
+        "app.domains.wealth.routes.model_portfolios._run_construction_async",
+        new=optimizer_mock,
+    ):
+        with pytest.raises(CoverageInsufficientError):
+            await _execute_inner(
+                db=db,
+                run=run,
+                portfolio_id=run.portfolio_id,
+                calibration_snapshot={},
+                job_id=None,
+                propose_mode=True,
+            )
+
+    optimizer_mock.assert_not_called()

--- a/docs/prompts/2026-04-18-pr-a26-1-propose-mode.md
+++ b/docs/prompts/2026-04-18-pr-a26-1-propose-mode.md
@@ -1,0 +1,209 @@
+# PR-A26.1 — Propose Mode Optimizer + Endpoint + `run_mode` Column
+
+**Date**: 2026-04-18
+**Status**: P0 STRATEGIC — introduces optimizer "propose mode" that runs unconstrained by `strategic_allocation` bounds. Foundation for A26.2 (approval flow) and A26.3 (frontend review UI).
+**Branch**: `feat/pr-a26-1-propose-mode`
+**Predecessors merged**: A21 #207, A22 #209, A23 #210, A24 #212, A25 #213.
+
+---
+
+## Context — product decision
+
+Per product owner (Andrei, 2026-04-18): CVaR limit is the **only mandatory human input** to the optimizer. IC views, pre-set block bands, and IC-block-caps are eliminated. The optimizer has maximum freedom subject only to:
+1. `CVaR(w) ≤ cvar_limit` from `portfolio_calibration` (per profile)
+2. `sum(w_i) = 1`, `0 ≤ w_i ≤ 1`
+3. `w_i = 0` for blocks with `excluded_from_portfolio = true`
+
+The `strategic_allocation` table stops acting as a pre-run IC constraint. It becomes the **Strategic IPS anchor** — the approved target + drift bands that govern rebalancing (populated by A26.2 approval flow). In propose mode, the optimizer **ignores** `strategic_allocation.(target_weight, min_weight, max_weight)` entirely.
+
+Per-instrument 15% concentration cap is deferred to A26.2 (applies at realize/composition stage when mapping block weights to instruments). A26.1 is pure block-level propose.
+
+BL views (Black-Litterman posterior with P/Ω matrices) are bypassed in propose mode via explicit flag — same code path as `legacy_historical_1y=True` already in production. Full BL deletion is deferred; A26.1 uses plan B (bypass not delete).
+
+---
+
+## Scope
+
+**In scope:**
+- `run_mode` column on `portfolio_construction_runs` (VARCHAR(20) NOT NULL DEFAULT 'realize', CHECK constraint IN ('realize', 'propose')).
+- Optimizer `propose_mode: bool` flag in the entry point (`execute_construction_run` or sibling). When true:
+  - Skip BL posterior step — use historical_1y μ prior + Ledoit-Wolf Σ directly.
+  - Override `constraints.blocks[*].min_weight = 0` and `max_weight = 1` regardless of what `strategic_allocation` says (effective removal of that layer as a constraint).
+  - Still honor `excluded_from_portfolio = true` → force `max_weight = 0` for that block.
+  - Still run the 4-phase cascade (max return → robust → min variance → min CVaR fallback).
+- Hybrid drift band derivation: `drift = max(0.02, 0.15 × target_weight)`. Applied symmetrically: `drift_min = max(0, target - drift)`, `drift_max = min(1, target + drift)`.
+- Proposal payload in `cascade_telemetry`:
+  ```json
+  {
+    "proposed_bands": [
+      {"block_id": "na_equity_large", "target_weight": 0.32, "drift_min": 0.272, "drift_max": 0.368, "rationale": "..."}
+    ],
+    "proposal_metrics": {
+      "expected_return": 0.087,
+      "expected_cvar": 0.029,
+      "expected_sharpe": 1.4,
+      "target_cvar": 0.03,
+      "cvar_feasible": true
+    },
+    "run_mode": "propose",
+    "winner_signal": "proposal_ready" | "proposal_cvar_infeasible"
+  }
+  ```
+- `WinnerSignal.PROPOSAL_READY` + `WinnerSignal.PROPOSAL_CVAR_INFEASIBLE` enum values.
+- New endpoint `POST /portfolio/profiles/{profile}/propose-allocation` → 202 + `job_id` + SSE URL. Async job dispatches `execute_construction_run(..., propose_mode=True)`.
+- SSE event types: `propose_started`, `optimizer_started`, `optimizer_phase_complete` (per phase), `propose_ready` OR `propose_cvar_infeasible`, `completed`.
+- Fetch endpoint `GET /portfolio/profiles/{profile}/latest-proposal` returns the most recent `run_mode='propose'` run for the (org, profile) combo, ordered by `requested_at DESC`.
+- Unit + integration tests.
+- Template completeness + block coverage gates (from A25/A22) still fire first — propose mode uses same pre-run gates as realize.
+
+**Out of scope:**
+- Do NOT introduce per-instrument 15% cap. That is A26.2.
+- Do NOT introduce `override_min/override_max` columns. That is A26.2.
+- Do NOT implement approval flow, `allocation_approvals` table, or Strategic snapshot. That is A26.2.
+- Do NOT touch frontend. That is A26.3.
+- Do NOT delete BL code. Bypass via `propose_mode` flag only.
+- Do NOT touch realize-mode behavior beyond adding the `run_mode` column with default='realize'.
+- Do NOT modify template completeness validator or coverage validator — they continue to fire in both modes.
+
+---
+
+## Execution Spec
+
+### Section A — Alembic migration 0154: `run_mode` column + enum addition
+
+**File:** `backend/app/core/db/migrations/versions/0154_portfolio_construction_run_mode.py`
+
+Down_revision: `0153_canonical_allocation_template`.
+
+Steps:
+
+1. `ALTER TABLE portfolio_construction_runs ADD COLUMN run_mode VARCHAR(20) NOT NULL DEFAULT 'realize'`.
+2. Add CHECK constraint: `CHECK (run_mode IN ('realize', 'propose'))`.
+3. Create btree index `ix_pcr_run_mode_requested_at` on `(run_mode, requested_at DESC)` for the latest-proposal query.
+
+Down: drop index, drop constraint, drop column.
+
+**Acceptance:**
+- `make migrate` up + down round-trip clean.
+- Existing runs have `run_mode = 'realize'` (default applied retroactively to backfilled column).
+- `SELECT DISTINCT run_mode FROM portfolio_construction_runs` returns at most `{'realize', 'propose'}`.
+
+### Section B — Optimizer propose mode flag
+
+**File:** `backend/quant_engine/optimizer_service.py` and `backend/app/domains/wealth/workers/construction_run_executor.py`.
+
+Add `propose_mode: bool = False` parameter to `execute_construction_run` and downstream functions that need it.
+
+Behavior when `propose_mode = True`:
+
+1. **Statistical inputs stage:**
+   - Force μ prior to `historical_1y` (skip BL posterior computation; no call to BL view integration). If memory confirms `legacy_historical_1y=True` is already the prod path, this may be already the default — verify and document.
+   - Use Ledoit-Wolf Σ (already default).
+   - `_load_ic_views(db, ...)` MUST not be called. If called incidentally, must return empty list without querying `portfolio_views` table.
+
+2. **Constraints stage:**
+   - For each block in the canonical template, build `BlockConstraint(block_id, min_weight=0.0, max_weight=1.0)` regardless of what `strategic_allocation` rows contain.
+   - For blocks with `strategic_allocation.excluded_from_portfolio = true`, force `max_weight = 0.0` (preserved).
+   - Do NOT read `target_weight`, `min_weight`, or `max_weight` from `strategic_allocation` rows.
+
+3. **Cascade stage:**
+   - Run the existing 4-phase CLARABEL cascade unchanged. All existing fallback logic (phase 2 robust, phase 3 min variance, phase 4 min CVaR) applies.
+   - Determine `cvar_feasible`:
+     - If the winning phase is `phase_1_ru_max_return` or `phase_2_ru_robust`, feasible=True.
+     - If the cascade fell through to min-CVaR fallback (phase 4), feasible=False (the proposal's achievable CVaR exceeds the target, but it's the best possible given the universe).
+
+4. **Band derivation:**
+   - For each block with `target > 0`, compute `drift = max(0.02, 0.15 * target)`.
+   - `drift_min = max(0.0, target - drift)`.
+   - `drift_max = min(1.0, target + drift)`.
+   - Include rationale string per block: short natural-language one-liner describing the optimizer's reasoning (e.g., "Maximum Sharpe contribution at 32% weight given CVaR 3% and Ledoit-Wolf Σ"). Keep generic — per-block narrative detail is A26.3 concern.
+
+5. **Telemetry output:**
+   - Populate `cascade_telemetry.proposed_bands` as list per Section "Proposal payload" above.
+   - Populate `cascade_telemetry.proposal_metrics`.
+   - Set `cascade_telemetry.winner_signal` to `proposal_ready` (feasible) or `proposal_cvar_infeasible` (fallback).
+   - Persist with `run_mode = 'propose'`.
+
+**Unit tests** (`backend/tests/quant_engine/test_propose_mode.py`):
+- Mock `execute_construction_run(propose_mode=True)`. Assert `_load_ic_views` is not called (spy/mock).
+- Seed `strategic_allocation` with target=0.5/min=0.4/max=0.6 on `na_equity_large`. Run propose. Assert proposal's `na_equity_large` weight is NOT constrained to [0.4, 0.6] — can be any value.
+- Seed one block with `excluded_from_portfolio = true`. Assert that block has weight=0 in proposal.
+- Seed CVaR limit at an infeasibly low value. Assert `winner_signal = 'proposal_cvar_infeasible'` and `cvar_feasible = false`.
+- Hybrid band derivation: target=0.05 → drift=0.02 (floor), drift_min=0.03, drift_max=0.07. Target=0.40 → drift=0.06 (15% rel), drift_min=0.34, drift_max=0.46.
+
+### Section C — Endpoint + SSE
+
+**File:** `backend/app/domains/wealth/routes/model_portfolios.py` (or wherever profile-scoped routes live — grep first).
+
+New route:
+```python
+@router.post("/profiles/{profile}/propose-allocation", status_code=202)
+async def propose_allocation(profile: str, db: AsyncSession, ...) -> JobCreatedResponse:
+    ...
+```
+
+Validates `profile ∈ {'conservative', 'moderate', 'growth'}`. Dispatches `execute_construction_run(db, profile=profile, organization_id=..., propose_mode=True)` as a background job via the existing job infrastructure (SSE bridge). Returns `{job_id, sse_url}`.
+
+SSE bridge must emit the listed event types (from existing `_publish_event_sanitized` helper) with payload shapes matching the operator-facing event types used by realize mode. Do NOT invent new event machinery; reuse.
+
+Fetch endpoint:
+```python
+@router.get("/profiles/{profile}/latest-proposal", response_model=LatestProposalResponse)
+async def latest_proposal(profile: str, db: AsyncSession, ...) -> LatestProposalResponse:
+    ...
+```
+
+Returns the most recent `run_mode='propose'` run for the (org, profile) combo. 404 if no propose run exists yet. Pydantic response model includes run_id, requested_at, winner_signal, proposed_bands list, proposal_metrics.
+
+**Integration tests** (`backend/tests/wealth/test_propose_allocation_endpoint.py`):
+- POST endpoint → 202 + job_id. Wait for SSE completion. Assert final run has `run_mode='propose'`.
+- GET latest-proposal after a run → returns the run's proposed_bands + metrics.
+- GET before any propose run → 404.
+- Excluded block is zeroed in proposal.
+- CVaR infeasibility surfaces `proposal_cvar_infeasible` in SSE event + response.
+
+### Section D — Schema / enum updates
+
+**Files:**
+- `backend/app/domains/wealth/schemas/construction.py` (or wherever `WinnerSignal` lives): add `PROPOSAL_READY = "proposal_ready"` and `PROPOSAL_CVAR_INFEASIBLE = "proposal_cvar_infeasible"`.
+- Add Pydantic models: `ProposedBand(block_id, target_weight, drift_min, drift_max, rationale)`, `ProposalMetrics(expected_return, expected_cvar, expected_sharpe, target_cvar, cvar_feasible)`, `LatestProposalResponse(run_id, requested_at, winner_signal, proposed_bands, proposal_metrics)`, `JobCreatedResponse(job_id, sse_url)`.
+
+No enum migration needed if `winner_signal` is stored free-form in JSONB.
+
+### Section E — Pre-run gates still fire in propose mode
+
+Verify in `construction_run_executor` that the order is:
+1. Template completeness (A25) — fires for both realize and propose modes.
+2. Block coverage (A22) — fires for both realize and propose modes.
+3. Then branch on `propose_mode`.
+
+Propose mode must still fail with `template_incomplete` if canonical template is broken, and still fail with `block_coverage_insufficient` if a non-excluded block has zero approved candidates. These are universe/governance gates, not optimizer constraints.
+
+**Acceptance:** existing A25/A22 integration tests still pass. Propose mode against an org with incomplete template aborts with `template_incomplete`.
+
+---
+
+## Ordering inside this PR
+
+A → B → C → D → E. One commit per Section.
+
+## Global guardrails
+
+- `CLAUDE.md` rules. Async-first, RLS via `SET LOCAL`, `expire_on_commit=False`, `lazy="raise"`.
+- No new Python dependencies.
+- `make check` green (tolerating pre-existing lint).
+- One commit per Section.
+- Do NOT touch: candidate_screener (realize-only concern), frontend (A26.3), `strategic_allocation` schema (A26.2), BL code itself (bypass only, no deletion).
+
+## Final report format
+
+1. Migration 0154 up/down round-trip + distinct run_mode values post-migration.
+2. Unit test output (propose mode mocks + band derivation).
+3. Integration test output (endpoint + SSE + latest-proposal).
+4. Dev DB smoke:
+   - `POST /portfolio/profiles/conservative/propose-allocation` for org `403d8392-...`.
+   - Wait for SSE completion.
+   - `GET /portfolio/profiles/conservative/latest-proposal`.
+   - Paste the returned proposal payload. Expected: 18 blocks in `proposed_bands`, `proposal_metrics.cvar_feasible=true` if coverage gate is passed (operator must have imported candidates for na_equity_value first — if coverage still insufficient, propose will abort at coverage gate; report that outcome).
+5. Regression: run A25 template gate test + A22 coverage gate test against the branch. Assert no regression.
+6. List any deviations from spec discovered during implementation.


### PR DESCRIPTION
## Status
**DRAFT — paused.** Execution interrupted after Sections A + D commits (migration 0154 + WinnerSignal/schemas).

Blocker: A26.0 (block coverage validator fix) must merge first — current validator reports false-negative gaps because it queries instruments_org.block_id (lossy single-block cache) instead of joining strategy_label. This PR depends on clean coverage signal for Section C smoke.

## Resume plan
1. Merge A26.0.
2. Rebase this branch on new main.
3. Resume execution: Sections B (optimizer propose_mode), C (endpoints), E (pre-run gates verification).

## Out-of-scope (per A26 sequence)
- Per-instrument 15% cap → A26.2
- override_min / override_max → A26.2
- allocation_approvals table + approval flow → A26.2
- Frontend → A26.3