### PR TITLE
PR-4 terminal-parity: live page cleanup + WS status + timeframe widen

### DIFF
--- a/frontends/wealth/src/lib/components/portfolio/live/LiveWorkbenchShell.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/live/LiveWorkbenchShell.svelte
@@ -157,7 +157,7 @@
 	});
 
 	// ── Chart state ───────────────────────────────────────────
-	type Timeframe = "1D" | "1W" | "1M" | "3M";
+	type Timeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
 	let chartTimeframe = $state<Timeframe>("1M");
 	let mockLastTick = $state<LiveTick | null>(null);
 

--- a/frontends/wealth/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte
@@ -30,7 +30,7 @@
 		value: number;
 	}
 
-	type Timeframe = "1D" | "1W" | "1M" | "3M";
+	type Timeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
 	export type DataStatus = "live" | "delayed" | "offline";
 
 	interface Props {
@@ -58,6 +58,8 @@
 		{ id: "1W", label: "1W" },
 		{ id: "1M", label: "1M" },
 		{ id: "3M", label: "3M" },
+		{ id: "6M", label: "6M" },
+		{ id: "1Y", label: "1Y" },
 	];
 
 	// ── Chart state ($state for reactivity tracking) ──────────

--- a/frontends/wealth/src/lib/components/terminal/live/ChartToolbar.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/ChartToolbar.svelte
@@ -11,7 +11,7 @@
 	import { TERMINAL_MARKET_DATA_KEY } from "$lib/components/portfolio/live/workbench-state";
 	import { createClientApiClient } from "$lib/api/client";
 
-	type Timeframe = "1D" | "1W" | "1M" | "3M" | "1Y";
+	type Timeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
 
 	interface Props {
 		ticker: string;
@@ -37,7 +37,7 @@
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 	const api = createClientApiClient(getToken);
 
-	const TIMEFRAMES: Timeframe[] = ["1D", "1W", "1M", "3M", "1Y"];
+	const TIMEFRAMES: Timeframe[] = ["1D", "1W", "1M", "3M", "6M", "1Y"];
 
 	// Live price from MarketDataStore
 	const tickData = $derived<PriceTick | undefined>(

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
@@ -49,6 +49,9 @@
 		TERMINAL_TWEAKS_KEY,
 		type TerminalTweaks,
 	} from "$lib/stores/terminal-tweaks.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "$lib/components/portfolio/live/workbench-state";
+	import type { MarketDataStore, WsStatus } from "$lib/stores/market-data.svelte";
+	import type { TerminalStatusBarConnectionStatus } from "./TerminalStatusBar.svelte";
 	import TerminalContextRail, {
 		type TerminalContextRailEntity,
 		type TerminalContextRailEntityKind,
@@ -82,9 +85,24 @@
 	const userInitials = "AR";
 
 	// ─── Connection status ──────────────────────────────────────
-	// Part C hardcodes "connecting" since no streams are mounted.
-	// Phase 5+ will aggregate real TerminalStream subscriptions.
-	const connectionStatus = "connecting" as const;
+	// Aggregated from the terminal-scoped MarketDataStore WS state
+	// (context set by (terminal)/+layout.svelte). Routes without a
+	// market stream still see "connecting" as the bootstrap default.
+	const marketStore = getContext<MarketDataStore | undefined>(
+		TERMINAL_MARKET_DATA_KEY,
+	);
+
+	const WS_STATUS_MAP: Record<WsStatus, TerminalStatusBarConnectionStatus> = {
+		connecting: "connecting",
+		connected: "open",
+		reconnecting: "degraded",
+		disconnected: "closed",
+		error: "error",
+	};
+
+	const connectionStatus = $derived<TerminalStatusBarConnectionStatus>(
+		marketStore ? WS_STATUS_MAP[marketStore.status] : "connecting",
+	);
 
 	// ─── Tweaks (density / accent / theme) ─────────────────────
 	// Bound as data-attributes on the shell root so tokens shipped

--- a/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
@@ -14,6 +14,7 @@
 	import { resolve } from "$app/paths";
 	import { getContext } from "svelte";
 	import { PanelErrorState } from "@investintell/ui/runtime";
+	import { formatPpDrift } from "@investintell/ui";
 	import { createClientApiClient } from "$lib/api/client";
 	import type { MarketDataStore } from "$lib/stores/market-data.svelte";
 	import { TERMINAL_MARKET_DATA_KEY } from "$lib/components/portfolio/live/workbench-state";
@@ -224,7 +225,7 @@
 
 	// ---- Chart state ----
 
-	type Timeframe = "1D" | "1W" | "1M" | "3M" | "1Y";
+	type Timeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
 	let selectedTicker = $state<string | null>(null);
 	let chartTimeframe = $state<Timeframe>("1M");
 	let compareTicker = $state<string | null>(null);
@@ -492,14 +493,12 @@
 				const drift = f.actual_weight - f.target_weight;
 				const absDrift = Math.abs(drift);
 				const severity: "warning" | "critical" = absDrift >= 0.03 ? "critical" : "warning";
-				const pct = (absDrift * 100).toFixed(1);
-				const direction = drift > 0 ? "over" : "under";
 				return {
 					id: `drift-${f.instrument_id}`,
 					source: "drift_monitor",
 					alert_type: "drift_breach",
 					severity,
-					title: `${f.ticker} ${direction}weight by ${pct}pp`,
+					title: `${f.ticker} drift ${formatPpDrift(drift, 1)}`,
 					subtitle: null,
 					subject_kind: "instrument",
 					subject_id: f.instrument_id,
@@ -622,7 +621,7 @@
 						{historicalBars}
 						portfolioNavBars={effectiveNavBars}
 						{lastTick}
-						timeframe={chartTimeframe === "1Y" ? "3M" : chartTimeframe}
+						timeframe={chartTimeframe}
 						onTimeframeChange={handleTimeframeChange}
 						{dataStatus}
 					/>
@@ -714,7 +713,7 @@
 	.lw-shell {
 		display: grid;
 		grid-template-columns: 280px 1fr 280px;
-		height: calc(100vh - 88px);
+		height: var(--terminal-shell-cage-height);
 		background: var(--terminal-bg-void);
 		font-family: var(--terminal-font-mono);
 	}


### PR DESCRIPTION
Sub-PR **4 of 4** from [docs/plans/2026-04-18-netz-terminal-parity.md](docs/plans/2026-04-18-netz-terminal-parity.md) §G.

**Base:** `feat/terminal-shell-tweaks-and-breadcrumb` (PR-3 #227).

Closes the violations listed in plan §E and wires `MarketDataStore` status through to the status bar. Delivers the cleanup half of PR-4; the **dual-mode Candle/Line chart (§A.9)** is intentionally deferred to a follow-up PR because the current `TerminalPriceChart` uses `BaselineSeries` + NAV overlay (not candle+line), so converting it is a substantive refactor that belongs outside this cleanup pass.

## Violations closed (§E)
| Line | Before | After |
|---|---|---|
| `+page.svelte:495` | `(absDrift * 100).toFixed(1)` + manual `over/under` phrase | `formatPpDrift(drift, 1)` — signed, Unicode minus, tabular |
| `+page.svelte:625` | `timeframe={chartTimeframe === "1Y" ? "3M" : chartTimeframe}` coercion | Direct pass-through |
| `+page.svelte:717` | `height: calc(100vh - 88px)` literal | `var(--terminal-shell-cage-height)` token |

## Timeframe widening
All four `Timeframe` unions aligned to `1D|1W|1M|3M|6M|1Y`:
- `TerminalPriceChart.svelte` — adds `6M`, `1Y` to union + `TIMEFRAMES` array
- `ChartToolbar.svelte` — adds `6M`
- `LiveWorkbenchShell.svelte` — adds `6M`, `1Y`
- `(terminal)/portfolio/live/+page.svelte` — adds `6M`

Backend `/market-data/historical/:ticker` already returns OHLC so long-window fetch is not blocking (verified via existing `_tf` effect in `+page.svelte`).

## Shell connection status
`TerminalShell` now reads the terminal-scoped `MarketDataStore` via `TERMINAL_MARKET_DATA_KEY` context and maps `WsStatus` → `TerminalStatusBarConnectionStatus`:

| WsStatus | StatusBar |
|---|---|
| connecting | connecting |
| connected | open |
| reconnecting | degraded |
| disconnected | closed |
| error | error |

Routes without a market stream still see `connecting` at bootstrap. Uses `$derived` so the badge tracks WS state live.

## Explicitly deferred (not in this PR)
- Dual-mode (Candle|Line) `TerminalPriceChart` per §A.9 — needs swap from `BaselineSeries+NAV` to `Candlestick+Line`, visible-range preservation, local tick aggregation. Backend returns OHLC so it is feasible but the refactor is large.
- `ChartToolbar` chart-type toggle (paired with above).
- `MacroRegimePanel` drag-drop simulation — no downstream consumer exists yet; would produce dead feature without further wiring.
- Playwright smoke test.

## Test plan
- [x] `pnpm -F netz-wealth-os check` — 0 new errors; pre-existing `RiskBudgetPanel.test` vitest-types error unchanged (confirmed on `main`)
- [x] `node scripts/check-terminal-tokens-sync.mjs` — green
- [x] `pnpm -F @investintell/ui test` — 114/114 (unchanged by this PR)
- [ ] Visual QA in browser with Clerk session — deferred to Andrei

🤖 Generated with [Claude Code](https://claude.com/claude-code)