### PR TITLE
fix(block_mapping): remove contaminated Cash Equivalent label, add 4 MMF canonical labels

### DIFF
--- a/backend/vertical_engines/wealth/model_portfolio/block_mapping.py
+++ b/backend/vertical_engines/wealth/model_portfolio/block_mapping.py
@@ -96,10 +96,16 @@ STRATEGY_LABEL_TO_BLOCKS: dict[str, list[str]] = {
     "Infrastructure": ["alt_commodities"],
     # Alternatives — Gold
     "Precious Metals": ["alt_gold"],
-    # Cash
+    # Cash — only real MMF categories (SEC sec_money_market_funds strategy_label values).
+    # "Cash Equivalent" was removed 2026-04-18 — label was contaminated upstream with
+    # equity/bond/muni funds (e.g., SCHB, FEZ, FZIIX) and mapping it to cash caused the
+    # optimizer to treat them as zero-vol cash proxies.
     "Money Market": ["cash"],
     "Liquidity Fund": ["cash"],
-    "Cash Equivalent": ["cash"],
+    "Government Money Market": ["cash"],
+    "Prime Money Market": ["cash"],
+    "Tax-Exempt Money Market": ["cash"],
+    "Single State Money Market": ["cash"],
 }
 
 


### PR DESCRIPTION
## Summary
Label cleanup in block_mapping.py. Corrects two issues exposed by A26.2 smoke:

1. **Remove `Cash Equivalent → cash`** — added in PR #216 as a quick fix but the label is contaminated upstream with equity ETFs (SCHB, FEZ), equity funds (GQLOX, ASPZX, ALGYX), bond funds (FBNRX Templeton Global Bond), and muni bond funds (FZIIX, FTABX, FSMNX, etc.). Mapping to cash caused the optimizer to treat 36 non-cash instruments as zero-volatility cash proxies, producing 50-60% cash allocation in all 3 profiles.

2. **Add 4 canonical MMF labels** — `Government Money Market`, `Prime Money Market`, `Tax-Exempt Money Market`, `Single State Money Market` — matching the strategy_label values written by `sec_bulk_ingestion` into `sec_money_market_funds` (373 real MMFs, ~$8.95T AUM).

## Known downstream state
`instruments_universe` currently has 0 active MMFs with these labels (SEC bulk ingestion populates `sec_money_market_funds` but the sync into the global catalog is incomplete — 45/373 bridged, all with stale/missing strategy_label). After this PR merges, coverage gate will correctly report `cash: 0 candidates` until a follow-up PR syncs MMFs into instruments_universe.

Coverage "failure" is honest signal, not regression.

## Test plan
- [x] `make check` green (grep of strategy_labels_for_block('cash') returns the 6 new labels).
- [x] Dev DB coverage validator direct check — expected 0 cash candidates post-fix (will be verified after merge).