### PR TITLE
PR-2 terminal-parity: @investintell/ui/terminal primitives

### DIFF
--- a/packages/investintell-ui/src/lib/components/terminal/AccentPicker.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/AccentPicker.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	export type Accent = "amber" | "cyan" | "violet";
+
+	interface Props {
+		value: Accent;
+		onChange: (v: Accent) => void;
+		class?: string;
+	}
+
+	let { value, onChange, class: className }: Props = $props();
+
+	const options: { label: string; val: Accent }[] = [
+		{ label: "AMBER", val: "amber" },
+		{ label: "CYAN", val: "cyan" },
+		{ label: "VIOLET", val: "violet" },
+	];
+</script>
+
+<div class="terminal-accent-picker {className ?? ''}" role="radiogroup" aria-label="Accent">
+	{#each options as opt (opt.val)}
+		<button
+			type="button"
+			class="terminal-accent-swatch terminal-accent-swatch--{opt.val}"
+			class:is-active={value === opt.val}
+			aria-pressed={value === opt.val}
+			aria-label={`Accent ${opt.label}`}
+			onclick={() => onChange(opt.val)}
+		>
+			<span class="terminal-accent-dot" aria-hidden="true"></span>
+			<span class="terminal-accent-label">{opt.label}</span>
+		</button>
+	{/each}
+</div>
+
+<style>
+	.terminal-accent-picker {
+		display: inline-flex;
+		gap: var(--terminal-space-1);
+	}
+
+	.terminal-accent-swatch {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		height: 20px;
+		background: var(--terminal-bg-panel-raised);
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-secondary);
+		cursor: pointer;
+		line-height: 1;
+	}
+
+	.terminal-accent-swatch:hover {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+	}
+
+	.terminal-accent-swatch.is-active {
+		color: var(--terminal-fg-primary);
+		background: var(--terminal-bg-panel-sunken);
+	}
+
+	.terminal-accent-swatch:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.terminal-accent-dot {
+		width: 8px;
+		height: 8px;
+		display: inline-block;
+		border-radius: 50%;
+	}
+	.terminal-accent-swatch--amber .terminal-accent-dot {
+		background: var(--terminal-accent-amber);
+	}
+	.terminal-accent-swatch--cyan .terminal-accent-dot {
+		background: var(--terminal-accent-cyan);
+	}
+	.terminal-accent-swatch--violet .terminal-accent-dot {
+		background: var(--terminal-accent-violet);
+	}
+
+	.terminal-accent-swatch.is-active {
+		border-color: var(--terminal-accent-amber);
+	}
+</style>

--- a/packages/investintell-ui/src/lib/components/terminal/AccentPicker.test.ts
+++ b/packages/investintell-ui/src/lib/components/terminal/AccentPicker.test.ts
@@ -1,0 +1,33 @@
+import { render, fireEvent } from "@testing-library/svelte";
+import { describe, expect, test, vi } from "vitest";
+import AccentPicker from "./AccentPicker.svelte";
+
+describe("AccentPicker", () => {
+	test("renders three radiogroup swatches", () => {
+		const { container } = render(AccentPicker, {
+			props: { value: "amber", onChange: () => {} },
+		});
+		const group = container.querySelector("[role='radiogroup']");
+		expect(group).not.toBeNull();
+		expect(container.querySelectorAll(".terminal-accent-swatch").length).toBe(3);
+	});
+
+	test("active swatch reflects value prop", () => {
+		const { container } = render(AccentPicker, {
+			props: { value: "cyan", onChange: () => {} },
+		});
+		const active = container.querySelector(".terminal-accent-swatch.is-active");
+		expect(active?.className).toContain("terminal-accent-swatch--cyan");
+		expect(active?.getAttribute("aria-pressed")).toBe("true");
+	});
+
+	test("click fires onChange with the clicked value", async () => {
+		const onChange = vi.fn();
+		const { container } = render(AccentPicker, {
+			props: { value: "amber", onChange },
+		});
+		const violet = container.querySelector(".terminal-accent-swatch--violet")!;
+		await fireEvent.click(violet);
+		expect(onChange).toHaveBeenCalledWith("violet");
+	});
+});

--- a/packages/investintell-ui/src/lib/components/terminal/DensityToggle.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/DensityToggle.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import Pill from "./Pill.svelte";
+
+	export type Density = "standard" | "compact";
+
+	interface Props {
+		value: Density;
+		onChange: (v: Density) => void;
+		class?: string;
+	}
+
+	let { value, onChange, class: className }: Props = $props();
+
+	const options: { label: string; val: Density }[] = [
+		{ label: "STANDARD", val: "standard" },
+		{ label: "COMPACT", val: "compact" },
+	];
+</script>
+
+<div class="terminal-density-toggle {className ?? ''}" role="radiogroup" aria-label="Density">
+	{#each options as opt (opt.val)}
+		<Pill
+			as="button"
+			label={opt.label}
+			tone={value === opt.val ? "accent" : "neutral"}
+			pressed={value === opt.val}
+			onclick={() => onChange(opt.val)}
+			ariaLabel={`Density ${opt.label}`}
+		/>
+	{/each}
+</div>
+
+<style>
+	.terminal-density-toggle {
+		display: inline-flex;
+		gap: var(--terminal-space-1);
+	}
+</style>

--- a/packages/investintell-ui/src/lib/components/terminal/Kbd.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/Kbd.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	/**
+	 * Terminal Kbd — renders a shortcut as tokenized key caps.
+	 * Example: keys={["Shift","T"]} → [Shift]+[T].
+	 * Source: docs/plans/2026-04-18-netz-terminal-parity.md §B.3.
+	 */
+	interface Props {
+		keys: string[];
+		class?: string;
+	}
+
+	let { keys, class: className }: Props = $props();
+</script>
+
+<span class="terminal-kbd-group {className ?? ''}" role="group">
+	{#each keys as key, i (i)}
+		{#if i > 0}
+			<span class="terminal-kbd-sep" aria-hidden="true">+</span>
+		{/if}
+		<kbd class="terminal-kbd">{key}</kbd>
+	{/each}
+</span>
+
+<style>
+	.terminal-kbd-group {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.terminal-kbd {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 16px;
+		height: 16px;
+		padding: 0 var(--terminal-space-1);
+		font-family: inherit;
+		font-size: inherit;
+		text-transform: uppercase;
+		color: var(--terminal-fg-secondary);
+		background: var(--terminal-bg-panel-sunken);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		line-height: 1;
+	}
+
+	.terminal-kbd-sep {
+		color: var(--terminal-fg-tertiary);
+		font-size: var(--terminal-text-10);
+	}
+</style>

--- a/packages/investintell-ui/src/lib/components/terminal/KpiCard.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/KpiCard.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+	/**
+	 * Terminal KpiCard — label + pre-formatted value + optional delta.
+	 * Values MUST be pre-formatted by callers using @investintell/ui
+	 * formatters (formatCompactCurrency, formatMonoPercent, etc.).
+	 * Source: docs/plans/2026-04-18-netz-terminal-parity.md §B.3.
+	 */
+	export type KpiCardSize = "sm" | "md" | "lg";
+	export type KpiDeltaTone = "up" | "down" | "neutral";
+
+	interface Props {
+		label: string;
+		value: string;
+		delta?: string;
+		deltaTone?: KpiDeltaTone;
+		size?: KpiCardSize;
+		mono?: boolean;
+		loading?: boolean;
+		class?: string;
+	}
+
+	let {
+		label,
+		value,
+		delta,
+		deltaTone = "neutral",
+		size = "md",
+		mono = true,
+		loading = false,
+		class: className,
+	}: Props = $props();
+</script>
+
+<div
+	class="terminal-kpi terminal-kpi--{size} {className ?? ''}"
+	data-loading={loading ? "" : undefined}
+	data-mono={mono ? "" : undefined}
+>
+	<div class="terminal-kpi__label">{label}</div>
+	<div class="terminal-kpi__value" aria-busy={loading}>
+		{#if loading}
+			<span class="terminal-kpi__skeleton" aria-hidden="true"></span>
+		{:else}
+			{value}
+		{/if}
+	</div>
+	{#if delta && !loading}
+		<div class="terminal-kpi__delta terminal-kpi__delta--{deltaTone}">{delta}</div>
+	{/if}
+</div>
+
+<style>
+	.terminal-kpi {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-3);
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		min-width: 0;
+	}
+
+	.terminal-kpi[data-mono] {
+		font-family: var(--terminal-font-mono);
+	}
+
+	.terminal-kpi__label {
+		font-size: var(--t-size-label);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		line-height: var(--terminal-leading-tight);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.terminal-kpi__value {
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+		font-weight: 500;
+		line-height: var(--terminal-leading-tight);
+		letter-spacing: var(--terminal-tracking-tight);
+	}
+
+	.terminal-kpi--sm .terminal-kpi__value {
+		font-size: var(--terminal-text-14);
+	}
+	.terminal-kpi--md .terminal-kpi__value {
+		font-size: var(--t-size-kpi);
+	}
+	.terminal-kpi--lg .terminal-kpi__value {
+		font-size: var(--t-size-hero);
+	}
+
+	.terminal-kpi__delta {
+		font-size: var(--terminal-text-11);
+		font-variant-numeric: tabular-nums;
+		line-height: 1;
+	}
+	.terminal-kpi__delta--up {
+		color: var(--up);
+	}
+	.terminal-kpi__delta--down {
+		color: var(--down);
+	}
+	.terminal-kpi__delta--neutral {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.terminal-kpi__skeleton {
+		display: inline-block;
+		width: 4ch;
+		height: 1em;
+		background: var(--terminal-bg-panel-sunken);
+		animation: terminal-kpi-pulse var(--terminal-motion-update) var(--terminal-motion-easing-out) infinite alternate;
+	}
+
+	@keyframes terminal-kpi-pulse {
+		from {
+			opacity: 0.4;
+		}
+		to {
+			opacity: 0.8;
+		}
+	}
+</style>

--- a/packages/investintell-ui/src/lib/components/terminal/KpiCard.test.ts
+++ b/packages/investintell-ui/src/lib/components/terminal/KpiCard.test.ts
@@ -1,0 +1,43 @@
+import { render } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+import KpiCard from "./KpiCard.svelte";
+
+describe("KpiCard", () => {
+	test("renders label + pre-formatted value", () => {
+		const { container } = render(KpiCard, {
+			props: { label: "TOTAL AUM", value: "$1.23B" },
+		});
+		expect(container.textContent).toContain("TOTAL AUM");
+		expect(container.textContent).toContain("$1.23B");
+	});
+
+	test("loading state suppresses delta + shows skeleton", () => {
+		const { container } = render(KpiCard, {
+			props: { label: "AUM", value: "$1.23B", delta: "+1.2pp", loading: true },
+		});
+		expect(container.querySelector(".terminal-kpi__skeleton")).not.toBeNull();
+		expect(container.querySelector(".terminal-kpi__delta")).toBeNull();
+	});
+
+	test("delta tone class follows prop", () => {
+		const { container } = render(KpiCard, {
+			props: { label: "P/L", value: "+2.1%", delta: "+0.3pp", deltaTone: "up" },
+		});
+		const delta = container.querySelector(".terminal-kpi__delta");
+		expect(delta?.className).toContain("terminal-kpi__delta--up");
+	});
+
+	test("size variant sets modifier class", () => {
+		const { container } = render(KpiCard, {
+			props: { label: "NAV", value: "100.00", size: "lg" },
+		});
+		expect(container.querySelector(".terminal-kpi--lg")).not.toBeNull();
+	});
+
+	test("mono attribute toggles font-family hook", () => {
+		const { container } = render(KpiCard, {
+			props: { label: "NAV", value: "100.00", mono: false },
+		});
+		expect(container.querySelector(".terminal-kpi[data-mono]")).toBeNull();
+	});
+});

--- a/packages/investintell-ui/src/lib/components/terminal/Pill.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/Pill.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	/**
+	 * Terminal Pill — small tokenized badge or segmented-control button.
+	 * Source: docs/plans/2026-04-18-netz-terminal-parity.md §B.3.
+	 */
+	export type PillTone = "neutral" | "accent" | "success" | "warn" | "error";
+	export type PillSize = "xs" | "sm";
+	export type PillAs = "button" | "span";
+
+	interface Props {
+		label: string;
+		tone?: PillTone;
+		size?: PillSize;
+		as?: PillAs;
+		pressed?: boolean;
+		disabled?: boolean;
+		ariaLabel?: string;
+		onclick?: () => void;
+		class?: string;
+	}
+
+	let {
+		label,
+		tone = "neutral",
+		size = "sm",
+		as = "span",
+		pressed,
+		disabled = false,
+		ariaLabel,
+		onclick,
+		class: className,
+	}: Props = $props();
+</script>
+
+{#if as === "button"}
+	<button
+		type="button"
+		class="terminal-pill terminal-pill--{tone} terminal-pill--{size} {className ?? ''}"
+		aria-pressed={pressed}
+		aria-label={ariaLabel}
+		{disabled}
+		onclick={() => onclick?.()}
+	>
+		{label}
+	</button>
+{:else}
+	<span
+		class="terminal-pill terminal-pill--{tone} terminal-pill--{size} {className ?? ''}"
+		aria-label={ariaLabel}
+	>
+		{label}
+	</span>
+{/if}
+
+<style>
+	.terminal-pill {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		font-family: var(--terminal-font-mono);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		border-radius: var(--terminal-radius-none);
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-fg-secondary);
+		line-height: 1;
+		white-space: nowrap;
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.terminal-pill--xs {
+		font-size: var(--terminal-text-10);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		height: 16px;
+	}
+	.terminal-pill--sm {
+		font-size: var(--terminal-text-11);
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		height: 20px;
+	}
+
+	.terminal-pill--accent {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber-dim);
+	}
+	.terminal-pill--success {
+		color: var(--terminal-status-success);
+		border-color: var(--terminal-status-success);
+	}
+	.terminal-pill--warn {
+		color: var(--terminal-status-warn);
+		border-color: var(--terminal-status-warn);
+	}
+	.terminal-pill--error {
+		color: var(--terminal-status-error);
+		border-color: var(--terminal-status-error);
+	}
+
+	button.terminal-pill {
+		cursor: pointer;
+	}
+	button.terminal-pill:hover:not(:disabled) {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+	}
+	button.terminal-pill[aria-pressed="true"] {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+		background: var(--terminal-bg-panel-sunken);
+	}
+	button.terminal-pill:disabled {
+		color: var(--terminal-fg-disabled);
+		border-color: var(--terminal-fg-disabled);
+		cursor: not-allowed;
+	}
+	button.terminal-pill:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+</style>

--- a/packages/investintell-ui/src/lib/components/terminal/Pill.test.ts
+++ b/packages/investintell-ui/src/lib/components/terminal/Pill.test.ts
@@ -1,0 +1,34 @@
+import { render, fireEvent } from "@testing-library/svelte";
+import { describe, expect, test, vi } from "vitest";
+import Pill from "./Pill.svelte";
+
+describe("Pill", () => {
+	test("renders as span by default", () => {
+		const { container } = render(Pill, { props: { label: "LIVE" } });
+		expect(container.querySelector("span.terminal-pill")?.textContent?.trim()).toBe("LIVE");
+		expect(container.querySelector("button")).toBeNull();
+	});
+
+	test("as=button renders button with aria-pressed when pressed set", () => {
+		const { container } = render(Pill, {
+			props: { label: "CANDLE", as: "button", pressed: true },
+		});
+		const btn = container.querySelector("button.terminal-pill");
+		expect(btn).not.toBeNull();
+		expect(btn?.getAttribute("aria-pressed")).toBe("true");
+	});
+
+	test("button fires onclick", async () => {
+		const onclick = vi.fn();
+		const { container } = render(Pill, {
+			props: { label: "GO", as: "button", onclick },
+		});
+		await fireEvent.click(container.querySelector("button")!);
+		expect(onclick).toHaveBeenCalledOnce();
+	});
+
+	test("tone applies modifier class", () => {
+		const { container } = render(Pill, { props: { label: "OK", tone: "success" } });
+		expect(container.querySelector(".terminal-pill--success")).not.toBeNull();
+	});
+});

--- a/packages/investintell-ui/src/lib/components/terminal/ThemeToggle.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/ThemeToggle.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import Pill from "./Pill.svelte";
+
+	export type TerminalTheme = "dark" | "light";
+
+	interface Props {
+		value: TerminalTheme;
+		onChange: (v: TerminalTheme) => void;
+		class?: string;
+	}
+
+	let { value, onChange, class: className }: Props = $props();
+
+	const options: { label: string; val: TerminalTheme }[] = [
+		{ label: "DARK", val: "dark" },
+		{ label: "LIGHT", val: "light" },
+	];
+</script>
+
+<div class="terminal-theme-toggle {className ?? ''}" role="radiogroup" aria-label="Theme">
+	{#each options as opt (opt.val)}
+		<Pill
+			as="button"
+			label={opt.label}
+			tone={value === opt.val ? "accent" : "neutral"}
+			pressed={value === opt.val}
+			onclick={() => onChange(opt.val)}
+			ariaLabel={`Theme ${opt.label}`}
+		/>
+	{/each}
+</div>
+
+<style>
+	.terminal-theme-toggle {
+		display: inline-flex;
+		gap: var(--terminal-space-1);
+	}
+</style>

--- a/packages/investintell-ui/src/lib/index.ts
+++ b/packages/investintell-ui/src/lib/index.ts
@@ -99,6 +99,21 @@ export type { BaseChartProps } from "./charts/index.js";
 export { default as SparklineSVG } from "./components/ui/charts/SparklineSVG.svelte";
 
 // ── Terminal primitives ──────────────────────────────────────
+// Components under @investintell/ui/components/terminal/*. Importing
+// these from any file outside (terminal)/ is discouraged — see
+// eslint restriction in frontends/eslint.config.js.
+export { default as TerminalPill } from "./components/terminal/Pill.svelte";
+export type { PillTone, PillSize, PillAs } from "./components/terminal/Pill.svelte";
+export { default as TerminalKbd } from "./components/terminal/Kbd.svelte";
+export { default as TerminalKpiCard } from "./components/terminal/KpiCard.svelte";
+export type { KpiCardSize, KpiDeltaTone } from "./components/terminal/KpiCard.svelte";
+export { default as TerminalDensityToggle } from "./components/terminal/DensityToggle.svelte";
+export type { Density } from "./components/terminal/DensityToggle.svelte";
+export { default as TerminalAccentPicker } from "./components/terminal/AccentPicker.svelte";
+export type { Accent } from "./components/terminal/AccentPicker.svelte";
+export { default as TerminalThemeToggle } from "./components/terminal/ThemeToggle.svelte";
+export type { TerminalTheme } from "./components/terminal/ThemeToggle.svelte";
+
 // Motion grammar + chart factory. Importing these from any file
 // outside (terminal)/ is discouraged — see eslint restriction.
 export {


### PR DESCRIPTION
Sub-PR **2 of 4** from [docs/plans/2026-04-18-netz-terminal-parity.md](docs/plans/2026-04-18-netz-terminal-parity.md) §G.

**Base:** `feat/terminal-ui-formatters-and-tokens` (PR-1 #225) — consumes the density/accent/theme/severity tokens shipped there.

## Summary
Six tokenized primitives under `packages/investintell-ui/src/lib/components/terminal/`. Zero hex literals; every surface reads `--terminal-*` and the `--t-*` / `--sev-*` / `--up` / `--down` tokens from PR-1.

| Component | Purpose |
|---|---|
| `Pill` | Tokenized badge / segmented-control button (tone × size, `as='button'` fires onclick with `aria-pressed`). |
| `Kbd` | Shortcut key caps: `[Shift]+[T]`. |
| `KpiCard` | Label + pre-formatted value + optional delta; `sm`/`md`/`lg`; loading skeleton; mono toggle. |
| `DensityToggle` | `standard` / `compact` radiogroup. |
| `AccentPicker` | `amber` / `cyan` / `violet` swatch with dot. |
| `ThemeToggle` | `dark` / `light` (exported as `TerminalThemeToggle` to avoid collision with existing analytical export). |

## Exports (`index.ts`)
`TerminalPill`, `TerminalKbd`, `TerminalKpiCard`, `TerminalDensityToggle`, `TerminalAccentPicker`, `TerminalThemeToggle` + types `PillTone`, `PillSize`, `PillAs`, `KpiCardSize`, `KpiDeltaTone`, `Density`, `Accent`, `TerminalTheme`.

## Test plan
- [x] `pnpm -F @investintell/ui test` → 114/114 pass (12 new: KpiCard×5, Pill×4, AccentPicker×3)
- [x] `KpiCard` covers loading, delta tone, size variant, mono toggle (per plan §F.4)
- [x] `Pill` covers span/button modes, onclick, tone classes
- [x] `AccentPicker` covers radiogroup, active state, onChange dispatch

## Pre-existing, unrelated
Same 3 svelte-check errors in `tests/terminal-options.test.ts:250-262` flagged in PR-1 — unchanged.

## Next
PR-3 wires `TerminalTweaksPanel` (uses DensityToggle/AccentPicker/ThemeToggle) + `TerminalBreadcrumb` + shell grid update. PR-4 wires ChartToolbar Candle/Line toggle using `Pill as='button'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)