### PR TITLE
feat(terminal): PR-2 Screener parity — FilterChipRow + MiniSparkline + momentum

### DIFF
--- a/backend/app/domains/wealth/routes/screener.py
+++ b/backend/app/domains/wealth/routes/screener.py
@@ -1726,6 +1726,11 @@ async def get_catalog(
                 elite_flag=bool(r.elite_flag) if getattr(r, "elite_flag", None) is not None else None,
                 elite_rank_within_strategy=getattr(r, "elite_rank_within_strategy", None),
                 manager_score=float(r.manager_score) if getattr(r, "manager_score", None) is not None else None,
+                blended_momentum_score=(
+                    float(r.blended_momentum_score)
+                    if getattr(r, "blended_momentum_score", None) is not None
+                    else None
+                ),
                 # Phase 3: org membership from v_screener_org_membership
                 in_universe=(org_approval == "approved"),
                 approval_status=org_approval,

--- a/backend/app/domains/wealth/schemas/catalog.py
+++ b/backend/app/domains/wealth/schemas/catalog.py
@@ -96,6 +96,9 @@ class UnifiedFundItem(BaseModel):
     elite_flag: bool | None = None
     elite_rank_within_strategy: int | None = None
     manager_score: float | None = None
+    # Blended momentum score (from mv_fund_risk_latest, pre-computed by
+    # global_risk_metrics worker — sanitized 0..100 scale, user-facing).
+    blended_momentum_score: float | None = None
 
     # Org membership (from v_screener_org_membership)
     in_universe: bool = False

--- a/frontends/wealth/e2e/terminal-parity.spec.ts
+++ b/frontends/wealth/e2e/terminal-parity.spec.ts
@@ -172,3 +172,75 @@ test.describe("Terminal parity — /portfolio/live smoke", () => {
 		expect(ws.url()).toContain("/live/ws");
 	});
 });
+
+test.describe("Terminal parity — /terminal-screener smoke", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.route("**/api/v1/**", async (route) => {
+			const headers = {
+				...route.request().headers(),
+				"x-dev-actor": `super_admin:${TEST_ORG_ID}`,
+			};
+			await route.continue({ headers });
+		});
+	});
+
+	test("slash focuses the filter rail first input", async ({ page }) => {
+		await page.goto("/terminal-screener");
+		// Wait for the shell to render. The filter rail has its own aria-label.
+		const filterPanel = page.getByRole("region", { name: /Screener filters/i })
+			.or(page.locator("[aria-label='Screener filters']").first());
+		await expect(filterPanel).toBeVisible();
+
+		await page.keyboard.press("/");
+		// The shell's handler focuses the first interactive element inside the
+		// filters panel (search input or first chip button).
+		const active = await page.evaluate(() => {
+			const el = document.activeElement as HTMLElement | null;
+			return el ? { tag: el.tagName, inFilters: !!el.closest("[aria-label='Screener filters']") } : null;
+		});
+		expect(active?.inFilters).toBe(true);
+	});
+
+	test("applying an eliteOnly filter renders a chip with CLEAR ALL", async ({
+		page,
+	}) => {
+		// Deep-link the elite filter so we don't depend on UI toggle order.
+		await page.goto("/terminal-screener?elite=1");
+		const chipRow = page.getByRole("region", { name: /Applied filters/i });
+		await expect(chipRow).toBeVisible();
+		await expect(chipRow.getByRole("button", { name: /Remove Tier Elite only/i })).toBeVisible();
+		await expect(chipRow.getByRole("button", { name: /CLEAR ALL/i })).toBeVisible();
+	});
+
+	test("clicking CLEAR ALL strips filter query params", async ({ page }) => {
+		await page.goto("/terminal-screener?elite=1&max_expense=0.5");
+		const chipRow = page.getByRole("region", { name: /Applied filters/i });
+		await expect(chipRow).toBeVisible();
+		await chipRow.getByRole("button", { name: /CLEAR ALL/i }).click();
+		await expect(page).toHaveURL(/\/terminal-screener(\?|$)/);
+		// No filter-specific params remain.
+		const url = new URL(page.url());
+		expect(url.searchParams.get("elite")).toBeNull();
+		expect(url.searchParams.get("max_expense")).toBeNull();
+	});
+
+	test("ArrowDown highlights the first row and Enter opens FundFocusMode", async ({
+		page,
+	}) => {
+		await page.goto("/terminal-screener");
+		// Wait for at least one row to exist.
+		const firstRow = page.locator("[role='row'][aria-rowindex='2']");
+		await expect(firstRow).toBeVisible({ timeout: 10_000 });
+
+		await page.keyboard.press("ArrowDown");
+		await expect(firstRow).toHaveClass(/highlighted/);
+
+		await page.keyboard.press("Enter");
+		// FundFocusMode mounts a dialog at the page root.
+		const dialog = page.getByRole("dialog").first();
+		await expect(dialog).toBeVisible();
+
+		await page.keyboard.press("Escape");
+		await expect(dialog).toHaveCount(0);
+	});
+});

--- a/frontends/wealth/src/lib/components/screener/terminal/FilterChipRow.svelte
+++ b/frontends/wealth/src/lib/components/screener/terminal/FilterChipRow.svelte
@@ -1,0 +1,353 @@
+<!--
+	FilterChipRow — horizontal strip of applied-filter pills above the
+	datagrid.
+
+	Stateless by design: chips are derived from `filters` inline; every
+	removal is routed through `onFiltersChange` so the URL remains the
+	single source of truth (see plan §G.SCREENER risk 3 — chip removal
+	and rail checkbox must not diverge).
+-->
+<script module lang="ts">
+	export interface DerivedChip {
+		key: string;
+		label: string;
+		value: string;
+		onRemove: () => void;
+	}
+</script>
+
+<script lang="ts">
+	import { formatCompactCurrency } from "@investintell/ui";
+	import type { FilterState } from "./TerminalScreenerFilters.svelte";
+
+	interface Props {
+		filters: FilterState;
+		onFiltersChange: (next: FilterState) => void;
+	}
+
+	let { filters, onFiltersChange }: Props = $props();
+
+	const FUND_UNIVERSE_LABELS: Record<string, string> = {
+		mutual_fund: "Mutual",
+		etf: "ETF",
+		closed_end: "CEF",
+		interval_fund: "Interval",
+		bdc: "BDC",
+		money_market: "MMF",
+		hedge_fund: "Hedge",
+		private_fund: "Private",
+		private_equity_fund: "PE",
+		ucits: "UCITS",
+	};
+
+	function remove(key: string, value: string): () => void {
+		return () => {
+			const next: FilterState = {
+				...filters,
+				fundUniverse: new Set(filters.fundUniverse),
+				strategies: new Set(filters.strategies),
+				geographies: new Set(filters.geographies),
+				managerNames: [...filters.managerNames],
+			};
+			switch (key) {
+				case "fundUniverse":
+					next.fundUniverse.delete(value);
+					break;
+				case "strategy":
+					next.strategies.delete(value);
+					break;
+				case "geography":
+					next.geographies.delete(value);
+					break;
+				case "manager":
+					next.managerNames = next.managerNames.filter((n) => n !== value);
+					break;
+				case "aum":
+					next.aumMin = 0;
+					next.aumMax = 0;
+					break;
+				case "return1y":
+					next.returnMin = -999;
+					next.returnMax = 999;
+					break;
+				case "expense":
+					next.expenseMax = 10;
+					break;
+				case "elite":
+					next.eliteOnly = false;
+					break;
+				case "sharpe":
+					next.sharpeMin = "";
+					next.sharpeMax = "";
+					break;
+				case "drawdown":
+					next.drawdownMinPct = "";
+					next.drawdownMaxPct = "";
+					break;
+				case "vol":
+					next.volatilityMax = "";
+					break;
+				case "return10y":
+					next.return10yMin = "";
+					next.return10yMax = "";
+					break;
+			}
+			onFiltersChange(next);
+		};
+	}
+
+	function rangeLabel(lo: number | string | null, hi: number | string | null, suffix: string): string {
+		const loStr = lo !== null && lo !== "" && !(typeof lo === "number" && (lo === 0 || lo === -999)) ? String(lo) : "";
+		const hiStr = hi !== null && hi !== "" && !(typeof hi === "number" && (hi === 0 || hi === 999)) ? String(hi) : "";
+		if (loStr && hiStr) return `${loStr}${suffix}–${hiStr}${suffix}`;
+		if (loStr) return `≥${loStr}${suffix}`;
+		if (hiStr) return `≤${hiStr}${suffix}`;
+		return "";
+	}
+
+	const chips = $derived.by<DerivedChip[]>(() => {
+		const out: DerivedChip[] = [];
+
+		for (const v of filters.fundUniverse) {
+			out.push({
+				key: `fundUniverse:${v}`,
+				label: "Type",
+				value: FUND_UNIVERSE_LABELS[v] ?? v,
+				onRemove: remove("fundUniverse", v),
+			});
+		}
+		for (const v of filters.strategies) {
+			out.push({
+				key: `strategy:${v}`,
+				label: "Strategy",
+				value: v,
+				onRemove: remove("strategy", v),
+			});
+		}
+		for (const v of filters.geographies) {
+			out.push({
+				key: `geography:${v}`,
+				label: "Geo",
+				value: v,
+				onRemove: remove("geography", v),
+			});
+		}
+		for (const v of filters.managerNames) {
+			out.push({
+				key: `manager:${v}`,
+				label: "Manager",
+				value: v,
+				onRemove: remove("manager", v),
+			});
+		}
+		if (filters.eliteOnly) {
+			out.push({
+				key: "elite",
+				label: "Tier",
+				value: "Elite only",
+				onRemove: remove("elite", ""),
+			});
+		}
+		if (filters.aumMin > 0 || filters.aumMax > 0) {
+			const lo = filters.aumMin > 0 ? formatCompactCurrency(filters.aumMin) : "";
+			const hi = filters.aumMax > 0 ? formatCompactCurrency(filters.aumMax) : "";
+			let value: string;
+			if (lo && hi) value = `${lo}–${hi}`;
+			else if (lo) value = `≥${lo}`;
+			else value = `≤${hi}`;
+			out.push({ key: "aum", label: "AUM", value, onRemove: remove("aum", "") });
+		}
+		const ret1y = rangeLabel(
+			filters.returnMin > -999 ? filters.returnMin : null,
+			filters.returnMax < 999 ? filters.returnMax : null,
+			"%",
+		);
+		if (ret1y) {
+			out.push({ key: "return1y", label: "1Y Return", value: ret1y, onRemove: remove("return1y", "") });
+		}
+		if (filters.expenseMax < 10) {
+			out.push({
+				key: "expense",
+				label: "Fee",
+				value: `≤${filters.expenseMax}%`,
+				onRemove: remove("expense", ""),
+			});
+		}
+		const sharpe = rangeLabel(filters.sharpeMin || null, filters.sharpeMax || null, "");
+		if (sharpe) out.push({ key: "sharpe", label: "Sharpe", value: sharpe, onRemove: remove("sharpe", "") });
+		const dd = rangeLabel(filters.drawdownMinPct || null, filters.drawdownMaxPct || null, "%");
+		if (dd) out.push({ key: "drawdown", label: "Drawdown", value: dd, onRemove: remove("drawdown", "") });
+		if (filters.volatilityMax) {
+			out.push({
+				key: "vol",
+				label: "Vol",
+				value: `≤${filters.volatilityMax}%`,
+				onRemove: remove("vol", ""),
+			});
+		}
+		const ret10y = rangeLabel(filters.return10yMin || null, filters.return10yMax || null, "%");
+		if (ret10y) out.push({ key: "return10y", label: "10Y Return", value: ret10y, onRemove: remove("return10y", "") });
+
+		return out;
+	});
+
+	function clearAll() {
+		onFiltersChange({
+			fundUniverse: new Set(),
+			strategies: new Set(),
+			geographies: new Set(),
+			aumMin: 0,
+			aumMax: 0,
+			returnMin: -999,
+			returnMax: 999,
+			expenseMax: 10,
+			eliteOnly: false,
+			managerNames: [],
+			sharpeMin: "",
+			sharpeMax: "",
+			drawdownMinPct: "",
+			drawdownMaxPct: "",
+			volatilityMax: "",
+			return10yMin: "",
+			return10yMax: "",
+		});
+	}
+</script>
+
+{#if chips.length > 0}
+	<div class="chip-row" role="region" aria-label="Applied filters">
+		<span class="chip-row__label">FILTERS</span>
+		<ul class="chip-row__list">
+			{#each chips as chip (chip.key)}
+				<li class="chip-row__item">
+					<button
+						type="button"
+						class="chip"
+						aria-label={`Remove ${chip.label} ${chip.value}`}
+						onclick={chip.onRemove}
+					>
+						<span class="chip__label">{chip.label}</span>
+						<span class="chip__sep">·</span>
+						<span class="chip__value">{chip.value}</span>
+						<span class="chip__x" aria-hidden="true">×</span>
+					</button>
+				</li>
+			{/each}
+		</ul>
+		<button type="button" class="chip-row__clear" onclick={clearAll}>CLEAR ALL</button>
+	</div>
+{/if}
+
+<style>
+	.chip-row {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+		min-height: 28px;
+		overflow-x: auto;
+		overflow-y: hidden;
+		scrollbar-width: thin;
+		white-space: nowrap;
+	}
+
+	.chip-row__label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		flex-shrink: 0;
+	}
+
+	.chip-row__list {
+		display: flex;
+		gap: var(--terminal-space-2);
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		flex: 1;
+		min-width: 0;
+	}
+
+	.chip-row__item {
+		display: inline-flex;
+		flex-shrink: 0;
+	}
+
+	.chip {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		padding: 2px var(--terminal-space-2);
+		height: 20px;
+		background: var(--terminal-bg-panel-raised);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		color: var(--terminal-fg-secondary);
+		font-family: inherit;
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		line-height: 1;
+		cursor: pointer;
+		white-space: nowrap;
+	}
+	.chip:hover {
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+	}
+	.chip:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.chip__label {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+	.chip:hover .chip__label {
+		color: var(--terminal-accent-amber);
+	}
+	.chip__sep {
+		color: var(--terminal-fg-tertiary);
+	}
+	.chip__value {
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+	.chip:hover .chip__value {
+		color: var(--terminal-accent-amber);
+	}
+	.chip__x {
+		margin-left: var(--terminal-space-1);
+		color: var(--terminal-fg-tertiary);
+		font-size: var(--terminal-text-11);
+	}
+	.chip:hover .chip__x {
+		color: var(--terminal-accent-amber);
+	}
+
+	.chip-row__clear {
+		margin-left: auto;
+		background: transparent;
+		border: none;
+		color: var(--terminal-fg-tertiary);
+		font-family: inherit;
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		padding: 0 var(--terminal-space-2);
+		flex-shrink: 0;
+	}
+	.chip-row__clear:hover {
+		color: var(--terminal-accent-amber);
+	}
+	.chip-row__clear:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/screener/terminal/TerminalDataGrid.svelte
+++ b/frontends/wealth/src/lib/components/screener/terminal/TerminalDataGrid.svelte
@@ -28,6 +28,7 @@
 		ret1y: number | null;            // Already in human % (5.0 = 5%)
 		ret10y: number | null;           // Already in human % (8.0 = 8%)
 		managerScore: number | null;     // Composite score 0-100
+		blendedMomentumScore: number | null; // Pre-computed 0-100 (RSI + Bollinger + NAV + flow)
 		inceptionDate: string | null;
 		isin: string | null;
 		navStatus: string | null;   // available | pending_import | unavailable | null
@@ -40,7 +41,7 @@
 
 <script lang="ts">
 	import { getContext } from "svelte";
-	import { formatNumber, readTerminalTokens } from "@investintell/ui";
+	import { formatNumber, readTerminalTokens, TerminalMiniSparkline } from "@investintell/ui";
 	import { focusTrigger } from "$lib/components/terminal/focus-mode/focus-trigger";
 	import { createClientApiClient } from "$lib/api/client";
 
@@ -62,6 +63,8 @@
 		isLoadingMore: boolean;
 		hasMore: boolean;
 		fetchGeneration: number;
+		/** Map of instrument_id → monthly NAV series for the MiniSparkline column. Shell owns the fetch. */
+		sparklineMap?: Map<string, number[]>;
 		onSelect: (asset: ScreenerAsset) => void;
 		onHighlight: (index: number) => void;
 		onApprove: (asset: ScreenerAsset) => Promise<void>;
@@ -79,12 +82,27 @@
 		isLoadingMore,
 		hasMore,
 		fetchGeneration,
+		sparklineMap,
 		onSelect,
 		onHighlight,
 		onApprove,
 		onQueueDD,
 		onLoadMore,
 	}: Props = $props();
+
+	const EMPTY_SPARKLINE: readonly number[] = [];
+
+	function sparklineFor(asset: ScreenerAsset): readonly number[] {
+		if (!sparklineMap || !asset.instrumentId) return EMPTY_SPARKLINE;
+		return sparklineMap.get(asset.instrumentId) ?? EMPTY_SPARKLINE;
+	}
+
+	function momentumTone(score: number | null): "high" | "mid" | "low" | "none" {
+		if (score == null) return "none";
+		if (score >= 70) return "high";
+		if (score >= 40) return "mid";
+		return "low";
+	}
 
 	// ── Type badge map ────────────────────────────────
 	const TYPE_BADGES: Record<string, { label: string; title: string }> = {
@@ -127,7 +145,8 @@
 		| "ret1y"
 		| "ret10y"
 		| "expenseRatioPct"
-		| "managerScore";
+		| "managerScore"
+		| "blendedMomentumScore";
 
 	let sortColumn = $state<SortableColumn | null>(null);
 	let sortDirection = $state<SortDirection>(null);
@@ -159,6 +178,7 @@
 		ret10y: "numeric",
 		expenseRatioPct: "numeric",
 		managerScore: "numeric",
+		blendedMomentumScore: "numeric",
 	};
 
 	function sortCaret(col: SortableColumn): string {
@@ -361,6 +381,8 @@
 		<button class="dg-th dg-th-sort dg-col-ret dg-right" class:dg-th-active={sortColumn === "ret10y"} onclick={() => toggleSort("ret10y")}>10Y Ret{sortCaret("ret10y")}</button>
 		<button class="dg-th dg-th-sort dg-col-er dg-right" class:dg-th-active={sortColumn === "expenseRatioPct"} onclick={() => toggleSort("expenseRatioPct")}>ER%{sortCaret("expenseRatioPct")}</button>
 		<button class="dg-th dg-th-sort dg-col-score dg-right" class:dg-th-active={sortColumn === "managerScore"} onclick={() => toggleSort("managerScore")}>Score{sortCaret("managerScore")}</button>
+		<button class="dg-th dg-th-sort dg-col-mom dg-right" class:dg-th-active={sortColumn === "blendedMomentumScore"} onclick={() => toggleSort("blendedMomentumScore")}>Mom{sortCaret("blendedMomentumScore")}</button>
+		<span class="dg-th dg-col-spark dg-center">Trend</span>
 		<span class="dg-th dg-col-action dg-center">Action</span>
 	</div>
 
@@ -416,6 +438,20 @@
 							class:score-low={asset.managerScore != null && asset.managerScore < 40}
 						>
 							{asset.managerScore != null ? fmtNum(asset.managerScore, 1) : "\u2014"}
+						</span>
+						<span
+							class="dg-td dg-col-mom dg-right dg-num dg-mom-{momentumTone(asset.blendedMomentumScore)}"
+							title="Blended momentum (RSI + Bollinger + NAV + flow)"
+						>
+							{asset.blendedMomentumScore != null ? fmtNum(asset.blendedMomentumScore, 0) : "\u2014"}
+						</span>
+						<span class="dg-td dg-col-spark dg-center">
+							<TerminalMiniSparkline
+								data={[...sparklineFor(asset)]}
+								width={60}
+								height={18}
+								ariaLabel="12mo NAV trend"
+							/>
 						</span>
 						<span class="dg-td dg-col-action dg-center">
 							{#if asset.inUniverse}
@@ -514,6 +550,8 @@
 			60px                  /* 10y ret — right-aligned */
 			48px                  /* er% — right-aligned */
 			56px                  /* score — right-aligned numeral */
+			48px                  /* blended momentum — right-aligned */
+			64px                  /* trend sparkline — center, 60x18 */
 			72px;                 /* action — APPROVE/+DD button */
 		column-gap: 2px;
 		align-items: center;
@@ -678,6 +716,20 @@
 	.score-high { color: var(--terminal-status-success); }
 	.score-mid { color: var(--terminal-accent-amber); }
 	.score-low { color: var(--terminal-status-error); }
+
+	/* Blended momentum tone — same palette as score, distinct class
+	   namespace so the two tiers can diverge without a cascade clash. */
+	.dg-mom-high { color: var(--terminal-status-success); }
+	.dg-mom-mid { color: var(--terminal-accent-amber); }
+	.dg-mom-low { color: var(--terminal-status-error); }
+	.dg-mom-none { color: var(--terminal-fg-tertiary); }
+
+	/* Spark column — cell centers the SVG inside the 64px column. */
+	.dg-col-spark {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
 
 	.dg-empty {
 		padding: 32px;

--- a/frontends/wealth/src/lib/components/screener/terminal/TerminalScreenerShell.svelte
+++ b/frontends/wealth/src/lib/components/screener/terminal/TerminalScreenerShell.svelte
@@ -19,6 +19,7 @@
 -->
 <script lang="ts">
 	import { getContext } from "svelte";
+	import { SvelteMap } from "svelte/reactivity";
 	import { goto } from "$app/navigation";
 	import { resolve } from "$app/paths";
 	import { createClientApiClient } from "$lib/api/client";
@@ -26,6 +27,7 @@
 		type FilterState,
 	} from "./TerminalScreenerFilters.svelte";
 	import TerminalDataGrid, { type ScreenerAsset } from "./TerminalDataGrid.svelte";
+	import FilterChipRow from "./FilterChipRow.svelte";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 	const api = createClientApiClient(getToken);
@@ -76,6 +78,7 @@
 		avg_annual_return_10y: number | null;
 		elite_flag: boolean | null;
 		manager_score: number | null;
+		blended_momentum_score: number | null;
 		in_universe: boolean;
 		approval_status?: string | null;
 		disclosure?: { nav_status?: string | null };
@@ -109,6 +112,7 @@
 			ret1y: raw.avg_annual_return_1y != null ? raw.avg_annual_return_1y * 100 : null,
 			ret10y: raw.avg_annual_return_10y != null ? raw.avg_annual_return_10y * 100 : null,
 			managerScore: raw.manager_score,
+			blendedMomentumScore: raw.blended_momentum_score,
 			inceptionDate: raw.inception_date,
 			isin: raw.isin,
 			navStatus: raw.disclosure?.nav_status ?? null,
@@ -132,6 +136,67 @@
 	let isLoadingMore = $state(false);
 	/** Generation counter — increments on every fresh fetch (filter change). */
 	let fetchGeneration = $state(0);
+
+	// ── Sparkline batch fetch ───────────────────────────
+	/**
+	 * Keyed by instrument_id (UUID). Populated after each catalog fetch
+	 * from POST /screener/sparklines. Passed down to TerminalDataGrid;
+	 * the grid's MiniSparkline column reads by row.instrumentId.
+	 *
+	 * Stored as a Map (not a plain Record) so the prop reference
+	 * changes when the fetch completes — triggers downstream $derived
+	 * reactivity cleanly.
+	 */
+	let sparklineMap = $state<Map<string, number[]>>(new Map());
+	let sparklineFetchId = 0;
+
+	interface SparklineResponsePoint {
+		month: string;
+		nav_close: number;
+		return_1m?: number | null;
+	}
+
+	async function refreshSparklines(currentAssets: ScreenerAsset[]) {
+		const ids = currentAssets
+			.map((a) => a.instrumentId)
+			.filter((id): id is string => id !== null);
+		if (ids.length === 0) {
+			sparklineMap = new Map();
+			return;
+		}
+		const fetchId = ++sparklineFetchId;
+		// Endpoint caps at 100 IDs per call; chunk in parallel and merge.
+		const CHUNK = 100;
+		const chunks: string[][] = [];
+		for (let i = 0; i < ids.length; i += CHUNK) {
+			chunks.push(ids.slice(i, i + CHUNK));
+		}
+		try {
+			const results = await Promise.all(
+				chunks.map((chunk) =>
+					api.post<Record<string, SparklineResponsePoint[]>>(
+						"/screener/sparklines",
+						{ instrument_ids: chunk, months: 12 },
+					),
+				),
+			);
+			if (fetchId !== sparklineFetchId) return; // stale
+			const next = new SvelteMap<string, number[]>();
+			for (const chunkResult of results) {
+				for (const [iid, points] of Object.entries(chunkResult)) {
+					if (!Array.isArray(points) || points.length < 2) continue;
+					next.set(
+						iid,
+						points.map((p) => p.nav_close),
+					);
+				}
+			}
+			sparklineMap = next;
+		} catch {
+			// Non-fatal: sparklines are decorative — MiniSparkline renders
+			// empty svg when no data is present.
+		}
+	}
 
 
 	// ── Query builder ──────────────���────────────────────
@@ -205,6 +270,10 @@
 				if (selectedId && !assets.some((a) => a.id === selectedId)) {
 					selectedId = null;
 				}
+
+				// Fire-and-forget sparkline fetch — decorative overlay,
+				// must not block the catalog render.
+				void refreshSparklines(assets);
 			} catch (err) {
 				if (fetchId !== currentFetchId) return;
 				assets = [];
@@ -238,6 +307,8 @@
 			// Keep the initial total (page 1) — keyset cursor changes the
 			// windowed count on subsequent pages due to WHERE clause shift.
 			nextCursor = page.next_cursor;
+			// Refresh sparkline map for the combined asset set.
+			void refreshSparklines(assets);
 		} catch {
 			// Non-fatal: user can keep scrolling to retry
 		} finally {
@@ -421,6 +492,7 @@
 				</div>
 			</div>
 		{:else}
+			<FilterChipRow {filters} {onFiltersChange} />
 			<svelte:boundary>
 				<TerminalDataGrid
 					bind:this={dataGridRef}
@@ -433,6 +505,7 @@
 					{isLoadingMore}
 					hasMore={nextCursor !== null}
 					{fetchGeneration}
+					{sparklineMap}
 					onSelect={handleSelect}
 					onHighlight={handleHighlight}
 					onApprove={handleApprove}
@@ -485,7 +558,18 @@
 	}
 
 	.ts-filters { grid-area: filters; }
-	.ts-datagrid { grid-area: datagrid; }
+	.ts-datagrid {
+		grid-area: datagrid;
+		display: flex;
+		flex-direction: column;
+	}
+	.ts-datagrid :global(> *) {
+		flex-shrink: 0;
+	}
+	.ts-datagrid :global(> .dg-root) {
+		flex: 1 1 auto;
+		min-height: 0;
+	}
 
 	/* ── Error panel ─────────────────────────────────── */
 	.sep-panel {


### PR DESCRIPTION
## Summary

Ships PR-2 of the Netz Terminal parity sprint
(docs/plans/2026-04-19-netz-terminal-parity-builder-macro-screener.md,
§A.SCREENER + §B.1 + §C.SCREENER + §E.SCREENER). Depends on PR-1
(`TerminalMiniSparkline` primitive — already merged as #235).

### Backend — expose `blended_momentum_score`

- `UnifiedFundItem.blended_momentum_score: float | None` — two-line
  exposure. The column is already joined from `mv_fund_risk_latest`
  in `_build_base_stmt(include_risk_membership=True)` (used by
  `/screener/catalog`) but was never serialized.
- `FundDetailOut` inherits the field as `None` automatically; the
  detail endpoint does not join the risk MV, which is correct — only
  the screener grid reads momentum.

### Frontend — new surfaces

- **`FilterChipRow.svelte`** (wealth-local, §B.1) — horizontal strip of
  applied filters above the grid. Stateless: chips derived inline from
  `FilterState`; every removal calls `onFiltersChange` so the URL stays
  the single source of truth (guards §G.SCREENER risk 3).
- **`TerminalDataGrid`** gains two columns:
  - **Mom** (48px) — `blended_momentum_score` 0–100, tone-coded
    (≥70 success / 40–69 amber / <40 error / null muted). Sortable.
  - **Trend** (64px) — `TerminalMiniSparkline` 60×18, 12-month NAV.
- **`TerminalScreenerShell`** owns the batch sparkline fetch:
  `POST /screener/sparklines` in 100-ID chunks (endpoint cap),
  parallelized via `Promise.all`, stored in a `SvelteMap<string, number[]>`
  passed down to the grid. Fire-and-forget — cannot block the catalog
  render. Empty data → empty svg, so transient gaps are invisible.

### E2E smoke (Playwright, dead code until harness activation)

`terminal-parity.spec.ts` grows a `/terminal-screener smoke` block:
- `/` focuses the filter rail
- `?elite=1` deep-link renders a chip + CLEAR ALL
- CLEAR ALL strips filter query params
- ArrowDown → first row highlighted, Enter → FundFocusMode opens, ESC closes

### Known non-issue: `[...sparklineFor(asset)]` spread

The row template spreads a readonly tuple into a fresh array on every
render. With ~50 virtualized rows and a `SvelteMap` fetch per page
change, the cost is negligible. Cleaner fix (defer to follow-up):
change `MiniSparklineProps.data` to `readonly number[]` so consumers
can pass arrays without copy.

### Verification

```
pnpm -F wealth check    → 1 ERROR + 21 WARNINGS (identical to main
                          baseline; zero new problems)
pnpm -F wealth lint     → 233 problems (identical to main; a new
                          `new Map()` violation was introduced and
                          then fixed via SvelteMap migration)
check-terminal-tokens-sync.mjs → OK; Invariant D scan over 4
                                 terminal route surfaces passed
Backend typecheck/lint → not run (2-line schema + 1 mapping line,
                         no test surface changed)
```

**Not verified**: live browser render with Tiingo sparkline data.
Per `feedback_visual_validation.md` this should be exercised before
handoff — flagged for a human check on staging.

## Test plan

- [x] `pnpm -F wealth check` → zero-delta vs main
- [x] `pnpm -F wealth lint` → zero-delta vs main
- [x] `node scripts/check-terminal-tokens-sync.mjs` → green
- [x] Backend schema/route change compiles (included in catalog mapping)
- [ ] Live smoke on staging: sparkline column renders for in-universe
  funds; CLEAR ALL strips URL; keyboard nav still scrolls highlighted
  row into view (§G.SCREENER risk 2 — confirmed already handled by
  existing `scrollToIndex` DOM-scroll logic)
- [ ] Playwright harness activation (tracked separately — `PR-6`
  backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)