### PR TITLE
PR-A26.0 — Block coverage validator: query by strategy_label, not block_id

### DIFF
--- a/backend/quant_engine/block_coverage_service.py
+++ b/backend/quant_engine/block_coverage_service.py
@@ -77,10 +77,13 @@ _STRATEGIC_ALLOCATION_SQL = text(
 _APPROVED_COUNT_SQL = text(
     """
     SELECT COUNT(*)
-      FROM instruments_org
-     WHERE organization_id = :organization_id
-       AND block_id = :block_id
-       AND approval_status = 'approved'
+      FROM instruments_org io
+      JOIN instruments_universe iu
+        ON iu.instrument_id = io.instrument_id
+     WHERE io.organization_id = :organization_id
+       AND io.approval_status = 'approved'
+       AND iu.is_active = TRUE
+       AND iu.attributes->>'strategy_label' = ANY(CAST(:labels AS text[]))
     """
 )
 
@@ -113,11 +116,13 @@ async def _count_approved(
     db: AsyncSession,
     *,
     organization_id: uuid.UUID,
-    block_id: str,
+    labels: list[str],
 ) -> int:
+    if not labels:
+        return 0
     row = await db.execute(
         _APPROVED_COUNT_SQL,
-        {"organization_id": organization_id, "block_id": block_id},
+        {"organization_id": organization_id, "labels": labels},
     )
     return int(row.scalar_one() or 0)
 
@@ -166,14 +171,14 @@ async def validate_block_coverage(
     gaps: list[BlockCoverageGap] = []
     weight_at_risk = 0.0
     for block_id, target_weight in rows:
+        labels = strategy_labels_for_block(block_id)
         n_candidates = await _count_approved(
             db,
             organization_id=organization_id,
-            block_id=block_id,
+            labels=labels,
         )
         if n_candidates > 0:
             continue
-        labels = strategy_labels_for_block(block_id)
         catalog_count, example_tickers = await _catalog_snapshot(
             db, labels=labels,
         )

--- a/backend/tests/quant_engine/test_block_coverage_service.py
+++ b/backend/tests/quant_engine/test_block_coverage_service.py
@@ -8,6 +8,7 @@ than seeding a real DB — and it isolates the test from the shared
 from __future__ import annotations
 
 import uuid
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -29,6 +30,13 @@ def _make_session(
 ) -> AsyncMock:
     """Mock an ``AsyncSession`` whose ``execute`` matches the validator's
     four query shapes by inspecting bind parameters.
+
+    Post PR-A26.0, approved counts are keyed by the first label in the
+    labels list passed to ``_APPROVED_COUNT_SQL`` — the same convention
+    already used for catalog counts. The validator no longer reads
+    ``instruments_org.block_id`` as source of truth; it counts org
+    instruments whose ``instruments_universe.strategy_label`` maps to
+    the block.
     """
     session = AsyncMock()
 
@@ -54,14 +62,14 @@ def _make_session(
         if "from strategic_allocation" in sql:
             return FakeResult(rows=list(allocations))
         if "from instruments_org" in sql and "count(" in sql:
-            block_id = params.get("block_id")
-            return FakeResult(scalar=approved_counts.get(block_id, 0))
+            # PR-A26.0: approved count is now a JOIN keyed by labels.
+            labels = params.get("labels") or []
+            key = labels[0] if labels else None
+            return FakeResult(scalar=approved_counts.get(key, 0))
         if (
             "from instruments_universe" in sql
             and "count(" in sql
         ):
-            # Use a stable key — the labels list passed in. Tests key
-            # counts by the first label in the list.
             labels = params.get("labels") or []
             key = labels[0] if labels else None
             return FakeResult(scalar=catalog_counts.get(key, 0))
@@ -79,9 +87,11 @@ def _make_session(
 @pytest.mark.asyncio
 async def test_all_blocks_covered_returns_sufficient() -> None:
     org_id = uuid.uuid4()
+    # na_equity_large's first mapped label is "Large Blend" — 3 approved
+    # instruments with that label satisfy coverage for the block.
     session = _make_session(
         allocations=[("na_equity_large", 1.0)],
-        approved_counts={"na_equity_large": 3},
+        approved_counts={"Large Blend": 3},
         catalog_counts={},
         catalog_tickers={},
     )
@@ -101,7 +111,7 @@ async def test_uncovered_block_with_catalog_candidates() -> None:
     first_label = "Large Blend"
     session = _make_session(
         allocations=[("na_equity_large", 0.5)],
-        approved_counts={"na_equity_large": 0},
+        approved_counts={first_label: 0},
         catalog_counts={first_label: 50},
         catalog_tickers={first_label: ["VOO", "IVV", "SPY", "VTI", "SCHX"]},
     )
@@ -126,7 +136,7 @@ async def test_uncovered_block_with_no_catalog_candidates() -> None:
     # catalog queries entirely.
     session = _make_session(
         allocations=[("synthetic_block", 0.3)],
-        approved_counts={"synthetic_block": 0},
+        approved_counts={},
         catalog_counts={},
         catalog_tickers={},
     )
@@ -151,11 +161,10 @@ async def test_multiple_blocks_mixed_coverage() -> None:
             ("fi_us_treasury", 0.3),
             ("alt_gold", 0.1),
         ],
-        approved_counts={
-            "na_equity_large": 0,
-            "fi_us_treasury": 5,
-            "alt_gold": 0,
-        },
+        # Approved counts keyed by the FIRST strategy_label of each
+        # block's mapping. fi_us_treasury → "Long Government" (5 covers);
+        # na_equity_large and alt_gold remain at 0 → gaps.
+        approved_counts={"Long Government": 5},
         catalog_counts={first_label: 10, "Precious Metals": 3},
         catalog_tickers={
             first_label: ["A", "B"],
@@ -184,6 +193,72 @@ async def test_empty_strategic_allocation_is_sufficient() -> None:
     report = await validate_block_coverage(session, org_id, "moderate")
     assert report.is_sufficient is True
     assert report.gaps == []
+
+
+@pytest.mark.asyncio
+async def test_block_id_drift_does_not_hide_candidates() -> None:
+    """Instruments classified into a wrong block_id due to classifier
+    single-pick are still correctly counted when their strategy_label
+    maps to the expected block.
+
+    Reproduces the dev-DB Commodities-in-na_equity_large case surfaced
+    2026-04-18: 3 instruments with ``strategy_label = 'Commodities'``
+    were written to ``instruments_org`` with the lossy
+    ``block_id = 'na_equity_large'`` cache. Pre-PR-A26.0 the validator
+    queried ``instruments_org.block_id = 'alt_commodities'`` and
+    returned zero — a false gap. Post-fix, the validator counts them
+    via strategy_label and the gap disappears.
+    """
+    org_id = uuid.uuid4()
+    # alt_commodities first mapped label is "Commodities Broad Basket";
+    # approved count is keyed by the first label the validator sends to
+    # the SQL. Seeding 3 there mimics 3 approved instruments whose
+    # strategy_label maps to alt_commodities — regardless of whatever
+    # (possibly drifted) block_id is cached on instruments_org.
+    first_label_alt = "Commodities Broad Basket"
+    recorded_params: list[dict[str, Any]] = []
+
+    session = AsyncMock()
+
+    class FakeResult:
+        def __init__(self, *, rows=None, scalar=None):  # noqa: ANN001
+            self._rows = rows or []
+            self._scalar = scalar
+
+        def fetchall(self):
+            return self._rows
+
+        def scalar_one(self):
+            return self._scalar if self._scalar is not None else 0
+
+    async def _execute(stmt, params=None):  # noqa: ANN001
+        sql = str(stmt).lower()
+        params = params or {}
+        recorded_params.append({"sql": sql, "params": dict(params)})
+        if "from strategic_allocation" in sql:
+            return FakeResult(rows=[("alt_commodities", 0.05)])
+        if "from instruments_org" in sql and "count(" in sql:
+            labels = params.get("labels") or []
+            key = labels[0] if labels else None
+            return FakeResult(scalar={first_label_alt: 3}.get(key, 0))
+        return FakeResult()
+
+    session.execute = _execute
+    report = await validate_block_coverage(session, org_id, "moderate")
+    assert report.is_sufficient is True
+    assert report.gaps == []
+    # Contract assertion: the approved-count query must be parameterized
+    # by strategy labels, never by block_id. This is what defeats the
+    # instruments_org.block_id drift in the dev DB.
+    approved_calls = [
+        r for r in recorded_params
+        if "from instruments_org" in r["sql"] and "count(" in r["sql"]
+    ]
+    assert approved_calls, "approved-count SQL must have been executed"
+    assert "block_id" not in approved_calls[0]["params"]
+    assert approved_calls[0]["params"].get("labels"), (
+        "validator must pass strategy_label list, not block_id"
+    )
 
 
 def test_build_coverage_operator_message_shape() -> None:


### PR DESCRIPTION
## Summary

P0 bug fix — pre-requisite for PR-A26.1 (propose mode, paused).

The `validate_block_coverage` helper was producing false-negative gaps on dev DB (`403d8392-...`): reported `na_equity_growth=0`, `na_equity_value=0`, `alt_commodities=0` when the org actually had 77 / 46 / 50 approved candidates for those blocks. Root cause: the validator counted via `instruments_org.block_id = :block_id`, but that column is a lossy single-pick cache written by the classifier at import time. Instruments whose `strategy_label` maps to multiple blocks only get one written — making them invisible to every other block they should cover.

Fix: rewrite `_APPROVED_COUNT_SQL` to count via a JOIN on `instruments_universe` filtered by `strategy_label = ANY(:labels)`, matching the source-of-truth pattern already used by `candidate_screener.py`.

- Section A: SQL + `_count_approved()` signature change (13 lines touched in `block_coverage_service.py`)
- Section B: 6 unit tests rekeyed from block_id to first strategy_label
- Section C: new regression `test_block_id_drift_does_not_hide_candidates` reproducing the Commodities-in-na_equity_large scenario

## Dev DB smoke (org `403d8392-...`)

| Profile | Pre-fix at_risk | Post-fix at_risk | Post-fix is_sufficient |
|---|---|---|---|
| conservative | — | 0.0000 | True |
| moderate | 0.1979 | 0.0000 | True |
| balanced | — | 0.0000 | True |
| growth | — | 0.0000 | True |
| aggressive | — | 0.0000 | True |

All five profiles now cleanly pass the validator.

## Test plan
- [x] `pytest backend/tests/quant_engine/test_block_coverage_service.py -v` — 7/7 pass (6 updated + 1 new)
- [x] A22 regression `test_construction_run_coverage_gate.py` — 2/2 pass
- [x] A25 regression `test_construction_run_template_gate.py` — 2/2 pass
- [x] Canonical universe coverage tests — 6/6 pass
- [x] Universe coverage gate tests — 8/8 pass
- [x] Dev DB smoke: all 5 profiles return `is_sufficient=True`

## Out of scope
- No `instruments_org.block_id` changes; it remains advisory.
- No reclassification of existing drifted rows.
- No schema change, no migration.

## Deviations
- Sections B and C are combined into a single commit (both touch the same test file; split was semantically artificial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)