### PR TITLE
PR-A26.3.3: fuzzy fund-name bridge + sec_etfs label backfill

### DIFF
--- a/backend/app/core/db/migrations/versions/0157_fuzzy_bridge_audit.py
+++ b/backend/app/core/db/migrations/versions/0157_fuzzy_bridge_audit.py
@@ -1,0 +1,63 @@
+"""PR-A26.3.3 — fuzzy bridge audit infrastructure.
+
+Adds two pieces of audit scaffolding consumed by A26.3.3 scripts:
+
+* ``sec_etfs.strategy_label_source`` — TEXT column recording whether
+  ``strategy_label`` came from SEC bulk ingestion (``'sec_bulk'``) or
+  from the Tiingo description cascade backfill
+  (``'tiingo_cascade'``) or remained unclassified (``'unclassified'``).
+  NULL before the backfill runs.
+* ``sec_mmf_bridge_candidates`` — per-match audit for
+  ``backend/scripts/bridge_mmf_catalog.py``. Auto-applied rows are
+  stamped with ``applied_at``; needs-review rows stay open until the
+  operator resolves them manually.
+
+Both objects are global, no RLS. Reversible.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0157_fuzzy_bridge_audit"
+down_revision = "0156_authoritative_label_refresh"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE sec_etfs ADD COLUMN IF NOT EXISTS strategy_label_source TEXT"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE sec_mmf_bridge_candidates (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            instrument_id UUID NOT NULL,
+            instrument_name TEXT NOT NULL,
+            matched_cik TEXT NOT NULL,
+            matched_series_id TEXT NOT NULL,
+            matched_fund_name TEXT NOT NULL,
+            score NUMERIC(5,4) NOT NULL,
+            match_tier TEXT NOT NULL,
+            applied_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX ix_mmf_bridge_instrument "
+        "ON sec_mmf_bridge_candidates(instrument_id)"
+    )
+    op.execute(
+        "CREATE INDEX ix_mmf_bridge_tier "
+        "ON sec_mmf_bridge_candidates(match_tier) "
+        "WHERE applied_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_mmf_bridge_tier")
+    op.execute("DROP INDEX IF EXISTS ix_mmf_bridge_instrument")
+    op.execute("DROP TABLE IF EXISTS sec_mmf_bridge_candidates")
+    op.execute("ALTER TABLE sec_etfs DROP COLUMN IF EXISTS strategy_label_source")

--- a/backend/app/domains/wealth/services/fuzzy_bridge.py
+++ b/backend/app/domains/wealth/services/fuzzy_bridge.py
@@ -1,0 +1,153 @@
+"""PR-A26.3.3 — deterministic fuzzy fund-name matching for MMF bridging.
+
+Pure stdlib (``difflib`` + ``re``). No external dependencies, no ML.
+Used by ``backend/scripts/bridge_mmf_catalog.py`` to bridge
+``instruments_universe`` rows to ``sec_money_market_funds`` via
+tokenized name similarity when the series_id bridge is missing.
+
+Scoring combines two signals:
+
+* Token-set Jaccard — robust to reordering and minor punctuation; weight 0.6.
+* ``difflib.SequenceMatcher`` ratio — captures character-level similarity
+  (typos, hyphenation, suffix differences); weight 0.4.
+
+Stopword discipline is critical for MMFs: generic fund-jargon tokens
+(``fund``, ``trust``, ``inc``, ``llc``, ``money``, ``market``, ``the``)
+are stopworded because they appear in virtually every name. Category
+qualifiers that DIFFERENTIATE funds (``government``, ``prime``,
+``federal``, ``treasury``, ``tax``, ``exempt``, ``municipal``,
+``retail``, ``institutional``) are NOT stopworded.
+
+A category gate runs before scoring: if one name implies Tax-Exempt /
+Municipal and the other implies Government / Treasury, the match is
+hard-zeroed. Prevents Vanguard Federal Money Market from bridging to
+Schwab Municipal Money Fund despite high token overlap.
+"""
+from __future__ import annotations
+
+import re
+from difflib import SequenceMatcher
+from typing import Final
+
+_TOKEN_RE: Final = re.compile(r"[A-Za-z0-9]+")
+
+# Generic fund-jargon tokens that add no discriminative signal.
+# Keep this list tight; never add category qualifiers here.
+_STOPWORDS: Final[frozenset[str]] = frozenset(
+    {
+        "fund", "funds", "trust", "trusts",
+        "inc", "llc", "lp", "ltd", "co", "corp", "corporation",
+        "the", "a", "an", "of", "for", "and",
+        "money", "market", "mmf", "mm",
+        "class", "shares", "share",
+        "series",
+    },
+)
+
+# Category families used by the hard gate. A token's family is the key
+# of the set it appears in; an empty family means "no category claim".
+# Two names with different (non-empty) families produce score=0.0.
+_GOVT_TOKENS: Final[frozenset[str]] = frozenset(
+    {"government", "govt", "treasury", "federal", "gov"},
+)
+_TAX_EXEMPT_TOKENS: Final[frozenset[str]] = frozenset(
+    {"tax", "exempt", "municipal", "muni", "taxexempt"},
+)
+_PRIME_TOKENS: Final[frozenset[str]] = frozenset({"prime"})
+
+
+def _tokenize(name: str | None) -> list[str]:
+    if not name:
+        return []
+    return [tok.lower() for tok in _TOKEN_RE.findall(name)]
+
+
+def _token_set(name: str | None) -> frozenset[str]:
+    """Lowercase tokens minus stopwords."""
+    return frozenset(tok for tok in _tokenize(name) if tok not in _STOPWORDS)
+
+
+def _jaccard(a: frozenset[str], b: frozenset[str]) -> float:
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def _seqmatch(a: str, b: str) -> float:
+    if not a or not b:
+        return 0.0
+    return SequenceMatcher(None, a.lower(), b.lower()).ratio()
+
+
+def _family(tokens: frozenset[str]) -> str:
+    """Single-label family derived from token membership.
+
+    Returns one of ``'govt'``, ``'tax_exempt'``, ``'prime'``, or ``''``
+    (no category claim). If a name carries tokens from multiple families
+    (rare but e.g. "Government Prime Obligations"), we prefer tax_exempt
+    > govt > prime for stricter gating.
+    """
+    if tokens & _TAX_EXEMPT_TOKENS:
+        return "tax_exempt"
+    if tokens & _GOVT_TOKENS:
+        return "govt"
+    if tokens & _PRIME_TOKENS:
+        return "prime"
+    return ""
+
+
+def _category_gate_passes(a_tokens: frozenset[str], b_tokens: frozenset[str]) -> bool:
+    """Hard filter: reject cross-family matches (govt ↔ tax_exempt, etc.).
+
+    Empty family on either side is permissive — we only reject when both
+    sides make explicit (and different) category claims.
+    """
+    fa = _family(a_tokens)
+    fb = _family(b_tokens)
+    if not fa or not fb:
+        return True
+    return fa == fb
+
+
+def score(iu_name: str | None, sec_name: str | None) -> float:
+    """Combined 0.0-1.0 similarity. Category mismatch → 0.0."""
+    if not iu_name or not sec_name:
+        return 0.0
+    a_tokens = _token_set(iu_name)
+    b_tokens = _token_set(sec_name)
+    if not _category_gate_passes(a_tokens, b_tokens):
+        return 0.0
+    if not a_tokens or not b_tokens:
+        return 0.0
+    j = _jaccard(a_tokens, b_tokens)
+    s = _seqmatch(iu_name, sec_name)
+    return round(0.6 * j + 0.4 * s, 4)
+
+
+def verify_auto_match(
+    iu_name: str, sec_name: str, combined: float,
+) -> tuple[bool, str]:
+    """Second-pass verification gate for auto-applied matches.
+
+    Returns ``(passed, reason)``. If ``passed`` is False, caller should
+    downgrade the tier from ``auto_applied`` to ``needs_review``.
+
+    Criteria (all must pass):
+    * combined score >= 0.85
+    * token-set Jaccard >= 0.70
+    * SequenceMatcher ratio >= 0.80
+    * same family (or both empty) — enforced again post-score for safety.
+    """
+    if combined < 0.85:
+        return False, f"combined_score<{0.85:.2f}"
+    a_tokens = _token_set(iu_name)
+    b_tokens = _token_set(sec_name)
+    if _jaccard(a_tokens, b_tokens) < 0.70:
+        return False, "jaccard<0.70"
+    if _seqmatch(iu_name, sec_name) < 0.80:
+        return False, "seqmatch<0.80"
+    if not _category_gate_passes(a_tokens, b_tokens):
+        return False, "category_mismatch"
+    return True, "ok"

--- a/backend/scripts/backfill_sec_etfs_strategy_label.py
+++ b/backend/scripts/backfill_sec_etfs_strategy_label.py
@@ -1,0 +1,204 @@
+"""PR-A26.3.3 Section D — populate ``sec_etfs.strategy_label`` for the
+~439 rows that SEC bulk ingestion left NULL.
+
+For each such row we look up the matching ``instruments_universe`` entry
+by ``series_id`` first, ``ticker`` second, and read
+``attributes->>'tiingo_description'``. The description is fed to the
+existing cascade classifier
+(:func:`app.domains.wealth.services.strategy_classifier.classify_fund`)
+which produces a label through name regex when description is missing.
+
+Writes:
+
+* ``sec_etfs.strategy_label = <classifier_output>``
+* ``sec_etfs.strategy_label_source`` =
+  - ``'tiingo_cascade'`` when classifier produced a label;
+  - ``'unclassified'`` when cascade fell back (caller may try brochure).
+
+After this script runs, ``refresh_authoritative_labels.py --apply`` will
+promote the new ``sec_etfs`` labels into
+``instruments_universe.attributes`` — that is what fixes the 382-row
+alt_real_estate / alt_gold contamination gap.
+
+Default mode is dry-run. Re-running is a no-op (only touches NULL rows).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import text
+
+from app.core.db.engine import async_session_factory
+from app.domains.wealth.services.strategy_classifier import classify_fund
+
+logger = logging.getLogger("backfill_sec_etfs_strategy_label")
+
+
+@dataclass(frozen=True)
+class EtfRow:
+    series_id: str
+    ticker: str | None
+    fund_name: str
+    tiingo_description: str | None
+
+
+async def _load_etfs_missing_label(db: Any) -> list[EtfRow]:
+    """Join sec_etfs (NULL strategy_label) ↔ instruments_universe by
+    series_id OR ticker to recover the tiingo_description when present."""
+    result = await db.execute(
+        text(
+            """
+            SELECT etf.series_id,
+                   etf.ticker,
+                   etf.fund_name,
+                   iu.attributes->>'tiingo_description' AS tiingo_description
+            FROM sec_etfs AS etf
+            LEFT JOIN instruments_universe AS iu
+              ON (iu.attributes->>'series_id' = etf.series_id)
+              OR (etf.ticker IS NOT NULL AND iu.ticker = etf.ticker)
+            WHERE etf.strategy_label IS NULL
+            """
+        )
+    )
+    rows: dict[str, EtfRow] = {}
+    for row in result:
+        # One etf may join multiple iu rows; first-write-wins keeps the
+        # cascade input deterministic. All iu rows with matching ticker
+        # share the same description in practice.
+        if row.series_id in rows:
+            existing = rows[row.series_id]
+            if existing.tiingo_description or not row.tiingo_description:
+                continue
+        rows[row.series_id] = EtfRow(
+            series_id=row.series_id,
+            ticker=row.ticker,
+            fund_name=row.fund_name,
+            tiingo_description=row.tiingo_description,
+        )
+    return list(rows.values())
+
+
+_UPDATE_SQL = text(
+    """
+    UPDATE sec_etfs
+    SET strategy_label = :label,
+        strategy_label_source = :source,
+        updated_at = NOW()
+    WHERE series_id = :series_id
+    """
+)
+
+
+def _classify(row: EtfRow) -> tuple[str | None, str]:
+    """Return ``(label, source)`` where source is one of
+    ``'tiingo_cascade'`` / ``'unclassified'``.
+    """
+    result = classify_fund(
+        fund_name=row.fund_name or "",
+        fund_type=None,
+        tiingo_description=row.tiingo_description,
+        holdings_analysis=None,
+    )
+    if result.strategy_label is None:
+        return None, "unclassified"
+    return result.strategy_label, "tiingo_cascade"
+
+
+async def run(*, apply: bool) -> dict[str, Any]:
+    counters: Counter[str] = Counter()
+    labels: Counter[str] = Counter()
+    samples: list[dict[str, Any]] = []
+
+    async with async_session_factory() as db:
+        async with db.begin():
+            etfs = await _load_etfs_missing_label(db)
+            logger.info("loaded etfs_missing_label=%d", len(etfs))
+
+            for row in etfs:
+                label, source = _classify(row)
+                counters[source] += 1
+                if label is not None:
+                    labels[label] += 1
+                if len(samples) < 10:
+                    samples.append(
+                        {
+                            "series_id": row.series_id,
+                            "ticker": row.ticker,
+                            "fund_name": row.fund_name,
+                            "label": label,
+                            "source": source,
+                            "had_description": row.tiingo_description is not None,
+                        }
+                    )
+                if apply:
+                    await db.execute(
+                        _UPDATE_SQL,
+                        {
+                            "label": label,
+                            "source": source,
+                            "series_id": row.series_id,
+                        },
+                    )
+
+            if not apply:
+                await db.rollback()
+
+    report = {
+        "dry_run": not apply,
+        "candidates_scanned": sum(counters.values()),
+        "populated": counters["tiingo_cascade"],
+        "unclassified": counters["unclassified"],
+        "top_20_labels": [
+            {"label": label, "count": count}
+            for label, count in labels.most_common(20)
+        ],
+        "samples": samples,
+    }
+    return report
+
+
+def _print_summary(report: dict[str, Any]) -> None:
+    print("=" * 70)
+    print(f"backfill_sec_etfs_strategy_label  dry_run={report['dry_run']}")
+    print(f"  candidates_scanned={report['candidates_scanned']}")
+    print(f"  populated={report['populated']}  "
+          f"unclassified={report['unclassified']}")
+    print()
+    print("Top 20 new labels:")
+    for entry in report["top_20_labels"]:
+        print(f"  [{entry['count']:>5}] {entry['label']}")
+    print()
+    print("Samples:")
+    for s in report["samples"]:
+        print(f"  {s['series_id']} {s['ticker'] or '-':<8} "
+              f"label={s['label']!r:30s} source={s['source']}  "
+              f"had_desc={s['had_description']}")
+    print("=" * 70)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Write changes.")
+    parser.add_argument("--dry-run", action="store_true", help="Explicit dry-run.")
+    parser.add_argument("--json", action="store_true",
+                        help="Emit the full JSON report.")
+    args = parser.parse_args()
+
+    if args.apply and args.dry_run:
+        raise SystemExit("--apply and --dry-run are mutually exclusive")
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    report = asyncio.run(run(apply=args.apply))
+    _print_summary(report)
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/bridge_mmf_catalog.py
+++ b/backend/scripts/bridge_mmf_catalog.py
@@ -36,7 +36,7 @@ from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from sqlalchemy import text
 

--- a/backend/scripts/bridge_mmf_catalog.py
+++ b/backend/scripts/bridge_mmf_catalog.py
@@ -1,0 +1,361 @@
+"""PR-A26.3.3 Section C — fuzzy bridge ``instruments_universe`` rows to
+``sec_money_market_funds`` by tokenized fund-name similarity.
+
+The A26.3.2 authoritative-first refresh bridges MMFs via
+``attributes->>'series_id'``; only 44 of ~373 SEC MMFs have that bridge
+populated. This script closes the gap using deterministic fuzzy matching
+(see :mod:`app.domains.wealth.services.fuzzy_bridge`).
+
+Tiers:
+
+* score ≥ 0.85 **AND** :func:`verify_auto_match` passes → ``auto_applied``
+  — writes ``sec_cik`` + ``sec_series_id`` into
+  ``instruments_universe.attributes``; inserts audit row with
+  ``applied_at = now()``.
+* 0.70 ≤ score < 0.85 (or auto-match verification fails) →
+  ``needs_review`` — insert audit row only; no catalog change.
+* score < 0.70 → discard.
+
+Pre-filter: only iu rows whose lowercased ``name`` contains one of
+``money market | cash management | liquidity | government money |
+prime obligations | tax-exempt | tax exempt`` are considered. Avoids
+O(N×M) over the full catalog.
+
+Idempotency: iu rows whose ``attributes->>'series_id'`` is already
+populated AND maps to a real ``sec_money_market_funds.series_id`` are
+excluded from the candidate set. Re-running the script after apply
+produces zero new writes.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import text
+
+from app.core.db.engine import async_session_factory
+from app.domains.wealth.services.fuzzy_bridge import score, verify_auto_match
+
+logger = logging.getLogger("bridge_mmf_catalog")
+
+DEFAULT_AUTO_THRESHOLD = 0.85
+DEFAULT_REVIEW_THRESHOLD = 0.70
+
+# SQL ILIKE clauses for the pre-filter. Kept as a list so new patterns
+# can be added without reshaping the query.
+_MMF_NAME_HINTS: tuple[str, ...] = (
+    "%money market%",
+    "%cash management%",
+    "%liquidity%",
+    "%government money%",
+    "%prime obligations%",
+    "%tax-exempt%",
+    "%tax exempt%",
+    "%treasury only%",
+    "%federal money%",
+)
+
+
+@dataclass(frozen=True)
+class IuCandidate:
+    instrument_id: str
+    name: str
+    current_series_id: str | None
+
+
+@dataclass(frozen=True)
+class SecMmfRow:
+    series_id: str
+    cik: str
+    fund_name: str
+    mmf_category: str
+
+
+# ---------------------------------------------------------------------------
+# Loaders
+# ---------------------------------------------------------------------------
+
+
+async def _load_iu_candidates(db: Any) -> list[IuCandidate]:
+    hints = " OR ".join([f"name ILIKE :hint_{i}" for i in range(len(_MMF_NAME_HINTS))])
+    params: dict[str, Any] = {
+        f"hint_{i}": pattern for i, pattern in enumerate(_MMF_NAME_HINTS)
+    }
+    sql = text(
+        f"""
+        SELECT iu.instrument_id::text AS instrument_id,
+               iu.name AS name,
+               iu.attributes->>'series_id' AS series_id
+        FROM instruments_universe AS iu
+        WHERE iu.is_active = true
+          AND iu.name IS NOT NULL
+          AND ({hints})
+          AND NOT EXISTS (
+              SELECT 1 FROM sec_money_market_funds AS mmf
+              WHERE mmf.series_id = iu.attributes->>'series_id'
+          )
+        """
+    )
+    result = await db.execute(sql, params)
+    return [
+        IuCandidate(
+            instrument_id=row.instrument_id,
+            name=row.name,
+            current_series_id=row.series_id,
+        )
+        for row in result
+    ]
+
+
+async def _load_sec_mmfs(db: Any) -> list[SecMmfRow]:
+    result = await db.execute(
+        text(
+            "SELECT series_id, cik, fund_name, mmf_category "
+            "FROM sec_money_market_funds "
+            "WHERE series_id IS NOT NULL AND fund_name IS NOT NULL"
+        )
+    )
+    return [
+        SecMmfRow(
+            series_id=row.series_id,
+            cik=row.cik,
+            fund_name=row.fund_name,
+            mmf_category=row.mmf_category or "",
+        )
+        for row in result
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Matching
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Match:
+    iu: IuCandidate
+    mmf: SecMmfRow
+    score: float
+    tier: str  # 'auto_applied' | 'needs_review'
+
+
+def _classify_best(
+    iu: IuCandidate,
+    mmfs: list[SecMmfRow],
+    *,
+    auto_threshold: float,
+    review_threshold: float,
+) -> Match | None:
+    best_score = 0.0
+    best: SecMmfRow | None = None
+    for mmf in mmfs:
+        s = score(iu.name, mmf.fund_name)
+        if s > best_score:
+            best_score = s
+            best = mmf
+    if best is None or best_score < review_threshold:
+        return None
+
+    tier = "needs_review"
+    if best_score >= auto_threshold:
+        ok, _reason = verify_auto_match(iu.name, best.fund_name, best_score)
+        tier = "auto_applied" if ok else "needs_review"
+    return Match(iu=iu, mmf=best, score=best_score, tier=tier)
+
+
+# ---------------------------------------------------------------------------
+# Writers
+# ---------------------------------------------------------------------------
+
+
+_AUDIT_INSERT = text(
+    """
+    INSERT INTO sec_mmf_bridge_candidates (
+        instrument_id, instrument_name,
+        matched_cik, matched_series_id, matched_fund_name,
+        score, match_tier, applied_at
+    ) VALUES (
+        :instrument_id, :instrument_name,
+        :matched_cik, :matched_series_id, :matched_fund_name,
+        :score, :match_tier, :applied_at
+    )
+    """
+)
+
+_IU_ATTRS_UPDATE = text(
+    """
+    UPDATE instruments_universe
+    SET attributes = COALESCE(attributes, '{}'::jsonb) || jsonb_build_object(
+        'sec_cik', CAST(:cik AS text),
+        'sec_series_id', CAST(:series_id AS text),
+        'series_id', CAST(:series_id AS text),
+        'mmf_bridge_source', 'fuzzy_name_v1',
+        'mmf_bridge_score', CAST(:score AS numeric),
+        'mmf_bridge_at', CAST(:ts AS text)
+    )
+    WHERE instrument_id::text = :instrument_id
+    """
+)
+
+
+async def _persist_match(
+    db: Any, *, match: Match, apply: bool, ts: datetime,
+) -> None:
+    applied_at = ts if (apply and match.tier == "auto_applied") else None
+    await db.execute(
+        _AUDIT_INSERT,
+        {
+            "instrument_id": match.iu.instrument_id,
+            "instrument_name": match.iu.name,
+            "matched_cik": match.mmf.cik,
+            "matched_series_id": match.mmf.series_id,
+            "matched_fund_name": match.mmf.fund_name,
+            "score": match.score,
+            "match_tier": match.tier,
+            "applied_at": applied_at,
+        },
+    )
+    if apply and match.tier == "auto_applied":
+        await db.execute(
+            _IU_ATTRS_UPDATE,
+            {
+                "cik": match.mmf.cik,
+                "series_id": match.mmf.series_id,
+                "score": match.score,
+                "ts": ts.isoformat(),
+                "instrument_id": match.iu.instrument_id,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+async def run(
+    *, apply: bool,
+    auto_threshold: float = DEFAULT_AUTO_THRESHOLD,
+    review_threshold: float = DEFAULT_REVIEW_THRESHOLD,
+) -> dict[str, Any]:
+    run_id = uuid4()
+    ts = datetime.now(timezone.utc)
+    counters: Counter[str] = Counter()
+    auto_samples: list[dict[str, Any]] = []
+    review_samples: list[dict[str, Any]] = []
+
+    async with async_session_factory() as db:
+        async with db.begin():
+            iu_candidates = await _load_iu_candidates(db)
+            mmfs = await _load_sec_mmfs(db)
+            logger.info(
+                "loaded iu_candidates=%d sec_mmfs=%d", len(iu_candidates), len(mmfs),
+            )
+
+            matches: list[Match] = []
+            for iu in iu_candidates:
+                m = _classify_best(
+                    iu, mmfs,
+                    auto_threshold=auto_threshold,
+                    review_threshold=review_threshold,
+                )
+                if m is not None:
+                    matches.append(m)
+                    counters[m.tier] += 1
+
+            for m in sorted(matches, key=lambda x: x.score, reverse=True):
+                row = {
+                    "iu_name": m.iu.name,
+                    "sec_name": m.mmf.fund_name,
+                    "series_id": m.mmf.series_id,
+                    "cik": m.mmf.cik,
+                    "score": m.score,
+                }
+                if m.tier == "auto_applied" and len(auto_samples) < 10:
+                    auto_samples.append(row)
+                elif m.tier == "needs_review" and len(review_samples) < 10:
+                    review_samples.append(row)
+                await _persist_match(db, match=m, apply=apply, ts=ts)
+
+            if not apply:
+                # Roll back any audit inserts performed during dry-run so
+                # the table only reflects apply runs.
+                await db.rollback()
+
+    report = {
+        "run_id": str(run_id),
+        "dry_run": not apply,
+        "candidates_scanned": len(iu_candidates),
+        "sec_mmfs_loaded": len(mmfs),
+        "auto_applied": counters["auto_applied"],
+        "needs_review": counters["needs_review"],
+        "auto_samples_top_10": auto_samples,
+        "review_samples_top_10": review_samples,
+    }
+    return report
+
+
+def _print_summary(report: dict[str, Any]) -> None:
+    print("=" * 70)
+    print(f"bridge_mmf_catalog — run_id={report['run_id']}")
+    print(f"  dry_run={report['dry_run']}")
+    print(f"  iu_candidates={report['candidates_scanned']}  "
+          f"sec_mmfs={report['sec_mmfs_loaded']}")
+    print(f"  auto_applied={report['auto_applied']}  "
+          f"needs_review={report['needs_review']}")
+    print()
+    print("Top auto_applied matches:")
+    for s in report["auto_samples_top_10"]:
+        print(f"  [{s['score']:.3f}] {s['iu_name']!r} -> "
+              f"{s['sec_name']!r}  ({s['series_id']})")
+    print()
+    print("Top needs_review matches:")
+    for s in report["review_samples_top_10"]:
+        print(f"  [{s['score']:.3f}] {s['iu_name']!r} -> "
+              f"{s['sec_name']!r}  ({s['series_id']})")
+    print("=" * 70)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Write changes.")
+    parser.add_argument("--dry-run", action="store_true", help="Explicit dry-run.")
+    parser.add_argument(
+        "--min-auto-score", type=float, default=DEFAULT_AUTO_THRESHOLD,
+        help=f"Combined score needed for auto-apply (default {DEFAULT_AUTO_THRESHOLD}).",
+    )
+    parser.add_argument(
+        "--min-review-score", type=float, default=DEFAULT_REVIEW_THRESHOLD,
+        help=f"Combined score needed for needs_review tier (default {DEFAULT_REVIEW_THRESHOLD}).",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit the full JSON report in addition to summary.",
+    )
+    args = parser.parse_args()
+
+    if args.apply and args.dry_run:
+        raise SystemExit("--apply and --dry-run are mutually exclusive")
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    report = asyncio.run(
+        run(
+            apply=args.apply,
+            auto_threshold=args.min_auto_score,
+            review_threshold=args.min_review_score,
+        )
+    )
+    _print_summary(report)
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/check_coverage_direct.py
+++ b/backend/scripts/check_coverage_direct.py
@@ -1,0 +1,44 @@
+"""Direct validator check — bypasses construction pipeline."""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://netz:password@127.0.0.1:5434/netz_engine",
+)
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+
+async def main() -> None:
+    from quant_engine.block_coverage_service import validate_block_coverage
+
+    engine = create_async_engine(os.environ["DATABASE_URL"], echo=False)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    org_id = uuid.UUID("403d8392-ebfa-5890-b740-45da49c556eb")
+    for profile in ("conservative", "moderate", "growth"):
+        async with Session() as db:
+            await db.execute(
+                text("SELECT set_config('app.current_organization_id', :oid, true)"),
+                {"oid": str(org_id)},
+            )
+            rpt = await validate_block_coverage(db, org_id, profile)
+            print(f"\n=== {profile} ===")
+            print(f"  is_sufficient={rpt.is_sufficient}")
+            print(f"  total_target_weight_at_risk={rpt.total_target_weight_at_risk}")
+            print(f"  n_gaps={len(rpt.gaps)}")
+            for g in rpt.gaps:
+                print(
+                    f"    {g.block_id:20} tw={g.target_weight:.4f} "
+                    f"catalog_avail={g.catalog_candidates_available} "
+                    f"labels={g.suggested_strategy_labels[:3]}"
+                )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/pr_a26_1_smoke.py
+++ b/backend/scripts/pr_a26_1_smoke.py
@@ -1,0 +1,82 @@
+"""PR-A26.1 live-DB smoke. Dispatches propose_mode runs for the 3 canonical
+model portfolios against the local Timescale container and prints the
+resulting proposal payloads.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://netz:password@127.0.0.1:5434/netz_engine",
+)
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+ORG_ID = uuid.UUID("403d8392-ebfa-5890-b740-45da49c556eb")
+PORTFOLIOS = [
+    ("Conservative Preservation", uuid.UUID("3945cee6-f85d-4903-a2dd-cf6a51e1c6a5")),
+    ("Balanced Income",           uuid.UUID("e5892474-7438-4ac5-85da-217abcf99932")),
+    ("Dynamic Growth",            uuid.UUID("3163d72b-3f8c-427e-9cd2-bead6377b59c")),
+]
+
+
+async def _with_rls(session: AsyncSession, org_id: uuid.UUID) -> None:
+    await session.execute(
+        text("SELECT set_config('app.current_organization_id', :oid, true)"),
+        {"oid": str(org_id)},
+    )
+
+
+async def main() -> None:
+    from app.domains.wealth.workers.construction_run_executor import (
+        execute_construction_run,
+    )
+
+    engine = create_async_engine(os.environ["DATABASE_URL"], echo=False)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    for name, pid in PORTFOLIOS:
+        print(f"\n=== PROPOSE: {name} ({pid}) ===", flush=True)
+        async with Session() as db:
+            await _with_rls(db, ORG_ID)
+            try:
+                run = await execute_construction_run(
+                    db,
+                    portfolio_id=pid,
+                    organization_id=ORG_ID,
+                    requested_by="pr_a26_1_smoke",
+                    propose_mode=True,
+                )
+            except Exception as exc:
+                print(f"  EXCEPTION: {type(exc).__name__}: {exc}", flush=True)
+                continue
+
+            print(f"  status={run.status}", flush=True)
+            ct = run.cascade_telemetry or {}
+            print(f"  winner_signal={ct.get('winner_signal')}", flush=True)
+            print(f"  run_mode={ct.get('run_mode')}", flush=True)
+            pm = ct.get("proposal_metrics") or {}
+            print(
+                f"  metrics: E[r]={pm.get('expected_return')} "
+                f"CVaR={pm.get('expected_cvar')} "
+                f"target={pm.get('target_cvar')} "
+                f"feasible={pm.get('cvar_feasible')} "
+                f"sharpe={pm.get('expected_sharpe')}",
+                flush=True,
+            )
+            bands = ct.get("proposed_bands") or []
+            print(f"  proposed_bands ({len(bands)} blocks):", flush=True)
+            for b in bands:
+                print(
+                    f"    {b.get('block_id'):20} t={b.get('target_weight'):.4f} "
+                    f"[min={b.get('drift_min'):.4f} max={b.get('drift_max'):.4f}]",
+                    flush=True,
+                )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/pr_a26_2_smoke.py
+++ b/backend/scripts/pr_a26_2_smoke.py
@@ -65,8 +65,10 @@ async def main() -> None:
                     propose_runs[profile] = run.id
                 await db.commit()
             except Exception as e:
+                import traceback
+
                 print(f"  EXCEPTION: {type(e).__name__}: {e}")
-                import traceback; traceback.print_exc()
+                traceback.print_exc()
 
     # ── Phase 2: approve ──
     print("\n=== APPROVE ===")

--- a/backend/scripts/pr_a26_2_smoke.py
+++ b/backend/scripts/pr_a26_2_smoke.py
@@ -1,0 +1,179 @@
+"""PR-A26.2 live-DB smoke. Full propose → approve → realize loop for the 3
+canonical portfolios against the local Timescale container.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://netz:password@127.0.0.1:5434/netz_engine",
+)
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+ORG_ID = uuid.UUID("403d8392-ebfa-5890-b740-45da49c556eb")
+PORTFOLIOS = [
+    ("Conservative Preservation", uuid.UUID("3945cee6-f85d-4903-a2dd-cf6a51e1c6a5"), "conservative"),
+    ("Balanced Income",           uuid.UUID("e5892474-7438-4ac5-85da-217abcf99932"), "moderate"),
+    ("Dynamic Growth",            uuid.UUID("3163d72b-3f8c-427e-9cd2-bead6377b59c"), "growth"),
+]
+
+
+async def _with_rls(session: AsyncSession, org_id: uuid.UUID) -> None:
+    await session.execute(
+        text("SELECT set_config('app.current_organization_id', :oid, true)"),
+        {"oid": str(org_id)},
+    )
+
+
+async def main() -> None:
+    from app.domains.wealth.workers.construction_run_executor import (
+        execute_construction_run,
+    )
+
+    engine = create_async_engine(os.environ["DATABASE_URL"], echo=False)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    propose_runs: dict[str, uuid.UUID] = {}
+
+    # ── Phase 1: propose ──
+    for name, pid, profile in PORTFOLIOS:
+        print(f"\n=== PROPOSE: {name} ({profile}) ===", flush=True)
+        async with Session() as db:
+            await _with_rls(db, ORG_ID)
+            try:
+                run = await execute_construction_run(
+                    db,
+                    portfolio_id=pid,
+                    organization_id=ORG_ID,
+                    requested_by="pr_a26_2_smoke_propose",
+                    propose_mode=True,
+                )
+                ct = run.cascade_telemetry or {}
+                print(f"  status={run.status} signal={ct.get('winner_signal')}")
+                pm = ct.get("proposal_metrics") or {}
+                print(
+                    f"  E[r]={pm.get('expected_return')} "
+                    f"CVaR={pm.get('expected_cvar')} "
+                    f"feasible={pm.get('cvar_feasible')}"
+                )
+                if run.status == "succeeded":
+                    propose_runs[profile] = run.id
+                await db.commit()
+            except Exception as e:
+                print(f"  EXCEPTION: {type(e).__name__}: {e}")
+                import traceback; traceback.print_exc()
+
+    # ── Phase 2: approve ──
+    print("\n=== APPROVE ===")
+    for profile, run_id in propose_runs.items():
+        async with Session() as db:
+            await _with_rls(db, ORG_ID)
+            # approve via direct SQL snapshot (endpoint logic inlined for test)
+            result = await db.execute(
+                text("""
+                    SELECT cascade_telemetry->'proposed_bands' AS bands,
+                           cascade_telemetry->'proposal_metrics' AS metrics
+                    FROM portfolio_construction_runs
+                    WHERE id = :rid
+                """),
+                {"rid": str(run_id)},
+            )
+            row = result.mappings().one_or_none()
+            if not row or not row["bands"]:
+                print(f"  {profile}: NO BANDS — skip")
+                continue
+            bands = row["bands"]
+            metrics = row["metrics"] or {}
+
+            # supersede any prior active approval
+            await db.execute(
+                text("""
+                    UPDATE allocation_approvals
+                       SET superseded_at = now()
+                     WHERE organization_id = :org
+                       AND profile = :prof
+                       AND superseded_at IS NULL
+                """),
+                {"org": str(ORG_ID), "prof": profile},
+            )
+
+            # insert approval
+            approval_id = uuid.uuid4()
+            await db.execute(
+                text("""
+                    INSERT INTO allocation_approvals
+                        (id, run_id, organization_id, profile, approved_by,
+                         cvar_at_approval, expected_return_at_approval,
+                         cvar_feasible_at_approval)
+                    VALUES
+                        (:id, :rid, :org, :prof, :by,
+                         :cvar, :er, :feas)
+                """),
+                {
+                    "id": str(approval_id),
+                    "rid": str(run_id),
+                    "org": str(ORG_ID),
+                    "prof": profile,
+                    "by": "pr_a26_2_smoke",
+                    "cvar": metrics.get("target_cvar"),
+                    "er": metrics.get("expected_return"),
+                    "feas": bool(metrics.get("cvar_feasible", True)),
+                },
+            )
+
+            # snapshot bands atomically
+            for band in bands:
+                await db.execute(
+                    text("""
+                        UPDATE strategic_allocation
+                           SET target_weight = :t,
+                               drift_min = :dmin,
+                               drift_max = :dmax,
+                               approved_from_run_id = :rid,
+                               approved_at = now(),
+                               approved_by = 'pr_a26_2_smoke'
+                         WHERE organization_id = :org
+                           AND profile = :prof
+                           AND block_id = :b
+                    """),
+                    {
+                        "org": str(ORG_ID),
+                        "prof": profile,
+                        "b": band["block_id"],
+                        "t": band["target_weight"],
+                        "dmin": band["drift_min"],
+                        "dmax": band["drift_max"],
+                        "rid": str(run_id),
+                    },
+                )
+            await db.commit()
+            print(f"  {profile}: approved run {run_id} (18 bands snapshotted)")
+
+    # ── Phase 3: realize ──
+    for name, pid, profile in PORTFOLIOS:
+        print(f"\n=== REALIZE: {name} ({profile}) ===")
+        async with Session() as db:
+            await _with_rls(db, ORG_ID)
+            try:
+                run = await execute_construction_run(
+                    db,
+                    portfolio_id=pid,
+                    organization_id=ORG_ID,
+                    requested_by="pr_a26_2_smoke_realize",
+                    propose_mode=False,
+                )
+                ct = run.cascade_telemetry or {}
+                print(f"  status={run.status} signal={ct.get('winner_signal')}")
+                n_weights = len(run.weights_proposed or {})
+                print(f"  n_instrument_weights={n_weights}")
+            except Exception as e:
+                print(f"  EXCEPTION: {type(e).__name__}: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/domains/wealth/services/test_fuzzy_bridge.py
+++ b/backend/tests/domains/wealth/services/test_fuzzy_bridge.py
@@ -1,0 +1,100 @@
+"""Unit tests for the MMF fuzzy-bridge scorer (PR-A26.3.3 Section B)."""
+from __future__ import annotations
+
+import pytest
+
+from app.domains.wealth.services.fuzzy_bridge import (
+    score,
+    verify_auto_match,
+    _token_set,
+)
+
+
+class TestTokenSet:
+    def test_stopwords_removed(self) -> None:
+        tokens = _token_set("Vanguard Federal Money Market Fund")
+        assert "vanguard" in tokens
+        assert "federal" in tokens
+        assert "fund" not in tokens
+        assert "money" not in tokens
+        assert "market" not in tokens
+
+    def test_category_tokens_preserved(self) -> None:
+        assert "government" in _token_set("Government Money Market")
+        assert "prime" in _token_set("Prime Money Market")
+        assert "tax" in _token_set("Tax-Exempt Money Market")
+        assert "exempt" in _token_set("Tax Exempt Money Market")
+        assert "municipal" in _token_set("Municipal Money Fund")
+        assert "treasury" in _token_set("Treasury Only Fund")
+
+    def test_empty_input(self) -> None:
+        assert _token_set(None) == frozenset()
+        assert _token_set("") == frozenset()
+
+
+class TestScore:
+    def test_exact_match_high(self) -> None:
+        s = score("Vanguard Federal Money Market Fund", "Vanguard Federal Money Market Fund")
+        assert s >= 0.95
+
+    def test_minor_typo_still_matches(self) -> None:
+        s = score("Fidelity Government Money Market Fund",
+                  "Fidelity Government Money Mkt Fund")
+        assert s >= 0.75
+
+    def test_token_permutation_matches(self) -> None:
+        s = score("Schwab Value Advantage Money Fund Inc",
+                  "Value Advantage Money Fund — Schwab")
+        assert s >= 0.80
+
+    def test_cross_family_zeroed(self) -> None:
+        # Govt MMF vs Tax-Exempt MMF must NOT bridge despite shared words.
+        s = score("Vanguard Federal Money Market Fund",
+                  "Vanguard Tax-Exempt Money Market Fund")
+        assert s == 0.0
+
+    def test_govt_vs_prime_zeroed(self) -> None:
+        s = score("Fidelity Government Money Market",
+                  "Fidelity Prime Money Market")
+        assert s == 0.0
+
+    def test_different_sponsors_low(self) -> None:
+        # Same family (both Government) but different sponsor — must not clear 0.85.
+        s = score("Vanguard Federal Money Market Fund",
+                  "Schwab Government Money Market Fund")
+        assert s < 0.85
+
+    def test_empty_inputs_zero(self) -> None:
+        assert score(None, "anything") == 0.0
+        assert score("anything", None) == 0.0
+        assert score("", "anything") == 0.0
+
+    def test_no_category_claim_permissive(self) -> None:
+        # Neither name makes a category claim — gate permits, score by overlap.
+        s = score("Acme Liquidity Reserve Fund", "Acme Liquidity Reserve Fund")
+        assert s >= 0.95
+
+
+class TestVerifyAutoMatch:
+    def test_verifies_genuine_high_score(self) -> None:
+        name = "Fidelity Government Money Market Fund"
+        ok, reason = verify_auto_match(name, name, score(name, name))
+        assert ok
+        assert reason == "ok"
+
+    def test_rejects_below_threshold(self) -> None:
+        ok, reason = verify_auto_match(
+            "Vanguard Federal MMF", "Schwab Government MMF", 0.80,
+        )
+        assert not ok
+
+    @pytest.mark.parametrize(
+        "a,b",
+        [
+            ("Vanguard Federal MMF", "Vanguard Tax-Exempt MMF"),
+        ],
+    )
+    def test_rejects_cross_family(self, a: str, b: str) -> None:
+        ok, reason = verify_auto_match(a, b, 0.90)
+        assert not ok
+        assert "category" in reason or "jaccard" in reason or "seqmatch" in reason

--- a/backend/tests/domains/wealth/services/test_fuzzy_bridge.py
+++ b/backend/tests/domains/wealth/services/test_fuzzy_bridge.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 import pytest
 
 from app.domains.wealth.services.fuzzy_bridge import (
+    _token_set,
     score,
     verify_auto_match,
-    _token_set,
 )
 
 

--- a/backend/tests/scripts/test_backfill_sec_etfs_strategy_label.py
+++ b/backend/tests/scripts/test_backfill_sec_etfs_strategy_label.py
@@ -1,0 +1,69 @@
+"""Unit tests for ``backend/scripts/backfill_sec_etfs_strategy_label.py`` —
+PR-A26.3.3 Section D. Exercises the ``_classify`` entry point against
+representative ETF rows; the DB round-trip is validated via the runbook.
+"""
+from __future__ import annotations
+
+from scripts.backfill_sec_etfs_strategy_label import EtfRow, _classify
+
+
+def _row(
+    fund_name: str,
+    tiingo_description: str | None = None,
+    ticker: str | None = None,
+    series_id: str = "S000001",
+) -> EtfRow:
+    return EtfRow(
+        series_id=series_id,
+        ticker=ticker,
+        fund_name=fund_name,
+        tiingo_description=tiingo_description,
+    )
+
+
+class TestClassify:
+    def test_real_estate_from_name(self) -> None:
+        label, source = _classify(_row("iShares U.S. Real Estate ETF"))
+        assert label == "Real Estate"
+        assert source == "tiingo_cascade"
+
+    def test_gold_from_description(self) -> None:
+        label, source = _classify(
+            _row(
+                "SPDR Gold Shares",
+                tiingo_description=(
+                    "The fund seeks to reflect the performance of the price "
+                    "of gold bullion, less expenses."
+                ),
+            )
+        )
+        assert label == "Precious Metals"
+        assert source == "tiingo_cascade"
+
+    def test_unclassified_when_no_signal(self) -> None:
+        # Neutral name + no description → cascade falls back, source marks unclassified.
+        label, source = _classify(_row("XYZ Opportunities Fund"))
+        assert source in {"tiingo_cascade", "unclassified"}
+        # If it classified, fine; otherwise marked unclassified.
+        if source == "unclassified":
+            assert label is None
+
+    def test_description_beats_name(self) -> None:
+        # Layer 1 (description) has higher authority than Layer 2 (name regex).
+        label, source = _classify(
+            _row(
+                "Innovator Growth Accelerator ETF",
+                tiingo_description=(
+                    "The fund invests in U.S. Treasury securities with "
+                    "short maturities and seeks current income consistent "
+                    "with preservation of capital."
+                ),
+            )
+        )
+        assert label is not None
+        assert source == "tiingo_cascade"
+
+    def test_returns_tuple_shape(self) -> None:
+        out = _classify(_row("Vanguard Total Bond Market ETF"))
+        assert isinstance(out, tuple)
+        assert len(out) == 2

--- a/backend/tests/scripts/test_bridge_mmf_catalog.py
+++ b/backend/tests/scripts/test_bridge_mmf_catalog.py
@@ -1,0 +1,112 @@
+"""Unit tests for ``backend/scripts/bridge_mmf_catalog.py`` — PR-A26.3.3.
+
+These cover the pure Python decision logic. The end-to-end DB run is
+validated manually via the runbook (apply mode + second-pass refresh).
+"""
+from __future__ import annotations
+
+from scripts.bridge_mmf_catalog import (
+    DEFAULT_AUTO_THRESHOLD,
+    DEFAULT_REVIEW_THRESHOLD,
+    IuCandidate,
+    SecMmfRow,
+    _classify_best,
+)
+
+
+def _iu(name: str, iid: str = "00000000-0000-0000-0000-000000000001") -> IuCandidate:
+    return IuCandidate(instrument_id=iid, name=name, current_series_id=None)
+
+
+def _mmf(
+    name: str, series: str = "S000001", cik: str = "1234567",
+    category: str = "Government",
+) -> SecMmfRow:
+    return SecMmfRow(
+        series_id=series, cik=cik, fund_name=name, mmf_category=category,
+    )
+
+
+class TestClassifyBest:
+    def test_exact_match_auto_applies(self) -> None:
+        iu = _iu("Fidelity Government Money Market Fund")
+        mmfs = [
+            _mmf("Fidelity Government Money Market Fund", "S000100"),
+            _mmf("Vanguard Treasury MMF", "S000200"),
+        ]
+        m = _classify_best(
+            iu, mmfs,
+            auto_threshold=DEFAULT_AUTO_THRESHOLD,
+            review_threshold=DEFAULT_REVIEW_THRESHOLD,
+        )
+        assert m is not None
+        assert m.tier == "auto_applied"
+        assert m.mmf.series_id == "S000100"
+        assert m.score >= DEFAULT_AUTO_THRESHOLD
+
+    def test_near_match_goes_to_review(self) -> None:
+        iu = _iu("Vanguard Federal Money Market Fund")
+        mmfs = [_mmf("Vanguard Federal Money Fund Inc", "S000101")]
+        m = _classify_best(
+            iu, mmfs,
+            auto_threshold=DEFAULT_AUTO_THRESHOLD,
+            review_threshold=DEFAULT_REVIEW_THRESHOLD,
+        )
+        assert m is not None
+        # May go either way depending on exact score — assert it's bounded
+        # and tier respects thresholds.
+        assert m.score >= DEFAULT_REVIEW_THRESHOLD
+        if m.score >= DEFAULT_AUTO_THRESHOLD:
+            assert m.tier == "auto_applied"
+        else:
+            assert m.tier == "needs_review"
+
+    def test_cross_family_not_bridged(self) -> None:
+        iu = _iu("Vanguard Federal Money Market Fund")
+        mmfs = [
+            # Tax-exempt decoy with otherwise high token overlap.
+            _mmf("Vanguard Tax-Exempt Money Market Fund",
+                 "S000102", category="Exempt Government"),
+        ]
+        m = _classify_best(
+            iu, mmfs,
+            auto_threshold=DEFAULT_AUTO_THRESHOLD,
+            review_threshold=DEFAULT_REVIEW_THRESHOLD,
+        )
+        assert m is None
+
+    def test_below_review_discarded(self) -> None:
+        iu = _iu("Vanguard Federal Money Market Fund")
+        mmfs = [_mmf("BlackRock Prime Cash Portfolio", "S000103",
+                     category="Prime")]
+        m = _classify_best(
+            iu, mmfs,
+            auto_threshold=DEFAULT_AUTO_THRESHOLD,
+            review_threshold=DEFAULT_REVIEW_THRESHOLD,
+        )
+        assert m is None
+
+    def test_best_of_many(self) -> None:
+        iu = _iu("Schwab Value Advantage Money Fund")
+        mmfs = [
+            _mmf("Fidelity Government MMF", "S000001"),
+            _mmf("Schwab Value Advantage Money Fund", "S000777"),
+            _mmf("Vanguard Prime MM", "S000002"),
+        ]
+        m = _classify_best(
+            iu, mmfs,
+            auto_threshold=DEFAULT_AUTO_THRESHOLD,
+            review_threshold=DEFAULT_REVIEW_THRESHOLD,
+        )
+        assert m is not None
+        assert m.mmf.series_id == "S000777"
+        assert m.tier == "auto_applied"
+
+    def test_empty_sec_universe(self) -> None:
+        m = _classify_best(
+            _iu("Anything Money Market"),
+            [],
+            auto_threshold=DEFAULT_AUTO_THRESHOLD,
+            review_threshold=DEFAULT_REVIEW_THRESHOLD,
+        )
+        assert m is None

--- a/docs/prompts/2026-04-18-pr-a26-0-coverage-validator-fix.md
+++ b/docs/prompts/2026-04-18-pr-a26-0-coverage-validator-fix.md
@@ -1,0 +1,156 @@
+# PR-A26.0 — Block Coverage Validator: Query by `strategy_label`, not `block_id`
+
+**Date**: 2026-04-18
+**Status**: P0 BUG FIX — pre-requisite for PR-A26.1 (propose mode). Very small, no schema, no migration.
+**Branch**: `feat/pr-a26-0-coverage-validator-fix`
+**Predecessors merged**: A21 #207, A22 #209, A23 #210, A24 #212, A25 #213.
+**Downstream blocker:** PR #214 (A26.1 draft, paused) — will resume after this merges.
+
+---
+
+## Context — the bug
+
+A22's `validate_block_coverage` produces false-negative gaps. Dev DB evidence (org `403d8392-...`, 2026-04-18):
+
+| Block | Validator reports | Actually approved in org |
+|---|---|---|
+| `na_equity_growth` | 0 | **77** (65 Large Growth + 12 Mid Growth) |
+| `na_equity_value` | 0 | **46** (37 Large Value + 9 Mid Value) |
+| `alt_commodities` | 0 | **50** ("Commodities" label) |
+
+**Root cause.** The validator queries `instruments_org.block_id = :block_id` to count candidates. But `instruments_org.block_id` is a **lossy single-block cache** produced by the classifier at import time: each instrument gets ONE block_id even when its strategy label maps to multiple blocks. Example: VUG has `strategy_label = 'Large Growth'`, which `block_mapping.py` maps to `['na_equity_large', 'na_equity_growth']`. The classifier picks the first — `na_equity_large` — and writes that to `instruments_org`. VUG is now invisible to the validator when counting `na_equity_growth` candidates, even though it's a perfectly valid candidate for that block.
+
+`candidate_screener.py` (used at composition/realize) already handles this correctly: it queries `instruments_universe` filtered by `strategy_label IN (labels for block)`. The validator is the only consumer still reading the lossy `block_id` cache as source of truth.
+
+**Consequence.** Operator sees false blockers. A22 gate fires `block_coverage_insufficient` on profiles that actually have full coverage. PR-A26.1 propose mode would inherit the same false negative — propose runs would abort before the optimizer ever sees the problem.
+
+---
+
+## Scope
+
+**In scope:**
+- Rewrite `_APPROVED_COUNT_SQL` in `backend/quant_engine/block_coverage_service.py` to count via strategy_label join instead of block_id equality.
+- Match the exact query pattern already used by `candidate_screener.py` (which is the source-of-truth consumer at composition time).
+- Update the 6 existing unit tests in `backend/tests/quant_engine/test_block_coverage_service.py` so their fixtures seed instruments via strategy_label rather than block_id.
+- Add one new integration test that reproduces the dev-DB scenario: create instruments with "Commodities" label classified into `na_equity_large` (wrong block_id) in `instruments_org`, assert validator correctly surfaces them as `alt_commodities` candidates.
+
+**Out of scope:**
+- Do NOT touch `instruments_org.block_id` — leave it as a (now officially) derived/advisory field. PR-A26.1 + A26.2 will evolve its role further; this PR only fixes the validator consumer.
+- Do NOT run the A23 reclassification script. The block_id drift will persist in DB; the validator just stops trusting it.
+- Do NOT modify `candidate_screener.py`, `block_mapping.py`, optimizer, or any other module.
+- Do NOT add a migration — no schema change.
+- Do NOT extend `BlockCoverageGap` / `CoverageReport` schemas.
+- Do NOT touch the frontend.
+
+---
+
+## Execution Spec
+
+### Section A — Validator query fix
+
+**File:** `backend/quant_engine/block_coverage_service.py`
+
+Current `_APPROVED_COUNT_SQL`:
+```sql
+SELECT COUNT(*)
+  FROM instruments_org
+ WHERE organization_id = :organization_id
+   AND block_id = :block_id
+   AND approval_status = 'approved'
+```
+
+Replace with:
+```sql
+SELECT COUNT(*)
+  FROM instruments_org io
+  JOIN instruments_universe iu
+    ON iu.instrument_id = io.instrument_id
+ WHERE io.organization_id = :organization_id
+   AND io.approval_status = 'approved'
+   AND iu.is_active = TRUE
+   AND iu.attributes->>'strategy_label' = ANY(CAST(:labels AS text[]))
+```
+
+The `is_active` filter matches `_CATALOG_COUNT_SQL`'s filter — org-approved but inactive (delisted) instruments should not count as coverage.
+
+The query uses `:labels` now. Update `_count_approved()` signature:
+```python
+async def _count_approved(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    labels: list[str],
+) -> int:
+    if not labels:
+        return 0
+    row = await db.execute(
+        _APPROVED_COUNT_SQL,
+        {"organization_id": organization_id, "labels": labels},
+    )
+    return int(row.scalar_one() or 0)
+```
+
+Update `validate_block_coverage()` to compute `labels = strategy_labels_for_block(block_id)` ONCE per iteration, pass to both `_count_approved` and `_catalog_snapshot`. If `labels` is empty (block has no label mapping — rare edge case), treat as 0 candidates (same as catalog helper).
+
+**Preserve semantics:**
+- Return shape unchanged (`CoverageReport` + `BlockCoverageGap` unchanged).
+- "Is sufficient" logic unchanged — still based on per-block `n_candidates > 0`.
+- Rationale / example_tickers / catalog_candidates_available fields unchanged.
+
+### Section B — Update existing unit tests
+
+**File:** `backend/tests/quant_engine/test_block_coverage_service.py`
+
+Current tests seed rows directly with `block_id`. Update each fixture to seed via `instruments_universe.attributes.strategy_label` + a matching `instruments_org` row (with any `block_id` or NULL — no longer the source of truth).
+
+6 tests to update:
+1. `test_all_blocks_covered_returns_sufficient` — seed ≥1 instrument per canonical block via strategy_label.
+2. `test_uncovered_block_with_catalog_candidates` — seed catalog instruments with label X, do NOT add them to instruments_org for the target org. Validator reports gap + catalog_candidates_available matching seed count.
+3. `test_uncovered_block_with_no_catalog_candidates` — no instruments in catalog with the block's labels. Gap reported, catalog_candidates_available=0, example_tickers=[].
+4. `test_multiple_blocks_mixed_coverage` — mixed: some blocks have approved instruments (via label), some don't. Validator reports only the missing ones.
+5. `test_empty_strategic_allocation_is_sufficient` — unchanged semantics: no allocation → is_sufficient=True.
+6. `test_build_coverage_operator_message_shape` — unchanged semantics; fixture adjustments only.
+
+Each test must assert the validator's output count matches the underlying strategy_label-based data, not the block_id.
+
+### Section C — New regression test
+
+**File:** same test file, add one new test:
+
+```python
+async def test_block_id_drift_does_not_hide_candidates(async_session):
+    """Instruments classified into a wrong block_id due to classifier
+    single-pick are still correctly counted when their strategy_label
+    maps to the expected block. Reproduces the dev-DB Commodities-in-
+    na_equity_large case.
+    """
+    ...
+```
+
+Seed:
+- 3 instruments in `instruments_universe` with `strategy_label = 'Commodities'`, `is_active = true`, `is_institutional = true`.
+- Seed all 3 in `instruments_org` for the target org with `block_id = 'na_equity_large'` (wrong!) and `approval_status = 'approved'`.
+- Seed `strategic_allocation` for the profile with `block_id = 'alt_commodities'`, `target_weight = 0.05`.
+
+Assert:
+- `validate_block_coverage(...).is_sufficient == True` for alt_commodities (the 3 instruments are correctly surfaced via label despite the wrong block_id cache).
+- No gap reported for `alt_commodities`.
+
+### Global guardrails
+
+- `CLAUDE.md` rules. Async-first, RLS via `SET LOCAL`, `expire_on_commit=False`, `lazy="raise"`.
+- No new Python dependencies. No new migration. No schema change.
+- `make check` green (tolerate pre-existing lint per `feedback_dev_first_ci_later.md`).
+- 3 commits: A (SQL + function signature), B (existing test updates), C (new regression test).
+- Keep the change SMALL — this is a surgical fix, not a refactor. If you find yourself touching >30 lines in `block_coverage_service.py`, stop and narrow the scope.
+
+## Final report format
+
+1. Diff summary: `block_coverage_service.py` lines changed, tests lines changed.
+2. Unit test output (`pytest backend/tests/quant_engine/test_block_coverage_service.py -v`): all 7 tests pass (6 updated + 1 new).
+3. Dev DB smoke validator output:
+   - Run `validate_block_coverage(db, org_id='403d8392-...', profile='moderate')` against local dev DB.
+   - Expected post-fix: `is_sufficient=True` OR much smaller `total_target_weight_at_risk` than the 19.79% reported pre-fix. Paste the full CoverageReport JSON.
+4. Regression: run A22 integration test (`test_construction_run_coverage_gate.py`) — expect no regression.
+5. Regression: run A25 template test — expect no regression.
+6. List deviations from spec (should be none for a query fix this small).

--- a/docs/prompts/2026-04-18-pr-a26-2-approval-flow.md
+++ b/docs/prompts/2026-04-18-pr-a26-2-approval-flow.md
@@ -1,0 +1,319 @@
+# PR-A26.2 — Approval Flow + Strategic IPS Refactor + Override Overrides + Realize Gate
+
+**Date**: 2026-04-18
+**Status**: P0 STRATEGIC — completes the propose-approve-realize loop. A26.1 ships propose; A26.2 ships approval + overrides + realize gate.
+**Branch**: `feat/pr-a26-2-approval-flow`
+**Predecessors merged**: A21 #207, A22 #209, A23 #210, A24 #212, A25 #213, A26.0 #215, #216 label patch, A26.1 #214.
+
+---
+
+## Context — product model
+
+After this PR the full flow is:
+
+1. Operator triggers `POST /portfolio/profiles/{profile}/propose-allocation` (A26.1 — done).
+2. Optimizer returns proposed bands + metrics in `portfolio_construction_runs` with `run_mode='propose'`.
+3. Operator reviews via `GET /latest-proposal`.
+4. Operator either:
+   - **Approves atomically** via `POST /approve-proposal/{run_id}` → bands snapshotted to `strategic_allocation`; becomes the **Strategic IPS anchor**.
+   - **Rejects / modifies** by setting ad-hoc `override_min/override_max` on one or more blocks via `POST /set-override`, then re-proposing (operator disagrees with optimizer's concentration in one block → constrain it, re-run, see the consequence on E[r] and other blocks).
+5. Realize mode (future construction runs that allocate to instruments) refuses-to-run until a Strategic has been approved. Once approved, realize composes the 18-block weights into per-instrument holdings subject to a 15% per-instrument concentration cap.
+6. Rebalance triggers (existing `drift_check` worker) compare actual holdings drift vs Strategic `(target_weight, drift_min, drift_max)`. Alerts fire when actual drifts outside the approved band.
+
+**Strategic IPS = approved snapshot of a propose run.** Not a pre-run IC constraint. Governance without bureaucracy.
+
+---
+
+## Scope
+
+**In scope (7 sections):**
+- Migration 0155: `strategic_allocation` schema refactor — drop `min_weight, max_weight`; add `drift_min, drift_max, override_min, override_max, approved_from_run_id, approved_at, approved_by`; all nullable.
+- `allocation_approvals` table (global, no RLS — audit log of who approved what when).
+- `POST /portfolio/profiles/{profile}/approve-proposal/{run_id}` — atomic snapshot of proposed bands into the 18 strategic_allocation rows; inserts allocation_approvals row; marks prior approval `superseded_at`.
+- `POST /portfolio/profiles/{profile}/set-override` — body `{block_id, override_min, override_max, rationale}`. Writes override on single strategic_allocation row. Does NOT affect live portfolios; takes effect on next propose run.
+- A26.1 optimizer propose mode update: respect `override_min/override_max` when set on any block. Pass as constraints to CLARABEL.
+- `execute_construction_run` realize mode: refuse-to-run if no approved Strategic for the (org, profile). Emit `winner_signal='no_approved_allocation'`.
+- Per-instrument 15% cap at realize composition stage. If composition would require any single instrument > 15%, fail with explicit error signaling which block/instrument breached.
+- `WinnerSignal.NO_APPROVED_ALLOCATION`, `WinnerSignal.INSTRUMENT_CONCENTRATION_BREACH`.
+- Unit + integration tests.
+
+**Out of scope:**
+- Frontend (A26.3).
+- BL code deletion (still plan B bypass).
+- New drift thresholds — `drift_check` worker already exists and will be rewired in A26.4 (separate sprint).
+- Modification of A22 coverage gate or A25 template gate — continue to fire unchanged.
+- Rebalance action generation / trade tickets (separate sprint).
+- Approval of proposals with `winner_signal='proposal_cvar_infeasible'` — require explicit operator confirmation parameter for this PR. If not confirmed, endpoint rejects.
+
+---
+
+## Execution Spec
+
+### Section A — Alembic migration 0155: `strategic_allocation` refactor
+
+**File:** `backend/app/core/db/migrations/versions/0155_strategic_allocation_approved_state.py`
+
+Down_revision: `0154_portfolio_construction_run_mode`.
+
+Transactional. Steps:
+
+1. **ADD columns:**
+   ```sql
+   ALTER TABLE strategic_allocation
+     ADD COLUMN drift_min NUMERIC(6,4),
+     ADD COLUMN drift_max NUMERIC(6,4),
+     ADD COLUMN override_min NUMERIC(6,4),
+     ADD COLUMN override_max NUMERIC(6,4),
+     ADD COLUMN approved_from_run_id UUID,
+     ADD COLUMN approved_at TIMESTAMPTZ,
+     ADD COLUMN approved_by TEXT;
+   ```
+
+2. **DROP legacy optimizer-bound columns:**
+   ```sql
+   ALTER TABLE strategic_allocation
+     DROP COLUMN min_weight,
+     DROP COLUMN max_weight;
+   ```
+   `target_weight` is preserved (becomes "approved target" semantic — NULL until first approval).
+
+3. **Backfill existing rows to NULL approved state:**
+   - The 54 existing rows (18 blocks × 3 profiles × 1 org) were populated by A25 trigger with `target_weight=NULL`. Leave them as-is. `approved_at IS NULL` means "never approved — realize mode must refuse".
+   - If any row has non-NULL `target_weight` from older seeds, do NOT clear it — it becomes a soft historical marker (can be cleared manually by operator if desired).
+
+4. **Add index for efficient realize-mode "is approved?" check:**
+   ```sql
+   CREATE INDEX ix_strategic_allocation_approval_state
+     ON strategic_allocation (organization_id, profile, approved_at);
+   ```
+
+5. **Add CHECK constraint: drift and override must be internally consistent when set:**
+   ```sql
+   ALTER TABLE strategic_allocation
+     ADD CONSTRAINT chk_drift_bounds
+       CHECK (drift_min IS NULL OR drift_max IS NULL OR drift_min <= drift_max),
+     ADD CONSTRAINT chk_override_bounds
+       CHECK (override_min IS NULL OR override_max IS NULL OR override_min <= override_max);
+   ```
+
+Down-migration: reverse each step in reverse order. Re-create `min_weight, max_weight` columns as nullable (cannot restore original values — document warning in down function).
+
+**Acceptance:**
+- `make migrate` up + down round-trip clean.
+- Post-migration: `SELECT approved_at, drift_min FROM strategic_allocation` returns NULL for all rows.
+- `make check` green.
+
+### Section B — `allocation_approvals` table
+
+**File:** same migration 0155.
+
+```sql
+CREATE TABLE allocation_approvals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID NOT NULL,  -- no FK; historical integrity via superseded_at
+  organization_id UUID NOT NULL,
+  profile VARCHAR(20) NOT NULL,
+  approved_by TEXT NOT NULL,
+  approved_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  superseded_at TIMESTAMPTZ,  -- NULL = currently active
+  cvar_at_approval NUMERIC(6,4),  -- snapshot of the target CVaR at approval time
+  expected_return_at_approval NUMERIC(8,6),  -- snapshot of E[r]
+  cvar_feasible_at_approval BOOLEAN NOT NULL DEFAULT TRUE,
+  operator_message TEXT
+);
+CREATE INDEX ix_allocation_approvals_org_profile_active
+  ON allocation_approvals (organization_id, profile, superseded_at)
+  WHERE superseded_at IS NULL;
+```
+
+Global table (no RLS) — audit history is admin-visible.
+
+**Acceptance:** table exists, at most one row per (org, profile) with `superseded_at IS NULL` after migration (but initially empty — no approvals yet).
+
+### Section C — Approval endpoint
+
+**File:** `backend/app/domains/wealth/routes/model_portfolios.py` (attach to `portfolio_meta_router`).
+
+```python
+@router.post("/profiles/{profile}/approve-proposal/{run_id}", status_code=200)
+async def approve_proposal(
+    profile: str,
+    run_id: UUID,
+    body: ApproveProposalRequest,  # {confirm_cvar_infeasible: bool = False, operator_message: str | None = None}
+    db: AsyncSession,
+    ...
+) -> ApprovalResponse:
+    ...
+```
+
+Transaction steps (ALL atomic — one transaction, one commit):
+
+1. Fetch the run. 404 if not found, not belonging to org, or `run_mode != 'propose'`.
+2. Check `winner_signal`:
+   - `proposal_ready` → proceed.
+   - `proposal_cvar_infeasible` → proceed only if `body.confirm_cvar_infeasible=True`. Otherwise 409 Conflict with message "proposal was infeasible — set confirm_cvar_infeasible=true to approve anyway".
+   - Any other → 409 Conflict.
+3. Parse `cascade_telemetry.proposed_bands` (list of 18 blocks). Assert exactly 18 blocks covering the canonical set (template completeness already enforced by A25 gate). If not 18, 500 Internal Error (bug in propose run).
+4. For each proposed band, UPDATE the corresponding `strategic_allocation` row:
+   ```sql
+   UPDATE strategic_allocation
+      SET target_weight = :target,
+          drift_min = :drift_min,
+          drift_max = :drift_max,
+          approved_from_run_id = :run_id,
+          approved_at = now(),
+          approved_by = :approver
+    WHERE organization_id = :org
+      AND profile = :profile
+      AND block_id = :block_id
+   ```
+   Do NOT touch `override_min, override_max` — those are operator-set and persist across approvals.
+5. Mark any prior active approval for this (org, profile) as superseded:
+   ```sql
+   UPDATE allocation_approvals SET superseded_at = now()
+    WHERE organization_id = :org AND profile = :profile AND superseded_at IS NULL
+   ```
+6. Insert new `allocation_approvals` row with:
+   - `run_id, organization_id, profile, approved_by = X-DEV-ACTOR or Clerk user id`
+   - `cvar_at_approval = cascade_telemetry.proposal_metrics.target_cvar`
+   - `expected_return_at_approval = cascade_telemetry.proposal_metrics.expected_return`
+   - `cvar_feasible_at_approval = cascade_telemetry.proposal_metrics.cvar_feasible`
+   - `operator_message = body.operator_message`
+7. Return `ApprovalResponse { approval_id, run_id, approved_at, strategic_snapshot: [18 blocks with target+drift] }`.
+
+**Acceptance tests** (`backend/tests/wealth/test_approve_proposal_endpoint.py`):
+- Approve a proposal_ready run → strategic_allocation rows updated, allocation_approvals row inserted, prior approval marked superseded.
+- Approve a proposal_cvar_infeasible run without confirm flag → 409.
+- Approve a proposal_cvar_infeasible run with confirm flag → success, `cvar_feasible_at_approval=false` recorded.
+- Approve a non-propose run (run_mode='realize') → 404 or 409 (depending on which check fires first; be explicit in spec).
+- Approve across orgs → RLS blocks cross-tenant access.
+
+### Section D — Override endpoint + optimizer integration
+
+**File:** same router + `quant_engine/optimizer_service.py` propose path.
+
+**Endpoint:**
+```python
+@router.post("/profiles/{profile}/set-override", status_code=200)
+async def set_override(
+    profile: str,
+    body: SetOverrideRequest,  # {block_id, override_min: float | None, override_max: float | None, rationale: str | None}
+    db: AsyncSession,
+    ...
+) -> StrategicAllocationRow:
+    ...
+```
+
+Behavior:
+- Validate block_id is canonical (is_canonical=true in allocation_blocks).
+- Validate `0 <= override_min <= override_max <= 1` when both set. Allow setting just one side (e.g., only override_max).
+- UPDATE the single row.
+- Return the updated row.
+
+**Optimizer integration (A26.1 update):**
+
+In `construction_run_executor.py` propose mode (Section B of A26.1), when building block constraints:
+```python
+# Before A26.2:
+blocks.append(BlockConstraint(block_id=b, min_weight=0.0, max_weight=1.0))
+
+# After A26.2:
+override = await _load_override(db, org, profile, b)
+min_w = override.override_min if override.override_min is not None else 0.0
+max_w = override.override_max if override.override_max is not None else 1.0
+if excluded: min_w = max_w = 0.0  # excluded trumps override
+blocks.append(BlockConstraint(block_id=b, min_weight=min_w, max_weight=max_w))
+```
+
+Overrides apply to propose mode runs. Realize mode reads approved Strategic separately (Section E).
+
+**Acceptance tests** (`test_set_override_endpoint.py` + extensions to `test_propose_mode.py`):
+- Set override on na_equity_large with override_max=0.15 → propose run honors cap (resulting target ≤ 0.15).
+- Set override with override_min > override_max → 400.
+- Excluded block: override has no effect (block still zeroed).
+- Override persists across runs until explicitly cleared (set to NULL via endpoint).
+
+### Section E — Realize mode gate
+
+**File:** `construction_run_executor.py`
+
+Add as a pre-cascade gate in realize mode (propose_mode=False), AFTER template completeness (A25) and coverage (A22) but BEFORE optimizer:
+
+```python
+if not propose_mode:
+    approved_count = await _count_approved_blocks(db, org, profile)
+    if approved_count < 18:  # not all blocks have approved_at set
+        raise NoApprovedAllocationError(...)
+```
+
+`_count_approved_blocks`:
+```sql
+SELECT COUNT(*) FROM strategic_allocation
+ WHERE organization_id = :org AND profile = :profile
+   AND approved_at IS NOT NULL
+```
+
+On error, persist run with `status='failed'`, `winner_signal='no_approved_allocation'`, operator message explaining that operator must run propose+approve cycle first.
+
+Add `WinnerSignal.NO_APPROVED_ALLOCATION = 'no_approved_allocation'`.
+
+**Acceptance test:** dispatch realize run (existing pr_a12_smoke.py pattern) against org without approval → fails with `winner_signal='no_approved_allocation'`. After approving via Section C, realize run succeeds.
+
+### Section F — Per-instrument 15% cap at composition
+
+**File:** `candidate_screener.py` or wherever block→instrument composition happens (grep `compose`, `instrument_weights`, `weights_proposed`).
+
+After the optimizer returns block-level weights, the composition layer distributes each block's weight across approved instruments in that block. Apply a **hard 15% per-instrument cap**:
+
+- For each block `b` with `block_weight = w_b`:
+  - Count approved instruments in that block: `n_b`.
+  - Max realizable per-instrument weight: `15% absolute`.
+  - Minimum instruments needed: `ceil(w_b / 0.15)`.
+  - If `n_b < ceil(w_b / 0.15)`: raise `InstrumentConcentrationBreachError(block_id=b, required=ceil(w_b/0.15), available=n_b)`.
+
+- Otherwise distribute weight across top-N instruments (by AUM or risk-adjusted criterion) subject to `instrument_weight <= 0.15`.
+
+Add `WinnerSignal.INSTRUMENT_CONCENTRATION_BREACH`.
+
+**Acceptance tests:**
+- Realize with block weight 30% and 2 approved instruments (15% each) → composition succeeds.
+- Realize with block weight 30% and 1 approved instrument → fails with `instrument_concentration_breach`.
+- Realize with block weight 15% and 1 approved instrument → succeeds with 15% in that instrument.
+
+### Section G — Schema + enum updates
+
+**Files:**
+- `backend/app/domains/wealth/schemas/model_portfolio.py`: add `ApproveProposalRequest`, `ApprovalResponse`, `SetOverrideRequest`, `StrategicAllocationRow`, updated proposed-bands schemas.
+- `backend/app/domains/wealth/schemas/sanitized.py`: add enum values `NO_APPROVED_ALLOCATION`, `INSTRUMENT_CONCENTRATION_BREACH`.
+- Update existing `strategic_allocation` ORM model to reflect new columns + dropped columns.
+
+---
+
+## Ordering inside this PR
+
+A (migration) → B (table, same migration) → G (schemas + enum) → C (approve endpoint) → D (override endpoint + optimizer wiring) → E (realize gate) → F (composition cap). One commit per Section.
+
+## Global guardrails
+
+- `CLAUDE.md` rules. Async-first, RLS via `SET LOCAL` for strategic_allocation (tenant-scoped); allocation_approvals is global but still joined with org_id in queries.
+- No new Python dependencies.
+- `make check` green.
+- Do NOT touch: BL code, block_mapping, A22 validator, A25 trigger, optimizer cascade internals.
+
+## Final report format
+
+1. Migration up + down round-trip verified.
+2. Unit + integration test output (all new test files).
+3. End-to-end dev DB smoke:
+   - Dispatch propose for all 3 profiles via A26.1 endpoint → 3 successful proposals.
+   - Approve each via the new endpoint → strategic_allocation rows updated; allocation_approvals rows inserted.
+   - Dispatch realize for all 3 → succeed this time (previously would fail with no_approved_allocation).
+   - Paste: allocation_approvals query showing 3 active approvals + strategic_allocation summary showing approved_at populated.
+4. Override smoke:
+   - Set override_max=0.10 on na_equity_large for moderate profile.
+   - Re-dispatch propose → observe proposal respects the cap.
+   - Paste proposed_bands showing na_equity_large target ≤ 0.10.
+5. Per-instrument cap smoke:
+   - Dispatch realize for a profile where one block has a single candidate but block_weight > 0.15 (engineer this via a test fixture if needed).
+   - Confirm fails with `instrument_concentration_breach`.
+6. List any deviations from spec.

--- a/docs/prompts/2026-04-18-pr-a26-3-3-fuzzy-bridge-backfill.md
+++ b/docs/prompts/2026-04-18-pr-a26-3-3-fuzzy-bridge-backfill.md
@@ -1,0 +1,242 @@
+# PR-A26.3.3 — Fuzzy Fund-Name Bridge Backfill for Authoritative Labels
+
+**Date**: 2026-04-18
+**Status**: P0 COMPLETES A26.3.2 — extends the authoritative-first refresh to resolve the ~90% of ETFs/MMFs that lack a direct CIK/ticker bridge, and populates `sec_etfs.strategy_label` for rows where it's NULL.
+**Branch**: `feat/pr-a26-3-3-fuzzy-bridge-backfill`
+**Predecessors merged**: A21–A26.2, #218 label patch revert, #220 authoritative-first refresh (A26.3.2).
+
+---
+
+## Context — why A26.3.2 alone wasn't enough
+
+Empirical finding 2026-04-18 after A26.3.2 apply against dev DB:
+
+| Block | Total approved in org | Rows with matching `sec_etfs.strategy_label` NOT NULL | Resolved by A26.3.2 | Still contaminated |
+|---|---|---|---|---|
+| alt_real_estate | 394 | 12 (3%) | ≤12 | 382 (97%) |
+| alt_gold | 26 | 3 (12%) | ≤3 | 23 (88%) |
+| alt_commodities | 50 | unknown (small) | small | most |
+| cash | 36 | — (MMF source) | 1 MMF bridged | 32 orphaned |
+
+**Two gaps behind 382+23+32 = 437 unresolved contaminated rows:**
+
+1. **Bridge gap.** 439 of 985 `sec_etfs` rows have `strategy_label IS NULL`. Even if `iu.ticker → sec_etfs.ticker` matches, the SEC row has no authority to offer. Root cause: sec_bulk_ingestion populated `sec_etfs.ticker` + basic metadata but left `strategy_label` unpopulated (no N-CEN `classification_fund_type` mapped, no Morningstar category).
+2. **Join gap.** For MMFs, `iu.attributes.sec_cik → sec_money_market_funds.cik` bridges only 44/373 rows (12%). 328 real MMFs in SEC data exist but are invisible to the catalog.
+
+Post-A26.3.2 smoke proved the proposition is unchanged: propose mode still allocates 51-61% to "cash" via contaminated "Cash Equivalent" labels (32 equity/bond funds kept the bad label; A26.3.2 only resolved 4 of 36).
+
+**A26.3.3 closes both gaps via two bridges:**
+
+1. **Fuzzy fund-name match** for MMFs: `instruments_universe.name` ↔ `sec_money_market_funds.fund_name` (tokenized Jaccard / trigram similarity). High-confidence matches (≥0.85) get `attributes.sec_cik` + `attributes.sec_series_id` written. Enables MMF bridge to jump from 44 to ~300+.
+2. **Populate sec_etfs.strategy_label** via Tiingo description cascade on the NULL-labeled 439 rows. Uses the same cascade classifier that A26.3.2 falls back to, but writes result into `sec_etfs.strategy_label` directly (not `instruments_universe.attributes`) so future `refresh_authoritative_labels` runs promote authoritatively.
+
+---
+
+## Scope
+
+**In scope:**
+- Migration 0157: `sec_etfs_strategy_label_source` audit column (tracks whether strategy_label came from SEC N-CEN or Tiingo cascade backfill). `sec_mmf_bridge_candidates` table for fuzzy match audit.
+- Helper service `backend/app/domains/wealth/services/fuzzy_bridge.py` — deterministic token Jaccard + string-similarity scorer with explicit thresholds (NO LLM, NO NLP library beyond stdlib).
+- Script `backend/scripts/bridge_mmf_catalog.py` — one-shot fuzzy matcher. Uses `difflib.SequenceMatcher` + token-set Jaccard. Thresholds 0.85 auto-match, 0.70-0.85 operator review (writes to `sec_mmf_bridge_candidates`). Writes `sec_cik` + `sec_series_id` to `instruments_universe.attributes` on auto-match. Dry-run default.
+- Script `backend/scripts/backfill_sec_etfs_strategy_label.py` — runs Tiingo cascade classifier against `sec_etfs` rows with NULL `strategy_label`. Writes `strategy_label` + `strategy_label_source='tiingo_cascade'`. Dry-run default.
+- Post-backfill, run `refresh_authoritative_labels.py --apply` a second time to propagate new bridges and new sec_etfs labels into `instruments_universe`.
+- Tests for fuzzy bridge thresholds, edge cases, idempotency.
+- Runbook extension: full `A26.3.2 + A26.3.3` combined execution sequence.
+
+**Out of scope:**
+- Do NOT implement LLM-based matching — deterministic only.
+- Do NOT fuzzy-bridge BDCs or ESMA funds — just MMFs this PR (highest-impact).
+- Do NOT touch the cascade classifier internals or add new Tiingo round 2 patches — we're populating `sec_etfs.strategy_label` with whatever the current cascade produces, not rewriting the cascade.
+- Do NOT modify `instruments_universe.name` — bridge uses existing names as-is.
+- Do NOT delete rows that fail to bridge — they remain with current labels + `needs_human_review` where applicable.
+- Do NOT frontend-expose the bridge-candidates review table — CLI-only in v1.
+
+---
+
+## Execution Spec
+
+### Section A — Migration 0157
+
+**File:** `backend/app/core/db/migrations/versions/0157_fuzzy_bridge_audit.py`
+
+Down_revision: `0156_authoritative_label_refresh`.
+
+```sql
+ALTER TABLE sec_etfs
+  ADD COLUMN strategy_label_source TEXT;  -- NULL before backfill, 'sec_bulk' or 'tiingo_cascade' after
+
+CREATE TABLE sec_mmf_bridge_candidates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  instrument_id UUID NOT NULL,
+  instrument_name TEXT NOT NULL,
+  matched_cik TEXT NOT NULL,
+  matched_series_id TEXT NOT NULL,
+  matched_fund_name TEXT NOT NULL,
+  score NUMERIC(5,4) NOT NULL,
+  match_tier TEXT NOT NULL,  -- 'auto_applied' (>=0.85) | 'needs_review' (0.70-0.85)
+  applied_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ix_mmf_bridge_instrument ON sec_mmf_bridge_candidates(instrument_id);
+CREATE INDEX ix_mmf_bridge_tier ON sec_mmf_bridge_candidates(match_tier) WHERE applied_at IS NULL;
+```
+
+Global tables, no RLS. Reversible.
+
+### Section B — Fuzzy bridge service
+
+**File:** `backend/app/domains/wealth/services/fuzzy_bridge.py`
+
+Pure Python (stdlib only — no rapidfuzz, no scikit-learn). Combines two signals:
+
+```python
+def _token_set(name: str) -> frozenset[str]:
+    """Lowercase, strip punctuation, drop common fund-jargon tokens
+    ('fund', 'trust', 'inc', 'llc', 'money', 'market' — but keep
+    'government', 'prime', 'tax', 'exempt'), return frozenset of
+    remaining tokens."""
+    ...
+
+def _jaccard(a: frozenset, b: frozenset) -> float:
+    """Token-set Jaccard coefficient."""
+    ...
+
+def _seqmatch(a: str, b: str) -> float:
+    """difflib.SequenceMatcher ratio on lowercased strings."""
+    ...
+
+def score(iu_name: str, sec_name: str) -> float:
+    """Combined 0.0-1.0 score. Weighted 0.6 * jaccard + 0.4 * seqmatch.
+    Returns 0.0 on empty inputs."""
+    ...
+```
+
+**Stopword discipline:** the stopword list is critical for muni/govt MMF matching. `"government"` MUST NOT be stopworded because "Vanguard Federal Money Market" vs "Fidelity Government Money Market" differ by that token. `"money market"` IS stopworded as it's universal.
+
+**Hard filter before scoring:** if `sec_name` mmf_category differs from implied category (e.g. iu_name mentions "tax exempt" but candidate is Government), return 0.0. Use a small keyword-to-category map.
+
+**Acceptance:** unit tests cover: exact match, token permutation, typo tolerance, stopword isolation (ensure "Vanguard Federal Money Market" and "Schwab Government Money Market" score < 0.85 despite sharing many tokens), empty inputs, None inputs.
+
+### Section C — MMF bridge script
+
+**File:** `backend/scripts/bridge_mmf_catalog.py`
+
+```
+Usage:
+  python backend/scripts/bridge_mmf_catalog.py [--dry-run | --apply]
+                                                [--min-auto-score 0.85]
+                                                [--min-review-score 0.70]
+```
+
+Algorithm:
+1. Load all `instruments_universe` rows where:
+   - `is_active = TRUE`
+   - `attributes->>'sec_cik'` does NOT appear in `sec_money_market_funds.cik` (i.e., not already bridged)
+   - `name ILIKE '%money market%' OR name ILIKE '%cash management%' OR name ILIKE '%liquidity%'` (pre-filter to plausible MMF candidates; avoids O(n*m) full product)
+2. Load all `sec_money_market_funds` rows.
+3. For each iu candidate × each SEC MMF, compute `score`. Keep best match per iu.
+4. Classify:
+   - `score >= 0.85` → **auto-apply**: update `iu.attributes` with `sec_cik`, `sec_series_id`. Insert audit row with `match_tier='auto_applied'`, `applied_at=now()`.
+   - `0.70 ≤ score < 0.85` → **needs_review**: insert audit row with `match_tier='needs_review'`, `applied_at=NULL`. No iu update.
+   - `score < 0.70` → discard.
+5. Report JSON: counts per tier, top 10 auto-matched, top 10 needs_review with their candidate fund names.
+6. Dry-run prints decisions without writes.
+
+**Idempotency:** re-running is a no-op. The pre-filter excludes already-bridged instruments.
+
+**Per-match validation:** before auto-applying, verify the claimed match via:
+- Token-set jaccard ≥ 0.70
+- SequenceMatcher ≥ 0.80
+- At least one "family" keyword in common (e.g., both have "Government" or both have "Tax-Exempt") OR both are categorized Prime.
+
+If any verifier fails, downgrade to `needs_review`.
+
+**Acceptance tests:**
+- Seed 5 iu rows ("Vanguard Federal Money Market Fund", "Schwab Value Advantage Money Fund", etc.) and 10 sec_mmf rows (including exact matches and decoys). Run apply mode. Assert correct matches were written and decoys didn't cross-bridge.
+- Dry-run produces no writes.
+- Re-run auto produces zero new changes.
+
+### Section D — sec_etfs strategy_label backfill
+
+**File:** `backend/scripts/backfill_sec_etfs_strategy_label.py`
+
+```
+Usage:
+  python backend/scripts/backfill_sec_etfs_strategy_label.py [--dry-run | --apply]
+```
+
+Algorithm:
+1. SELECT rows from `sec_etfs` where `strategy_label IS NULL` (439 rows).
+2. For each, load the matching row in `instruments_universe` via `ticker` OR `series_id`. Extract `attributes->>'tiingo_description'` if present.
+3. Run the existing Tiingo cascade classifier against the description.
+4. Write `sec_etfs.strategy_label = <classifier_output>` + `sec_etfs.strategy_label_source = 'tiingo_cascade'`.
+5. Rows with no Tiingo description OR classifier returns NULL → leave `strategy_label IS NULL` with `strategy_label_source = 'unclassified'`.
+6. Report: count populated, count unclassified, top 20 new strategy_label values, sample 10 (ticker, fund_name, new_label).
+
+**Acceptance:**
+- Dry-run output shows plausible distribution (no single label dominates; some NULLs for ETFs without Tiingo data).
+- Apply mode increments `sec_etfs.strategy_label` non-NULL count.
+- Re-run is no-op (only touches NULL rows).
+
+### Section E — Final refresh
+
+Document in runbook: after Sections C + D apply, re-run `refresh_authoritative_labels.py --apply`. Expected outcome:
+- MMF resolutions: ~300 more rows (up from 1 to ~300+).
+- sec_etf resolutions: ~440 more rows (up from 507 to ~950).
+- `needs_human_review` count drops proportionally.
+- Post-smoke: cash allocation drops from 60% to 5-15% range (real MMFs compete realistically).
+
+### Section F — Integration tests
+
+**File:** `backend/tests/scripts/test_bridge_mmf_catalog.py` + `backend/tests/scripts/test_backfill_sec_etfs_strategy_label.py`.
+
+Each file: 4-5 tests covering dry-run, apply, idempotency, threshold boundary cases, bad-input tolerance.
+
+### Section G — Runbook update
+
+**File:** `docs/reference/authoritative-label-refresh-runbook.md` — extend with section "A26.3.3 extension".
+
+Commands in order:
+```bash
+# 1. A26.3.3 migrations
+make migrate
+
+# 2. Fuzzy bridge MMFs (dry-run first)
+python backend/scripts/bridge_mmf_catalog.py
+python backend/scripts/bridge_mmf_catalog.py --apply
+
+# 3. Backfill sec_etfs.strategy_label (dry-run first)
+python backend/scripts/backfill_sec_etfs_strategy_label.py
+python backend/scripts/backfill_sec_etfs_strategy_label.py --apply
+
+# 4. Re-run authoritative labels refresh to propagate new bridges
+python backend/scripts/refresh_authoritative_labels.py --apply
+
+# 5. Verify via smoke
+python backend/scripts/pr_a26_2_smoke.py
+```
+
+Document expected outcomes at each step with concrete numbers (post-dev-DB validation).
+
+---
+
+## Ordering inside this PR
+
+A (migration) → B (fuzzy_bridge service + tests) → C (bridge script + tests) → D (sec_etfs backfill script + tests) → G (runbook) → E (documented in runbook; not a code section). One commit per Section A-D + one for runbook.
+
+## Global guardrails
+
+- `CLAUDE.md` rules. Async-first where applicable; sync scripts OK for one-shot tooling.
+- No new Python dependencies.
+- `make check` green.
+- Do NOT touch: optimizer, composition, propose/approve, frontend, cascade classifier internals.
+
+## Final report format
+
+1. Migration up/down round-trip.
+2. Unit + integration test output.
+3. MMF bridge dry-run output → apply output: count before/after of `sec_mmf.cik` bridged to `instruments_universe`.
+4. sec_etfs backfill dry-run → apply: count of `strategy_label IS NOT NULL` before/after.
+5. Second-pass `refresh_authoritative_labels.py --apply` output showing increased counts in `applied_by_source.sec_mmf` + `applied_by_source.sec_etf`.
+6. `pr_a26_2_smoke.py` final run — **paste complete allocation distribution by family** (equity / FI / alt / cash). Expected: cash 5-15%, alt 10-20%, FI 30-50%, equity 20-50%. Sharpe 1.5-2.5.
+7. List deviations from spec.

--- a/docs/reference/authoritative-label-refresh-runbook.md
+++ b/docs/reference/authoritative-label-refresh-runbook.md
@@ -131,3 +131,83 @@ WHERE b.run_id = '<run_id>'
 | `strategy_label_source_table` | text | every apply (NULL for needs_review) |
 | `strategy_label_refreshed_at` | text (ISO-8601) | every apply |
 | `needs_human_review` | boolean | only when source = `needs_review` |
+
+---
+
+## A26.3.3 extension — fuzzy bridge + sec_etfs backfill
+
+**Migration:** `0157_fuzzy_bridge_audit`
+**Scripts:** `backend/scripts/bridge_mmf_catalog.py`, `backend/scripts/backfill_sec_etfs_strategy_label.py`
+
+Two new closures for the gaps documented above:
+
+1. **MMF fuzzy bridge** — `bridge_mmf_catalog.py` uses deterministic token-set Jaccard + `difflib.SequenceMatcher` (pure stdlib) to match `instruments_universe.name` against `sec_money_market_funds.fund_name`. Auto-apply threshold 0.85 with a second-pass verifier (Jaccard ≥ 0.70 AND SeqMatch ≥ 0.80 AND same category family). 0.70–0.85 matches land in `sec_mmf_bridge_candidates` tier `needs_review` for manual resolution. Writes `sec_cik` + `sec_series_id` into `instruments_universe.attributes`.
+2. **sec_etfs label backfill** — `backfill_sec_etfs_strategy_label.py` runs the Tiingo cascade classifier (`classify_fund`) against the 439 `sec_etfs` rows with `strategy_label IS NULL`, writes result plus `strategy_label_source = 'tiingo_cascade'` (or `'unclassified'` when cascade falls back).
+
+### Full execution sequence (A26.3.2 already applied, running the A26.3.3 extension)
+
+```bash
+# 1. Apply 0157
+make migrate                                              # head becomes 0157_fuzzy_bridge_audit
+
+# 2. Fuzzy bridge MMFs — dry-run, inspect top auto / needs_review, then apply
+python backend/scripts/bridge_mmf_catalog.py --json | tee /tmp/mmf_bridge_dryrun.json
+python backend/scripts/bridge_mmf_catalog.py --apply --json | tee /tmp/mmf_bridge_apply.json
+
+# 3. Backfill sec_etfs.strategy_label — dry-run, then apply
+python backend/scripts/backfill_sec_etfs_strategy_label.py --json | tee /tmp/etf_backfill_dryrun.json
+python backend/scripts/backfill_sec_etfs_strategy_label.py --apply --json | tee /tmp/etf_backfill_apply.json
+
+# 4. Re-run authoritative labels to propagate new bridges + new sec_etfs labels
+python backend/scripts/refresh_authoritative_labels.py --apply --json | tee /tmp/authoritative_second_pass.json
+
+# 5. Smoke test
+python backend/scripts/pr_a26_2_smoke.py
+```
+
+### Expected outcomes
+
+| Step | Before | After (target) |
+|---|---|---|
+| `sec_etfs.strategy_label NOT NULL` | 546 (of 985) | ≥ 900 |
+| `sec_mmf` bridges in IU | 44 | 300+ |
+| `applied_by_source.sec_mmf` (second pass) | 1 | 50+ |
+| `applied_by_source.sec_etf` (second pass) | 507 | 950+ |
+| Cash block share in propose output | 51–61 % | 5–15 % |
+| Portfolio Sharpe (Balanced) | 3.1–3.6 (inflated) | 1.5–2.5 |
+
+### Rollback
+
+```sql
+-- 1. Undo the second-pass authoritative refresh
+UPDATE instruments_universe iu
+SET attributes = COALESCE(attributes, '{}'::jsonb) ||
+                 jsonb_build_object('strategy_label', b.previous_strategy_label)
+FROM strategy_label_authoritative_backup b
+WHERE b.run_id = '<second_pass_run_id>'
+  AND b.instrument_id = iu.instrument_id;
+
+-- 2. Undo the fuzzy MMF bridge (only auto_applied rows wrote into attributes)
+UPDATE instruments_universe iu
+SET attributes = iu.attributes - 'sec_cik' - 'sec_series_id'
+                                - 'mmf_bridge_source' - 'mmf_bridge_score'
+                                - 'mmf_bridge_at'
+FROM sec_mmf_bridge_candidates c
+WHERE c.match_tier = 'auto_applied'
+  AND c.applied_at IS NOT NULL
+  AND c.instrument_id = iu.instrument_id;
+
+-- 3. Undo the sec_etfs backfill
+UPDATE sec_etfs
+SET strategy_label = NULL, strategy_label_source = NULL
+WHERE strategy_label_source = 'tiingo_cascade';
+
+-- 4. Drop migration if needed
+-- alembic downgrade 0156_authoritative_label_refresh
+```
+
+### Known limitations remaining after A26.3.3
+
+* BDC and ESMA bridges still rely on direct identifier matching — no fuzzy extension in v1.
+* Funds where Tiingo has no description and the fund name is a short opaque mark (e.g. `"AAA"`, `"XYZ"`) stay `unclassified`. Manual brochure classification is the follow-on path.
+* `sec_mmf_bridge_candidates` rows with `match_tier = 'needs_review'` accumulate until an operator resolves them via SQL update — no UI in v1.

--- a/docs/reference/scientific-portfolio-methodology-comparison.md
+++ b/docs/reference/scientific-portfolio-methodology-comparison.md
@@ -1,0 +1,360 @@
+# Scientific Portfolio (EDHEC) vs Netz Analysis Engine — Análise Metodológica Comparativa
+
+**Data:** 2026-04-18
+**Autor:** Andrei / Netz
+**Escopo:** Comparação entre o Methodology Guide do Scientific Portfolio e a implementação atual do Netz Analysis Engine (vertical wealth)
+**Fonte SP:** https://scientific-portfolio.atlassian.net/wiki/spaces/MG/pages/25591816/Methodology+Guide + knowledge center público + papers EDHEC
+**Fonte Netz:** CLAUDE.md + auditoria direta em `quant_engine/`, `vertical_engines/wealth/`, `ai_engine/`
+
+---
+
+## 1. Sumário executivo
+
+O Scientific Portfolio é um spin-off da EDHEC Business School (EDHEC-Risk Institute) posicionado como plataforma acadêmica de **análise independente de portfólios de equity**. O produto atende institucionais (asset owners, consultants, fund selectors) que querem decompor exposições de risco, avaliar fundos sob framework fator + sustentabilidade, e rodar simulações/otimizações sob restrições.
+
+O Netz Analysis Engine tem **um escopo mais amplo** (wealth management institucional multi-asset, não apenas equity) e **funcionalidades operacionais** que a SP não possui (due diligence report gerado por LLM, RAG sobre documentos de fundos, fund copilot, pipeline de ingestão multi-fonte, integração com catálogos regulatórios globais — SEC N-PORT/N-CEN/ADV, ESMA, 13F, Form 345). A SP tem profundidade acadêmica superior em três áreas específicas — (i) modelo de fator dinâmico via IPCA (Kelly-Pruitt-Su), (ii) stack climático completo, e (iii) Robust Sharpe + métricas de diversificação mais sofisticadas — mas **apenas (i) e (iii) são relevantes para o Netz**.
+
+**Decisão de escopo explícita:** Climate Transition, Carbon Decomposition, Climate Alignment e ESG Screening multi-tier **estão fora do roadmap do Netz**. Não são atributos de análise financeira pura — são overlays de política/ideologia que reduzem o universo investível por critérios não-financeiros. O cliente UHNW offshore do Netz avalia retorno ajustado ao risco, liquidez, governança do gestor e alinhamento fiduciário — não pathway 1,5°C. Evitar o stack ESG/climate é **decisão de produto**, não lacuna técnica, e será explicitado nos materiais de marketing como princípio de neutralidade analítica.
+
+**Veredito estratégico:** o Netz já cobre ~78% do framework quantitativo *relevante* da SP (excluindo por decisão as seções climate/ESG), excede em operacional/documental, e tem gaps materiais reais em **(a) fator dinâmico/IPCA, (b) Robust Sharpe + Effective Number of Bets, e (c) atribuição de performance resiliente à ausência de benchmark constituents pagos (Morningstar/Bloomberg).** Este último é o gap prático mais urgente.
+
+---
+
+## 2. Framework Scientific Portfolio
+
+### 2.1 Posicionamento
+
+SP se apresenta em três pilares:
+
+- **Financial pillar** — investidores devem olhar além da alocação por ativo e examinar exposições sistemáticas a fatores, favorecendo fontes remuneradas de risco e controlando/diversificando as não remuneradas.
+- **Sustainability pillar** — "do no harm" alinhado aos 17 UN SDGs, integrando ESG screening + climate transition de forma operacional.
+- **Independência acadêmica** — metodologia aberta (Methodology Guide público), publicações com EDHEC.
+
+### 2.2 Estrutura do Methodology Guide (16 seções)
+
+Navegação extraída do Confluence público:
+
+| # | Seção | Objeto metodológico principal |
+|---|---|---|
+| 1 | Risk Model | IPCA factor model + rotating PCA, 10+ fatores latentes condicionais |
+| 2 | Risk Model Applications | Decomposição de risco (fator, setor, país), risk budgeting |
+| 3 | Performance Attribution | Brinson-Fachler + atribuição por fator (não só por setor) |
+| 4 | Climate Transition Factor | Fator sistemático de transição climática |
+| 5 | Climate Transition Scenarios | NGFS / IEA scenario overlay |
+| 6 | Conditional Transition Loss | Impacto operacional e de receita por cenário — aplicado a 1.287 companhias listadas |
+| 7 | ESG Screening | 3 screens: consensus, comprehensive (com net zero), ambitious (UN SDGs negativos) |
+| 8 | Carbon Emissions Decomposition | Scopes 1/2/3, atribuição de carbono por fator/setor |
+| 9 | Extreme Risk | CVaR, EVT, tail dependency, extreme scenarios |
+| 10 | Macro | Fator macro (inflação, crescimento, taxa, crédito) |
+| 11 | Portfolio Allocation | Otimização com restrições + view blending |
+| 12 | Simulations | Monte Carlo + bootstrap para distribuição de P&L |
+| 13 | Robust Sharpe Ratio | Sharpe corrigido para não-normalidade + erro amostral |
+| 14 | Diversification | Effective number of bets, diversification ratio, entropy |
+| 15 | Climate Alignment | Implied temperature rise, pathway alignment |
+| 16 | Appendix / Glossary | Notação e referências |
+
+### 2.3 Diferenciadores quantitativos da SP
+
+- **IPCA (Instrumented Principal Component Analysis)** — Kelly, Pruitt, Su (2019, *Journal of Financial Economics*). Ao contrário do PCA estático, o IPCA permite que as cargas fatoriais variem no tempo em função de características observáveis (instrumentos). Produz fatores latentes mais estáveis entre reestimações e requer apenas dados de preço + características, escalando para multi-região sem reestimação completa.
+- **Conditional Transition Loss** — modelo híbrido forward-looking (cenário NGFS/IEA) + backward-looking (fator financeiro) que deriva perda esperada por companhia e agrega no portfólio. Perdas setoriais chegam a 10-60% em Utilities, com impacto agregado de 0,5-6% no portfólio.
+- **Robust Sharpe** — correção para skewness/kurtosis (Cornish-Fisher) e erro amostral, evitando inflar skill em séries não-normais ou curtas.
+
+---
+
+## 3. Comparação chapter-by-chapter
+
+### 3.1 Tabela-síntese de paridade
+
+| # | Seção SP | Netz hoje | Paridade | Arquivo Netz |
+|---|---|---|---|---|
+| 1 | Risk Model (IPCA) | PCA estático + SVD, 8 fatores | **Parcial — 50%** | `quant_engine/factor_model_service.py` |
+| 2 | Risk Model Applications | Decomposição por bloco, contribuição de risco | **60%** | `factor_model_pca.py` + scoring |
+| 3 | Performance Attribution | Brinson-Fachler + Carino multi-período | **70% (gated em benchmark data)** | `vertical_engines/wealth/attribution/` |
+| 4 | Climate Transition Factor | **Fora de escopo por decisão** | N/A | — |
+| 5 | Climate Transition Scenarios | **Fora de escopo por decisão** (macro stress continua 80%) | N/A | `quant_engine/stress_severity_service.py` |
+| 6 | Conditional Transition Loss | **Fora de escopo por decisão** | N/A | — |
+| 7 | ESG Screening | **Fora de escopo por decisão** (mandate_fit mantém flags fiduciárias não-ESG) | N/A | `vertical_engines/wealth/mandate_fit/` |
+| 8 | Carbon Decomposition | **Fora de escopo por decisão** | N/A | — |
+| 9 | Extreme Risk (CVaR + EVT + tail dep) | CVaR histórico + paramétrico + Cornish-Fisher; sem EVT | **60%** | `cvar_service.py`, `tail_var_service.py` |
+| 10 | Macro | Multi-signal (VIX/curve/CPI/spreads), regional, hysteresis | **80%** | `regime_service.py`, `regional_macro_service.py` |
+| 11 | Portfolio Allocation | CLARABEL cascata 4 fases + SOCP robusto + BL + Ledoit-Wolf + GARCH + regime-conditioned cov | **100% — superior em alguns aspectos** | `quant_engine/optimizer_service.py`, `black_litterman_service.py` |
+| 12 | Simulations | Block bootstrap 21-day + walk-forward backtest | **85%** | `monte_carlo_service.py`, `backtest_service.py` |
+| 13 | Robust Sharpe | Sharpe tradicional apenas | **0%** | — |
+| 14 | Diversification | Diversification ratio + absorption ratio (Marchenko-Pastur) | **60%** | `correlation_regime_service.py` |
+| 15 | Climate Alignment | **Fora de escopo por decisão** | N/A | — |
+
+**Paridade média ponderada considerando apenas as seções in-scope:** ~73%. As 6 seções climate/ESG são excluídas do cálculo por decisão de produto — Netz é plataforma de análise financeira neutra, não overlay de política climática.
+
+### 3.2 Análise detalhada por capítulo
+
+#### Capítulo 1-2 — Risk Model (IPCA vs PCA)
+
+O Netz implementa PCA clássico em retornos residuais (após regressão contra 8 benchmarks) com SVD para extração de loadings. Isso captura estrutura estática de fatores, mas tem duas fraquezas:
+
+1. Reestimação completa a cada rebalanceamento — fatores podem "pular" entre reestimações, gerando ruído na atribuição.
+2. Cargas fatoriais são constantes no estimation window — não captam que a sensibilidade de um fundo a "growth" muda quando growth deixa de ser caro.
+
+O IPCA da SP resolve ambas: as cargas são função de características observáveis (`β(x_it)`) que atualizam naturalmente. A literatura (Kelly et al. 2019) mostra que IPCA supera Fama-French, Barra, e PCA estático em out-of-sample R² e estabilidade.
+
+**Implicação prática:** em uma carteira com rotação setorial, o PCA do Netz vai atribuir parte do retorno ao fator "residual idiossincrático" quando na verdade foi uma mudança de exposição fatorial — prejudicando qualidade de atribuição.
+
+#### Capítulo 3 — Performance Attribution (GAP CRÍTICO)
+
+O Netz tem Brinson-Fachler implementado com decomposição alocação/seleção/interação e linking multi-período via Carino. Limitação atual: **retorna vazio quando constituents do benchmark não estão disponíveis**. Pagar Bloomberg/Morningstar/MSCI por feed de composição de índice custa USD 30-100k/ano por provedor e cria dependência não-arquitetônica.
+
+**Solução proposta — três vias não-dependentes de provedor pago, combinadas em cascata:**
+
+**Via 1 — Returns-Based Style Analysis (Sharpe 1992).** Regressão restrita dos retornos do fundo contra um conjunto de índices de estilo (Russell 1000 Value, R1000 Growth, R2000, MSCI EAFE, Bloomberg Agg, etc.), com pesos ≥ 0 e soma = 1. Produz **weights implícitos por estilo** sem precisar de constituents. Inputs: apenas NAV do fundo (que Netz já tem via `nav_timeseries`) + retornos dos índices de estilo (Yahoo Finance via ETFs proxy — SPY, IWM, EFA, AGG). Zero dependência externa paga. Implementável em ~400 LOC com `scipy.optimize`.
+
+**Via 2 — Holdings-Based Attribution via N-PORT.** Para `registered_us`, `etf`, `bdc`: o Netz já ingere holdings trimestrais via N-PORT (worker `nport_ingestion`, lock 900_018). Isso **é** a composição do portfólio. Brinson-Fachler roda direto sobre essas holdings, sem benchmark externo. Cobertura: ~4.800 fundos da universe.
+
+**Via 3 — Benchmark Proxy via ETF Canonicamente Associado.** Quando o fundo declara benchmark em N-CEN (campo `primary_benchmark`) e é um índice padrão (S&P 500 → SPY, Russell 2000 → IWM, MSCI EAFE → EFA, Bloomberg US Agg → AGG, MSCI ACWI → ACWI), usamos as **holdings do ETF tracker mais líquido** como proxy da composição do benchmark. Essas holdings também vêm via N-PORT. Mapa canônico de 20-30 benchmarks cobre ~90% da universe registered.
+
+**Arquitetura sugerida:**
+
+```
+vertical_engines/wealth/attribution/
+  ├── service.py              ← orquestrador, roda cascata
+  ├── returns_based.py        ← NOVO — Sharpe 1992 style analysis
+  ├── holdings_based.py       ← NOVO — N-PORT direct
+  ├── benchmark_proxy.py      ← NOVO — N-CEN → ETF canonical map
+  ├── brinson_fachler.py      ← existente, alimentado por holdings_based + benchmark_proxy
+  └── models.py
+```
+
+**Cascata de fallback:**
+
+1. Se fundo tem N-PORT + benchmark mapeado → **Via 2 + Via 3** (holdings-based contra proxy). Confidence ALTA.
+2. Se fundo tem N-PORT mas benchmark não mapeável → **Via 2 sozinho** (análise absoluta, não relativa). Confidence MÉDIA.
+3. Se fundo não tem N-PORT (privados, UCITS sem holdings) → **Via 1** (returns-based style analysis). Confidence MÉDIA — inferência estatística, não observação direta.
+4. Apenas se nenhuma rodar → retornar None com flag `data_unavailable`.
+
+**Implicação:** fecha o gap sem contratar dados pagos, usando assets que Netz já ingere. Torna attribution **universal** — hoje ela quebra para fundos sem benchmark constituents; com essa cascata, roda em ≥95% da universe. E o SP não tem Via 3, só faz factor-based (que é equivalente da Via 1). É uma oportunidade de **superar a SP neste capítulo**, não apenas igualar.
+
+#### Capítulos 4-8, 15 — Stack Climático e ESG (FORA DE ESCOPO POR DECISÃO)
+
+O Netz **não implementará** Climate Transition Factor, Climate Scenarios, Conditional Transition Loss, ESG Screening multi-tier, Carbon Decomposition ou Climate Alignment. A decisão não é técnica — é de posicionamento de produto.
+
+**Rationale:**
+
+- Esses módulos não avaliam atributos de análise financeira pura. Carbon footprint, pathway 1,5°C e UN SDGs são critérios **normativos** (o que *deve* ser financiado) sobrepostos a instrumentos financeiros. O Netz se posiciona como plataforma de análise **neutra**: avalia risco, retorno, liquidez, governança, alinhamento fiduciário — não prescreve que setores da economia real o cliente deve privilegiar.
+- O cliente UHNW offshore (core do Netz hoje via BTG Cayman) avalia fundos por mérito financeiro, não por rating ESG de terceiros. Adicionar overlays reduz universo investível por critérios que não são do próprio cliente.
+- Evita dependência de dados caros e controversos (MSCI ESG, Sustainalytics, Trucost: USD 50-150k/ano cada) cuja metodologia é opaca e inconsistente entre provedores. Estudos acadêmicos mostram correlação baixa (~0,3-0,5) entre ratings ESG de provedores diferentes — não é sinal analítico estável.
+- O `mandate_fit/constraint_evaluator.py` permanece como mecanismo de flags fiduciárias (e.g. "evitar derivativos alavancados", "liquidez mínima 30 dias", "sem concentração single-manager > 15%") — restrições que o próprio cliente ou mandato impõem, não overlays externos.
+
+**Se um cliente europeu futuro exigir SFDR Article 8/9:** será tratado como integração opt-in com provedor terceiro (MSCI ou similar) via feature flag, sem incorporar a metodologia no core analítico do Netz. O Netz continuará sendo plataforma neutra; ESG será um adapter externo que o cliente contrata se quiser.
+
+**Mensagem de marketing associada:** *"Netz analisa o que é mensurável financeiramente. Decisões de política — climate, ESG, temáticas — são do cliente, não da ferramenta."*
+
+#### Capítulo 9 — Extreme Risk
+
+O Netz tem CVaR histórico + paramétrico com ajuste Cornish-Fisher para caudas gordas. Não tem:
+
+- EVT (Generalized Pareto Distribution para além do 5% / 1% quantil).
+- Tail dependency modeling (copulas) — relevante para medir co-quedas em regime de crise.
+- Monte Carlo CVaR com simulação de dependência não-linear.
+
+A ausência de EVT é sentida quando o cliente pergunta "qual a perda esperada em um evento 1-em-50-anos?". CVaR histórico a 95% não responde; EVT responde.
+
+#### Capítulo 10 — Macro
+
+**Área onde o Netz está em paridade ou à frente.** O regime_service do Netz faz classificação multi-signal (VIX, yield curve, CPI, credit spreads) com hierarquia CRISIS > INFLATION > RISK_OFF > RISK_ON e hysteresis assimétrica (para evitar thrashing). Regional via ICE BofA spreads + GDP-weighted global override. A SP publica fator macro (inflação, crescimento, taxa, crédito) mas o framework do Netz de **classificação discreta de regime com histerese** é mais direto para trading/rebalance decisions.
+
+#### Capítulo 11 — Portfolio Allocation
+
+**O Netz supera a SP neste capítulo** em termos de engenharia:
+
+- CLARABEL 4-fase cascade (max risk-adj return → robust SOCP → variance-capped → min-variance → heurístico).
+- Fallback solver SCS em cada fase.
+- Black-Litterman com IC views e flagging de inconsistência.
+- Ledoit-Wolf shrinkage (toward constant-correlation target).
+- Regime-conditioned covariance (curto window em stress, longo em normalidade).
+- GARCH(1,1) condicional + incondicional.
+- Turnover penalty via L1 slack.
+- Stress testing parametrizado (GFC, COVID, Taper, Rate Shock).
+
+O SP tem otimização robusta, mas a arquitetura de cascata + fallback do Netz é produção-grade (timeout 120s, construction_run_executor com lock 900_101, alert_sweeper).
+
+#### Capítulo 12 — Simulations
+
+Block bootstrap de 21 dias preserva autocorrelação — sólido. Walk-forward backtest existe. O que a SP tem e o Netz não:
+
+- Cenários customizáveis pelo usuário (e.g. "rates +200bps + USD -10% + equity -20%").
+- Monte Carlo com dependência não-gaussiana (copulas de Student-t ou Clayton).
+
+#### Capítulo 13 — Robust Sharpe (AUSENTE)
+
+Apenas Sharpe tradicional. Sem correções para:
+
+- **Cornish-Fisher Sharpe** — penaliza skew negativa e excess kurtosis.
+- **Opdyke (2007)** — intervalo de confiança para Sharpe sob não-normalidade.
+- **Ledoit-Wolf corrected** — ajuste para amostras curtas.
+
+Gap pequeno em esforço, grande em credibilidade acadêmica. Fundos hedge com série curta e caudas gordas têm Sharpe inflado quando calculado tradicionalmente — a SP expõe isso.
+
+#### Capítulo 14 — Diversification
+
+O Netz tem diversification ratio + absorption ratio (Marchenko-Pastur denoising) + eigenvalue concentration. Bom, mas não tem:
+
+- **Effective Number of Bets (ENB)** — Meucci (2009), converte exposição fatorial em número efetivo de apostas independentes.
+- **Entropy-based diversification** — Shannon entropy sobre pesos ou contribuições de risco.
+
+ENB é especialmente útil para comunicação com comitê de investimento: "seu portfólio tem 40 fundos mas só 3 apostas efetivas".
+
+---
+
+## 4. Onde o Netz vai além da SP
+
+Áreas onde o Netz oferece valor que a SP não oferece (porque tem escopo distinto):
+
+### 4.1 Operacional / Documental
+
+- **DD Report de 8 capítulos** gerado por LLM com evidence pack, confidence scoring, critic adversarial, circuit-breaker (`vertical_engines/wealth/dd_report/` + `critic/`).
+- **Long-form DD report** com SSE streaming e Semaphore(2) para paralelismo controlado.
+- **Fund Copilot RAG** — busca semântica sobre prospectos, brochures, DD chapters (wealth_vector_chunks, 12 sources, 16 embedding streams).
+- **Macro Committee Engine** — gera relatórios regionais macro semanais automaticamente.
+- **Flash Report** — event-driven market flash com cooldown 48h.
+- **Investment Outlook** — narrativa macro trimestral via LLM.
+- **Manager Spotlight** — análise deep-dive de um PM específico.
+- **Fact Sheet PDF** — Executive e Institutional, PT/EN i18n.
+
+A SP **não gera relatórios**. Ela mostra números na plataforma; o analista escreve o memo. O Netz produz o memo.
+
+### 4.2 Catálogo regulatório global
+
+- **SEC** — 13F, N-PORT, N-CEN, N-MFP, ADV (Parts 1 e 2), Form 345, NCSR XBRL, bulk DERA ZIPs.
+- **ESMA** — Fund Register + ManCo.
+- **Universe unificado** — 6 universos (registered, ETF, BDC, MMF, private, UCITS) em materialized view única (`mv_unified_funds`).
+- **Strategy labels** — 37 estratégias granulares via 3-layer classifier.
+
+A SP foca em equity listada. O Netz cobre listed + private + UCITS + MMF + BDC.
+
+### 4.3 Multi-tenant operacional
+
+- RLS PostgreSQL com `SET LOCAL` + ConfigService por tenant.
+- Auth Clerk com RBAC (ADMIN/INVESTMENT_TEAM/investor).
+- Data lake bronze/silver/gold com `{organization_id}/{vertical}/` prefix.
+- Audit trail imutável com before/after JSONB snapshots.
+- Stability guardrails (P1-P6: Bounded, Batched, Isolated, Lifecycle, Idempotent, Fault-Tolerant).
+
+A SP é SaaS single-tenant-per-contract tradicional. O Netz foi desenhado multi-tenant desde o dia zero.
+
+### 4.4 Credit vertical
+
+Fora do escopo desta comparação, mas vale registrar: o Netz tem um vertical **credit** completo (IC memos, deal pipeline, underwriting artifact, sponsor engine, KYC, EDGAR, pipeline intelligence) que a SP nem tenta cobrir. SP é equity-only.
+
+### 4.5 Quant-engine em produção
+
+- Optimizer cascade com fallback solver (SCS) e timeout 120s.
+- Momentum pré-computado globalmente (lock 900_071) — todos os tenants veem score sem reimportar fundo.
+- Live price poll a 60s para carteiras live/paused com alertas de staleness.
+- 3176+ testes passando, import-linter enforcement.
+
+---
+
+## 5. Gap analysis priorizado
+
+### 5.1 Matriz Impacto × Esforço (apenas gaps in-scope)
+
+| # | Gap | Impacto | Esforço | Prioridade |
+|---|---|---|---|---|
+| G1 | Robust Sharpe (Cornish-Fisher + Opdyke) | **Alto** (credibilidade) | **Baixo** (~200 LOC) | **P0** |
+| G2 | Effective Number of Bets (Meucci 2009) | **Alto** (comunicação comitê) | **Baixo** (~150 LOC) | **P0** |
+| G3 | **Attribution cascade (returns-based + N-PORT + benchmark proxy)** | **Muito alto** (destrava relatórios hoje travados) | **Médio-alto** (~1500 LOC total, 3 vias) | **P0** |
+| G4 | EVT para extreme risk (GPD fitting) | Médio-alto | Médio (~600 LOC + tests) | **P1** |
+| G5 | IPCA factor model (Kelly-Pruitt-Su) | **Alto** (diferencial acadêmico) | **Alto** (3-6 meses, paper reference) | **P1** |
+| G6 | Copula-based tail dependency | Baixo-médio | Médio | **P2** |
+| G7 | Entropy-based diversification | Baixo | Baixo | **P2** |
+
+**Removidos do roadmap (decisão de produto):** Climate Transition stack, ESG Screening multi-tier, Carbon decomposition Scope 1/2/3, Climate Alignment. Ver seção 3.2 para rationale.
+
+### 5.2 Recomendações de P0 (executar agora)
+
+**G3 — Attribution cascade (prioridade máxima)**
+
+É o único gap que já está **quebrando entregas atuais** (Brinson-Fachler retornando vazio). As outras P0 são upgrades de credibilidade; essa é correção de funcionalidade travada.
+
+Plano de execução em 3 fases, cada uma entregável independentemente:
+
+*Fase 1 — Returns-Based Style Analysis (2 semanas, ~400 LOC).* Novo módulo `attribution/returns_based.py`. Inputs: série NAV do fundo (de `nav_timeseries`) + série de retornos de um basket configurável de índices de estilo (proxied via ETFs SPY, IWM, EFA, EEM, AGG, HYG, LQD — todos já em `benchmark_nav`). Optimizer `scipy.optimize.minimize` com constraint `Σw=1, w≥0`. Output: vetor de pesos de estilo + R² + tracking error. Cobertura: 100% da universe que tem ≥ 36 meses de NAV.
+
+*Fase 2 — Holdings-Based via N-PORT (3 semanas, ~600 LOC).* Novo módulo `attribution/holdings_based.py`. Lê `sec_nport_holdings` (já existe, preenchido pelo worker `nport_ingestion`). Agrega por setor/país/style usando classificação SEC. Computa contribuição de cada posição ao retorno total. Cobertura: ~4.800 fundos (registered_us + ETF + BDC).
+
+*Fase 3 — Benchmark Proxy via N-CEN (1 semana, ~200 LOC + tabela de mapeamento).* Novo módulo `attribution/benchmark_proxy.py` + tabela `benchmark_etf_canonical_map` (seed data em `benchmark_etf_map.yaml`, 20-30 entradas: S&P 500 → SPY CIK/series, Russell 2000 → IWM, etc). Lê `primary_benchmark` de `sec_registered_funds` (campo N-CEN já ingerido), resolve para ETF tracker, puxa holdings via Fase 2. Completa o ciclo: `brinson_fachler.py` agora tem tanto portfolio holdings quanto benchmark holdings sem depender de Bloomberg.
+
+Arquivos tocar:
+- `vertical_engines/wealth/attribution/service.py` — orquestrador da cascata
+- `vertical_engines/wealth/attribution/returns_based.py` — NOVO
+- `vertical_engines/wealth/attribution/holdings_based.py` — NOVO
+- `vertical_engines/wealth/attribution/benchmark_proxy.py` — NOVO
+- `vertical_engines/wealth/attribution/brinson_fachler.py` — refatorar para aceitar holdings por ambos os lados
+- `backend/alembic/versions/0132_benchmark_etf_canonical_map.py` — NOVO, tabela + seed
+- DD Report capítulo 4 (Performance Analysis) — renderizar qualquer que a Via tenha rodado, com confidence badge
+
+**G1 — Robust Sharpe**
+
+Adicionar em `quant_engine/scoring_service.py` uma função `robust_sharpe(returns, rf_rate)` que retorne tripla `(traditional_sharpe, cornish_fisher_sharpe, opdyke_95_ci)`. Usar como componente adicional no scoring (`risk_adjusted_return` já tem peso 0,25; pode ser substituído pelo robust variant sem quebrar retrocompat, apenas com feature flag). Dependência: nenhuma nova biblioteca — scipy.stats já no stack.
+
+**G2 — Effective Number of Bets**
+
+Adicionar em `quant_engine/factor_model_service.py` (ou novo `diversification_service.py`) a função `effective_number_of_bets(weights, factor_loadings, factor_cov)` seguindo Meucci (2009). Surface no DD Report capítulo 5 (Risk Management Framework) e no dashboard do portfolio construction. Baixíssimo esforço, alto impacto comunicacional.
+
+### 5.3 Recomendações de P1 (próximos 2 trimestres)
+
+**G4 — EVT**
+
+Implementar Peaks-Over-Threshold com GPD fitting (`scipy.stats.genpareto`). Expor em `cvar_service.py` como `extreme_var_evt(returns, quantile, threshold_method="mean_excess")`. Útil para tail risk reporting em eventos 1-em-50, 1-em-100 anos.
+
+**G5 — IPCA factor model**
+
+Este é o diferencial acadêmico da SP. Tem biblioteca open-source de referência: `github.com/bkelly-lab/ipca`. Plano:
+
+1. Spike de 2 semanas para replicar resultados do paper em dados Netz (500 instrumentos liquid equity US).
+2. Comparar R² out-of-sample contra PCA estático atual. Se > 15% melhoria, go.
+3. Implementar como `factor_model_ipca_service.py` com mesma interface que `factor_model_service.py` atual, feature flag por tenant.
+4. Benchmark de estabilidade em reestimações trimestrais.
+5. Uma vez pronto, **quarta via** na cascata de attribution: factor-based attribution `return = Σ β_i · f_i + α`, usando IPCA como gerador dos fatores. Cobertura total da universe, independente de N-PORT ou benchmark mapeável.
+
+---
+
+## 6. Recomendações finais
+
+### 6.1 Mensagem de marketing derivada
+
+Em marketing materials e decks institucionais, o Netz pode se posicionar como:
+
+> "Análise financeira institucional sem overlays políticos. Mesma profundidade quantitativa da Scientific Portfolio em otimização (CLARABEL cascade), regime (multi-signal com histerese) e extreme risk (CVaR + Cornish-Fisher), mais o que a SP não tem: DD reports gerados por LLM, catálogo regulatório global (SEC + ESMA + 13F), arquitetura multi-tenant institucional, e atribuição de performance que não depende de feeds pagos de composição de índice."
+
+Três princípios declarativos:
+
+1. **Neutralidade analítica** — avaliamos risco, retorno, liquidez e governança. Não prescrevemos alinhamento climático nem filtros ESG. Decisões normativas são do cliente.
+2. **Independência de provedor** — infra de dados construída sobre fontes públicas reguladas (SEC, ESMA, FRED, Treasury, BIS, IMF). Atribuição, risk model e screening não param quando o contrato com Bloomberg vence.
+3. **Profundidade acadêmica comprovada** — mesmos métodos publicados em journals (Black-Litterman, Ledoit-Wolf, GARCH, CVaR Cornish-Fisher, Brinson-Fachler, Meucci ENB, Cornish-Fisher Sharpe) implementados em produção com testes e guardrails.
+
+### 6.2 Quick wins antes do próximo IC
+
+Três entregas que mudam percepção de rigor sem esforço alto:
+
+1. **Attribution cascade Fase 1 (returns-based)** — destrava DD Report capítulo 4 para 100% da universe imediatamente, sem custo de dados. Prioridade máxima.
+2. **Robust Sharpe** no DD Report capítulo 4 (Performance Analysis) — uma linha: "Traditional Sharpe 1.42; Robust Sharpe (Cornish-Fisher) 1.18; 95% CI Opdyke [0.71, 1.65]." Imediato upgrade de credibilidade.
+3. **Effective Number of Bets** no capítulo 5 (Risk Management) — "Carteira de 40 fundos equivale a 4.2 apostas efetivas — abaixo do target 6.0."
+
+### 6.3 Longo prazo
+
+O valor diferencial do Netz não está em **superar a SP em toda metodologia quantitativa** (ela é spin-off acadêmico da EDHEC, sempre terá 6-18 meses de vantagem em publicações específicas). Está em ser **a única plataforma que une análise quant rigorosa + geração de relatórios institucionais + catálogo regulatório global + arquitetura multi-tenant + neutralidade analítica (sem overlays políticos)**. A SP é ferramenta do analista; o Netz é o analista.
+
+Manter foco em (a) fechar attribution cascade para destravar entregas, (b) quick wins de credibilidade (Robust Sharpe, ENB), (c) trilhar IPCA como diferencial de médio prazo, e (d) rejeitar explicitamente o stack climate/ESG como decisão de produto — transformando o que a SP trata como feature em **linha editorial do Netz**.
+
+---
+
+## 7. Referências
+
+- Kelly, B., Pruitt, S., Su, Y. (2019). *Characteristics are covariances: A unified model of risk and return*. Journal of Financial Economics.
+- Meucci, A. (2009). *Managing Diversification*. Risk Magazine.
+- Opdyke, J. D. (2007). *Comparing Sharpe Ratios: So Where are the p-values?*. Journal of Asset Management.
+- Cornish, E., Fisher, R. (1938). *Moments and cumulants in the specification of distributions*.
+- Ledoit, O., Wolf, M. (2004). *Honey, I shrunk the sample covariance matrix*.
+- EDHEC-Risk Institute. *Multi-Dimensional Risk and Performance Analysis for Equity Portfolios* (2016).
+- NGFS Scenarios Portal — https://www.ngfs.net/ngfs-scenarios-portal/
+- Scientific Portfolio Methodology Guide — https://scientific-portfolio.atlassian.net/wiki/spaces/MG/pages/25591816/Methodology+Guide (acesso Confluence, conteúdo público)
+- Scientific Portfolio Knowledge Center — https://scientificportfolio.com/knowledge-center/


### PR DESCRIPTION
## Summary

Closes the two gaps A26.3.2 could not reach:

1. **MMF bridge gap** — only 44 of 373 `sec_money_market_funds` bridge to `instruments_universe` via `series_id`. `bridge_mmf_catalog.py` adds deterministic fuzzy name matching (token Jaccard + `difflib.SequenceMatcher`, stdlib-only) with tiered auto-apply (≥0.85 + verify gate) vs. needs_review (0.70-0.85). Writes `sec_cik` + `sec_series_id` into `instruments_universe.attributes`; audit trail in `sec_mmf_bridge_candidates`.

2. **sec_etfs.strategy_label NULL gap** — 439 of 985 ETFs have NULL `strategy_label` from SEC bulk ingestion. `backfill_sec_etfs_strategy_label.py` runs the existing Tiingo cascade classifier (`classify_fund`) against those rows and stamps `strategy_label_source` (`tiingo_cascade` / `unclassified`). Downstream `refresh_authoritative_labels.py --apply` then promotes the new labels into `instruments_universe`, unblocking SCHD/QQQM/SCHB/VMIAX/SPMQX-class contamination.

A critical category gate (govt vs. tax-exempt vs. prime) prevents cross-family MMF bridging despite high token overlap.

## Changes

- `backend/app/core/db/migrations/versions/0157_fuzzy_bridge_audit.py` — new column `sec_etfs.strategy_label_source` + new table `sec_mmf_bridge_candidates`
- `backend/app/domains/wealth/services/fuzzy_bridge.py` — pure-stdlib scorer + auto-match verifier
- `backend/scripts/bridge_mmf_catalog.py` — dry-run/apply MMF bridge with tiered thresholds
- `backend/scripts/backfill_sec_etfs_strategy_label.py` — cascade classifier over NULL-labeled ETFs
- `backend/tests/**` — 25 new unit tests (all passing)
- `docs/reference/authoritative-label-refresh-runbook.md` — full A26.3.3 execution sequence, rollback SQL, limitations

## Test plan

- [x] 14 fuzzy_bridge unit tests pass
- [x] 6 bridge_mmf_catalog `_classify_best` tests pass
- [x] 5 backfill_sec_etfs cascade tests pass
- [x] `make lint` clean
- [x] `make architecture` 31/31 contracts kept
- [x] mypy clean on new files (pre-existing errors in bis/benchmark/cusip workers unrelated)
- [ ] DB apply: run migration 0157
- [ ] DB apply: `bridge_mmf_catalog.py --apply`
- [ ] DB apply: `backfill_sec_etfs_strategy_label.py --apply`
- [ ] DB apply: second-pass `refresh_authoritative_labels.py --apply`
- [ ] Smoke test: cash allocation drops to 5-15%, Sharpe to 1.5-2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)