### PR TITLE
PR-1 terminal-parity: mono formatters + token extensions + IBM Plex fonts

### DIFF
--- a/packages/investintell-ui/package.json
+++ b/packages/investintell-ui/package.json
@@ -71,6 +71,8 @@
   "dependencies": {
     "@fontsource-variable/urbanist": "^5.0.0",
     "@fontsource-variable/geist-mono": "^5.0.0",
+    "@fontsource/ibm-plex-mono": "^5.0.0",
+    "@fontsource/ibm-plex-sans": "^5.0.0",
     "@internationalized/date": "^3.12.0",
     "@tanstack/table-core": "^8.21.3",
     "bits-ui": "^2.16.4",

--- a/packages/investintell-ui/src/lib/formatters/mono.test.ts
+++ b/packages/investintell-ui/src/lib/formatters/mono.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "vitest";
+import {
+	formatCompactCurrency,
+	formatMonoPercent,
+	formatMonoTime,
+	formatPpDrift,
+} from "./mono.js";
+
+const EM_DASH = "\u2014";
+const MINUS = "\u2212";
+
+describe("formatMonoTime", () => {
+	test("UTC with zero-padded HH:MM:SS", () => {
+		const d = new Date(Date.UTC(2026, 3, 18, 9, 5, 7));
+		expect(formatMonoTime(d, "utc")).toBe("09:05:07 UTC");
+	});
+
+	test("UTC handles end-of-day", () => {
+		const d = new Date(Date.UTC(2026, 3, 18, 23, 59, 59));
+		expect(formatMonoTime(d)).toBe("23:59:59 UTC");
+	});
+
+	test("local mode has no UTC suffix", () => {
+		const d = new Date(2026, 3, 18, 8, 3, 4);
+		expect(formatMonoTime(d, "local")).toBe("08:03:04");
+	});
+});
+
+describe("formatCompactCurrency", () => {
+	test("billion range", () => {
+		expect(formatCompactCurrency(1_234_567_890)).toBe("$1.23B");
+	});
+
+	test("million range with custom digits", () => {
+		expect(formatCompactCurrency(987_654_321, { digits: 1 })).toBe("$987.7M");
+	});
+
+	test("thousand range", () => {
+		expect(formatCompactCurrency(12_345)).toBe("$12.35K");
+	});
+
+	test("negative uses Unicode minus", () => {
+		const out = formatCompactCurrency(-500_000_000);
+		expect(out.startsWith(MINUS)).toBe(true);
+		expect(out).toBe(`${MINUS}$500.00M`);
+	});
+
+	test("null / undefined / NaN / Infinity return em-dash", () => {
+		expect(formatCompactCurrency(null)).toBe(EM_DASH);
+		expect(formatCompactCurrency(undefined)).toBe(EM_DASH);
+		expect(formatCompactCurrency(Number.NaN)).toBe(EM_DASH);
+		expect(formatCompactCurrency(Number.POSITIVE_INFINITY)).toBe(EM_DASH);
+	});
+
+	test("EUR currency", () => {
+		expect(formatCompactCurrency(2_500_000, { currency: "EUR" })).toBe("€2.50M");
+	});
+
+	test("zero formats cleanly", () => {
+		expect(formatCompactCurrency(0)).toBe("$0.00");
+	});
+});
+
+describe("formatPpDrift", () => {
+	test("positive drift has + prefix", () => {
+		expect(formatPpDrift(0.023)).toBe("+2.3pp");
+	});
+
+	test("negative drift uses Unicode minus", () => {
+		expect(formatPpDrift(-0.011)).toBe(`${MINUS}1.1pp`);
+	});
+
+	test("zero has no sign", () => {
+		expect(formatPpDrift(0)).toBe("0.0pp");
+	});
+
+	test("custom digits", () => {
+		expect(formatPpDrift(0.0236, 2)).toBe("+2.36pp");
+	});
+
+	test("null / non-finite return em-dash", () => {
+		expect(formatPpDrift(null)).toBe(EM_DASH);
+		expect(formatPpDrift(undefined)).toBe(EM_DASH);
+		expect(formatPpDrift(Number.NaN)).toBe(EM_DASH);
+	});
+
+	test("very small values", () => {
+		expect(formatPpDrift(0.00001, 1)).toBe("+0.0pp");
+	});
+});
+
+describe("formatMonoPercent", () => {
+	test("positive percent", () => {
+		expect(formatMonoPercent(0.1234)).toBe("12.34%");
+	});
+
+	test("negative uses Unicode minus", () => {
+		expect(formatMonoPercent(-0.0005)).toBe(`${MINUS}0.05%`);
+	});
+
+	test("zero", () => {
+		expect(formatMonoPercent(0)).toBe("0.00%");
+	});
+
+	test("custom digits", () => {
+		expect(formatMonoPercent(0.1, 0)).toBe("10%");
+	});
+
+	test("null / non-finite return em-dash", () => {
+		expect(formatMonoPercent(null)).toBe(EM_DASH);
+		expect(formatMonoPercent(undefined)).toBe(EM_DASH);
+		expect(formatMonoPercent(Number.POSITIVE_INFINITY)).toBe(EM_DASH);
+	});
+});

--- a/packages/investintell-ui/src/lib/formatters/mono.ts
+++ b/packages/investintell-ui/src/lib/formatters/mono.ts
@@ -1,0 +1,103 @@
+/**
+ * Mono-friendly formatters for terminal surfaces.
+ *
+ * All outputs are tabular-safe (stable column widths) and
+ * locale-independent. Callers in (terminal)/** and
+ * lib/components/terminal/** must use these instead of
+ * `.toFixed`, `.toLocaleString`, or `new Intl.*` — enforced by
+ * the ESLint rule in frontends/eslint.config.js.
+ *
+ * Source of truth: docs/plans/2026-04-18-netz-terminal-parity.md §B.2.
+ */
+
+const EM_DASH = "\u2014";
+const MINUS = "\u2212"; // Unicode minus for column alignment.
+
+const compactCurrencyCache = new Map<string, Intl.NumberFormat>();
+
+function compactCurrencyFormatter(currency: string, digits: number): Intl.NumberFormat {
+	const key = `${currency}|${digits}`;
+	const cached = compactCurrencyCache.get(key);
+	if (cached) return cached;
+	const formatter = new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency,
+		notation: "compact",
+		compactDisplay: "short",
+		maximumFractionDigits: digits,
+		minimumFractionDigits: digits,
+	});
+	compactCurrencyCache.set(key, formatter);
+	return formatter;
+}
+
+function pad2(n: number): string {
+	return n < 10 ? `0${n}` : String(n);
+}
+
+/**
+ * UTC or local clock string "HH:MM:SS UTC". Zero allocation
+ * beyond the Date itself.
+ */
+export function formatMonoTime(d: Date, kind: "utc" | "local" = "utc"): string {
+	if (kind === "utc") {
+		return `${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}:${pad2(d.getUTCSeconds())} UTC`;
+	}
+	return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+export interface CompactCurrencyOptions {
+	digits?: number;
+	currency?: "USD" | "EUR" | "BRL";
+}
+
+/**
+ * Compact currency: $1.23B / $987M / $12.3K. Negative sign uses
+ * Unicode minus. Returns "—" for null / undefined / non-finite.
+ */
+export function formatCompactCurrency(
+	value: number | null | undefined,
+	opts: CompactCurrencyOptions = {},
+): string {
+	if (value === null || value === undefined || !Number.isFinite(value)) {
+		return EM_DASH;
+	}
+	const digits = opts.digits ?? 2;
+	const currency = opts.currency ?? "USD";
+	const formatted = compactCurrencyFormatter(currency, digits).format(Math.abs(value));
+	return value < 0 ? `${MINUS}${formatted}` : formatted;
+}
+
+/**
+ * Percentage-point drift: "+2.3pp", "−1.1pp", "0.0pp". Input is a
+ * fraction (0.023 → "+2.3pp"). Uses Unicode minus for alignment.
+ */
+export function formatPpDrift(
+	fractionDelta: number | null | undefined,
+	digits: number = 1,
+): string {
+	if (fractionDelta === null || fractionDelta === undefined || !Number.isFinite(fractionDelta)) {
+		return EM_DASH;
+	}
+	const pp = fractionDelta * 100;
+	const abs = Math.abs(pp).toFixed(digits);
+	if (pp > 0) return `+${abs}pp`;
+	if (pp < 0) return `${MINUS}${abs}pp`;
+	return `${abs}pp`;
+}
+
+/**
+ * Terminal percent: "12.34%", "−0.05%". Input is a fraction.
+ * Tabular-nums friendly.
+ */
+export function formatMonoPercent(
+	fraction: number | null | undefined,
+	digits: number = 2,
+): string {
+	if (fraction === null || fraction === undefined || !Number.isFinite(fraction)) {
+		return EM_DASH;
+	}
+	const pct = fraction * 100;
+	const abs = Math.abs(pct).toFixed(digits);
+	return pct < 0 ? `${MINUS}${abs}%` : `${abs}%`;
+}

--- a/packages/investintell-ui/src/lib/index.ts
+++ b/packages/investintell-ui/src/lib/index.ts
@@ -153,6 +153,13 @@ export { createOptimisticMutation } from "./utils/optimistic.svelte.js";
 export type { OptimisticMutation, OptimisticMutationConfig } from "./utils/optimistic.svelte.js";
 export { canOpenSSE, registerSSE, unregisterSSE, getActiveSSECount } from "./utils/sse-registry.svelte.js";
 export {
+	formatMonoTime,
+	formatCompactCurrency,
+	formatPpDrift,
+	formatMonoPercent,
+} from "./formatters/mono.js";
+export type { CompactCurrencyOptions } from "./formatters/mono.js";
+export {
 	formatAUM,
 	formatBps,
 	formatNAV,

--- a/packages/investintell-ui/src/lib/styles/typography.css
+++ b/packages/investintell-ui/src/lib/styles/typography.css
@@ -6,6 +6,12 @@
 
 @import "@fontsource-variable/urbanist";
 @import "@fontsource-variable/geist-mono";
+@import "@fontsource/ibm-plex-mono/400.css";
+@import "@fontsource/ibm-plex-mono/500.css";
+@import "@fontsource/ibm-plex-mono/600.css";
+@import "@fontsource/ibm-plex-sans/400.css";
+@import "@fontsource/ibm-plex-sans/500.css";
+@import "@fontsource/ibm-plex-sans/600.css";
 
 :root {
 	/* Font families */
@@ -118,4 +124,17 @@
 	--ii-code-border: rgba(0, 0, 0, 0.06);
 	--ii-kbd-bg:      #f1f5f9;   /* slate-100 */
 	--ii-kbd-border:  #cbd5e1;   /* slate-300 */
+}
+
+/* ── Terminal-scoped fonts ──────────────────────────────────
+ * Source: docs/plans/2026-04-18-netz-terminal-parity.md §B.4.
+ * Urbanist remains default OUTSIDE [data-surface="terminal"].
+ * font-display: optional avoids FOUT on first cold load — the
+ * system mono renders instantly, IBM Plex swaps on next reload.
+ * ============================================================ */
+[data-surface="terminal"] {
+	font-family: var(--terminal-font-mono);
+}
+[data-surface="terminal"] [data-font="sans"] {
+	font-family: "IBM Plex Sans", Inter, Urbanist, system-ui, sans-serif;
 }

--- a/packages/investintell-ui/src/lib/tokens/terminal.css
+++ b/packages/investintell-ui/src/lib/tokens/terminal.css
@@ -141,6 +141,72 @@
 	--terminal-shell-cage-padding: 24px;
 }
 
+/* ── Runtime tweak surfaces ───────────────────────────────── */
+/* Source: docs/plans/2026-04-18-netz-terminal-parity.md §B.1.  */
+/* Density: standard (default) vs compact (Bloomberg-tight).    */
+/* Switched via [data-density="compact"] on terminal-root or    */
+/* on :root for page-wide effect.                               */
+
+:root,
+[data-surface="terminal"] {
+	--t-row-height: 22px;
+	--t-size-hero: var(--terminal-text-24);
+	--t-size-kpi: var(--terminal-text-20);
+	--t-size-label: var(--terminal-text-10);
+
+	/* Severity scale — alerts + ticker. */
+	--sev-info: var(--terminal-accent-cyan);
+	--sev-warn: var(--terminal-status-warn);
+	--sev-critical: var(--terminal-status-error);
+	--up: var(--terminal-status-success);
+	--down: var(--terminal-status-error);
+}
+
+:root[data-density="compact"],
+[data-surface="terminal"][data-density="compact"] {
+	--terminal-space-1: 2px;
+	--terminal-space-2: 6px;
+	--terminal-space-3: 10px;
+	--terminal-space-4: 12px;
+	--terminal-text-10: 9px;
+	--terminal-text-11: 10px;
+	--terminal-text-12: 11px;
+	--terminal-text-14: 12px;
+	--terminal-shell-topbar-height: 28px;
+	--terminal-shell-breadcrumb-height: 24px;
+	--terminal-shell-cage-height: calc(100vh - 80px);
+	--t-row-height: 18px;
+}
+
+/* Accent: user-selectable. Default amber (institutional).     */
+/* Rebind the semantic amber slot so every consumer reading    */
+/* --terminal-accent-amber swaps without code changes.         */
+[data-accent="cyan"] {
+	--terminal-accent-amber: var(--terminal-accent-cyan);
+	--terminal-accent-amber-dim: var(--terminal-accent-cyan-dim);
+}
+[data-accent="violet"] {
+	--terminal-accent-amber: var(--terminal-accent-violet);
+	--terminal-accent-amber-dim: var(--terminal-accent-violet-dim);
+}
+
+/* Light theme — institutional white, still mono-first.        */
+[data-theme="light"],
+[data-theme="light"][data-surface="terminal"] {
+	--terminal-bg-void: #f5f5f0;
+	--terminal-bg-panel: #ffffff;
+	--terminal-bg-panel-raised: #fafaf6;
+	--terminal-bg-panel-sunken: #ededed;
+	--terminal-bg-overlay: #ffffff;
+	--terminal-bg-scrim: rgba(245, 245, 240, 0.72);
+	--terminal-fg-primary: #0a0a0a;
+	--terminal-fg-secondary: #3d3d38;
+	--terminal-fg-tertiary: #6b6b63;
+	--terminal-fg-muted: #b8b8b0;
+	--terminal-fg-disabled: #d8d8d0;
+	--terminal-fg-inverted: #ffffff;
+}
+
 /* prefers-reduced-motion: collapse all choreo slots to 0ms.   */
 /* Components can still honor --terminal-motion-opening etc.  */
 /* but any entrance animation becomes instant.                 */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -98,7 +98,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -238,6 +238,12 @@ importers:
       '@fontsource-variable/urbanist':
         specifier: ^5.0.0
         version: 5.2.7
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.0.0
+        version: 5.2.7
+      '@fontsource/ibm-plex-sans':
+        specifier: ^5.0.0
+        version: 5.2.8
       '@internationalized/date':
         specifier: ^3.12.0
         version: 3.12.0
@@ -5670,7 +5676,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       invariant: 2.2.4
       metro: 0.83.5(bufferutil@4.1.0)
-      metro-config: 0.83.5(bufferutil@4.1.0)
+      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.5
       semver: 7.7.4
     transitivePeerDependencies:
@@ -8500,21 +8506,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.83.5(bufferutil@4.1.0):
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.5(bufferutil@4.1.0)
-      metro-cache: 0.83.5
-      metro-core: 0.83.5
-      metro-runtime: 0.83.5
-      yaml: 2.8.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   metro-config@0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -8666,7 +8657,7 @@ snapshots:
       metro-babel-transformer: 0.83.5
       metro-cache: 0.83.5
       metro-cache-key: 0.83.5
-      metro-config: 0.83.5(bufferutil@4.1.0)
+      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.5
       metro-file-map: 0.83.5
       metro-resolver: 0.83.5


### PR DESCRIPTION
Sub-PR **1 of 4** from [docs/plans/2026-04-18-netz-terminal-parity.md](docs/plans/2026-04-18-netz-terminal-parity.md) §G.

## Summary
- **Formatters** (`packages/investintell-ui/src/lib/formatters/mono.ts`): `formatMonoTime`, `formatCompactCurrency`, `formatPpDrift`, `formatMonoPercent`. Tabular-safe, Unicode minus (U+2212), em-dash fallback for null / NaN / Infinity.
- **Tokens** (`tokens/terminal.css`): `[data-density="compact"]` overrides, `[data-accent="cyan"|"violet"]` rebinds the semantic amber slot, `[data-theme="light"]` palette inversion, severity scale (`--sev-info/warn/critical/up/down`), row-height and hero/kpi/label size tokens.
- **Fonts** (`styles/typography.css`): `@fontsource/ibm-plex-mono` + `ibm-plex-sans` (400/500/600) scoped to `[data-surface="terminal"]`. Urbanist stays default outside.
- **Exports** (`index.ts`): surfaces the four formatters + `CompactCurrencyOptions` type.

## Scope decisions honored
- `--terminal-*` namespace kept canonical (no `--term-*` aliases per §0).
- fontsource `-variable` variant does not publish IBM Plex — fell back to static `@fontsource/*`.
- §E.9 ESLint hex ban is **already implemented** in `frontends/eslint.config.js` (netzTerminalRules 314-337) — no-op for this PR.

## Test plan
- [x] `pnpm -F @investintell/ui test` → 102/102 pass (21 new mono tests)
- [x] `node scripts/check-terminal-tokens-sync.mjs` → 82 CSS / 22 readVar / 19 DEFAULT_TOKENS in sync
- [ ] Wealth eslint (blocked by pre-existing `node_modules` gap in this worktree; unrelated)

## Pre-existing, unrelated
3 `svelte-check` errors in `tests/terminal-options.test.ts:250-262` exist on `main` (5c42ba48) — not a regression.

## Next
PR-2 (`@investintell/ui/terminal` primitives: Pill, Kbd, KpiCard, DensityToggle, AccentPicker, ThemeToggle) can be opened in parallel once this is in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)