### PR TITLE
PR-3 terminal-parity: shell tweaks panel + breadcrumb + mono clock

### DIFF
--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalBreadcrumb.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalBreadcrumb.svelte
@@ -1,0 +1,143 @@
+<!--
+	TerminalBreadcrumb.svelte
+	=========================
+
+	28px persistent row rendered BETWEEN TerminalTopNav and LayoutCage.
+	Segments: Screener → Terminal → Macro → Builder. Each is an <a>
+	with SvelteKit preload. Active segment matches page.route.id.
+
+	Keyboard: Alt+1..4 jumps to each segment. Ignored when focus is in
+	an editable field. Namespace does not collide with CommandPalette
+	go-to sequences (g-prefix) or palette shortcut (Cmd+K).
+
+	Source: docs/plans/2026-04-18-netz-terminal-parity.md §A.4, §C.1.
+-->
+<script lang="ts">
+	import { page } from "$app/state";
+	import { goto } from "$app/navigation";
+
+	interface Segment {
+		key: string;
+		label: string;
+		href: string;
+		/** Path prefix used to resolve the active state against page.route.id. */
+		match: string;
+	}
+
+	const segments: Segment[] = [
+		{ key: "screener", label: "SCREENER", href: "/terminal-screener", match: "/terminal-screener" },
+		{ key: "terminal", label: "TERMINAL", href: "/portfolio/live", match: "/portfolio/live" },
+		{ key: "macro", label: "MACRO", href: "/macro", match: "/macro" },
+		{ key: "builder", label: "BUILDER", href: "/portfolio/builder", match: "/portfolio/builder" },
+	];
+
+	const activeKey = $derived.by(() => {
+		const path = page.url.pathname;
+		for (const seg of segments) {
+			if (path.startsWith(seg.match)) return seg.key;
+		}
+		return null;
+	});
+
+	function isEditableTarget(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		const tag = target.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+		if (target.isContentEditable) return true;
+		const role = target.getAttribute("role");
+		if (role === "textbox" || role === "searchbox" || role === "combobox") {
+			return true;
+		}
+		return false;
+	}
+
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const handler = (event: KeyboardEvent) => {
+			if (!event.altKey || event.metaKey || event.ctrlKey || event.shiftKey) return;
+			if (isEditableTarget(event.target)) return;
+			const idx = Number.parseInt(event.key, 10);
+			if (Number.isNaN(idx) || idx < 1 || idx > segments.length) return;
+			event.preventDefault();
+			const target = segments[idx - 1];
+			if (!target) return;
+			// Route hrefs are string-typed here (mapped from segments[]),
+			// so resolve() type inference narrows to never. Cast keeps
+			// the runtime behavior identical and svelte-check quiet.
+			void goto(target.href as Parameters<typeof goto>[0]);
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	});
+</script>
+
+<nav class="tb-crumb" aria-label="Terminal sections">
+	{#each segments as seg, i (seg.key)}
+		{#if i > 0}
+			<span class="tb-sep" aria-hidden="true">›</span>
+		{/if}
+		<a
+			class="tb-link"
+			class:is-active={activeKey === seg.key}
+			href={seg.href}
+			data-sveltekit-preload-data="hover"
+			aria-current={activeKey === seg.key ? "page" : undefined}
+		>
+			<span class="tb-alt" aria-hidden="true">{i + 1}</span>
+			<span class="tb-label">{seg.label}</span>
+		</a>
+	{/each}
+</nav>
+
+<style>
+	.tb-crumb {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		height: var(--terminal-shell-breadcrumb-height, 28px);
+		padding: 0 var(--terminal-space-4);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		overflow: hidden;
+		white-space: nowrap;
+	}
+
+	.tb-link {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		text-decoration: none;
+		padding: 0 var(--terminal-space-2);
+		height: 100%;
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.tb-link:hover {
+		color: var(--terminal-fg-primary);
+	}
+	.tb-link.is-active {
+		color: var(--terminal-accent-amber);
+		border-bottom: 1px solid var(--terminal-accent-amber);
+	}
+	.tb-link:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -2px;
+	}
+
+	.tb-alt {
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+	}
+	.tb-link.is-active .tb-alt {
+		color: var(--terminal-accent-amber-dim);
+	}
+
+	.tb-sep {
+		color: var(--terminal-fg-muted);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
@@ -42,7 +42,13 @@
 	import { resolve } from "$app/paths";
 	import { createClientApiClient } from "$lib/api/client";
 	import TerminalTopNav from "./TerminalTopNav.svelte";
+	import TerminalBreadcrumb from "./TerminalBreadcrumb.svelte";
+	import TerminalTweaksPanel from "./TerminalTweaksPanel.svelte";
 	import TerminalStatusBar from "./TerminalStatusBar.svelte";
+	import {
+		TERMINAL_TWEAKS_KEY,
+		type TerminalTweaks,
+	} from "$lib/stores/terminal-tweaks.svelte";
 	import TerminalContextRail, {
 		type TerminalContextRailEntity,
 		type TerminalContextRailEntityKind,
@@ -79,6 +85,12 @@
 	// Part C hardcodes "connecting" since no streams are mounted.
 	// Phase 5+ will aggregate real TerminalStream subscriptions.
 	const connectionStatus = "connecting" as const;
+
+	// ─── Tweaks (density / accent / theme) ─────────────────────
+	// Bound as data-attributes on the shell root so tokens shipped
+	// in @investintell/ui/tokens/terminal.css activate via attribute
+	// selectors. Store is populated by (terminal)/+layout.svelte.
+	const tweaks = getContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY);
 
 	// ─── DD queue badge count ───────────────────────────────────
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
@@ -277,7 +289,14 @@
 	<AlertTicker />
 {/snippet}
 
-<div class="ts-shell" class:ts-shell--has-rail={entity !== null}>
+<div
+	class="ts-shell"
+	class:ts-shell--has-rail={entity !== null}
+	data-surface="terminal"
+	data-density={tweaks?.density ?? "standard"}
+	data-accent={tweaks?.accent ?? "amber"}
+	data-theme={tweaks?.theme ?? "dark"}
+>
 	<div class="ts-nav-row">
 		<TerminalTopNav
 			activePath={page.url.pathname}
@@ -286,6 +305,10 @@
 			{userInitials}
 			{orgName}
 		/>
+	</div>
+
+	<div class="ts-crumb-row">
+		<TerminalBreadcrumb />
 	</div>
 
 	<main class="ts-content">
@@ -313,16 +336,18 @@
 </div>
 
 <CommandPalette bind:open={paletteOpen} />
+<TerminalTweaksPanel />
 
 <style>
 	.ts-shell {
 		position: fixed;
 		inset: 0;
 		display: grid;
-		grid-template-rows: 32px 1fr 28px;
+		grid-template-rows: 32px var(--terminal-shell-breadcrumb-height, 28px) 1fr 28px;
 		grid-template-columns: 1fr;
 		grid-template-areas:
 			"nav"
+			"crumb"
 			"content"
 			"status";
 		height: 100dvh;
@@ -338,12 +363,18 @@
 		grid-template-columns: 1fr 280px;
 		grid-template-areas:
 			"nav nav"
+			"crumb crumb"
 			"content rail"
 			"status status";
 	}
 
 	.ts-nav-row {
 		grid-area: nav;
+		min-width: 0;
+	}
+
+	.ts-crumb-row {
+		grid-area: crumb;
 		min-width: 0;
 	}
 

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalStatusBar.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalStatusBar.svelte
@@ -25,6 +25,7 @@
 -->
 <script lang="ts">
 	import type { Snippet } from "svelte";
+	import { formatMonoTime } from "@investintell/ui";
 
 	export type TerminalStatusBarConnectionStatus =
 		| "connecting"
@@ -81,14 +82,14 @@
 
 	let utcClock = $state("--:--:-- UTC");
 
-	// 1Hz UTC clock. ISO extraction is locale-independent, so it does
-	// not route through @investintell/ui formatters (those handle
-	// currency / percent / date, not raw ISO time). `$effect` cleanup
-	// guarantees the interval stops when the shell unmounts.
+	// 1Hz UTC clock via the mono formatter from @investintell/ui. The
+	// formatter is tabular-safe (zero-padded HH:MM:SS) and locale-
+	// independent. `$effect` cleanup guarantees the interval stops
+	// when the shell unmounts.
 	$effect(() => {
 		if (typeof window === "undefined") return;
 		const tick = () => {
-			utcClock = new Date().toISOString().substring(11, 19) + " UTC";
+			utcClock = formatMonoTime(new Date(), "utc");
 		};
 		tick();
 		const interval = window.setInterval(tick, 1000);

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalTweaksPanel.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalTweaksPanel.svelte
@@ -1,0 +1,252 @@
+<!--
+	TerminalTweaksPanel.svelte
+	==========================
+
+	Floating gear button (bottom-right) + right-side drawer with density,
+	accent, and theme toggles. Reads/writes the terminal-tweaks store
+	wired via context at (terminal)/+layout.svelte.
+
+	Source: docs/plans/2026-04-18-netz-terminal-parity.md §C.2.
+
+	Keyboard: Shift+T toggles open/close. Ignored inside editable fields.
+	Mount location: TerminalShell root (OUTSIDE LayoutCage) so the drawer
+	is unaffected by the cage padding override pattern — see plan §H risk #4.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import {
+		TerminalAccentPicker,
+		TerminalDensityToggle,
+		TerminalPill,
+		TerminalThemeToggle,
+		TerminalKbd,
+	} from "@investintell/ui";
+	import {
+		TERMINAL_TWEAKS_KEY,
+		type TerminalTweaks,
+	} from "$lib/stores/terminal-tweaks.svelte";
+
+	const tweaks = getContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY);
+
+	let open = $state(false);
+
+	function isEditableTarget(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		const tag = target.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+		if (target.isContentEditable) return true;
+		const role = target.getAttribute("role");
+		if (role === "textbox" || role === "searchbox" || role === "combobox") {
+			return true;
+		}
+		return false;
+	}
+
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const handler = (event: KeyboardEvent) => {
+			if (
+				event.shiftKey &&
+				!event.metaKey &&
+				!event.ctrlKey &&
+				!event.altKey &&
+				(event.key === "T" || event.key === "t")
+			) {
+				if (isEditableTarget(event.target)) return;
+				event.preventDefault();
+				open = !open;
+			} else if (event.key === "Escape" && open) {
+				open = false;
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	});
+</script>
+
+<button
+	type="button"
+	class="tweaks-fab"
+	aria-label="Open terminal tweaks (Shift+T)"
+	aria-expanded={open}
+	aria-controls="terminal-tweaks-drawer"
+	onclick={() => (open = !open)}
+>
+	<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+		<path
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.25"
+			d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Zm5.6 2.5a5.7 5.7 0 0 0-.1-1l1.3-1-1.3-2.3-1.6.5a5.6 5.6 0 0 0-1.7-1L9.8 1H7.2l-.4 1.7a5.6 5.6 0 0 0-1.7 1l-1.6-.5-1.3 2.3 1.3 1a5.7 5.7 0 0 0 0 2l-1.3 1 1.3 2.3 1.6-.5a5.6 5.6 0 0 0 1.7 1l.4 1.7h2.6l.4-1.7a5.6 5.6 0 0 0 1.7-1l1.6.5 1.3-2.3-1.3-1c.1-.3.1-.7.1-1Z"
+		/>
+	</svg>
+</button>
+
+{#if open}
+	<div
+		class="tweaks-scrim"
+		aria-hidden="true"
+		role="presentation"
+		onclick={() => (open = false)}
+		onkeydown={(e) => {
+			if (e.key === "Enter" || e.key === " ") open = false;
+		}}
+	></div>
+	<div
+		id="terminal-tweaks-drawer"
+		class="tweaks-drawer"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Terminal tweaks"
+		tabindex="-1"
+	>
+		<header class="tweaks-header">
+			<span class="tweaks-title">TWEAKS</span>
+			<span class="tweaks-shortcut">
+				<TerminalKbd keys={["Shift", "T"]} />
+			</span>
+			<button
+				type="button"
+				class="tweaks-close"
+				aria-label="Close"
+				onclick={() => (open = false)}
+			>
+				×
+			</button>
+		</header>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">DENSITY</div>
+			<TerminalDensityToggle
+				value={tweaks.density}
+				onChange={(v) => tweaks.setDensity(v)}
+			/>
+		</section>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">ACCENT</div>
+			<TerminalAccentPicker
+				value={tweaks.accent}
+				onChange={(v) => tweaks.setAccent(v)}
+			/>
+		</section>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">THEME</div>
+			<TerminalThemeToggle
+				value={tweaks.theme}
+				onChange={(v) => tweaks.setTheme(v)}
+			/>
+		</section>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">LIVE SIM</div>
+			<TerminalPill label="OFF" tone="neutral" size="sm" />
+		</section>
+	</div>
+{/if}
+
+<style>
+	.tweaks-fab {
+		position: fixed;
+		bottom: calc(var(--terminal-shell-statusbar-height) + var(--terminal-space-3));
+		right: var(--terminal-space-3);
+		z-index: var(--terminal-z-toast);
+		width: 32px;
+		height: 32px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-fg-secondary);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		cursor: pointer;
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.tweaks-fab:hover {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+	.tweaks-fab:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.tweaks-scrim {
+		position: fixed;
+		inset: 0;
+		background: var(--terminal-bg-scrim);
+		z-index: calc(var(--terminal-z-toast) - 1);
+	}
+
+	.tweaks-drawer {
+		position: fixed;
+		top: var(--terminal-shell-topbar-height);
+		right: 0;
+		bottom: var(--terminal-shell-statusbar-height);
+		width: 320px;
+		background: var(--terminal-bg-panel);
+		border-left: var(--terminal-border-strong);
+		z-index: var(--terminal-z-toast);
+		padding: var(--terminal-space-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-6);
+		overflow-y: auto;
+		font-family: var(--terminal-font-mono);
+	}
+
+	.tweaks-header {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding-bottom: var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.tweaks-title {
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-primary);
+		text-transform: uppercase;
+		flex: 1;
+	}
+	.tweaks-shortcut {
+		display: inline-flex;
+	}
+	.tweaks-close {
+		width: 20px;
+		height: 20px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: transparent;
+		color: var(--terminal-fg-tertiary);
+		border: var(--terminal-border-hairline);
+		font-size: var(--terminal-text-14);
+		line-height: 1;
+		cursor: pointer;
+	}
+	.tweaks-close:hover {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+	}
+	.tweaks-close:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.tweaks-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+	}
+	.tweaks-section__label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+</style>

--- a/frontends/wealth/src/lib/stores/terminal-tweaks.svelte.ts
+++ b/frontends/wealth/src/lib/stores/terminal-tweaks.svelte.ts
@@ -1,0 +1,56 @@
+/**
+ * Terminal runtime tweaks — density / accent / theme.
+ *
+ * In-memory only. No localStorage, no URL param. Resets on
+ * hard reload (confirmed trade-off per plan scope-decision #3:
+ * docs/plans/2026-04-18-netz-terminal-parity.md §0).
+ *
+ * Usage:
+ *   const tweaks = createTerminalTweaks();
+ *   setContext(TERMINAL_TWEAKS_KEY, tweaks);
+ *   ...
+ *   const tweaks = getContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY);
+ *
+ * The TerminalShell binds `data-density`, `data-accent`, `data-theme`
+ * onto its root element so the @investintell/ui tokens shipped in
+ * PR-1 activate via attribute selectors.
+ */
+
+import type { Accent, Density, TerminalTheme } from "@investintell/ui";
+
+export const TERMINAL_TWEAKS_KEY = Symbol("netz:terminal-tweaks");
+
+export interface TerminalTweaks {
+	readonly density: Density;
+	readonly accent: Accent;
+	readonly theme: TerminalTheme;
+	setDensity(v: Density): void;
+	setAccent(v: Accent): void;
+	setTheme(v: TerminalTheme): void;
+}
+
+export function createTerminalTweaks(): TerminalTweaks {
+	let density = $state<Density>("standard");
+	let accent = $state<Accent>("amber");
+	let theme = $state<TerminalTheme>("dark");
+	return {
+		get density() {
+			return density;
+		},
+		get accent() {
+			return accent;
+		},
+		get theme() {
+			return theme;
+		},
+		setDensity(v) {
+			density = v;
+		},
+		setAccent(v) {
+			accent = v;
+		},
+		setTheme(v) {
+			theme = v;
+		},
+	};
+}

--- a/frontends/wealth/src/routes/(terminal)/+layout.svelte
+++ b/frontends/wealth/src/routes/(terminal)/+layout.svelte
@@ -28,6 +28,11 @@
 	} from "$lib/stores/market-data.svelte";
 	import { TERMINAL_MARKET_DATA_KEY } from "$lib/components/portfolio/live/workbench-state";
 	import TerminalShell from "$lib/components/terminal/shell/TerminalShell.svelte";
+	import {
+		createTerminalTweaks,
+		TERMINAL_TWEAKS_KEY,
+		type TerminalTweaks,
+	} from "$lib/stores/terminal-tweaks.svelte";
 
 	let { children }: { children: Snippet } = $props();
 
@@ -38,6 +43,12 @@
 	// the (app) dashboard's store.
 	const marketStore = createMarketDataStore({ getToken });
 	setContext<MarketDataStore>(TERMINAL_MARKET_DATA_KEY, marketStore);
+
+	// Terminal runtime tweaks (density / accent / theme). In-memory,
+	// session-scoped. Consumed by TerminalShell (data-attrs) and
+	// TerminalTweaksPanel (UI controls).
+	const tweaks = createTerminalTweaks();
+	setContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY, tweaks);
 </script>
 
 <TerminalShell>

--- a/packages/investintell-ui/package.json
+++ b/packages/investintell-ui/package.json
@@ -71,6 +71,8 @@
   "dependencies": {
     "@fontsource-variable/urbanist": "^5.0.0",
     "@fontsource-variable/geist-mono": "^5.0.0",
+    "@fontsource/ibm-plex-mono": "^5.0.0",
+    "@fontsource/ibm-plex-sans": "^5.0.0",
     "@internationalized/date": "^3.12.0",
     "@tanstack/table-core": "^8.21.3",
     "bits-ui": "^2.16.4",

--- a/packages/investintell-ui/src/lib/components/terminal/AccentPicker.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/AccentPicker.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	export type Accent = "amber" | "cyan" | "violet";
+
+	interface Props {
+		value: Accent;
+		onChange: (v: Accent) => void;
+		class?: string;
+	}
+
+	let { value, onChange, class: className }: Props = $props();
+
+	const options: { label: string; val: Accent }[] = [
+		{ label: "AMBER", val: "amber" },
+		{ label: "CYAN", val: "cyan" },
+		{ label: "VIOLET", val: "violet" },
+	];
+</script>
+
+<div class="terminal-accent-picker {className ?? ''}" role="radiogroup" aria-label="Accent">
+	{#each options as opt (opt.val)}
+		<button
+			type="button"
+			class="terminal-accent-swatch terminal-accent-swatch--{opt.val}"
+			class:is-active={value === opt.val}
+			aria-pressed={value === opt.val}
+			aria-label={`Accent ${opt.label}`}
+			onclick={() => onChange(opt.val)}
+		>
+			<span class="terminal-accent-dot" aria-hidden="true"></span>
+			<span class="terminal-accent-label">{opt.label}</span>
+		</button>
+	{/each}
+</div>
+
+<style>
+	.terminal-accent-picker {
+		display: inline-flex;
+		gap: var(--terminal-space-1);
+	}
+
+	.terminal-accent-swatch {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		height: 20px;
+		background: var(--terminal-bg-panel-raised);
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-secondary);
+		cursor: pointer;
+		line-height: 1;
+	}
+
+	.terminal-accent-swatch:hover {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+	}
+
+	.terminal-accent-swatch.is-active {
+		color: var(--terminal-fg-primary);
+		background: var(--terminal-bg-panel-sunken);
+	}
+
+	.terminal-accent-swatch:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.terminal-accent-dot {
+		width: 8px;
+		height: 8px;
+		display: inline-block;
+		border-radius: 50%;
+	}
+	.terminal-accent-swatch--amber .terminal-accent-dot {
+		background: var(--terminal-accent-amber);
+	}
+	.terminal-accent-swatch--cyan .terminal-accent-dot {
+		background: var(--terminal-accent-cyan);
+	}
+	.terminal-accent-swatch--violet .terminal-accent-dot {
+		background: var(--terminal-accent-violet);
+	}
+
+	.terminal-accent-swatch.is-active {
+		border-color: var(--terminal-accent-amber);
+	}
+</style>

--- a/packages/investintell-ui/src/lib/components/terminal/AccentPicker.test.ts
+++ b/packages/investintell-ui/src/lib/components/terminal/AccentPicker.test.ts
@@ -1,0 +1,33 @@
+import { render, fireEvent } from "@testing-library/svelte";
+import { describe, expect, test, vi } from "vitest";
+import AccentPicker from "./AccentPicker.svelte";
+
+describe("AccentPicker", () => {
+	test("renders three radiogroup swatches", () => {
+		const { container } = render(AccentPicker, {
+			props: { value: "amber", onChange: () => {} },
+		});
+		const group = container.querySelector("[role='radiogroup']");
+		expect(group).not.toBeNull();
+		expect(container.querySelectorAll(".terminal-accent-swatch").length).toBe(3);
+	});
+
+	test("active swatch reflects value prop", () => {
+		const { container } = render(AccentPicker, {
+			props: { value: "cyan", onChange: () => {} },
+		});
+		const active = container.querySelector(".terminal-accent-swatch.is-active");
+		expect(active?.className).toContain("terminal-accent-swatch--cyan");
+		expect(active?.getAttribute("aria-pressed")).toBe("true");
+	});
+
+	test("click fires onChange with the clicked value", async () => {
+		const onChange = vi.fn();
+		const { container } = render(AccentPicker, {
+			props: { value: "amber", onChange },
+		});
+		const violet = container.querySelector(".terminal-accent-swatch--violet")!;
+		await fireEvent.click(violet);
+		expect(onChange).toHaveBeenCalledWith("violet");
+	});
+});

--- a/packages/investintell-ui/src/lib/components/terminal/DensityToggle.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/DensityToggle.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import Pill from "./Pill.svelte";
+
+	export type Density = "standard" | "compact";
+
+	interface Props {
+		value: Density;
+		onChange: (v: Density) => void;
+		class?: string;
+	}
+
+	let { value, onChange, class: className }: Props = $props();
+
+	const options: { label: string; val: Density }[] = [
+		{ label: "STANDARD", val: "standard" },
+		{ label: "COMPACT", val: "compact" },
+	];
+</script>
+
+<div class="terminal-density-toggle {className ?? ''}" role="radiogroup" aria-label="Density">
+	{#each options as opt (opt.val)}
+		<Pill
+			as="button"
+			label={opt.label}
+			tone={value === opt.val ? "accent" : "neutral"}
+			pressed={value === opt.val}
+			onclick={() => onChange(opt.val)}
+			ariaLabel={`Density ${opt.label}`}
+		/>
+	{/each}
+</div>
+
+<style>
+	.terminal-density-toggle {
+		display: inline-flex;
+		gap: var(--terminal-space-1);
+	}
+</style>

--- a/packages/investintell-ui/src/lib/components/terminal/Kbd.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/Kbd.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	/**
+	 * Terminal Kbd — renders a shortcut as tokenized key caps.
+	 * Example: keys={["Shift","T"]} → [Shift]+[T].
+	 * Source: docs/plans/2026-04-18-netz-terminal-parity.md §B.3.
+	 */
+	interface Props {
+		keys: string[];
+		class?: string;
+	}
+
+	let { keys, class: className }: Props = $props();
+</script>
+
+<span class="terminal-kbd-group {className ?? ''}" role="group">
+	{#each keys as key, i (i)}
+		{#if i > 0}
+			<span class="terminal-kbd-sep" aria-hidden="true">+</span>
+		{/if}
+		<kbd class="terminal-kbd">{key}</kbd>
+	{/each}
+</span>
+
+<style>
+	.terminal-kbd-group {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.terminal-kbd {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 16px;
+		height: 16px;
+		padding: 0 var(--terminal-space-1);
+		font-family: inherit;
+		font-size: inherit;
+		text-transform: uppercase;
+		color: var(--terminal-fg-secondary);
+		background: var(--terminal-bg-panel-sunken);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		line-height: 1;
+	}
+
+	.terminal-kbd-sep {
+		color: var(--terminal-fg-tertiary);
+		font-size: var(--terminal-text-10);
+	}
+</style>

--- a/packages/investintell-ui/src/lib/components/terminal/KpiCard.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/KpiCard.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+	/**
+	 * Terminal KpiCard — label + pre-formatted value + optional delta.
+	 * Values MUST be pre-formatted by callers using @investintell/ui
+	 * formatters (formatCompactCurrency, formatMonoPercent, etc.).
+	 * Source: docs/plans/2026-04-18-netz-terminal-parity.md §B.3.
+	 */
+	export type KpiCardSize = "sm" | "md" | "lg";
+	export type KpiDeltaTone = "up" | "down" | "neutral";
+
+	interface Props {
+		label: string;
+		value: string;
+		delta?: string;
+		deltaTone?: KpiDeltaTone;
+		size?: KpiCardSize;
+		mono?: boolean;
+		loading?: boolean;
+		class?: string;
+	}
+
+	let {
+		label,
+		value,
+		delta,
+		deltaTone = "neutral",
+		size = "md",
+		mono = true,
+		loading = false,
+		class: className,
+	}: Props = $props();
+</script>
+
+<div
+	class="terminal-kpi terminal-kpi--{size} {className ?? ''}"
+	data-loading={loading ? "" : undefined}
+	data-mono={mono ? "" : undefined}
+>
+	<div class="terminal-kpi__label">{label}</div>
+	<div class="terminal-kpi__value" aria-busy={loading}>
+		{#if loading}
+			<span class="terminal-kpi__skeleton" aria-hidden="true"></span>
+		{:else}
+			{value}
+		{/if}
+	</div>
+	{#if delta && !loading}
+		<div class="terminal-kpi__delta terminal-kpi__delta--{deltaTone}">{delta}</div>
+	{/if}
+</div>
+
+<style>
+	.terminal-kpi {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-3);
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		min-width: 0;
+	}
+
+	.terminal-kpi[data-mono] {
+		font-family: var(--terminal-font-mono);
+	}
+
+	.terminal-kpi__label {
+		font-size: var(--t-size-label);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		line-height: var(--terminal-leading-tight);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.terminal-kpi__value {
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+		font-weight: 500;
+		line-height: var(--terminal-leading-tight);
+		letter-spacing: var(--terminal-tracking-tight);
+	}
+
+	.terminal-kpi--sm .terminal-kpi__value {
+		font-size: var(--terminal-text-14);
+	}
+	.terminal-kpi--md .terminal-kpi__value {
+		font-size: var(--t-size-kpi);
+	}
+	.terminal-kpi--lg .terminal-kpi__value {
+		font-size: var(--t-size-hero);
+	}
+
+	.terminal-kpi__delta {
+		font-size: var(--terminal-text-11);
+		font-variant-numeric: tabular-nums;
+		line-height: 1;
+	}
+	.terminal-kpi__delta--up {
+		color: var(--up);
+	}
+	.terminal-kpi__delta--down {
+		color: var(--down);
+	}
+	.terminal-kpi__delta--neutral {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.terminal-kpi__skeleton {
+		display: inline-block;
+		width: 4ch;
+		height: 1em;
+		background: var(--terminal-bg-panel-sunken);
+		animation: terminal-kpi-pulse var(--terminal-motion-update) var(--terminal-motion-easing-out) infinite alternate;
+	}
+
+	@keyframes terminal-kpi-pulse {
+		from {
+			opacity: 0.4;
+		}
+		to {
+			opacity: 0.8;
+		}
+	}
+</style>

--- a/packages/investintell-ui/src/lib/components/terminal/KpiCard.test.ts
+++ b/packages/investintell-ui/src/lib/components/terminal/KpiCard.test.ts
@@ -1,0 +1,43 @@
+import { render } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+import KpiCard from "./KpiCard.svelte";
+
+describe("KpiCard", () => {
+	test("renders label + pre-formatted value", () => {
+		const { container } = render(KpiCard, {
+			props: { label: "TOTAL AUM", value: "$1.23B" },
+		});
+		expect(container.textContent).toContain("TOTAL AUM");
+		expect(container.textContent).toContain("$1.23B");
+	});
+
+	test("loading state suppresses delta + shows skeleton", () => {
+		const { container } = render(KpiCard, {
+			props: { label: "AUM", value: "$1.23B", delta: "+1.2pp", loading: true },
+		});
+		expect(container.querySelector(".terminal-kpi__skeleton")).not.toBeNull();
+		expect(container.querySelector(".terminal-kpi__delta")).toBeNull();
+	});
+
+	test("delta tone class follows prop", () => {
+		const { container } = render(KpiCard, {
+			props: { label: "P/L", value: "+2.1%", delta: "+0.3pp", deltaTone: "up" },
+		});
+		const delta = container.querySelector(".terminal-kpi__delta");
+		expect(delta?.className).toContain("terminal-kpi__delta--up");
+	});
+
+	test("size variant sets modifier class", () => {
+		const { container } = render(KpiCard, {
+			props: { label: "NAV", value: "100.00", size: "lg" },
+		});
+		expect(container.querySelector(".terminal-kpi--lg")).not.toBeNull();
+	});
+
+	test("mono attribute toggles font-family hook", () => {
+		const { container } = render(KpiCard, {
+			props: { label: "NAV", value: "100.00", mono: false },
+		});
+		expect(container.querySelector(".terminal-kpi[data-mono]")).toBeNull();
+	});
+});

--- a/packages/investintell-ui/src/lib/components/terminal/Pill.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/Pill.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	/**
+	 * Terminal Pill — small tokenized badge or segmented-control button.
+	 * Source: docs/plans/2026-04-18-netz-terminal-parity.md §B.3.
+	 */
+	export type PillTone = "neutral" | "accent" | "success" | "warn" | "error";
+	export type PillSize = "xs" | "sm";
+	export type PillAs = "button" | "span";
+
+	interface Props {
+		label: string;
+		tone?: PillTone;
+		size?: PillSize;
+		as?: PillAs;
+		pressed?: boolean;
+		disabled?: boolean;
+		ariaLabel?: string;
+		onclick?: () => void;
+		class?: string;
+	}
+
+	let {
+		label,
+		tone = "neutral",
+		size = "sm",
+		as = "span",
+		pressed,
+		disabled = false,
+		ariaLabel,
+		onclick,
+		class: className,
+	}: Props = $props();
+</script>
+
+{#if as === "button"}
+	<button
+		type="button"
+		class="terminal-pill terminal-pill--{tone} terminal-pill--{size} {className ?? ''}"
+		aria-pressed={pressed}
+		aria-label={ariaLabel}
+		{disabled}
+		onclick={() => onclick?.()}
+	>
+		{label}
+	</button>
+{:else}
+	<span
+		class="terminal-pill terminal-pill--{tone} terminal-pill--{size} {className ?? ''}"
+		aria-label={ariaLabel}
+	>
+		{label}
+	</span>
+{/if}
+
+<style>
+	.terminal-pill {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		font-family: var(--terminal-font-mono);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		border-radius: var(--terminal-radius-none);
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-fg-secondary);
+		line-height: 1;
+		white-space: nowrap;
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.terminal-pill--xs {
+		font-size: var(--terminal-text-10);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		height: 16px;
+	}
+	.terminal-pill--sm {
+		font-size: var(--terminal-text-11);
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		height: 20px;
+	}
+
+	.terminal-pill--accent {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber-dim);
+	}
+	.terminal-pill--success {
+		color: var(--terminal-status-success);
+		border-color: var(--terminal-status-success);
+	}
+	.terminal-pill--warn {
+		color: var(--terminal-status-warn);
+		border-color: var(--terminal-status-warn);
+	}
+	.terminal-pill--error {
+		color: var(--terminal-status-error);
+		border-color: var(--terminal-status-error);
+	}
+
+	button.terminal-pill {
+		cursor: pointer;
+	}
+	button.terminal-pill:hover:not(:disabled) {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+	}
+	button.terminal-pill[aria-pressed="true"] {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+		background: var(--terminal-bg-panel-sunken);
+	}
+	button.terminal-pill:disabled {
+		color: var(--terminal-fg-disabled);
+		border-color: var(--terminal-fg-disabled);
+		cursor: not-allowed;
+	}
+	button.terminal-pill:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+</style>

--- a/packages/investintell-ui/src/lib/components/terminal/Pill.test.ts
+++ b/packages/investintell-ui/src/lib/components/terminal/Pill.test.ts
@@ -1,0 +1,34 @@
+import { render, fireEvent } from "@testing-library/svelte";
+import { describe, expect, test, vi } from "vitest";
+import Pill from "./Pill.svelte";
+
+describe("Pill", () => {
+	test("renders as span by default", () => {
+		const { container } = render(Pill, { props: { label: "LIVE" } });
+		expect(container.querySelector("span.terminal-pill")?.textContent?.trim()).toBe("LIVE");
+		expect(container.querySelector("button")).toBeNull();
+	});
+
+	test("as=button renders button with aria-pressed when pressed set", () => {
+		const { container } = render(Pill, {
+			props: { label: "CANDLE", as: "button", pressed: true },
+		});
+		const btn = container.querySelector("button.terminal-pill");
+		expect(btn).not.toBeNull();
+		expect(btn?.getAttribute("aria-pressed")).toBe("true");
+	});
+
+	test("button fires onclick", async () => {
+		const onclick = vi.fn();
+		const { container } = render(Pill, {
+			props: { label: "GO", as: "button", onclick },
+		});
+		await fireEvent.click(container.querySelector("button")!);
+		expect(onclick).toHaveBeenCalledOnce();
+	});
+
+	test("tone applies modifier class", () => {
+		const { container } = render(Pill, { props: { label: "OK", tone: "success" } });
+		expect(container.querySelector(".terminal-pill--success")).not.toBeNull();
+	});
+});

--- a/packages/investintell-ui/src/lib/components/terminal/ThemeToggle.svelte
+++ b/packages/investintell-ui/src/lib/components/terminal/ThemeToggle.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import Pill from "./Pill.svelte";
+
+	export type TerminalTheme = "dark" | "light";
+
+	interface Props {
+		value: TerminalTheme;
+		onChange: (v: TerminalTheme) => void;
+		class?: string;
+	}
+
+	let { value, onChange, class: className }: Props = $props();
+
+	const options: { label: string; val: TerminalTheme }[] = [
+		{ label: "DARK", val: "dark" },
+		{ label: "LIGHT", val: "light" },
+	];
+</script>
+
+<div class="terminal-theme-toggle {className ?? ''}" role="radiogroup" aria-label="Theme">
+	{#each options as opt (opt.val)}
+		<Pill
+			as="button"
+			label={opt.label}
+			tone={value === opt.val ? "accent" : "neutral"}
+			pressed={value === opt.val}
+			onclick={() => onChange(opt.val)}
+			ariaLabel={`Theme ${opt.label}`}
+		/>
+	{/each}
+</div>
+
+<style>
+	.terminal-theme-toggle {
+		display: inline-flex;
+		gap: var(--terminal-space-1);
+	}
+</style>

--- a/packages/investintell-ui/src/lib/formatters/mono.test.ts
+++ b/packages/investintell-ui/src/lib/formatters/mono.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "vitest";
+import {
+	formatCompactCurrency,
+	formatMonoPercent,
+	formatMonoTime,
+	formatPpDrift,
+} from "./mono.js";
+
+const EM_DASH = "\u2014";
+const MINUS = "\u2212";
+
+describe("formatMonoTime", () => {
+	test("UTC with zero-padded HH:MM:SS", () => {
+		const d = new Date(Date.UTC(2026, 3, 18, 9, 5, 7));
+		expect(formatMonoTime(d, "utc")).toBe("09:05:07 UTC");
+	});
+
+	test("UTC handles end-of-day", () => {
+		const d = new Date(Date.UTC(2026, 3, 18, 23, 59, 59));
+		expect(formatMonoTime(d)).toBe("23:59:59 UTC");
+	});
+
+	test("local mode has no UTC suffix", () => {
+		const d = new Date(2026, 3, 18, 8, 3, 4);
+		expect(formatMonoTime(d, "local")).toBe("08:03:04");
+	});
+});
+
+describe("formatCompactCurrency", () => {
+	test("billion range", () => {
+		expect(formatCompactCurrency(1_234_567_890)).toBe("$1.23B");
+	});
+
+	test("million range with custom digits", () => {
+		expect(formatCompactCurrency(987_654_321, { digits: 1 })).toBe("$987.7M");
+	});
+
+	test("thousand range", () => {
+		expect(formatCompactCurrency(12_345)).toBe("$12.35K");
+	});
+
+	test("negative uses Unicode minus", () => {
+		const out = formatCompactCurrency(-500_000_000);
+		expect(out.startsWith(MINUS)).toBe(true);
+		expect(out).toBe(`${MINUS}$500.00M`);
+	});
+
+	test("null / undefined / NaN / Infinity return em-dash", () => {
+		expect(formatCompactCurrency(null)).toBe(EM_DASH);
+		expect(formatCompactCurrency(undefined)).toBe(EM_DASH);
+		expect(formatCompactCurrency(Number.NaN)).toBe(EM_DASH);
+		expect(formatCompactCurrency(Number.POSITIVE_INFINITY)).toBe(EM_DASH);
+	});
+
+	test("EUR currency", () => {
+		expect(formatCompactCurrency(2_500_000, { currency: "EUR" })).toBe("€2.50M");
+	});
+
+	test("zero formats cleanly", () => {
+		expect(formatCompactCurrency(0)).toBe("$0.00");
+	});
+});
+
+describe("formatPpDrift", () => {
+	test("positive drift has + prefix", () => {
+		expect(formatPpDrift(0.023)).toBe("+2.3pp");
+	});
+
+	test("negative drift uses Unicode minus", () => {
+		expect(formatPpDrift(-0.011)).toBe(`${MINUS}1.1pp`);
+	});
+
+	test("zero has no sign", () => {
+		expect(formatPpDrift(0)).toBe("0.0pp");
+	});
+
+	test("custom digits", () => {
+		expect(formatPpDrift(0.0236, 2)).toBe("+2.36pp");
+	});
+
+	test("null / non-finite return em-dash", () => {
+		expect(formatPpDrift(null)).toBe(EM_DASH);
+		expect(formatPpDrift(undefined)).toBe(EM_DASH);
+		expect(formatPpDrift(Number.NaN)).toBe(EM_DASH);
+	});
+
+	test("very small values", () => {
+		expect(formatPpDrift(0.00001, 1)).toBe("+0.0pp");
+	});
+});
+
+describe("formatMonoPercent", () => {
+	test("positive percent", () => {
+		expect(formatMonoPercent(0.1234)).toBe("12.34%");
+	});
+
+	test("negative uses Unicode minus", () => {
+		expect(formatMonoPercent(-0.0005)).toBe(`${MINUS}0.05%`);
+	});
+
+	test("zero", () => {
+		expect(formatMonoPercent(0)).toBe("0.00%");
+	});
+
+	test("custom digits", () => {
+		expect(formatMonoPercent(0.1, 0)).toBe("10%");
+	});
+
+	test("null / non-finite return em-dash", () => {
+		expect(formatMonoPercent(null)).toBe(EM_DASH);
+		expect(formatMonoPercent(undefined)).toBe(EM_DASH);
+		expect(formatMonoPercent(Number.POSITIVE_INFINITY)).toBe(EM_DASH);
+	});
+});

--- a/packages/investintell-ui/src/lib/formatters/mono.ts
+++ b/packages/investintell-ui/src/lib/formatters/mono.ts
@@ -1,0 +1,103 @@
+/**
+ * Mono-friendly formatters for terminal surfaces.
+ *
+ * All outputs are tabular-safe (stable column widths) and
+ * locale-independent. Callers in (terminal)/** and
+ * lib/components/terminal/** must use these instead of
+ * `.toFixed`, `.toLocaleString`, or `new Intl.*` — enforced by
+ * the ESLint rule in frontends/eslint.config.js.
+ *
+ * Source of truth: docs/plans/2026-04-18-netz-terminal-parity.md §B.2.
+ */
+
+const EM_DASH = "\u2014";
+const MINUS = "\u2212"; // Unicode minus for column alignment.
+
+const compactCurrencyCache = new Map<string, Intl.NumberFormat>();
+
+function compactCurrencyFormatter(currency: string, digits: number): Intl.NumberFormat {
+	const key = `${currency}|${digits}`;
+	const cached = compactCurrencyCache.get(key);
+	if (cached) return cached;
+	const formatter = new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency,
+		notation: "compact",
+		compactDisplay: "short",
+		maximumFractionDigits: digits,
+		minimumFractionDigits: digits,
+	});
+	compactCurrencyCache.set(key, formatter);
+	return formatter;
+}
+
+function pad2(n: number): string {
+	return n < 10 ? `0${n}` : String(n);
+}
+
+/**
+ * UTC or local clock string "HH:MM:SS UTC". Zero allocation
+ * beyond the Date itself.
+ */
+export function formatMonoTime(d: Date, kind: "utc" | "local" = "utc"): string {
+	if (kind === "utc") {
+		return `${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}:${pad2(d.getUTCSeconds())} UTC`;
+	}
+	return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+export interface CompactCurrencyOptions {
+	digits?: number;
+	currency?: "USD" | "EUR" | "BRL";
+}
+
+/**
+ * Compact currency: $1.23B / $987M / $12.3K. Negative sign uses
+ * Unicode minus. Returns "—" for null / undefined / non-finite.
+ */
+export function formatCompactCurrency(
+	value: number | null | undefined,
+	opts: CompactCurrencyOptions = {},
+): string {
+	if (value === null || value === undefined || !Number.isFinite(value)) {
+		return EM_DASH;
+	}
+	const digits = opts.digits ?? 2;
+	const currency = opts.currency ?? "USD";
+	const formatted = compactCurrencyFormatter(currency, digits).format(Math.abs(value));
+	return value < 0 ? `${MINUS}${formatted}` : formatted;
+}
+
+/**
+ * Percentage-point drift: "+2.3pp", "−1.1pp", "0.0pp". Input is a
+ * fraction (0.023 → "+2.3pp"). Uses Unicode minus for alignment.
+ */
+export function formatPpDrift(
+	fractionDelta: number | null | undefined,
+	digits: number = 1,
+): string {
+	if (fractionDelta === null || fractionDelta === undefined || !Number.isFinite(fractionDelta)) {
+		return EM_DASH;
+	}
+	const pp = fractionDelta * 100;
+	const abs = Math.abs(pp).toFixed(digits);
+	if (pp > 0) return `+${abs}pp`;
+	if (pp < 0) return `${MINUS}${abs}pp`;
+	return `${abs}pp`;
+}
+
+/**
+ * Terminal percent: "12.34%", "−0.05%". Input is a fraction.
+ * Tabular-nums friendly.
+ */
+export function formatMonoPercent(
+	fraction: number | null | undefined,
+	digits: number = 2,
+): string {
+	if (fraction === null || fraction === undefined || !Number.isFinite(fraction)) {
+		return EM_DASH;
+	}
+	const pct = fraction * 100;
+	const abs = Math.abs(pct).toFixed(digits);
+	return pct < 0 ? `${MINUS}${abs}%` : `${abs}%`;
+}

--- a/packages/investintell-ui/src/lib/index.ts
+++ b/packages/investintell-ui/src/lib/index.ts
@@ -99,6 +99,21 @@ export type { BaseChartProps } from "./charts/index.js";
 export { default as SparklineSVG } from "./components/ui/charts/SparklineSVG.svelte";
 
 // ── Terminal primitives ──────────────────────────────────────
+// Components under @investintell/ui/components/terminal/*. Importing
+// these from any file outside (terminal)/ is discouraged — see
+// eslint restriction in frontends/eslint.config.js.
+export { default as TerminalPill } from "./components/terminal/Pill.svelte";
+export type { PillTone, PillSize, PillAs } from "./components/terminal/Pill.svelte";
+export { default as TerminalKbd } from "./components/terminal/Kbd.svelte";
+export { default as TerminalKpiCard } from "./components/terminal/KpiCard.svelte";
+export type { KpiCardSize, KpiDeltaTone } from "./components/terminal/KpiCard.svelte";
+export { default as TerminalDensityToggle } from "./components/terminal/DensityToggle.svelte";
+export type { Density } from "./components/terminal/DensityToggle.svelte";
+export { default as TerminalAccentPicker } from "./components/terminal/AccentPicker.svelte";
+export type { Accent } from "./components/terminal/AccentPicker.svelte";
+export { default as TerminalThemeToggle } from "./components/terminal/ThemeToggle.svelte";
+export type { TerminalTheme } from "./components/terminal/ThemeToggle.svelte";
+
 // Motion grammar + chart factory. Importing these from any file
 // outside (terminal)/ is discouraged — see eslint restriction.
 export {

--- a/packages/investintell-ui/src/lib/index.ts
+++ b/packages/investintell-ui/src/lib/index.ts
@@ -153,6 +153,13 @@ export { createOptimisticMutation } from "./utils/optimistic.svelte.js";
 export type { OptimisticMutation, OptimisticMutationConfig } from "./utils/optimistic.svelte.js";
 export { canOpenSSE, registerSSE, unregisterSSE, getActiveSSECount } from "./utils/sse-registry.svelte.js";
 export {
+	formatMonoTime,
+	formatCompactCurrency,
+	formatPpDrift,
+	formatMonoPercent,
+} from "./formatters/mono.js";
+export type { CompactCurrencyOptions } from "./formatters/mono.js";
+export {
 	formatAUM,
 	formatBps,
 	formatNAV,

--- a/packages/investintell-ui/src/lib/styles/typography.css
+++ b/packages/investintell-ui/src/lib/styles/typography.css
@@ -6,6 +6,12 @@
 
 @import "@fontsource-variable/urbanist";
 @import "@fontsource-variable/geist-mono";
+@import "@fontsource/ibm-plex-mono/400.css";
+@import "@fontsource/ibm-plex-mono/500.css";
+@import "@fontsource/ibm-plex-mono/600.css";
+@import "@fontsource/ibm-plex-sans/400.css";
+@import "@fontsource/ibm-plex-sans/500.css";
+@import "@fontsource/ibm-plex-sans/600.css";
 
 :root {
 	/* Font families */
@@ -118,4 +124,17 @@
 	--ii-code-border: rgba(0, 0, 0, 0.06);
 	--ii-kbd-bg:      #f1f5f9;   /* slate-100 */
 	--ii-kbd-border:  #cbd5e1;   /* slate-300 */
+}
+
+/* ── Terminal-scoped fonts ──────────────────────────────────
+ * Source: docs/plans/2026-04-18-netz-terminal-parity.md §B.4.
+ * Urbanist remains default OUTSIDE [data-surface="terminal"].
+ * font-display: optional avoids FOUT on first cold load — the
+ * system mono renders instantly, IBM Plex swaps on next reload.
+ * ============================================================ */
+[data-surface="terminal"] {
+	font-family: var(--terminal-font-mono);
+}
+[data-surface="terminal"] [data-font="sans"] {
+	font-family: "IBM Plex Sans", Inter, Urbanist, system-ui, sans-serif;
 }

--- a/packages/investintell-ui/src/lib/tokens/terminal.css
+++ b/packages/investintell-ui/src/lib/tokens/terminal.css
@@ -136,6 +136,7 @@
 	/* Sacred calc() from feedback_layout_cage_pattern.md.     */
 	/* DO NOT migrate to flex/grid min-h-0 — proven broken.    */
 	--terminal-shell-topbar-height: 64px;
+	--terminal-shell-breadcrumb-height: 28px;
 	--terminal-shell-statusbar-height: 24px;
 	--terminal-shell-cage-height: calc(100vh - 88px);
 	--terminal-shell-cage-padding: 24px;

--- a/packages/investintell-ui/src/lib/tokens/terminal.css
+++ b/packages/investintell-ui/src/lib/tokens/terminal.css
@@ -141,6 +141,72 @@
 	--terminal-shell-cage-padding: 24px;
 }
 
+/* ── Runtime tweak surfaces ───────────────────────────────── */
+/* Source: docs/plans/2026-04-18-netz-terminal-parity.md §B.1.  */
+/* Density: standard (default) vs compact (Bloomberg-tight).    */
+/* Switched via [data-density="compact"] on terminal-root or    */
+/* on :root for page-wide effect.                               */
+
+:root,
+[data-surface="terminal"] {
+	--t-row-height: 22px;
+	--t-size-hero: var(--terminal-text-24);
+	--t-size-kpi: var(--terminal-text-20);
+	--t-size-label: var(--terminal-text-10);
+
+	/* Severity scale — alerts + ticker. */
+	--sev-info: var(--terminal-accent-cyan);
+	--sev-warn: var(--terminal-status-warn);
+	--sev-critical: var(--terminal-status-error);
+	--up: var(--terminal-status-success);
+	--down: var(--terminal-status-error);
+}
+
+:root[data-density="compact"],
+[data-surface="terminal"][data-density="compact"] {
+	--terminal-space-1: 2px;
+	--terminal-space-2: 6px;
+	--terminal-space-3: 10px;
+	--terminal-space-4: 12px;
+	--terminal-text-10: 9px;
+	--terminal-text-11: 10px;
+	--terminal-text-12: 11px;
+	--terminal-text-14: 12px;
+	--terminal-shell-topbar-height: 28px;
+	--terminal-shell-breadcrumb-height: 24px;
+	--terminal-shell-cage-height: calc(100vh - 80px);
+	--t-row-height: 18px;
+}
+
+/* Accent: user-selectable. Default amber (institutional).     */
+/* Rebind the semantic amber slot so every consumer reading    */
+/* --terminal-accent-amber swaps without code changes.         */
+[data-accent="cyan"] {
+	--terminal-accent-amber: var(--terminal-accent-cyan);
+	--terminal-accent-amber-dim: var(--terminal-accent-cyan-dim);
+}
+[data-accent="violet"] {
+	--terminal-accent-amber: var(--terminal-accent-violet);
+	--terminal-accent-amber-dim: var(--terminal-accent-violet-dim);
+}
+
+/* Light theme — institutional white, still mono-first.        */
+[data-theme="light"],
+[data-theme="light"][data-surface="terminal"] {
+	--terminal-bg-void: #f5f5f0;
+	--terminal-bg-panel: #ffffff;
+	--terminal-bg-panel-raised: #fafaf6;
+	--terminal-bg-panel-sunken: #ededed;
+	--terminal-bg-overlay: #ffffff;
+	--terminal-bg-scrim: rgba(245, 245, 240, 0.72);
+	--terminal-fg-primary: #0a0a0a;
+	--terminal-fg-secondary: #3d3d38;
+	--terminal-fg-tertiary: #6b6b63;
+	--terminal-fg-muted: #b8b8b0;
+	--terminal-fg-disabled: #d8d8d0;
+	--terminal-fg-inverted: #ffffff;
+}
+
 /* prefers-reduced-motion: collapse all choreo slots to 0ms.   */
 /* Components can still honor --terminal-motion-opening etc.  */
 /* but any entrance animation becomes instant.                 */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -98,7 +98,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -238,6 +238,12 @@ importers:
       '@fontsource-variable/urbanist':
         specifier: ^5.0.0
         version: 5.2.7
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.0.0
+        version: 5.2.7
+      '@fontsource/ibm-plex-sans':
+        specifier: ^5.0.0
+        version: 5.2.8
       '@internationalized/date':
         specifier: ^3.12.0
         version: 3.12.0
@@ -5670,7 +5676,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       invariant: 2.2.4
       metro: 0.83.5(bufferutil@4.1.0)
-      metro-config: 0.83.5(bufferutil@4.1.0)
+      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.5
       semver: 7.7.4
     transitivePeerDependencies:
@@ -8500,21 +8506,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.83.5(bufferutil@4.1.0):
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.5(bufferutil@4.1.0)
-      metro-cache: 0.83.5
-      metro-core: 0.83.5
-      metro-runtime: 0.83.5
-      yaml: 2.8.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   metro-config@0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -8666,7 +8657,7 @@ snapshots:
       metro-babel-transformer: 0.83.5
       metro-cache: 0.83.5
       metro-cache-key: 0.83.5
-      metro-config: 0.83.5(bufferutil@4.1.0)
+      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.5
       metro-file-map: 0.83.5
       metro-resolver: 0.83.5


### PR DESCRIPTION
Re-opened after base branch deleted on PR-2 merge. Original: #227. Content unchanged.

Sub-PR 3 of docs/plans/2026-04-18-netz-terminal-parity.md §G.

- terminal-tweaks.svelte.ts store (density/accent/theme, $state in-memory)
- TerminalBreadcrumb.svelte (28px row, Alt+1..4 nav)
- TerminalTweaksPanel.svelte (gear FAB + drawer, Shift+T)
- Shell grid adds +28px breadcrumb row, data-surface/density/accent/theme attrs
- StatusBar clock uses formatMonoTime (closes violation §E.4)

svelte-check: 0 new errors. Token-sync green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)