### PR TITLE
feat(data): default cash override_max per profile (30/20/15 pct)

### DIFF
--- a/backend/app/core/db/migrations/versions/0161_default_cash_caps.py
+++ b/backend/app/core/db/migrations/versions/0161_default_cash_caps.py
@@ -1,0 +1,61 @@
+"""default cash override_max per profile (institutional mandate defaults)
+
+Sets `strategic_allocation.override_max` for the cash block on all existing
+(org, profile) combos, so the optimizer cannot over-allocate to MMFs in high
+short-rate regimes. Defaults reflect institutional wealth practice for
+international portfolios (Brazilian offshore structures):
+
+- conservative: 30% max cash — defensive tolerance
+- moderate:     20% max cash — balanced tolerance
+- growth:       15% max cash — aggressive tolerance
+
+Operator can override via `POST /set-override` at any time (A26.2 flow);
+this migration only establishes the default where no override exists.
+
+Idempotent: only touches rows where override_max IS NULL.
+
+Revision ID: 0161_default_cash_caps
+Revises: 0160_approve_mmf_for_canonical_org
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0161_default_cash_caps"
+down_revision = "0160_approve_mmf_for_canonical_org"
+branch_labels = None
+depends_on = None
+
+DEFAULTS: dict[str, float] = {
+    "conservative": 0.30,
+    "moderate": 0.20,
+    "growth": 0.15,
+}
+
+
+def upgrade() -> None:
+    for profile, cap in DEFAULTS.items():
+        op.execute(
+            f"""
+            UPDATE strategic_allocation
+               SET override_max = {cap}
+             WHERE block_id = 'cash'
+               AND profile = '{profile}'
+               AND override_max IS NULL;
+            """
+        )
+
+
+def downgrade() -> None:
+    # Clear only the defaults set by this migration (rows where override_max
+    # matches the exact default value and no explicit rationale was recorded).
+    for profile, cap in DEFAULTS.items():
+        op.execute(
+            f"""
+            UPDATE strategic_allocation
+               SET override_max = NULL
+             WHERE block_id = 'cash'
+               AND profile = '{profile}'
+               AND override_max = {cap};
+            """
+        )


### PR DESCRIPTION
## Summary
Sets institutional mandate defaults for cash block override_max across all existing (org, profile) combos.

Without this, optimizer loads 50-60% into MMFs in current high short-rate regime (Fed ~5%, historical_1Y prior favors cash Sharpe).

Defaults reflect international wealth practice for Brazilian offshore portfolios:
- Conservative: 30% max cash (defensive tolerance)
- Moderate: 20% (balanced)
- Growth: 15% (aggressive)

Operator overrides via existing `POST /set-override` A26.2 flow at any time.

## Idempotent
Only touches rows where `override_max IS NULL`. Down-migration clears only exact-match values set by this migration.

## Test plan
- [x] `make migrate` up+down clean.
- [x] Post-migration cash override_max populated for 3 profiles.
- [x] Smoke with defaults: Conservative 0/46/24/30, Moderate 6/53/21/20, Growth 16/44/25/15. All optimal, CVaR feasible.
