### PR TITLE
chore(block_mapping): +3 catalog labels to close coverage gaps

### DIFF
--- a/backend/vertical_engines/wealth/model_portfolio/block_mapping.py
+++ b/backend/vertical_engines/wealth/model_portfolio/block_mapping.py
@@ -51,6 +51,7 @@ STRATEGY_LABEL_TO_BLOCKS: dict[str, list[str]] = {
     # Equity — Asia
     "Japan Stock": ["dm_asia_equity"],
     "Pacific/Asia ex-Japan Stock": ["dm_asia_equity"],
+    "Asian Equity": ["dm_asia_equity"],
     # Equity — Emerging Markets
     "Diversified Emerging Mkts": ["em_equity"],
     "Emerging Markets": ["em_equity"],
@@ -73,6 +74,7 @@ STRATEGY_LABEL_TO_BLOCKS: dict[str, list[str]] = {
     "Ultrashort Bond": ["fi_us_short_term"],
     # Fixed Income — TIPS
     "Inflation-Protected Bond": ["fi_us_tips"],
+    "Inflation-Linked Bond": ["fi_us_tips"],
     # Fixed Income — High Yield
     "High Yield Bond": ["fi_us_high_yield"],
     "Private Credit": ["fi_us_high_yield"],
@@ -97,6 +99,7 @@ STRATEGY_LABEL_TO_BLOCKS: dict[str, list[str]] = {
     # Cash
     "Money Market": ["cash"],
     "Liquidity Fund": ["cash"],
+    "Cash Equivalent": ["cash"],
 }
 
 


### PR DESCRIPTION
## Summary
Label-drift patch extending PR-A25 Section B. The live dev-DB smoke for PR-A26.1 propose mode surfaced three more labels present in the catalog but absent from block_mapping.py:

| Catalog label | N active+institutional | Target block |
|---|---|---|
| Cash Equivalent | 53 | cash |
| Asian Equity | 24 | dm_asia_equity |
| Inflation-Linked Bond | 10 | fi_us_tips |

## Effect
Pre-patch coverage (canonical org, 2026-04-18):
- conservative: at_risk=17.96% (fi_us_tips, cash)
- moderate: at_risk=10.07% (fi_us_tips, cash, dm_asia_equity)
- growth: at_risk=5.41% (dm_asia_equity)

Post-patch: all three profiles `is_sufficient=True`, `at_risk=0.0`, `n_gaps=0`.

## Test plan
- [x] Direct validator check against dev DB for the 3 canonical profiles post-patch.
- [x] No existing tests modified (additive only).