### PR TITLE
feat(ii-terminal): X1 scaffold — empty SvelteKit app at terminal.investintell.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: check test lint typecheck architecture serve migrate migration help pipeline \
        dev-ui build-ui dev-credit build-credit dev-wealth build-wealth \
+       dev-terminal build-terminal check-terminal lint-terminal \
        dev-all build-all lint-frontend check-all types coverage-runtime \
        tokens-sync loadtest
 
@@ -99,6 +100,18 @@ dev-wealth:
 build-wealth:
 	pnpm --filter netz-wealth-os build
 
+dev-terminal:
+	pnpm --filter ii-terminal dev
+
+build-terminal:
+	pnpm --filter ii-terminal build
+
+check-terminal:
+	pnpm --filter ii-terminal check
+
+lint-terminal:
+	pnpm --filter ii-terminal lint
+
 dev-all:
 	pnpm exec turbo run dev
 
@@ -132,6 +145,10 @@ help:
 	@echo "make build-ui    - Build @investintell/ui package"
 	@echo "make dev-credit  - Credit frontend dev server"
 	@echo "make dev-wealth  - Wealth frontend dev server"
+	@echo "make dev-terminal - II Terminal frontend dev server (:5175)"
+	@echo "make build-terminal - Build II Terminal frontend"
+	@echo "make check-terminal - svelte-check on II Terminal"
+	@echo "make lint-terminal  - ESLint on II Terminal"
 	@echo "make dev-all     - All packages in parallel (Turborepo)"
 	@echo "make build-all   - Build all packages (topological order)"
 	@echo "make lint-frontend - ESLint all frontend packages"

--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -59,6 +59,7 @@ class Settings(BaseSettings):
         "https://wealth.investintell.com",
         "https://credit.investintell.com",
         "https://admin.investintell.com",
+        "https://terminal.investintell.com",
         # Cloudflare Pages (legacy)
         "https://netz-wealth.pages.dev",
         "https://netz-credit.pages.dev",

--- a/docs/plans/2026-04-19-ii-terminal-extraction.md
+++ b/docs/plans/2026-04-19-ii-terminal-extraction.md
@@ -1,0 +1,340 @@
+# II Terminal — Extração para Frontend Isolado
+
+**Data**: 2026-04-19
+**Dono**: Andrei
+**Status**: aguardando dispatch
+**Predecessor**: `docs/plans/_deprecated/2026-04-19-ii-tokens-adoption.md` (token swap in-wealth, abandonado pelo pivot)
+
+## Context
+
+A parity sprint #230-#239 fechou estrutura mas o terminal segue alojado em `frontends/wealth/src/routes/(terminal)/`. Dois problemas com isso:
+
+1. **UX errada**: para abrir o terminal o usuário entra no wealth, vai para portfolio/live, navega para dentro do route group. Bloomberg-style workspace não funciona escondido dentro de outro produto.
+2. **Acoplamento de produto**: "II Terminal" e "Wealth Client Portal" têm perfis de usuário distintos (analyst/PM vs advisor/investor) e ciclos de release incompatíveis.
+
+**Decisões já batidas**:
+
+1. **URL isolada**: terminal vive em `terminal.investintell.com` com entry-point próprio.
+2. **Auth**: Clerk SSO via cookie domain `.investintell.com` — mesmo login entre `wealth.*` e `terminal.*`.
+3. **Wealth pós-split**: read-only client-facing advisor portal (NAV reports, compliance views, IC memo delivery, investor statements). Sem Screener/Macro/Allocation/Live/Research.
+4. **Estado compartilhado**: backend-owned. Watchlist/alerts/notifications vivem em Postgres, ambas apps leem via API. Sem cross-domain sync no cliente.
+5. **Branding**: produto = **InvestIntell** / **II Terminal**. Remover "Netz" de product chrome (breadcrumb, topnav, titles, score labels, logos). "Netz" continua existindo como **tenant** dentro do Clerk, com sua branding injetada runtime via `injectBranding()` — mas não aparece em chrome unauthenticated, em empty state do produto, em nome de score, em logo do app shell.
+6. **Visual**: 1:1 com bundle `docs/ux/Netz Terminal/` — não "parity estrutural". Pixel-level review, cor/fonte/densidade exatas.
+
+## Escopo de sprints (7 sub-PRs, cada 1 sessão Opus independente)
+
+### X1 — Scaffold `frontends/terminal/` (SvelteKit empty shell)
+
+**Branch**: `feat/ii-terminal-x1-scaffold` → main
+
+Arquivos novos:
+- `frontends/terminal/package.json` — name `"ii-terminal"`, deps: `@sveltejs/kit`, `svelte@^5`, `vite`, `@investintell/ui`, `clerk-sveltekit`, `svelte-clerk`, `@fontsource-variable/ibm-plex-sans`, `@fontsource-variable/ibm-plex-mono`, `@fontsource/montserrat`
+- `frontends/terminal/svelte.config.js` — adapter-node
+- `frontends/terminal/vite.config.ts` — porta 5175 (wealth=5174, credit=5173)
+- `frontends/terminal/tailwind.config.ts` — theme IBM Plex + bundle palette
+- `frontends/terminal/src/app.html` — title "II Terminal", meta, font preload
+- `frontends/terminal/src/app.css` — importa `@investintell/ui/styles` + tokens do bundle (ii-tokens)
+- `frontends/terminal/src/hooks.server.ts` — Clerk JWT verify (reusar `packages/investintell-ui/src/lib/utils/auth.ts`), cookie domain `.investintell.com` (via env `CLERK_COOKIE_DOMAIN`)
+- `frontends/terminal/src/hooks.client.ts` — session expiry monitor
+- `frontends/terminal/src/routes/+layout.svelte` — shell vazio com placeholder "II Terminal boots here"
+- `frontends/terminal/src/routes/+page.svelte` — redirect para `/live` (ou landing)
+- `frontends/terminal/railway.toml` — deploy target `terminal.investintell.com`
+- `Makefile` — targets `dev-terminal`, `build-terminal`, `check-terminal`
+- `turbo.json` — pipeline entries para `ii-terminal#build`, `ii-terminal#dev`, `ii-terminal#check`
+- `pnpm-workspace.yaml` — já cobre `frontends/*`, nada a alterar
+
+Backend:
+- `backend/app/core/config.py` — adicionar `terminal.investintell.com` em `ALLOWED_ORIGINS`
+- `backend/app/main.py` — CORS middleware já reusa a lista
+
+Clerk (manual, operador):
+- Configurar **Cookie Domain** no Clerk dashboard para `.investintell.com` (unlocks SSO)
+- Adicionar `https://terminal.investintell.com` em Allowed origins e Redirect URLs
+
+**Verificação X1**:
+- `make dev-terminal` sobe em `localhost:5175`, renderiza placeholder, Clerk login funciona
+- Login no wealth → cookie compartilhado → navegar para `localhost:5175` já autenticado (SSO local via `.localhost` cookie domain em dev)
+- Build passa: `pnpm -F ii-terminal build`
+- Scanner terminal-tokens continua verde (nada mudou em wealth)
+
+---
+
+### X2 — Move routes `(terminal)/` para `frontends/terminal/src/routes/`
+
+**Branch**: `feat/ii-terminal-x2-route-move` → main
+
+Movimentação:
+- `frontends/wealth/src/routes/(terminal)/live/` → `frontends/terminal/src/routes/live/`
+- `frontends/wealth/src/routes/(terminal)/portfolio/live/` → `frontends/terminal/src/routes/portfolio/live/`
+- `frontends/wealth/src/routes/(terminal)/allocation/` → `frontends/terminal/src/routes/allocation/`
+- `frontends/wealth/src/routes/(terminal)/macro/` → `frontends/terminal/src/routes/macro/`
+- `frontends/wealth/src/routes/(terminal)/terminal-screener/` → `frontends/terminal/src/routes/screener/` (simplifica nome — namespace do produto já é terminal)
+- `frontends/wealth/src/routes/(terminal)/research/` → `frontends/terminal/src/routes/research/`
+- `frontends/wealth/src/routes/(terminal)/alerts/` → `frontends/terminal/src/routes/alerts/`
+- `frontends/wealth/src/routes/(terminal)/+layout.svelte` → `frontends/terminal/src/routes/+layout.svelte` (merge com placeholder de X1)
+
+Estratégia de imports durante a transição:
+- Terminal importa componentes de `frontends/wealth/src/lib/components/**` via **workspace path** em `tsconfig.json`:
+  ```json
+  "paths": {
+    "$wealth-components/*": ["../../wealth/src/lib/components/*"]
+  }
+  ```
+- Isso é temporário — Sprint X5 promove para package. Durante X2, ambas apps rodam com o mesmo código de componente.
+- Loaders `+page.server.ts` mantêm a mesma assinatura (reusam `$lib/api/client`).
+- Rotas antigas em `frontends/wealth/src/routes/(terminal)/` **continuam vivas** durante X2 — espelham o conteúdo. Wealth e terminal servem os mesmos URLs em domínios diferentes.
+
+**Verificação X2**:
+- `localhost:5174/allocation/moderate` (wealth) e `localhost:5175/allocation/moderate` (terminal) renderizam idêntico
+- Mesma chamada `/portfolio/profiles/moderate/latest-proposal` em ambos
+- Login SSO funciona em ambos
+- Nenhum hard-code de domínio em fetch (tudo via `createClientApiClient`)
+
+---
+
+### X3 — Visual migration (ii-tokens + surface CSS do bundle)
+
+**Branch**: `feat/ii-terminal-x3-visual` → main
+
+Reusa a intenção do plano deprecated, mas escopado ao terminal frontend:
+
+- `packages/investintell-ui/src/lib/styles/tokens.css` — estender com `--ii-navy-deep`, status 6-slot, severity 4-tier, dataviz 8-slot, density, text scale (detalhes em `_deprecated/2026-04-19-ii-tokens-adoption.md` §PR-T1)
+- `packages/investintell-ui/src/lib/styles/terminal.css` — rewire façade `--terminal-*` → `var(--ii-*)` (bundle paleta)
+- `packages/investintell-ui/src/lib/styles/surfaces/` — nova pasta com `terminal.css`, `builder.css`, `screener.css`, `macro.css` portados de `docs/ux/Netz Terminal/*.css` (renomeados, prefixos migrados)
+- `packages/investintell-ui/src/lib/styles/typography.css` — swap Urbanist/Geist → IBM Plex Sans/Mono + Montserrat (via @fontsource)
+- `packages/investintell-ui/package.json` — swap deps de fontes
+- `frontends/terminal/src/app.css` — import `@investintell/ui/styles/surfaces/terminal`
+- Terminal routes importam CSS por rota (`allocation/+page.svelte` importa `surfaces/builder`, etc.)
+- `scripts/check-terminal-tokens-sync.mjs` — nova Invariant E (ii-tokens sync)
+
+**Acceptance 1:1 com bundle** (não parity — fidelidade):
+- Screenshots side-by-side de cada rota × bundle PNG correspondente
+- Gates: cor de fundo `#05081A` exato, accent `#FF965A` exato, fonte IBM Plex Sans computada, row-height 22px compact mode
+- Ferramenta sugerida: Playwright + pixelmatch para regression automático
+
+**Verificação X3**:
+- Todas as 6 rotas do terminal renderizam bundle-like
+- Wealth `(terminal)/` ainda existe e ainda usa paleta antiga (não tocada neste PR)
+- Scanner verde com Invariant E
+
+---
+
+### X4 — Brand cleanup (remover "Netz" de product chrome)
+
+**Branch**: `feat/ii-terminal-x4-brand` → main
+
+Blast radius mapeado (3 arquivos + assets):
+- `frontends/terminal/src/lib/components/.../FundDetailsDrawer.svelte` — "Netz Score" → "II Score" (ou só "Score")
+- `frontends/terminal/src/lib/components/.../TerminalRiskKpis.svelte` — "Netz Elite" → "Elite"
+- `frontends/terminal/src/lib/components/terminal/shell/TerminalTopNav.svelte` — "NETZ / TERMINAL" → "II / TERMINAL" ou só "TERMINAL"
+- `frontends/terminal/src/app.html` — `<title>` e meta
+- `frontends/terminal/static/` — logo InvestIntell (substituir qualquer netz-logo.svg)
+- Screener ELITE badge — mantém "ELITE" (sem prefixo "Netz")
+
+Copy review manual:
+- Empty states ("Carregando dados Netz..." → "Carregando...")
+- Error messages
+- Loading screens
+- Tooltip text
+- Aria labels
+- Alt text em imagens
+
+Arquivos de assets a auditar:
+- `packages/investintell-ui/src/lib/styles/assets/` (se houver netz-pattern.svg do bundle)
+
+**Preservar**: `BrandingConfig` runtime per-tenant em `packages/investintell-ui/src/lib/utils/branding.ts`. Netz como tenant continua injetando sua marca quando o usuário Netz loga. Mas o **default/unauthenticated chrome** é InvestIntell.
+
+**Verificação X4**:
+- Grep `-i "netz"` em `frontends/terminal/src/` + `packages/investintell-ui/src/lib/components/terminal/` → zero hits em strings user-visible
+- Meta title do terminal = "II Terminal"
+- Unauthenticated route (login screen) mostra InvestIntell logo
+
+---
+
+### X5 — Promote componentes para `packages/ii-terminal-core/`
+
+**Branch**: `feat/ii-terminal-x5-promote` → main
+
+Novo package:
+- `packages/ii-terminal-core/package.json` — name `"@investintell/ii-terminal-core"`
+- `packages/ii-terminal-core/src/lib/` — move:
+  - Tudo de `frontends/wealth/src/lib/components/terminal/**` (shell, focus-mode, drawer, tweaks, chart, market-data-store, formatters mono)
+  - `frontends/wealth/src/lib/components/allocation/**` (CascadeTimeline, IpsSummaryStrip, RegimeContextStrip, ProposalReviewPanel, ApprovalHistoryTable, OverrideBandsEditor, AllocationDonut, StrategicAllocationTable, ProposeButton)
+  - `frontends/wealth/src/lib/components/screener/terminal/**` (FilterChipRow, TerminalScreenerShell, TerminalDataGrid)
+- `packages/ii-terminal-core/src/lib/index.ts` — barrel
+- `packages/ii-terminal-core/package.json` `exports` — `./components/terminal/*`, `./components/allocation/*`, etc.
+
+Terminal frontend consome via `import { TerminalShell } from "@investintell/ii-terminal-core/components/terminal"`.
+
+Wealth:
+- Se wealth NÃO precisar mais desses componentes (read-only portal não tem builder/screener/live), **remove** o import path workspace configurado em X2.
+- Se wealth ainda referencia algum (ex: IC memo delivery usa ECharts compartilhado), deixa wealth consumir também via `@investintell/ii-terminal-core` — não diferencia.
+
+`packages/investintell-ui/` fica lean: design system genérico (Button, Dialog, Input, FormField, ChartContainer), tokens globais, layouts genéricos (AppLayout, AppShell, Sidebar, TopNav genéricos — não terminal-specific).
+
+**Verificação X5**:
+- `pnpm -F ii-terminal build` passa sem resolver `../../wealth/src/lib/components/*`
+- Wealth também compila
+- Zero referência entre `frontends/terminal/` e `frontends/wealth/`
+
+---
+
+### X6 — DNS + Railway deploy cutover
+
+**Branch**: `feat/ii-terminal-x6-deploy` → main
+
+Infra:
+- Railway: criar serviço novo `ii-terminal` apontando para `frontends/terminal/` (adapter-node build)
+- DNS: CNAME `terminal.investintell.com` → Railway target
+- Clerk dashboard (operador): verificar que cookie domain `.investintell.com` e allowed origin `https://terminal.investintell.com` estão ativos (preparado em X1, confirmar)
+- Backend CORS: confirmar `terminal.investintell.com` em `ALLOWED_ORIGINS` (feito em X1)
+- Environment: `.env.production` do terminal com `PUBLIC_API_BASE_URL=https://api.investintell.com`, `PUBLIC_CLERK_PUBLISHABLE_KEY=...`
+
+Testes prod:
+- SSO real: logar em `wealth.investintell.com`, navegar para `terminal.investintell.com`, confirmar sessão persistida
+- Navegação entre apps: cross-domain = full reload (esperado), mas com cookie SSO é transparente
+- Performance: FCP/LCP do terminal em prod
+
+**Verificação X6**:
+- Terminal acessível em `terminal.investintell.com` com HTTPS
+- SSO funciona
+- Todas as 6 rotas carregam dados reais do backend prod
+- Zero regressão em `wealth.investintell.com`
+
+---
+
+### X7 — Wealth cleanup (remover rotas migradas)
+
+**Branch**: `feat/ii-terminal-x7-wealth-cleanup` → main
+
+Deleta:
+- `frontends/wealth/src/routes/(terminal)/**` inteiro
+- Links de navegação no wealth que apontam para rotas do terminal
+- `frontends/wealth/src/lib/components/terminal/**` (já promovido em X5)
+- `frontends/wealth/src/lib/components/allocation/**` (idem)
+- `frontends/wealth/src/lib/components/screener/terminal/**` (idem)
+
+Redirects (opcional, 6 meses transição):
+- `frontends/wealth/src/hooks.server.ts` — detecta path `/allocation/*`, `/live`, `/macro`, `/screener/*` → 301 para `terminal.investintell.com/...`
+
+Wealth pós-X7:
+- Rotas: `/`, `/dashboard`, `/reports`, `/clients`, `/compliance`, `/admin`
+- Sem escrita — read-only portal per decisão batida
+- TopNav simplificado: "InvestIntell Wealth — Client Portal"
+- Reuses `@investintell/ui` (design system institucional)
+- Não importa `@investintell/ii-terminal-core`
+
+**Verificação X7**:
+- `wealth.investintell.com/allocation/moderate` → 301 para `terminal.investintell.com/allocation/moderate`
+- `pnpm -F netz-wealth-os build` passa com tree menor
+- Nenhum link quebrado entre os dois domínios
+
+---
+
+## Arquivos críticos (paths absolutos)
+
+**Criar** (X1):
+- `frontends/terminal/` (pasta inteira — scaffold SvelteKit)
+
+**Criar** (X5):
+- `packages/ii-terminal-core/` (promoção)
+
+**Mover** (X2):
+- `frontends/wealth/src/routes/(terminal)/**` → `frontends/terminal/src/routes/**`
+
+**Mover** (X5):
+- `frontends/wealth/src/lib/components/terminal/**` → `packages/ii-terminal-core/src/lib/components/terminal/**`
+- `frontends/wealth/src/lib/components/allocation/**` → `packages/ii-terminal-core/src/lib/components/allocation/**`
+- `frontends/wealth/src/lib/components/screener/terminal/**` → `packages/ii-terminal-core/src/lib/components/screener/**`
+
+**Modificar** (X3):
+- `packages/investintell-ui/src/lib/styles/tokens.css`, `typography.css`, `terminal.css`, `package.json`
+- `packages/investintell-ui/src/lib/styles/surfaces/*.css` (novo)
+- `scripts/check-terminal-tokens-sync.mjs` (nova Invariant E)
+
+**Modificar** (X4):
+- Arquivos com strings "Netz" em product chrome (3 arquivos identificados + varredura manual)
+
+**Modificar** (X6):
+- `backend/app/core/config.py` (ALLOWED_ORIGINS — feito em X1)
+- `railway.toml` raiz (adicionar serviço terminal)
+- DNS (operador, fora do git)
+
+**Deletar** (X7):
+- `frontends/wealth/src/routes/(terminal)/**`
+- `frontends/wealth/src/lib/components/{terminal,allocation,screener/terminal}/**`
+
+---
+
+## Funções e utilitários a reusar
+
+- `packages/investintell-ui/src/lib/utils/auth.ts` — `createClerkHook`, `startSessionExpiryMonitor` (Clerk JWT handling, funciona entre apps)
+- `packages/investintell-ui/src/lib/utils/api-client.ts` — `createClientApiClient`, `createServerApiClient` (zero mudança)
+- `packages/investintell-ui/src/lib/utils/sse-client.svelte.ts` — SSE infra funciona em ambas apps
+- `packages/investintell-ui/src/lib/utils/branding.ts` — `injectBranding`, per-tenant runtime branding (preservar, não confundir com X4 que é product chrome)
+- `packages/investintell-ui/src/lib/charts/terminal-options.ts` — `readVar`, `createTerminalChartOptions`, continua sendo SSR-safe layer
+- `scripts/check-terminal-tokens-sync.mjs` — extender com Invariant E
+
+---
+
+## Verificação end-to-end
+
+Após X7:
+
+```bash
+# 1. Builds independentes
+pnpm -F ii-terminal build
+pnpm -F netz-wealth-os build
+pnpm -F netz-credit build
+pnpm -F @investintell/ui build
+pnpm -F @investintell/ii-terminal-core build
+
+# 2. Scanner de tokens
+node scripts/check-terminal-tokens-sync.mjs
+
+# 3. Dev servers simultâneos (3 portas)
+make dev-terminal  # :5175
+make dev-wealth    # :5174
+make dev-credit    # :5173
+
+# 4. SSO smoke (local via .localhost cookie domain)
+# Logar em localhost:5174 (wealth)
+# Abrir localhost:5175 em nova aba → já autenticado
+
+# 5. Prod smoke (após X6)
+# https://wealth.investintell.com login
+# https://terminal.investintell.com abrir → autenticado via SSO
+# Navegar entre rotas
+# 6 rotas do terminal carregam dados reais
+
+# 6. Visual parity 1:1 com bundle (X3 acceptance)
+# Playwright + pixelmatch para cada rota contra docs/ux/Netz Terminal/prints
+```
+
+Gates de bloqueio:
+- X3 não fecha sem 1:1 visual (pixel diff < 2% contra bundle PNG)
+- X6 não fecha sem SSO funcionando em prod
+- X7 não fecha sem redirects testados (ou decisão consciente de hard-break)
+
+---
+
+## Out of scope
+
+- **Credit frontend**: fora. Credit continua em credit.investintell.com como está.
+- **Mobile apps**: fora. Terminal é desktop-first (32" monitor target per memory).
+- **Refactor do backend**: zero mudança em `backend/app/`. API endpoints idênticos.
+- **Dark/light mode para wealth client portal**: X7 mantém wealth como está visualmente. Re-skin do wealth é outra sprint.
+- **Migração `@netz/*` → `@investintell/*`** (67 imports deprecated): sprint separada, ortogonal.
+
+---
+
+## Dependências de decisão (manual, operador)
+
+Antes de X1 rodar:
+1. Clerk dashboard: configurar cookie domain `.investintell.com` + allowed origins + redirect URLs para `terminal.investintell.com`
+2. Decidir nome exato do subdomínio: `terminal.investintell.com` (assumido) ou `ii.investintell.com` ou outro?
+3. DNS control: confirmar que GoDaddy ou similar permite CNAME para Railway target
+
+Antes de X6 rodar:
+4. Railway: autorizar criação de novo service
+5. Backup/rollback strategy caso SSO falhe em prod (rollback = manter wealth (terminal) como ativo, apenas DNS não propaga)

--- a/docs/plans/2026-04-19-ii-tokens-adoption.md
+++ b/docs/plans/2026-04-19-ii-tokens-adoption.md
@@ -1,0 +1,243 @@
+# ii-tokens — Substituição da Camada de Tokens + Superfícies de Página
+
+**Branch**: `feat/ii-tokens-adoption` (long-lived, não merge em main até visual pass)
+**Plano**: apenas este arquivo é editável em plan mode; o artefato versionado final do plano vai para `docs/plans/2026-04-19-ii-tokens-adoption.md` durante execução.
+
+---
+
+## Context
+
+Os 10 PRs da parity sprint do Netz Terminal (#230–#239) fecharam estrutura de componentes mas preservaram a **paleta errada**: `--terminal-bg-void: #000000` e `--terminal-accent-amber: #ffb020` estão em 3191 refs. O UX bundle em `docs/ux/Netz Terminal/` pede `#05081A` (navy deep) + `#FF965A` (orange), IBM Plex Sans/Mono e densidade Bloomberg que o visual atual não entrega.
+
+Existem 2 catálogos de tokens hoje:
+- `packages/investintell-ui/src/lib/styles/tokens.css` — `--ii-*` (278 linhas, `(app)` institucional)
+- `packages/investintell-ui/src/lib/styles/terminal.css` — `--terminal-*` (225 linhas, superfície terminal)
+
+O bundle traz 4 arquivos CSS (`netz-tokens.css`, `terminal.css`, `builder.css`, `screener.css`, `macro.css`) que representam a paleta + camadas de superfície corretas, mas usam `--netz-*`/`--term-*` com Google Fonts CDN e deltas (sem dataviz 1..8, status só 3-color, severity 3-tier).
+
+**Decisões confirmadas**:
+1. `--terminal-*` permanece como fachada — consumers não mudam; valores passam a resolver via `var(--ii-*)`.
+2. Fontes via `@fontsource` npm (ibm-plex-sans + ibm-plex-mono + montserrat).
+3. Escopo: core token swap + fonts + replicar as 4 CSSs de superfície sob `styles/surfaces/`. Urbanist cleanup nas 91 .svelte e migração `@netz/*`→`@investintell/*` ficam fora.
+4. Branch staging longo; merge único em main após visual pass nas 4 páginas contra prints do bundle.
+
+---
+
+## Sub-PRs
+
+### PR-T1 — ii-tokens base + fonts
+**Branch**: `feat/ii-tokens-t1-base` → merge em `feat/ii-tokens-adoption`
+
+Arquivos:
+- `packages/investintell-ui/src/lib/styles/tokens.css` → **reescrever** a partir de `docs/ux/Netz Terminal/assets/netz-tokens.css`, renomeando prefixos:
+  - `--netz-*` → `--ii-*` (navy/orange/sky/steel/indigo/cyan + neutrals)
+  - `--color-*` → `--ii-color-*` (semantic layer)
+  - `--font-*` → `--ii-font-*`
+  - `--fs-*` → `--ii-fs-*`, `--fw-*` → `--ii-fw-*`, `--lh-*` → `--ii-lh-*`, `--tracking-*` → `--ii-tracking-*`
+  - `--space-*` → `--ii-space-*`, `--radius-*` → `--ii-radius-*`, `--shadow-*` → `--ii-shadow-*`
+  - `--ease-*` → `--ii-ease-*`, `--dur-*` → `--ii-dur-*`
+  - Utility classes do bundle (`.netz-hero`, `.netz-display`, `h1-4`, `.body`, `.caption`, `.bg-navy`, `.bg-sky`) — NÃO portar para `tokens.css`; vão para `globals.css` se necessário.
+- **Estender** com camadas faltantes (reutilizar valores do atual `terminal.css` para zero drift de status/dataviz):
+  - `--ii-navy-deep: #05081A` (bundle terminal bg-void; adicionar ao brand core)
+  - Status: `--ii-status-success: #3DD39A`, `--ii-status-warn: #F2C94C`, `--ii-status-error: #FF5C7A`, `--ii-status-critical: #FF5C7A`, `--ii-status-info: #6689BC`, `--ii-status-neutral: var(--ii-stone)`
+  - Severity: `--ii-sev-tail: #FF5C7A`, `--ii-sev-mod: #F2C94C`, `--ii-sev-high: #FF965A`, `--ii-sev-upside: #3DD39A`
+  - Dataviz ordinal 1..8 (reusar valores de `terminal.css` atuais: amber, cyan, violet, success-green, terracotta, bone-white, cobalt, ash-grey — remapeados para paleta warm do bundle onde faz sentido)
+  - `--ii-font-mono: "IBM Plex Mono", "JetBrains Mono", "Menlo", monospace`
+  - Density scale para terminal: `--ii-density-row-compact: 22px`, `--ii-density-row-normal: 28px`, `--ii-density-row-relaxed: 36px`
+  - Text scale terminal-specific: `--ii-text-10: 10px`, `--ii-text-11: 11px`, `--ii-text-12: 12px`, `--ii-text-14: 14px`
+- `packages/investintell-ui/src/lib/styles/typography.css`:
+  - Remover `@fontsource-variable/urbanist` + `@fontsource-variable/geist-mono` imports
+  - Adicionar `@fontsource-variable/ibm-plex-sans`, `@fontsource-variable/ibm-plex-mono`, `@fontsource/montserrat`
+  - `font-family` chain: `"IBM Plex Sans Variable"` → `"IBM Plex Sans"` → system-ui; mono: `"IBM Plex Mono Variable"` → `"IBM Plex Mono"` → Menlo
+  - Manter override `[data-surface="terminal"]` usando `var(--ii-font-mono)`
+- `packages/investintell-ui/package.json`:
+  - `dependencies`: swap `@fontsource-variable/urbanist` + `@fontsource-variable/geist-mono` por `@fontsource-variable/ibm-plex-sans` + `@fontsource-variable/ibm-plex-mono` + `@fontsource/montserrat`
+- `packages/investintell-ui/src/lib/styles/globals.css`:
+  - Garantir que importa tokens.css + typography.css atualizados
+- **Preservar intactos**: `spacing.css`, `shadows.css`, `animations.css` (bundle cobre parcialmente — não duplicar agora)
+- **Preservar intactos**: `terminal.css` do repo (rewire acontece em PR-T2)
+
+Verificação PR-T1:
+- `pnpm -F @investintell/ui build` passa
+- Nenhum consumer de `--terminal-*` quebra (eles ainda apontam para os hex literals atuais)
+- `node scripts/check-terminal-tokens-sync.mjs` segue verde (sem mudança em terminal.css/terminal-options.ts)
+- Páginas `(app)` que consomem `--ii-*` renderizam com nova paleta bundle
+
+---
+
+### PR-T2 — terminal.css rewire (fachada → ii-*)
+**Branch**: `feat/ii-tokens-t2-rewire-terminal` → merge em staging
+
+Arquivos:
+- `packages/investintell-ui/src/lib/styles/terminal.css`: **reescrever valores**, preservando **todos os nomes** `--terminal-*`. Cada token literal hex resolve via `var(--ii-*)`:
+  - `--terminal-bg-void: var(--ii-navy-deep)` (era `#000000`)
+  - `--terminal-bg-panel: var(--ii-navy)` (era `#050505`)
+  - `--terminal-bg-panel-raised: var(--ii-navy-2)` (era `#0a0a0a`)
+  - `--terminal-fg-primary: var(--ii-offwhite)` (era `#f5f5f0`)
+  - `--terminal-fg-secondary: var(--ii-sky-3)`, `--terminal-fg-tertiary: var(--ii-steel)`, `--terminal-fg-muted: var(--ii-silver)`
+  - `--terminal-accent-amber: var(--ii-orange)` (era `#ffb020`)
+  - `--terminal-accent-amber-dim: var(--ii-orange-soft)`
+  - `--terminal-accent-cyan: var(--ii-cyan)`, `--terminal-accent-violet: #A080FF` (bundle não tem violet; manter literal por ora)
+  - `--terminal-status-success: var(--ii-status-success)`, `-warn: var(--ii-status-warn)`, `-error: var(--ii-status-error)`
+  - `--terminal-dataviz-1..8: var(--ii-dataviz-1..8)`
+  - `--terminal-space-*: var(--ii-space-*)` (mapear 4/8/12/16/24/32/48 → ii escala)
+  - `--terminal-radius-*: var(--ii-radius-*)`
+  - `--terminal-font-mono: var(--ii-font-mono)`, `--terminal-font-sans: var(--ii-font-sans)`
+  - `--terminal-text-10..14: var(--ii-text-10..14)`
+- `packages/investintell-ui/src/lib/charts/terminal-options.ts`: `DEFAULT_TOKENS` permanece idêntico (SSR fallback é agnóstico de qual layer resolve). Mas os hex literals de fallback devem ser atualizados para a nova paleta (`bgVoid: "#05081A"` em vez de `#000000`; `accentAmber: "#FF965A"` etc.) para evitar FOUC entre SSR e CSS hydration.
+- `scripts/check-terminal-tokens-sync.mjs`: **nova Invariant E** — todo `var(--ii-*)` referenciado em `terminal.css` deve existir em `tokens.css`.
+
+Verificação PR-T2:
+- Scanner verde com Invariant E nova
+- Visual: todas as páginas terminal (live, allocation, screener, macro, builder) renderizam com navy/orange do bundle em vez de black/amber — **comparar contra os 10 prints do bundle**
+- SSR: primeira pintura do terminal não mostra o preto antigo (no-FOUC)
+
+---
+
+### PR-T3 — Surfaces (builder / screener / macro)
+**Branch**: `feat/ii-tokens-t3-surfaces` → merge em staging
+
+Arquivos:
+- **Nova pasta**: `packages/investintell-ui/src/lib/styles/surfaces/`
+- `surfaces/builder.css` — portar `docs/ux/Netz Terminal/builder.css`:
+  - Classes `.bd-shell`, `.bd-breadcrumb`, `.bd-left`, `.bd-zone-*`, `.bd-tabs`, `.bd-cascade`, `.bd-phase*`, `.bd-kpis`, `.weights-table`, `.factor-row`, `.risk-*`, `.stress-*`, `.mc-metrics`, `.advisor-card*` → manter nomes; trocar `--term-*`/`--netz-*` por `var(--terminal-*)` (façade).
+  - Stress severity classes (`.tail`, `.mod`, `.upside`) resolvem via `var(--ii-sev-*)` através do terminal façade.
+- `surfaces/screener.css` — portar `docs/ux/Netz Terminal/screener.css`:
+  - Classes `.scr-shell`, `.scr-filters*`, `.chip*`, `.scr-table*`, `.elite-badge`, `.universe-badge*`, `.fund-focus*`, `.fund-hero`, `.kpi-grid`, `.perf-chart`, `.radar-wrap`, `.dd-chapters`, `.peer-bar-row`.
+  - Score pills `.score/.warn/.alert` → via `var(--terminal-status-*)`.
+- `surfaces/macro.css` — portar `docs/ux/Netz Terminal/macro.css`:
+  - Classes `.macro-shell`, `.macro-toolbar*`, `.macro-grid`, `.regime-panel*`, `.liq-gauge*`, `.sent-grid`, `.sent-tile*`, `.econ-list`, `.cb-list`, `.news-feed`, `.drawer*`.
+  - Sentiment `.esur.hot/.esur.cool` → via status tokens.
+  - CB calendar `.cb-chg.cut/hold/hike` → via status tokens.
+- `surfaces/index.css` — barrel que importa os 3 acima; consumer importa uma linha só.
+- `packages/investintell-ui/package.json` exports:
+  - Adicionar `"./styles/surfaces/builder"`, `"./styles/surfaces/screener"`, `"./styles/surfaces/macro"`
+- `frontends/wealth/src/routes/(terminal)/allocation/+layout.svelte` (ou nível onde faz sentido): `import "@investintell/ui/styles/surfaces/builder";`
+- `frontends/wealth/src/routes/(terminal)/terminal-screener/+page.svelte`: `import "@investintell/ui/styles/surfaces/screener";`
+- `frontends/wealth/src/routes/(terminal)/macro/+page.svelte`: `import "@investintell/ui/styles/surfaces/macro";`
+
+**Blocking issues do bundle a resolver durante o port**:
+- `url('assets/netz-pattern.svg')` em terminal.css do bundle → copiar o SVG para `packages/investintell-ui/src/lib/styles/assets/` ou inlinar como data URI.
+- Google Fonts `@import` em netz-tokens.css + terminal.css do bundle → **remover completamente**; fontes já vêm de PR-T1 via @fontsource.
+- `@font-face` aliases Charter→Source Serif 4 e Arboria→DM Sans → **não portar** (eram para slide deck, não app).
+
+Verificação PR-T3:
+- Páginas /allocation/*, /terminal-screener, /macro renderizam densidade bundle (rows 22px compact, grid layouts, pill chips, filter rail)
+- Nenhuma classe bundle conflita com classes existentes do @investintell/ui (checar colisão `.chip`, `.pill`, `.panel`, `.drawer`)
+- Scanner Invariant D ainda verde (nenhum hex literal novo em .svelte, nenhum localStorage/EventSource/emoji)
+
+---
+
+### PR-T4 — Visual pass + merge para main
+**Branch**: `feat/ii-tokens-adoption` → PR para main
+
+Conteúdo:
+- Zero código novo. É apenas a PR que consolida T1+T2+T3 em main.
+- Descrição contém screenshots lado a lado: implementação atual × bundle reference × nova implementação, para cada uma das 4 páginas (live/allocation/screener/macro — live já é navy; allocation com cascade+donut; screener com filter rail + table; macro com 3-col rail + regime matrix).
+- CI: `check-frontends` pré-existente red OK conforme `feedback_dev_first_ci_later.md`; `check-terminal-tokens-sync` DEVE estar verde; `test-backend` skipped (nenhuma mudança backend).
+
+Verificação PR-T4:
+- Visual parity dos 10 prints do bundle
+- `pnpm -F netz-wealth-os build` passa
+- Scanner verde nas 4 invariants (A/B/C/D) + nova E
+- Zero regressão em `(app)` — surfaces institucionais seguem renderizando via `--ii-*` direto (que agora têm a paleta corporativa correta do bundle)
+
+---
+
+## Arquivos críticos (paths absolutos)
+
+Modificar:
+- `packages/investintell-ui/src/lib/styles/tokens.css` (PR-T1 — reescrita)
+- `packages/investintell-ui/src/lib/styles/typography.css` (PR-T1 — font swap)
+- `packages/investintell-ui/src/lib/styles/globals.css` (PR-T1 — imports)
+- `packages/investintell-ui/src/lib/styles/terminal.css` (PR-T2 — façade rewire)
+- `packages/investintell-ui/src/lib/charts/terminal-options.ts` (PR-T2 — DEFAULT_TOKENS fallback hex)
+- `packages/investintell-ui/package.json` (PR-T1 — deps; PR-T3 — exports)
+- `scripts/check-terminal-tokens-sync.mjs` (PR-T2 — Invariant E)
+
+Criar:
+- `packages/investintell-ui/src/lib/styles/surfaces/builder.css` (PR-T3)
+- `packages/investintell-ui/src/lib/styles/surfaces/screener.css` (PR-T3)
+- `packages/investintell-ui/src/lib/styles/surfaces/macro.css` (PR-T3)
+- `packages/investintell-ui/src/lib/styles/surfaces/index.css` (PR-T3)
+- `packages/investintell-ui/src/lib/styles/assets/netz-pattern.svg` (PR-T3 — copiar do bundle se usado)
+
+Tocar (um import cada):
+- `frontends/wealth/src/routes/(terminal)/allocation/[profile]/+page.svelte` (PR-T3)
+- `frontends/wealth/src/routes/(terminal)/terminal-screener/+page.svelte` (PR-T3)
+- `frontends/wealth/src/routes/(terminal)/macro/+page.svelte` (PR-T3)
+
+Fonte de verdade (read-only):
+- `docs/ux/Netz Terminal/assets/netz-tokens.css`
+- `docs/ux/Netz Terminal/terminal.css`
+- `docs/ux/Netz Terminal/builder.css`
+- `docs/ux/Netz Terminal/screener.css`
+- `docs/ux/Netz Terminal/macro.css`
+
+Não modificar:
+- `packages/investintell-ui/src/lib/styles/spacing.css` (utility, bundle cobre parcialmente — deixa pra depois)
+- `packages/investintell-ui/src/lib/styles/shadows.css` (mesmo)
+- `packages/investintell-ui/src/lib/styles/animations.css` (mesmo)
+- Qualquer `.svelte` com `font-family: 'Urbanist'` literal (out of scope — fallback cascade vai resolver)
+- Arquivos com import `from "@netz/..."` (out of scope — migração separada)
+
+---
+
+## Funções e utilitários a reusar
+
+- `readVar(style, name, fallback)` em `packages/investintell-ui/src/lib/charts/terminal-options.ts` — já resolve `--terminal-*` com fallback hex; continua válido pós-rewire (CSS var resolution é transparente a múltiplos níveis de `var()` indirection).
+- `createTerminalChartOptions(...)` e `createTerminalLightweightChartOptions(...)` — idem, não precisam mudar.
+- `injectBranding(config)` em `packages/investintell-ui/src/lib/utils/branding.ts` — já injeta tokens por tenant; substituição é paleta default, não mecanismo de branding.
+- Scanner `scripts/check-terminal-tokens-sync.mjs` — extender com Invariant E, reusar parser existente de CSS custom-property declarations e readVar references.
+
+---
+
+## Verificação end-to-end
+
+Após PR-T4 em main, executar sequencialmente:
+
+```bash
+# 1. Integridade do catálogo de tokens
+node scripts/check-terminal-tokens-sync.mjs
+# Esperado: OK — X CSS tokens, Y readVar references, Z DEFAULT_TOKENS keys in sync; Invariant E green
+
+# 2. Build + type-check
+pnpm -F @investintell/ui build
+pnpm -F netz-wealth-os build
+pnpm -F netz-wealth-os check
+
+# 3. Dev server + smoke visual
+pnpm -F netz-wealth-os dev
+# Abrir manualmente:
+# http://localhost:5174/live          → compara contra prints/live-bundle.png
+# http://localhost:5174/allocation/moderate → compara contra allocation-bundle.png
+# http://localhost:5174/terminal-screener    → compara contra screener-bundle.png
+# http://localhost:5174/macro                → compara contra macro-bundle.png
+
+# 4. Regressão em (app)
+# http://localhost:5174/research, /portfolio, etc. (surfaces que usam --ii-* direto)
+# Headings em IBM Plex Sans (não Urbanist); paleta navy/orange do bundle
+```
+
+Gates visuais (manual, operador):
+- Background: navy deep, não preto
+- Accent primário: laranja quente `#FF965A`, não amarelo âmbar
+- Tipografia interface: IBM Plex Sans (serifas leves, proporcional), não Urbanist (grotesque round)
+- Tipografia data: IBM Plex Mono (tabular-nums, ligatures off), não Geist Mono
+- Densidade: rows 22px em tables, gutters 24px, gaps 16px
+- Filter rail / chip groups / score pills renderizam com classes bundle (dentro das surfaces CSS)
+
+Gates automatizados:
+- `check-terminal-tokens-sync.mjs` — exit 0, todas as 5 invariants (A/B/C/D/E)
+- `pnpm -F netz-wealth-os build` — exit 0
+- CI `check-frontends` — pré-existente red aceitável; `test-backend` SKIPPED
+
+---
+
+## Out of scope (flags explícitas para Opus)
+
+- Remover `font-family: 'Urbanist'` literal nas 91 .svelte (fallback cascade vai resolver via typography.css; cleanup físico fica para PR separado)
+- Migrar 67 imports `from "@netz/..."` para `@investintell/...` (independente desta sprint)
+- Dataviz palette remapeada para paleta warm do bundle (reusar valores atuais de terminal.css; tunning visual em PR separado)
+- Dark mode vs light mode semântico — bundle netz-tokens.css é light-mode corporate; terminal é dark-mode. Continuamos com `[data-surface="terminal"]` como scope override para dark; `(app)` institucional continua light. Não consolidar no mesmo arquivo.
+- Classes utility do bundle (`.netz-hero`, `.netz-display`, etc.) — fora de escopo; institucional já tem sua própria escala tipográfica em typography.css

--- a/docs/plans/_deprecated/2026-04-19-ii-tokens-adoption.md
+++ b/docs/plans/_deprecated/2026-04-19-ii-tokens-adoption.md
@@ -1,4 +1,12 @@
-# ii-tokens — Substituição da Camada de Tokens + Superfícies de Página
+# [DEPRECATED 2026-04-19] ii-tokens — Substituição da Camada de Tokens + Superfícies de Página
+
+> **Status**: deprecated. Não executar. Plano abandonado no mesmo dia por pivot estratégico: em vez de migrar tokens dentro de `frontends/wealth/src/routes/(terminal)/`, o Terminal vai ser extraído para um frontend próprio (`frontends/terminal/`) com URL isolada (`terminal.investintell.com`). Ver plano de extração em `docs/plans/` quando escrito.
+>
+> **Branches relacionadas deletadas**: `feat/ii-tokens-adoption` (remote + local), `feat/ii-tokens-t1-base` (local). WIP do Opus preservado em `git stash` local sob mensagem "ii-tokens-t1-base WIP".
+>
+> **Arquivo mantido** como registro histórico da arquitetura considerada (façade `--terminal-*` → `--ii-*`, fonts via @fontsource, 4 sub-PRs T1-T4). Se a extração do terminal adotar a mesma estratégia de tokens, este plano pode ser re-promovido para `docs/plans/` e re-escopado ao novo frontend.
+
+---
 
 **Branch**: `feat/ii-tokens-adoption` (long-lived, não merge em main até visual pass)
 **Plano**: apenas este arquivo é editável em plan mode; o artefato versionado final do plano vai para `docs/plans/2026-04-19-ii-tokens-adoption.md` durante execução.

--- a/frontends/terminal/.env.example
+++ b/frontends/terminal/.env.example
@@ -1,0 +1,22 @@
+# II Terminal — environment template.
+# Copy to .env for local dev. Railway injects production values at build time.
+
+# Backend API base URL (exposed to client via $env/dynamic/public).
+PUBLIC_API_BASE_URL=http://127.0.0.1:8000
+
+# Clerk publishable key (pk_test_... in dev, pk_live_... in prod).
+PUBLIC_CLERK_PUBLISHABLE_KEY=
+
+# Clerk server secret — required when devBypass is off.
+CLERK_SECRET_KEY=
+
+# Optional JWKS override; derived from PUBLIC_CLERK_PUBLISHABLE_KEY otherwise.
+CLERK_JWKS_URL=
+
+# Cookie domain used for cross-subdomain SSO. Leave empty in dev (localhost
+# rejects single-label cookie domains). In prod set to ".investintell.com"
+# so wealth.investintell.com and terminal.investintell.com share sessions.
+CLERK_COOKIE_DOMAIN=
+
+# Must match backend DEV_TOKEN — local dev only.
+DEV_TOKEN=dev-token

--- a/frontends/terminal/Dockerfile
+++ b/frontends/terminal/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+# Install pnpm
+RUN npm install -g pnpm@10.28.1
+
+# Cache bust to force fresh copy on every build
+ARG RAILWAY_GIT_COMMIT_SHA
+RUN echo "build: ${RAILWAY_GIT_COMMIT_SHA:-unknown}"
+
+# Copy monorepo root files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/ packages/
+COPY frontends/terminal/ frontends/terminal/
+
+# Install deps
+RUN pnpm install --frozen-lockfile
+
+# Build-time env vars (Railway injects these as build args automatically)
+ARG PUBLIC_CLERK_PUBLISHABLE_KEY
+ARG PUBLIC_API_BASE_URL
+ENV PUBLIC_CLERK_PUBLISHABLE_KEY=$PUBLIC_CLERK_PUBLISHABLE_KEY
+ENV PUBLIC_API_BASE_URL=$PUBLIC_API_BASE_URL
+
+# Build UI packages then terminal frontend
+RUN pnpm --filter @netz/ui build && pnpm --filter @investintell/ui build && pnpm --filter ii-terminal build
+
+WORKDIR /app/frontends/terminal
+EXPOSE 3000
+CMD ["node", "build/index.js"]

--- a/frontends/terminal/eslint.config.js
+++ b/frontends/terminal/eslint.config.js
@@ -1,0 +1,36 @@
+import tseslint from "typescript-eslint";
+import svelteParser from "svelte-eslint-parser";
+import tsParser from "@typescript-eslint/parser";
+import sveltePlugin from "eslint-plugin-svelte";
+import { netzFormatterRules, netzTerminalRules } from "../eslint.config.js";
+
+export default [
+	tseslint.configs.base,
+	...sveltePlugin.configs["flat/recommended"],
+	{
+		files: ["**/*.svelte", "**/*.svelte.ts", "**/*.svelte.js"],
+		languageOptions: {
+			parser: svelteParser,
+			parserOptions: {
+				parser: tsParser,
+				extraFileExtensions: [".svelte"],
+				svelteFeatures: {
+					experimentalGenerics: true,
+				},
+			},
+		},
+	},
+	...netzFormatterRules,
+	...netzTerminalRules,
+	{
+		files: ["**/*.svelte"],
+		rules: {
+			// Svelte 5 rune files — keep formatter discipline in <script lang="ts">.
+			"no-restricted-syntax": netzFormatterRules[0].rules["no-restricted-syntax"],
+		},
+	},
+	{
+		// Build artifacts and vendored code
+		ignores: [".svelte-kit/**", "build/**", "node_modules/**", "dist/**"],
+	},
+];

--- a/frontends/terminal/package.json
+++ b/frontends/terminal/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "ii-terminal",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vite dev",
+		"build": "vite build",
+		"preview": "vite preview",
+		"check": "svelte-check --tsconfig ./tsconfig.json",
+		"lint": "eslint src/"
+	},
+	"dependencies": {
+		"@clerk/clerk-js": "^6.3.2",
+		"@fontsource/ibm-plex-sans": "^5.0.0",
+		"@fontsource/ibm-plex-mono": "^5.0.0",
+		"@fontsource/montserrat": "^5.0.0",
+		"@investintell/ui": "workspace:*",
+		"clerk-sveltekit": "^0.4.3",
+		"svelte-clerk": "^1.1.3"
+	},
+	"devDependencies": {
+		"@sveltejs/adapter-node": "^5.5.4",
+		"@sveltejs/kit": "^2.0.0",
+		"@sveltejs/vite-plugin-svelte": "^5.0.0",
+		"@tailwindcss/vite": "^4.2.1",
+		"@typescript-eslint/parser": "^8.58.1",
+		"eslint": "^10.0.3",
+		"eslint-plugin-svelte": "^3.17.0",
+		"svelte": "^5.0.0",
+		"svelte-check": "^4.0.0",
+		"svelte-eslint-parser": "^1.6.0",
+		"tailwindcss": "^4.0.0",
+		"typescript": "^5.5.0",
+		"typescript-eslint": "^8.57.1",
+		"vite": "^6.0.0"
+	},
+	"packageManager": "pnpm@10.28.1"
+}

--- a/frontends/terminal/railway.toml
+++ b/frontends/terminal/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "frontends/terminal/Dockerfile"
+
+[deploy]
+startCommand = "node build/index.js"
+healthcheckPath = "/"
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3

--- a/frontends/terminal/src/app.css
+++ b/frontends/terminal/src/app.css
@@ -1,0 +1,18 @@
+/* Import @investintell/ui design tokens + base reset (--ii-* tokens).
+ * X3 (visual sprint) will extend with bundle-specific surfaces.
+ */
+@import "@investintell/ui/styles";
+@import "tailwindcss";
+
+/* ── Content sources (replaces tailwind.config content[]) ── */
+@source "../../../packages/investintell-ui/src/**/*.{svelte,ts}";
+
+/* ── Custom theme tokens (Tailwind v4 @theme) ── */
+@theme {
+	--color-ii-brand: var(--ii-brand-primary);
+	--color-ii-accent: var(--ii-brand-accent);
+	--color-ii-surface: var(--ii-surface);
+	--color-ii-muted: var(--ii-text-muted);
+	--font-sans: var(--ii-font-sans), "IBM Plex Sans", system-ui, sans-serif;
+	--font-mono: var(--ii-font-mono), "IBM Plex Mono", "Menlo", monospace;
+}

--- a/frontends/terminal/src/app.d.ts
+++ b/frontends/terminal/src/app.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="@sveltejs/kit" />
+
+import type { Actor } from "@investintell/ui/utils";
+
+declare global {
+	namespace App {
+		interface Locals {
+			actor: Actor;
+			token: string;
+		}
+	}
+}
+
+export {};

--- a/frontends/terminal/src/app.html
+++ b/frontends/terminal/src/app.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<!--
+  II Terminal — dark-only institutional workspace.
+  data-theme="dark" is a hard-coded SSR baseline; unlike wealth's setup we
+  intentionally do not register a themeHook, because the terminal visual
+  bundle (docs/ux/Netz Terminal/) is dark-only. X3 will wire ii-tokens on
+  top of this baseline.
+-->
+<html lang="en" data-theme="dark">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta
+			name="description"
+			content="II Terminal — InvestIntell institutional investment workstation."
+		/>
+		<title>II Terminal</title>
+		%sveltekit.head%
+	</head>
+	<body data-sveltekit-preload-data="hover">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>

--- a/frontends/terminal/src/hooks.client.ts
+++ b/frontends/terminal/src/hooks.client.ts
@@ -1,0 +1,19 @@
+/**
+ * Client hook — session expiry monitor.
+ *
+ * Shows a 2-minute pre-expiry warning so long-running terminal analyses
+ * (live workbench polling, screener tasks) surface a session-renewal UX
+ * before Clerk auto-refresh silently kicks in.
+ *
+ * The actual token used by the warning is picked up inside +layout.svelte
+ * via setContext("netz:getToken"). This hook is intentionally minimal
+ * because X2+ components wire the real token flow.
+ */
+import type { HandleClientError } from "@sveltejs/kit";
+
+export const handleError: HandleClientError = ({ error }) => {
+	const message = error instanceof Error ? error.message : String(error);
+	return {
+		message,
+	};
+};

--- a/frontends/terminal/src/hooks.server.ts
+++ b/frontends/terminal/src/hooks.server.ts
@@ -1,0 +1,68 @@
+/**
+ * SvelteKit server hook — Clerk JWT verification for II Terminal.
+ *
+ * Mirrors `frontends/wealth/src/hooks.server.ts` so that both apps share
+ * the same verified-JWT → Actor path via `@investintell/ui` `createClerkHook`.
+ *
+ * Cookie-domain SSO note: `createClerkHook` does not manage cookie domain
+ * itself — that is configured in the Clerk Dashboard (`.investintell.com`
+ * allowed subdomains). `CLERK_COOKIE_DOMAIN` is read here so the operator
+ * can wire it in X6 (cutover to prod) without re-touching this file.
+ */
+import { createClerkHook } from "@investintell/ui/utils";
+import type { Handle } from "@sveltejs/kit";
+import { sequence } from "@sveltejs/kit/hooks";
+import { env } from "$env/dynamic/private";
+import { env as pubEnv } from "$env/dynamic/public";
+
+/** Derive Clerk JWKS URL from publishable key if not explicitly set.
+ *  pk_test_Y2Fw... → base64 decode → capital-tarpon-42.clerk.accounts.dev
+ */
+function deriveJwksUrl(pk: string): string {
+	try {
+		const encoded = pk.replace(/^pk_(test|live)_/, "");
+		const domain = atob(encoded).replace(/\$$/, "");
+		return `https://${domain}/.well-known/jwks.json`;
+	} catch {
+		return "";
+	}
+}
+
+const PK = pubEnv.PUBLIC_CLERK_PUBLISHABLE_KEY ?? "";
+const CLERK_JWKS_URL = env.CLERK_JWKS_URL || deriveJwksUrl(PK);
+const DEV_TOKEN = env.DEV_TOKEN ?? "dev-token";
+const IS_DEV = import.meta.env.DEV;
+
+// Read but currently unused — wired to Clerk Dashboard config in X6.
+// Leaving the lookup here so env is validated early on boot.
+const _CLERK_COOKIE_DOMAIN = env.CLERK_COOKIE_DOMAIN ?? (IS_DEV ? "localhost" : ".investintell.com");
+void _CLERK_COOKIE_DOMAIN;
+
+const SIGN_IN_URL = IS_DEV
+	? "/auth/callback"
+	: "https://accounts.investintell.com/sign-in?redirect_url=https://terminal.investintell.com/auth/callback";
+
+const authHook = createClerkHook({
+	jwksUrl: IS_DEV ? undefined : CLERK_JWKS_URL,
+	devBypass: IS_DEV,
+	devToken: DEV_TOKEN,
+	publicPrefixes: ["/health", "/.well-known/", "/auth/"],
+	signInUrl: SIGN_IN_URL,
+});
+
+/**
+ * Security headers hook.
+ *
+ * NOTE — CSP rules will ship with X3/X6. X1 only sets the baseline headers
+ * that are framework-agnostic. Railway + adapter-node does not parse a
+ * `_headers` file (Cloudflare Pages format), so any CSP must live here.
+ */
+const securityHeadersHook: Handle = async ({ event, resolve }) => {
+	const response = await resolve(event);
+	response.headers.set("X-Frame-Options", "DENY");
+	response.headers.set("X-Content-Type-Options", "nosniff");
+	response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+	return response;
+};
+
+export const handle: Handle = sequence(authHook, securityHeadersHook);

--- a/frontends/terminal/src/routes/+layout.server.ts
+++ b/frontends/terminal/src/routes/+layout.server.ts
@@ -1,0 +1,29 @@
+/**
+ * Root layout server loader — loads Actor + token for all terminal pages.
+ *
+ * X1 scaffold scope: just surface the verified actor/token from hooks.
+ * X3 swaps `defaultDarkBranding` for ii-bundle branding; X4 removes
+ * any residual Netz strings from chrome.
+ */
+import type { LayoutServerLoad } from "./$types";
+import { defaultDarkBranding } from "@investintell/ui/utils";
+
+/** Normalize Clerk role — strip "org:" prefix so frontend lists match. */
+function normalizeRole(raw: string | null | undefined): string | null {
+	if (!raw) return null;
+	return raw.replace(/^org:/, "");
+}
+
+export const load: LayoutServerLoad = async ({ locals }) => {
+	const { actor, token } = locals;
+
+	const normalizedActor = actor
+		? { ...actor, role: normalizeRole(actor.role) }
+		: actor;
+
+	return {
+		actor: normalizedActor,
+		token,
+		branding: defaultDarkBranding,
+	};
+};

--- a/frontends/terminal/src/routes/+layout.svelte
+++ b/frontends/terminal/src/routes/+layout.svelte
@@ -1,0 +1,45 @@
+<!--
+  Root layout — auth context + session expiry monitor.
+
+  Scope note: X1 deliberately keeps this minimal — no TopNav, no sidebar,
+  no ErrorBoundary Toast plumbing. The real shell (TerminalTopNav, focus
+  mode chrome) lands in X2 when routes move over. This layout only does:
+    1. Propagate `netz:getToken` so API clients in child routes can fetch.
+    2. Wire branding (ii-bundle injection in X3 swaps the default).
+    3. Start Clerk session expiry monitor once the token is known.
+
+  Auth-pattern note: we intentionally do NOT use svelte-clerk's
+  <SignedIn>/<SignedOut> gates. Wealth uses server-side gating via the
+  createClerkHook in hooks.server.ts, and X1 mirrors that so both apps
+  share one verified-JWT path. svelte-clerk is installed but only
+  reserved for component-level UI (e.g. UserButton) in later sprints.
+-->
+<script lang="ts">
+	import "../app.css";
+	import { setContext } from "svelte";
+	import { injectBranding, startSessionExpiryMonitor } from "@investintell/ui/utils";
+	import type { LayoutData } from "./$types";
+
+	let { data, children }: { data: LayoutData; children: import("svelte").Snippet } = $props();
+
+	// Auth context — provides getToken to child routes.
+	setContext("netz:getToken", () => Promise.resolve(data.token));
+
+	// Branding CSS injection (X3 swaps defaultDarkBranding for ii-bundle).
+	$effect(() => {
+		if (typeof document !== "undefined" && data.branding) {
+			injectBranding(document.documentElement, data.branding);
+		}
+	});
+
+	// Session expiry — client-only warning before Clerk token expiration.
+	$effect(() => {
+		if (typeof window === "undefined" || !data.token) return;
+		const cleanup = startSessionExpiryMonitor(data.token, () => {
+			console.warn("II Terminal session approaching expiry — refresh recommended.");
+		});
+		return cleanup;
+	});
+</script>
+
+{@render children()}

--- a/frontends/terminal/src/routes/+page.svelte
+++ b/frontends/terminal/src/routes/+page.svelte
@@ -1,0 +1,47 @@
+<!--
+  II Terminal — X1 scaffold placeholder.
+
+  Routes (live, allocation, macro, screener, research, alerts) land in X2
+  when they move out of frontends/wealth/src/routes/(terminal)/.
+-->
+<script lang="ts">
+	const env = import.meta.env.VITE_ENV ?? "dev";
+	const sha = import.meta.env.VITE_BUILD_SHA ?? "local-dev";
+</script>
+
+<svelte:head>
+	<title>II Terminal — Scaffold</title>
+</svelte:head>
+
+<main class="min-h-screen bg-black text-white font-sans antialiased px-10 py-10">
+	<header class="mb-12">
+		<p class="text-xs uppercase tracking-[0.24em] text-white/40">InvestIntell</p>
+		<h1 class="mt-2 text-3xl font-semibold">II Terminal</h1>
+		<p class="mt-1 text-sm text-white/60">
+			Institutional investment workstation.
+		</p>
+	</header>
+
+	<section class="max-w-xl space-y-4 text-sm leading-relaxed text-white/80">
+		<p>
+			II Terminal scaffolded. Routes populated in X2.
+		</p>
+		<p class="text-white/50">
+			This placeholder proves the SvelteKit app boots at
+			<code class="font-mono text-white/70">terminal.investintell.com</code>
+			with the shared Clerk session and the @investintell/ui design tokens.
+		</p>
+		<div class="pt-4">
+			<a
+				href="/live"
+				class="inline-flex h-10 items-center rounded-full border border-white/20 bg-white/5 px-5 text-xs font-medium uppercase tracking-[0.16em] text-white/80 transition hover:border-white/40 hover:bg-white/10"
+			>
+				Placeholder nav → /live (404 until X2)
+			</a>
+		</div>
+	</section>
+
+	<footer class="mt-16 text-[11px] font-mono text-white/30">
+		env={env} · build={sha}
+	</footer>
+</main>

--- a/frontends/terminal/svelte.config.js
+++ b/frontends/terminal/svelte.config.js
@@ -1,0 +1,15 @@
+import adapter from "@sveltejs/adapter-node";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	preprocess: vitePreprocess(),
+	kit: {
+		adapter: adapter(),
+		alias: {
+			$lib: "src/lib",
+		},
+	},
+};
+
+export default config;

--- a/frontends/terminal/tsconfig.json
+++ b/frontends/terminal/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"strict": true,
+		"moduleResolution": "bundler",
+		"target": "ES2022",
+		"module": "ES2022",
+		"verbatimModuleSyntax": true,
+		"noUncheckedIndexedAccess": true,
+		"skipLibCheck": true
+	},
+	"exclude": [
+		"node_modules",
+		"../../backend",
+		"../../docs",
+		"../../profiles",
+		"../../calibration",
+		"../../frontends/credit",
+		"../../frontends/wealth"
+	]
+}

--- a/frontends/terminal/vite.config.ts
+++ b/frontends/terminal/vite.config.ts
@@ -1,0 +1,24 @@
+import { sveltekit } from "@sveltejs/kit/vite";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+
+// Build metadata exposed to the client bundle via import.meta.env.
+// Railway injects GIT_SHA in production deploys; local dev falls back
+// to "local-dev". Mirrors the convention used by frontends/wealth.
+const BUILD_SHA = process.env.GIT_SHA ?? "local-dev";
+const BUILD_ENV = process.env.NODE_ENV === "production" ? "prod" : "dev";
+
+export default defineConfig({
+	plugins: [tailwindcss(), sveltekit()],
+	define: {
+		"import.meta.env.VITE_BUILD_SHA": JSON.stringify(BUILD_SHA),
+		"import.meta.env.VITE_ENV": JSON.stringify(BUILD_ENV),
+	},
+	server: {
+		port: 5175,
+		strictPort: false,
+	},
+	build: {
+		chunkSizeWarningLimit: 1000,
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -94,11 +94,78 @@ importers:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)
 
+  frontends/terminal:
+    dependencies:
+      '@clerk/clerk-js':
+        specifier: ^6.3.2
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.0.0
+        version: 5.2.7
+      '@fontsource/ibm-plex-sans':
+        specifier: ^5.0.0
+        version: 5.2.8
+      '@fontsource/montserrat':
+        specifier: ^5.0.0
+        version: 5.2.8
+      '@investintell/ui':
+        specifier: workspace:*
+        version: link:../../packages/investintell-ui
+      clerk-sveltekit:
+        specifier: ^0.4.3
+        version: 0.4.3(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(react-dom@19.2.5(react@19.2.4))(react@19.2.4)(svelte@5.53.12)
+      svelte-clerk:
+        specifier: ^1.1.3
+        version: 1.1.3(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(react-dom@19.2.5(react@19.2.4))(react@19.2.4)(svelte@5.53.12)
+    devDependencies:
+      '@sveltejs/adapter-node':
+        specifier: ^5.5.4
+        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))
+      '@sveltejs/kit':
+        specifier: ^2.0.0
+        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.0
+        version: 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2))
+      '@tailwindcss/vite':
+        specifier: ^4.2.1
+        version: 4.2.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2))
+      '@typescript-eslint/parser':
+        specifier: ^8.58.1
+        version: 8.58.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      eslint:
+        specifier: ^10.0.3
+        version: 10.0.3(jiti@2.6.1)
+      eslint-plugin-svelte:
+        specifier: ^3.17.0
+        version: 3.17.0(eslint@10.0.3(jiti@2.6.1))(svelte@5.53.12)
+      svelte:
+        specifier: ^5.0.0
+        version: 5.53.12
+      svelte-check:
+        specifier: ^4.0.0
+        version: 4.4.5(picomatch@4.0.3)(svelte@5.53.12)(typescript@5.9.3)
+      svelte-eslint-parser:
+        specifier: ^1.6.0
+        version: 1.6.0(svelte@5.53.12)
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.2.1
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.57.1
+        version: 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)
+
   frontends/wealth:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -622,9 +689,44 @@ packages:
   '@base-org/account@2.0.1':
     resolution: {integrity: sha512-tySVNx+vd6XEynZL0uvB10uKiwnAfThr8AbKTwILVG86mPbLAhEOInQIk+uDnvpTvfdUhC1Bi5T/46JvFoLZQQ==}
 
+  '@clerk/backend@0.32.1':
+    resolution: {integrity: sha512-ZH3Mez3f9SZwjpRbC1oaw3+q1+jXkF02HpUB+3vH2+PNxdY+AJ0MW4ACtJhIMNqeY8zAEKzYKMpuGsI+3NVyOA==}
+    engines: {node: '>=14'}
+
+  '@clerk/backend@3.2.7':
+    resolution: {integrity: sha512-8IdAKqFpmWhaK0HkyheXv4kP5E3eE1KCCbTokNvVKA3xWh8Jk1CjrYCk+Uq1R/PA3b2h418qbsA21ZCFoSUY7g==}
+    engines: {node: '>=20.9.0'}
+
+  '@clerk/clerk-js@4.73.14':
+    resolution: {integrity: sha512-X2E7jP1aBm1Qa7+Ykgbd46+dYvwGKCw9/WJkfVQm3gYc0b+u2v22trSWT58ngM3Gt4cLA/frhnpjhxAO+ypUjg==}
+    peerDependencies:
+      react: '>=18'
+
   '@clerk/clerk-js@6.3.2':
     resolution: {integrity: sha512-pJiQPo5obSHEhBT/Io9irAyre5VAWbHP8mjb7+1a+WUPpWMg3Gl5z6xFcP8gg92Gswuzfv/F1PCtUIeURDuBSA==}
     engines: {node: '>=20.9.0'}
+
+  '@clerk/localizations@1.28.10':
+    resolution: {integrity: sha512-eTJ1DJeMKNIie4TB4vE5rqkU1ZJgPG4/j4XTiisFtcag+YUgNxABMuaCdxojIZE5jcKaJ4k1OrUtYFnHAe7TWw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16'
+
+  '@clerk/shared@1.0.1':
+    resolution: {integrity: sha512-jUmDlU9FYJi1AhCDkyoI0alh3L/gXpw9HzuB49uiqtU8pdCtjJNLHE5EY7mfHoGP5DdCZlmApzC+HyCamyOUVA==}
+    peerDependencies:
+      react: '>=16'
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  '@clerk/shared@1.4.2':
+    resolution: {integrity: sha512-R+OkzCtnNU7sn/F6dBfdY5lKs84TN785VZdBBefmyr7zsXcFEqbCcfQzyvgtIS28Ln5SifFEBoAyYR334IXO8w==}
+    peerDependencies:
+      react: '>=16'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@clerk/shared@4.3.2':
     resolution: {integrity: sha512-tYYzdY4Fxb02TO4RHoLRFzEjXJn0iFDfoKhWtGyqf2AaIgkprTksunQtX0hnVssHMr3XD/E2S00Vrb+PzX3jCQ==}
@@ -637,6 +739,28 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  '@clerk/shared@4.5.0':
+    resolution: {integrity: sha512-01xc2Mb6/srZa9kvk9apEFr98Zsoe3XZusTUrSzAQDaX0ltQn5W0r7V1cJiDGHKTYG5vv4ACeNfZ7sZgspKTbA==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/types@3.57.0':
+    resolution: {integrity: sha512-i+XqgqRbcMn5gMwWGiA3W6lCTSDYdonDAgoJgNyRemQg7Zesnbd4OoJZfqyW6vN3wvD9Bl+gMb7gQ3VquNWUOA==}
+    engines: {node: '>=14'}
+    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
+
+  '@clerk/types@3.65.5':
+    resolution: {integrity: sha512-RGO8v2a52Ybo1jwVj42UWT8VKyxAk/qOxrkA3VNIYBNEajPSmZNa9r9MTgqSgZRyz1XTlQHdVb7UK7q78yAGfA==}
+    engines: {node: '>=14'}
+    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
 
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
@@ -702,6 +826,50 @@ packages:
   '@dagrejs/graphlib@2.2.4':
     resolution: {integrity: sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==}
     engines: {node: '>17.0.0'}
+
+  '@emotion/babel-plugin@11.13.5':
+    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
+
+  '@emotion/cache@11.11.0':
+    resolution: {integrity: sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==}
+
+  '@emotion/hash@0.9.2':
+    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
+
+  '@emotion/memoize@0.8.1':
+    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+
+  '@emotion/react@11.11.1':
+    resolution: {integrity: sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@emotion/serialize@1.3.3':
+    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
+
+  '@emotion/sheet@1.4.0':
+    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
+
+  '@emotion/unitless@0.10.0':
+    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
+    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@emotion/utils@1.4.2':
+    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
+
+  '@emotion/weak-memoize@0.3.1':
+    resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -926,6 +1094,21 @@ packages:
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.25.4':
+    resolution: {integrity: sha512-lWRQ/UiTvSIBxohn0/2HFHEmnmOVRjl7j6XcRJuLH0ls6f/9AyHMWVzkAJFuwx0n9gaEeCmg9VccCSCJzbEJig==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.1.6':
+    resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
+
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
@@ -949,6 +1132,9 @@ packages:
 
   '@fontsource/ibm-plex-sans@5.2.8':
     resolution: {integrity: sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==}
+
+  '@fontsource/montserrat@5.2.8':
+    resolution: {integrity: sha512-xTjLxSbSfCycDB0pwmNsfNvdfWPaDaRQ2LC6yt/ZI7SdvXG52zHnzNYC/09mzuAuWNJyShkteutfCoDgym56hQ==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -1079,6 +1265,17 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@peculiar/asn1-schema@2.6.0':
+    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
+
+  '@peculiar/json-schema@1.1.12':
+    resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
+    engines: {node: '>=8.0.0'}
+
+  '@peculiar/webcrypto@1.4.1':
+    resolution: {integrity: sha512-eK4C6WTNYxoI7JOabMoZICiyqRRtJB220bh0Mbj5RwRycleZf9BPyZoxsTvpP0FpmVS2aS13NKOuh5/tN3sIRw==}
+    engines: {node: '>=10.12.0'}
 
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
@@ -1502,6 +1699,9 @@ packages:
   '@solana/web3.js@1.98.4':
     resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1772,8 +1972,14 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@16.18.6':
+    resolution: {integrity: sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/parse-json@4.0.2':
+    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -2088,6 +2294,10 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1js@3.0.7:
+    resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
+    engines: {node: '>=12.0.0'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2112,6 +2322,10 @@ packages:
   babel-plugin-jest-hoist@29.6.3:
     resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  babel-plugin-macros@3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
 
   babel-plugin-syntax-hermes-parser@0.32.0:
     resolution: {integrity: sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==}
@@ -2184,6 +2398,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-tabs-lock@1.2.15:
+    resolution: {integrity: sha512-J8K9vdivK0Di+b8SBdE7EZxDr88TnATing7XoLw6+nFkXMQ6sVBh92K3NQvZlZU91AIkFRi0w3sztk5Z+vsswA==}
+
   browser-tabs-lock@1.3.0:
     resolution: {integrity: sha512-g6nHaobTiT0eMZ7jh16YpD2kcjAp+PInbiVq3M1x6KKaEIVhT4v9oURNIpZLOZ3LQbQ3XYfNhMAb/9hzNLIWrw==}
 
@@ -2217,6 +2434,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -2291,6 +2512,13 @@ packages:
 
   class-validator@0.14.4:
     resolution: {integrity: sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==}
+
+  clerk-sveltekit@0.4.3:
+    resolution: {integrity: sha512-gIm0t4dtqK0qkLg1oBCZ5STCoRNgWLbIr8DVNDfJIsMESKaUJAtqSDBm9y6shYQM7+QyQk5YQIG78q+yZIX0IQ==}
+    deprecated: 'This package is deprecated. Please use svelte-clerk instead: https://github.com/wobsoriano/svelte-clerk'
+    peerDependencies:
+      '@sveltejs/kit': ^1.25.1||^2.0.2
+      svelte: ^4.0.0||^5.0.0
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
@@ -2369,15 +2597,32 @@ packages:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
 
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
+  copy-to-clipboard@3.3.3:
+    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
+
+  core-js@3.26.1:
+    resolution: {integrity: sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==}
+
   core-js@3.47.0:
     resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
+
+  cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -2400,6 +2645,9 @@ packages:
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
+
+  csstype@3.1.1:
+    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2548,6 +2796,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.2.2:
+    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+    engines: {node: '>=0.10.0'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -2602,6 +2854,9 @@ packages:
 
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2665,6 +2920,9 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -2849,6 +3107,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
@@ -2887,6 +3148,9 @@ packages:
   finalhandler@1.1.2:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
+
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -3024,6 +3288,9 @@ packages:
   hermes-parser@0.33.3:
     resolution: {integrity: sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==}
 
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -3104,6 +3371,9 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -3225,6 +3495,10 @@ packages:
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
+  js-cookie@3.0.1:
+    resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==}
+    engines: {node: '>=12'}
+
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
@@ -3266,6 +3540,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
   json-schema-library@9.3.5:
     resolution: {integrity: sha512-5eBDx7cbfs+RjylsVO+N36b0GOPtv78rfqgf2uON+uaHUIC62h63Y8pkV2ovKbaL4ZpQcHp21968x5nx/dFwqQ==}
@@ -3403,6 +3680,9 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
@@ -3440,6 +3720,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3460,6 +3743,10 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
 
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
@@ -3660,6 +3947,12 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
+  node-fetch-native@1.0.1:
+    resolution: {integrity: sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg==}
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -3696,6 +3989,10 @@ packages:
   ob1@0.83.5:
     resolution: {integrity: sha512-vNKPYC8L5ycVANANpF/S+WZHpfnRWKx/F3AYP4QMn6ZJTh+l2HOrId0clNkEmua58NB9vmI9Qh7YOoV/4folYg==}
     engines: {node: '>=20.19.4'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -3770,6 +4067,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
@@ -3795,6 +4096,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3906,10 +4211,26 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
+  qrcode.react@3.1.0:
+    resolution: {integrity: sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  qs@6.11.0:
+    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
@@ -3927,6 +4248,14 @@ packages:
 
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -4129,6 +4458,22 @@ packages:
   shiki@1.29.2:
     resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -4146,6 +4491,13 @@ packages:
   smtp-address-parser@1.0.10:
     resolution: {integrity: sha512-Osg9LmvGeAG/hyao4mldbflLOkkr3a+h4m1lwKCK5U8M6ZAr7tdXEz/+/vr752TSGE4MNUlUl9cIK2cB8cgzXg==}
     engines: {node: '>=0.10'}
+
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  snakecase-keys@5.4.4:
+    resolution: {integrity: sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==}
+    engines: {node: '>=12'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4181,6 +4533,9 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -4227,6 +4582,9 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
+
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
     engines: {node: '>=14.0.0'}
@@ -4254,6 +4612,15 @@ packages:
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
+
+  svelte-clerk@1.1.3:
+    resolution: {integrity: sha512-RLeZ5sVCbD/EtbHJoxq0L6eO1Po8Qez5SFVHdSXlwxjKtJORBEqNZTPQuJaR/nX1VZdTJHaQGWpp28d4bPMxvg==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.20.0
+      svelte: ^5.29.0
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
 
   svelte-dnd-action@0.9.69:
     resolution: {integrity: sha512-NAmSOH7htJoYraTQvr+q5whlIuVoq88vEuHr4NcFgscDRUxfWPPxgie2OoxepBCQCikrXZV4pqV86aun60wVyw==}
@@ -4313,6 +4680,11 @@ packages:
     peerDependencies:
       '@sveltejs/kit': 1.x || 2.x
       svelte: 3.x || 4.x || >=5.0.0-next.51
+
+  swr@2.2.0:
+    resolution: {integrity: sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -4397,6 +4769,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toggle-selection@1.0.6:
+    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -4437,6 +4812,9 @@ packages:
 
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
+  tslib@2.4.1:
+    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -4546,6 +4924,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   utf-8-validate@6.0.6:
     resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
@@ -4698,6 +5081,9 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  webcrypto-core@1.8.1:
+    resolution: {integrity: sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -5085,7 +5471,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-org/account@2.0.1(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)':
+  '@base-org/account@2.0.1(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
@@ -5094,7 +5480,7 @@ snapshots:
       ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
       preact: 10.24.2
       viem: 2.47.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
-      zustand: 5.0.3(react@19.2.4)
+      zustand: 5.0.3(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -5105,10 +5491,56 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@clerk/clerk-js@6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)':
+  '@clerk/backend@0.32.1(react@19.2.4)':
     dependencies:
-      '@base-org/account': 2.0.1(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
-      '@clerk/shared': 4.3.2(react@19.2.4)
+      '@clerk/shared': 1.0.1(react@19.2.4)
+      '@clerk/types': 3.57.0
+      '@peculiar/webcrypto': 1.4.1
+      '@types/node': 16.18.6
+      cookie: 0.5.0
+      deepmerge: 4.2.2
+      node-fetch-native: 1.0.1
+      snakecase-keys: 5.4.4
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - react
+
+  '@clerk/backend@3.2.7(react-dom@19.2.5(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@clerk/shared': 4.5.0(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/clerk-js@4.73.14(react-dom@19.2.5(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@clerk/localizations': 1.28.10(react@19.2.4)
+      '@clerk/shared': 1.4.2(react@19.2.4)
+      '@clerk/types': 3.65.5
+      '@emotion/cache': 11.11.0
+      '@emotion/react': 11.11.1(react@19.2.4)
+      '@floating-ui/react': 0.25.4(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
+      '@zxcvbn-ts/core': 3.0.4
+      '@zxcvbn-ts/language-common': 3.0.4
+      browser-tabs-lock: 1.2.15
+      copy-to-clipboard: 3.3.3
+      core-js: 3.26.1
+      dequal: 2.0.3
+      qrcode.react: 3.1.0(react@19.2.4)
+      qs: 6.11.0
+      react: 19.2.4
+      regenerator-runtime: 0.13.11
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+      - supports-color
+
+  '@clerk/clerk-js@6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)':
+    dependencies:
+      '@base-org/account': 2.0.1(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)
+      '@clerk/shared': 4.3.2(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
       '@coinbase/wallet-sdk': 4.3.0
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))
       '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)
@@ -5139,10 +5571,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@clerk/clerk-js@6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6)':
+  '@clerk/clerk-js@6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)':
     dependencies:
-      '@base-org/account': 2.0.1(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
-      '@clerk/shared': 4.3.2(react@19.2.4)
+      '@base-org/account': 2.0.1(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)
+      '@clerk/shared': 4.3.2(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
       '@coinbase/wallet-sdk': 4.3.0
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))
       '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -5173,7 +5605,28 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@clerk/shared@4.3.2(react@19.2.4)':
+  '@clerk/localizations@1.28.10(react@19.2.4)':
+    dependencies:
+      '@clerk/types': 3.65.5
+      react: 19.2.4
+
+  '@clerk/shared@1.0.1(react@19.2.4)':
+    dependencies:
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.1
+      swr: 2.2.0(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
+
+  '@clerk/shared@1.4.2(react@19.2.4)':
+    dependencies:
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.1
+      swr: 2.2.0(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
+
+  '@clerk/shared@4.3.2(react-dom@19.2.5(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@tanstack/query-core': 5.90.16
       dequal: 2.0.3
@@ -5182,6 +5635,26 @@ snapshots:
       std-env: 3.10.0
     optionalDependencies:
       react: 19.2.4
+      react-dom: 19.2.5(react@19.2.4)
+
+  '@clerk/shared@4.5.0(react-dom@19.2.5(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.90.16
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.5(react@19.2.4)
+
+  '@clerk/types@3.57.0':
+    dependencies:
+      csstype: 3.1.1
+
+  '@clerk/types@3.65.5':
+    dependencies:
+      csstype: 3.1.1
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:
@@ -5280,6 +5753,70 @@ snapshots:
       '@dagrejs/graphlib': 2.2.4
 
   '@dagrejs/graphlib@2.2.4': {}
+
+  '@emotion/babel-plugin@11.13.5':
+    dependencies:
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/runtime': 7.28.6
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/serialize': 1.3.3
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/cache@11.11.0':
+    dependencies:
+      '@emotion/memoize': 0.8.1
+      '@emotion/sheet': 1.4.0
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.3.1
+      stylis: 4.2.0
+
+  '@emotion/hash@0.9.2': {}
+
+  '@emotion/memoize@0.8.1': {}
+
+  '@emotion/memoize@0.9.0': {}
+
+  '@emotion/react@11.11.1(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.11.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.4)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.3.1
+      hoist-non-react-statics: 3.3.2
+      react: 19.2.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/serialize@1.3.3':
+    dependencies:
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/unitless': 0.10.0
+      '@emotion/utils': 1.4.2
+      csstype: 3.2.3
+
+  '@emotion/sheet@1.4.0': {}
+
+  '@emotion/unitless@0.10.0': {}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+
+  '@emotion/utils@1.4.2': {}
+
+  '@emotion/weak-memoize@0.3.1': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -5445,6 +5982,22 @@ snapshots:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.5(react@19.2.4)
+
+  '@floating-ui/react@0.25.4(react-dom@19.2.5(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
+      '@floating-ui/utils': 0.1.6
+      react: 19.2.4
+      react-dom: 19.2.5(react@19.2.4)
+      tabbable: 6.4.0
+
+  '@floating-ui/utils@0.1.6': {}
+
   '@floating-ui/utils@0.2.11': {}
 
   '@fontsource-variable/geist-mono@5.2.7': {}
@@ -5460,6 +6013,8 @@ snapshots:
   '@fontsource/ibm-plex-mono@5.2.7': {}
 
   '@fontsource/ibm-plex-sans@5.2.8': {}
+
+  '@fontsource/montserrat@5.2.8': {}
 
   '@hapi/hoek@9.3.0':
     optional: true
@@ -5636,6 +6191,24 @@ snapshots:
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@1.8.0': {}
+
+  '@peculiar/asn1-schema@2.6.0':
+    dependencies:
+      asn1js: 3.0.7
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/json-schema@1.1.12':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/webcrypto@1.4.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/json-schema': 1.1.12
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+      webcrypto-core: 1.8.1
 
   '@playwright/test@1.58.2':
     dependencies:
@@ -6252,6 +6825,8 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@stripe/stripe-js@5.6.0': {}
@@ -6523,9 +7098,13 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@16.18.6': {}
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/parse-json@4.0.2': {}
 
   '@types/resolve@1.20.2': {}
 
@@ -6941,6 +7520,12 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1js@3.0.7:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
@@ -6976,6 +7561,12 @@ snapshots:
       '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
+
+  babel-plugin-macros@3.1.0:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      cosmiconfig: 7.1.0
+      resolve: 1.22.11
 
   babel-plugin-syntax-hermes-parser@0.32.0:
     dependencies:
@@ -7072,6 +7663,10 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browser-tabs-lock@1.2.15:
+    dependencies:
+      lodash: 4.17.23
+
   browser-tabs-lock@1.3.0:
     dependencies:
       lodash: 4.17.23
@@ -7114,6 +7709,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -7189,6 +7789,18 @@ snapshots:
       libphonenumber-js: 1.12.41
       validator: 13.15.26
     optional: true
+
+  clerk-sveltekit@0.4.3(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(react-dom@19.2.5(react@19.2.4))(react@19.2.4)(svelte@5.53.12):
+    dependencies:
+      '@clerk/backend': 0.32.1(react@19.2.4)
+      '@clerk/clerk-js': 4.73.14(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
+      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2))
+      svelte: 5.53.12
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - react-dom
+      - supports-color
 
   cliui@6.0.0:
     dependencies:
@@ -7279,11 +7891,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  convert-source-map@1.9.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie@0.5.0: {}
 
   cookie@0.6.0: {}
 
+  copy-to-clipboard@3.3.3:
+    dependencies:
+      toggle-selection: 1.0.6
+
+  core-js@3.26.1: {}
+
   core-js@3.47.0: {}
+
+  cosmiconfig@7.1.0:
+    dependencies:
+      '@types/parse-json': 4.0.2
+      import-fresh: 3.3.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.3
 
   crelt@1.0.6: {}
 
@@ -7303,6 +7933,8 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
+
+  csstype@3.1.1: {}
 
   csstype@3.2.3: {}
 
@@ -7434,6 +8066,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@4.2.2: {}
+
   deepmerge@4.3.1: {}
 
   delaunator@5.1.0:
@@ -7472,6 +8106,11 @@ snapshots:
   dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
 
   dunder-proto@1.0.1:
     dependencies:
@@ -7526,6 +8165,10 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -7773,6 +8416,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-stable-stringify@1.0.0: {}
 
   fastest-levenshtein@1.0.16: {}
@@ -7808,6 +8453,8 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  find-root@1.1.0: {}
 
   find-up@4.1.0:
     dependencies:
@@ -7957,6 +8604,10 @@ snapshots:
     dependencies:
       hermes-estree: 0.33.3
 
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -8032,6 +8683,8 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  is-arrayish@0.2.1: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -8195,6 +8848,8 @@ snapshots:
 
   js-base64@3.7.8: {}
 
+  js-cookie@3.0.1: {}
+
   js-cookie@3.0.5: {}
 
   js-levenshtein@1.1.6: {}
@@ -8245,6 +8900,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-parse-even-better-errors@2.3.1: {}
 
   json-schema-library@9.3.5:
     dependencies:
@@ -8390,6 +9047,8 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
+  lines-and-columns@1.2.4: {}
+
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
@@ -8420,6 +9079,10 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -8439,6 +9102,8 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  map-obj@4.3.0: {}
 
   markdown-it@14.1.1:
     dependencies:
@@ -8808,6 +9473,13 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
+
+  node-fetch-native@1.0.1: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -8831,6 +9503,8 @@ snapshots:
   ob1@0.83.5:
     dependencies:
       flow-enums-runtime: 0.0.6
+
+  object-inspect@1.13.4: {}
 
   on-finished@2.3.0:
     dependencies:
@@ -8931,6 +9605,13 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   parse-json@8.3.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -8950,6 +9631,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-type@4.0.0: {}
 
   pathe@2.0.3: {}
 
@@ -9035,11 +9718,25 @@ snapshots:
   pure-rand@6.1.0:
     optional: true
 
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
+
+  qrcode.react@3.1.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   qrcode@1.5.4:
     dependencies:
       dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
+
+  qs@6.11.0:
+    dependencies:
+      side-channel: 1.1.0
 
   queue@6.0.2:
     dependencies:
@@ -9061,6 +9758,13 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  react-dom@19.2.5(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 
@@ -9366,6 +10070,34 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -9381,6 +10113,17 @@ snapshots:
   smtp-address-parser@1.0.10:
     dependencies:
       nearley: 2.20.1
+
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
+  snakecase-keys@5.4.4:
+    dependencies:
+      map-obj: 4.3.0
+      snake-case: 3.0.4
+      type-fest: 2.19.0
 
   source-map-js@1.2.1: {}
 
@@ -9408,6 +10151,11 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@1.5.0: {}
 
@@ -9452,6 +10200,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  stylis@4.2.0: {}
+
   superstruct@2.0.2: {}
 
   supports-color@10.2.2: {}
@@ -9477,6 +10227,18 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
+
+  svelte-clerk@1.1.3(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(react-dom@19.2.5(react@19.2.4))(react@19.2.4)(svelte@5.53.12):
+    dependencies:
+      '@clerk/backend': 3.2.7(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
+      '@clerk/shared': 4.5.0(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
+      set-cookie-parser: 3.0.1
+      svelte: 5.53.12
+    optionalDependencies:
+      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2))
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   svelte-dnd-action@0.9.69(svelte@5.53.12):
     dependencies:
@@ -9582,6 +10344,11 @@ snapshots:
       - '@types/json-schema'
       - typescript
 
+  swr@2.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+
   symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
@@ -9647,6 +10414,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toggle-selection@1.0.6: {}
+
   toidentifier@1.0.1: {}
 
   toposort@2.0.2:
@@ -9676,6 +10445,8 @@ snapshots:
   ts-deepmerge@7.0.3: {}
 
   tslib@2.3.0: {}
+
+  tslib@2.4.1: {}
 
   tslib@2.8.1: {}
 
@@ -9714,8 +10485,7 @@ snapshots:
 
   type-fest@0.7.1: {}
 
-  type-fest@2.19.0:
-    optional: true
+  type-fest@2.19.0: {}
 
   type-fest@4.41.0: {}
 
@@ -9786,6 +10556,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   utf-8-validate@6.0.6:
     dependencies:
@@ -9941,6 +10715,14 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
+  webcrypto-core@1.8.1:
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/json-schema': 1.1.12
+      asn1js: 3.0.7
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
@@ -10083,8 +10865,9 @@ snapshots:
     dependencies:
       tslib: 2.3.0
 
-  zustand@5.0.3(react@19.2.4):
+  zustand@5.0.3(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:
       react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- **Sprint X1 of 7** per `docs/plans/2026-04-19-ii-terminal-extraction.md`. Scaffold-only — no routes, no components, no token changes.
- Stands up `frontends/terminal/` as a new SvelteKit workspace so X2–X7 can migrate content incrementally without blocking wealth.
- Mirrors wealth's auth + deploy shape (`createClerkHook`, `adapter-node`, Docker build) so both apps share one verified-JWT path.

## Files created

**Frontend (`frontends/terminal/`):**
- `package.json` — name `ii-terminal`, deps on `@investintell/ui` (workspace), `@clerk/clerk-js`, `clerk-sveltekit@0.4.3`, `svelte-clerk@1.1.3`, `@fontsource/{ibm-plex-sans,ibm-plex-mono,montserrat}`, SvelteKit, Svelte 5, Tailwind v4
- `svelte.config.js` — adapter-node + `$lib` alias
- `vite.config.ts` — port 5175, BUILD_SHA/ENV defines, no warmup
- `tsconfig.json` — extends `.svelte-kit/tsconfig.json` (no cross-frontend paths — that's X2)
- `src/app.html` — `<title>II Terminal</title>` + `data-theme="dark"` SSR baseline
- `src/app.css` — imports `@investintell/ui/styles` + Tailwind v4 `@theme` (IBM Plex sans/mono)
- `src/app.d.ts` — `App.Locals { actor, token }` via `@investintell/ui/utils`
- `src/hooks.server.ts` — `createClerkHook` + securityHeaders (X-Frame-Options, X-Content-Type-Options, Referrer-Policy). Reads `CLERK_COOKIE_DOMAIN` env for X6 wiring.
- `src/hooks.client.ts` — `handleError` stub (session expiry wired in layout)
- `src/routes/+layout.server.ts` — returns `{ actor, token, branding: defaultDarkBranding }`
- `src/routes/+layout.svelte` — minimal shell: `setContext("netz:getToken")`, `injectBranding`, `startSessionExpiryMonitor`. No svelte-clerk gates (flagged below).
- `src/routes/+page.svelte` — placeholder "II Terminal scaffolded. Routes populated in X2."
- `Dockerfile` — mirrors `frontends/wealth/Dockerfile` (builder=dockerfile, builds `@netz/ui` + `@investintell/ui` + `ii-terminal`)
- `railway.toml` — `dockerfilePath = "frontends/terminal/Dockerfile"`, healthcheck `/`
- `.env.example` — documents `PUBLIC_API_BASE_URL`, `PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `CLERK_COOKIE_DOMAIN`
- `eslint.config.js` — reuses shared `netzFormatterRules` + `netzTerminalRules`

**Root:**
- `Makefile` — `dev-terminal`, `build-terminal`, `check-terminal`, `lint-terminal` targets + help entries
- `backend/app/core/config/settings.py` — adds `https://terminal.investintell.com` to `cors_origins` (explicit allowlist; `allow_origin_regex` in `main.py:339` already matched)
- `pnpm-lock.yaml` — resolved new deps

No changes to `frontends/wealth/`, `frontends/credit/`, or `packages/investintell-ui/`.

## Deviations from the prompt (flagged for review)

1. **Dropped `@fontsource-variable/ibm-plex-mono`** — this package does not exist on npm (404). Using the non-variable `@fontsource/ibm-plex-mono` (matches what `@investintell/ui` already declares). Same swap for sans for symmetry.
2. **Dropped `tailwind.config.ts`** — wealth has no tailwind config file either; this repo is on Tailwind v4 CSS-first (`@theme` in `app.css` + `@source` directives). Following codebase convention.
3. **No `svelte-clerk` `<SignedIn>/<SignedOut>` gates in `+layout.svelte`** — wealth's root layout does not use them either; server-side `createClerkHook` handles auth. `svelte-clerk` is installed for component-level UI (e.g. `UserButton`) in later sprints.
4. **`clerk-sveltekit@0.9.0` / `svelte-clerk@0.7.0` versions adjusted** — those versions don't exist on npm. Using `clerk-sveltekit@0.4.3` (latest) and `svelte-clerk@1.1.3` (latest). Both will likely change further in X2+.
5. **No `static/favicon.png`** — no InvestIntell asset exists yet; avoiding a netz-branded placeholder per X4 intent. Added in X4 when the brand cleanup lands.
6. **No `turbo.json` changes** — root tasks (`build`, `dev`, `check`, `lint`) auto-apply to any workspace package. Verified terminal is picked up automatically.

## Verification

```
pnpm install                     # resolved clean (peer warnings are pre-existing)
pnpm -F @investintell/ui build   # clean (svelte-package)
pnpm -F ii-terminal build        # ✓ built in 6.75s (adapter-node)
pnpm -F ii-terminal check        # 286 files, 0 errors, 0 warnings
pnpm -F netz-wealth-os build     # ✓ built in 35.69s (no regression)
pnpm -F netz-credit-intelligence build  # ✓ built in 1m 4s (no regression)
node scripts/check-terminal-tokens-sync.mjs
  → OK — 82 CSS tokens, 22 readVar references, 19 DEFAULT_TOKENS in sync
```

Dev smoke (local):
- `pnpm -F ii-terminal dev` boots vite and binds to :5177 locally (ports :5175 + :5176 were held by a parallel session; `strictPort: false` falls back correctly — prod Railway is unaffected).
- `curl -H "X-DEV-ACTOR: {}" http://localhost:5177/` → **HTTP 200, 217 KB**, grep confirms `II Terminal`, `II Terminal scaffolded. Routes populated in X2.`, `InvestIntell`, `Placeholder nav → /live (404 until X2)`.
- Screenshot attached (`ii-terminal-x1-scaffold.png` at repo root, local).

**SSO note:** dev "SSO" is `devBypass` via `X-DEV-ACTOR` — NOT a real cross-port cookie. Real `.investintell.com` cookie-SSO is an X6 validation item once DNS propagates and Clerk Dashboard finalises.

## DNS / Railway status

- DNS `terminal.investintell.com` → propagating.
- Railway service `terminal-investintell` already provisioned by operator; this PR provides the `Dockerfile` + `railway.toml` it needs.
- Expect the first deploy to respond at `terminal-investintell-production.up.railway.app` until DNS finishes.

## Test plan

- [ ] Railway build succeeds against this branch
- [ ] Placeholder renders at `terminal-investintell-production.up.railway.app` (or `terminal.investintell.com` once DNS is live)
- [ ] Unauthenticated visit redirects to `https://accounts.investintell.com/sign-in?redirect_url=https://terminal.investintell.com/auth/callback`
- [ ] Logging into `wealth.investintell.com` and opening `terminal.investintell.com` in a new tab arrives authenticated (validates X6 cookie SSO preconditions)
- [ ] `pnpm -F netz-wealth-os build` on main still green after merge
- [ ] Terminal tokens sync scanner remains green on main

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)