### PR TITLE
PR-5 terminal-parity: dual-mode Candle/Line chart + toolbar toggle

### DIFF
--- a/frontends/wealth/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte
@@ -32,25 +32,38 @@
 
 	type Timeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
 	export type DataStatus = "live" | "delayed" | "offline";
+	export type ChartMode = "candle" | "line";
+
+	export interface CandleBar {
+		time: number;
+		open: number;
+		high: number;
+		low: number;
+		close: number;
+	}
 
 	interface Props {
 		ticker: string;
 		historicalBars: BarData[];
+		candleBars?: CandleBar[];
 		lastTick: LiveTick | null;
 		portfolioNavBars: BarData[];
 		timeframe: Timeframe;
 		onTimeframeChange: (tf: Timeframe) => void;
 		dataStatus?: DataStatus;
+		mode?: ChartMode;
 	}
 
 	let {
 		ticker,
 		historicalBars,
+		candleBars = [],
 		lastTick,
 		portfolioNavBars,
 		timeframe,
 		onTimeframeChange,
 		dataStatus = "live",
+		mode = "line",
 	}: Props = $props();
 
 	const TIMEFRAMES: { id: Timeframe; label: string }[] = [
@@ -68,6 +81,10 @@
 	let series = $state<any>(null);
 	let navSeries = $state<any>(null);
 	let showNav = $state(true);
+	let lcModule = $state<typeof import("lightweight-charts") | null>(null);
+	let currentSeriesMode = $state<ChartMode | null>(null);
+	/** Last rolled candle — used to aggregate live ticks in candle mode. */
+	let currentCandle: CandleBar | null = null;
 
 	// ── Async chart initialization (SSR-safe) ─────────────────
 	onMount(() => {
@@ -83,18 +100,8 @@
 			});
 			const c = lc.createChart(containerEl, { autoSize: true, ...opts });
 
-			// Series 1: Instrument (baseline — cyan/red)
+			// Series 2: Portfolio NAV (amber line) — stable across mode swaps.
 			const sc = terminalLWSeriesColors();
-			const s = c.addSeries(lc.BaselineSeries, {
-				baseValue: { type: "price", price: 0 },
-				...sc.baseline,
-				lineWidth: 2,
-				priceLineVisible: true,
-				lastValueVisible: true,
-				title: "",
-			});
-
-			// Series 2: Portfolio NAV (amber line)
 			const nav = c.addSeries(lc.LineSeries, {
 				...sc.navOverlay,
 				lineWidth: 2,
@@ -105,8 +112,8 @@
 				lastValueVisible: true,
 			});
 
+			lcModule = lc;
 			chart = c;
-			series = s;
 			navSeries = nav;
 		})();
 
@@ -121,18 +128,135 @@
 		};
 	});
 
+	/**
+	 * Build the instrument series for the current `mode`. Creates the
+	 * baseline/candlestick series on the owning chart, seeds it with
+	 * the appropriate data source, and returns the handle. Keeps the
+	 * <div> container + IChartApi instance stable (plan §A.9 contract).
+	 */
+	function mountInstrumentSeries(lc: typeof import("lightweight-charts"), c: any, m: ChartMode) {
+		const sc = terminalLWSeriesColors();
+		if (m === "candle") {
+			const s = c.addSeries(lc.CandlestickSeries, {
+				upColor: "#22c55e",
+				downColor: "#ef4444",
+				borderUpColor: "#22c55e",
+				borderDownColor: "#ef4444",
+				wickUpColor: "#22c55e",
+				wickDownColor: "#ef4444",
+				priceLineVisible: true,
+				lastValueVisible: true,
+			});
+			return s;
+		}
+		const s = c.addSeries(lc.BaselineSeries, {
+			baseValue: { type: "price", price: 0 },
+			...sc.baseline,
+			lineWidth: 2,
+			priceLineVisible: true,
+			lastValueVisible: true,
+			title: "",
+		});
+		return s;
+	}
+
+	// ── Effect: mode swap (preserve visible range) ───────────
+	// Replaces the instrument series in place when mode changes.
+	// Captures the visible range BEFORE removing the old series and
+	// restores it after the new series is seeded, so the viewport
+	// does not reset on toggle (plan §A.9).
+	$effect(() => {
+		const lc = lcModule;
+		const c = chart;
+		const m = mode;
+		if (!lc || !c) return;
+		if (currentSeriesMode === m && series !== null) return;
+
+		const priorRange = (() => {
+			try {
+				return c.timeScale().getVisibleRange();
+			} catch {
+				return null;
+			}
+		})();
+
+		if (series !== null) {
+			try {
+				c.removeSeries(series);
+			} catch {
+				// If removal fails (e.g. disposed chart), bail — the
+				// next onMount cycle will rebuild from scratch.
+				return;
+			}
+		}
+
+		const next = mountInstrumentSeries(lc, c, m);
+
+		// Swap price-scale mode per series type: percentage for the
+		// baseline line (% change vs first bar), normal for candles
+		// (absolute OHLC values).
+		c.applyOptions({
+			rightPriceScale: {
+				mode: m === "candle" ? lc.PriceScaleMode.Normal : lc.PriceScaleMode.Percentage,
+			},
+		});
+
+		// Seed with data appropriate for the mode.
+		if (m === "candle" && candleBars.length) {
+			next.setData(candleBars);
+			currentCandle = candleBars[candleBars.length - 1] ?? null;
+		} else if (m === "line" && historicalBars.length) {
+			next.applyOptions({
+				baseValue: { type: "price", price: historicalBars[0]!.value },
+			});
+			next.setData(historicalBars);
+			currentCandle = null;
+		}
+
+		// Restore the user's viewport if one existed.
+		if (priorRange) {
+			try {
+				c.timeScale().setVisibleRange(priorRange);
+			} catch {
+				// Ranges can mismatch if the two datasets have
+				// different domains; fall back to fit.
+				c.timeScale().fitContent();
+			}
+		} else {
+			c.timeScale().fitContent();
+		}
+
+		series = next;
+		currentSeriesMode = m;
+	});
+
 	// ── Effect 1: Historical instrument bars ─────────────────
+	// Reseed when the underlying bars array changes AND the current
+	// series matches mode=line. The mode-swap effect above handles
+	// the cross-mode reseed path.
 	$effect(() => {
 		const s = series;
 		const c = chart;
 		const bars = historicalBars;
-		if (!s || !c || !bars.length) return;
+		if (!s || !c || mode !== "line" || !bars.length) return;
+		if (currentSeriesMode !== "line") return;
 
 		s.applyOptions({
 			baseValue: { type: "price", price: bars[0]!.value },
 		});
 		s.setData(bars);
-		c.timeScale().fitContent();
+	});
+
+	// ── Effect 1b: Historical candle bars ────────────────────
+	$effect(() => {
+		const s = series;
+		const c = chart;
+		const bars = candleBars;
+		if (!s || !c || mode !== "candle" || !bars.length) return;
+		if (currentSeriesMode !== "candle") return;
+
+		s.setData(bars);
+		currentCandle = bars[bars.length - 1] ?? null;
 	});
 
 	// ── Effect 2: Portfolio NAV bars ─────────────────────────
@@ -147,9 +271,12 @@
 	});
 
 	// ── Effect 3: NAV visibility toggle ──────────────────────
+	// NAV is hidden in candle mode because the price axis switches to
+	// absolute values — a percent-baselined NAV line on an absolute
+	// OHLC axis is visually misleading.
 	$effect(() => {
 		const ns = navSeries;
-		const visible = showNav;
+		const visible = showNav && mode === "line";
 		if (!ns) return;
 		ns.applyOptions({ visible });
 	});
@@ -159,7 +286,31 @@
 		const s = series;
 		const tick = lastTick;
 		if (!s || !tick) return;
-		s.update({ time: tick.time, value: tick.value });
+
+		if (mode === "line") {
+			s.update({ time: tick.time, value: tick.value });
+			return;
+		}
+
+		// Candle mode: aggregate tick into the current bar. If the
+		// tick timestamp advances past the current bar, roll a new
+		// candle seeded from the prior close. This mirrors plan §A.9
+		// "local tick aggregation" until a dedicated 1m-bars stream
+		// exists on the backend.
+		const price = tick.value;
+		const t = tick.time;
+		if (!currentCandle || t > currentCandle.time) {
+			const open = currentCandle?.close ?? price;
+			currentCandle = { time: t, open, high: price, low: price, close: price };
+		} else {
+			currentCandle = {
+				...currentCandle,
+				high: Math.max(currentCandle.high, price),
+				low: Math.min(currentCandle.low, price),
+				close: price,
+			};
+		}
+		s.update(currentCandle);
 	});
 
 	function toggleNav() {

--- a/frontends/wealth/src/lib/components/terminal/live/ChartToolbar.svelte
+++ b/frontends/wealth/src/lib/components/terminal/live/ChartToolbar.svelte
@@ -6,12 +6,13 @@
 -->
 <script lang="ts">
 	import { getContext } from "svelte";
-	import { formatCurrency, formatPercent } from "@investintell/ui";
+	import { formatCurrency, formatPercent, TerminalPill } from "@investintell/ui";
 	import type { MarketDataStore, PriceTick } from "$lib/stores/market-data.svelte";
 	import { TERMINAL_MARKET_DATA_KEY } from "$lib/components/portfolio/live/workbench-state";
 	import { createClientApiClient } from "$lib/api/client";
 
 	type Timeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
+	export type ChartMode = "candle" | "line";
 
 	interface Props {
 		ticker: string;
@@ -21,6 +22,8 @@
 		onCompare: (ticker: string) => void;
 		compareTicker: string | null;
 		onClearCompare: () => void;
+		mode?: ChartMode;
+		onModeChange?: (m: ChartMode) => void;
 	}
 
 	let {
@@ -31,6 +34,8 @@
 		onCompare,
 		compareTicker,
 		onClearCompare,
+		mode = "line",
+		onModeChange,
 	}: Props = $props();
 
 	const marketStore = getContext<MarketDataStore>(TERMINAL_MARKET_DATA_KEY);
@@ -38,6 +43,44 @@
 	const api = createClientApiClient(getToken);
 
 	const TIMEFRAMES: Timeframe[] = ["1D", "1W", "1M", "3M", "6M", "1Y"];
+
+	const CHART_MODES: { id: ChartMode; label: string }[] = [
+		{ id: "candle", label: "CANDLE" },
+		{ id: "line", label: "LINE" },
+	];
+
+	function setMode(m: ChartMode) {
+		if (onModeChange) onModeChange(m);
+	}
+
+	function isEditableTarget(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		const tag = target.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+		if (target.isContentEditable) return true;
+		const role = target.getAttribute("role");
+		if (role === "textbox" || role === "searchbox" || role === "combobox") {
+			return true;
+		}
+		return false;
+	}
+
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const handler = (event: KeyboardEvent) => {
+			if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+			if (isEditableTarget(event.target)) return;
+			if (event.key === "c" || event.key === "C") {
+				event.preventDefault();
+				setMode("candle");
+			} else if (event.key === "l" || event.key === "L") {
+				event.preventDefault();
+				setMode("line");
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	});
 
 	// Live price from MarketDataStore
 	const tickData = $derived<PriceTick | undefined>(
@@ -107,6 +150,23 @@
 
 	<!-- Right: controls -->
 	<div class="ct-controls">
+		<!-- Chart type toggle (Candle | Line) -->
+		<div class="ct-mode" role="radiogroup" aria-label="Chart type">
+			{#each CHART_MODES as cm (cm.id)}
+				<TerminalPill
+					as="button"
+					label={cm.label}
+					tone={mode === cm.id ? "accent" : "neutral"}
+					pressed={mode === cm.id}
+					size="sm"
+					ariaLabel={`Chart type ${cm.label}`}
+					onclick={() => setMode(cm.id)}
+				/>
+			{/each}
+		</div>
+
+		<span class="ct-divider"></span>
+
 		<!-- Timeframe pills -->
 		<div class="ct-timeframes" role="group" aria-label="Timeframe">
 			{#each TIMEFRAMES as tf}
@@ -237,6 +297,12 @@
 		width: 1px;
 		height: 16px;
 		background: var(--terminal-fg-muted);
+	}
+
+	/* -- Chart mode toggle -- */
+	.ct-mode {
+		display: inline-flex;
+		gap: var(--terminal-space-1);
 	}
 
 	/* -- Timeframes -- */

--- a/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/portfolio/live/+page.svelte
@@ -226,8 +226,10 @@
 	// ---- Chart state ----
 
 	type Timeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
+	type ChartMode = "candle" | "line";
 	let selectedTicker = $state<string | null>(null);
 	let chartTimeframe = $state<Timeframe>("1M");
+	let chartMode = $state<ChartMode>("line");
 	let compareTicker = $state<string | null>(null);
 
 	// Reset selection when portfolio changes
@@ -252,7 +254,15 @@
 	});
 
 	// Historical bars from REST quote endpoint
+	interface CandleBar {
+		time: number;
+		open: number;
+		high: number;
+		low: number;
+		close: number;
+	}
 	let historicalBars = $state<BarData[]>([]);
+	let candleBars = $state<CandleBar[]>([]);
 	let portfolioNavBars = $state<BarData[]>([]);
 
 	$effect(() => {
@@ -271,15 +281,30 @@
 		}>(`/market-data/historical/${encodeURIComponent(t)}`)
 			.then((res) => {
 				if (cancelled) return;
-				historicalBars = (res.bars ?? [])
-					.filter((b) => b.close != null)
-					.map((b) => ({
+				const raw = (res.bars ?? []).filter((b) => b.close != null);
+				historicalBars = raw.map((b) => ({
+					time: Math.floor(new Date(b.timestamp).getTime() / 1000),
+					value: Number(b.close),
+				}));
+				// Candle bars require full OHLC. Fall back to the close
+				// price when open/high/low are missing so candle mode
+				// still renders (degenerate doji rather than a gap).
+				candleBars = raw.map((b) => {
+					const close = Number(b.close);
+					return {
 						time: Math.floor(new Date(b.timestamp).getTime() / 1000),
-						value: Number(b.close),
-					}));
+						open: b.open != null ? Number(b.open) : close,
+						high: b.high != null ? Number(b.high) : close,
+						low: b.low != null ? Number(b.low) : close,
+						close,
+					};
+				});
 			})
 			.catch(() => {
-				if (!cancelled) historicalBars = [];
+				if (!cancelled) {
+					historicalBars = [];
+					candleBars = [];
+				}
 			});
 		return () => {
 			cancelled = true;
@@ -612,6 +637,8 @@
 						onCompare={handleCompare}
 						{compareTicker}
 						onClearCompare={handleClearCompare}
+						mode={chartMode}
+						onModeChange={(m) => (chartMode = m)}
 					/>
 				</div>
 
@@ -619,11 +646,13 @@
 					<TerminalPriceChart
 						ticker={effectiveTicker}
 						{historicalBars}
+						{candleBars}
 						portfolioNavBars={effectiveNavBars}
 						{lastTick}
 						timeframe={chartTimeframe}
 						onTimeframeChange={handleTimeframeChange}
 						{dataStatus}
+						mode={chartMode}
 					/>
 				</section>
 


### PR DESCRIPTION
Sub-PR **5 of 5** from [docs/plans/2026-04-18-netz-terminal-parity.md](docs/plans/2026-04-18-netz-terminal-parity.md) §A.9 — the deferred half of original PR-4. Chart now flips between a baseline-line view and a full OHLC candlestick view without remounting the chart container or resetting the viewport.

**Base:** `feat/terminal-live-parity-and-cleanup` (PR-4 #228).

## `TerminalPriceChart`
- `mode: 'candle' | 'line'` prop (default `'line'` → existing callers unchanged) + optional `candleBars: CandleBar[]`.
- `mountInstrumentSeries()` helper creates the correct series type for the current mode. `onMount` now only provisions the NAV overlay line — the instrument series is (re)created by a dedicated **mode-swap `$effect`** so the swap is hot-path without chart reinit.
- **Mode-swap contract (plan §A.9):** captures `timeScale().getVisibleRange()` BEFORE `removeSeries`, creates the new series, seeds it, then restores the visible range (fallback to `fitContent()` if the new domain rejects the old range). The `<div>` container + `IChartApi` instance stay stable — no flicker, no remount.
- Price-scale mode switches with the series type:
  - `line` → `PriceScaleMode.Percentage` (existing baseline behavior)
  - `candle` → `PriceScaleMode.Normal` (absolute OHLC)
- NAV overlay auto-hides in candle mode (percent-baselined NAV on an absolute OHLC axis is visually misleading; overlay reappears when flipping back to line).
- Live tick handling:
  - line mode → `series.update({ time, value })` (unchanged)
  - candle mode → aggregate tick into `currentCandle`; roll a new bar when the tick timestamp advances past the prior close. Plan §A.9 local aggregation until a dedicated 1m-bars stream lands.

## `ChartToolbar`
- `mode` + `onModeChange` props.
- Renders `CANDLE | LINE` as a `role="radiogroup"` of `TerminalPill as="button"` with `aria-pressed` reflecting `mode`. Inherits all terminal tokens from PR-2.
- Keyboard: `C` / `L` flip the mode. Suppressed inside `input / textarea / contenteditable / role=textbox|searchbox|combobox` (same detector used by TerminalShell + TweaksPanel).

## Live page
- `chartMode = $state<ChartMode>('line')` — in-memory only, matches Tweaks-panel policy (no localStorage, no URL).
- Parallel `candleBars` state built from the same REST response that already returns OHLC. Null `open/high/low` fall back to `close` so candle mode renders a doji rather than a gap.
- Pipes `mode` + `onModeChange` → ChartToolbar, `mode` + `candleBars` → TerminalPriceChart.

## Scope intentionally out
- **Playwright smoke** for the toggle — wealth has no working vitest/Playwright rig yet (existing `RiskBudgetPanel.test.ts` broken on `main` for missing types). svelte-check + visual QA cover this PR; harnessing wealth tests is a separate workstream.
- **MacroRegimePanel drag-drop simulation** — still deferred until a downstream consumer exists.

## Test plan
- [x] `pnpm -F netz-wealth-os check` → 0 new errors; pre-existing `RiskBudgetPanel.test` vitest-types issue unchanged
- [x] `pnpm -F @investintell/ui test` → 114/114 (unchanged)
- [ ] Visual QA in browser with Clerk session — swap CANDLE ↔ LINE, verify zero flicker + preserved viewport — deferred to Andrei

## Full stack
#225 (PR-1 tokens/formatters) ← #226 (PR-2 primitives) ← #227 (PR-3 shell tweaks/breadcrumb) ← #228 (PR-4 live cleanup) ← **this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)