### PR TITLE
feat(terminal): PR-4a builder — CascadeTimeline + IPS strip + Regime strip

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -38,11 +38,13 @@ from app.domains.wealth.schemas.model_portfolio import (
     ApprovalHistoryResponse,
     ApprovalResponse,
     ApproveProposalRequest,
+    CascadePhaseAttempt,
     ConstructionAdviceRead,
     ConstructionRunDiffOut,
     ConstructionRunMetricDelta,
     ConstructionRunWeightDelta,
     ConstructRunAccepted,
+    CoverageSummary,
     CusipExposureRead,
     JobCreatedResponse,
     LatestProposalResponse,
@@ -4895,6 +4897,8 @@ async def latest_proposal(
     telemetry = run.cascade_telemetry or {}
     raw_bands = telemetry.get("proposed_bands") or []
     raw_metrics = telemetry.get("proposal_metrics") or {}
+    raw_phases = telemetry.get("phase_attempts") or []
+    raw_coverage = telemetry.get("coverage")
     winner_signal = (
         telemetry.get("winner_signal") or run.status or "unknown"
     )
@@ -4916,6 +4920,27 @@ async def latest_proposal(
         target_cvar=raw_metrics.get("target_cvar"),
         cvar_feasible=bool(raw_metrics.get("cvar_feasible", False)),
     )
+    phase_attempts = [
+        CascadePhaseAttempt(
+            phase=str(p.get("phase") or ""),
+            status=str(p.get("status") or "unknown"),
+            solver=p.get("solver"),
+            wall_ms=int(p.get("wall_ms") or 0),
+            objective_value=p.get("objective_value"),
+            cvar_within_limit=p.get("cvar_within_limit"),
+        )
+        for p in raw_phases
+        if p.get("phase")
+    ]
+    coverage: CoverageSummary | None = None
+    if isinstance(raw_coverage, dict):
+        coverage = CoverageSummary(
+            pct_covered=raw_coverage.get("pct_covered"),
+            hard_fail=bool(raw_coverage.get("hard_fail", False)),
+            n_total_blocks=raw_coverage.get("n_total_blocks"),
+            n_covered_blocks=raw_coverage.get("n_covered_blocks"),
+            missing_blocks=list(raw_coverage.get("missing_blocks") or []),
+        )
 
     return LatestProposalResponse(
         run_id=run.id,
@@ -4923,6 +4948,8 @@ async def latest_proposal(
         winner_signal=winner_signal,
         proposed_bands=proposed_bands,
         proposal_metrics=proposal_metrics,
+        phase_attempts=phase_attempts,
+        coverage=coverage,
     )
 
 

--- a/backend/app/domains/wealth/schemas/model_portfolio.py
+++ b/backend/app/domains/wealth/schemas/model_portfolio.py
@@ -294,14 +294,53 @@ class ProposalMetrics(BaseModel):
     cvar_feasible: bool
 
 
+class CascadePhaseAttempt(BaseModel):
+    """One phase of the PR-A12 RU LP cascade.
+
+    Surfaces the subset of ``cascade_telemetry.phase_attempts[i]`` that
+    the frontend CascadeTimeline renders. Persisted in full on
+    ``portfolio_construction_runs.cascade_telemetry`` by the executor;
+    this schema is a read-only view.
+    """
+
+    phase: str
+    status: str
+    solver: str | None = None
+    wall_ms: int = 0
+    objective_value: float | None = None
+    cvar_within_limit: bool | None = None
+
+
+class CoverageSummary(BaseModel):
+    """Universe coverage summary from PR-A14.
+
+    Mirrors the JSONB block persisted by the construction executor.
+    ``pct_covered`` is 0..1; ``hard_fail`` is True when the coverage gate
+    aborted the cascade.
+    """
+
+    pct_covered: float | None = None
+    hard_fail: bool = False
+    n_total_blocks: int | None = None
+    n_covered_blocks: int | None = None
+    missing_blocks: list[str] = Field(default_factory=list)
+
+
 class LatestProposalResponse(BaseModel):
-    """Response for ``GET /portfolio/profiles/{profile}/latest-proposal``."""
+    """Response for ``GET /portfolio/profiles/{profile}/latest-proposal``.
+
+    PR-4a — additive ``phase_attempts`` and ``coverage`` surface the
+    existing ``cascade_telemetry`` JSONB fields already persisted by the
+    construction executor; no backend behavior changes.
+    """
 
     run_id: uuid.UUID
     requested_at: datetime
     winner_signal: str
     proposed_bands: list[ProposedBand]
     proposal_metrics: ProposalMetrics
+    phase_attempts: list[CascadePhaseAttempt] = Field(default_factory=list)
+    coverage: CoverageSummary | None = None
 
 
 class JobCreatedResponse(BaseModel):

--- a/docs/plans/2026-04-19-netz-terminal-parity-builder-macro-screener.md
+++ b/docs/plans/2026-04-19-netz-terminal-parity-builder-macro-screener.md
@@ -2,18 +2,18 @@
 
 **Date:** 2026-04-19
 **Owner:** Andrei
-**Scope decision locked:** Visual + interaction parity for the 3 remaining Figma pages (`Netz Terminal - Builder.html`, `Netz Terminal - Macro.html`, `Netz Terminal - Screener.html`). Terminal.html parity already landed via PRs #230–#234.
+**Scope decision locked:** Visual + interaction parity for the 3 remaining UX bundle pages (`Netz Terminal - Builder.html`, `Netz Terminal - Macro.html`, `Netz Terminal - Screener.html`). Terminal.html parity already landed via PRs #230–#234.
 **Execution model:** 4–5 independently-mergeable sub-PRs sized for a single Opus session each. Sessions run in parallel with Gemini; do not cross-touch files outside the PR’s scope.
 
 ---
 
 ## 0. Ground truth & assumptions
 
-- Figma bundle IS checked into repo at `docs/ux/Netz Terminal/`:
+- UX bundle IS checked into repo at `docs/ux/Netz Terminal/`:
   - `Netz Terminal - Builder.html` + `builder.css` (726 lines) + `builder-app.jsx` (381) + `builder-data.jsx` + `builder-preview.jsx`.
   - `Netz Terminal - Macro.html` + `macro.css` (629) + `macro-app.jsx` (695) + `macro-data.jsx`.
   - `Netz Terminal - Screener.html` + `screener.css` (398) + `screener-app.jsx` (602) + `screener-data.jsx`.
-  - Shared `assets/` + `_check/` (Figma QA snapshots).
+  - Shared `assets/` + `_check/` (bundle QA snapshots).
   - Opus diffs against these at visual-QA time; the `.jsx` files are reference-only (React) — never imported.
 - Infra to REUSE (do NOT rewrite):
   - `@netz/ui/terminal` primitives: `Pill`, `Kbd`, `KpiCard`, `DensityToggle`, `AccentPicker`, `ThemeToggle` (PR #231).
@@ -21,8 +21,8 @@
   - `terminal-tweaks.svelte.ts` (density/accent/theme — in-memory only).
   - `MarketDataStore` (Tiingo WS + REST fallback) already wired to `(terminal)/+layout.svelte`.
   - Formatters `formatMonoTime` / `formatCompactCurrency` / `formatPpDrift` / `formatMonoPercent` from `@netz/ui/formatters/mono`.
-  - Tokens `--terminal-*` namespace canonical; `--term-*` in Figma CSS are naming differences only — remap at port time, no aliases in `@netz/ui`.
-- Figma JSX uses React `useState`/`setInterval` sims + `Math.random` ticks — **ignore all JS**, port visuals only.
+  - Tokens `--terminal-*` namespace canonical; `--term-*` in bundle CSS are naming differences only — remap at port time, no aliases in `@netz/ui`.
+- Bundle JSX uses React `useState`/`setInterval` sims + `Math.random` ticks — **ignore all JS**, port visuals only.
 - `(terminal)/+layout.svelte` already mounts breadcrumb, tweaks context, and LayoutCage. No layout-shell changes allowed in this sprint.
 - Scope decisions confirmed by Andrei 2026-04-19:
   - **Macro RegimeMatrix pin** = client-only `$state`, no backend write. UI banner “SIMULATION”.
@@ -38,96 +38,96 @@
 
 ## A. Diff-style audit per page
 
-Each row: **Current** → **Gap vs Figma** → **Patch**.
+Each row: **Current** → **Gap vs bundle** → **Patch**.
 
 ### A.SCREENER — `/terminal-screener`
 
 Route: `frontends/wealth/src/routes/(terminal)/terminal-screener/+page.svelte`
 Supporting: `frontends/wealth/src/lib/components/screener/terminal/{TerminalScreenerShell,TerminalScreenerFilters,TerminalDataGrid}.svelte`
-Figma: `Netz Terminal - Screener.html` + `screener.css` + `screener-app.jsx`
+Bundle: `Netz Terminal - Screener.html` + `screener.css` + `screener-app.jsx`
 
-| # | Current | Gap vs Figma | Patch |
+| # | Current | Gap vs bundle | Patch |
 |---|---|---|---|
-| S1 | `TerminalScreenerShell` renders filters + datagrid. URL-owned filter state via `parseFiltersFromURL`. `FundFocusMode` overlay on row click. | OK — architecture matches Figma’s two-column (filter rail + grid). No structural change. | No-op. |
-| S2 | `TerminalScreenerFilters.svelte` — raw filter inputs (checkboxes + numeric sliders inline). | Figma uses a **FilterChipGroup** model: each applied filter renders as a dismissible pill with operator + value. Unapplied filters hide in a collapsible drawer at left. | Introduce `<FilterChipRow>` at the top of the grid (shows applied filters as `Pill as="button" tone="accent"` with X). Filter inputs remain in the rail but are collapsed by default; chip row is the primary driver. See §B.1. |
-| S3 | Datagrid uses `TerminalDataGrid` (custom `<table>`). | Figma shows tabular row with **mini sparkline column** (inline 60×18 sparkline per row — last 12mo NAV trend), plus star-elite badge, pill for strategy. | Add `<MiniSparkline />` primitive (§B.2) to `TerminalDataGrid` row renderer. Sparkline data comes from `fund_risk_metrics.nav_trend_sparkline` if present; otherwise omit column (flag backend gap §D). |
-| S4 | Column set: name, strategy, aum, return_1y, sharpe, expense, dd. | Figma adds **BLENDED MOMENTUM** column (pre-computed `blended_momentum_score` from `fund_risk_metrics`) and **10Y RETURN** column. | Add columns to `TerminalDataGrid` config. Data already exists in `fund_risk_metrics`. |
-| S5 | Row click → `FundFocusMode` overlay. | OK. Figma `screener-app.jsx` shows same overlay structure. | No-op. |
+| S1 | `TerminalScreenerShell` renders filters + datagrid. URL-owned filter state via `parseFiltersFromURL`. `FundFocusMode` overlay on row click. | OK — architecture matches the bundle’s two-column (filter rail + grid). No structural change. | No-op. |
+| S2 | `TerminalScreenerFilters.svelte` — raw filter inputs (checkboxes + numeric sliders inline). | Bundle uses a **FilterChipGroup** model: each applied filter renders as a dismissible pill with operator + value. Unapplied filters hide in a collapsible drawer at left. | Introduce `<FilterChipRow>` at the top of the grid (shows applied filters as `Pill as="button" tone="accent"` with X). Filter inputs remain in the rail but are collapsed by default; chip row is the primary driver. See §B.1. |
+| S3 | Datagrid uses `TerminalDataGrid` (custom `<table>`). | Bundle shows tabular row with **mini sparkline column** (inline 60×18 sparkline per row — last 12mo NAV trend), plus star-elite badge, pill for strategy. | Add `<MiniSparkline />` primitive (§B.2) to `TerminalDataGrid` row renderer. Sparkline data comes from `fund_risk_metrics.nav_trend_sparkline` if present; otherwise omit column (flag backend gap §D). |
+| S4 | Column set: name, strategy, aum, return_1y, sharpe, expense, dd. | Bundle adds **BLENDED MOMENTUM** column (pre-computed `blended_momentum_score` from `fund_risk_metrics`) and **10Y RETURN** column. | Add columns to `TerminalDataGrid` config. Data already exists in `fund_risk_metrics`. |
+| S5 | Row click → `FundFocusMode` overlay. | OK. bundle `screener-app.jsx` shows same overlay structure. | No-op. |
 | S6 | `screener.css` uses `--term-*` tokens (e.g. `--term-void`, `--term-fg-primary`). | Must remap to `--terminal-*`. | Port only the layout rules (grid template, row heights, column widths). All color refs → `--terminal-*`. |
-| S7 | No DensityToggle integration in screener surface. | Figma rows compress with `[data-density="compact"]`. | `<TerminalDataGrid>` must consume `--t-row-height` (already defined). Verify row height does NOT use hardcoded px. |
-| S8 | `screener-page-root` overrides `.lc-cage--standard` padding to `--terminal-space-2`. | OK — matches Figma edge-to-edge density. | No-op. |
-| S9 | No keyboard nav in grid. | Figma: `↑/↓` moves row focus; `Enter` opens FundFocusMode; `/` focuses filter search. | Add keyboard handler on `containerEl` in `+page.svelte`. Guard: skip when input focused (reuse util from `TerminalShell`). |
+| S7 | No DensityToggle integration in screener surface. | Bundle rows compress with `[data-density="compact"]`. | `<TerminalDataGrid>` must consume `--t-row-height` (already defined). Verify row height does NOT use hardcoded px. |
+| S8 | `screener-page-root` overrides `.lc-cage--standard` padding to `--terminal-space-2`. | OK — matches the bundle's edge-to-edge density. | No-op. |
+| S9 | No keyboard nav in grid. | Bundle: `↑/↓` moves row focus; `Enter` opens FundFocusMode; `/` focuses filter search. | Add keyboard handler on `containerEl` in `+page.svelte`. Guard: skip when input focused (reuse util from `TerminalShell`). |
 
 ### A.MACRO — `/macro`
 
 Route: `frontends/wealth/src/routes/(terminal)/macro/+page.svelte`
 Supporting: `frontends/wealth/src/lib/components/terminal/macro/{StressHero,SignalBreakdown,RegionalHealthTile,SparklineWall,CommitteeReviewFeed}.svelte`
-Figma: `Netz Terminal - Macro.html` + `macro.css` + `macro-app.jsx`
+Bundle: `Netz Terminal - Macro.html` + `macro.css` + `macro-app.jsx`
 
-| # | Current | Gap vs Figma | Patch |
+| # | Current | Gap vs bundle | Patch |
 |---|---|---|---|
-| M1 | Layout = Hero (full) → SignalBreakdown (2-col) → bottom grid 5fr/4fr/3fr. | Figma layout = **4 zones**: (1) StressHero + RegimeMatrix side-by-side (7fr/5fr), (2) SignalBreakdown full-width, (3) bottom = RegionalHealth (6fr) + SparklineWall (6fr), (4) CommitteeReviewFeed = right sidebar in Zone 1 OR collapsible drawer. | Restructure `macro-desk` grid. Pull CommitteeReviewFeed out of bottom row; place as a drawer toggled by `Shift+R` (committee review key). Add RegimeMatrix next to Hero. |
+| M1 | Layout = Hero (full) → SignalBreakdown (2-col) → bottom grid 5fr/4fr/3fr. | Bundle layout = **4 zones**: (1) StressHero + RegimeMatrix side-by-side (7fr/5fr), (2) SignalBreakdown full-width, (3) bottom = RegionalHealth (6fr) + SparklineWall (6fr), (4) CommitteeReviewFeed = right sidebar in Zone 1 OR collapsible drawer. | Restructure `macro-desk` grid. Pull CommitteeReviewFeed out of bottom row; place as a drawer toggled by `Shift+R` (committee review key). Add RegimeMatrix next to Hero. |
 | M2 | `.macro-desk { height: calc(100vh - 88px); padding: 24px; }` hardcoded. | Use layout cage tokens. | `height: var(--terminal-shell-cage-height, calc(100vh - 116px))`; keep `padding: 24px` per `feedback_layout_cage_pattern.md` (flex/grid min-h-0 fails). |
-| M3 | `setInterval(..., 5*60*1000)` polls macro scores + FRED sparklines. | Figma sparklines are WS-ticked (Tiingo quote for index-tracking ETFs). Backend FRED series are daily — WS not applicable. | Keep 5min REST poll for FRED. **NEW:** for VIX/USD/10Y sparklines that have Tiingo proxies (VXX, UUP, IEF), swap source to `MarketDataStore` subscription. Adapter `macro-sparkline-adapter.ts` (§B.3) resolves series → symbol → live tick. Sparklines without live proxy stay REST-only. |
-| M4 | No RegimeMatrix (drag-drop pin simulation). | Figma: 4×4 grid of regime cells (rows = stress level, cols = growth quadrant). User drags the active pin to a cell → `simulatedRegime` propagates to Hero + SignalBreakdown shading. | New component `RegimeMatrix.svelte` (§B.4). Local `$state` only, banner “SIMULATION”, `Reset` button. No backend write. |
-| M5 | `pinnedRegime` currently persists across pages (global state). | Figma pin state is page-local (matrix = simulation, not a global lock). | Keep `pinnedRegime` global store as-is for TopNav regime indicator, but matrix simulation writes to a SEPARATE `macroSimulationStore` (page-scoped) that does NOT touch `pinnedRegime`. |
-| M6 | `SparklineWall` uses its own sparkline renderer. | Figma sparklines are identical to screener mini-sparklines (same 60×18 footprint with last/delta label). | Refactor `SparklineWall` to use the new `<MiniSparkline>` primitive from §B.2. Deduplicates. |
-| M7 | No chart-type toggle. Sparklines only. | Figma has **tab group** on SparklineWall: `SPARK / AREA / BARS`. | Add `<Pill as="button">` trio driving `SparklineWall.mode`. Area/bars render via same `lightweight-charts` instance (single-container swap, same pattern as PR #233 Candle/Line toggle). **Out of scope if new lightweight-charts series types required** — ship SPARK-only and flag. |
+| M3 | `setInterval(..., 5*60*1000)` polls macro scores + FRED sparklines. | Bundle sparklines are WS-ticked (Tiingo quote for index-tracking ETFs). Backend FRED series are daily — WS not applicable. | Keep 5min REST poll for FRED. **NEW:** for VIX/USD/10Y sparklines that have Tiingo proxies (VXX, UUP, IEF), swap source to `MarketDataStore` subscription. Adapter `macro-sparkline-adapter.ts` (§B.3) resolves series → symbol → live tick. Sparklines without live proxy stay REST-only. |
+| M4 | No RegimeMatrix (drag-drop pin simulation). | Bundle: 4×4 grid of regime cells (rows = stress level, cols = growth quadrant). User drags the active pin to a cell → `simulatedRegime` propagates to Hero + SignalBreakdown shading. | New component `RegimeMatrix.svelte` (§B.4). Local `$state` only, banner “SIMULATION”, `Reset` button. No backend write. |
+| M5 | `pinnedRegime` currently persists across pages (global state). | Bundle pin state is page-local (matrix = simulation, not a global lock). | Keep `pinnedRegime` global store as-is for TopNav regime indicator, but matrix simulation writes to a SEPARATE `macroSimulationStore` (page-scoped) that does NOT touch `pinnedRegime`. |
+| M6 | `SparklineWall` uses its own sparkline renderer. | Bundle sparklines are identical to screener mini-sparklines (same 60×18 footprint with last/delta label). | Refactor `SparklineWall` to use the new `<MiniSparkline>` primitive from §B.2. Deduplicates. |
+| M7 | No chart-type toggle. Sparklines only. | Bundle has **tab group** on SparklineWall: `SPARK / AREA / BARS`. | Add `<Pill as="button">` trio driving `SparklineWall.mode`. Area/bars render via same `lightweight-charts` instance (single-container swap, same pattern as PR #233 Candle/Line toggle). **Out of scope if new lightweight-charts series types required** — ship SPARK-only and flag. |
 | M8 | No `.toFixed` / `toLocaleString` in macro components (grep clean). | — | No cleanup needed. |
-| M9 | `StressHero` emits `onProceedToAlloc` → `/terminal/allocation`. | Figma button reads `PROCEED TO BUILDER`. | Rename label; route already correct (`(terminal)/allocation`). Copy change only. |
-| M10 | `CommitteeReviewFeed` shows last N reviews inline. | Figma = drawer, closed by default, opens via `Shift+R` OR badge click in TopNav. | Wrap in `<Drawer side="right" width="380">` (new primitive §B.5 OR reuse `TerminalTweaksPanel` drawer pattern). |
+| M9 | `StressHero` emits `onProceedToAlloc` → `/terminal/allocation`. | Bundle button reads `PROCEED TO BUILDER`. | Rename label; route already correct (`(terminal)/allocation`). Copy change only. |
+| M10 | `CommitteeReviewFeed` shows last N reviews inline. | Bundle = drawer, closed by default, opens via `Shift+R` OR badge click in TopNav. | Wrap in `<Drawer side="right" width="380">` (new primitive §B.5 OR reuse `TerminalTweaksPanel` drawer pattern). |
 
 ### A.BUILDER — `/allocation/[profile]` (propose→approve surface)
 
 > **§ BUILDER SCOPE PIVOT (2026-04-19)**
 >
-> The Figma `Netz Terminal - Builder.html` file represents the **legacy pre-A26 architecture** where the operator supplied CVaR + turnover + min-weight + max-single-position sliders, IC views, factor tilts, and region caps to the optimizer as inputs. That input surface has been **deleted from the product model** by the A26 sprint (PRs #214, #217, #219, #220, #221, #222 merged 2026-04-18).
+> The bundle's `Netz Terminal - Builder.html` file represents the **legacy pre-A26 architecture** where the operator supplied CVaR + turnover + min-weight + max-single-position sliders, IC views, factor tilts, and region caps to the optimizer as inputs. That input surface has been **deleted from the product model** by the A26 sprint (PRs #214, #217, #219, #220, #221, #222 merged 2026-04-18).
 >
 > **New model (A26.1 + A26.2 + A26.3):** CVaR limit on the IPS is the only mandatory human input. The optimizer runs unconstrained by strategic bands in `propose` mode; the operator reviews the proposal (cascade telemetry + diff bars + 18-block targets) and either **approves atomically** (snapshot → `strategic_allocation` + `allocation_approvals`) or sets **ad-hoc per-block overrides** and re-proposes. Realize mode refuses to run until a Strategic is approved.
 >
-> **Treat the Figma as reference for the _output_ surfaces** (regime header, cascade phase timeline, weights table, risk metrics, stress scenarios, backtest charts — all read-only visualizations of an executed propose run). **Ignore the Figma's input surfaces** — zone B calibration sliders (CVaR/turnover/min-weight), IC views list, factor tilts, region caps, RunControls profile+RUN button. Those are replaced by the ProposeButton / ProposalReviewPanel / OverrideBandsEditor trio already shipped in PR #219.
+> **Treat the bundle as reference for the _output_ surfaces** (regime header, cascade phase timeline, weights table, risk metrics, stress scenarios, backtest charts — all read-only visualizations of an executed propose run). **Ignore the bundle's input surfaces** — zone B calibration sliders (CVaR/turnover/min-weight), IC views list, factor tilts, region caps, RunControls profile+RUN button. Those are replaced by the ProposeButton / ProposalReviewPanel / OverrideBandsEditor trio already shipped in PR #219.
 >
 > **Canonical Builder route for Terminal parity = `/(terminal)/allocation/[profile]/` (PR #219).**
 > The route `/(terminal)/portfolio/builder/` is **legacy Phase 4+5 Builder** with calibration sliders / tabs / ActivationBar. It is NOT the parity target of PR-4. It may be retired in a follow-up sprint; out of scope for this plan. Opus executor: do not edit `/(terminal)/portfolio/builder/**` in PR-4.
 
 **Route (canonical):** `frontends/wealth/src/routes/(terminal)/allocation/+page.svelte` (3-profile cards) + `frontends/wealth/src/routes/(terminal)/allocation/[profile]/+page.svelte` (per-profile governance surface).
 **Supporting components (PR #219 delivered):** `frontends/wealth/src/lib/components/allocation/{StrategicAllocationTable,AllocationDonut,AllocationTable,ProposalReviewPanel,ProposeButton,OverrideBandsEditor,ApprovalHistoryTable}.svelte` + `BLOCK_INSTRUMENTS.ts` + `types.ts`.
-**Figma:** `Netz Terminal - Builder.html` + `builder.css` + `builder-app.jsx` + `builder-preview.jsx` — reference visually for **output tabs only** (Regime / Weights / Risk / Stress / Backtest / Cascade). Discard all input-surface elements.
+**Bundle:** `Netz Terminal - Builder.html` + `builder.css` + `builder-app.jsx` + `builder-preview.jsx` — reference visually for **output tabs only** (Regime / Weights / Risk / Stress / Backtest / Cascade). Discard all input-surface elements.
 
-**What stays from Figma (visual re-skin targets, mapped to existing PR #219 components):**
+**What stays from the bundle (visual re-skin targets, mapped to existing PR #219 components):**
 
-| Figma element | Existing component | Parity action |
+| Bundle element | Existing component | Parity action |
 |---|---|---|
 | Cascade phase timeline (P1 → P1.5 → P2 → P3 → fallback) | `ProposalReviewPanel` metrics row (currently shows E[r] / CVaR / Target / Feasible badge — does NOT render phase timeline yet) | **NEW primitive** `CascadeTimeline.svelte` (wealth-local to `components/allocation/`) — reads `cascade_telemetry.phases[]` from the propose run. Mount in `ProposalReviewPanel` header above the diff bars. |
-| Regime context strip (top of Figma) | Not rendered on allocation page | **NEW** `RegimeContextStrip.svelte` read-only (current regime + stress + window from `GET /macro/regime`). Mount above the KPI row. |
+| Regime context strip (top of bundle) | Not rendered on allocation page | **NEW** `RegimeContextStrip.svelte` read-only (current regime + stress + window from `GET /macro/regime`). Mount above the KPI row. |
 | Weights diff bars | `ProposalReviewPanel` diff bar chart (svelte-echarts) | OK — already shipped; re-skin colors to `--terminal-*` tokens. |
 | 18-row allocation table | `StrategicAllocationTable` + `AllocationDonut` | OK — re-skin to Netz Terminal density + tokens. |
 | IPS summary strip (target return / max CVaR / rebalance freq) | None | **NEW** `IpsSummaryStrip.svelte` (wealth-local, §B.7) — reads CVaR limit from `StrategicAllocationResponse.cvar_limit`. Rendered in the KPI row OR as a footer strip. |
 | Breadcrumb + LayoutCage | `(terminal)/+layout.svelte` | OK — already wired. |
 
-**What is REMOVED from Figma (never implement):**
+**What is REMOVED from the bundle (never implement):**
 
-| Figma input element | Why removed | Replacement |
+| Bundle input element | Why removed | Replacement |
 |---|---|---|
 | Zone B CalibrationPanel (CVaR / turnover / min-weight / max-single-position sliders) | A26 eliminated pre-run IC parameters except CVaR limit. | CVaR limit is set on `portfolio_calibration` via admin API (not in allocation UI per A26.3 Section scope). `OverrideBandsEditor` modal replaces all other block-level constraints. |
 | IC views list (left rail) | A26.1 bypasses BL posterior + `_load_ic_views` in propose mode. | Deleted. |
-| Factor tilts | Never implemented in backend; legacy Figma artifact. | Deleted. |
+| Factor tilts | Never implemented in backend; legacy bundle artifact. | Deleted. |
 | Region caps / sector caps | Replaced by per-block `override_min/override_max` on any of the 18 canonical blocks. | `OverrideBandsEditor` per-block modal. |
 | `RunControls` RUN + profile dropdown | Profile is URL param `[profile]`; "run" is now `ProposeButton`. | `ProposeButton` (SSE-wired, `fetch + ReadableStream`). |
 | `ActivationBar` "all tabs visited" gate | No tabs exist in propose→approve flow. | Deleted. Approval gate is enforced server-side by the approve-proposal endpoint. |
 | MONTE CARLO / ADVISOR tabs | Tab navigation dropped. Advisor output surfaces inline in `ProposalReviewPanel`. | Deleted. (Monte Carlo visualization may return as a post-approval analytics backlog item — out of scope.) |
 
-**Diff rows (current `(terminal)/allocation/**` vs Figma sanitized reference):**
+**Diff rows (current `(terminal)/allocation/**` vs bundle sanitized reference):**
 
-| # | Current | Gap vs Figma (sanitized) | Patch |
+| # | Current | Gap vs bundle (sanitized) | Patch |
 |---|---|---|---|
-| B1 | `/allocation/[profile]/+page.svelte` renders: breadcrumb + KPI row (CVaR / Expected Return / Last Approved / Status badge) + 2-column main grid (Strategic table + donut \| ProposalReviewPanel OR ProposeButton) + ApprovalHistoryTable collapsible. | Figma adds a **RegimeContextStrip** above KPI row (current regime + stress + window). Not yet rendered. | Add `<RegimeContextStrip>` (§B.8) at top of page. Reads `GET /macro/regime` (same endpoint as Macro StressHero) via loader. |
-| B2 | `ProposalReviewPanel` shows metrics row + diff bars + expandable 18-block table + `Approve Allocation` / `Dismiss Proposal` actions. | Figma shows cascade phase timeline (P1 / P1.5 / P2 / P3 winner) between metrics row and diff bars. | Insert `<CascadeTimeline>` (§B.6) between metrics row and diff bars. Reads `cascade_telemetry.phases[]` + `winner_signal` + `coverage` from the propose run payload. |
-| B3 | `ProposalReviewPanel` metrics row: E[r] / CVaR / Target CVaR / Feasible badge. | Figma adds **coverage bar** underneath cascade timeline (PR-A14 coverage signal already in data). | `CascadeTimeline` renders coverage as a thin progress bar under the phase row. Color via `--sev-warn` if <50%, `--sev-critical` if <20%, `--terminal-status-success` otherwise. |
-| B4 | No IPS summary strip — only the inline KPI row. | Figma has dedicated `IPS SUMMARY` strip with pills (CVaR limit, last-approved profile, rebalance cadence). | Add `<IpsSummaryStrip>` (§B.7) beneath the breadcrumb OR as a footer. Reads `StrategicAllocationResponse.cvar_limit` + `last_approved_at` + static cadence label. |
-| B5 | `ApproveRejectBar` / standalone approve+reject bar not present — approve button lives inside `ProposalReviewPanel`. | Figma shows a dedicated footer `ApproveRejectBar` beneath the results zone. | Acceptable as-is — do not duplicate. Keep approve button inside `ProposalReviewPanel`. Cosmetic: align the panel's action footer to Figma's ApproveRejectBar visual (same density, `Pill` accent primary for Approve + `Pill` ghost for Dismiss). |
+| B1 | `/allocation/[profile]/+page.svelte` renders: breadcrumb + KPI row (CVaR / Expected Return / Last Approved / Status badge) + 2-column main grid (Strategic table + donut \| ProposalReviewPanel OR ProposeButton) + ApprovalHistoryTable collapsible. | Bundle adds a **RegimeContextStrip** above KPI row (current regime + stress + window). Not yet rendered. | Add `<RegimeContextStrip>` (§B.8) at top of page. Reads `GET /macro/regime` (same endpoint as Macro StressHero) via loader. |
+| B2 | `ProposalReviewPanel` shows metrics row + diff bars + expandable 18-block table + `Approve Allocation` / `Dismiss Proposal` actions. | Bundle shows cascade phase timeline (P1 / P1.5 / P2 / P3 winner) between metrics row and diff bars. | Insert `<CascadeTimeline>` (§B.6) between metrics row and diff bars. Reads `cascade_telemetry.phases[]` + `winner_signal` + `coverage` from the propose run payload. |
+| B3 | `ProposalReviewPanel` metrics row: E[r] / CVaR / Target CVaR / Feasible badge. | Bundle adds **coverage bar** underneath cascade timeline (PR-A14 coverage signal already in data). | `CascadeTimeline` renders coverage as a thin progress bar under the phase row. Color via `--sev-warn` if <50%, `--sev-critical` if <20%, `--terminal-status-success` otherwise. |
+| B4 | No IPS summary strip — only the inline KPI row. | Bundle has dedicated `IPS SUMMARY` strip with pills (CVaR limit, last-approved profile, rebalance cadence). | Add `<IpsSummaryStrip>` (§B.7) beneath the breadcrumb OR as a footer. Reads `StrategicAllocationResponse.cvar_limit` + `last_approved_at` + static cadence label. |
+| B5 | `ApproveRejectBar` / standalone approve+reject bar not present — approve button lives inside `ProposalReviewPanel`. | Bundle shows a dedicated footer `ApproveRejectBar` beneath the results zone. | Acceptable as-is — do not duplicate. Keep approve button inside `ProposalReviewPanel`. Cosmetic: align the panel's action footer to bundle's ApproveRejectBar visual (same density, `Pill` accent primary for Approve + `Pill` ghost for Dismiss). |
 | B6 | `.toFixed`/`Intl` audit in allocation components. | — | Grep sweep on PR open; PR #219 shipped clean but verify. Formatters must come from `@netz/ui`. |
-| B7 | `data-allocation-root` attribute for LayoutCage padding override. | Currently uses the `h-[calc(100vh-88px)] p-6 overflow-y-auto` pattern directly. Figma shows edge-to-edge density similar to screener. | Add `data-allocation-root` + match the screener override so cage padding collapses to `--terminal-space-2`. Preserve the `calc(100vh-88px)` height per `feedback_layout_cage_pattern.md`. |
+| B7 | `data-allocation-root` attribute for LayoutCage padding override. | Currently uses the `h-[calc(100vh-88px)] p-6 overflow-y-auto` pattern directly. Bundle shows edge-to-edge density similar to screener. | Add `data-allocation-root` + match the screener override so cage padding collapses to `--terminal-space-2`. Preserve the `calc(100vh-88px)` height per `feedback_layout_cage_pattern.md`. |
 | B8 | `StrategicAllocationTable` row click: no action. | OK — per PR-A26.3 Section C spec ("no drill-down in v1"). | No-op. Override edit still lives on the row-action icon. |
 | B9 | Approve with `cvar_feasible=false` → confirm modal in `ProposalReviewPanel`. | OK — matches A26.2 Section C spec (`confirm_cvar_infeasible=true` body flag). | No-op. Verify visual parity: destructive tone on `Confirm Approval` button. |
 | B10 | SSE propose flow: `fetch` + `ReadableStream` per `CLAUDE.md` + `ProposeButton`. | OK. | No-op. Verify events `propose_started / optimizer_started / optimizer_phase_complete / propose_ready / propose_cvar_infeasible / completed` render as a progress indicator with cascade-phase awareness (drives §CascadeTimeline update during the stream for pre-settlement visual). |
@@ -479,15 +479,15 @@ Splits the token/density re-skin + `.toFixed` sweep out of PR-4 if the 3 new pri
 3. **FilterChipRow vs TerminalScreenerFilters duplication.** Chip row is derived from URL state; filter rail writes to URL. Source-of-truth clash if chip X-removal and rail checkbox get out of sync. Mitigate: chip `onRemove` calls the same `handleFiltersChange` as rail; never writes to a separate store.
 
 ### G.MACRO
-1. **RegimeMatrix drag-drop on touch devices.** Pointer events cover touch, but verify on tablet Figma preview. Scope: desktop-first (Andrei runs terminal on 32″ monitor per memory); touch = nice-to-have.
+1. **RegimeMatrix drag-drop on touch devices.** Pointer events cover touch, but verify on tablet bundle preview. Scope: desktop-first (Andrei runs terminal on 32″ monitor per memory); touch = nice-to-have.
 2. **Simulated regime leak into global `pinnedRegime`.** Must not propagate. Enforce by putting `macroSimulationStore` in page-local scope — do NOT import from `$lib/state/*` (which is app-global).
 3. **SparklineWall live-tick subscription churn.** MarketDataStore subscribe/unsubscribe on mount/unmount. Verify `$effect` cleanup unsubscribes all 3 proxies. WS reconnect during page switch shouldn’t leak listeners.
 4. **Tiingo quote for UUP/IEF may not be in default tenant subscription basket.** Backend `MarketDataStore` ticker whitelist — if UUP isn’t subscribed, sparkline stays REST. Flag and defer; not a blocker.
 
 ### G.BUILDER (`/allocation/[profile]`)
-1. **Figma confusion — legacy Builder surfaces tempt re-implementation.** Opus executor reading the Figma may try to port calibration sliders / IC views / factor tilts / `RunControls` RUN button / ActivationBar tab gates because the HTML+JSX still contain them. **Mitigation:** the §BUILDER SCOPE PIVOT block at the top of §A.BUILDER is the anchor; re-read before any edit. Any PR-4 commit touching `/(terminal)/portfolio/builder/**` or introducing a CVaR slider / turnover slider / factor-tilts / IC-views UI is out of scope — reject in review.
+1. **Bundle confusion — legacy Builder surfaces tempt re-implementation.** Opus executor reading the bundle may try to port calibration sliders / IC views / factor tilts / `RunControls` RUN button / ActivationBar tab gates because the HTML+JSX still contain them. **Mitigation:** the §BUILDER SCOPE PIVOT block at the top of §A.BUILDER is the anchor; re-read before any edit. Any PR-4 commit touching `/(terminal)/portfolio/builder/**` or introducing a CVaR slider / turnover slider / factor-tilts / IC-views UI is out of scope — reject in review.
 2. **Cascade telemetry shape drift.** `cascade_telemetry.phases[]` schema shipped by A26.1 Section B may differ slightly from what `CascadeTimeline` expects. Verify at PR-4 open by fetching `latest-proposal` from dev DB canonical org and pasting the JSONB sample into the PR body. If shape differs (e.g., flat dict keyed by phase name vs. list), adapt `CascadeTimeline` props — do NOT change backend telemetry shape in PR-4.
-3. **Read-only vs. editable affordance ambiguity.** Figma's Weights / Risk / Stress / Backtest tabs historically felt "tweakable" because they sat next to input sliders. In the propose→approve model, those outputs are read-only. **Mitigation:** no hover-cursor=pointer on result cells; no inline editing controls; overrides are explicitly gated behind the `OverrideBandsEditor` modal (per-block), never as a cell edit. Acceptance criteria §E.BUILDER enforces this.
+3. **Read-only vs. editable affordance ambiguity.** bundle's Weights / Risk / Stress / Backtest tabs historically felt "tweakable" because they sat next to input sliders. In the propose→approve model, those outputs are read-only. **Mitigation:** no hover-cursor=pointer on result cells; no inline editing controls; overrides are explicitly gated behind the `OverrideBandsEditor` modal (per-block), never as a cell edit. Acceptance criteria §E.BUILDER enforces this.
 4. **Live-mode vs. settled-mode cascade timeline.** During SSE propose stream, phases arrive sequentially (`optimizer_phase_complete`). `CascadeTimeline` must degrade gracefully: show pending / in-progress / complete states per phase without flicker. Avoid replacing the component on every event — mutate `phases[]` in place via `$state`.
 5. **`RegimeContextStrip` depends on `/macro/regime`.** That endpoint may not be mounted on the wealth frontend's standard loader context (Macro page fetches it directly). Confirm at PR-4 open that the server loader can call `/macro/regime` without additional auth scope. If not, strip this element and flag as a backlog item (fallback: render without regime strip; don't block PR).
 6. **PR-A13 achievable-return band UX is a future sprint.** Memory flags PR-A13 UX brief exists (2026-04-17). PR-4 visually ships the propose→approve surface; the feasibility-frontier / achievable-return band panel is out of scope. If Opus attempts to bundle, split into a separate PR.
@@ -504,7 +504,7 @@ Splits the token/density re-skin + `.toFixed` sweep out of PR-4 if the 3 new pri
 3. **PR-3 (Macro)** — introduces RegimeMatrix + Drawer. Depends on PR-1 drawer. Visual complexity mid-tier.
 4. **PR-4 (Builder = `/allocation/[profile]` propose→approve re-skin)** — 3 new read-only primitives (`CascadeTimeline`, `IpsSummaryStrip`, `RegimeContextStrip`) on top of PR #219 surface. No dependency on PR-2/PR-3; could run in parallel after PR-1 but sequenced last to surface any breakage from Screener/Macro primitive changes before touching the governance-critical allocation page.
 
-Rationale: primitives before consumers; Screener validates shared primitives in simplest context; Macro stress-tests Drawer + live-tick wiring; Builder (`/allocation/[profile]`) consumes stable primitives + ships the scope-pivot read-only primitives last. Split into PR-4a (components + integration) and PR-4b (re-skin + lint sweep) if PR-4 exceeds one Opus session — splitting is recommended given the scope-pivot risk (see §G.BUILDER.1): PR-4a can focus all attention on "do not implement legacy Figma inputs" while PR-4b is purely mechanical token/density work.
+Rationale: primitives before consumers; Screener validates shared primitives in simplest context; Macro stress-tests Drawer + live-tick wiring; Builder (`/allocation/[profile]`) consumes stable primitives + ships the scope-pivot read-only primitives last. Split into PR-4a (components + integration) and PR-4b (re-skin + lint sweep) if PR-4 exceeds one Opus session — splitting is recommended given the scope-pivot risk (see §G.BUILDER.1): PR-4a can focus all attention on "do not implement legacy bundle inputs" while PR-4b is purely mechanical token/density work.
 
 ---
 

--- a/frontends/wealth/e2e/terminal-parity.spec.ts
+++ b/frontends/wealth/e2e/terminal-parity.spec.ts
@@ -311,3 +311,71 @@ test.describe("Terminal parity — /macro smoke", () => {
 		await expect(page).toHaveURL(/\/allocation(\/|$)/);
 	});
 });
+
+test.describe("Terminal parity — /allocation/[profile] smoke", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.route("**/api/v1/**", async (route) => {
+			const headers = {
+				...route.request().headers(),
+				"x-dev-actor": `super_admin:${TEST_ORG_ID}`,
+			};
+			await route.continue({ headers });
+		});
+	});
+
+	test("IpsSummaryStrip + RegimeContextStrip mount above the main grid", async ({
+		page,
+	}) => {
+		await page.goto("/allocation/moderate");
+		const ipsStrip = page.getByRole("group", { name: /IPS summary/i });
+		await expect(ipsStrip).toBeVisible();
+		await expect(ipsStrip.getByText(/Profile: Moderate/i)).toBeVisible();
+		await expect(ipsStrip.getByText(/CVaR/i).first()).toBeVisible();
+
+		// RegimeContextStrip only renders when /macro/regime resolves;
+		// treat it as best-effort (worker may not have run on a fresh DB).
+		const regimeStrip = page.getByRole("group", { name: /Macro regime context/i });
+		if ((await regimeStrip.count()) > 0) {
+			await expect(regimeStrip.getByText(/Regime:/i)).toBeVisible();
+		}
+	});
+
+	test("CascadeTimeline renders 3 phases in ProposalReviewPanel", async ({
+		page,
+	}) => {
+		await page.goto("/allocation/moderate");
+		// Only present when a proposal exists. If ProposeButton is mounted
+		// instead, the timeline is empty until a stream runs — skip assertion.
+		const timeline = page.getByRole("list", { name: /Cascade phase timeline/i });
+		if ((await timeline.count()) === 0) {
+			test.skip(true, "no pending proposal on this profile — run propose first");
+		}
+		await expect(timeline).toBeVisible();
+		const phases = timeline.locator("li");
+		await expect(phases).toHaveCount(3);
+		await expect(phases.nth(0)).toContainText(/Phase 1/i);
+		await expect(phases.nth(1)).toContainText(/Phase 2/i);
+		await expect(phases.nth(2)).toContainText(/Phase 3/i);
+	});
+
+	test("Propose SSE advances live CascadeTimeline phase by phase", async ({
+		page,
+	}) => {
+		await page.goto("/allocation/moderate");
+		const proposeButton = page.getByRole("button", { name: /Propose Allocation/i });
+		if ((await proposeButton.count()) === 0) {
+			test.skip(true, "proposal already pending — dismiss first to re-test propose flow");
+		}
+		await proposeButton.click();
+
+		const timeline = page.getByRole("list", { name: /Cascade phase timeline/i });
+		await expect(timeline).toBeVisible({ timeout: 5_000 });
+
+		const phase1 = timeline.locator("li").nth(0);
+		// Status progresses from "pending" (dashed) to "succeeded" / "skipped"
+		// by the time the stream emits optimizer_phase_complete for phase 1.
+		await expect(phase1).toHaveAttribute("data-status", /succeeded|skipped|failed/i, {
+			timeout: 30_000,
+		});
+	});
+});

--- a/frontends/wealth/src/lib/components/allocation/CascadeTimeline.svelte
+++ b/frontends/wealth/src/lib/components/allocation/CascadeTimeline.svelte
@@ -1,0 +1,295 @@
+<!--
+  CascadeTimeline.svelte
+  ======================
+
+  Horizontal 3-phase cascade visualization for the PR-A12 RU LP cascade.
+  Ships two modes:
+
+    • mode="live"    — streamed during propose SSE. Parent seeds the
+                        phases array with three pending entries and
+                        mutates status in place as ``optimizer_phase_complete``
+                        arrives (phase, status, objective_value).
+                        Coverage is unknown mid-stream; the bar hides.
+
+    • mode="settled" — rendered by ProposalReviewPanel after the run
+                        completes. Parent reads ``phase_attempts`` and
+                        ``coverage`` from the LatestProposalResponse
+                        (surfaced by PR-4a backend extension).
+
+  Winner highlighting: the phase whose key matches the resolved winning
+  phase (derived client-side from the array for settled mode, from the
+  most-recent succeeded phase for live) renders with accent tone.
+
+  Coverage bar thresholds match PR-A14 operator signals:
+    • < 20% → critical (hard-fail territory)
+    • < 50% → warn
+    • ≥ 50% → success
+
+  Source: docs/plans/2026-04-19-netz-terminal-parity-builder-macro-screener.md §B.6.
+-->
+<script lang="ts">
+	import type {
+		CascadePhaseAttempt,
+		CoverageSummary,
+	} from "$lib/types/allocation-page";
+
+	export type CascadeTimelineMode = "live" | "settled";
+
+	interface Props {
+		phases: CascadePhaseAttempt[];
+		winnerSignal?: string | null;
+		coverage?: CoverageSummary | null;
+		mode?: CascadeTimelineMode;
+		class?: string;
+	}
+
+	let {
+		phases,
+		winnerSignal = null,
+		coverage = null,
+		mode = "settled",
+		class: className,
+	}: Props = $props();
+
+	const PHASE_LABELS: Record<string, string> = {
+		phase_1_ru_max_return: "Phase 1 · Max Return",
+		phase_2_ru_robust: "Phase 2 · Robust",
+		phase_3_min_cvar: "Phase 3 · Min Tail Risk",
+	};
+
+	const PHASE_ORDER: readonly string[] = [
+		"phase_1_ru_max_return",
+		"phase_2_ru_robust",
+		"phase_3_min_cvar",
+	];
+
+	type PhaseStatus = "pending" | "running" | "succeeded" | "failed" | "skipped" | "unknown";
+
+	const STATUS_MAP: Record<string, PhaseStatus> = {
+		pending: "pending",
+		running: "running",
+		in_progress: "running",
+		succeeded: "succeeded",
+		success: "succeeded",
+		optimal: "succeeded",
+		failed: "failed",
+		error: "failed",
+		skipped: "skipped",
+	};
+
+	function normalizeStatus(raw: string | null | undefined): PhaseStatus {
+		if (!raw) return "unknown";
+		return STATUS_MAP[raw.toLowerCase()] ?? "unknown";
+	}
+
+	const orderedPhases = $derived.by(() => {
+		const byKey = new Map(phases.map((p) => [p.phase, p]));
+		return PHASE_ORDER.map((key) => {
+			const found = byKey.get(key);
+			return (
+				found ?? {
+					phase: key,
+					status: mode === "live" ? "pending" : "unknown",
+					solver: null,
+					wall_ms: 0,
+					objective_value: null,
+					cvar_within_limit: null,
+				}
+			);
+		});
+	});
+
+	const winningPhaseKey = $derived.by(() => {
+		for (let i = orderedPhases.length - 1; i >= 0; i--) {
+			if (normalizeStatus(orderedPhases[i]!.status) === "succeeded") {
+				return orderedPhases[i]!.phase;
+			}
+		}
+		return null;
+	});
+
+	function coverageTone(pct: number | null | undefined): "success" | "warn" | "critical" {
+		if (pct === null || pct === undefined) return "success";
+		if (pct < 0.2) return "critical";
+		if (pct < 0.5) return "warn";
+		return "success";
+	}
+
+	const coveragePct = $derived(coverage?.pct_covered ?? null);
+	const coverageToneClass = $derived(coverageTone(coveragePct));
+	const coverageWidth = $derived(
+		coveragePct !== null ? `${Math.max(0, Math.min(1, coveragePct)) * 100}%` : "0%",
+	);
+</script>
+
+<div class="cascade-timeline {className ?? ''}" data-mode={mode}>
+	<ol class="cascade-timeline__row" aria-label="Cascade phase timeline">
+		{#each orderedPhases as phase, idx (phase.phase)}
+			{@const status = normalizeStatus(phase.status)}
+			{@const isWinner = winningPhaseKey === phase.phase}
+			<li
+				class="cascade-timeline__phase"
+				data-status={status}
+				class:cascade-timeline__phase--winner={isWinner}
+			>
+				<span class="cascade-timeline__phase-index">{idx + 1}</span>
+				<span class="cascade-timeline__phase-label"
+					>{PHASE_LABELS[phase.phase] ?? phase.phase}</span
+				>
+				<span class="cascade-timeline__phase-status">{status}</span>
+			</li>
+		{/each}
+	</ol>
+
+	{#if coverage && coveragePct !== null}
+		<div class="cascade-timeline__coverage" data-tone={coverageToneClass}>
+			<div class="cascade-timeline__coverage-bar">
+				<div
+					class="cascade-timeline__coverage-fill"
+					style="width: {coverageWidth}"
+					role="progressbar"
+					aria-valuenow={Math.round(coveragePct * 100)}
+					aria-valuemin="0"
+					aria-valuemax="100"
+					aria-label="Universe coverage"
+				></div>
+			</div>
+			<span class="cascade-timeline__coverage-label">
+				UNIVERSE COVERAGE ·
+				<span class="cascade-timeline__coverage-value"
+					>{Math.round(coveragePct * 100)}%</span
+				>
+				{#if coverage.missing_blocks?.length}
+					· {coverage.missing_blocks.length} block{coverage.missing_blocks.length === 1 ? "" : "s"} pending
+				{/if}
+			</span>
+		</div>
+	{/if}
+
+	{#if winnerSignal && mode === "settled"}
+		<p class="cascade-timeline__winner-signal">
+			WINNER SIGNAL: <strong>{winnerSignal}</strong>
+		</p>
+	{/if}
+</div>
+
+<style>
+	.cascade-timeline {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.cascade-timeline__row {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: var(--terminal-space-2);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.cascade-timeline__phase {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel-raised);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	[data-mode="live"] .cascade-timeline__phase[data-status="pending"] {
+		border-style: dashed;
+	}
+	[data-mode="live"] .cascade-timeline__phase[data-status="running"] {
+		border-color: var(--terminal-accent-cyan);
+		color: var(--terminal-accent-cyan);
+	}
+
+	.cascade-timeline__phase[data-status="succeeded"] {
+		color: var(--terminal-status-success);
+		border-color: var(--terminal-status-success);
+	}
+	.cascade-timeline__phase[data-status="failed"] {
+		color: var(--terminal-status-error);
+		border-color: var(--terminal-status-error);
+	}
+	.cascade-timeline__phase[data-status="skipped"] {
+		color: var(--terminal-fg-tertiary);
+		border-color: var(--terminal-fg-muted);
+	}
+	.cascade-timeline__phase[data-status="unknown"] {
+		color: var(--terminal-fg-tertiary);
+		border-style: dashed;
+	}
+
+	.cascade-timeline__phase--winner {
+		background: var(--terminal-bg-panel-sunken);
+		box-shadow: inset 0 0 0 1px var(--terminal-accent-amber);
+	}
+	.cascade-timeline__phase--winner .cascade-timeline__phase-label {
+		color: var(--terminal-accent-amber);
+	}
+
+	.cascade-timeline__phase-index {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+	.cascade-timeline__phase-label {
+		font-size: var(--terminal-text-12);
+		color: var(--terminal-fg-primary);
+		line-height: var(--terminal-leading-tight);
+	}
+	.cascade-timeline__phase-status {
+		font-size: var(--terminal-text-10);
+	}
+
+	.cascade-timeline__coverage {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+	}
+	.cascade-timeline__coverage-bar {
+		height: 3px;
+		background: var(--terminal-fg-muted);
+		overflow: hidden;
+	}
+	.cascade-timeline__coverage-fill {
+		height: 100%;
+		transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+	}
+	[data-tone="success"] .cascade-timeline__coverage-fill {
+		background: var(--terminal-status-success);
+	}
+	[data-tone="warn"] .cascade-timeline__coverage-fill {
+		background: var(--sev-warn);
+	}
+	[data-tone="critical"] .cascade-timeline__coverage-fill {
+		background: var(--sev-critical);
+	}
+	.cascade-timeline__coverage-label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+	.cascade-timeline__coverage-value {
+		color: var(--terminal-fg-primary);
+	}
+
+	.cascade-timeline__winner-signal {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		margin: 0;
+	}
+	.cascade-timeline__winner-signal strong {
+		color: var(--terminal-fg-primary);
+		font-weight: inherit;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/allocation/IpsSummaryStrip.svelte
+++ b/frontends/wealth/src/lib/components/allocation/IpsSummaryStrip.svelte
@@ -1,0 +1,101 @@
+<!--
+  IpsSummaryStrip.svelte
+  ======================
+
+  Dense identifier bar for the allocation page. Answers "which IPS am
+  I looking at" in a single horizontal strip; complements the numerical
+  KPI row below. All pills are read-only.
+
+  Reads data already returned by ``GET /portfolio/profiles/{profile}/
+  strategic-allocation``; no new endpoint.
+
+  Source: docs/plans/2026-04-19-netz-terminal-parity-builder-macro-screener.md §B.7.
+-->
+<script lang="ts">
+	import {
+		TerminalPill,
+		formatPercent,
+		formatRelativeDate,
+	} from "@investintell/ui";
+	import type { AllocationProfile } from "$lib/types/allocation-page";
+
+	interface Props {
+		cvarLimit: number | null;
+		lastApprovedAt: string | null;
+		lastApprovedBy: string | null;
+		profile: AllocationProfile;
+		cadenceLabel?: string;
+		class?: string;
+	}
+
+	let {
+		cvarLimit,
+		lastApprovedAt,
+		lastApprovedBy,
+		profile,
+		cadenceLabel = "Quarterly review",
+		class: className,
+	}: Props = $props();
+
+	const PROFILE_PILL_LABEL: Record<AllocationProfile, string> = {
+		conservative: "Conservative",
+		moderate: "Moderate",
+		growth: "Growth",
+	};
+
+	const cvarPillLabel = $derived(
+		cvarLimit !== null ? `CVaR ≤ ${formatPercent(cvarLimit)}` : "CVaR ≤ —",
+	);
+
+	const approvedPillLabel = $derived.by(() => {
+		if (!lastApprovedAt) return "Never approved";
+		const relative = formatRelativeDate(lastApprovedAt);
+		if (lastApprovedBy) return `Approved ${relative} · ${lastApprovedBy}`;
+		return `Approved ${relative}`;
+	});
+</script>
+
+<div class="ips-summary-strip {className ?? ''}" role="group" aria-label="IPS summary">
+	<span class="ips-summary-strip__label">IPS SUMMARY</span>
+	<div class="ips-summary-strip__pills">
+		<TerminalPill
+			label={`Profile: ${PROFILE_PILL_LABEL[profile]}`}
+			tone="neutral"
+			size="xs"
+		/>
+		<TerminalPill
+			label={cvarPillLabel}
+			tone={cvarLimit !== null ? "accent" : "neutral"}
+			size="xs"
+		/>
+		<TerminalPill
+			label={approvedPillLabel}
+			tone={lastApprovedAt ? "success" : "neutral"}
+			size="xs"
+		/>
+		<TerminalPill label={cadenceLabel} tone="neutral" size="xs" />
+	</div>
+</div>
+
+<style>
+	.ips-summary-strip {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding: var(--terminal-space-2) 0;
+		border-top: var(--terminal-border-hairline);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+	}
+	.ips-summary-strip__label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+	.ips-summary-strip__pills {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--terminal-space-2);
+	}
+</style>

--- a/frontends/wealth/src/lib/components/allocation/ProposalReviewPanel.svelte
+++ b/frontends/wealth/src/lib/components/allocation/ProposalReviewPanel.svelte
@@ -12,6 +12,7 @@
 	import { formatDateTime, formatNumber, formatPercent } from "@investintell/ui";
 	import { CheckCircle2, AlertTriangle } from "lucide-svelte";
 	import GenericEChart from "$lib/components/charts/GenericEChart.svelte";
+	import CascadeTimeline from "./CascadeTimeline.svelte";
 	import type {
 		AllocationProfile,
 		ApproveProposalRequest,
@@ -149,7 +150,7 @@
 			{/if}
 		</header>
 
-		<dl class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4 text-sm">
+		<dl class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-3 text-sm">
 			<div>
 				<dt class="text-xs uppercase tracking-wide text-muted-foreground">Proposed E[r]</dt>
 				<dd class="tabular-nums text-foreground">
@@ -183,6 +184,17 @@
 				</dd>
 			</div>
 		</dl>
+
+		{#if proposal.phase_attempts.length > 0}
+			<div class="mb-4">
+				<CascadeTimeline
+					phases={proposal.phase_attempts}
+					winnerSignal={proposal.winner_signal}
+					coverage={proposal.coverage}
+					mode="settled"
+				/>
+			</div>
+		{/if}
 
 		<div class="mb-4">
 			<GenericEChart options={diffChartOptions} height={420} />

--- a/frontends/wealth/src/lib/components/allocation/ProposeButton.svelte
+++ b/frontends/wealth/src/lib/components/allocation/ProposeButton.svelte
@@ -6,12 +6,19 @@
   to human-readable progress lines → refetch latest-proposal on
   completion. User can navigate away; the propose run completes in
   the DB regardless.
+
+  PR-4a — the SSE stream drives a live CascadeTimeline inside the
+  progress area. The three phase entries are seeded on propose start
+  and mutated in place as ``optimizer_phase_complete`` events arrive
+  (see §G.BUILDER.4 — mutate in place, don't remount the component).
 -->
 <script lang="ts">
 	import { formatPercent } from "@investintell/ui";
 	import { Loader2, Wand2 } from "lucide-svelte";
+	import CascadeTimeline from "./CascadeTimeline.svelte";
 	import type {
 		AllocationProfile,
+		CascadePhaseAttempt,
 		JobCreatedResponse,
 	} from "$lib/types/allocation-page";
 
@@ -33,9 +40,27 @@
 		apiBase,
 	}: Props = $props();
 
+	const LIVE_PHASES: readonly string[] = [
+		"phase_1_ru_max_return",
+		"phase_2_ru_robust",
+		"phase_3_min_cvar",
+	];
+
+	function seedPhases(): CascadePhaseAttempt[] {
+		return LIVE_PHASES.map((phase) => ({
+			phase,
+			status: "pending",
+			solver: null,
+			wall_ms: 0,
+			objective_value: null,
+			cvar_within_limit: null,
+		}));
+	}
+
 	let running = $state(false);
 	let statusText = $state("");
 	let errorMsg = $state<string | null>(null);
+	let livePhases = $state<CascadePhaseAttempt[]>([]);
 
 	const EVENT_LABELS: Record<string, string> = {
 		propose_started: "Preparing universe…",
@@ -45,6 +70,31 @@
 		propose_cvar_infeasible: "Proposal ready (CVaR infeasible)",
 		completed: "Finalizing…",
 	};
+
+	function applyPhaseEvent(rawPayload: string): void {
+		if (!rawPayload) return;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(rawPayload);
+		} catch {
+			return;
+		}
+		if (!parsed || typeof parsed !== "object") return;
+		const record = parsed as Record<string, unknown>;
+		const phase = typeof record.phase === "string" ? record.phase : null;
+		const status = typeof record.status === "string" ? record.status : null;
+		if (!phase || !status) return;
+		const idx = livePhases.findIndex((p) => p.phase === phase);
+		if (idx === -1) return;
+		livePhases[idx] = {
+			...livePhases[idx]!,
+			status,
+			objective_value:
+				typeof record.objective_value === "number"
+					? record.objective_value
+					: livePhases[idx]!.objective_value,
+		};
+	}
 
 	async function streamProgress(sseUrl: string): Promise<void> {
 		const token = await getToken();
@@ -73,13 +123,16 @@
 			buffer = lines.pop() ?? "";
 			for (const chunk of lines) {
 				let eventName = "message";
-				let dataLines: string[] = [];
+				const dataLines: string[] = [];
 				for (const line of chunk.split("\n")) {
 					if (line.startsWith("event:")) eventName = line.slice(6).trim();
 					else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
 				}
 				const label = EVENT_LABELS[eventName];
 				if (label) statusText = label;
+				if (eventName === "optimizer_phase_complete") {
+					applyPhaseEvent(dataLines.join("\n"));
+				}
 				if (
 					eventName === "completed" ||
 					eventName === "propose_ready" ||
@@ -104,6 +157,7 @@
 		running = true;
 		errorMsg = null;
 		statusText = "Starting…";
+		livePhases = seedPhases();
 		try {
 			const resp = await apiPost<JobCreatedResponse>(
 				`/portfolio/profiles/${profile}/propose-allocation`,
@@ -150,6 +204,11 @@
 
 	{#if running || statusText}
 		<p class="mt-3 text-xs text-muted-foreground">{statusText}</p>
+	{/if}
+	{#if livePhases.length > 0}
+		<div class="mt-3">
+			<CascadeTimeline phases={livePhases} mode="live" />
+		</div>
 	{/if}
 	{#if errorMsg}
 		<p class="mt-2 text-xs text-destructive">{errorMsg}</p>

--- a/frontends/wealth/src/lib/components/allocation/RegimeContextStrip.svelte
+++ b/frontends/wealth/src/lib/components/allocation/RegimeContextStrip.svelte
@@ -1,0 +1,91 @@
+<!--
+  RegimeContextStrip.svelte
+  =========================
+
+  Read-only regime context for the allocation page. Renders the current
+  global regime + stress score as two pills. The macro regime window is
+  not exposed by ``GET /macro/regime`` (GlobalRegimeRead has no ``window``
+  field) so it is intentionally omitted; keep this component honest.
+
+  Data arrives via the page loader (``+page.server.ts``) fetching
+  ``/macro/regime`` in parallel; null when the endpoint is unavailable
+  (404 when the regime_detection worker has never run, transient 5xx)
+  and the component renders nothing so it never blocks page load.
+
+  Source: docs/plans/2026-04-19-netz-terminal-parity-builder-macro-screener.md §B.8.
+-->
+<script lang="ts">
+	import { TerminalPill, formatPercent } from "@investintell/ui";
+
+	interface RegimeContextStripData {
+		regime: string | null;
+		stressScore: number | null;
+	}
+
+	interface Props {
+		data: RegimeContextStripData | null;
+		class?: string;
+	}
+
+	let { data, class: className }: Props = $props();
+
+	function regimeTone(regime: string | null): "neutral" | "success" | "warn" | "error" {
+		if (!regime) return "neutral";
+		const upper = regime.toUpperCase();
+		if (upper.includes("CRISIS") || upper.includes("RISK_OFF")) return "error";
+		if (upper.includes("CAUTION") || upper.includes("TRANSITION")) return "warn";
+		if (upper.includes("RISK_ON") || upper.includes("EXPANSION")) return "success";
+		return "neutral";
+	}
+
+	function stressTone(
+		score: number | null,
+	): "neutral" | "success" | "warn" | "error" {
+		if (score === null) return "neutral";
+		if (score >= 0.75) return "error";
+		if (score >= 0.5) return "warn";
+		if (score >= 0.25) return "neutral";
+		return "success";
+	}
+</script>
+
+{#if data && data.regime}
+	<div class="regime-context-strip {className ?? ''}" role="group" aria-label="Macro regime context">
+		<span class="regime-context-strip__label">MACRO CONTEXT</span>
+		<div class="regime-context-strip__pills">
+			<TerminalPill
+				label={`Regime: ${data.regime}`}
+				tone={regimeTone(data.regime)}
+				size="xs"
+			/>
+			{#if data.stressScore !== null}
+				<TerminalPill
+					label={`Stress: ${formatPercent(data.stressScore)}`}
+					tone={stressTone(data.stressScore)}
+					size="xs"
+				/>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.regime-context-strip {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding: var(--terminal-space-2) 0;
+		font-family: var(--terminal-font-mono);
+	}
+	.regime-context-strip__label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+	.regime-context-strip__pills {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--terminal-space-2);
+	}
+</style>

--- a/frontends/wealth/src/lib/types/allocation-page.ts
+++ b/frontends/wealth/src/lib/types/allocation-page.ts
@@ -69,12 +69,39 @@ export interface ProposalMetrics {
 	cvar_feasible: boolean;
 }
 
+/**
+ * PR-4a — surfaced from ``cascade_telemetry.phase_attempts``.
+ * Matches ``backend.app.domains.wealth.schemas.model_portfolio.CascadePhaseAttempt``.
+ */
+export interface CascadePhaseAttempt {
+	phase: string;
+	status: string;
+	solver: string | null;
+	wall_ms: number;
+	objective_value: number | null;
+	cvar_within_limit: boolean | null;
+}
+
+/**
+ * PR-4a — PR-A14 universe coverage summary.
+ * Matches ``backend.app.domains.wealth.schemas.model_portfolio.CoverageSummary``.
+ */
+export interface CoverageSummary {
+	pct_covered: number | null;
+	hard_fail: boolean;
+	n_total_blocks: number | null;
+	n_covered_blocks: number | null;
+	missing_blocks: string[];
+}
+
 export interface LatestProposalResponse {
 	run_id: string;
 	requested_at: string;
 	winner_signal: string;
 	proposed_bands: ProposedBand[];
 	proposal_metrics: ProposalMetrics;
+	phase_attempts: CascadePhaseAttempt[];
+	coverage: CoverageSummary | null;
 }
 
 export interface JobCreatedResponse {

--- a/frontends/wealth/src/routes/(terminal)/allocation/[profile]/+page.server.ts
+++ b/frontends/wealth/src/routes/(terminal)/allocation/[profile]/+page.server.ts
@@ -2,8 +2,13 @@
  * PR-A26.3 Section B — Allocation page server loader.
  *
  * Uses the RouteData<T> contract (§3.2 Stability Guardrails). Strategic
- * is the only hard dependency; history + proposal degrade gracefully
- * to empty / null when the backend returns 404 or times out.
+ * is the only hard dependency; history + proposal + regime degrade
+ * gracefully to empty / null when the backend returns 404 or times out.
+ *
+ * PR-4a — adds an optional ``regime`` fetch (``GET /macro/regime``)
+ * used by ``RegimeContextStrip``. Null when the regime_detection
+ * worker has never run or the endpoint is unavailable; never blocks
+ * page load.
  */
 import type { PageServerLoad } from "./$types";
 import { okData, errData, type RouteData } from "@investintell/ui/runtime";
@@ -18,6 +23,17 @@ import {
 
 const FETCH_TIMEOUT_MS = 8000;
 
+interface RegimeSnapshot {
+	regime: string | null;
+	stressScore: number | null;
+}
+
+interface GlobalRegimeRead {
+	as_of_date: string;
+	raw_regime: string | null;
+	stress_score: number | null;
+}
+
 function isAllocationProfile(raw: string): raw is AllocationProfile {
 	return (ALLOCATION_PROFILES as readonly string[]).includes(raw);
 }
@@ -27,6 +43,7 @@ interface LoadResult {
 	strategic: RouteData<StrategicAllocationResponse>;
 	history: ApprovalHistoryResponse;
 	proposal: LatestProposalResponse | null;
+	regime: RegimeSnapshot | null;
 	actorRole: string | null;
 }
 
@@ -41,6 +58,7 @@ export const load: PageServerLoad = async ({ params, parent }): Promise<LoadResu
 			strategic: errData("HTTP_401", "Not authenticated", true),
 			history: emptyHistory(profileRaw),
 			proposal: null,
+			regime: null,
 			actorRole,
 		};
 	}
@@ -54,6 +72,7 @@ export const load: PageServerLoad = async ({ params, parent }): Promise<LoadResu
 			),
 			history: emptyHistory(profileRaw),
 			proposal: null,
+			regime: null,
 			actorRole,
 		};
 	}
@@ -109,13 +128,25 @@ export const load: PageServerLoad = async ({ params, parent }): Promise<LoadResu
 		)
 		.catch(() => null);
 
-	const [strategic, history, proposal] = await Promise.all([
+	const regimePromise = api
+		.get<GlobalRegimeRead>("/macro/regime", undefined, {
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		})
+		.then((r): RegimeSnapshot | null => ({
+			regime: r.raw_regime ?? null,
+			stressScore:
+				typeof r.stress_score === "number" ? r.stress_score : null,
+		}))
+		.catch(() => null);
+
+	const [strategic, history, proposal, regime] = await Promise.all([
 		strategicPromise,
 		historyPromise,
 		proposalPromise,
+		regimePromise,
 	]);
 
-	return { profile, strategic, history, proposal, actorRole };
+	return { profile, strategic, history, proposal, regime, actorRole };
 };
 
 function emptyHistory(profile: string): ApprovalHistoryResponse {

--- a/frontends/wealth/src/routes/(terminal)/allocation/[profile]/+page.svelte
+++ b/frontends/wealth/src/routes/(terminal)/allocation/[profile]/+page.svelte
@@ -32,6 +32,8 @@
 	import ProposeButton from "$lib/components/allocation/ProposeButton.svelte";
 	import OverrideBandsEditor from "$lib/components/allocation/OverrideBandsEditor.svelte";
 	import ApprovalHistoryTable from "$lib/components/allocation/ApprovalHistoryTable.svelte";
+	import IpsSummaryStrip from "$lib/components/allocation/IpsSummaryStrip.svelte";
+	import RegimeContextStrip from "$lib/components/allocation/RegimeContextStrip.svelte";
 	import type { PageData } from "./$types";
 
 	let { data }: { data: PageData } = $props();
@@ -102,6 +104,16 @@
 		<ChevronRight class="w-3 h-3" />
 		<span class="text-foreground">{PROFILE_LABELS[profile]}</span>
 	</nav>
+
+	<IpsSummaryStrip
+		class="mb-3"
+		{profile}
+		cvarLimit={strategic.cvar_limit}
+		lastApprovedAt={strategic.last_approved_at}
+		lastApprovedBy={strategic.last_approved_by}
+	/>
+
+	<RegimeContextStrip class="mb-3" data={data.regime} />
 
 	<header class="mb-5">
 		<h1 class="text-2xl font-semibold text-foreground">


### PR DESCRIPTION
## Summary

PR-4a of the **Netz Terminal parity plan** — propose→approve surface gets the three new read-only primitives the UX bundle demands, plus a minimal additive backend surface so the cascade timeline can render in settled mode without fabricated data.

Plan: `docs/plans/2026-04-19-netz-terminal-parity-builder-macro-screener.md` §BUILDER SCOPE PIVOT / §A.BUILDER / §B.6 / §B.7 / §B.8 / §C.BUILDER / §H.

- `CascadeTimeline.svelte` — 3-phase chevron row (Phase 1 / 2 / 3) with coverage bar + winner-signal caption. Two modes: `live` (seeded pending + mutated in place as SSE events stream) and `settled` (driven by persisted `phase_attempts[]`).
- `IpsSummaryStrip.svelte` — dense identifier bar beneath the breadcrumb. Pills via `@netz/ui` `TerminalPill`. Does NOT replace the existing KPI row — complementary.
- `RegimeContextStrip.svelte` — read-only "MACRO CONTEXT" strip driven by `GET /macro/regime`. Hides silently on 404 so it never blocks page load.
- `ProposeButton.svelte` — SSE stream now drives a live `CascadeTimeline` in the progress area; mutate in place per §G.BUILDER.4, no remounts.
- `ProposalReviewPanel.svelte` — mounts `<CascadeTimeline mode="settled">` between the metrics row and the diff bars.

## Plan–code deltas resolved (§G.BUILDER.2)

| Plan said | Reality | Action |
|---|---|---|
| 4 phases (§B.6) | PR-A12 retired variance-capped + heuristic fallback; cascade is 3 | Component models 3 phases matching code |
| `latest-proposal` returns `cascade_telemetry.phases[]` (§C.BUILDER) | Route reads JSONB internally, exposes only 3 fields | PR-4a adds `phase_attempts[]` + `coverage` as additive response fields; zero changes to telemetry builder |
| RegimeContextStrip has a `window` pill (§B.8) | `GlobalRegimeRead` has no `window` field | Strip ships 2 pills (regime + stress) — honest over guessed |

## Dev DB cascade_telemetry sample

```json
// SELECT jsonb_pretty(cascade_telemetry->'phase_attempts')
// FROM portfolio_construction_runs WHERE run_mode='propose' LIMIT 1;
[
  {"phase": "phase_1_ru_max_return", "solver": "CLARABEL", "status": "succeeded",
   "wall_ms": 2033, "objective_value": 0.167781, "cvar_within_limit": true},
  {"phase": "phase_2_ru_robust", "solver": null, "status": "skipped", "wall_ms": 0},
  {"phase": "phase_3_min_cvar", "solver": "CLARABEL", "status": "succeeded",
   "wall_ms": 1573, "objective_value": 0.04485, "cvar_within_limit": true}
]

// SELECT jsonb_pretty(cascade_telemetry->'coverage') ...
{"hard_fail": false, "pct_covered": 1.0,
 "covered_blocks": [13 items], "missing_blocks": [5 items],
 "n_total_blocks": 18, "n_covered_blocks": 13}
```

## Out of scope (deferred to PR-4b)

- `data-allocation-root` + LayoutCage padding override.
- Token/density re-skin of `StrategicAllocationTable` / `ProposalReviewPanel` / `ApprovalHistoryTable` / `OverrideBandsEditor`.
- `.toFixed` / `Intl.*` audit sweep across existing allocation components.
- Affordance-cursor audit (§G.BUILDER.3).
- Legacy `/portfolio/builder` retirement decision.

## Test plan

- [x] Backend schemas import clean (`CascadePhaseAttempt`, `CoverageSummary`).
- [x] `pytest backend/tests/wealth -k "propose or approve or cascade"` → 20 passed.
- [x] `pnpm -F netz-wealth-os build` → success.
- [x] Lint clean for touched files; `svelte-check` has no new errors in `components/allocation/**`.
- [x] Visual validation on dev server at 1440×900:
  - [x] `/allocation/moderate` — IPS strip + Regime strip render above KPI row; no collision. Cascade timeline shows P1 succeeded / P2 skipped / P3 succeeded; coverage bar 100% (5 pending); winner_signal `proposal_ready`.
  - [x] `/allocation/conservative` — CVaR ≤ 5.00% pill; propose panel / cascade render clean.
  - [x] `/allocation/growth` — CVaR ≤ 10.00% pill; propose panel / cascade render clean.
  - [x] Console errors: 0.
- [ ] Playwright e2e (requires `pnpm add -D @playwright/test` activation per existing skeleton note).

## Follow-ups (backlog)

- `coverage.pct_covered` semantics — dev DB shows `pct_covered=1.0` while `n_covered_blocks=13/18`; likely the field means "pct of target weight covered" rather than "pct of blocks". Surface to Andrei for naming clarification.
- `--sev-*` tokens only expose `warn` + `critical` for the coverage bar; a `success` tone is currently mapped to `--terminal-status-success`. Consider promoting `--sev-success` as a first-class token if the pattern repeats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)