### PR TITLE
PR-A26.2: approval flow + strategic IPS refactor + override overrides + realize gate

### DIFF
--- a/backend/app/core/db/migrations/versions/0155_strategic_allocation_approved_state.py
+++ b/backend/app/core/db/migrations/versions/0155_strategic_allocation_approved_state.py
@@ -1,0 +1,175 @@
+"""PR-A26.2 — strategic_allocation approved state refactor + allocation_approvals.
+
+Section A — ``strategic_allocation`` schema refactor:
+
+* Drop legacy optimizer-bound columns ``min_weight`` / ``max_weight``.
+  Post-A26.2 the propose-then-approve flow owns the bands; the optimizer
+  reads ``drift_min / drift_max`` (realize mode) or ``override_min /
+  override_max`` (propose mode with operator overrides) instead.
+* Add ``drift_min, drift_max`` — approved drift tolerance around
+  ``target_weight``; set atomically by the approve-proposal endpoint.
+* Add ``override_min, override_max`` — operator-set guard rails that
+  apply only on propose runs. Persist across approvals until explicitly
+  cleared.
+* Add ``approved_from_run_id, approved_at`` — provenance back to the
+  ``portfolio_construction_runs`` row that seeded the approved snapshot.
+  ``approved_at IS NULL`` is the realize-mode "never approved" sentinel.
+* ``approved_by`` already exists (``String(100)``) from migration 0002;
+  leave it untouched.
+* Index ``(organization_id, profile, approved_at)`` so the realize-mode
+  gate's ``COUNT(approved_at IS NOT NULL)`` query is a cheap range scan.
+* ``CHECK`` constraints on drift + override bounds — bookkeeping only.
+
+Section B — new ``allocation_approvals`` audit table (global, no RLS).
+
+Both sections live in a single transactional migration; down-migration
+reverses the steps in reverse order. The reverse re-creates
+``min_weight / max_weight`` as nullable ``NUMERIC(6,4)`` (original
+values are lost — documented in the downgrade docstring).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0155_strategic_allocation_approved_state"
+down_revision = "0154_portfolio_construction_run_mode"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── Section A ─────────────────────────────────────────────────
+
+    # 1. ADD new columns (nullable — seeded by approve-proposal flow).
+    op.execute(
+        """
+        ALTER TABLE strategic_allocation
+          ADD COLUMN IF NOT EXISTS drift_min NUMERIC(6,4),
+          ADD COLUMN IF NOT EXISTS drift_max NUMERIC(6,4),
+          ADD COLUMN IF NOT EXISTS override_min NUMERIC(6,4),
+          ADD COLUMN IF NOT EXISTS override_max NUMERIC(6,4),
+          ADD COLUMN IF NOT EXISTS approved_from_run_id UUID,
+          ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ
+        """
+    )
+
+    # 2. DROP legacy optimizer-bound columns.
+    op.execute(
+        """
+        ALTER TABLE strategic_allocation
+          DROP COLUMN IF EXISTS min_weight,
+          DROP COLUMN IF EXISTS max_weight
+        """
+    )
+
+    # 3. Approval-state index.
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_strategic_allocation_approval_state
+          ON strategic_allocation (organization_id, profile, approved_at)
+        """
+    )
+
+    # 4. CHECK constraints (idempotent).
+    op.execute(
+        """
+        ALTER TABLE strategic_allocation
+          DROP CONSTRAINT IF EXISTS chk_drift_bounds
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE strategic_allocation
+          ADD CONSTRAINT chk_drift_bounds
+            CHECK (drift_min IS NULL OR drift_max IS NULL
+                   OR drift_min <= drift_max)
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE strategic_allocation
+          DROP CONSTRAINT IF EXISTS chk_override_bounds
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE strategic_allocation
+          ADD CONSTRAINT chk_override_bounds
+            CHECK (override_min IS NULL OR override_max IS NULL
+                   OR override_min <= override_max)
+        """
+    )
+
+    # ── Section B — allocation_approvals audit table ──────────────
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS allocation_approvals (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          run_id UUID NOT NULL,
+          organization_id UUID NOT NULL,
+          profile VARCHAR(20) NOT NULL,
+          approved_by TEXT NOT NULL,
+          approved_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          superseded_at TIMESTAMPTZ,
+          cvar_at_approval NUMERIC(6,4),
+          expected_return_at_approval NUMERIC(8,6),
+          cvar_feasible_at_approval BOOLEAN NOT NULL DEFAULT TRUE,
+          operator_message TEXT
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_allocation_approvals_org_profile_active
+          ON allocation_approvals (organization_id, profile, superseded_at)
+          WHERE superseded_at IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """Reverse the migration.
+
+    WARNING: the original ``min_weight`` / ``max_weight`` values that
+    existed before upgrade are irrecoverable — we re-create the columns
+    as nullable so the reverse round-trip schema check passes, but the
+    data is not restored. Operators that need the pre-A26.2 numbers
+    should restore from backup.
+    """
+    # Drop allocation_approvals + index.
+    op.execute("DROP INDEX IF EXISTS ix_allocation_approvals_org_profile_active")
+    op.execute("DROP TABLE IF EXISTS allocation_approvals")
+
+    # Drop CHECK constraints.
+    op.execute(
+        "ALTER TABLE strategic_allocation DROP CONSTRAINT IF EXISTS chk_override_bounds"
+    )
+    op.execute(
+        "ALTER TABLE strategic_allocation DROP CONSTRAINT IF EXISTS chk_drift_bounds"
+    )
+
+    # Drop approval-state index.
+    op.execute("DROP INDEX IF EXISTS ix_strategic_allocation_approval_state")
+
+    # Drop new columns.
+    op.execute(
+        """
+        ALTER TABLE strategic_allocation
+          DROP COLUMN IF EXISTS approved_at,
+          DROP COLUMN IF EXISTS approved_from_run_id,
+          DROP COLUMN IF EXISTS override_max,
+          DROP COLUMN IF EXISTS override_min,
+          DROP COLUMN IF EXISTS drift_max,
+          DROP COLUMN IF EXISTS drift_min
+        """
+    )
+
+    # Re-create legacy columns (nullable; original data cannot be restored).
+    op.execute(
+        """
+        ALTER TABLE strategic_allocation
+          ADD COLUMN IF NOT EXISTS min_weight NUMERIC(6,4),
+          ADD COLUMN IF NOT EXISTS max_weight NUMERIC(6,4)
+        """
+    )

--- a/backend/app/core/db/migrations/versions/0155_strategic_allocation_approved_state.py
+++ b/backend/app/core/db/migrations/versions/0155_strategic_allocation_approved_state.py
@@ -126,6 +126,117 @@ def upgrade() -> None:
         """
     )
 
+    # ── A25 trigger refresh ───────────────────────────────────────
+    # Migration 0153 defined ``fn_enforce_allocation_template_sa`` and
+    # ``fn_enforce_allocation_template_blocks`` with INSERTs that
+    # reference the now-dropped ``min_weight`` / ``max_weight`` columns.
+    # Rebuild both functions without those columns so the canonical
+    # template trigger keeps firing post-A26.2.
+    op.execute(
+        r"""
+        CREATE OR REPLACE FUNCTION fn_enforce_allocation_template_sa()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            missing_block RECORD;
+            existing_rows INT;
+        BEGIN
+            SELECT COUNT(*)
+              INTO existing_rows
+              FROM strategic_allocation
+             WHERE organization_id = NEW.organization_id
+               AND profile = NEW.profile;
+            IF existing_rows <> 1 THEN
+                RETURN NEW;
+            END IF;
+
+            FOR missing_block IN
+                SELECT block_id FROM allocation_blocks
+                 WHERE is_canonical = true
+                   AND block_id <> NEW.block_id
+            LOOP
+                INSERT INTO strategic_allocation (
+                    allocation_id, organization_id, profile, block_id,
+                    target_weight, risk_budget,
+                    rationale, approved_by, effective_from, effective_to,
+                    actor_source, excluded_from_portfolio
+                )
+                VALUES (
+                    gen_random_uuid(), NEW.organization_id, NEW.profile,
+                    missing_block.block_id,
+                    NULL, NULL,
+                    'Auto-inserted by enforce_allocation_template trigger',
+                    'system', CURRENT_DATE, NULL,
+                    'trigger_enforce', false
+                );
+
+                INSERT INTO allocation_template_audit (
+                    trigger_reason, organization_id, profile, block_id,
+                    action, details
+                )
+                VALUES (
+                    'new_profile_created', NEW.organization_id,
+                    NEW.profile, missing_block.block_id, 'inserted',
+                    jsonb_build_object('source_row_id', NEW.allocation_id)
+                );
+            END LOOP;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql SECURITY DEFINER
+        """
+    )
+    op.execute(
+        r"""
+        CREATE OR REPLACE FUNCTION fn_enforce_allocation_template_blocks()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            combo RECORD;
+        BEGIN
+            IF NOT (NEW.is_canonical = true AND
+                    COALESCE(OLD.is_canonical, false) = false) THEN
+                RETURN NEW;
+            END IF;
+
+            FOR combo IN
+                SELECT DISTINCT organization_id, profile
+                  FROM strategic_allocation
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM strategic_allocation sa
+                      WHERE sa.organization_id = strategic_allocation.organization_id
+                        AND sa.profile = strategic_allocation.profile
+                        AND sa.block_id = NEW.block_id
+                 )
+            LOOP
+                INSERT INTO strategic_allocation (
+                    allocation_id, organization_id, profile, block_id,
+                    target_weight, risk_budget,
+                    rationale, approved_by, effective_from, effective_to,
+                    actor_source, excluded_from_portfolio
+                )
+                VALUES (
+                    gen_random_uuid(), combo.organization_id, combo.profile,
+                    NEW.block_id,
+                    NULL, NULL,
+                    'Auto-inserted by enforce_allocation_template_blocks trigger',
+                    'system', CURRENT_DATE, NULL,
+                    'trigger_enforce', false
+                );
+
+                INSERT INTO allocation_template_audit (
+                    trigger_reason, organization_id, profile, block_id,
+                    action, details
+                )
+                VALUES (
+                    'block_marked_canonical', combo.organization_id,
+                    combo.profile, NEW.block_id, 'inserted',
+                    jsonb_build_object('source_block_id', NEW.block_id)
+                );
+            END LOOP;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql SECURITY DEFINER
+        """
+    )
+
 
 def downgrade() -> None:
     """Reverse the migration.
@@ -170,5 +281,113 @@ def downgrade() -> None:
         ALTER TABLE strategic_allocation
           ADD COLUMN IF NOT EXISTS min_weight NUMERIC(6,4),
           ADD COLUMN IF NOT EXISTS max_weight NUMERIC(6,4)
+        """
+    )
+
+    # Restore A25 trigger function bodies that reference the re-created
+    # ``min_weight`` / ``max_weight`` columns so upstream rollback leaves
+    # the canonical template enforcement intact.
+    op.execute(
+        r"""
+        CREATE OR REPLACE FUNCTION fn_enforce_allocation_template_sa()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            missing_block RECORD;
+            existing_rows INT;
+        BEGIN
+            SELECT COUNT(*)
+              INTO existing_rows
+              FROM strategic_allocation
+             WHERE organization_id = NEW.organization_id
+               AND profile = NEW.profile;
+            IF existing_rows <> 1 THEN
+                RETURN NEW;
+            END IF;
+
+            FOR missing_block IN
+                SELECT block_id FROM allocation_blocks
+                 WHERE is_canonical = true
+                   AND block_id <> NEW.block_id
+            LOOP
+                INSERT INTO strategic_allocation (
+                    allocation_id, organization_id, profile, block_id,
+                    target_weight, min_weight, max_weight, risk_budget,
+                    rationale, approved_by, effective_from, effective_to,
+                    actor_source, excluded_from_portfolio
+                )
+                VALUES (
+                    gen_random_uuid(), NEW.organization_id, NEW.profile,
+                    missing_block.block_id,
+                    NULL, NULL, NULL, NULL,
+                    'Auto-inserted by enforce_allocation_template trigger',
+                    'system', CURRENT_DATE, NULL,
+                    'trigger_enforce', false
+                );
+
+                INSERT INTO allocation_template_audit (
+                    trigger_reason, organization_id, profile, block_id,
+                    action, details
+                )
+                VALUES (
+                    'new_profile_created', NEW.organization_id,
+                    NEW.profile, missing_block.block_id, 'inserted',
+                    jsonb_build_object('source_row_id', NEW.allocation_id)
+                );
+            END LOOP;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql SECURITY DEFINER
+        """
+    )
+    op.execute(
+        r"""
+        CREATE OR REPLACE FUNCTION fn_enforce_allocation_template_blocks()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            combo RECORD;
+        BEGIN
+            IF NOT (NEW.is_canonical = true AND
+                    COALESCE(OLD.is_canonical, false) = false) THEN
+                RETURN NEW;
+            END IF;
+
+            FOR combo IN
+                SELECT DISTINCT organization_id, profile
+                  FROM strategic_allocation
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM strategic_allocation sa
+                      WHERE sa.organization_id = strategic_allocation.organization_id
+                        AND sa.profile = strategic_allocation.profile
+                        AND sa.block_id = NEW.block_id
+                 )
+            LOOP
+                INSERT INTO strategic_allocation (
+                    allocation_id, organization_id, profile, block_id,
+                    target_weight, min_weight, max_weight, risk_budget,
+                    rationale, approved_by, effective_from, effective_to,
+                    actor_source, excluded_from_portfolio
+                )
+                VALUES (
+                    gen_random_uuid(), combo.organization_id, combo.profile,
+                    NEW.block_id,
+                    NULL, NULL, NULL, NULL,
+                    'Auto-inserted by enforce_allocation_template_blocks trigger',
+                    'system', CURRENT_DATE, NULL,
+                    'trigger_enforce', false
+                );
+
+                INSERT INTO allocation_template_audit (
+                    trigger_reason, organization_id, profile, block_id,
+                    action, details
+                )
+                VALUES (
+                    'block_marked_canonical', combo.organization_id,
+                    combo.profile, NEW.block_id, 'inserted',
+                    jsonb_build_object('source_block_id', NEW.block_id)
+                );
+            END LOOP;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql SECURITY DEFINER
         """
     )

--- a/backend/app/core/db/migrations/versions/0155_strategic_allocation_approved_state.py
+++ b/backend/app/core/db/migrations/versions/0155_strategic_allocation_approved_state.py
@@ -29,7 +29,6 @@ values are lost — documented in the downgrade docstring).
 """
 from __future__ import annotations
 
-import sqlalchemy as sa
 from alembic import op
 
 revision = "0155_strategic_allocation_approved_state"

--- a/backend/app/domains/wealth/models/allocation.py
+++ b/backend/app/domains/wealth/models/allocation.py
@@ -12,8 +12,10 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
-    false as sa_false,
     func,
+)
+from sqlalchemy import (
+    false as sa_false,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column

--- a/backend/app/domains/wealth/models/allocation.py
+++ b/backend/app/domains/wealth/models/allocation.py
@@ -31,12 +31,25 @@ class StrategicAllocation(OrganizationScopedMixin, Base):
     block_id: Mapped[str] = mapped_column(
         String(80), ForeignKey("allocation_blocks.block_id"), nullable=False,
     )
-    # PR-A25 (migration 0153): weights relaxed to nullable so the canonical
-    # 18-block template can be seeded before the operator or PR-A26's
-    # propose-then-approve flow fills the bands.
+    # PR-A26.2 (migration 0155): optimizer-bound ``min_weight`` /
+    # ``max_weight`` columns were dropped. ``target_weight`` persists as
+    # the "approved anchor" — NULL until the propose-then-approve flow
+    # snapshots a propose run into the row. Operator overrides and the
+    # drift band now own the optimizer-facing semantics.
     target_weight: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
-    min_weight: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
-    max_weight: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
+    # Drift band around the approved target. Populated atomically by the
+    # approve-proposal endpoint; NULL when the block has never been
+    # approved. Realize-mode BlockConstraint reads these two columns.
+    drift_min: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
+    drift_max: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
+    # Operator-set propose-mode overrides. Persist across approvals;
+    # cleared only via ``POST /set-override`` with explicit NULL. Have
+    # no effect on realize-mode runs.
+    override_min: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
+    override_max: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
+    # Provenance back to the propose run that seeded the approved snapshot.
+    approved_from_run_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     risk_budget: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
     rationale: Mapped[str | None] = mapped_column(Text)
     approved_by: Mapped[str | None] = mapped_column(String(100))
@@ -55,6 +68,46 @@ class StrategicAllocation(OrganizationScopedMixin, Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(),
     )
+
+
+class AllocationApproval(Base):
+    """PR-A26.2 — audit log of approved propose-mode allocations.
+
+    GLOBAL table (no RLS) — admin-visible audit history. Queries that
+    want org scope must still filter by ``organization_id`` explicitly.
+
+    At most one row per ``(organization_id, profile)`` carries
+    ``superseded_at IS NULL`` at any given time; the approve-proposal
+    endpoint supersedes the prior active row before inserting the new
+    one (single transaction).
+    """
+
+    __tablename__ = "allocation_approvals"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    # No FK — historical runs can be purged independently. Integrity
+    # comes from the (run_id, organization_id, profile) triple plus
+    # the superseded_at lifecycle.
+    run_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False,
+    )
+    profile: Mapped[str] = mapped_column(String(20), nullable=False)
+    approved_by: Mapped[str] = mapped_column(Text, nullable=False)
+    approved_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False,
+    )
+    superseded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    cvar_at_approval: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
+    expected_return_at_approval: Mapped[Decimal | None] = mapped_column(
+        Numeric(8, 6),
+    )
+    cvar_feasible_at_approval: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True,
+    )
+    operator_message: Mapped[str | None] = mapped_column(Text)
 
 
 class MacroRegimeSnapshot(Base):

--- a/backend/app/domains/wealth/routes/allocation.py
+++ b/backend/app/domains/wealth/routes/allocation.py
@@ -97,12 +97,17 @@ async def update_strategic(
     # Create new allocations
     new_rows: list[StrategicAllocation] = []
     for item in body.allocations:
+        # PR-A26.2 — the legacy ``min_weight/max_weight`` columns were dropped
+        # in migration 0155. The ``PUT /allocation/{profile}`` endpoint is
+        # repurposed as a manual drift setter: the incoming ``min_weight`` /
+        # ``max_weight`` now land on ``drift_min`` / ``drift_max``. The full
+        # approval lifecycle lives behind the propose-approve flow.
         row = StrategicAllocation(
             profile=profile,
             block_id=item.block_id,
             target_weight=item.target_weight,
-            min_weight=item.min_weight,
-            max_weight=item.max_weight,
+            drift_min=item.min_weight,
+            drift_max=item.max_weight,
             risk_budget=item.risk_budget,
             rationale=item.rationale,
             approved_by=user.name,
@@ -254,8 +259,8 @@ async def get_effective(
                 strategic_weight=s.target_weight if s else None,
                 tactical_overweight=t.overweight if t else None,
                 effective_weight=s_weight + t_weight,
-                min_weight=s.min_weight if s else None,
-                max_weight=s.max_weight if s else None,
+                min_weight=s.drift_min if s else None,
+                max_weight=s.drift_max if s else None,
             ),
         )
     return effective
@@ -573,9 +578,13 @@ async def get_regime_bands(
         band = effective_bands_raw.get(sa.block_id)
         if band is None:
             continue
-        if band.get("min", 0) > float(sa.min_weight) + 1e-6:
+        # PR-A26.2 — ``min_weight/max_weight`` columns were dropped; the drift
+        # band is now the canonical source of truth for clamp detection.
+        sa_min = sa.drift_min
+        sa_max = sa.drift_max
+        if sa_min is not None and band.get("min", 0) > float(sa_min) + 1e-6:
             ips_clamps.append(f"{sa.block_id}_min_raised")
-        if band.get("max", 1) < float(sa.max_weight) - 1e-6:
+        if sa_max is not None and band.get("max", 1) < float(sa_max) - 1e-6:
             ips_clamps.append(f"{sa.block_id}_max_lowered")
 
     return RegimeBandsRead(
@@ -707,8 +716,8 @@ async def get_effective_with_regime(
                 strategic_weight=s.target_weight if s else None,
                 tactical_overweight=t.overweight if t else None,
                 effective_weight=s_weight + t_weight,
-                min_weight=s.min_weight if s else None,
-                max_weight=s.max_weight if s else None,
+                min_weight=s.drift_min if s else None,
+                max_weight=s.drift_max if s else None,
                 regime_min=band.get("min") if band else None,
                 regime_max=band.get("max") if band else None,
                 regime_center=band.get("center") if band else None,

--- a/backend/app/domains/wealth/routes/analytics.py
+++ b/backend/app/domains/wealth/routes/analytics.py
@@ -283,11 +283,13 @@ async def optimize(
         return OptimizeResult(**cached)
 
     # Build constraints from strategic allocation
+    # PR-A26.2 — the legacy ``min_weight/max_weight`` columns were dropped;
+    # realize-mode optimization now reads the approved drift band.
     block_constraints = [
         BlockConstraint(
             block_id=a.block_id,
-            min_weight=float(a.min_weight),
-            max_weight=float(a.max_weight),
+            min_weight=float(a.drift_min) if a.drift_min is not None else 0.0,
+            max_weight=float(a.drift_max) if a.drift_max is not None else 1.0,
         )
         for a in allocations
     ]
@@ -382,7 +384,11 @@ async def optimize_pareto(
     )
     frozen_cov = cov_matrix.tolist()
     frozen_constraints = [
-        {"block_id": a.block_id, "min_weight": float(a.min_weight), "max_weight": float(a.max_weight)}
+        {
+            "block_id": a.block_id,
+            "min_weight": float(a.drift_min) if a.drift_min is not None else 0.0,
+            "max_weight": float(a.drift_max) if a.drift_max is not None else 1.0,
+        }
         for a in allocations
     ]
     profile = body.profile

--- a/backend/app/domains/wealth/routes/macro.py
+++ b/backend/app/domains/wealth/routes/macro.py
@@ -493,13 +493,17 @@ async def _generate_allocation_proposals(
         for bp in proposal.proposals:
             from decimal import Decimal as D
 
+            # PR-A26.2 — the legacy SA ``min_weight/max_weight`` columns
+            # were dropped in migration 0155; the macro proposal's bounds
+            # land on ``drift_min/drift_max`` (realize-mode BlockConstraint
+            # now reads those).
             row = StrategicAllocation(
                 organization_id=org_id,
                 profile=profile_name,
                 block_id=bp.block_id,
                 target_weight=D(str(bp.proposed_weight)),
-                min_weight=D(str(bp.min_weight)),
-                max_weight=D(str(bp.max_weight)),
+                drift_min=D(str(bp.min_weight)),
+                drift_max=D(str(bp.max_weight)),
                 rationale=proposal.rationale,
                 approved_by=actor_id,
                 effective_from=today,

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -34,6 +34,8 @@ from app.domains.wealth.models.model_portfolio import (
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 from app.domains.wealth.schemas.generated_report import ReportGenerateRequest
 from app.domains.wealth.schemas.model_portfolio import (
+    ApprovalResponse,
+    ApproveProposalRequest,
     ConstructionAdviceRead,
     ConstructionRunDiffOut,
     ConstructionRunMetricDelta,
@@ -55,6 +57,8 @@ from app.domains.wealth.schemas.model_portfolio import (
     RebalancePreviewResponse,
     RegimeCurrentRead,
     SectorExposureRead,
+    SetOverrideRequest,
+    StrategicAllocationRow,
     StressScenarioCatalog,
     StressScenarioCatalogEntry,
     StressTestRequest,
@@ -4865,4 +4869,379 @@ async def latest_proposal(
         winner_signal=winner_signal,
         proposed_bands=proposed_bands,
         proposal_metrics=proposal_metrics,
+    )
+
+
+# ── PR-A26.2 — Approval flow + override endpoints ────────────────────
+
+
+_APPROVE_VALID_WINNER_SIGNALS: frozenset[str] = frozenset(
+    {"proposal_ready", "proposal_cvar_infeasible"},
+)
+
+
+@portfolio_meta_router.post(
+    "/profiles/{profile}/approve-proposal/{run_id}",
+    response_model=ApprovalResponse,
+    status_code=status.HTTP_200_OK,
+    summary=(
+        "PR-A26.2 - Atomically snapshot a propose-mode run's bands onto "
+        "strategic_allocation; becomes the Strategic IPS anchor"
+    ),
+)
+async def approve_proposal(
+    profile: str,
+    run_id: uuid.UUID,
+    body: ApproveProposalRequest,
+    db: AsyncSession = Depends(get_db_with_rls),
+    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(get_actor),
+    org_id: str = Depends(get_org_id),
+) -> ApprovalResponse:
+    """Approve a propose run for the given profile.
+
+    Atomic transaction - the 18 strategic_allocation rows are updated,
+    the prior active allocation_approvals row (if any) is superseded,
+    and the new audit row is inserted, all in one commit.
+
+    Rejects proposal_cvar_infeasible runs unless the operator sets
+    ``confirm_cvar_infeasible=true`` on the body - avoids a silent
+    accept of an IPS that cannot meet the configured CVaR target.
+    """
+    from sqlalchemy import text as _sa_text
+
+    _require_ic_role(actor)
+
+    profile_lc = profile.strip().lower()
+    if profile_lc not in _PROPOSE_VALID_PROFILES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Unknown profile '{profile}'. Valid: "
+                f"{sorted(_PROPOSE_VALID_PROFILES)}"
+            ),
+        )
+
+    run_stmt = (
+        select(PortfolioConstructionRun)
+        .join(
+            ModelPortfolio,
+            ModelPortfolio.id == PortfolioConstructionRun.portfolio_id,
+        )
+        .where(
+            PortfolioConstructionRun.id == run_id,
+            ModelPortfolio.profile == profile_lc,
+        )
+        .limit(1)
+    )
+    run = (await db.execute(run_stmt)).scalar_one_or_none()
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"No run {run_id} found for profile '{profile_lc}' in the "
+                "current organization."
+            ),
+        )
+    if run.run_mode != "propose":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"Run {run_id} is not a propose-mode run "
+                f"(run_mode={run.run_mode!r})."
+            ),
+        )
+
+    telemetry = run.cascade_telemetry or {}
+    winner_signal_raw = telemetry.get("winner_signal")
+    if winner_signal_raw == "proposal_cvar_infeasible":
+        if not body.confirm_cvar_infeasible:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "Proposal was infeasible against the configured CVaR "
+                    "target - set confirm_cvar_infeasible=true to approve "
+                    "anyway."
+                ),
+            )
+    elif winner_signal_raw not in _APPROVE_VALID_WINNER_SIGNALS:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Run {run_id} carries winner_signal={winner_signal_raw!r}; "
+                "only proposal_ready or proposal_cvar_infeasible runs can "
+                "be approved."
+            ),
+        )
+
+    raw_proposed_bands = telemetry.get("proposed_bands") or []
+    if len(raw_proposed_bands) != 18:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                f"Run {run_id} carries {len(raw_proposed_bands)} proposed "
+                "bands; expected 18 (canonical template). Propose run "
+                "invariant violated."
+            ),
+        )
+
+    proposal_metrics = telemetry.get("proposal_metrics") or {}
+    approver = actor.actor_id
+    org_uuid = uuid.UUID(str(org_id))
+    now_ts = await db.scalar(_sa_text("SELECT now()"))
+
+    updated_rows: list[dict[str, Any]] = []
+    for band in raw_proposed_bands:
+        bid = band["block_id"]
+        target = band.get("target_weight")
+        dmin = band.get("drift_min")
+        dmax = band.get("drift_max")
+        update_stmt = _sa_text(
+            """
+            UPDATE strategic_allocation
+               SET target_weight = :target,
+                   drift_min = :dmin,
+                   drift_max = :dmax,
+                   approved_from_run_id = :run_id,
+                   approved_at = :ts,
+                   approved_by = :approver
+             WHERE organization_id = :org
+               AND profile = :profile
+               AND block_id = :block_id
+            RETURNING block_id, target_weight, drift_min, drift_max,
+                      override_min, override_max, approved_at, approved_by,
+                      excluded_from_portfolio
+            """
+        )
+        result = await db.execute(
+            update_stmt,
+            {
+                "target": target,
+                "dmin": dmin,
+                "dmax": dmax,
+                "run_id": run_id,
+                "ts": now_ts,
+                "approver": approver[:100],
+                "org": org_uuid,
+                "profile": profile_lc,
+                "block_id": bid,
+            },
+        )
+        row = result.mappings().one_or_none()
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=(
+                    f"strategic_allocation row missing for block "
+                    f"{bid!r}; canonical template trigger is broken."
+                ),
+            )
+        updated_rows.append(dict(row))
+
+    await db.execute(
+        _sa_text(
+            """
+            UPDATE allocation_approvals
+               SET superseded_at = :ts
+             WHERE organization_id = :org
+               AND profile = :profile
+               AND superseded_at IS NULL
+            """
+        ),
+        {"ts": now_ts, "org": org_uuid, "profile": profile_lc},
+    )
+
+    approval_id = uuid.uuid4()
+    await db.execute(
+        _sa_text(
+            """
+            INSERT INTO allocation_approvals
+                (id, run_id, organization_id, profile, approved_by,
+                 approved_at, superseded_at, cvar_at_approval,
+                 expected_return_at_approval, cvar_feasible_at_approval,
+                 operator_message)
+            VALUES
+                (:id, :run_id, :org, :profile, :approver,
+                 :ts, NULL, :cvar, :er, :feasible, :msg)
+            """
+        ),
+        {
+            "id": approval_id,
+            "run_id": run_id,
+            "org": org_uuid,
+            "profile": profile_lc,
+            "approver": approver,
+            "ts": now_ts,
+            "cvar": proposal_metrics.get("target_cvar"),
+            "er": proposal_metrics.get("expected_return"),
+            "feasible": bool(proposal_metrics.get("cvar_feasible", True)),
+            "msg": body.operator_message,
+        },
+    )
+
+    await db.flush()
+
+    snapshot = [
+        StrategicAllocationRow(
+            block_id=str(r["block_id"]),
+            target_weight=(
+                float(r["target_weight"])
+                if r.get("target_weight") is not None
+                else None
+            ),
+            drift_min=(
+                float(r["drift_min"]) if r.get("drift_min") is not None else None
+            ),
+            drift_max=(
+                float(r["drift_max"]) if r.get("drift_max") is not None else None
+            ),
+            override_min=(
+                float(r["override_min"])
+                if r.get("override_min") is not None
+                else None
+            ),
+            override_max=(
+                float(r["override_max"])
+                if r.get("override_max") is not None
+                else None
+            ),
+            approved_at=r.get("approved_at"),
+            approved_by=r.get("approved_by"),
+            excluded_from_portfolio=bool(r.get("excluded_from_portfolio") or False),
+        )
+        for r in updated_rows
+    ]
+
+    return ApprovalResponse(
+        approval_id=approval_id,
+        run_id=run_id,
+        organization_id=org_uuid,
+        profile=profile_lc,
+        approved_at=now_ts,
+        approved_by=approver,
+        cvar_feasible_at_approval=bool(
+            proposal_metrics.get("cvar_feasible", True),
+        ),
+        strategic_snapshot=snapshot,
+    )
+
+
+@portfolio_meta_router.post(
+    "/profiles/{profile}/set-override",
+    response_model=StrategicAllocationRow,
+    status_code=status.HTTP_200_OK,
+    summary=(
+        "PR-A26.2 - Write override_min/override_max on a single "
+        "strategic_allocation row; affects next propose run only"
+    ),
+)
+async def set_override(
+    profile: str,
+    body: SetOverrideRequest,
+    db: AsyncSession = Depends(get_db_with_rls),
+    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(get_actor),
+    org_id: str = Depends(get_org_id),
+) -> StrategicAllocationRow:
+    """Set or clear override_min/override_max on one block.
+
+    The override applies to the next propose-mode run only; realize
+    mode reads the approved drift band instead. Either bound may be
+    ``None`` to clear just one side; pass both as ``None`` to reset
+    the override entirely.
+    """
+    from sqlalchemy import text as _sa_text
+
+    from app.domains.wealth.models.block import AllocationBlock as _AB
+
+    _require_ic_role(actor)
+
+    profile_lc = profile.strip().lower()
+    if profile_lc not in _PROPOSE_VALID_PROFILES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Unknown profile '{profile}'. Valid: "
+                f"{sorted(_PROPOSE_VALID_PROFILES)}"
+            ),
+        )
+
+    block_row = (
+        await db.execute(
+            select(_AB.is_canonical).where(_AB.block_id == body.block_id)
+        )
+    ).scalar_one_or_none()
+    if block_row is None or not bool(block_row):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"block_id {body.block_id!r} is not a canonical "
+                "allocation block."
+            ),
+        )
+
+    update_stmt = _sa_text(
+        """
+        UPDATE strategic_allocation
+           SET override_min = :omin,
+               override_max = :omax,
+               rationale = COALESCE(:rationale, rationale)
+         WHERE organization_id = :org
+           AND profile = :profile
+           AND block_id = :block_id
+        RETURNING block_id, target_weight, drift_min, drift_max,
+                  override_min, override_max, approved_at, approved_by,
+                  excluded_from_portfolio
+        """
+    )
+    result = await db.execute(
+        update_stmt,
+        {
+            "omin": body.override_min,
+            "omax": body.override_max,
+            "rationale": body.rationale,
+            "org": uuid.UUID(str(org_id)),
+            "profile": profile_lc,
+            "block_id": body.block_id,
+        },
+    )
+    row = result.mappings().one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"No strategic_allocation row for (profile={profile_lc}, "
+                f"block_id={body.block_id}). Canonical template may not "
+                "have been seeded for this organization."
+            ),
+        )
+
+    await db.flush()
+
+    return StrategicAllocationRow(
+        block_id=str(row["block_id"]),
+        target_weight=(
+            float(row["target_weight"])
+            if row.get("target_weight") is not None
+            else None
+        ),
+        drift_min=(
+            float(row["drift_min"]) if row.get("drift_min") is not None else None
+        ),
+        drift_max=(
+            float(row["drift_max"]) if row.get("drift_max") is not None else None
+        ),
+        override_min=(
+            float(row["override_min"])
+            if row.get("override_min") is not None
+            else None
+        ),
+        override_max=(
+            float(row["override_max"])
+            if row.get("override_max") is not None
+            else None
+        ),
+        approved_at=row.get("approved_at"),
+        approved_by=row.get("approved_by"),
+        excluded_from_portfolio=bool(row.get("excluded_from_portfolio") or False),
     )

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -1841,6 +1841,55 @@ def _extract_fund_weights(
     return fund_ids, weights
 
 
+def _build_propose_block_constraints(
+    *,
+    allocations: list[Any],
+    canonical_block_ids: list[str],
+    block_constraint_cls: Any,
+) -> tuple[list[Any], list[str]]:
+    """PR-A26.2 Section D - build propose-mode block constraints.
+
+    For every canonical block:
+    * ``excluded_from_portfolio = True`` collapses to ``[0, 0]`` (exclusion
+      trumps override).
+    * Otherwise the bounds default to ``[0, 1]`` and tighten to the
+      operator-set ``override_min``/``override_max`` when present.
+
+    Returns ``(block_constraints, override_block_ids)`` — the second
+    tuple slot feeds the ``taa_provenance`` telemetry so downstream
+    consumers know which blocks were override-constrained without
+    re-walking the SA rows.
+    """
+    excluded_block_ids = {
+        a.block_id for a in allocations if a.excluded_from_portfolio
+    }
+    overrides_by_block: dict[str, tuple[float | None, float | None]] = {
+        a.block_id: (
+            float(a.override_min) if a.override_min is not None else None,
+            float(a.override_max) if a.override_max is not None else None,
+        )
+        for a in allocations
+        if a.override_min is not None or a.override_max is not None
+    }
+
+    constraints: list[Any] = []
+    for bid in canonical_block_ids:
+        if bid in excluded_block_ids:
+            constraints.append(
+                block_constraint_cls(block_id=bid, min_weight=0.0, max_weight=0.0),
+            )
+            continue
+        omin, omax = overrides_by_block.get(bid, (None, None))
+        constraints.append(
+            block_constraint_cls(
+                block_id=bid,
+                min_weight=omin if omin is not None else 0.0,
+                max_weight=omax if omax is not None else 1.0,
+            ),
+        )
+    return constraints, sorted(overrides_by_block.keys())
+
+
 async def _run_construction_async(
     db: AsyncSession,
     profile: str,
@@ -2030,23 +2079,24 @@ async def _run_construction_async(
         ).all()
         canonical_block_ids = sorted({r[0] for r in canonical_rows})
 
+        block_constraints, override_blocks = _build_propose_block_constraints(
+            allocations=allocations,
+            canonical_block_ids=canonical_block_ids,
+            block_constraint_cls=BlockConstraint,
+        )
         excluded_block_ids = {
             a.block_id for a in allocations if a.excluded_from_portfolio
         }
-
-        block_constraints = [
-            BlockConstraint(
-                block_id=bid,
-                min_weight=0.0,
-                max_weight=0.0 if bid in excluded_block_ids else 1.0,
-            )
-            for bid in canonical_block_ids
-        ]
         taa_provenance = {
             "mode": "propose_mode_skipped",
             "n_canonical_blocks": len(canonical_block_ids),
             "n_excluded_blocks": len(excluded_block_ids),
             "excluded_blocks": sorted(excluded_block_ids),
+            # PR-A26.2 - telemetry surfaces operator overrides so the
+            # Builder UI can render a "constrained by override" chip on
+            # the affected blocks in the proposal diff view.
+            "n_override_blocks": len(override_blocks),
+            "override_blocks": sorted(override_blocks),
         }
     else:
         # ── TAA: Resolve dynamic regime bands (or fallback to static IPS) ──

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -2099,12 +2099,19 @@ async def _run_construction_async(
             if taa_cfg_result:
                 taa_config = taa_cfg_result.value
 
+        # PR-A26.2 — realize-mode BlockConstraint is driven by the approved
+        # drift band (``drift_min/drift_max``). Legacy ``min_weight/
+        # max_weight`` columns were dropped in migration 0155. Unapproved
+        # blocks (``drift_min IS NULL``) fall back to ``[0, 1]``; the
+        # realize-mode gate (Section E below) refuses to run when any
+        # canonical block lacks ``approved_at``, so the fallback only
+        # surfaces in transitional states / integration tests.
         alloc_dicts = [
             {
                 "block_id": a.block_id,
                 "target_weight": float(a.target_weight) if a.target_weight is not None else 0.0,
-                "min_weight": float(a.min_weight) if a.min_weight is not None else 0.0,
-                "max_weight": float(a.max_weight) if a.max_weight is not None else 1.0,
+                "min_weight": float(a.drift_min) if a.drift_min is not None else 0.0,
+                "max_weight": float(a.drift_max) if a.drift_max is not None else 1.0,
             }
             for a in allocations
         ]

--- a/backend/app/domains/wealth/schemas/allocation.py
+++ b/backend/app/domains/wealth/schemas/allocation.py
@@ -10,20 +10,54 @@ from app.domains.wealth.schemas.sanitized import humanize_regime
 
 
 class StrategicAllocationRead(BaseModel):
+    # PR-A26.2 — ``min_weight/max_weight`` are serialized from the ORM's
+    # ``drift_min/drift_max`` columns via explicit validator (the legacy
+    # SA columns were dropped in migration 0155). Kept on the wire so
+    # existing frontend consumers don't need to follow the rename.
     model_config = ConfigDict(from_attributes=True, extra="ignore")
 
     allocation_id: uuid.UUID
     profile: str
     block_id: str
-    target_weight: Decimal
-    min_weight: Decimal
-    max_weight: Decimal
+    target_weight: Decimal | None = None
+    min_weight: Decimal | None = None
+    max_weight: Decimal | None = None
     risk_budget: Decimal | None = None
     rationale: str | None = None
     approved_by: str | None = None
     effective_from: date
     effective_to: date | None = None
     created_at: datetime
+
+    @model_validator(mode="before")
+    @classmethod
+    def _map_drift_to_legacy(cls, data: object) -> object:
+        """Populate ``min_weight/max_weight`` from ``drift_min/drift_max``.
+
+        Runs only when the incoming data is an ORM instance (from_attributes
+        path) or a mapping that carries ``drift_min``/``drift_max``.
+        """
+        # Mapping path (e.g. manual dict construction).
+        if isinstance(data, dict):
+            if "min_weight" not in data and "drift_min" in data:
+                data["min_weight"] = data.get("drift_min")
+            if "max_weight" not in data and "drift_max" in data:
+                data["max_weight"] = data.get("drift_max")
+            return data
+        # ORM / arbitrary-object path — synthesize a mapping so downstream
+        # validation reads the alias even if the source object lacks
+        # ``min_weight`` entirely.
+        if not hasattr(data, "drift_min") and not hasattr(data, "drift_max"):
+            return data
+        mapping: dict[str, object] = {}
+        for field_name in cls.model_fields:
+            if hasattr(data, field_name):
+                mapping[field_name] = getattr(data, field_name)
+        if hasattr(data, "drift_min"):
+            mapping["min_weight"] = getattr(data, "drift_min")
+        if hasattr(data, "drift_max"):
+            mapping["max_weight"] = getattr(data, "drift_max")
+        return mapping
 
 
 class StrategicAllocationItem(BaseModel):

--- a/backend/app/domains/wealth/schemas/allocation.py
+++ b/backend/app/domains/wealth/schemas/allocation.py
@@ -54,9 +54,9 @@ class StrategicAllocationRead(BaseModel):
             if hasattr(data, field_name):
                 mapping[field_name] = getattr(data, field_name)
         if hasattr(data, "drift_min"):
-            mapping["min_weight"] = getattr(data, "drift_min")
+            mapping["min_weight"] = data.drift_min
         if hasattr(data, "drift_max"):
-            mapping["max_weight"] = getattr(data, "drift_max")
+            mapping["max_weight"] = data.drift_max
         return mapping
 
 

--- a/backend/app/domains/wealth/schemas/model_portfolio.py
+++ b/backend/app/domains/wealth/schemas/model_portfolio.py
@@ -312,6 +312,79 @@ class JobCreatedResponse(BaseModel):
     run_id: uuid.UUID
 
 
+# ── PR-A26.2 — Approval flow + overrides ────────────────────────────
+
+
+class ApproveProposalRequest(BaseModel):
+    """Body for ``POST /portfolio/profiles/{profile}/approve-proposal/{run_id}``.
+
+    ``confirm_cvar_infeasible=True`` is required when approving a run
+    that completed with ``winner_signal = 'proposal_cvar_infeasible'``
+    — the operator is explicitly accepting a Strategic IPS whose bands
+    cannot meet the configured CVaR target. ``operator_message`` lands
+    on ``allocation_approvals.operator_message`` for audit.
+    """
+
+    confirm_cvar_infeasible: bool = False
+    operator_message: str | None = Field(default=None, max_length=5000)
+
+
+class StrategicAllocationRow(BaseModel):
+    """Single strategic_allocation row after approval (Section C)."""
+
+    block_id: str
+    target_weight: float | None = None
+    drift_min: float | None = None
+    drift_max: float | None = None
+    override_min: float | None = None
+    override_max: float | None = None
+    approved_at: datetime | None = None
+    approved_by: str | None = None
+    excluded_from_portfolio: bool = False
+
+
+class ApprovalResponse(BaseModel):
+    """Response for ``POST /portfolio/profiles/{profile}/approve-proposal/{run_id}``.
+
+    ``strategic_snapshot`` carries one entry per canonical block — the
+    post-approval state of the 18 ``strategic_allocation`` rows that
+    make up the Strategic IPS anchor. The frontend renders this as
+    confirmation before wiring up the realize-mode CTA.
+    """
+
+    approval_id: uuid.UUID
+    run_id: uuid.UUID
+    organization_id: uuid.UUID
+    profile: str
+    approved_at: datetime
+    approved_by: str
+    cvar_feasible_at_approval: bool
+    strategic_snapshot: list[StrategicAllocationRow]
+
+
+class SetOverrideRequest(BaseModel):
+    """Body for ``POST /portfolio/profiles/{profile}/set-override``.
+
+    Either bound may be ``None`` — set just one side (e.g. only
+    ``override_max``) or both, or clear both by passing ``None``.
+    """
+
+    block_id: str
+    override_min: float | None = Field(default=None, ge=0.0, le=1.0)
+    override_max: float | None = Field(default=None, ge=0.0, le=1.0)
+    rationale: str | None = Field(default=None, max_length=5000)
+
+    @model_validator(mode="after")
+    def _validate_override_bounds(self) -> SetOverrideRequest:
+        if (
+            self.override_min is not None
+            and self.override_max is not None
+            and self.override_min > self.override_max
+        ):
+            raise ValueError("override_min must be <= override_max when both set")
+        return self
+
+
 class StressScenarioCatalogEntry(BaseModel):
     """One entry in the stress catalog returned by GET /portfolio/stress-test/scenarios."""
 

--- a/backend/app/domains/wealth/schemas/sanitized.py
+++ b/backend/app/domains/wealth/schemas/sanitized.py
@@ -112,6 +112,16 @@ class WinnerSignal(str, Enum):
     # the universe.
     PROPOSAL_READY = "proposal_ready"
     PROPOSAL_CVAR_INFEASIBLE = "proposal_cvar_infeasible"
+    # PR-A26.2 — realize-mode runs require an approved Strategic IPS
+    # (``strategic_allocation.approved_at`` populated for all 18 canonical
+    # blocks). Operator remedy: run the propose-then-approve cycle.
+    NO_APPROVED_ALLOCATION = "no_approved_allocation"
+    # PR-A26.2 — composition stage detected a block whose realize weight
+    # cannot be distributed under the hard 15% per-instrument cap given
+    # the approved instrument count in that block. Operator remedy:
+    # approve more instruments for the breaching block OR accept a
+    # lower realize weight for it.
+    INSTRUMENT_CONCENTRATION_BREACH = "instrument_concentration_breach"
 
 
 def compute_winner_signal(

--- a/backend/app/domains/wealth/schemas/sanitized.py
+++ b/backend/app/domains/wealth/schemas/sanitized.py
@@ -63,7 +63,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-
 # ── PR-A19.1 Section C — cascade-aware operator signal ───────────────
 #
 # ``winner_status`` on the optimizer result only distinguishes

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -161,6 +161,53 @@ class TemplateIncompleteError(Exception):
         self.report = report
 
 
+class NoApprovedAllocationError(Exception):
+    """PR-A26.2 Section E — realize-mode requires an approved Strategic IPS.
+
+    Raised pre-optimizer when any canonical ``strategic_allocation`` row
+    for the ``(organization_id, profile)`` pair has ``approved_at IS
+    NULL``. The operator remedy is to run the propose → approve cycle
+    before realizing any portfolio.
+    """
+
+    def __init__(
+        self, *, organization_id: uuid.UUID, profile: str,
+        approved_count: int, total_count: int,
+    ) -> None:
+        super().__init__(
+            f"no_approved_allocation profile={profile!r} "
+            f"approved={approved_count}/{total_count}"
+        )
+        self.organization_id = organization_id
+        self.profile = profile
+        self.approved_count = approved_count
+        self.total_count = total_count
+
+
+class InstrumentConcentrationBreachError(Exception):
+    """PR-A26.2 Section F — realize composition breached the 15% per-instrument cap.
+
+    The block's realized weight ``w_b`` would require at least
+    ``ceil(w_b / 0.15)`` approved instruments to distribute under the
+    hard 15% ceiling. Operator remedy: approve more instruments for
+    the breaching block or accept a lower block weight.
+    """
+
+    def __init__(
+        self, *, block_id: str, block_weight: float,
+        required: int, available: int,
+    ) -> None:
+        super().__init__(
+            f"instrument_concentration_breach block={block_id} "
+            f"block_weight={block_weight:.4f} required={required} "
+            f"available={available}"
+        )
+        self.block_id = block_id
+        self.block_weight = block_weight
+        self.required = required
+        self.available = available
+
+
 # ── Helpers ────────────────────────────────────────────────────
 
 
@@ -938,6 +985,112 @@ async def _persist_template_failure(
     )
 
 
+async def _count_approved_blocks(
+    db: AsyncSession, organization_id: uuid.UUID | str, profile: str,
+) -> tuple[int, int]:
+    """PR-A26.2 Section E — return ``(approved, total)`` canonical-block count.
+
+    ``approved`` counts rows with ``approved_at IS NOT NULL``; ``total``
+    is the number of rows present for the ``(org, profile)`` pair.
+    Realize mode requires ``approved == 18`` (== total once the A25
+    canonical trigger has run).
+    """
+    from sqlalchemy import text as _sa_text
+
+    row = await db.execute(
+        _sa_text(
+            """
+            SELECT COUNT(*) FILTER (WHERE approved_at IS NOT NULL) AS approved,
+                   COUNT(*) AS total
+              FROM strategic_allocation
+             WHERE organization_id = :org
+               AND profile = :profile
+            """
+        ),
+        {"org": str(organization_id), "profile": profile},
+    )
+    record = row.one_or_none()
+    if record is None:
+        return 0, 0
+    return int(record[0] or 0), int(record[1] or 0)
+
+
+async def _persist_no_approval_failure(
+    db: AsyncSession,
+    *,
+    run: PortfolioConstructionRun,
+    organization_id: uuid.UUID,
+    profile: str,
+    approved_count: int,
+    total_count: int,
+) -> None:
+    """PR-A26.2 Section E — persist the no-approved-allocation failure."""
+    existing = run.cascade_telemetry or {}
+    run.cascade_telemetry = {
+        **existing,
+        "winner_signal": WinnerSignal.NO_APPROVED_ALLOCATION.value,
+        "operator_signal": WinnerSignal.NO_APPROVED_ALLOCATION.value,
+        "operator_message": {
+            "title": "No approved Strategic IPS",
+            "body": (
+                f"Realize mode requires an approved Strategic allocation "
+                f"for the '{profile}' profile — currently "
+                f"{approved_count}/{total_count} canonical blocks are "
+                "approved. Run POST /portfolio/profiles/{profile}/"
+                "propose-allocation and then POST approve-proposal/{run_id} "
+                "to seed the Strategic IPS anchor before realizing."
+            ),
+            "severity": "warning",
+            "action_hint": "run_propose_then_approve",
+        },
+        "cascade_summary": "no_approved_allocation",
+        "approval_state": {
+            "approved_count": approved_count,
+            "total_count": total_count,
+        },
+    }
+    run.status = "failed"
+    run.failure_reason = (
+        f"no_approved_allocation: {approved_count}/{total_count} "
+        f"canonical blocks approved for profile '{profile}'"
+    )
+
+
+async def _persist_instrument_concentration_breach(
+    db: AsyncSession,
+    *,
+    run: PortfolioConstructionRun,
+    breaches: list[dict[str, Any]],
+) -> None:
+    """PR-A26.2 Section F — persist instrument concentration breach."""
+    existing = run.cascade_telemetry or {}
+    run.cascade_telemetry = {
+        **existing,
+        "winner_signal": WinnerSignal.INSTRUMENT_CONCENTRATION_BREACH.value,
+        "operator_signal": WinnerSignal.INSTRUMENT_CONCENTRATION_BREACH.value,
+        "operator_message": {
+            "title": "Per-instrument concentration cap breached",
+            "body": (
+                "One or more blocks would require a single instrument to "
+                "hold more than 15% of the total portfolio to distribute "
+                "the block's realize weight. Approve additional "
+                "instruments for the breaching block(s) or accept a "
+                "lower realize weight."
+            ),
+            "severity": "warning",
+            "action_hint": "approve_more_instruments_or_reduce_block_weight",
+        },
+        "cascade_summary": "instrument_concentration_breach",
+        "concentration_breaches": breaches,
+    }
+    run.status = "failed"
+    first = breaches[0] if breaches else {}
+    run.failure_reason = (
+        f"instrument_concentration_breach: block={first.get('block_id')!r} "
+        f"required={first.get('required')} available={first.get('available')}"
+    )
+
+
 async def _persist_coverage_failure(
     db: AsyncSession,
     *,
@@ -1255,6 +1408,87 @@ async def execute_construction_run(
             },
         )
         return run
+    except NoApprovedAllocationError as no_approval_exc:
+        # PR-A26.2 Section E — realize mode blocked; emit structured signal.
+        await _persist_no_approval_failure(
+            db,
+            run=run,
+            organization_id=no_approval_exc.organization_id,
+            profile=no_approval_exc.profile,
+            approved_count=no_approval_exc.approved_count,
+            total_count=no_approval_exc.total_count,
+        )
+        run.completed_at = datetime.now(tz=timezone.utc)
+        run.wall_clock_ms = int((time.perf_counter() - start_ts) * 1000)
+        await db.flush()
+        await _publish_terminal_event_sanitized(
+            db,
+            run_id=run_id,
+            job_id=job_id,
+            raw_type="run_failed",
+            raw_payload={
+                "run_id": str(run_id),
+                "reason": "no_approved_allocation",
+                "winner_signal": WinnerSignal.NO_APPROVED_ALLOCATION.value,
+                "approved_count": no_approval_exc.approved_count,
+                "total_count": no_approval_exc.total_count,
+            },
+        )
+        logger.info(
+            "construction_run_no_approved_allocation",
+            extra={
+                "run_id": str(run_id),
+                "portfolio_id": str(portfolio_id),
+                "profile": no_approval_exc.profile,
+                "approved": no_approval_exc.approved_count,
+                "total": no_approval_exc.total_count,
+            },
+        )
+        return run
+    except InstrumentConcentrationBreachError as conc_exc:
+        # PR-A26.2 Section F — realize composition refused; emit signal.
+        await _persist_instrument_concentration_breach(
+            db,
+            run=run,
+            breaches=[
+                {
+                    "block_id": conc_exc.block_id,
+                    "block_weight": conc_exc.block_weight,
+                    "required": conc_exc.required,
+                    "available": conc_exc.available,
+                },
+            ],
+        )
+        run.completed_at = datetime.now(tz=timezone.utc)
+        run.wall_clock_ms = int((time.perf_counter() - start_ts) * 1000)
+        await db.flush()
+        await _publish_terminal_event_sanitized(
+            db,
+            run_id=run_id,
+            job_id=job_id,
+            raw_type="run_failed",
+            raw_payload={
+                "run_id": str(run_id),
+                "reason": "instrument_concentration_breach",
+                "winner_signal": (
+                    WinnerSignal.INSTRUMENT_CONCENTRATION_BREACH.value
+                ),
+                "block_id": conc_exc.block_id,
+                "required": conc_exc.required,
+                "available": conc_exc.available,
+            },
+        )
+        logger.info(
+            "construction_run_instrument_concentration_breach",
+            extra={
+                "run_id": str(run_id),
+                "portfolio_id": str(portfolio_id),
+                "block_id": conc_exc.block_id,
+                "required": conc_exc.required,
+                "available": conc_exc.available,
+            },
+        )
+        return run
     except CoverageInsufficientError as coverage_exc:
         # PR-A22 — pre-solve failure with structured gap report.
         await _persist_coverage_failure(
@@ -1441,6 +1675,24 @@ async def _execute_inner(
     coverage = await validate_block_coverage(db, organization_id, profile)
     if not coverage.is_sufficient:
         raise CoverageInsufficientError(coverage)
+
+    # ── PR-A26.2 Section E. Realize-mode approval gate ──
+    # Refuse-to-run until an approved Strategic IPS exists for the
+    # (org, profile) pair. Propose mode skips this check — it generates
+    # the anchor bands the operator later approves.
+    if not propose_mode:
+        approved, total = await _count_approved_blocks(
+            db, organization_id, profile,
+        )
+        # ``total`` is 18 post-A25; allow for transitional fixtures by
+        # requiring ``approved == total`` AND ``approved > 0``.
+        if total == 0 or approved < total:
+            raise NoApprovedAllocationError(
+                organization_id=organization_id,
+                profile=profile,
+                approved_count=approved,
+                total_count=total,
+            )
 
     await _check_cancellation(job_id, "pre_optimizer")
     await _publish_event_sanitized(

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -985,6 +985,72 @@ async def _persist_template_failure(
     )
 
 
+_INSTRUMENT_CONCENTRATION_CAP = 0.15
+
+
+async def _check_instrument_concentration_feasibility(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID | str,
+    profile: str,
+) -> None:
+    """PR-A26.2 Section F — pre-optimizer per-instrument 15% cap check.
+
+    For every canonical block with ``target_weight > 0.15`` we require
+    at least ``ceil(target_weight / 0.15)`` approved instruments in
+    ``instruments_org``. Anything less guarantees the composition layer
+    would have to violate the 15% per-instrument cap to distribute the
+    block's realize weight. Raises :class:`InstrumentConcentrationBreachError`
+    on the first breach (operators get one gap at a time to avoid an
+    avalanche of error detail).
+    """
+    from math import ceil
+
+    from sqlalchemy import text as _sa_text
+
+    # Join SA (target_weight) with instruments_org (approved candidates)
+    # grouped by block_id. ``approval_status = 'approved'`` matches the
+    # live realize-mode universe loader.
+    rows = (
+        await db.execute(
+            _sa_text(
+                """
+                SELECT sa.block_id,
+                       COALESCE(sa.target_weight, 0.0) AS target_weight,
+                       COALESCE(counts.n_approved, 0)  AS n_approved
+                  FROM strategic_allocation sa
+                  LEFT JOIN (
+                       SELECT block_id, COUNT(*) AS n_approved
+                         FROM instruments_org
+                        WHERE organization_id = :org
+                          AND approval_status = 'approved'
+                          AND block_id IS NOT NULL
+                        GROUP BY block_id
+                  ) counts ON counts.block_id = sa.block_id
+                 WHERE sa.organization_id = :org
+                   AND sa.profile = :profile
+                   AND COALESCE(sa.excluded_from_portfolio, false) = false
+                """
+            ),
+            {"org": str(organization_id), "profile": profile},
+        )
+    ).all()
+
+    for block_id, target_weight, n_approved in rows:
+        target = float(target_weight or 0.0)
+        if target <= _INSTRUMENT_CONCENTRATION_CAP:
+            # A single instrument at 15% can fully fund the block.
+            continue
+        required = int(ceil(target / _INSTRUMENT_CONCENTRATION_CAP))
+        if int(n_approved or 0) < required:
+            raise InstrumentConcentrationBreachError(
+                block_id=str(block_id),
+                block_weight=target,
+                required=required,
+                available=int(n_approved or 0),
+            )
+
+
 async def _count_approved_blocks(
     db: AsyncSession, organization_id: uuid.UUID | str, profile: str,
 ) -> tuple[int, int]:
@@ -1693,6 +1759,16 @@ async def _execute_inner(
                 approved_count=approved,
                 total_count=total,
             )
+
+        # PR-A26.2 Section F. Per-instrument 15% cap feasibility.
+        # Refuse to invoke the optimizer when any block's approved
+        # target weight cannot be distributed without breaching the
+        # hard 15% per-instrument ceiling given the approved-universe
+        # count. Ensures the operator never sees a silent optimizer
+        # infeasibility that could be explained structurally.
+        await _check_instrument_concentration_feasibility(
+            db, organization_id=organization_id, profile=profile,
+        )
 
     await _check_cancellation(job_id, "pre_optimizer")
     await _publish_event_sanitized(

--- a/backend/app/domains/wealth/workers/risk_calc.py
+++ b/backend/app/domains/wealth/workers/risk_calc.py
@@ -1498,8 +1498,12 @@ async def _compute_and_persist_taa_state(
             block_center = smoothed[ac] * block_ratio
             block_half = half_widths.get(ac, 0.05) * block_ratio
 
+            # PR-A26.2 — ``min_weight/max_weight`` columns dropped; read the
+            # approved drift band. NULL (pre-approval) falls back to [0, 1].
+            _min_w = float(a.drift_min) if a.drift_min is not None else 0.0
+            _max_w = float(a.drift_max) if a.drift_max is not None else 1.0
             eff_min, eff_max = compute_effective_band(
-                float(a.min_weight), float(a.max_weight),
+                _min_w, _max_w,
                 block_center, block_half,
             )
             effective_bands[a.block_id] = {

--- a/backend/scripts/pr_a12_smoke.py
+++ b/backend/scripts/pr_a12_smoke.py
@@ -22,7 +22,7 @@ os.environ.setdefault(
 )
 
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 ORG_ID = uuid.UUID("403d8392-ebfa-5890-b740-45da49c556eb")
 PORTFOLIOS = [

--- a/backend/scripts/pr_a19_1_argmax_resolver.py
+++ b/backend/scripts/pr_a19_1_argmax_resolver.py
@@ -27,7 +27,6 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from app.core.config import settings
 
-
 DETAIL_SQL = text(
     """
     SELECT

--- a/backend/scripts/smoke_pra17.py
+++ b/backend/scripts/smoke_pra17.py
@@ -69,7 +69,8 @@ with psycopg.connect(DB) as conn, conn.cursor() as cur:
     for r in cur.fetchall():
         name, profile, status, limit, er, cv, summary, floor, cov, sec = r
         flipped = summary == "phase_1_succeeded"
-        if flipped: any_phase1 = True
+        if flipped:
+            any_phase1 = True
         mark = "  ** FLIPPED TO PHASE 1 **" if flipped else ""
         print(f"\n--- {name} [{profile}] status={status}{mark}")
         print(f"    limit={float(limit)*100:.2f}%  delivered_CVaR={float(cv)*100:.2f}%  E[r]={float(er)*100:.2f}%" if cv and er else f"    limit={float(limit)*100:.2f}%")

--- a/backend/tests/db/test_allocation_template_trigger.py
+++ b/backend/tests/db/test_allocation_template_trigger.py
@@ -62,7 +62,7 @@ async def test_template_trigger_fans_out_canonical_rows() -> None:
             """
             INSERT INTO strategic_allocation (
                 allocation_id, organization_id, profile, block_id,
-                target_weight, min_weight, max_weight, risk_budget,
+                target_weight, drift_min, drift_max, risk_budget,
                 rationale, approved_by, effective_from, effective_to,
                 actor_source, excluded_from_portfolio
             )

--- a/backend/tests/quant_engine/test_always_solvable_cascade.py
+++ b/backend/tests/quant_engine/test_always_solvable_cascade.py
@@ -174,7 +174,7 @@ def test_achievable_band_monotonic() -> None:
 
     # Upper bound is non-increasing as we tighten the limit.
     uppers = [b[1] for b in bands]
-    for prev, cur in zip(uppers, uppers[1:]):
+    for prev, cur in zip(uppers, uppers[1:], strict=False):
         assert cur <= prev + 1e-6, f"band.upper not monotonic: {uppers}"
 
     # When the limit drops below the universe floor the band collapses.

--- a/backend/tests/quant_engine/test_cascade_telemetry.py
+++ b/backend/tests/quant_engine/test_cascade_telemetry.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import asyncio
 
 import numpy as np
-import pytest
 
 from quant_engine.optimizer_service import (
     BlockConstraint,

--- a/backend/tests/quant_engine/test_phase_winner_invariant.py
+++ b/backend/tests/quant_engine/test_phase_winner_invariant.py
@@ -14,8 +14,6 @@ solutions where SCS's looser tolerance admitted 2× constraint violations.
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import numpy as np
 import pytest
 

--- a/backend/tests/quant_engine/test_propose_mode.py
+++ b/backend/tests/quant_engine/test_propose_mode.py
@@ -27,7 +27,6 @@ from app.domains.wealth.workers.construction_run_executor import (
     _derive_drift_band,
 )
 
-
 # ── Drift band math ─────────────────────────────────────────────
 
 

--- a/backend/tests/test_rebalancing.py
+++ b/backend/tests/test_rebalancing.py
@@ -83,8 +83,10 @@ def _make_allocation(
     a.organization_id = org_id
     a.block_id = block_id
     a.target_weight = Decimal(str(target))
-    a.min_weight = Decimal(str(min_w))
-    a.max_weight = Decimal(str(max_w))
+    # PR-A26.2 — legacy ``min_weight/max_weight`` replaced by
+    # ``drift_min/drift_max`` on the ORM.
+    a.drift_min = Decimal(str(min_w))
+    a.drift_max = Decimal(str(max_w))
     a.effective_to = None
     return a
 

--- a/backend/tests/wealth/test_approve_proposal_endpoint.py
+++ b/backend/tests/wealth/test_approve_proposal_endpoint.py
@@ -1,0 +1,282 @@
+"""PR-A26.2 Section C - approve-proposal endpoint unit coverage.
+
+The handler talks to the DB directly via ``text()`` updates; we stub
+``AsyncSession.execute``/``scalar`` in each test so the shape of the
+SQL traffic is asserted without standing up Postgres. Live-DB smoke
+coverage lives in ``backend/scripts/pr_a26_2_smoke.py``.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.security.clerk_auth import Actor
+from app.domains.wealth.models.model_portfolio import PortfolioConstructionRun
+from app.domains.wealth.routes.model_portfolios import approve_proposal
+from app.domains.wealth.schemas.model_portfolio import ApproveProposalRequest
+
+
+_CANONICAL_BLOCKS: tuple[str, ...] = (
+    "na_equity_large", "na_equity_growth", "na_equity_value", "na_equity_small",
+    "dm_europe_equity", "dm_asia_equity", "em_equity",
+    "fi_us_aggregate", "fi_us_treasury", "fi_us_short_term",
+    "fi_us_high_yield", "fi_us_tips", "fi_ig_corporate", "fi_em_debt",
+    "alt_real_estate", "alt_gold", "alt_commodities", "cash",
+)
+
+
+def _make_actor(role: str = "INVESTMENT_TEAM") -> Actor:
+    from app.shared.enums import Role
+
+    return Actor(
+        actor_id="tester",
+        name="Tester",
+        email="tester@example.com",
+        roles=[Role(role)],
+        organization_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        fund_ids=[],
+    )
+
+
+def _make_user() -> Any:
+    user = MagicMock()
+    user.name = "tester"
+    return user
+
+
+def _make_run(
+    *,
+    winner_signal: str = "proposal_ready",
+    cvar_feasible: bool = True,
+    run_mode: str = "propose",
+    n_bands: int = 18,
+) -> PortfolioConstructionRun:
+    bands = [
+        {
+            "block_id": _CANONICAL_BLOCKS[i],
+            "target_weight": 1.0 / n_bands,
+            "drift_min": 0.0,
+            "drift_max": 1.0,
+        }
+        for i in range(min(n_bands, len(_CANONICAL_BLOCKS)))
+    ]
+    telemetry = {
+        "winner_signal": winner_signal,
+        "proposed_bands": bands,
+        "proposal_metrics": {
+            "target_cvar": 0.05,
+            "expected_return": 0.08,
+            "cvar_feasible": cvar_feasible,
+        },
+    }
+    run = PortfolioConstructionRun(
+        id=uuid.uuid4(),
+        organization_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        portfolio_id=uuid.uuid4(),
+        calibration_snapshot={},
+        calibration_hash="x",
+        universe_fingerprint="pending",
+        status="succeeded",
+        run_mode=run_mode,
+        requested_by="tester",
+    )
+    run.cascade_telemetry = telemetry
+    return run
+
+
+def _make_db_for_approve(
+    *,
+    run: PortfolioConstructionRun | None,
+) -> AsyncMock:
+    """Stub AsyncSession that simulates the sequence the handler issues.
+
+    Call pattern per handler:
+      1. ``execute(run_stmt).scalar_one_or_none()`` → run or None
+      2. ``scalar(text("SELECT now()"))`` → a timestamp
+      3. 18 × ``execute(update sa).mappings().one_or_none()`` → band row
+      4. ``execute(update approvals ...)`` (no return)
+      5. ``execute(insert approvals ...)`` (no return)
+      6. ``flush()``
+    """
+    db = AsyncMock()
+
+    run_result = MagicMock()
+    run_result.scalar_one_or_none.return_value = run
+
+    now_ts = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    db.scalar = AsyncMock(return_value=now_ts)
+
+    # Each SA band update returns one row.
+    def _make_sa_result(block_id: str) -> MagicMock:
+        result = MagicMock()
+        mappings = MagicMock()
+        mappings.one_or_none.return_value = {
+            "block_id": block_id,
+            "target_weight": 0.05,
+            "drift_min": 0.02,
+            "drift_max": 0.08,
+            "override_min": None,
+            "override_max": None,
+            "approved_at": now_ts,
+            "approved_by": "tester",
+            "excluded_from_portfolio": False,
+        }
+        result.mappings.return_value = mappings
+        return result
+
+    # Approvals supersede/insert — no RETURNING, so bare MagicMock ok.
+    generic_result = MagicMock()
+
+    execute_calls = {"i": 0}
+
+    async def _execute(stmt, params: dict | None = None):
+        execute_calls["i"] += 1
+        # First call is the run lookup.
+        if execute_calls["i"] == 1:
+            return run_result
+        # Next 18 are SA band updates.
+        if 2 <= execute_calls["i"] <= 19 and params and "block_id" in params:
+            return _make_sa_result(params["block_id"])
+        return generic_result
+
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_approve_proposal_ready_happy_path() -> None:
+    run = _make_run(winner_signal="proposal_ready", cvar_feasible=True)
+    db = _make_db_for_approve(run=run)
+
+    resp = await approve_proposal(
+        profile="moderate",
+        run_id=run.id,
+        body=ApproveProposalRequest(),
+        db=db,
+        user=_make_user(),
+        actor=_make_actor(),
+        org_id="00000000-0000-0000-0000-000000000001",
+    )
+
+    assert resp.run_id == run.id
+    assert resp.cvar_feasible_at_approval is True
+    assert len(resp.strategic_snapshot) == 18
+
+
+@pytest.mark.asyncio
+async def test_approve_infeasible_without_confirm_409() -> None:
+    run = _make_run(
+        winner_signal="proposal_cvar_infeasible", cvar_feasible=False,
+    )
+    db = _make_db_for_approve(run=run)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await approve_proposal(
+            profile="moderate",
+            run_id=run.id,
+            body=ApproveProposalRequest(confirm_cvar_infeasible=False),
+            db=db,
+            user=_make_user(),
+            actor=_make_actor(),
+            org_id="00000000-0000-0000-0000-000000000001",
+        )
+    assert excinfo.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_approve_infeasible_with_confirm_succeeds() -> None:
+    run = _make_run(
+        winner_signal="proposal_cvar_infeasible", cvar_feasible=False,
+    )
+    db = _make_db_for_approve(run=run)
+
+    resp = await approve_proposal(
+        profile="moderate",
+        run_id=run.id,
+        body=ApproveProposalRequest(
+            confirm_cvar_infeasible=True,
+            operator_message="accepting infeasible universe floor",
+        ),
+        db=db,
+        user=_make_user(),
+        actor=_make_actor(),
+        org_id="00000000-0000-0000-0000-000000000001",
+    )
+    assert resp.cvar_feasible_at_approval is False
+
+
+@pytest.mark.asyncio
+async def test_approve_realize_run_404() -> None:
+    run = _make_run(run_mode="realize")
+    db = _make_db_for_approve(run=run)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await approve_proposal(
+            profile="moderate",
+            run_id=run.id,
+            body=ApproveProposalRequest(),
+            db=db,
+            user=_make_user(),
+            actor=_make_actor(),
+            org_id="00000000-0000-0000-0000-000000000001",
+        )
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_approve_missing_run_404() -> None:
+    db = _make_db_for_approve(run=None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await approve_proposal(
+            profile="moderate",
+            run_id=uuid.uuid4(),
+            body=ApproveProposalRequest(),
+            db=db,
+            user=_make_user(),
+            actor=_make_actor(),
+            org_id="00000000-0000-0000-0000-000000000001",
+        )
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_approve_template_incomplete_500() -> None:
+    """Propose run with fewer than 18 bands is a structural invariant bug."""
+    run = _make_run(n_bands=17)
+    db = _make_db_for_approve(run=run)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await approve_proposal(
+            profile="moderate",
+            run_id=run.id,
+            body=ApproveProposalRequest(),
+            db=db,
+            user=_make_user(),
+            actor=_make_actor(),
+            org_id="00000000-0000-0000-0000-000000000001",
+        )
+    assert excinfo.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_approve_rejects_unknown_profile() -> None:
+    run = _make_run()
+    db = _make_db_for_approve(run=run)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await approve_proposal(
+            profile="ultra",
+            run_id=run.id,
+            body=ApproveProposalRequest(),
+            db=db,
+            user=_make_user(),
+            actor=_make_actor(),
+            org_id="00000000-0000-0000-0000-000000000001",
+        )
+    assert excinfo.value.status_code == 400

--- a/backend/tests/wealth/test_approve_proposal_endpoint.py
+++ b/backend/tests/wealth/test_approve_proposal_endpoint.py
@@ -20,7 +20,6 @@ from app.domains.wealth.models.model_portfolio import PortfolioConstructionRun
 from app.domains.wealth.routes.model_portfolios import approve_proposal
 from app.domains.wealth.schemas.model_portfolio import ApproveProposalRequest
 
-
 _CANONICAL_BLOCKS: tuple[str, ...] = (
     "na_equity_large", "na_equity_growth", "na_equity_value", "na_equity_small",
     "dm_europe_equity", "dm_asia_equity", "em_equity",

--- a/backend/tests/wealth/test_instrument_concentration_cap.py
+++ b/backend/tests/wealth/test_instrument_concentration_cap.py
@@ -1,0 +1,117 @@
+"""PR-A26.2 Section F - per-instrument 15% cap feasibility check.
+
+The gate fires in realize mode only, AFTER the approval gate. It
+walks every canonical strategic_allocation row with target_weight >
+15% and counts the block's approved instruments in instruments_org
+via a single SQL aggregate. If ``n_b < ceil(target / 0.15)`` it
+raises ``InstrumentConcentrationBreachError`` and the optimizer is
+never invoked.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domains.wealth.workers.construction_run_executor import (
+    InstrumentConcentrationBreachError,
+    _check_instrument_concentration_feasibility,
+)
+
+
+def _db_returning(rows: list[tuple[str, float, int]]) -> AsyncMock:
+    db = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = rows
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_block_weight_under_cap_always_passes() -> None:
+    # 10% block with ONE approved instrument - feasible (one at 10% fits).
+    db = _db_returning([("na_equity_large", 0.10, 1)])
+    await _check_instrument_concentration_feasibility(
+        db,
+        organization_id=uuid.uuid4(),
+        profile="moderate",
+    )
+
+
+@pytest.mark.asyncio
+async def test_block_weight_30pct_with_two_instruments_feasible() -> None:
+    # 30% target -> ceil(0.30 / 0.15) = 2 instruments required; 2 available.
+    db = _db_returning([("na_equity_large", 0.30, 2)])
+    await _check_instrument_concentration_feasibility(
+        db,
+        organization_id=uuid.uuid4(),
+        profile="moderate",
+    )
+
+
+@pytest.mark.asyncio
+async def test_block_weight_30pct_with_one_instrument_raises() -> None:
+    db = _db_returning([("na_equity_large", 0.30, 1)])
+    with pytest.raises(InstrumentConcentrationBreachError) as excinfo:
+        await _check_instrument_concentration_feasibility(
+            db,
+            organization_id=uuid.uuid4(),
+            profile="moderate",
+        )
+    assert excinfo.value.block_id == "na_equity_large"
+    assert excinfo.value.required == 2
+    assert excinfo.value.available == 1
+
+
+@pytest.mark.asyncio
+async def test_block_weight_15pct_edge_with_one_instrument_passes() -> None:
+    # 15% exactly -> target_weight <= cap, no check fires.
+    db = _db_returning([("cash", 0.15, 1)])
+    await _check_instrument_concentration_feasibility(
+        db,
+        organization_id=uuid.uuid4(),
+        profile="moderate",
+    )
+
+
+@pytest.mark.asyncio
+async def test_block_weight_just_above_cap_with_one_instrument_raises() -> None:
+    # 16% -> ceil(0.16/0.15) = 2 instruments required.
+    db = _db_returning([("na_equity_large", 0.16, 1)])
+    with pytest.raises(InstrumentConcentrationBreachError) as excinfo:
+        await _check_instrument_concentration_feasibility(
+            db,
+            organization_id=uuid.uuid4(),
+            profile="moderate",
+        )
+    assert excinfo.value.required == 2
+
+
+@pytest.mark.asyncio
+async def test_null_target_weight_passes() -> None:
+    # Unapproved blocks (target_weight IS NULL) get coerced to 0.0 and pass.
+    db = _db_returning([("em_equity", None, 0)])
+    await _check_instrument_concentration_feasibility(
+        db,
+        organization_id=uuid.uuid4(),
+        profile="moderate",
+    )
+
+
+@pytest.mark.asyncio
+async def test_only_first_breach_reported() -> None:
+    # Both blocks breach; the first one in the query result surfaces.
+    db = _db_returning(
+        [
+            ("na_equity_large", 0.30, 1),
+            ("fi_us_high_yield", 0.40, 1),
+        ]
+    )
+    with pytest.raises(InstrumentConcentrationBreachError) as excinfo:
+        await _check_instrument_concentration_feasibility(
+            db,
+            organization_id=uuid.uuid4(),
+            profile="moderate",
+        )
+    assert excinfo.value.block_id == "na_equity_large"

--- a/backend/tests/wealth/test_load_universe_funds_prefilter.py
+++ b/backend/tests/wealth/test_load_universe_funds_prefilter.py
@@ -93,7 +93,7 @@ async def _seed_strategic_allocation(
             """
             INSERT INTO strategic_allocation (
                 allocation_id, organization_id, profile, block_id,
-                target_weight, min_weight, max_weight, effective_from
+                target_weight, drift_min, drift_max, effective_from
             )
             VALUES (
                 :allocation_id, :org_id, :profile, :block_id,

--- a/backend/tests/wealth/test_pr_a21_sanitization.py
+++ b/backend/tests/wealth/test_pr_a21_sanitization.py
@@ -324,7 +324,7 @@ async def test_migration_0149_aborts_when_strategic_allocation_references_fi_gov
             """
             INSERT INTO strategic_allocation
                 (allocation_id, organization_id, profile, block_id,
-                 target_weight, min_weight, max_weight, effective_from)
+                 target_weight, drift_min, drift_max, effective_from)
             VALUES ($1, $2, 'moderate', 'fi_govt', 0.1, 0.05, 0.2, '2026-01-01')
             """,
             alloc_id, org_id,

--- a/backend/tests/wealth/test_propose_mode_override.py
+++ b/backend/tests/wealth/test_propose_mode_override.py
@@ -1,0 +1,124 @@
+"""PR-A26.2 Section D - propose-mode honours operator overrides.
+
+Exercises ``_build_propose_block_constraints`` directly: given a set
+of StrategicAllocation-shaped stubs, asserts the resulting
+``BlockConstraint`` list carries the override bounds verbatim, that
+excluded blocks collapse to ``[0, 0]`` even with an override, and that
+unmarked blocks default to ``[0, 1]``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from app.domains.wealth.routes.model_portfolios import (
+    _build_propose_block_constraints,
+)
+
+
+@dataclass
+class _BC:
+    block_id: str
+    min_weight: float
+    max_weight: float
+
+
+class _Row:
+    """Minimal StrategicAllocation stand-in (attribute access only)."""
+
+    def __init__(
+        self,
+        block_id: str,
+        *,
+        excluded: bool = False,
+        override_min: float | None = None,
+        override_max: float | None = None,
+    ) -> None:
+        self.block_id = block_id
+        self.excluded_from_portfolio = excluded
+        self.override_min = (
+            Decimal(str(override_min)) if override_min is not None else None
+        )
+        self.override_max = (
+            Decimal(str(override_max)) if override_max is not None else None
+        )
+
+
+CANON: list[str] = [
+    "na_equity_large", "na_equity_growth", "na_equity_value", "na_equity_small",
+    "dm_europe_equity", "dm_asia_equity", "em_equity",
+    "fi_us_aggregate", "fi_us_treasury", "fi_us_short_term",
+    "fi_us_high_yield", "fi_us_tips", "fi_ig_corporate", "fi_em_debt",
+    "alt_real_estate", "alt_gold", "alt_commodities", "cash",
+]
+
+
+def _as_map(constraints) -> dict[str, tuple[float, float]]:
+    return {bc.block_id: (bc.min_weight, bc.max_weight) for bc in constraints}
+
+
+def test_override_bounds_propagate_to_block_constraints() -> None:
+    allocations = [_Row(b) for b in CANON]
+    # Override only two blocks.
+    allocations[0] = _Row("na_equity_large", override_max=0.15)
+    allocations[10] = _Row(
+        "fi_us_high_yield", override_min=0.02, override_max=0.10,
+    )
+
+    constraints, override_blocks = _build_propose_block_constraints(
+        allocations=allocations,
+        canonical_block_ids=CANON,
+        block_constraint_cls=_BC,
+    )
+    bc_map = _as_map(constraints)
+
+    assert bc_map["na_equity_large"] == (0.0, 0.15)
+    assert bc_map["fi_us_high_yield"] == (0.02, 0.10)
+    # Unconstrained blocks remain [0, 1].
+    assert bc_map["cash"] == (0.0, 1.0)
+    assert bc_map["em_equity"] == (0.0, 1.0)
+
+    # Telemetry tag surfaces exactly the two override blocks.
+    assert set(override_blocks) == {"na_equity_large", "fi_us_high_yield"}
+
+
+def test_excluded_block_collapses_to_zero_even_with_override() -> None:
+    allocations = [_Row(b) for b in CANON]
+    allocations[15] = _Row(
+        "alt_gold", excluded=True, override_max=0.25,
+    )
+
+    constraints, _ = _build_propose_block_constraints(
+        allocations=allocations,
+        canonical_block_ids=CANON,
+        block_constraint_cls=_BC,
+    )
+    bc_map = _as_map(constraints)
+    assert bc_map["alt_gold"] == (0.0, 0.0)
+
+
+def test_only_one_bound_set_keeps_other_at_default() -> None:
+    allocations = [_Row(b) for b in CANON]
+    allocations[0] = _Row("na_equity_large", override_max=0.20)  # min defaults
+    allocations[1] = _Row("na_equity_growth", override_min=0.05)  # max defaults
+
+    constraints, _ = _build_propose_block_constraints(
+        allocations=allocations,
+        canonical_block_ids=CANON,
+        block_constraint_cls=_BC,
+    )
+    bc_map = _as_map(constraints)
+    assert bc_map["na_equity_large"] == (0.0, 0.20)
+    assert bc_map["na_equity_growth"] == (0.05, 1.0)
+
+
+def test_no_overrides_at_all_yields_bare_zero_one() -> None:
+    allocations = [_Row(b) for b in CANON]
+    constraints, overrides = _build_propose_block_constraints(
+        allocations=allocations,
+        canonical_block_ids=CANON,
+        block_constraint_cls=_BC,
+    )
+    assert overrides == []
+    for bc in constraints:
+        assert (bc.min_weight, bc.max_weight) == (0.0, 1.0)

--- a/backend/tests/wealth/test_realize_gate_no_approval.py
+++ b/backend/tests/wealth/test_realize_gate_no_approval.py
@@ -1,0 +1,226 @@
+"""PR-A26.2 Section E - realize-mode refuses to run without approvals.
+
+Drives the pre-optimizer gate in ``_execute_inner`` with a stubbed
+``_count_approved_blocks`` that reports ``approved < total`` and
+asserts ``NoApprovedAllocationError`` bubbles out before the optimizer
+is ever invoked. Propose mode bypasses the gate - it is the path that
+SEEDS the approval.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domains.wealth.models.model_portfolio import PortfolioConstructionRun
+from app.domains.wealth.workers import construction_run_executor as executor_mod
+from app.domains.wealth.workers.construction_run_executor import (
+    NoApprovedAllocationError,
+    _execute_inner,
+)
+from quant_engine.allocation_template_service import TemplateReport
+from quant_engine.block_coverage_service import CoverageReport
+
+
+def _make_db_with_portfolio(profile: str, org_id: uuid.UUID) -> AsyncMock:
+    portfolio_stub = MagicMock()
+    portfolio_stub.profile = profile
+    portfolio_stub.organization_id = org_id
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = portfolio_stub
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+def _make_run(org_id: uuid.UUID, run_mode: str = "realize") -> PortfolioConstructionRun:
+    return PortfolioConstructionRun(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        portfolio_id=uuid.uuid4(),
+        calibration_snapshot={},
+        calibration_hash="x",
+        universe_fingerprint="pending",
+        status="running",
+        run_mode=run_mode,
+        requested_by="tester",
+    )
+
+
+def _template_complete(org_id: uuid.UUID, profile: str) -> TemplateReport:
+    return TemplateReport(
+        organization_id=org_id,
+        profile=profile,
+        is_complete=True,
+        missing_canonical_blocks=[],
+        extra_non_canonical_blocks=[],
+    )
+
+
+def _coverage_sufficient(org_id: uuid.UUID, profile: str) -> CoverageReport:
+    return CoverageReport(
+        organization_id=org_id,
+        profile=profile,
+        is_sufficient=True,
+        gaps=[],
+        total_target_weight_at_risk=0.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_realize_mode_aborts_when_no_approvals() -> None:
+    org_id = uuid.uuid4()
+    profile = "moderate"
+    db = _make_db_with_portfolio(profile, org_id)
+    run = _make_run(org_id, run_mode="realize")
+    optimizer_mock = AsyncMock()
+
+    with patch.object(
+        executor_mod,
+        "validate_template_completeness",
+        new=AsyncMock(return_value=_template_complete(org_id, profile)),
+    ), patch.object(
+        executor_mod,
+        "validate_block_coverage",
+        new=AsyncMock(return_value=_coverage_sufficient(org_id, profile)),
+    ), patch.object(
+        executor_mod,
+        "_count_approved_blocks",
+        new=AsyncMock(return_value=(0, 18)),
+    ), patch(
+        "app.domains.wealth.routes.model_portfolios._run_construction_async",
+        new=optimizer_mock,
+    ):
+        with pytest.raises(NoApprovedAllocationError) as excinfo:
+            await _execute_inner(
+                db=db,
+                run=run,
+                portfolio_id=run.portfolio_id,
+                calibration_snapshot={},
+                job_id=None,
+                propose_mode=False,
+            )
+
+    assert excinfo.value.approved_count == 0
+    assert excinfo.value.total_count == 18
+    optimizer_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_realize_mode_partial_approval_still_refused() -> None:
+    org_id = uuid.uuid4()
+    profile = "moderate"
+    db = _make_db_with_portfolio(profile, org_id)
+    run = _make_run(org_id, run_mode="realize")
+    optimizer_mock = AsyncMock()
+
+    with patch.object(
+        executor_mod,
+        "validate_template_completeness",
+        new=AsyncMock(return_value=_template_complete(org_id, profile)),
+    ), patch.object(
+        executor_mod,
+        "validate_block_coverage",
+        new=AsyncMock(return_value=_coverage_sufficient(org_id, profile)),
+    ), patch.object(
+        executor_mod,
+        "_count_approved_blocks",
+        new=AsyncMock(return_value=(17, 18)),
+    ), patch(
+        "app.domains.wealth.routes.model_portfolios._run_construction_async",
+        new=optimizer_mock,
+    ):
+        with pytest.raises(NoApprovedAllocationError):
+            await _execute_inner(
+                db=db,
+                run=run,
+                portfolio_id=run.portfolio_id,
+                calibration_snapshot={},
+                job_id=None,
+                propose_mode=False,
+            )
+    optimizer_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_propose_mode_bypasses_the_gate() -> None:
+    org_id = uuid.uuid4()
+    profile = "moderate"
+    db = _make_db_with_portfolio(profile, org_id)
+    run = _make_run(org_id, run_mode="propose")
+
+    # Optimizer mock raises a benign sentinel so we can stop the test
+    # as soon as control flow passes the gate. Also stub downstream
+    # helpers so post-optimizer logic doesn't crash with mocks.
+    optimizer_mock = AsyncMock(side_effect=AssertionError("stop-post-gate"))
+    count_mock = AsyncMock(return_value=(0, 18))
+
+    with patch.object(
+        executor_mod,
+        "validate_template_completeness",
+        new=AsyncMock(return_value=_template_complete(org_id, profile)),
+    ), patch.object(
+        executor_mod,
+        "validate_block_coverage",
+        new=AsyncMock(return_value=_coverage_sufficient(org_id, profile)),
+    ), patch.object(
+        executor_mod, "_count_approved_blocks", new=count_mock,
+    ), patch(
+        "app.domains.wealth.routes.model_portfolios._run_construction_async",
+        new=optimizer_mock,
+    ):
+        try:
+            await _execute_inner(
+                db=db,
+                run=run,
+                portfolio_id=run.portfolio_id,
+                calibration_snapshot={},
+                job_id=None,
+                propose_mode=True,
+            )
+        except AssertionError as exc:
+            assert str(exc) == "stop-post-gate"
+
+    # Propose never queries approval state.
+    count_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_realize_mode_proceeds_when_all_blocks_approved() -> None:
+    org_id = uuid.uuid4()
+    profile = "moderate"
+    db = _make_db_with_portfolio(profile, org_id)
+    run = _make_run(org_id, run_mode="realize")
+
+    optimizer_mock = AsyncMock(side_effect=AssertionError("stop-post-gate"))
+
+    with patch.object(
+        executor_mod,
+        "validate_template_completeness",
+        new=AsyncMock(return_value=_template_complete(org_id, profile)),
+    ), patch.object(
+        executor_mod,
+        "validate_block_coverage",
+        new=AsyncMock(return_value=_coverage_sufficient(org_id, profile)),
+    ), patch.object(
+        executor_mod,
+        "_count_approved_blocks",
+        new=AsyncMock(return_value=(18, 18)),
+    ), patch(
+        "app.domains.wealth.routes.model_portfolios._run_construction_async",
+        new=optimizer_mock,
+    ):
+        try:
+            await _execute_inner(
+                db=db,
+                run=run,
+                portfolio_id=run.portfolio_id,
+                calibration_snapshot={},
+                job_id=None,
+                propose_mode=False,
+            )
+        except AssertionError as exc:
+            assert str(exc) == "stop-post-gate"
+
+    optimizer_mock.assert_called_once()

--- a/backend/tests/wealth/test_set_override_endpoint.py
+++ b/backend/tests/wealth/test_set_override_endpoint.py
@@ -1,0 +1,188 @@
+"""PR-A26.2 Section D - set-override endpoint + optimizer wiring.
+
+Covers the override endpoint itself (request validation, canonical-
+block membership, row update + RETURNING) and the schema-level guard
+on ``override_min <= override_max``. The propose-mode optimizer
+integration (``BlockConstraint`` carrying the override bounds) lives
+in ``test_propose_mode_override.py``.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.core.security.clerk_auth import Actor
+from app.domains.wealth.routes.model_portfolios import set_override
+from app.domains.wealth.schemas.model_portfolio import SetOverrideRequest
+
+
+def _make_actor() -> Actor:
+    from app.shared.enums import Role
+
+    return Actor(
+        actor_id="tester",
+        name="Tester",
+        email="tester@example.com",
+        roles=[Role.INVESTMENT_TEAM],
+        organization_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        fund_ids=[],
+    )
+
+
+def _make_user() -> Any:
+    user = MagicMock()
+    user.name = "tester"
+    return user
+
+
+def _make_db_for_override(
+    *, block_canonical: bool | None, sa_row: dict | None,
+) -> AsyncMock:
+    """Stub AsyncSession for the set-override handler.
+
+    Call sequence:
+      1. ``execute(canonical_check).scalar_one_or_none()`` -> bool | None
+      2. ``execute(update ... RETURNING).mappings().one_or_none()`` -> row
+      3. ``flush()``
+    """
+    db = AsyncMock()
+
+    canonical_result = MagicMock()
+    canonical_result.scalar_one_or_none.return_value = block_canonical
+
+    sa_result = MagicMock()
+    mappings = MagicMock()
+    mappings.one_or_none.return_value = sa_row
+    sa_result.mappings.return_value = mappings
+
+    calls = {"i": 0}
+
+    async def _execute(stmt, params: dict | None = None):
+        calls["i"] += 1
+        if calls["i"] == 1:
+            return canonical_result
+        return sa_result
+
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+def test_schema_rejects_min_above_max() -> None:
+    with pytest.raises(ValidationError):
+        SetOverrideRequest(
+            block_id="na_equity_large", override_min=0.30, override_max=0.10,
+        )
+
+
+def test_schema_accepts_single_sided_override() -> None:
+    req = SetOverrideRequest(block_id="na_equity_large", override_max=0.15)
+    assert req.override_min is None
+    assert req.override_max == 0.15
+
+
+@pytest.mark.asyncio
+async def test_set_override_happy_path() -> None:
+    now_ts = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    sa_row = {
+        "block_id": "na_equity_large",
+        "target_weight": 0.05,
+        "drift_min": 0.02,
+        "drift_max": 0.08,
+        "override_min": None,
+        "override_max": 0.10,
+        "approved_at": now_ts,
+        "approved_by": "tester",
+        "excluded_from_portfolio": False,
+    }
+    db = _make_db_for_override(block_canonical=True, sa_row=sa_row)
+
+    resp = await set_override(
+        profile="moderate",
+        body=SetOverrideRequest(
+            block_id="na_equity_large",
+            override_max=0.10,
+            rationale="cap equity concentration",
+        ),
+        db=db,
+        user=_make_user(),
+        actor=_make_actor(),
+        org_id="00000000-0000-0000-0000-000000000001",
+    )
+
+    assert resp.block_id == "na_equity_large"
+    assert resp.override_max == 0.10
+    assert resp.override_min is None
+
+
+@pytest.mark.asyncio
+async def test_set_override_rejects_non_canonical_block() -> None:
+    db = _make_db_for_override(block_canonical=False, sa_row=None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await set_override(
+            profile="moderate",
+            body=SetOverrideRequest(
+                block_id="not_a_block", override_max=0.10,
+            ),
+            db=db,
+            user=_make_user(),
+            actor=_make_actor(),
+            org_id="00000000-0000-0000-0000-000000000001",
+        )
+    assert excinfo.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_set_override_404_when_row_missing() -> None:
+    db = _make_db_for_override(block_canonical=True, sa_row=None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await set_override(
+            profile="moderate",
+            body=SetOverrideRequest(
+                block_id="na_equity_large", override_max=0.10,
+            ),
+            db=db,
+            user=_make_user(),
+            actor=_make_actor(),
+            org_id="00000000-0000-0000-0000-000000000001",
+        )
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_set_override_clears_both_bounds() -> None:
+    now_ts = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    sa_row = {
+        "block_id": "na_equity_large",
+        "target_weight": 0.05,
+        "drift_min": 0.02,
+        "drift_max": 0.08,
+        "override_min": None,
+        "override_max": None,
+        "approved_at": now_ts,
+        "approved_by": "tester",
+        "excluded_from_portfolio": False,
+    }
+    db = _make_db_for_override(block_canonical=True, sa_row=sa_row)
+
+    resp = await set_override(
+        profile="moderate",
+        body=SetOverrideRequest(
+            block_id="na_equity_large",
+            override_min=None,
+            override_max=None,
+        ),
+        db=db,
+        user=_make_user(),
+        actor=_make_actor(),
+        org_id="00000000-0000-0000-0000-000000000001",
+    )
+    assert resp.override_min is None
+    assert resp.override_max is None

--- a/backend/vertical_engines/wealth/rebalancing/weight_proposer.py
+++ b/backend/vertical_engines/wealth/rebalancing/weight_proposer.py
@@ -191,8 +191,14 @@ def propose_weights(
         )
 
     # 4. Build bounds map and redistribute proportionally
+    # PR-A26.2 — ``min_weight/max_weight`` dropped; read the approved
+    # drift band. Unapproved blocks fall back to ``[0, 1]`` so the
+    # rebalance proposer can still produce a feasible redistribution.
     bounds: dict[str, tuple[float, float]] = {
-        a.block_id: (float(a.min_weight), float(a.max_weight))
+        a.block_id: (
+            float(a.drift_min) if a.drift_min is not None else 0.0,
+            float(a.drift_max) if a.drift_max is not None else 1.0,
+        )
         for a in allocations
     }
 


### PR DESCRIPTION
## Summary

Completes the propose→approve→realize loop for portfolio construction (spec: `docs/prompts/2026-04-18-pr-a26-2-approval-flow.md`).

- **Migration 0155** — refactors `strategic_allocation`: drops `min_weight/max_weight`, adds `drift_min/drift_max/override_min/override_max/approved_from_run_id/approved_at/approved_by`. Creates `allocation_approvals` audit table (global). Refreshes A25 triggers to the new column shape. Up+down round-trip clean.
- **Section C** — `POST /portfolio/profiles/{profile}/approve-proposal/{run_id}`: atomic snapshot of proposed bands into 18 strategic_allocation rows + audit log insert + prior-approval supersede. 409 on `proposal_cvar_infeasible` unless `confirm_cvar_infeasible=true`.
- **Section D** — `POST /portfolio/profiles/{profile}/set-override` + optimizer propose-mode wiring. Overrides constrain CLARABEL via `BlockConstraint(min_weight, max_weight)`; excluded blocks still trump overrides (zeroed).
- **Section E** — Realize-mode gate: refuses to run when any of the 18 strategic rows has `approved_at IS NULL`. Emits `winner_signal='no_approved_allocation'`.
- **Section F** — Pre-optimizer per-instrument 15% cap feasibility check. Raises `INSTRUMENT_CONCENTRATION_BREACH` when `ceil(target_weight / 0.15) > approved_instruments` for any block.
- **Schemas/enum** — `ApproveProposalRequest`, `ApprovalResponse`, `SetOverrideRequest`, `StrategicAllocationRow`; `WinnerSignal.NO_APPROVED_ALLOCATION`, `WinnerSignal.INSTRUMENT_CONCENTRATION_BREACH`.

Strategic IPS is now the approved snapshot of a propose run, not a pre-run constraint. Governance without bureaucracy.

## Testing

- 30/30 A26.2 tests pass across:
  - `test_approve_proposal_endpoint.py` (7)
  - `test_set_override_endpoint.py` (6)
  - `test_propose_mode_override.py` (4)
  - `test_realize_gate_no_approval.py` (4)
  - `test_instrument_concentration_cap.py` (7)
  - `test_propose_mode_gate_order.py` (2) — A26.1 regression intact
- Migration 0155 up+down+up round-trip clean.
- `make lint` + `make architecture` pass (31 contracts kept).
- Pre-existing typecheck/test failures on main unrelated to A26.2 verified by stashing the branch.

## Deviations from spec

1. `approved_by` kept as `String(100)` — column exists from 0002; spec implicitly ADDed which would fail.
2. `StrategicAllocationRead` Pydantic schema keeps `min_weight/max_weight` field names on the wire (mapped from `drift_min/drift_max` via `model_validator(mode="before")`) so frontend contract stays stable.
3. Section F implemented as pre-optimizer feasibility check (single SQL aggregate) rather than post-composition — matches spec language.
4. Live-DB 3-profile propose→approve→realize smoke deferred to post-merge (needs Tiingo + prod-like universe).
5. Tests are handler-level with mocked `AsyncSession`, matching the A26.1 `test_propose_mode_gate_order.py` pattern.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Logs: `winner_signal=no_approved_allocation`, `winner_signal=instrument_concentration_breach`, `approve_proposal` handler errors
  - Metrics: `allocation_approvals` row count trend; `strategic_allocation.approved_at IS NULL` coverage per (org, profile)
- **Validation checks**
  - `SELECT organization_id, profile, COUNT(*) FILTER (WHERE approved_at IS NOT NULL) FROM strategic_allocation GROUP BY 1,2;`
  - `SELECT * FROM allocation_approvals WHERE superseded_at IS NULL;`
  - Dispatch propose for 3 profiles → approve each → dispatch realize; all succeed.
- **Expected healthy behavior**
  - At most one active (non-superseded) approval per (org, profile). All 18 strategic rows for that (org, profile) have non-null `approved_at` after approval.
- **Failure signal / rollback trigger**
  - Any realize run emitting `no_approved_allocation` for a profile that the operator already approved → rollback migration 0155 and re-investigate.
- **Validation window & owner**
  - 48h post-merge; owner: Andrei.

## Predecessors

- A21 #207, A22 #209, A23 #210, A24 #212, A25 #213, A26.0 #215, A26.1 #214

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>