### PR TITLE
PR-3 terminal-parity: shell tweaks panel + breadcrumb + mono clock

### DIFF
--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalBreadcrumb.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalBreadcrumb.svelte
@@ -1,0 +1,143 @@
+<!--
+	TerminalBreadcrumb.svelte
+	=========================
+
+	28px persistent row rendered BETWEEN TerminalTopNav and LayoutCage.
+	Segments: Screener → Terminal → Macro → Builder. Each is an <a>
+	with SvelteKit preload. Active segment matches page.route.id.
+
+	Keyboard: Alt+1..4 jumps to each segment. Ignored when focus is in
+	an editable field. Namespace does not collide with CommandPalette
+	go-to sequences (g-prefix) or palette shortcut (Cmd+K).
+
+	Source: docs/plans/2026-04-18-netz-terminal-parity.md §A.4, §C.1.
+-->
+<script lang="ts">
+	import { page } from "$app/state";
+	import { goto } from "$app/navigation";
+
+	interface Segment {
+		key: string;
+		label: string;
+		href: string;
+		/** Path prefix used to resolve the active state against page.route.id. */
+		match: string;
+	}
+
+	const segments: Segment[] = [
+		{ key: "screener", label: "SCREENER", href: "/terminal-screener", match: "/terminal-screener" },
+		{ key: "terminal", label: "TERMINAL", href: "/portfolio/live", match: "/portfolio/live" },
+		{ key: "macro", label: "MACRO", href: "/macro", match: "/macro" },
+		{ key: "builder", label: "BUILDER", href: "/portfolio/builder", match: "/portfolio/builder" },
+	];
+
+	const activeKey = $derived.by(() => {
+		const path = page.url.pathname;
+		for (const seg of segments) {
+			if (path.startsWith(seg.match)) return seg.key;
+		}
+		return null;
+	});
+
+	function isEditableTarget(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		const tag = target.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+		if (target.isContentEditable) return true;
+		const role = target.getAttribute("role");
+		if (role === "textbox" || role === "searchbox" || role === "combobox") {
+			return true;
+		}
+		return false;
+	}
+
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const handler = (event: KeyboardEvent) => {
+			if (!event.altKey || event.metaKey || event.ctrlKey || event.shiftKey) return;
+			if (isEditableTarget(event.target)) return;
+			const idx = Number.parseInt(event.key, 10);
+			if (Number.isNaN(idx) || idx < 1 || idx > segments.length) return;
+			event.preventDefault();
+			const target = segments[idx - 1];
+			if (!target) return;
+			// Route hrefs are string-typed here (mapped from segments[]),
+			// so resolve() type inference narrows to never. Cast keeps
+			// the runtime behavior identical and svelte-check quiet.
+			void goto(target.href as Parameters<typeof goto>[0]);
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	});
+</script>
+
+<nav class="tb-crumb" aria-label="Terminal sections">
+	{#each segments as seg, i (seg.key)}
+		{#if i > 0}
+			<span class="tb-sep" aria-hidden="true">›</span>
+		{/if}
+		<a
+			class="tb-link"
+			class:is-active={activeKey === seg.key}
+			href={seg.href}
+			data-sveltekit-preload-data="hover"
+			aria-current={activeKey === seg.key ? "page" : undefined}
+		>
+			<span class="tb-alt" aria-hidden="true">{i + 1}</span>
+			<span class="tb-label">{seg.label}</span>
+		</a>
+	{/each}
+</nav>
+
+<style>
+	.tb-crumb {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		height: var(--terminal-shell-breadcrumb-height, 28px);
+		padding: 0 var(--terminal-space-4);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		overflow: hidden;
+		white-space: nowrap;
+	}
+
+	.tb-link {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		text-decoration: none;
+		padding: 0 var(--terminal-space-2);
+		height: 100%;
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.tb-link:hover {
+		color: var(--terminal-fg-primary);
+	}
+	.tb-link.is-active {
+		color: var(--terminal-accent-amber);
+		border-bottom: 1px solid var(--terminal-accent-amber);
+	}
+	.tb-link:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -2px;
+	}
+
+	.tb-alt {
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+	}
+	.tb-link.is-active .tb-alt {
+		color: var(--terminal-accent-amber-dim);
+	}
+
+	.tb-sep {
+		color: var(--terminal-fg-muted);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
@@ -42,7 +42,13 @@
 	import { resolve } from "$app/paths";
 	import { createClientApiClient } from "$lib/api/client";
 	import TerminalTopNav from "./TerminalTopNav.svelte";
+	import TerminalBreadcrumb from "./TerminalBreadcrumb.svelte";
+	import TerminalTweaksPanel from "./TerminalTweaksPanel.svelte";
 	import TerminalStatusBar from "./TerminalStatusBar.svelte";
+	import {
+		TERMINAL_TWEAKS_KEY,
+		type TerminalTweaks,
+	} from "$lib/stores/terminal-tweaks.svelte";
 	import TerminalContextRail, {
 		type TerminalContextRailEntity,
 		type TerminalContextRailEntityKind,
@@ -79,6 +85,12 @@
 	// Part C hardcodes "connecting" since no streams are mounted.
 	// Phase 5+ will aggregate real TerminalStream subscriptions.
 	const connectionStatus = "connecting" as const;
+
+	// ─── Tweaks (density / accent / theme) ─────────────────────
+	// Bound as data-attributes on the shell root so tokens shipped
+	// in @investintell/ui/tokens/terminal.css activate via attribute
+	// selectors. Store is populated by (terminal)/+layout.svelte.
+	const tweaks = getContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY);
 
 	// ─── DD queue badge count ───────────────────────────────────
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
@@ -277,7 +289,14 @@
 	<AlertTicker />
 {/snippet}
 
-<div class="ts-shell" class:ts-shell--has-rail={entity !== null}>
+<div
+	class="ts-shell"
+	class:ts-shell--has-rail={entity !== null}
+	data-surface="terminal"
+	data-density={tweaks?.density ?? "standard"}
+	data-accent={tweaks?.accent ?? "amber"}
+	data-theme={tweaks?.theme ?? "dark"}
+>
 	<div class="ts-nav-row">
 		<TerminalTopNav
 			activePath={page.url.pathname}
@@ -286,6 +305,10 @@
 			{userInitials}
 			{orgName}
 		/>
+	</div>
+
+	<div class="ts-crumb-row">
+		<TerminalBreadcrumb />
 	</div>
 
 	<main class="ts-content">
@@ -313,16 +336,18 @@
 </div>
 
 <CommandPalette bind:open={paletteOpen} />
+<TerminalTweaksPanel />
 
 <style>
 	.ts-shell {
 		position: fixed;
 		inset: 0;
 		display: grid;
-		grid-template-rows: 32px 1fr 28px;
+		grid-template-rows: 32px var(--terminal-shell-breadcrumb-height, 28px) 1fr 28px;
 		grid-template-columns: 1fr;
 		grid-template-areas:
 			"nav"
+			"crumb"
 			"content"
 			"status";
 		height: 100dvh;
@@ -338,12 +363,18 @@
 		grid-template-columns: 1fr 280px;
 		grid-template-areas:
 			"nav nav"
+			"crumb crumb"
 			"content rail"
 			"status status";
 	}
 
 	.ts-nav-row {
 		grid-area: nav;
+		min-width: 0;
+	}
+
+	.ts-crumb-row {
+		grid-area: crumb;
 		min-width: 0;
 	}
 

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalStatusBar.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalStatusBar.svelte
@@ -25,6 +25,7 @@
 -->
 <script lang="ts">
 	import type { Snippet } from "svelte";
+	import { formatMonoTime } from "@investintell/ui";
 
 	export type TerminalStatusBarConnectionStatus =
 		| "connecting"
@@ -81,14 +82,14 @@
 
 	let utcClock = $state("--:--:-- UTC");
 
-	// 1Hz UTC clock. ISO extraction is locale-independent, so it does
-	// not route through @investintell/ui formatters (those handle
-	// currency / percent / date, not raw ISO time). `$effect` cleanup
-	// guarantees the interval stops when the shell unmounts.
+	// 1Hz UTC clock via the mono formatter from @investintell/ui. The
+	// formatter is tabular-safe (zero-padded HH:MM:SS) and locale-
+	// independent. `$effect` cleanup guarantees the interval stops
+	// when the shell unmounts.
 	$effect(() => {
 		if (typeof window === "undefined") return;
 		const tick = () => {
-			utcClock = new Date().toISOString().substring(11, 19) + " UTC";
+			utcClock = formatMonoTime(new Date(), "utc");
 		};
 		tick();
 		const interval = window.setInterval(tick, 1000);

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalTweaksPanel.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalTweaksPanel.svelte
@@ -1,0 +1,252 @@
+<!--
+	TerminalTweaksPanel.svelte
+	==========================
+
+	Floating gear button (bottom-right) + right-side drawer with density,
+	accent, and theme toggles. Reads/writes the terminal-tweaks store
+	wired via context at (terminal)/+layout.svelte.
+
+	Source: docs/plans/2026-04-18-netz-terminal-parity.md §C.2.
+
+	Keyboard: Shift+T toggles open/close. Ignored inside editable fields.
+	Mount location: TerminalShell root (OUTSIDE LayoutCage) so the drawer
+	is unaffected by the cage padding override pattern — see plan §H risk #4.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import {
+		TerminalAccentPicker,
+		TerminalDensityToggle,
+		TerminalPill,
+		TerminalThemeToggle,
+		TerminalKbd,
+	} from "@investintell/ui";
+	import {
+		TERMINAL_TWEAKS_KEY,
+		type TerminalTweaks,
+	} from "$lib/stores/terminal-tweaks.svelte";
+
+	const tweaks = getContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY);
+
+	let open = $state(false);
+
+	function isEditableTarget(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		const tag = target.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+		if (target.isContentEditable) return true;
+		const role = target.getAttribute("role");
+		if (role === "textbox" || role === "searchbox" || role === "combobox") {
+			return true;
+		}
+		return false;
+	}
+
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const handler = (event: KeyboardEvent) => {
+			if (
+				event.shiftKey &&
+				!event.metaKey &&
+				!event.ctrlKey &&
+				!event.altKey &&
+				(event.key === "T" || event.key === "t")
+			) {
+				if (isEditableTarget(event.target)) return;
+				event.preventDefault();
+				open = !open;
+			} else if (event.key === "Escape" && open) {
+				open = false;
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	});
+</script>
+
+<button
+	type="button"
+	class="tweaks-fab"
+	aria-label="Open terminal tweaks (Shift+T)"
+	aria-expanded={open}
+	aria-controls="terminal-tweaks-drawer"
+	onclick={() => (open = !open)}
+>
+	<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+		<path
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.25"
+			d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Zm5.6 2.5a5.7 5.7 0 0 0-.1-1l1.3-1-1.3-2.3-1.6.5a5.6 5.6 0 0 0-1.7-1L9.8 1H7.2l-.4 1.7a5.6 5.6 0 0 0-1.7 1l-1.6-.5-1.3 2.3 1.3 1a5.7 5.7 0 0 0 0 2l-1.3 1 1.3 2.3 1.6-.5a5.6 5.6 0 0 0 1.7 1l.4 1.7h2.6l.4-1.7a5.6 5.6 0 0 0 1.7-1l1.6.5 1.3-2.3-1.3-1c.1-.3.1-.7.1-1Z"
+		/>
+	</svg>
+</button>
+
+{#if open}
+	<div
+		class="tweaks-scrim"
+		aria-hidden="true"
+		role="presentation"
+		onclick={() => (open = false)}
+		onkeydown={(e) => {
+			if (e.key === "Enter" || e.key === " ") open = false;
+		}}
+	></div>
+	<div
+		id="terminal-tweaks-drawer"
+		class="tweaks-drawer"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Terminal tweaks"
+		tabindex="-1"
+	>
+		<header class="tweaks-header">
+			<span class="tweaks-title">TWEAKS</span>
+			<span class="tweaks-shortcut">
+				<TerminalKbd keys={["Shift", "T"]} />
+			</span>
+			<button
+				type="button"
+				class="tweaks-close"
+				aria-label="Close"
+				onclick={() => (open = false)}
+			>
+				×
+			</button>
+		</header>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">DENSITY</div>
+			<TerminalDensityToggle
+				value={tweaks.density}
+				onChange={(v) => tweaks.setDensity(v)}
+			/>
+		</section>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">ACCENT</div>
+			<TerminalAccentPicker
+				value={tweaks.accent}
+				onChange={(v) => tweaks.setAccent(v)}
+			/>
+		</section>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">THEME</div>
+			<TerminalThemeToggle
+				value={tweaks.theme}
+				onChange={(v) => tweaks.setTheme(v)}
+			/>
+		</section>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">LIVE SIM</div>
+			<TerminalPill label="OFF" tone="neutral" size="sm" />
+		</section>
+	</div>
+{/if}
+
+<style>
+	.tweaks-fab {
+		position: fixed;
+		bottom: calc(var(--terminal-shell-statusbar-height) + var(--terminal-space-3));
+		right: var(--terminal-space-3);
+		z-index: var(--terminal-z-toast);
+		width: 32px;
+		height: 32px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-fg-secondary);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		cursor: pointer;
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.tweaks-fab:hover {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+	.tweaks-fab:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.tweaks-scrim {
+		position: fixed;
+		inset: 0;
+		background: var(--terminal-bg-scrim);
+		z-index: calc(var(--terminal-z-toast) - 1);
+	}
+
+	.tweaks-drawer {
+		position: fixed;
+		top: var(--terminal-shell-topbar-height);
+		right: 0;
+		bottom: var(--terminal-shell-statusbar-height);
+		width: 320px;
+		background: var(--terminal-bg-panel);
+		border-left: var(--terminal-border-strong);
+		z-index: var(--terminal-z-toast);
+		padding: var(--terminal-space-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-6);
+		overflow-y: auto;
+		font-family: var(--terminal-font-mono);
+	}
+
+	.tweaks-header {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding-bottom: var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.tweaks-title {
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-primary);
+		text-transform: uppercase;
+		flex: 1;
+	}
+	.tweaks-shortcut {
+		display: inline-flex;
+	}
+	.tweaks-close {
+		width: 20px;
+		height: 20px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: transparent;
+		color: var(--terminal-fg-tertiary);
+		border: var(--terminal-border-hairline);
+		font-size: var(--terminal-text-14);
+		line-height: 1;
+		cursor: pointer;
+	}
+	.tweaks-close:hover {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+	}
+	.tweaks-close:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.tweaks-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+	}
+	.tweaks-section__label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+</style>

--- a/frontends/wealth/src/lib/stores/terminal-tweaks.svelte.ts
+++ b/frontends/wealth/src/lib/stores/terminal-tweaks.svelte.ts
@@ -1,0 +1,56 @@
+/**
+ * Terminal runtime tweaks — density / accent / theme.
+ *
+ * In-memory only. No localStorage, no URL param. Resets on
+ * hard reload (confirmed trade-off per plan scope-decision #3:
+ * docs/plans/2026-04-18-netz-terminal-parity.md §0).
+ *
+ * Usage:
+ *   const tweaks = createTerminalTweaks();
+ *   setContext(TERMINAL_TWEAKS_KEY, tweaks);
+ *   ...
+ *   const tweaks = getContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY);
+ *
+ * The TerminalShell binds `data-density`, `data-accent`, `data-theme`
+ * onto its root element so the @investintell/ui tokens shipped in
+ * PR-1 activate via attribute selectors.
+ */
+
+import type { Accent, Density, TerminalTheme } from "@investintell/ui";
+
+export const TERMINAL_TWEAKS_KEY = Symbol("netz:terminal-tweaks");
+
+export interface TerminalTweaks {
+	readonly density: Density;
+	readonly accent: Accent;
+	readonly theme: TerminalTheme;
+	setDensity(v: Density): void;
+	setAccent(v: Accent): void;
+	setTheme(v: TerminalTheme): void;
+}
+
+export function createTerminalTweaks(): TerminalTweaks {
+	let density = $state<Density>("standard");
+	let accent = $state<Accent>("amber");
+	let theme = $state<TerminalTheme>("dark");
+	return {
+		get density() {
+			return density;
+		},
+		get accent() {
+			return accent;
+		},
+		get theme() {
+			return theme;
+		},
+		setDensity(v) {
+			density = v;
+		},
+		setAccent(v) {
+			accent = v;
+		},
+		setTheme(v) {
+			theme = v;
+		},
+	};
+}

--- a/frontends/wealth/src/routes/(terminal)/+layout.svelte
+++ b/frontends/wealth/src/routes/(terminal)/+layout.svelte
@@ -28,6 +28,11 @@
 	} from "$lib/stores/market-data.svelte";
 	import { TERMINAL_MARKET_DATA_KEY } from "$lib/components/portfolio/live/workbench-state";
 	import TerminalShell from "$lib/components/terminal/shell/TerminalShell.svelte";
+	import {
+		createTerminalTweaks,
+		TERMINAL_TWEAKS_KEY,
+		type TerminalTweaks,
+	} from "$lib/stores/terminal-tweaks.svelte";
 
 	let { children }: { children: Snippet } = $props();
 
@@ -38,6 +43,12 @@
 	// the (app) dashboard's store.
 	const marketStore = createMarketDataStore({ getToken });
 	setContext<MarketDataStore>(TERMINAL_MARKET_DATA_KEY, marketStore);
+
+	// Terminal runtime tweaks (density / accent / theme). In-memory,
+	// session-scoped. Consumed by TerminalShell (data-attrs) and
+	// TerminalTweaksPanel (UI controls).
+	const tweaks = createTerminalTweaks();
+	setContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY, tweaks);
 </script>
 
 <TerminalShell>

--- a/packages/investintell-ui/src/lib/tokens/terminal.css
+++ b/packages/investintell-ui/src/lib/tokens/terminal.css
@@ -136,6 +136,7 @@
 	/* Sacred calc() from feedback_layout_cage_pattern.md.     */
 	/* DO NOT migrate to flex/grid min-h-0 — proven broken.    */
 	--terminal-shell-topbar-height: 64px;
+	--terminal-shell-breadcrumb-height: 28px;
 	--terminal-shell-statusbar-height: 24px;
 	--terminal-shell-cage-height: calc(100vh - 88px);
 	--terminal-shell-cage-padding: 24px;


### PR DESCRIPTION
Sub-PR **3 of 4** from [docs/plans/2026-04-18-netz-terminal-parity.md](docs/plans/2026-04-18-netz-terminal-parity.md) §G.

**Base:** `feat/terminal-ui-primitives` (PR-2 #226) — consumes `TerminalDensityToggle`, `TerminalAccentPicker`, `TerminalThemeToggle`, `TerminalPill`, `TerminalKbd` + `formatMonoTime` shipped in PRs #225 / #226.

## Summary
Wires the shell with runtime tweaks, a persistent breadcrumb row, and swaps the status-bar clock to the tokenized mono formatter.

## New
- `frontends/wealth/src/lib/stores/terminal-tweaks.svelte.ts` — `$state`-backed store (density, accent, theme). In-memory only, no localStorage, no URL (scope decision #3).
- `TerminalBreadcrumb.svelte` — 28px row under TopNav: `Screener → Terminal → Macro → Builder`. `Alt+1..4` nav, active segment via `page.route.id` prefix match, SvelteKit preload-on-hover. Ignores editable focus targets.
- `TerminalTweaksPanel.svelte` — floating gear FAB (bottom-right, `z=toast`) + right-side drawer. `Shift+T` toggles; Escape closes; scrim click closes. Mounted at shell root **outside** `LayoutCage` to dodge the `:has()` padding override (§H risk #4).

## Edits
- `tokens/terminal.css` — adds `--terminal-shell-breadcrumb-height: 28px` to standard `:root` (compact override was already in PR-1).
- `TerminalShell.svelte` — grid rows `32px [breadcrumb] 1fr 28px`, new `ts-crumb-row` area, root carries `data-surface="terminal" + data-density/accent/theme`. Mounts `<TerminalTweaksPanel>`.
- `TerminalStatusBar.svelte` — `new Date().toISOString().substring(11,19)+' UTC'` → `formatMonoTime(new Date(), 'utc')`. Closes violation §E.4.
- `(terminal)/+layout.svelte` — creates tweaks store and sets context.

## Test plan
- [x] `pnpm -F netz-wealth-os check` — 0 new errors; only pre-existing `RiskBudgetPanel.test` vitest-types issue (verified unchanged on main)
- [x] `node scripts/check-terminal-tokens-sync.mjs` — 82/22/19 in sync
- [x] `pnpm -F @investintell/ui build` — passes
- [x] Drawer uses `<div role="dialog" aria-modal="true" tabindex="-1">` (avoids non-interactive `<aside>` a11y warning)

## Remaining scope for PR-4
`(terminal)/portfolio/live/+page.svelte` cleanup, regime drag-drop sim, MarketDataStore status → shell connectionStatus, dual-mode `TerminalPriceChart` (Candle/Line) + toolbar toggle, viewport-preservation series swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)