### PR TITLE
feat(ii-terminal): X3 visual migration — bundle palette + surface CSS + X2 debt

### DIFF
--- a/frontends/terminal/.env.example
+++ b/frontends/terminal/.env.example
@@ -1,8 +1,9 @@
 # II Terminal — environment template.
 # Copy to .env for local dev. Railway injects production values at build time.
 
-# Backend API base URL (exposed to client via $env/dynamic/public).
-PUBLIC_API_BASE_URL=http://127.0.0.1:8000
+# Backend API base URL used by the @investintell/ui api-client.
+# Must include the /api/v1 prefix — the client appends route paths only.
+VITE_API_BASE_URL=http://localhost:8000/api/v1
 
 # Clerk publishable key (pk_test_... in dev, pk_live_... in prod).
 PUBLIC_CLERK_PUBLISHABLE_KEY=
@@ -18,5 +19,8 @@ CLERK_JWKS_URL=
 # so wealth.investintell.com and terminal.investintell.com share sessions.
 CLERK_COOKIE_DOMAIN=
 
-# Must match backend DEV_TOKEN — local dev only.
-DEV_TOKEN=dev-token
+# Backend dev bypass token — copy the actual value from backend/.env or
+# frontends/wealth/.env. The placeholder below will produce 401 on every
+# API call in dev; the server-side +page.server.ts routes will render
+# their degraded error state until this matches the backend DEV_TOKEN.
+DEV_TOKEN=<copy real value from backend/.env>

--- a/frontends/terminal/src/app.css
+++ b/frontends/terminal/src/app.css
@@ -1,7 +1,20 @@
-/* Import @investintell/ui design tokens + base reset (--ii-* tokens).
- * X3 (visual sprint) will extend with bundle-specific surfaces.
+/* Terminal app bootstrap CSS.
+ *
+ * Load order:
+ *   1. @investintell/ui/styles — base --ii-* tokens + typography.
+ *   2. surfaces/terminal — bundle palette (navy + orange) overrides
+ *      :root with terminal canvas tokens. Route-specific surfaces
+ *      (builder/screener/macro) are imported per-route and scope
+ *      themselves under [data-surface="..."] attributes.
+ *   3. tailwindcss — utility classes, resolved against the tokens
+ *      above via @theme custom-properties.
+ *
+ * Wealth deliberately does NOT import the terminal surface — it keeps
+ * the blue InvestIntell palette. Surface isolation is enforced by the
+ * token scanner (scripts/check-terminal-tokens-sync.mjs, Invariant E).
  */
 @import "@investintell/ui/styles";
+@import "@investintell/ui/styles/surfaces/terminal";
 @import "tailwindcss";
 
 /* ── Content sources (replaces tailwind.config content[]) ── */

--- a/frontends/terminal/src/routes/+layout.svelte
+++ b/frontends/terminal/src/routes/+layout.svelte
@@ -82,6 +82,10 @@
 	});
 </script>
 
-<TerminalShell>
+<!-- hideWorkflowStepper: the TopNav already renders the F1..F6 workflow
+	 tabs in the II Terminal app, so the secondary breadcrumb stepper
+	 (SCREENER → TERMINAL → MACRO → BUILDER) would double up the chrome.
+	 Wealth's (terminal)/ routes keep the default (stepper visible). -->
+<TerminalShell hideWorkflowStepper={true}>
 	{@render children()}
 </TerminalShell>

--- a/frontends/terminal/src/routes/allocation/+page.svelte
+++ b/frontends/terminal/src/routes/allocation/+page.svelte
@@ -4,6 +4,7 @@
   per-profile Strategic Allocation surface.
 -->
 <script lang="ts">
+	import "@investintell/ui/styles/surfaces/builder";
 	import { resolve } from "$app/paths";
 	import { formatDateTime, formatPercent } from "@investintell/ui";
 	import { PROFILE_LABELS } from "$wealth/types/allocation-page";
@@ -12,7 +13,7 @@
 	let { data }: { data: PageData } = $props();
 </script>
 
-<div class="h-[calc(100vh-88px)] overflow-y-auto p-6">
+<div class="h-[calc(100vh-88px)] overflow-y-auto p-6" data-surface="builder">
 	<header class="mb-6">
 		<h1 class="text-2xl font-semibold text-foreground">Allocation Profiles</h1>
 		<p class="text-sm text-muted-foreground mt-1">

--- a/frontends/terminal/src/routes/allocation/[profile]/+page.svelte
+++ b/frontends/terminal/src/routes/allocation/[profile]/+page.svelte
@@ -19,6 +19,7 @@
   (strategic / history / proposal / regime) re-fetch in parallel.
 -->
 <script lang="ts">
+	import "@investintell/ui/styles/surfaces/builder";
 	import { invalidateAll } from "$app/navigation";
 	import { resolve } from "$app/paths";
 	import { getContext } from "svelte";
@@ -88,7 +89,7 @@
 	);
 </script>
 
-<div data-allocation-root class="allocation-root">
+<div data-allocation-root data-surface="builder" class="allocation-root">
 	{#if strategicErr || !strategic || !profile}
 		<div class="allocation-error">
 			<h2 class="allocation-error__title">Unable to load allocation</h2>

--- a/frontends/terminal/src/routes/macro/+page.svelte
+++ b/frontends/terminal/src/routes/macro/+page.svelte
@@ -14,6 +14,7 @@
   pinnedRegime store and never to the backend.
 -->
 <script lang="ts">
+  import "@investintell/ui/styles/surfaces/macro";
   import { goto } from "$app/navigation";
   import { resolve } from "$app/paths";
   import { getContext } from "svelte";
@@ -348,7 +349,7 @@
   });
 </script>
 
-<div class="macro-desk" data-macro-root>
+<div class="macro-desk" data-macro-root data-surface="macro">
   {#if loading}
     <div class="macro-state">Loading macro data...</div>
   {:else if fetchError}

--- a/frontends/terminal/src/routes/portfolio/builder/+page.svelte
+++ b/frontends/terminal/src/routes/portfolio/builder/+page.svelte
@@ -9,6 +9,7 @@
   tab-visit tracking gate for Session 3 activation unlock.
 -->
 <script lang="ts">
+	import "@investintell/ui/styles/surfaces/builder";
 	import { getContext } from "svelte";
 	import { SvelteSet } from "svelte/reactivity";
 	import { page } from "$app/state";
@@ -167,7 +168,7 @@
 	<title>Builder — InvestIntell</title>
 </svelte:head>
 
-<div class="builder-shell">
+<div class="builder-shell" data-surface="builder">
 	<!-- LEFT COLUMN (40%) — Command Panel -->
 	<div class="builder-left">
 		<!-- Breadcrumb back to screener -->

--- a/frontends/terminal/src/routes/screener/+page.svelte
+++ b/frontends/terminal/src/routes/screener/+page.svelte
@@ -10,6 +10,7 @@
   FundFocusMode. ESC or backdrop click dismisses FocusMode.
 -->
 <script lang="ts">
+	import "@investintell/ui/styles/surfaces/screener";
 	import { page } from "$app/state";
 	import { goto } from "$app/navigation";
 	import TerminalScreenerShell from "$wealth/components/screener/terminal/TerminalScreenerShell.svelte";
@@ -102,7 +103,7 @@
 	}
 </script>
 
-<div bind:this={containerEl} data-screener-root class="screener-page-root">
+<div bind:this={containerEl} data-screener-root data-surface="screener" class="screener-page-root">
 	<TerminalScreenerShell filters={currentFilters} onFiltersChange={handleFiltersChange} />
 </div>
 

--- a/frontends/terminal/src/routes/screener/research/+page.svelte
+++ b/frontends/terminal/src/routes/screener/research/+page.svelte
@@ -2,7 +2,16 @@
   Research — Terminal OS risk analysis & charting surface.
 -->
 <script lang="ts">
+	import "@investintell/ui/styles/surfaces/screener";
 	import TerminalResearchShell from "$wealth/components/research/terminal/TerminalResearchShell.svelte";
 </script>
 
-<TerminalResearchShell />
+<div data-surface="screener" class="research-page-root">
+	<TerminalResearchShell />
+</div>
+
+<style>
+	.research-page-root {
+		display: contents;
+	}
+</style>

--- a/frontends/wealth/src/lib/components/analytics/entity/EntityAnalyticsVitrine.svelte
+++ b/frontends/wealth/src/lib/components/analytics/entity/EntityAnalyticsVitrine.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { onMount } from "svelte";
+	import { getContext, onMount } from "svelte";
 	import { formatNumber } from "@investintell/ui";
 	import { ChartContainer } from "@investintell/ui/charts";
+	import { createClientApiClient } from "$wealth/api/client";
 	import ScoreCompositionPanel from "./ScoreCompositionPanel.svelte";
 
 	interface Props {
@@ -15,23 +16,27 @@
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 
+	// Auth-aware API client — fixes X2 smoke regression where the
+	// terminal app (different dev port) hit its own origin on a
+	// relative /api/v1 path and 404'd. api-client resolves against
+	// VITE_API_BASE_URL and attaches the Clerk bearer token.
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
 	// Fetch Data
 	$effect(() => {
 		if (!id) return;
 		loading = true;
 		error = null;
 
-		fetch(`/api/v1/wealth/entity-analytics/${id}`)
-			.then(r => {
-				if (!r.ok) throw new Error("Failed to load entity analytics");
-				return r.json();
-			})
+		api
+			.get<any>(`/wealth/entity-analytics/${id}`)
 			.then(d => {
 				data = d;
 				loading = false;
 			})
 			.catch(e => {
-				error = e.message;
+				error = e instanceof Error ? e.message : String(e);
 				loading = false;
 			});
 	});

--- a/frontends/wealth/src/lib/components/layout/OperationalRiskCard.svelte
+++ b/frontends/wealth/src/lib/components/layout/OperationalRiskCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { onMount, onDestroy } from "svelte";
+	import { getContext, onMount, onDestroy } from "svelte";
+	import { createClientApiClient } from "$wealth/api/client";
 
 	let alerts = $state<any[]>([]);
 	let loading = $state(true);
@@ -7,14 +8,15 @@
 
 	let intervalId: ReturnType<typeof setInterval>;
 
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
 	async function fetchAlerts() {
 		try {
-			const res = await fetch("/api/v1/wealth/monitoring/alerts");
-			if (!res.ok) throw new Error("Failed to fetch alerts");
-			alerts = await res.json();
+			alerts = await api.get<any[]>("/wealth/monitoring/alerts");
 			error = null;
 		} catch (err: any) {
-			error = err.message;
+			error = err instanceof Error ? err.message : String(err);
 		} finally {
 			loading = false;
 		}

--- a/frontends/wealth/src/lib/components/screener/FundFactSheetContent.svelte
+++ b/frontends/wealth/src/lib/components/screener/FundFactSheetContent.svelte
@@ -16,9 +16,11 @@
 	import ReturnDistributionChart from "$wealth/components/charts/ReturnDistributionChart.svelte";
 	import RollingReturnsChart from "$wealth/components/charts/RollingReturnsChart.svelte";
 	import { getContext, onMount } from "svelte";
+	import { createClientApiClient } from "$wealth/api/client";
 	import "./factsheet.css";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
 
 	interface RouteDataShape {
 		data: Record<string, unknown> | null;
@@ -74,14 +76,7 @@
 	async function fetchAnalytics(id: string) {
 		analyticsLoading = true;
 		try {
-			const token = getToken ? await getToken() : "";
-			const apiBase = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
-			const res = await fetch(`${apiBase}/wealth/entity-analytics/${id}?window=1y`, {
-				headers: { Authorization: `Bearer ${token}` }
-			});
-			if (res.ok) {
-				analytics = await res.json();
-			}
+			analytics = await api.get<any>(`/wealth/entity-analytics/${id}?window=1y`);
 		} catch (e) {
 			console.error("Failed to fetch analytics", e);
 		} finally {

--- a/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
+++ b/frontends/wealth/src/lib/components/terminal/shell/TerminalShell.svelte
@@ -64,9 +64,22 @@
 		children: Snippet;
 		/** Density for the LayoutCage: "standard" (24px) or "compact" (8px). */
 		cageDensity?: "standard" | "compact";
+		/**
+		 * Hide the TerminalBreadcrumb workflow stepper row. The II Terminal
+		 * app (frontends/terminal/) sets this to `true` because its TopNav
+		 * already carries the workflow tabs (F1..F6) — rendering the
+		 * breadcrumb too produces a double-nav stack. Wealth's (terminal)/
+		 * routes keep the legacy default (false) while the shell lives in
+		 * both apps; X7 retires the wealth copy entirely.
+		 */
+		hideWorkflowStepper?: boolean;
 	}
 
-	let { children, cageDensity = "standard" }: TerminalShellProps = $props();
+	let {
+		children,
+		cageDensity = "standard",
+		hideWorkflowStepper = false,
+	}: TerminalShellProps = $props();
 
 	// ─── Build metadata ─────────────────────────────────────────
 	// Exposed via vite `define` in frontends/wealth/vite.config.ts
@@ -310,6 +323,7 @@
 <div
 	class="ts-shell"
 	class:ts-shell--has-rail={entity !== null}
+	class:ts-shell--no-crumb={hideWorkflowStepper}
 	data-surface="terminal"
 	data-density={tweaks?.density ?? "standard"}
 	data-accent={tweaks?.accent ?? "amber"}
@@ -325,9 +339,11 @@
 		/>
 	</div>
 
-	<div class="ts-crumb-row">
-		<TerminalBreadcrumb />
-	</div>
+	{#if !hideWorkflowStepper}
+		<div class="ts-crumb-row">
+			<TerminalBreadcrumb />
+		</div>
+	{/if}
 
 	<main class="ts-content">
 		<LayoutCage density={cageDensity}>
@@ -377,11 +393,30 @@
 		isolation: isolate;
 	}
 
+	/* II Terminal path — stepper hidden. Collapse the breadcrumb row
+	 * entirely so the content gets the full height back, including
+	 * the 28px previously reserved by --terminal-shell-breadcrumb. */
+	.ts-shell--no-crumb {
+		grid-template-rows: 32px 1fr 28px;
+		grid-template-areas:
+			"nav"
+			"content"
+			"status";
+	}
+
 	.ts-shell--has-rail {
 		grid-template-columns: 1fr 280px;
 		grid-template-areas:
 			"nav nav"
 			"crumb crumb"
+			"content rail"
+			"status status";
+	}
+
+	.ts-shell--has-rail.ts-shell--no-crumb {
+		grid-template-rows: 32px 1fr 28px;
+		grid-template-areas:
+			"nav nav"
 			"content rail"
 			"status status";
 	}

--- a/packages/investintell-ui/package.json
+++ b/packages/investintell-ui/package.json
@@ -11,6 +11,10 @@
       "svelte": "./dist/index.js"
     },
     "./styles": "./src/lib/styles/globals.css",
+    "./styles/surfaces/terminal": "./src/lib/styles/surfaces/terminal.css",
+    "./styles/surfaces/builder": "./src/lib/styles/surfaces/builder.css",
+    "./styles/surfaces/screener": "./src/lib/styles/surfaces/screener.css",
+    "./styles/surfaces/macro": "./src/lib/styles/surfaces/macro.css",
     "./components/ui/*": {
       "types": "./dist/components/ui/*/index.d.ts",
       "svelte": "./dist/components/ui/*/index.js"
@@ -49,30 +53,45 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@sveltejs/kit": "^2.0.0",
-    "svelte": "^5.0.0",
     "@codemirror/commands": "^6.0.0",
     "@codemirror/lang-json": "^6.0.0",
     "@codemirror/lint": "^6.0.0",
     "@codemirror/merge": "^6.0.0",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
-    "codemirror-json-schema": "^0.8.0"
+    "@sveltejs/kit": "^2.0.0",
+    "codemirror-json-schema": "^0.8.0",
+    "svelte": "^5.0.0"
   },
   "peerDependenciesMeta": {
-    "@codemirror/commands": { "optional": true },
-    "@codemirror/lang-json": { "optional": true },
-    "@codemirror/lint": { "optional": true },
-    "@codemirror/merge": { "optional": true },
-    "@codemirror/state": { "optional": true },
-    "@codemirror/view": { "optional": true },
-    "codemirror-json-schema": { "optional": true }
+    "@codemirror/commands": {
+      "optional": true
+    },
+    "@codemirror/lang-json": {
+      "optional": true
+    },
+    "@codemirror/lint": {
+      "optional": true
+    },
+    "@codemirror/merge": {
+      "optional": true
+    },
+    "@codemirror/state": {
+      "optional": true
+    },
+    "@codemirror/view": {
+      "optional": true
+    },
+    "codemirror-json-schema": {
+      "optional": true
+    }
   },
   "dependencies": {
-    "@fontsource-variable/urbanist": "^5.0.0",
     "@fontsource-variable/geist-mono": "^5.0.0",
+    "@fontsource-variable/urbanist": "^5.0.0",
     "@fontsource/ibm-plex-mono": "^5.0.0",
     "@fontsource/ibm-plex-sans": "^5.0.0",
+    "@fontsource/montserrat": "^5.2.8",
     "@internationalized/date": "^3.12.0",
     "@tanstack/table-core": "^8.21.3",
     "bits-ui": "^2.16.4",
@@ -83,8 +102,8 @@
     "formsnap": "^2.0.1",
     "jose": "^5.0.0",
     "layerchart": "2.0.0-next.43",
-    "mode-watcher": "^1.1.0",
     "lucide-svelte": "^0.469.0",
+    "mode-watcher": "^1.1.0",
     "paneforge": "^1.0.2",
     "svelte-sonner": "^1.1.0",
     "sveltekit-superforms": "^2.30.1",

--- a/packages/investintell-ui/src/lib/styles/surfaces/builder.css
+++ b/packages/investintell-ui/src/lib/styles/surfaces/builder.css
@@ -1,0 +1,740 @@
+/* ============================================================
+ * @investintell/ui — surfaces/builder.css
+ *
+ * Builder (Portfolio Construction) surface — 40/60 split, 3-zone
+ * left panel, 7-tab right preview, cascade timeline.
+ *
+ * Ported from docs/ux/Netz Terminal/builder.css (bundle source).
+ * Imported per-route by /allocation, /allocation/[profile],
+ * /portfolio/builder. Root element carries data-surface="builder".
+ *
+ * Depends on surfaces/terminal.css for token overrides — this
+ * file is rules-only (.bd-* namespace).
+ * ============================================================ */
+
+/* Builder — styles for 40/60 split, 3-zone left, 7-tab right, cascade timeline */
+
+.bd-shell {
+  display: grid;
+  grid-template-columns: 40% 60%;
+  height: calc(100vh - 44px); /* minus breadcrumb/header */
+  background: var(--ii-bg);
+  font-family: var(--ii-font-sans);
+}
+
+/* ── breadcrumb / context bar ── */
+.bd-breadcrumb {
+  height: 44px;
+  background: var(--ii-surface);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  gap: 14px;
+  font-family: var(--ii-font-mono);
+  font-size: 11px;
+}
+.bd-crumb {
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-decoration: none;
+}
+.bd-crumb:hover { color: var(--ii-brand-primary); }
+.bd-crumb.current { color: var(--ii-text-primary); font-weight: 700; }
+.bd-crumb-sep { color: var(--ii-terminal-fg-dim); }
+.bd-port-badge {
+  background: var(--ii-brand-primary);
+  color: var(--ii-bg);
+  padding: 3px 8px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  font-size: 10px;
+  margin-left: auto;
+}
+.bd-port-sel {
+  background: var(--ii-surface-alt);
+  border: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-primary);
+  padding: 4px 10px;
+  font-family: var(--ii-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.bd-port-sel:hover { border-color: var(--ii-brand-primary); }
+
+/* ── LEFT column ── */
+.bd-left {
+  border-right: 1px solid var(--ii-border-subtle);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  overflow: hidden;
+  background: var(--ii-bg);
+}
+
+/* Zone A — regime context strip */
+.bd-zone-a {
+  background: linear-gradient(180deg, var(--ii-surface) 0%, var(--ii-bg) 100%);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  padding: 10px 14px;
+}
+.bd-za-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 8px;
+}
+.bd-za-title {
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--ii-terminal-fg-muted);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.bd-regime-pill {
+  background: var(--ii-brand-primary);
+  color: var(--ii-bg);
+  padding: 3px 8px;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+.bd-za-bands {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+.bd-za-band {
+  background: var(--ii-surface-alt);
+  padding: 6px 8px;
+  border-left: 2px solid var(--ii-terminal-fg-dim);
+  font-family: var(--ii-font-mono);
+}
+.bd-za-band.hot  { border-color: var(--ii-danger); }
+.bd-za-band.cool { border-color: var(--ii-success); }
+.bd-za-band .c { font-size: 10px; font-weight: 700; color: var(--ii-brand-primary); letter-spacing: 0.06em; }
+.bd-za-band .v { font-size: 11px; color: var(--ii-text-primary); font-variant-numeric: tabular-nums; }
+.bd-za-band .z { font-size: 9px; color: var(--ii-terminal-fg-muted); }
+.bd-za-band.hot  .z { color: var(--ii-danger); }
+.bd-za-band.cool .z { color: var(--ii-success); }
+
+/* Zone B — calibration panel (scrollable) */
+.bd-zone-b {
+  overflow-y: auto;
+  padding: 14px;
+}
+.bd-zone-b::-webkit-scrollbar { width: 6px; }
+.bd-zone-b::-webkit-scrollbar-track { background: transparent; }
+.bd-zone-b::-webkit-scrollbar-thumb { background: var(--ii-border-subtle); border-radius: 3px; }
+
+.bd-section {
+  margin-bottom: 18px;
+}
+.bd-section-hd {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+}
+.bd-section-hd h4 {
+  font-family: var(--ii-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--ii-text-primary);
+  font-weight: 700;
+  text-transform: uppercase;
+  margin: 0;
+}
+.bd-section-hd .sub {
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: 0.06em;
+}
+
+/* preset chips */
+.bd-presets { display: flex; gap: 6px; }
+.bd-preset {
+  flex: 1;
+  background: var(--ii-surface);
+  border: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-secondary);
+  padding: 8px;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all .15s var(--ii-terminal-ease);
+  text-transform: uppercase;
+}
+.bd-preset:hover { border-color: var(--ii-brand-primary); color: var(--ii-brand-primary); }
+.bd-preset.active {
+  background: var(--ii-brand-primary);
+  border-color: var(--ii-brand-primary);
+  color: var(--ii-bg);
+}
+
+/* sliders */
+.bd-slider {
+  display: grid;
+  grid-template-columns: 100px 1fr 50px;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 0;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+}
+.bd-slider label { color: var(--ii-text-secondary); letter-spacing: 0.04em; }
+.bd-slider input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--ii-surface-alt);
+  height: 3px;
+  border-radius: 1px;
+  outline: none;
+}
+.bd-slider input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px; height: 12px;
+  background: var(--ii-brand-primary);
+  border-radius: 50%;
+  cursor: pointer;
+  border: 1px solid var(--ii-bg);
+}
+.bd-slider input[type="range"]::-moz-range-thumb {
+  width: 12px; height: 12px;
+  background: var(--ii-brand-primary);
+  border-radius: 50%;
+  cursor: pointer;
+  border: 1px solid var(--ii-bg);
+}
+.bd-slider .val {
+  color: var(--ii-text-primary);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.bd-slider .val.pos { color: var(--ii-success); }
+.bd-slider .val.neg { color: var(--ii-danger); }
+
+/* cap pills */
+.bd-caps-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
+}
+.bd-cap {
+  background: var(--ii-surface);
+  border: 1px solid var(--ii-border-subtle);
+  padding: 6px 8px;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.bd-cap .n { color: var(--ii-text-secondary); letter-spacing: 0.04em; }
+.bd-cap .v { color: var(--ii-brand-primary); font-weight: 700; font-variant-numeric: tabular-nums; }
+
+/* Zone C — run controls (sticky bottom) */
+.bd-zone-c {
+  background: var(--ii-surface);
+  border-top: 1px solid var(--ii-border-subtle);
+  padding: 14px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+.bd-run-info { font-family: var(--ii-font-mono); font-size: 10px; color: var(--ii-terminal-fg-muted); letter-spacing: 0.04em; }
+.bd-run-info .t { color: var(--ii-text-primary); font-weight: 700; font-size: 11px; margin-bottom: 2px; letter-spacing: 0.08em; }
+.bd-btn-build {
+  background: var(--ii-brand-primary);
+  color: var(--ii-bg);
+  border: none;
+  padding: 14px 28px;
+  font-family: var(--ii-font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  cursor: pointer;
+  transition: all .15s var(--ii-terminal-ease);
+  text-transform: uppercase;
+}
+.bd-btn-build:hover { background: var(--ii-terminal-orange-hi); box-shadow: 0 0 20px rgba(255, 150, 90, 0.4); }
+.bd-btn-build:disabled { background: var(--ii-terminal-fg-dim); color: var(--ii-terminal-fg-muted); cursor: not-allowed; }
+.bd-btn-build.running { background: var(--ii-surface-alt); color: var(--ii-brand-primary); border: 1px solid var(--ii-brand-primary); }
+
+/* ── RIGHT column ── */
+.bd-right {
+  display: grid;
+  grid-template-rows: auto auto 1fr auto;
+  overflow: hidden;
+  background: var(--ii-bg);
+}
+
+/* tab bar */
+.bd-tabs {
+  display: flex;
+  background: var(--ii-surface);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  overflow-x: auto;
+}
+.bd-tab {
+  flex: 1;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--ii-border-subtle);
+  border-bottom: 2px solid transparent;
+  color: var(--ii-terminal-fg-muted);
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  cursor: pointer;
+  text-transform: uppercase;
+  text-align: center;
+  position: relative;
+  transition: all .12s var(--ii-terminal-ease);
+}
+.bd-tab:hover { color: var(--ii-text-primary); background: var(--ii-surface-alt); }
+.bd-tab.active {
+  color: var(--ii-brand-primary);
+  border-bottom-color: var(--ii-brand-primary);
+  background: var(--ii-bg);
+}
+.bd-tab.visited::after {
+  content: "";
+  position: absolute;
+  top: 5px; right: 8px;
+  width: 4px; height: 4px;
+  border-radius: 50%;
+  background: var(--ii-success);
+}
+.bd-tab.pulsing {
+  color: var(--ii-brand-primary);
+  animation: tabPulse 1s ease-in-out infinite;
+}
+@keyframes tabPulse {
+  0%, 100% { background: transparent; }
+  50%      { background: rgba(255, 150, 90, 0.15); }
+}
+.bd-tab.locked {
+  color: var(--ii-terminal-fg-dim);
+  cursor: not-allowed;
+}
+
+/* cascade timeline (above content during/after run) */
+.bd-cascade {
+  background: var(--ii-surface);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  padding: 10px 16px;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 6px;
+  max-height: 80px;
+  overflow: hidden;
+  transition: max-height .3s var(--ii-terminal-ease), padding .3s var(--ii-terminal-ease);
+}
+.bd-cascade.collapsed { max-height: 0; padding: 0 16px; border-bottom: none; }
+.bd-phase {
+  background: var(--ii-bg);
+  border: 1px solid var(--ii-border-subtle);
+  padding: 6px 8px;
+  position: relative;
+  overflow: hidden;
+  font-family: var(--ii-font-mono);
+}
+.bd-phase .ph-num {
+  font-size: 8px;
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: 0.08em;
+}
+.bd-phase .ph-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--ii-text-secondary);
+  letter-spacing: 0.04em;
+  line-height: 1.25;
+  margin: 2px 0;
+}
+.bd-phase .ph-sub {
+  font-size: 8px;
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: 0.04em;
+}
+.bd-phase.active {
+  border-color: var(--ii-brand-primary);
+  background: rgba(255, 150, 90, 0.08);
+}
+.bd-phase.active .ph-label { color: var(--ii-brand-primary); }
+.bd-phase.done {
+  border-color: var(--ii-terminal-up-dim);
+}
+.bd-phase.done .ph-num::before { content: "✓ "; color: var(--ii-success); }
+.bd-phase.done .ph-label { color: var(--ii-success); }
+.bd-phase-fill {
+  position: absolute;
+  left: 0; bottom: 0;
+  height: 2px;
+  background: var(--ii-brand-primary);
+  width: 0;
+  transition: width .1s linear;
+}
+.bd-phase.done .bd-phase-fill { width: 100% !important; background: var(--ii-success); }
+
+/* preview content */
+.bd-content {
+  overflow-y: auto;
+  padding: 14px 16px;
+}
+.bd-content::-webkit-scrollbar { width: 6px; }
+.bd-content::-webkit-scrollbar-thumb { background: var(--ii-border-subtle); border-radius: 3px; }
+
+/* empty state */
+.bd-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 400px;
+  color: var(--ii-terminal-fg-muted);
+  font-family: var(--ii-font-mono);
+  text-align: center;
+  gap: 12px;
+}
+.bd-empty-ico {
+  width: 70px; height: 70px;
+  border: 2px dashed var(--ii-border-subtle);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 28px;
+  color: var(--ii-terminal-fg-dim);
+}
+.bd-empty-t { font-size: 13px; letter-spacing: 0.1em; font-weight: 700; color: var(--ii-text-secondary); text-transform: uppercase; }
+.bd-empty-s { font-size: 11px; color: var(--ii-terminal-fg-muted); letter-spacing: 0.04em; max-width: 360px; line-height: 1.5; }
+
+/* kpi ribbon */
+.bd-kpis {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.bd-kpi {
+  background: var(--ii-surface);
+  border: 1px solid var(--ii-border-subtle);
+  padding: 9px 11px;
+  font-family: var(--ii-font-mono);
+}
+.bd-kpi .lb { font-size: 9px; color: var(--ii-terminal-fg-muted); letter-spacing: 0.1em; font-weight: 700; text-transform: uppercase; }
+.bd-kpi .vl { font-size: 16px; color: var(--ii-text-primary); font-weight: 700; font-variant-numeric: tabular-nums; margin: 2px 0; letter-spacing: 0.01em; }
+.bd-kpi .vl.up   { color: var(--ii-success); }
+.bd-kpi .vl.down { color: var(--ii-danger); }
+.bd-kpi .vs { font-size: 9px; color: var(--ii-terminal-fg-muted); letter-spacing: 0.04em; }
+.bd-kpi .vs.up { color: var(--ii-success); }
+
+/* reusable pane */
+.pane {
+  background: var(--ii-surface);
+  border: 1px solid var(--ii-border-subtle);
+  margin-bottom: 12px;
+}
+.pane > h5 {
+  margin: 0;
+  padding: 8px 12px;
+  background: var(--ii-surface-alt);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--ii-text-primary);
+  text-transform: uppercase;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.pane > h5 .sub {
+  font-size: 9px;
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: 0.06em;
+  font-weight: 400;
+  text-transform: none;
+}
+.pane > .body { padding: 12px; }
+
+/* weights table */
+.weights-table { width: 100%; border-collapse: collapse; font-family: var(--ii-font-mono); font-size: 10px; }
+.weights-table thead th {
+  text-align: right;
+  padding: 6px 8px;
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  border-bottom: 1px solid var(--ii-border-subtle);
+  text-transform: uppercase;
+  font-size: 9px;
+}
+.weights-table thead th.lft { text-align: left; }
+.weights-table tbody td {
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  text-align: right;
+  color: var(--ii-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.weights-table tbody td.lft { text-align: left; }
+.weights-table tbody td.tk { color: var(--ii-brand-primary); font-weight: 700; }
+.weights-table tbody td.nm { color: var(--ii-text-secondary); font-size: 10px; }
+.weights-table tbody td.w { font-weight: 700; color: var(--ii-text-primary); }
+.weights-table tbody td.delta.up   { color: var(--ii-success); }
+.weights-table tbody td.delta.down { color: var(--ii-danger); }
+.wbar {
+  display: inline-block;
+  height: 8px;
+  background: var(--ii-brand-primary);
+  border-radius: 1px;
+  min-width: 2px;
+  vertical-align: middle;
+}
+
+/* factor rows */
+.factor-row {
+  display: grid;
+  grid-template-columns: 100px 1fr 60px 70px;
+  gap: 10px;
+  align-items: center;
+  padding: 6px 0;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+}
+.factor-row .fr-nm { color: var(--ii-text-secondary); font-weight: 600; letter-spacing: 0.04em; }
+.factor-row .fr-bar {
+  position: relative;
+  height: 16px;
+  background: var(--ii-surface-alt);
+  border-radius: 2px;
+}
+.factor-row .fr-bar .mid {
+  position: absolute;
+  left: 50%;
+  top: 0; bottom: 0;
+  width: 1px;
+  background: var(--ii-border-subtle);
+}
+.factor-row .fr-bar .port {
+  position: absolute;
+  top: 3px; bottom: 3px;
+  background: var(--ii-brand-primary);
+  border-radius: 1px;
+}
+.factor-row .fr-bar .target {
+  position: absolute;
+  top: 0; bottom: 0;
+  width: 2px;
+  background: var(--ii-success);
+}
+.factor-row .fr-v { text-align: right; font-variant-numeric: tabular-nums; font-weight: 700; }
+.factor-row .fr-v.port   { color: var(--ii-brand-primary); }
+.factor-row .fr-v.target { color: var(--ii-success); font-size: 9px; font-weight: 400; }
+
+/* risk decomp */
+.risk-bar-container {
+  display: flex;
+  height: 28px;
+  margin-bottom: 12px;
+  border-radius: 2px;
+  overflow: hidden;
+}
+.risk-bar-seg { height: 100%; }
+.risk-legend {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
+}
+.risk-legend .row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+}
+.risk-legend .dot { width: 10px; height: 10px; border-radius: 2px; }
+.risk-legend .nm { flex: 1; color: var(--ii-text-secondary); letter-spacing: 0.02em; }
+.risk-legend .pc { color: var(--ii-text-primary); font-weight: 700; font-variant-numeric: tabular-nums; }
+
+/* stress cards */
+.stress-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+.stress-card {
+  background: var(--ii-surface-alt);
+  border-left: 3px solid var(--ii-terminal-fg-dim);
+  padding: 10px 12px;
+  font-family: var(--ii-font-mono);
+}
+.stress-card.tail   { border-color: var(--ii-danger); }
+.stress-card.mod    { border-color: var(--ii-brand-primary); }
+.stress-card.upside { border-color: var(--ii-success); }
+.stress-card .sh { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 4px; }
+.stress-card .snm { font-size: 11px; color: var(--ii-text-primary); font-weight: 700; letter-spacing: 0.04em; }
+.stress-card .spnl { font-size: 14px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.stress-card .spnl.up   { color: var(--ii-success); }
+.stress-card .spnl.down { color: var(--ii-danger); }
+.stress-card .sprob {
+  display: inline-block;
+  padding: 2px 6px;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  margin-right: 6px;
+}
+.stress-card .sprob.tail   { background: var(--ii-danger); color: var(--ii-bg); }
+.stress-card .sprob.mod    { background: var(--ii-terminal-fg-muted); color: var(--ii-bg); }
+.stress-card .sprob.upside { background: var(--ii-success); color: var(--ii-bg); }
+.stress-card .snote { font-size: 9px; color: var(--ii-terminal-fg-muted); letter-spacing: 0.02em; margin-top: 4px; line-height: 1.4; }
+
+/* MC metrics */
+.mc-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.mc-metric {
+  background: var(--ii-surface);
+  border: 1px solid var(--ii-border-subtle);
+  border-top: 2px solid var(--ii-brand-primary);
+  padding: 10px;
+  font-family: var(--ii-font-mono);
+}
+.mc-metric .l { font-size: 9px; color: var(--ii-terminal-fg-muted); letter-spacing: 0.08em; text-transform: uppercase; font-weight: 700; }
+.mc-metric .v { font-size: 18px; font-weight: 700; font-variant-numeric: tabular-nums; margin-top: 2px; }
+.mc-metric .v.up   { color: var(--ii-success); }
+.mc-metric .v.down { color: var(--ii-danger); }
+.mc-metric .v.acc  { color: var(--ii-brand-primary); }
+
+/* advisor cards */
+.advisor-card {
+  background: var(--ii-surface-alt);
+  border-left: 3px solid var(--ii-info);
+  padding: 12px 14px;
+  margin-bottom: 8px;
+  font-family: var(--ii-font-sans);
+}
+.advisor-card.crit { border-color: var(--ii-danger); background: rgba(255, 92, 122, 0.05); }
+.advisor-card.warn { border-color: var(--ii-brand-primary); background: rgba(255, 150, 90, 0.05); }
+.advisor-card.info { border-color: var(--ii-info); }
+.advisor-card .ah { display: flex; gap: 8px; align-items: center; margin-bottom: 6px; }
+.advisor-card .asev {
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  padding: 2px 6px;
+}
+.advisor-card .asev.crit { background: var(--ii-danger); color: var(--ii-bg); }
+.advisor-card .asev.warn { background: var(--ii-brand-primary); color: var(--ii-bg); }
+.advisor-card .asev.info { background: var(--ii-info); color: var(--ii-bg); }
+.advisor-card .atag {
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.advisor-card .atit {
+  font-family: var(--ii-font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ii-text-primary);
+  margin-bottom: 6px;
+  letter-spacing: -0.005em;
+}
+.advisor-card .abody {
+  font-size: 11px;
+  color: var(--ii-text-secondary);
+  line-height: 1.55;
+  margin-bottom: 10px;
+}
+.advisor-card .aacts { display: flex; gap: 6px; }
+.advisor-card .aact {
+  background: var(--ii-surface);
+  border: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-secondary);
+  padding: 5px 10px;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  font-weight: 600;
+}
+.advisor-card .aact:hover { border-color: var(--ii-brand-primary); color: var(--ii-brand-primary); }
+
+/* activation bar (bottom right) */
+.bd-activation {
+  background: var(--ii-surface);
+  border-top: 1px solid var(--ii-border-subtle);
+  padding: 10px 16px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 14px;
+  align-items: center;
+}
+.bd-act-dots {
+  display: flex;
+  gap: 5px;
+}
+.bd-act-dot {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  background: var(--ii-terminal-fg-dim);
+  border: 1px solid var(--ii-border-subtle);
+  position: relative;
+}
+.bd-act-dot.visited { background: var(--ii-success); border-color: var(--ii-success); }
+.bd-act-dot.active  { background: var(--ii-brand-primary); border-color: var(--ii-brand-primary); box-shadow: 0 0 10px rgba(255,150,90,0.6); }
+.bd-act-info {
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  color: var(--ii-text-secondary);
+  letter-spacing: 0.04em;
+}
+.bd-act-info strong { color: var(--ii-text-primary); font-weight: 700; }
+.bd-btn-activate {
+  background: var(--ii-terminal-fg-dim);
+  color: var(--ii-terminal-fg-muted);
+  border: none;
+  padding: 10px 20px;
+  font-family: var(--ii-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  cursor: not-allowed;
+  text-transform: uppercase;
+  transition: all .15s var(--ii-terminal-ease);
+}
+.bd-btn-activate.ready {
+  background: var(--ii-success);
+  color: var(--ii-bg);
+  cursor: pointer;
+}
+.bd-btn-activate.ready:hover {
+  background: #5CE2AD;
+  box-shadow: 0 0 20px rgba(61, 211, 154, 0.4);
+}

--- a/packages/investintell-ui/src/lib/styles/surfaces/macro.css
+++ b/packages/investintell-ui/src/lib/styles/surfaces/macro.css
@@ -1,0 +1,643 @@
+/* ============================================================
+ * @investintell/ui — surfaces/macro.css
+ *
+ * Macro surface — 3-column regime matrix, mini-card cross-asset
+ * list, factor/liquidity/sentiment panel, Asset Drawer.
+ *
+ * Ported from docs/ux/Netz Terminal/macro.css (bundle source).
+ * Imported per-route by /macro. Root element carries
+ * data-surface="macro".
+ *
+ * Depends on surfaces/terminal.css for token overrides — this
+ * file is rules-only (.macro-*, .mini-card, .drawer, etc).
+ * ============================================================ */
+
+/* Macro page styles — extends terminal.css */
+
+.macro-shell {
+  display: grid;
+  grid-template-rows: 32px 1fr;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.macro-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 12px;
+  background: var(--ii-surface);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+}
+.macro-toolbar .group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.macro-toolbar .group .l {
+  color: var(--ii-text-muted);
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  margin-right: 4px;
+}
+.macro-toolbar .seg {
+  display: flex;
+  background: var(--ii-surface-alt);
+  border: 1px solid var(--ii-border-subtle);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.macro-toolbar .seg button {
+  background: transparent;
+  border: none;
+  color: var(--ii-text-secondary);
+  padding: 3px 9px;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  border-right: 1px solid var(--ii-border-subtle);
+}
+.macro-toolbar .seg button:last-child { border-right: none; }
+.macro-toolbar .seg button:hover { color: var(--ii-brand-primary); }
+.macro-toolbar .seg button.on {
+  background: var(--ii-brand-primary);
+  color: var(--ii-bg);
+  font-weight: 700;
+}
+.macro-toolbar .macro-pill {
+  padding: 2px 8px;
+  font-size: 10px;
+  font-family: var(--ii-font-mono);
+  border: 1px solid var(--ii-terminal-accent-dim);
+  color: var(--ii-brand-primary);
+  background: rgba(255, 150, 90, 0.08);
+  border-radius: 2px;
+  letter-spacing: 0.06em;
+}
+
+.macro-grid {
+  display: grid;
+  grid-template-columns: 320px 1fr 300px;
+  gap: 1px;
+  background: var(--ii-border-subtle);
+  min-height: 0;
+  overflow: hidden;
+}
+.macro-col {
+  background: var(--ii-bg);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+.macro-center {
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  gap: 1px;
+  background: var(--ii-border-subtle);
+  min-height: 0;
+  overflow: hidden;
+}
+.macro-center-top {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--ii-border-subtle);
+  min-height: 0;
+}
+
+/* Regime matrix */
+.regime-panel {
+  background: var(--ii-surface);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+.regime-chart {
+  flex: 1;
+  padding: 10px 14px 14px;
+  position: relative;
+  min-height: 0;
+}
+.regime-legend {
+  border-top: 1px solid var(--ii-border-subtle);
+  padding: 8px 12px 10px;
+  background: var(--ii-surface-alt);
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.regime-legend .tag {
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.regime-legend .tag .dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+}
+.regime-panel h3 {
+  margin: 0;
+  padding: 10px 14px 6px;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  color: var(--ii-text-muted);
+  font-weight: 700;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.regime-panel h3 .curr {
+  color: var(--ii-brand-primary);
+  font-weight: 700;
+}
+
+/* Mini chart card */
+.mini-card {
+  background: var(--ii-surface);
+  padding: 8px 10px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  transition: background 80ms var(--ii-terminal-ease);
+  display: grid;
+  grid-template-columns: 1fr 80px 100px;
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+}
+.mini-card:hover { background: var(--ii-surface-alt); }
+.mini-card.selected {
+  background: var(--ii-surface-alt);
+  box-shadow: inset 2px 0 0 var(--ii-brand-primary);
+}
+.mini-card .mc-head {
+  min-width: 0;
+}
+.mini-card .mc-tk {
+  font-family: var(--ii-font-mono);
+  font-size: 11px;
+  color: var(--ii-brand-primary);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+.mini-card .mc-name {
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  color: var(--ii-text-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+.mini-card .mc-chart {
+  height: 28px;
+  overflow: hidden;
+}
+.mini-card .mc-nums {
+  text-align: right;
+  font-family: var(--ii-font-mono);
+  font-variant-numeric: tabular-nums;
+}
+.mini-card .mc-last {
+  font-size: 12px;
+  color: var(--ii-text-primary);
+  font-weight: 600;
+}
+.mini-card .mc-chg {
+  font-size: 10px;
+  margin-top: 1px;
+}
+.mini-card .mc-chg.up { color: var(--ii-success); }
+.mini-card .mc-chg.down { color: var(--ii-danger); }
+.mini-card input[type="checkbox"] {
+  margin-right: 6px;
+  accent-color: var(--ii-brand-primary);
+}
+
+.panel-list {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+}
+
+/* Section header for cross-asset panel */
+.sec-hd {
+  position: sticky;
+  top: 0;
+  background: var(--ii-border-subtle);
+  color: var(--ii-text-muted);
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  padding: 4px 10px;
+  font-weight: 700;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+}
+.sec-hd .count {
+  color: var(--ii-terminal-fg-muted);
+}
+
+/* Liquidity + sentiment + econ grid */
+.factor-panel {
+  background: var(--ii-surface);
+  padding: 12px 14px;
+  overflow: auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.factor-panel h3 {
+  margin: 0 0 6px;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  color: var(--ii-text-muted);
+  font-weight: 700;
+}
+.liq-gauge {
+  position: relative;
+  height: 44px;
+  background: var(--ii-surface-alt);
+  border: 1px solid var(--ii-border-subtle);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.liq-gauge .track {
+  position: absolute; inset: 0;
+  background: linear-gradient(90deg,
+    rgba(255, 92, 122, 0.4) 0%,
+    rgba(255, 92, 122, 0.15) 30%,
+    rgba(255, 255, 255, 0.05) 50%,
+    rgba(61, 211, 154, 0.15) 70%,
+    rgba(61, 211, 154, 0.4) 100%);
+}
+.liq-gauge .needle {
+  position: absolute;
+  top: 0; bottom: 0;
+  width: 3px;
+  background: var(--ii-brand-primary);
+  box-shadow: 0 0 8px rgba(255, 150, 90, 0.6);
+}
+.liq-gauge .labels {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 8px;
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  color: var(--ii-text-muted);
+  pointer-events: none;
+}
+.liq-spark {
+  height: 36px;
+  margin-top: 6px;
+}
+
+/* Sentiment cluster tiles */
+.sent-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+.sent-tile {
+  background: var(--ii-surface-alt);
+  border: 1px solid var(--ii-border-subtle);
+  padding: 8px 10px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: border 80ms var(--ii-terminal-ease);
+}
+.sent-tile:hover { border-color: var(--ii-brand-primary); }
+.sent-tile .t-name {
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  color: var(--ii-text-muted);
+  text-transform: uppercase;
+}
+.sent-tile .t-val {
+  font-family: var(--ii-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ii-text-primary);
+  margin-top: 2px;
+}
+.sent-tile .t-chg {
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+}
+.sent-tile .t-chg.up { color: var(--ii-success); }
+.sent-tile .t-chg.down { color: var(--ii-danger); }
+.sent-tile .t-spark {
+  width: 60px; height: 26px;
+}
+
+/* Econ pulse list */
+.econ-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--ii-border-subtle);
+  background: var(--ii-surface-alt);
+}
+.econ-row {
+  display: grid;
+  grid-template-columns: 1fr 46px 60px 60px 40px;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  align-items: center;
+}
+.econ-row:last-child { border-bottom: none; }
+.econ-row .ename {
+  color: var(--ii-text-primary);
+  font-weight: 600;
+}
+.econ-row .eperiod { color: var(--ii-terminal-fg-muted); font-size: 9px; letter-spacing: var(--ii-terminal-tr-caps); }
+.econ-row .eact {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  font-weight: 700;
+}
+.econ-row .econs {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  color: var(--ii-terminal-fg-muted);
+}
+.econ-row .esur {
+  text-align: center;
+  font-size: 9px;
+  padding: 1px 4px;
+  border-radius: 2px;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+}
+.econ-row .esur.hot { background: rgba(255, 92, 122, 0.15); color: var(--ii-danger); border: 1px solid var(--ii-terminal-down-dim); }
+.econ-row .esur.cool { background: rgba(61, 211, 154, 0.15); color: var(--ii-success); border: 1px solid var(--ii-terminal-up-dim); }
+
+/* CB calendar */
+.cb-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--ii-border-subtle);
+}
+.cb-row {
+  display: grid;
+  grid-template-columns: 46px 46px 1fr auto;
+  gap: 10px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  align-items: center;
+  background: var(--ii-surface-alt);
+}
+.cb-row:last-child { border-bottom: none; }
+.cb-row .cb-name { color: var(--ii-brand-primary); font-weight: 700; }
+.cb-row .cb-date { color: var(--ii-terminal-fg-muted); font-size: 9px; letter-spacing: var(--ii-terminal-tr-caps); }
+.cb-row .cb-rate {
+  color: var(--ii-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.cb-row .cb-rate .arrow { color: var(--ii-terminal-fg-muted); padding: 0 4px; }
+.cb-row .cb-chg {
+  padding: 1px 6px;
+  font-size: 9px;
+  font-weight: 700;
+  border-radius: 2px;
+  letter-spacing: 0.06em;
+}
+.cb-row .cb-chg.cut { color: var(--ii-success); border: 1px solid var(--ii-terminal-up-dim); }
+.cb-row .cb-chg.hold { color: var(--ii-text-secondary); border: 1px solid var(--ii-border-subtle); }
+.cb-row .cb-chg.hike { color: var(--ii-danger); border: 1px solid var(--ii-terminal-down-dim); }
+
+/* News column */
+.news-feed {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+  padding: 4px 0;
+}
+.news-item {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  cursor: pointer;
+  transition: background 80ms var(--ii-terminal-ease);
+}
+.news-item:hover { background: var(--ii-surface-alt); }
+.news-item .nh {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 4px;
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+}
+.news-item .nh .src { color: var(--ii-brand-primary); font-weight: 700; }
+.news-item .nh .time { color: var(--ii-terminal-fg-muted); }
+.news-item .nh .tag {
+  padding: 0 5px;
+  border: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-secondary);
+  border-radius: 2px;
+}
+.news-item .ntitle {
+  font-family: var(--ii-font-sans);
+  font-size: 12px;
+  color: var(--ii-text-primary);
+  line-height: 1.35;
+}
+.news-item .ntickers {
+  display: flex;
+  gap: 4px;
+  margin-top: 5px;
+  flex-wrap: wrap;
+}
+.news-item .ntickers .chip {
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  padding: 1px 5px;
+  border: 1px solid var(--ii-terminal-accent-dim);
+  color: var(--ii-brand-primary);
+  border-radius: 2px;
+}
+
+/* Compare bar */
+.compare-bar {
+  position: sticky;
+  bottom: 0;
+  background: var(--ii-surface-alt);
+  border-top: 1px solid var(--ii-brand-primary);
+  padding: 6px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+}
+.compare-bar .lbl {
+  color: var(--ii-brand-primary);
+  font-weight: 700;
+  letter-spacing: var(--ii-terminal-tr-caps);
+}
+.compare-bar .cchip {
+  padding: 2px 6px;
+  border: 1px solid var(--ii-terminal-accent-dim);
+  background: rgba(255, 150, 90, 0.08);
+  color: var(--ii-brand-primary);
+  border-radius: 2px;
+  cursor: pointer;
+}
+.compare-bar .cchip::after { content: " ×"; color: var(--ii-terminal-fg-muted); }
+.compare-bar .spacer { flex: 1; }
+
+/* Asset Drawer */
+.drawer-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 80;
+  display: flex;
+  justify-content: flex-end;
+  animation: fadein 160ms var(--ii-terminal-ease);
+}
+@keyframes fadein { from { opacity: 0; } to { opacity: 1; } }
+.drawer {
+  width: 720px;
+  max-width: 92vw;
+  height: 100%;
+  background: var(--ii-surface);
+  border-left: 1px solid var(--ii-border-subtle);
+  display: flex;
+  flex-direction: column;
+  animation: slidein 200ms var(--ii-terminal-ease);
+}
+@keyframes slidein {
+  from { transform: translateX(40px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+.drawer-head {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--ii-border-subtle);
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+}
+.drawer-head .title {
+  font-family: var(--ii-font-sans);
+  font-size: 20px;
+  font-weight: 300;
+  color: var(--ii-text-primary);
+}
+.drawer-head .sub {
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  color: var(--ii-text-muted);
+  text-transform: uppercase;
+  margin-top: 4px;
+  display: flex;
+  gap: 10px;
+}
+.drawer-head .last {
+  font-family: var(--ii-font-mono);
+  font-size: 28px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--ii-text-primary);
+}
+.drawer-head .chg {
+  font-family: var(--ii-font-mono);
+  font-size: 12px;
+  text-align: right;
+  margin-top: 2px;
+  font-variant-numeric: tabular-nums;
+}
+.drawer-head .chg.up { color: var(--ii-success); }
+.drawer-head .chg.down { color: var(--ii-danger); }
+.drawer-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+.drawer-chart {
+  height: 280px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--ii-border-subtle);
+}
+.drawer-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--ii-border-subtle);
+  border-bottom: 1px solid var(--ii-border-subtle);
+}
+.drawer-stats .cell {
+  background: var(--ii-surface);
+  padding: 10px 14px;
+}
+.drawer-stats .cell .l {
+  font-family: var(--ii-font-mono);
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  color: var(--ii-text-muted);
+  text-transform: uppercase;
+}
+.drawer-stats .cell .v {
+  font-family: var(--ii-font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  margin-top: 3px;
+}
+.drawer-stats .cell .v.up { color: var(--ii-success); }
+.drawer-stats .cell .v.down { color: var(--ii-danger); }
+.drawer-section {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--ii-border-subtle);
+}
+.drawer-section h4 {
+  margin: 0 0 10px;
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  color: var(--ii-text-muted);
+  font-weight: 700;
+}
+.drawer-foot {
+  border-top: 1px solid var(--ii-border-subtle);
+  padding: 10px 14px;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}

--- a/packages/investintell-ui/src/lib/styles/surfaces/screener.css
+++ b/packages/investintell-ui/src/lib/styles/surfaces/screener.css
@@ -1,0 +1,412 @@
+/* ============================================================
+ * @investintell/ui — surfaces/screener.css
+ *
+ * Screener surface — 240px filter rail + main results grid with
+ * sticky header, Fund Focus modal, axis-bar radar charts.
+ *
+ * Ported from docs/ux/Netz Terminal/screener.css (bundle source).
+ * Imported per-route by /screener, /screener/research. Root
+ * element carries data-surface="screener".
+ *
+ * Depends on surfaces/terminal.css for token overrides — this
+ * file is rules-only (.scr-*, .fund-focus, .chip, etc).
+ * ============================================================ */
+
+/* Screener-specific styles — extends terminal.css */
+
+.scr-shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.scr-filters {
+  border-right: 1px solid var(--ii-border-subtle);
+  background: var(--ii-surface);
+  display: flex; flex-direction: column;
+  min-height: 0; overflow: hidden;
+}
+.scr-filters-body {
+  flex: 1;
+  overflow: auto;
+  padding: 4px 0;
+}
+.filter-group {
+  border-bottom: 1px solid var(--ii-border-subtle);
+  padding: 8px 10px 10px;
+}
+.filter-group .label {
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  color: var(--ii-text-muted);
+  text-transform: uppercase;
+  font-weight: 600;
+  margin-bottom: 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.filter-group .count { color: var(--ii-brand-primary); font-variant-numeric: tabular-nums; }
+.chip-row { display: flex; flex-wrap: wrap; gap: 4px; }
+.chip {
+  padding: 3px 7px;
+  font-size: 10px;
+  background: transparent;
+  border: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-secondary);
+  font-family: var(--ii-font-mono);
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: all 100ms var(--ii-terminal-ease);
+}
+.chip:hover { color: var(--ii-brand-primary); border-color: var(--ii-terminal-accent-dim); }
+.chip.on {
+  background: var(--ii-brand-primary);
+  color: var(--ii-bg);
+  border-color: var(--ii-brand-primary);
+  font-weight: 700;
+}
+.range-inputs {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 6px;
+  align-items: center;
+}
+.range-inputs input {
+  width: 100%;
+  background: var(--ii-surface-alt);
+  border: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-primary);
+  padding: 4px 6px;
+  font-family: var(--ii-font-mono);
+  font-size: 11px;
+  outline: none;
+  border-radius: 2px;
+}
+.range-inputs input:focus { border-color: var(--ii-brand-primary); }
+.range-inputs .sep { color: var(--ii-terminal-fg-muted); font-size: 10px; text-align: center; }
+.filter-group .toggle {
+  display: flex; justify-content: space-between; align-items: center;
+  cursor: pointer;
+  padding: 4px 0;
+}
+.filter-group .toggle-state {
+  font-size: 10px;
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+}
+.filter-group .toggle-state.on { color: var(--ii-brand-primary); font-weight: 700; }
+
+.scr-filters-foot {
+  border-top: 1px solid var(--ii-border-subtle);
+  padding: 8px;
+  display: flex; gap: 6px;
+}
+.scr-filters-foot .btn {
+  flex: 1;
+  padding: 6px 8px;
+  font-size: 10px;
+}
+
+/* Results */
+.scr-results {
+  display: flex; flex-direction: column;
+  min-width: 0; min-height: 0;
+  overflow: hidden;
+}
+.scr-toolbar {
+  display: flex; align-items: center;
+  gap: 12px;
+  height: 32px;
+  padding: 0 12px;
+  background: var(--ii-surface);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  flex-shrink: 0;
+}
+.scr-toolbar .summary {
+  font-size: 11px;
+  color: var(--ii-text-secondary);
+  letter-spacing: 0.04em;
+}
+.scr-toolbar .summary .num { color: var(--ii-brand-primary); font-weight: 700; font-variant-numeric: tabular-nums; }
+.scr-toolbar .search {
+  flex: 1;
+  display: flex; align-items: center; gap: 6px;
+  background: var(--ii-surface-alt);
+  border: 1px solid var(--ii-border-subtle);
+  padding: 0 8px;
+  height: 22px;
+  border-radius: 2px;
+  max-width: 320px;
+}
+.scr-toolbar .search input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: var(--ii-font-mono);
+  font-size: 11px;
+  color: var(--ii-text-primary);
+}
+.scr-toolbar .prompt { color: var(--ii-terminal-fg-muted); }
+
+.scr-table-wrap {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+.scr-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-sm);
+}
+.scr-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--ii-surface);
+  z-index: 2;
+  text-align: left;
+  padding: 0 8px;
+  height: 22px;
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--ii-text-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--ii-border-subtle);
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+.scr-table thead th:hover { color: var(--ii-text-primary); }
+.scr-table thead th.sort-active { color: var(--ii-brand-primary); }
+.scr-table thead th.num { text-align: right; }
+.scr-table tbody td {
+  padding: 0 8px;
+  height: var(--ii-terminal-t-row);
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.scr-table tbody tr {
+  cursor: pointer;
+  transition: background 80ms var(--ii-terminal-ease);
+}
+.scr-table tbody tr:hover { background: var(--ii-surface-alt); }
+.scr-table tbody tr.selected { background: var(--ii-surface-alt); }
+.scr-table tbody tr.selected td:first-child {
+  box-shadow: inset 2px 0 0 var(--ii-brand-primary);
+}
+.scr-table .tk { color: var(--ii-brand-primary); font-weight: 600; }
+.scr-table .name { color: var(--ii-text-primary); max-width: 260px; overflow: hidden; text-overflow: ellipsis; }
+.scr-table .dim { color: var(--ii-text-muted); font-size: 10px; }
+.scr-table .num { text-align: right; color: var(--ii-text-primary); }
+.scr-table .up { color: var(--ii-success); }
+.scr-table .down { color: var(--ii-danger); }
+.elite-badge {
+  display: inline-block;
+  font-size: 9px;
+  padding: 1px 5px;
+  background: var(--ii-brand-primary);
+  color: var(--ii-bg);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  border-radius: 2px;
+  vertical-align: middle;
+}
+.universe-badge {
+  display: inline-block;
+  font-size: 9px;
+  padding: 1px 5px;
+  border: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-secondary);
+  letter-spacing: 0.06em;
+  border-radius: 2px;
+}
+.universe-badge.elite { border-color: var(--ii-brand-primary); color: var(--ii-brand-primary); font-weight: 700; }
+.universe-badge.recommended { border-color: var(--ii-terminal-up-dim); color: var(--ii-success); }
+
+/* Fund Focus Mode — reuse .focus-overlay / .focus-modal from terminal.css */
+.fund-focus .fund-hero {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--ii-border-subtle);
+  background: var(--ii-surface-alt);
+}
+.fund-focus .fund-hero h1 {
+  font-family: var(--ii-font-sans);
+  font-size: 22px;
+  font-weight: 300;
+  color: var(--ii-text-primary);
+  margin: 0 0 4px;
+  letter-spacing: -0.01em;
+}
+.fund-focus .fund-hero .meta {
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  color: var(--ii-text-muted);
+  text-transform: uppercase;
+  display: flex; gap: 14px;
+  margin-top: 6px;
+}
+.fund-focus .fund-hero .meta .accent { color: var(--ii-brand-primary); font-weight: 600; }
+
+.fund-focus .kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1px;
+  background: var(--ii-border-subtle);
+  padding: 1px;
+}
+.fund-focus .kpi-grid .kpi {
+  background: var(--ii-surface);
+  padding: 10px 12px;
+}
+.fund-focus .kpi-grid .kpi .l {
+  font-size: 9px; letter-spacing: var(--ii-terminal-tr-caps); color: var(--ii-text-muted); text-transform: uppercase;
+}
+.fund-focus .kpi-grid .kpi .v {
+  font-family: var(--ii-font-mono); font-size: 18px; font-weight: 600; color: var(--ii-text-primary);
+  margin-top: 4px; font-variant-numeric: tabular-nums;
+}
+.fund-focus .kpi-grid .kpi .v.up { color: var(--ii-success); }
+.fund-focus .kpi-grid .kpi .v.down { color: var(--ii-danger); }
+
+.fund-focus .fund-body {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 1px;
+  background: var(--ii-border-subtle);
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.fund-focus .fund-section { background: var(--ii-surface); padding: 14px 18px; overflow: auto; }
+.fund-focus .fund-section h3 {
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  color: var(--ii-text-muted);
+  text-transform: uppercase;
+  margin: 0 0 10px;
+  font-weight: 700;
+}
+
+.perf-chart { height: 160px; margin-bottom: 14px; }
+
+.radar-wrap {
+  display: flex;
+  justify-content: center;
+  padding: 8px 0 14px;
+}
+.axis-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-top: 1px solid var(--ii-border-subtle);
+  padding-top: 14px;
+  margin-top: 14px;
+}
+.axis-row {
+  display: grid;
+  grid-template-columns: 160px 1fr 36px;
+  gap: 14px;
+  align-items: center;
+  font-size: 10px;
+  padding: 2px 0;
+  min-width: 0;
+}
+.axis-lbl {
+  color: var(--ii-text-muted);
+  font-family: var(--ii-font-mono);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  font-size: 9px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.axis-bar-wrap {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 8px;
+  background: var(--ii-surface-alt);
+  border: 1px solid var(--ii-border-subtle);
+  border-radius: 1px;
+  overflow: hidden;
+  min-width: 0;
+}
+.axis-bar {
+  position: absolute; left: 0; top: 0; bottom: 0;
+  background: var(--ii-brand-primary);
+  transition: width 200ms var(--ii-terminal-ease);
+}
+.axis-val {
+  text-align: right;
+  color: var(--ii-text-primary);
+  font-family: var(--ii-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.dd-chapters { display: flex; flex-direction: column; gap: 6px; }
+.dd-chapter {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  gap: 10px;
+  padding: 7px 9px;
+  border: 1px solid var(--ii-border-subtle);
+  background: var(--ii-surface-alt);
+  align-items: center;
+  font-size: 11px;
+}
+.dd-chapter .n { color: var(--ii-brand-primary); font-weight: 700; font-family: var(--ii-font-mono); }
+.dd-chapter .title { color: var(--ii-text-primary); }
+.dd-chapter .score {
+  font-family: var(--ii-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  color: var(--ii-success);
+  padding: 1px 6px;
+  border: 1px solid var(--ii-terminal-up-dim);
+  border-radius: 2px;
+}
+.dd-chapter .score.warn { color: var(--ii-brand-primary); border-color: var(--ii-terminal-accent-dim); }
+.dd-chapter .score.alert { color: var(--ii-danger); border-color: var(--ii-terminal-down-dim); }
+
+.peer-bar-row {
+  display: grid;
+  grid-template-columns: 90px 1fr 50px;
+  gap: 10px;
+  align-items: center;
+  padding: 5px 0;
+  font-size: 11px;
+}
+.peer-bar-row .lbl { color: var(--ii-text-secondary); }
+.peer-bar-row .bar-wrap {
+  position: relative;
+  height: 10px;
+  background: var(--ii-surface-alt);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.peer-bar-row .bar {
+  position: absolute; left: 0; top: 0; bottom: 0;
+  background: var(--ii-brand-primary);
+}
+.peer-bar-row .bar.self { background: var(--ii-success); }
+.peer-bar-row .val {
+  text-align: right;
+  color: var(--ii-text-primary);
+  font-family: var(--ii-font-mono);
+  font-variant-numeric: tabular-nums;
+}

--- a/packages/investintell-ui/src/lib/styles/surfaces/terminal.css
+++ b/packages/investintell-ui/src/lib/styles/surfaces/terminal.css
@@ -1,0 +1,1079 @@
+/* ============================================================
+ * @investintell/ui — surfaces/terminal.css
+ *
+ * Netz Terminal — Live Workbench surface skin (navy-deep + orange).
+ * Bloomberg-density canvas rendered under [data-surface="terminal"].
+ *
+ * Ported from docs/ux/Netz Terminal/terminal.css (bundle source).
+ * Loaded by frontends/terminal/src/app.css — it overrides base
+ * --ii-* tokens with bundle palette values and introduces a
+ * --ii-terminal-* namespace for terminal-only slots with no
+ * counterpart in the base InvestIntell design system.
+ *
+ * Do NOT import from frontends/wealth/: wealth retains the blue
+ * InvestIntell palette. Isolation is enforced by the token scanner
+ * Invariant E (scripts/check-terminal-tokens-sync.mjs).
+ * ============================================================ */
+
+:root {
+	/* ── Base --ii-* overrides ─────────────────────────────── */
+	/* Brand. */
+	--ii-brand-navy:     #001B5C;
+	--ii-brand-primary:  #FF965A;
+	--ii-brand-accent:   #FF965A;
+	--ii-text-accent:    #FF965A;
+
+	/* Canvas + surfaces. */
+	--ii-bg:             #05081A;
+	--ii-surface:        #0B1230;
+	--ii-surface-alt:    #10194A;
+	--ii-surface-elevated: #10194A;
+	--ii-surface-raised: #10194A;
+	--ii-surface-panel:  #0B1230;
+	--ii-surface-inset:  #05081A;
+	--ii-surface-overlay: rgba(5, 8, 26, 0.72);
+
+	/* Borders — bundle uses one edge tone, so both subtle and default map to it. */
+	--ii-border-subtle:  #1A2458;
+	--ii-border:         #1A2458;
+	--ii-border-strong:  #2A3470;
+
+	/* Typography foreground. */
+	--ii-text-primary:   #E9EEFB;
+	--ii-text-secondary: #A8B4D4;
+	--ii-text-muted:     #6D7DA6;
+	--ii-text-tertiary:  #6D7DA6;
+
+	/* Semantic status. */
+	--ii-success:        #3DD39A;
+	--ii-danger:         #FF5C7A;
+	--ii-danger-strong:  #FF5C7A;
+	--ii-warning:        #F2C94C;
+	--ii-info:           #6689BC;
+
+	/* Semantic subtle wash (bundle values). */
+	--ii-success-subtle: rgba(61, 211, 154, 0.14);
+	--ii-danger-subtle:  rgba(255, 92, 122, 0.14);
+	--ii-warning-subtle: rgba(242, 201, 76, 0.14);
+	--ii-info-subtle:    rgba(102, 137, 188, 0.14);
+
+	/* Regime palette — mapped to bundle tones. */
+	--ii-regime-risk-on:   #3DD39A;
+	--ii-regime-risk-off:  #F2C94C;
+	--ii-regime-inflation: #FF965A;
+	--ii-regime-crisis:    #FF5C7A;
+
+	/* Chart palette (bundle accent + support). */
+	--ii-chart-1: #FF965A;
+	--ii-chart-2: #6689BC;
+	--ii-chart-3: #A8B4D4;
+	--ii-chart-4: #3A527A;
+	--ii-chart-5: #1A2458;
+	--ii-chart-accent: #3DD39A;
+
+	/* Font stack — rebind to terminal family imported from typography.css. */
+	--ii-font-sans: var(--ii-font-terminal-sans);
+	--ii-font-mono: var(--ii-font-terminal-mono);
+
+	/* ── --ii-terminal-* namespaced tokens (bundle-only) ─────── */
+	--ii-terminal-navy-2:        #002F6C;
+	--ii-terminal-orange-hi:     #FFB888;
+	--ii-terminal-sky:           #E4F3FF;
+	--ii-terminal-steel-dim:     #3A527A;
+	--ii-terminal-indigo:        #30558E;
+	--ii-terminal-hair:          rgba(102, 137, 188, 0.14);
+	--ii-terminal-hair-hot:      rgba(255, 150, 90, 0.30);
+	--ii-terminal-fg-muted:      #4A5680;
+	--ii-terminal-fg-dim:        #2F3A5C;
+	--ii-terminal-accent-dim:    #8C5838;
+	--ii-terminal-up-dim:        #1F6A54;
+	--ii-terminal-down-dim:      #7A2F40;
+
+	/* Density + typography scale (row heights, label sizes). */
+	--ii-terminal-t-size-xs: 10px;
+	--ii-terminal-t-size-sm: 11px;
+	--ii-terminal-t-size-md: 12px;
+	--ii-terminal-t-size-lg: 13px;
+	--ii-terminal-t-size-xl: 14px;
+	--ii-terminal-t-row:     22px;
+	--ii-terminal-t-row-sm:  20px;
+	--ii-terminal-t-pad:     8px;
+	--ii-terminal-tr-caps:   0.08em;
+
+	/* Motion. */
+	--ii-terminal-ease: cubic-bezier(.2, .6, .2, 1);
+}
+
+/* Density — comfy tier. Activated via [data-density="comfy"] on the
+ * shell root (TerminalTweaksPanel) and mirrored on :root for pages that
+ * render before the shell wires context (e.g. login flash). */
+[data-density="comfy"] {
+	--ii-terminal-t-size-xs: 11px;
+	--ii-terminal-t-size-sm: 12px;
+	--ii-terminal-t-size-md: 13px;
+	--ii-terminal-t-size-lg: 14px;
+	--ii-terminal-t-size-xl: 15px;
+	--ii-terminal-t-row:     28px;
+	--ii-terminal-t-row-sm:  24px;
+	--ii-terminal-t-pad:     10px;
+}
+
+/* Light theme override — bundle calibrated for institutional print. */
+[data-theme="light"] {
+	--ii-bg:               #F3F5FA;
+	--ii-surface:          #FFFFFF;
+	--ii-surface-alt:      #EEF2FB;
+	--ii-border-subtle:    #D7DEEC;
+	--ii-border:           #D7DEEC;
+	--ii-text-primary:     #081438;
+	--ii-text-secondary:   #394867;
+	--ii-text-muted:       #6B7897;
+	--ii-terminal-hair:    rgba(0, 27, 92, 0.10);
+	--ii-terminal-fg-muted: #9BA6BE;
+	--ii-terminal-fg-dim:  #D7DEEC;
+}
+
+/* Accent swaps. Values stay in the bundle's amber/bloomberg/netz family
+ * — this never promotes a cyan/violet accent since the terminal palette
+ * is orange-anchored. Override --ii-brand-primary at the shell scope. */
+[data-accent="amber"] {
+	--ii-brand-primary: #F5A524;
+	--ii-brand-accent:  #F5A524;
+	--ii-text-accent:   #F5A524;
+	--ii-terminal-accent-dim: #7A5213;
+}
+[data-accent="bloomberg"] {
+	--ii-brand-primary: #FF7A00;
+	--ii-brand-accent:  #FF7A00;
+	--ii-text-accent:   #FF7A00;
+	--ii-terminal-accent-dim: #7A3A00;
+}
+[data-accent="netz"] {
+	--ii-brand-primary: #FF965A;
+	--ii-brand-accent:  #FF965A;
+	--ii-text-accent:   #FF965A;
+	--ii-terminal-accent-dim: #8C5838;
+}
+
+/* ==========================================================================
+   Base
+   ========================================================================== */
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; margin: 0; }
+body {
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-sm);
+  color: var(--ii-text-primary);
+  background: var(--ii-bg);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* Scrollbars */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--ii-terminal-fg-dim); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--ii-terminal-fg-muted); }
+
+/* ==========================================================================
+   App shell — topbar / main / statusbar
+   ========================================================================== */
+.app {
+  display: grid;
+  grid-template-rows: 36px 1fr 22px;
+  height: 100vh;
+  background: var(--ii-bg);
+}
+
+/* -------- TOPBAR -------- */
+.topbar {
+  display: flex;
+  align-items: stretch;
+  background: var(--ii-surface);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-sm);
+  position: relative;
+  z-index: 10;
+}
+.topbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 14px;
+  border-right: 1px solid var(--ii-border-subtle);
+}
+.topbar-brand .symbol { width: 18px; height: 18px; }
+.topbar-brand .wm {
+  font-family: var(--ii-font-sans);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  color: var(--ii-text-primary);
+}
+.topbar-brand .wm .accent { color: var(--ii-brand-primary); }
+.topbar-brand .mode {
+  font-size: 9px;
+  color: var(--ii-text-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  padding: 2px 6px;
+  border: 1px solid var(--ii-border-subtle);
+  border-radius: 2px;
+}
+
+.topbar-tabs { display: flex; align-items: stretch; }
+.topbar-tab {
+  display: flex; align-items: center; gap: 6px;
+  padding: 0 14px;
+  font-size: var(--ii-terminal-t-size-sm);
+  color: var(--ii-text-secondary);
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  border: none; background: transparent;
+  font-family: var(--ii-font-mono);
+  position: relative;
+  transition: color 120ms var(--ii-terminal-ease), background 120ms var(--ii-terminal-ease);
+}
+.topbar-tab:hover { color: var(--ii-text-primary); background: rgba(255,255,255,.02); }
+.topbar-tab .kbd {
+  font-size: 9px;
+  padding: 1px 4px;
+  border: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-muted);
+  border-radius: 2px;
+}
+.topbar-tab.active {
+  color: var(--ii-brand-primary);
+}
+.topbar-tab.active::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -1px;
+  height: 2px;
+  background: var(--ii-brand-primary);
+}
+
+.topbar-cmd {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  border-left: 1px solid var(--ii-border-subtle);
+  border-right: 1px solid var(--ii-border-subtle);
+}
+.topbar-cmd input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--ii-text-primary);
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-sm);
+  outline: none;
+  caret-color: var(--ii-brand-primary);
+}
+.topbar-cmd .prompt { color: var(--ii-brand-primary); font-weight: 600; }
+.topbar-cmd .hint { color: var(--ii-terminal-fg-muted); font-size: var(--ii-terminal-t-size-xs); }
+
+.topbar-meta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 14px;
+}
+.meta-item {
+  display: flex; flex-direction: column; align-items: flex-end;
+  line-height: 1;
+}
+.meta-label {
+  font-size: 9px;
+  color: var(--ii-text-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+}
+.meta-value {
+  font-size: var(--ii-terminal-t-size-sm);
+  color: var(--ii-text-primary);
+  margin-top: 2px;
+}
+.meta-value.up { color: var(--ii-success); }
+.meta-value.down { color: var(--ii-danger); }
+
+.status-dot {
+  display: inline-block;
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--ii-success);
+  box-shadow: 0 0 6px var(--ii-success);
+  margin-right: 5px;
+  animation: pulse-dot 2s var(--ii-terminal-ease) infinite;
+}
+.status-dot.delayed { background: var(--ii-warning); box-shadow: 0 0 6px var(--ii-warning); }
+.status-dot.off { background: var(--ii-danger); box-shadow: 0 0 6px var(--ii-danger); }
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+/* -------- STATUS BAR -------- */
+.statusbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0 12px;
+  background: var(--ii-surface);
+  border-top: 1px solid var(--ii-border-subtle);
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-xs);
+  color: var(--ii-text-muted);
+}
+.statusbar .sb-hint { display: flex; align-items: center; gap: 4px; }
+.statusbar .kbd {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 14px; padding: 0 4px;
+  background: var(--ii-surface-alt);
+  border: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-secondary);
+  border-radius: 2px;
+  font-size: 9px;
+}
+.statusbar .sb-spacer { flex: 1; }
+
+/* ==========================================================================
+   Main grid: 3 cols with column resizers
+   ========================================================================== */
+.grid {
+  display: grid;
+  grid-template-columns: 260px 1fr 300px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.col {
+  display: flex; flex-direction: column;
+  min-width: 0; min-height: 0;
+  overflow: hidden;
+}
+.col-left  { border-right: 1px solid var(--ii-border-subtle); }
+.col-right { border-left:  1px solid var(--ii-border-subtle); }
+
+/* ==========================================================================
+   Panel primitives
+   ========================================================================== */
+.panel {
+  display: flex; flex-direction: column;
+  min-height: 0;
+  background: var(--ii-surface);
+  overflow: hidden;
+}
+.panel + .panel { border-top: 1px solid var(--ii-border-subtle); }
+
+.phead {
+  display: flex; align-items: center; justify-content: space-between;
+  height: 22px;
+  padding: 0 8px;
+  background: var(--ii-surface);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  font-family: var(--ii-font-mono);
+  font-size: 10px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  color: var(--ii-text-secondary);
+  flex-shrink: 0;
+}
+.phead .title { text-transform: uppercase; font-weight: 600; }
+.phead .counter { color: var(--ii-terminal-fg-muted); margin-left: 6px; }
+.phead .actions { display: flex; gap: 4px; }
+.phead .icon-btn {
+  width: 16px; height: 16px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--ii-text-muted);
+  cursor: pointer;
+  border-radius: 2px;
+  font-size: 11px;
+}
+.phead .icon-btn:hover { color: var(--ii-brand-primary); border-color: var(--ii-border-subtle); }
+
+.pbody { flex: 1; min-height: 0; overflow: auto; }
+
+/* ==========================================================================
+   Watchlist
+   ========================================================================== */
+.wl-header {
+  display: grid;
+  grid-template-columns: 52px 1fr 54px 46px;
+  align-items: center;
+  height: 18px;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--ii-border-subtle);
+  font-size: 9px;
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+.wl-row {
+  display: grid;
+  grid-template-columns: 52px 1fr 54px 46px;
+  align-items: center;
+  height: var(--ii-terminal-t-row);
+  padding: 0 8px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  cursor: pointer;
+  font-size: var(--ii-terminal-t-size-sm);
+  transition: background 80ms var(--ii-terminal-ease);
+  position: relative;
+}
+.wl-row:hover { background: var(--ii-surface-alt); }
+.wl-row.selected {
+  background: var(--ii-surface-alt);
+}
+.wl-row.selected::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0; width: 2px;
+  background: var(--ii-brand-primary);
+}
+.wl-row .tk { color: var(--ii-text-primary); font-weight: 600; }
+.wl-row .nm { color: var(--ii-text-muted); font-size: var(--ii-terminal-t-size-xs); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wl-row .px { text-align: right; color: var(--ii-text-primary); font-variant-numeric: tabular-nums; }
+.wl-row .chg { text-align: right; font-variant-numeric: tabular-nums; font-size: var(--ii-terminal-t-size-xs); }
+.wl-row .chg.up   { color: var(--ii-success); }
+.wl-row .chg.down { color: var(--ii-danger); }
+
+/* price flash */
+.flash-up   { animation: flashUp 500ms var(--ii-terminal-ease); }
+.flash-down { animation: flashDown 500ms var(--ii-terminal-ease); }
+@keyframes flashUp   { 0% { background-color: rgba(61, 211, 154, .30); } 100% { background-color: transparent; } }
+@keyframes flashDown { 0% { background-color: rgba(255,  92, 122, .30); } 100% { background-color: transparent; } }
+
+/* ==========================================================================
+   Portfolio selector
+   ========================================================================== */
+.psel {
+  position: relative;
+  border-bottom: 1px solid var(--ii-border-subtle);
+  background: var(--ii-surface);
+  flex-shrink: 0;
+}
+.psel-btn {
+  display: flex; align-items: center; justify-content: space-between;
+  width: 100%;
+  height: 30px;
+  padding: 0 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: var(--ii-font-mono);
+  color: var(--ii-brand-primary);
+  font-weight: 600;
+  font-size: var(--ii-terminal-t-size-sm);
+  letter-spacing: 0.04em;
+}
+.psel-btn:hover { background: var(--ii-surface-alt); }
+.psel-btn .chev { color: var(--ii-text-muted); font-size: 10px; }
+.psel-menu {
+  position: absolute;
+  left: 0; right: 0; top: 100%;
+  z-index: 100;
+  background: var(--ii-surface-alt);
+  border: 1px solid var(--ii-border-subtle);
+  box-shadow: 0 8px 24px rgba(0,0,0,.5);
+  max-height: 320px;
+  overflow-y: auto;
+}
+.psel-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  padding: 7px 10px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  align-items: center;
+  gap: 10px;
+}
+.psel-item:hover { background: var(--ii-surface-alt); }
+.psel-item.active { border-left: 2px solid var(--ii-brand-primary); padding-left: 8px; }
+.psel-item .name { color: var(--ii-text-primary); font-size: var(--ii-terminal-t-size-sm); }
+.psel-item .profile { color: var(--ii-text-muted); font-size: 9px; letter-spacing: var(--ii-terminal-tr-caps); }
+
+/* ==========================================================================
+   Alerts
+   ========================================================================== */
+.alert-row {
+  display: grid;
+  grid-template-columns: 4px 46px 1fr 54px;
+  align-items: center;
+  min-height: var(--ii-terminal-t-row);
+  padding: 4px 8px 4px 0;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  font-size: var(--ii-terminal-t-size-sm);
+  gap: 8px;
+  cursor: pointer;
+  transition: background 80ms var(--ii-terminal-ease);
+}
+.alert-row:hover { background: var(--ii-surface-alt); }
+.alert-row .sev-bar { width: 3px; height: 100%; min-height: 16px; }
+.alert-row.critical .sev-bar { background: var(--ii-danger-strong); }
+.alert-row.warning  .sev-bar { background: var(--ii-brand-primary); }
+.alert-row.info     .sev-bar { background: var(--ii-info); }
+.alert-row .src {
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  color: var(--ii-text-muted);
+  font-weight: 600;
+}
+.alert-row .title { color: var(--ii-text-primary); font-size: var(--ii-terminal-t-size-sm); line-height: 1.25; }
+.alert-row .tm { color: var(--ii-terminal-fg-muted); font-size: var(--ii-terminal-t-size-xs); text-align: right; font-variant-numeric: tabular-nums; }
+.alert-row.critical .title { color: var(--ii-danger-strong); }
+
+/* ==========================================================================
+   Trade log
+   ========================================================================== */
+.trade-row {
+  display: grid;
+  grid-template-columns: 34px 48px 1fr 60px 50px;
+  align-items: center;
+  height: var(--ii-terminal-t-row);
+  padding: 0 8px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  font-size: var(--ii-terminal-t-size-sm);
+  gap: 6px;
+}
+.trade-row .side { font-weight: 700; font-size: var(--ii-terminal-t-size-xs); letter-spacing: 0.06em; }
+.trade-row .side.BUY  { color: var(--ii-success); }
+.trade-row .side.SELL { color: var(--ii-danger); }
+.trade-row .tk { color: var(--ii-text-primary); font-weight: 600; }
+.trade-row .qty { text-align: right; color: var(--ii-text-secondary); font-variant-numeric: tabular-nums; }
+.trade-row .px  { text-align: right; color: var(--ii-text-secondary); font-variant-numeric: tabular-nums; }
+.trade-row .tm  { text-align: right; color: var(--ii-terminal-fg-muted); font-size: var(--ii-terminal-t-size-xs); }
+
+/* ==========================================================================
+   Center column — toolbar / chart / summary / holdings
+   ========================================================================== */
+.chart-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  height: 32px;
+  padding: 0;
+  background: var(--ii-surface);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.ticker-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+  border-right: 1px solid var(--ii-border-subtle);
+  height: 100%;
+  min-width: 0;
+}
+.ticker-head .tk {
+  font-family: var(--ii-font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ii-brand-primary);
+  letter-spacing: 0.04em;
+}
+.ticker-head .nm {
+  font-size: var(--ii-terminal-t-size-xs);
+  color: var(--ii-text-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+.tf-group { display: flex; height: 100%; }
+.tf-btn {
+  padding: 0 10px;
+  height: 100%;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-secondary);
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-sm);
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  transition: all 100ms var(--ii-terminal-ease);
+}
+.tf-btn:hover { background: var(--ii-surface-alt); color: var(--ii-text-primary); }
+.tf-btn.active { color: var(--ii-brand-primary); background: rgba(255, 150, 90, 0.06); }
+
+.chart-price-big {
+  display: flex; flex-direction: column; align-items: flex-end;
+  padding: 0 12px;
+  border-right: 1px solid var(--ii-border-subtle);
+  height: 100%;
+  justify-content: center;
+  min-width: 110px;
+}
+.chart-price-big .big {
+  font-family: var(--ii-font-mono);
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--ii-text-primary);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.chart-price-big .chg {
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  margin-top: 3px;
+}
+.chart-price-big .chg.up   { color: var(--ii-success); }
+.chart-price-big .chg.down { color: var(--ii-danger); }
+
+.chart-tools-right {
+  display: flex;
+  gap: 0;
+  margin-left: auto;
+  height: 100%;
+  align-items: stretch;
+}
+.icon-cta {
+  height: 100%;
+  padding: 0 10px;
+  background: transparent;
+  border: none;
+  border-left: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-muted);
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-xs);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  cursor: pointer;
+  display: flex; align-items: center; gap: 5px;
+  transition: color 100ms var(--ii-terminal-ease), background 100ms var(--ii-terminal-ease);
+}
+.icon-cta:hover { color: var(--ii-brand-primary); background: var(--ii-surface-alt); }
+.icon-cta.primary { color: var(--ii-brand-primary); }
+.icon-cta.primary:hover { background: rgba(255, 150, 90, 0.12); color: var(--ii-terminal-orange-hi); }
+
+/* chart area itself */
+.chart-area {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  background: var(--ii-surface);
+  overflow: hidden;
+}
+
+/* bottom of center column — summary + holdings */
+.center-bottom {
+  display: grid;
+  grid-template-columns: 230px 1fr;
+  min-height: 0;
+  border-top: 1px solid var(--ii-border-subtle);
+  flex-shrink: 0;
+  height: 260px;
+}
+
+/* Portfolio summary */
+.summary {
+  display: flex; flex-direction: column;
+  border-right: 1px solid var(--ii-border-subtle);
+  background: var(--ii-surface);
+  overflow: hidden;
+}
+.summary-body {
+  flex: 1;
+  padding: 10px 12px;
+  display: flex; flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  overflow: auto;
+}
+.sum-row {
+  display: flex; justify-content: space-between; align-items: baseline;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  padding-bottom: 6px;
+}
+.sum-row .lbl { font-size: 9px; color: var(--ii-text-muted); letter-spacing: var(--ii-terminal-tr-caps); text-transform: uppercase; }
+.sum-row .val { font-family: var(--ii-font-mono); font-size: var(--ii-terminal-t-size-md); color: var(--ii-text-primary); font-variant-numeric: tabular-nums; }
+.sum-row .val.big { font-size: 16px; font-weight: 600; }
+.sum-row .val.up { color: var(--ii-success); }
+.sum-row .val.down { color: var(--ii-danger); }
+
+.pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 6px;
+  border: 1px solid var(--ii-border-subtle);
+  border-radius: 2px;
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  color: var(--ii-text-secondary);
+}
+.pill.ok      { border-color: var(--ii-terminal-up-dim); color: var(--ii-success); }
+.pill.warn    { border-color: var(--ii-terminal-accent-dim); color: var(--ii-brand-primary); }
+.pill.alert   { border-color: var(--ii-terminal-down-dim); color: var(--ii-danger); }
+.pill.dot::before { content: ""; width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+.summary .rebal-btn {
+  margin: 8px;
+  padding: 8px 12px;
+  background: transparent;
+  border: 1px solid var(--ii-brand-primary);
+  color: var(--ii-brand-primary);
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-sm);
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: all 120ms var(--ii-terminal-ease);
+  text-align: center;
+  border-radius: 2px;
+}
+.summary .rebal-btn:hover {
+  background: var(--ii-brand-primary);
+  color: var(--ii-bg);
+}
+
+/* ==========================================================================
+   Holdings table
+   ========================================================================== */
+.holdings {
+  display: flex; flex-direction: column;
+  min-width: 0; min-height: 0;
+  overflow: hidden;
+}
+.holdings-head {
+  display: grid;
+  grid-template-columns: 56px 1fr 80px 60px 60px 72px 60px 60px;
+  align-items: center;
+  height: 22px;
+  padding: 0 10px;
+  background: var(--ii-surface);
+  border-bottom: 1px solid var(--ii-border-subtle);
+  font-size: 9px;
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.holdings-head .sortable {
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 3px;
+}
+.holdings-head .sortable:hover { color: var(--ii-text-secondary); }
+.holdings-head .sort-active { color: var(--ii-brand-primary); }
+.holdings-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+.holdings-row {
+  display: grid;
+  grid-template-columns: 56px 1fr 80px 60px 60px 72px 60px 60px;
+  align-items: center;
+  gap: 6px;
+  height: var(--ii-terminal-t-row);
+  padding: 0 10px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  font-size: var(--ii-terminal-t-size-sm);
+  cursor: pointer;
+  transition: background 80ms var(--ii-terminal-ease);
+  position: relative;
+}
+.holdings-row:hover { background: var(--ii-surface-alt); }
+.holdings-row.selected { background: var(--ii-surface-alt); }
+.holdings-row.selected::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
+  background: var(--ii-brand-primary);
+}
+.holdings-row .tk { color: var(--ii-brand-primary); font-weight: 600; }
+.holdings-row .nm { color: var(--ii-text-secondary); font-size: var(--ii-terminal-t-size-xs); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.holdings-row .px { text-align: right; color: var(--ii-text-primary); font-variant-numeric: tabular-nums; }
+.holdings-row .dp { text-align: right; font-variant-numeric: tabular-nums; font-size: var(--ii-terminal-t-size-xs); }
+.holdings-row .dp.up   { color: var(--ii-success); }
+.holdings-row .dp.down { color: var(--ii-danger); }
+.holdings-row .wt { text-align: right; color: var(--ii-text-secondary); font-variant-numeric: tabular-nums; }
+.holdings-row .tgt { text-align: right; color: var(--ii-text-muted); font-variant-numeric: tabular-nums; font-size: var(--ii-terminal-t-size-xs); }
+.holdings-row .drift-bar-wrap {
+  position: relative;
+  height: 14px;
+  background: var(--ii-border-subtle);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.holdings-row .drift-mid { position: absolute; left: 50%; top: 0; bottom: 0; width: 1px; background: var(--ii-terminal-fg-muted); opacity: .5; }
+.holdings-row .drift-bar {
+  position: absolute; top: 2px; bottom: 2px;
+  background: var(--ii-brand-primary);
+  min-width: 1px;
+}
+
+/* ==========================================================================
+   Right column — News + Macro
+   ========================================================================== */
+.news-row {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  cursor: pointer;
+  transition: background 80ms var(--ii-terminal-ease);
+}
+.news-row:hover { background: var(--ii-surface-alt); }
+.news-meta {
+  display: flex; justify-content: space-between;
+  font-size: 9px;
+  color: var(--ii-terminal-fg-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  margin-bottom: 2px;
+}
+.news-meta .src { color: var(--ii-brand-primary); font-weight: 600; }
+.news-title { color: var(--ii-text-primary); font-size: var(--ii-terminal-t-size-sm); line-height: 1.3; font-family: var(--ii-font-sans); font-weight: 400; }
+.news-tickers { margin-top: 3px; display: flex; gap: 4px; flex-wrap: wrap; }
+.news-tk {
+  font-size: 9px;
+  color: var(--ii-brand-primary);
+  padding: 1px 4px;
+  border: 1px solid var(--ii-terminal-accent-dim);
+  border-radius: 2px;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+/* Macro regime */
+.macro-row {
+  display: grid;
+  grid-template-columns: 48px 1fr 32px 12px;
+  gap: 6px;
+  align-items: center;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+}
+.macro-row .region { color: var(--ii-text-primary); font-weight: 600; letter-spacing: 0.04em; }
+.macro-row .lbl { font-size: var(--ii-terminal-t-size-xs); color: var(--ii-text-muted); }
+.macro-row .stress { font-variant-numeric: tabular-nums; text-align: right; }
+.macro-row .stress.ok    { color: var(--ii-success); }
+.macro-row .stress.warn  { color: var(--ii-brand-primary); }
+.macro-row .stress.alert { color: var(--ii-danger); }
+.macro-row .trend {
+  text-align: center;
+  color: var(--ii-text-muted);
+  font-size: 12px;
+}
+
+/* ==========================================================================
+   Tweaks panel
+   ========================================================================== */
+.tweaks {
+  position: fixed;
+  right: 16px;
+  bottom: 36px;
+  width: 300px;
+  background: var(--ii-surface-alt);
+  border: 1px solid var(--ii-border-subtle);
+  box-shadow: 0 16px 48px rgba(0,0,0,.6);
+  z-index: 200;
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-sm);
+}
+.tweaks-head {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--ii-border-subtle);
+  background: var(--ii-surface);
+}
+.tweaks-head .title {
+  color: var(--ii-brand-primary);
+  font-size: var(--ii-terminal-t-size-sm);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.tweaks-head .close {
+  background: transparent; border: none;
+  color: var(--ii-text-muted); cursor: pointer;
+  font-family: var(--ii-font-mono); font-size: 14px;
+  padding: 2px 6px;
+}
+.tweaks-head .close:hover { color: var(--ii-brand-primary); }
+.tweaks-body { padding: 10px 12px; display: flex; flex-direction: column; gap: 12px; }
+.tweak-field { display: flex; flex-direction: column; gap: 5px; }
+.tweak-field .label {
+  font-size: 9px;
+  letter-spacing: var(--ii-terminal-tr-caps);
+  color: var(--ii-text-muted);
+  text-transform: uppercase;
+}
+.tweak-seg {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  border: 1px solid var(--ii-border-subtle);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.tweak-seg button {
+  padding: 5px 0;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-secondary);
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-xs);
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.tweak-seg button:last-child { border-right: none; }
+.tweak-seg button:hover { background: var(--ii-surface-alt); }
+.tweak-seg button.active { background: var(--ii-brand-primary); color: var(--ii-bg); font-weight: 700; }
+.tweak-toggle {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 6px 8px;
+  background: var(--ii-surface);
+  border: 1px solid var(--ii-border-subtle);
+  border-radius: 2px;
+  cursor: pointer;
+}
+.tweak-toggle:hover { background: var(--ii-surface-alt); }
+.tweak-toggle .label { color: var(--ii-text-secondary); font-size: var(--ii-terminal-t-size-sm); }
+.tweak-toggle .state { font-size: var(--ii-terminal-t-size-xs); color: var(--ii-brand-primary); font-weight: 600; letter-spacing: var(--ii-terminal-tr-caps); }
+
+/* ==========================================================================
+   Focus mode overlay (Rebalance)
+   ========================================================================== */
+.focus-overlay {
+  position: fixed; inset: 0;
+  background: rgba(5, 8, 26, 0.78);
+  backdrop-filter: blur(6px);
+  z-index: 500;
+  display: flex; align-items: center; justify-content: center;
+  animation: fade-in 160ms var(--ii-terminal-ease);
+}
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+.focus-modal {
+  width: 920px;
+  max-width: 92vw;
+  max-height: 86vh;
+  background: var(--ii-surface);
+  border: 1px solid var(--ii-border-subtle);
+  box-shadow: 0 32px 96px rgba(0,0,0,.75);
+  display: flex; flex-direction: column;
+  animation: slide-up 240ms var(--ii-terminal-ease);
+}
+@keyframes slide-up { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+.focus-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 16px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--ii-border-subtle);
+  background: var(--ii-surface-alt);
+}
+.focus-head > div:first-child { min-width: 0; flex: 1; }
+.focus-head .close { flex-shrink: 0; }
+.focus-head .title {
+  font-family: var(--ii-font-sans);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ii-text-primary);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.focus-head .sub {
+  font-size: var(--ii-terminal-t-size-xs);
+  color: var(--ii-text-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+.focus-head .close {
+  background: transparent; border: 1px solid var(--ii-border-subtle);
+  color: var(--ii-text-muted); padding: 4px 10px;
+  cursor: pointer; font-family: var(--ii-font-mono); font-size: var(--ii-terminal-t-size-xs);
+  letter-spacing: 0.04em;
+}
+.focus-head .close:hover { color: var(--ii-brand-primary); border-color: var(--ii-brand-primary); }
+.focus-body { flex: 1; padding: 20px; overflow: auto; min-height: 0; }
+
+.focus-table { width: 100%; border-collapse: collapse; font-family: var(--ii-font-mono); font-size: var(--ii-terminal-t-size-md); }
+.focus-table th {
+  text-align: left;
+  padding: 6px 8px;
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--ii-text-muted);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--ii-border-subtle);
+}
+.focus-table td {
+  padding: 8px;
+  border-bottom: 1px solid var(--ii-terminal-hair);
+  font-variant-numeric: tabular-nums;
+}
+.focus-table .tk { color: var(--ii-brand-primary); font-weight: 600; }
+.focus-table .num { text-align: right; color: var(--ii-text-primary); }
+.focus-table .drift.up { color: var(--ii-success); }
+.focus-table .drift.down { color: var(--ii-danger); }
+.focus-table .action {
+  text-align: center;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 2px;
+  display: inline-block;
+}
+.focus-table .action.BUY  { color: var(--ii-success); border: 1px solid var(--ii-terminal-up-dim); }
+.focus-table .action.SELL { color: var(--ii-danger); border: 1px solid var(--ii-terminal-down-dim); }
+.focus-table .action.HOLD { color: var(--ii-terminal-fg-muted); border: 1px solid var(--ii-terminal-fg-dim); }
+
+.focus-foot {
+  padding: 14px 20px;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  border-top: 1px solid var(--ii-border-subtle);
+  background: var(--ii-surface);
+}
+.btn {
+  padding: 8px 16px;
+  border: 1px solid var(--ii-border-subtle);
+  background: transparent;
+  color: var(--ii-text-secondary);
+  font-family: var(--ii-font-mono);
+  font-size: var(--ii-terminal-t-size-sm);
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  border-radius: 2px;
+}
+.btn:hover { color: var(--ii-text-primary); border-color: var(--ii-text-muted); }
+.btn.primary { background: var(--ii-brand-primary); color: var(--ii-bg); border-color: var(--ii-brand-primary); }
+.btn.primary:hover { background: var(--ii-terminal-orange-hi); border-color: var(--ii-terminal-orange-hi); }
+
+/* ==========================================================================
+   Utilities
+   ========================================================================== */
+.pattern-bg {
+  position: absolute; inset: 0;
+  pointer-events: none;
+  opacity: .04;
+  background-image: url('assets/netz-pattern.svg');
+  background-size: 240px;
+}
+
+.num { font-variant-numeric: tabular-nums; }
+.mono { font-family: var(--ii-font-mono); }
+.sans { font-family: var(--ii-font-sans); }
+
+.splash-empty {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  height: 100%;
+  gap: 10px;
+  color: var(--ii-terminal-fg-muted);
+  font-size: var(--ii-terminal-t-size-xs);
+  letter-spacing: var(--ii-terminal-tr-caps);
+  text-transform: uppercase;
+}

--- a/packages/investintell-ui/src/lib/styles/typography.css
+++ b/packages/investintell-ui/src/lib/styles/typography.css
@@ -6,17 +6,34 @@
 
 @import "@fontsource-variable/urbanist";
 @import "@fontsource-variable/geist-mono";
+@import "@fontsource/ibm-plex-mono/300.css";
 @import "@fontsource/ibm-plex-mono/400.css";
 @import "@fontsource/ibm-plex-mono/500.css";
 @import "@fontsource/ibm-plex-mono/600.css";
+@import "@fontsource/ibm-plex-mono/700.css";
+@import "@fontsource/ibm-plex-sans/300.css";
 @import "@fontsource/ibm-plex-sans/400.css";
 @import "@fontsource/ibm-plex-sans/500.css";
 @import "@fontsource/ibm-plex-sans/600.css";
+@import "@fontsource/ibm-plex-sans/700.css";
+@import "@fontsource/montserrat/400.css";
+@import "@fontsource/montserrat/600.css";
+@import "@fontsource/montserrat/700.css";
 
 :root {
 	/* Font families */
 	--ii-font-sans: "Urbanist Variable", "Urbanist", ui-sans-serif, system-ui, sans-serif;
 	--ii-font-mono: "Geist Mono Variable", "Geist Mono", "Menlo", ui-monospace, monospace;
+
+	/* Terminal font stack — activated by the surfaces/terminal overlay,
+	 * which rebinds --ii-font-sans / --ii-font-mono to these slots.
+	 * Static weights (300/400/500/600/700) imported above; IBM Plex has
+	 * no variable-font package on fontsource. Montserrat reserved for
+	 * rare display slots (brand mark only).
+	 */
+	--ii-font-terminal-sans: "IBM Plex Sans", Inter, Urbanist, system-ui, -apple-system, sans-serif;
+	--ii-font-terminal-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+	--ii-font-terminal-display: "Montserrat", "IBM Plex Sans", Inter, system-ui, sans-serif;
 
 	/* Font feature settings — Urbanist supports contextual alternates + tabular nums */
 	--ii-font-features: "calt" 1, "tnum" 1;   /* tnum: tabular nums for financial data */

--- a/packages/investintell-ui/src/lib/tokens/terminal.css
+++ b/packages/investintell-ui/src/lib/tokens/terminal.css
@@ -19,55 +19,53 @@
 
 :root {
 	/* ── Backgrounds ───────────────────────────────────────── */
-	/* void: terminal canvas behind every panel.                */
-	/* panel: default surface of every TerminalPanel.           */
-	/* panel-raised: elevated (drawer, focus mode content).     */
-	/* panel-sunken: inset (input, readout).                    */
-	/* overlay: for floating command palette / dropdown.        */
-	/* scrim: FocusMode background dimmer.                      */
-	--terminal-bg-void: #000000;
-	--terminal-bg-panel: #050505;
-	--terminal-bg-panel-raised: #0a0a0a;
-	--terminal-bg-panel-sunken: #020202;
-	--terminal-bg-overlay: #0c0c0c;
-	--terminal-bg-scrim: rgba(0, 0, 0, 0.72);
+	/* Façade rewired to --ii-* (X3). Values resolve to the     */
+	/* base InvestIntell palette by default (wealth = blue      */
+	/* petroleum); in terminal app, surfaces/terminal.css       */
+	/* overrides --ii-bg / --ii-surface to navy-deep + orange.  */
+	--terminal-bg-void: var(--ii-bg);
+	--terminal-bg-panel: var(--ii-surface);
+	--terminal-bg-panel-raised: var(--ii-surface-alt);
+	--terminal-bg-panel-sunken: var(--ii-surface-inset);
+	--terminal-bg-overlay: var(--ii-surface-raised);
+	--terminal-bg-scrim: var(--ii-surface-overlay);
 
 	/* ── Foregrounds (tiers) ───────────────────────────────── */
-	--terminal-fg-primary: #f5f5f0;
-	--terminal-fg-secondary: #b8b8b0;
-	--terminal-fg-tertiary: #6b6b63;
-	--terminal-fg-muted: #3d3d38;
-	--terminal-fg-disabled: #2a2a27;
-	--terminal-fg-inverted: #000000;
+	--terminal-fg-primary: var(--ii-text-primary);
+	--terminal-fg-secondary: var(--ii-text-secondary);
+	--terminal-fg-tertiary: var(--ii-text-muted);
+	--terminal-fg-muted: var(--ii-border-strong);
+	--terminal-fg-disabled: var(--ii-border-subtle);
+	--terminal-fg-inverted: var(--ii-text-inverse);
 
 	/* ── Accents ───────────────────────────────────────────── */
-	/* amber: primary attention — ELITE, focus, hero metric.   */
-	/* cyan: live/streaming data.                               */
-	/* violet: AI-touched surfaces (DD critic, Copilot).       */
-	--terminal-accent-amber: #ffb020;
-	--terminal-accent-amber-dim: #8a5f12;
-	--terminal-accent-cyan: #00e5ff;
-	--terminal-accent-cyan-dim: #0a7a8a;
+	/* amber: primary brand (orange in terminal, blue in wealth) */
+	/* cyan: live/streaming (steel blue in terminal)             */
+	/* violet: AI-touched surfaces — no wealth token equivalent  */
+	--terminal-accent-amber: var(--ii-brand-primary);
+	--terminal-accent-amber-dim: color-mix(in srgb, var(--ii-brand-primary) 45%, transparent);
+	--terminal-accent-cyan: var(--ii-info);
+	--terminal-accent-cyan-dim: color-mix(in srgb, var(--ii-info) 45%, transparent);
 	--terminal-accent-violet: #a080ff;
 	--terminal-accent-violet-dim: #4a3a80;
 
 	/* ── Status ────────────────────────────────────────────── */
-	--terminal-status-success: #3ed67b;
-	--terminal-status-warn: #ffb020;
-	--terminal-status-error: #ff3b4b;
-	--terminal-status-neutral: #6b6b63;
+	--terminal-status-success: var(--ii-success);
+	--terminal-status-warn: var(--ii-warning);
+	--terminal-status-error: var(--ii-danger);
+	--terminal-status-neutral: var(--ii-text-muted);
 
 	/* ── Dataviz ordinal palette (1..8) ───────────────────── */
 	/* Colorblind-safe, derived from accents and status. Used  */
 	/* in order for series colors, heatmaps, scatter plots.    */
-	--terminal-dataviz-1: #ffb020; /* amber */
-	--terminal-dataviz-2: #00e5ff; /* cyan */
-	--terminal-dataviz-3: #a080ff; /* violet */
-	--terminal-dataviz-4: #3ed67b; /* success green */
-	--terminal-dataviz-5: #ff7a4a; /* terracotta */
+	--terminal-dataviz-1: var(--ii-brand-primary); /* brand accent */
+	--terminal-dataviz-2: var(--ii-info); /* info blue */
+	--terminal-dataviz-3: #a080ff; /* violet — no --ii-* map */
+	--terminal-dataviz-4: var(--ii-success); /* green */
+	--terminal-dataviz-5: #ff7a4a; /* terracotta — complement */
 	--terminal-dataviz-6: #f0f0e6; /* bone white */
-	--terminal-dataviz-7: #6b8cff; /* cobalt */
-	--terminal-dataviz-8: #b8b8b0; /* ash grey */
+	--terminal-dataviz-7: #6b8cff; /* cobalt — complement */
+	--terminal-dataviz-8: var(--ii-text-secondary); /* ash */
 
 	/* ── Spacing (4px grid) ────────────────────────────────── */
 	--terminal-space-1: 4px;
@@ -91,8 +89,10 @@
 	/* ── Typography ───────────────────────────────────────── */
 	/* Mono: primary register for every numeric, header, label */
 	/* Sans: narrative long-form copy only (DD chapter body).  */
-	--terminal-font-mono: "JetBrains Mono", "IBM Plex Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-	--terminal-font-sans: "Inter", "Urbanist", system-ui, -apple-system, sans-serif;
+	/* X3: rebind to --ii-font-terminal-* which the surface     */
+	/* override rewires --ii-font-{sans,mono} through.          */
+	--terminal-font-mono: var(--ii-font-terminal-mono, "JetBrains Mono", "IBM Plex Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+	--terminal-font-sans: var(--ii-font-terminal-sans, "Inter", "Urbanist", system-ui, -apple-system, sans-serif);
 
 	--terminal-text-10: 10px;
 	--terminal-text-11: 11px;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,9 @@ importers:
       '@fontsource/ibm-plex-sans':
         specifier: ^5.0.0
         version: 5.2.8
+      '@fontsource/montserrat':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@internationalized/date':
         specifier: ^3.12.0
         version: 3.12.0

--- a/scripts/check-terminal-tokens-sync.mjs
+++ b/scripts/check-terminal-tokens-sync.mjs
@@ -243,18 +243,102 @@ function main() {
 	const routeScanErrors = scanRouteSurfaces();
 	errors.push(...routeScanErrors);
 
+	// ── Invariant E — surface CSS isolation ─────────────────────
+	const surfaceErrors = scanSurfaceCssFiles();
+	errors.push(...surfaceErrors);
+
 	if (errors.length > 0) {
 		console.error("[token-sync] terminal drift detected:\n");
 		for (const e of errors) console.error(`  - ${e}`);
 		console.error(
-			`\n[token-sync] FAIL — fix terminal.css, terminal-options.ts, or the offending terminal route/component files.`,
+			`\n[token-sync] FAIL — fix terminal.css, terminal-options.ts, surfaces/*.css, or the offending terminal route/component files.`,
 		);
 		process.exit(1);
 	}
 
 	console.log(
-		`[token-sync] OK — ${cssTokens.size} CSS tokens, ${readVarRefs.size} readVar references, ${defaultKeys.size} DEFAULT_TOKENS keys are in sync; forbidden-pattern scan passed.`,
+		`[token-sync] OK — ${cssTokens.size} CSS tokens, ${readVarRefs.size} readVar references, ${defaultKeys.size} DEFAULT_TOKENS keys are in sync; forbidden-pattern + surface-isolation scans passed.`,
 	);
+}
+
+// ── Invariant E — surface CSS isolation ───────────────────
+//
+// Every rule declared in packages/investintell-ui/src/lib/styles/
+// surfaces/*.css must either (a) override a base --ii-* token that
+// exists in tokens.css, (b) define a new --ii-terminal-* namespaced
+// token, or (c) live inside a [data-surface="..."] selector block.
+//
+// Operationalized as a leak check: bare `--netz-*`, `--term-*`,
+// `--fg-*`, `--up`, `--down`, `--warn`, `--accent` (and their
+// dim/-hot siblings) references or declarations FAIL the scanner.
+// These are bundle-native names that belong in docs/ux/Netz Terminal/
+// sources only — not in the exported surface CSS.
+
+const SURFACE_CSS_DIR = resolve(
+	REPO_ROOT,
+	"packages/investintell-ui/src/lib/styles/surfaces",
+);
+
+/**
+ * Regex for the bundle-native variable prefixes that must not leak
+ * into the exported surface CSS. Matches both usage (`var(--X)`) and
+ * declaration (`--X:`) positions.
+ */
+const LEAK_PATTERNS = [
+	{ label: "netz-*", re: /--netz-[a-z0-9-]*/g },
+	{ label: "term-*", re: /--term-[a-z0-9-]*/g },
+	{ label: "fg-*", re: /--fg-[a-z0-9-]*/g },
+	{ label: "sev-*", re: /--sev-[a-z0-9-]*/g },
+	{ label: "up / up-dim", re: /--up(?:-dim)?\b/g },
+	{ label: "down / down-dim", re: /--down(?:-dim)?\b/g },
+	{ label: "warn (bare)", re: /--warn\b/g },
+	{ label: "accent (bare)", re: /--accent(?:-dim)?\b/g },
+	{ label: "info (bare)", re: /--info\b/g },
+	{ label: "t-size/row/pad (bare)", re: /--t-(?:size-[a-z]+|row(?:-sm)?|pad)\b/g },
+	{ label: "tr-caps (bare)", re: /--tr-caps\b/g },
+	{ label: "ease (bare)", re: /--ease\b/g },
+];
+
+function scanSurfaceCssFiles() {
+	const errors = [];
+	if (!existsSync(SURFACE_CSS_DIR)) return errors;
+	let entries;
+	try {
+		entries = readdirSync(SURFACE_CSS_DIR);
+	} catch {
+		return errors;
+	}
+	for (const name of entries) {
+		if (!name.endsWith(".css")) continue;
+		const abs = join(SURFACE_CSS_DIR, name);
+		const rel = relative(REPO_ROOT, abs).replaceAll("\\", "/");
+		let text;
+		try {
+			text = readFileSync(abs, "utf8");
+		} catch {
+			continue;
+		}
+		// Strip CSS block comments so comment prose mentioning legacy
+		// names (--netz-orange, --fg-primary) does not trip the scan.
+		const stripped = text.replace(/\/\*[\s\S]*?\*\//g, (block) =>
+			block.replace(/[^\n]/g, " "),
+		);
+		for (const rule of LEAK_PATTERNS) {
+			rule.re.lastIndex = 0;
+			let m;
+			while ((m = rule.re.exec(stripped)) !== null) {
+				if (m[0] === "") {
+					rule.re.lastIndex++;
+					continue;
+				}
+				const line = offsetToLine(stripped, m.index);
+				errors.push(
+					`E. ${rel}:${line} bundle-native leak "${m[0]}" (${rule.label}) — rewrite as var(--ii-*) or --ii-terminal-*`,
+				);
+			}
+		}
+	}
+	return errors;
 }
 
 // ── Invariant D — route-dir forbidden-pattern scan ─────────


### PR DESCRIPTION
## Summary

Migrate the II Terminal app (frontends/terminal/, terminal.investintell.com) from the --ii-* blue palette to the Netz Terminal bundle's **navy-deep + orange** skin. Wealth keeps blue unchanged — isolation enforced by the surface-CSS architecture and scanner Invariant E.

Third sprint of the 7-PR extraction plan (docs/plans/2026-04-19-ii-terminal-extraction.md). X1 (#240) and X2 (#241) merged; this PR is the one that visibly flips the terminal's skin.

## Architecture — surface overrides base tokens

```
tokens.css             :root { --ii-bg: #0a0e17 }        [base blue, unchanged]
surfaces/terminal.css  :root { --ii-bg: #05081A }        [override → navy]
tokens/terminal.css    --terminal-bg-void: var(--ii-bg)  [façade, rewired]
```

* Wealth's `app.css` imports only `@investintell/ui/styles` → blue palette survives untouched.
* Terminal's `app.css` imports styles + `@investintell/ui/styles/surfaces/terminal` → every `--ii-*` token flips to the bundle value, and every `--terminal-*` consumer cascades along for free.

## Changes

### Surface CSS — ported from `docs/ux/Netz Terminal/`

| File | Lines | Role |
| --- | --- | --- |
| `surfaces/terminal.css` | 1079 | LIVE canvas, token overrides, 18-slot `--ii-terminal-*` namespace for bundle-only tokens (hair/fg-dim/accent-dim/t-size scale/ease/etc) |
| `surfaces/builder.css` | 740 | `/allocation`, `/allocation/[profile]`, `/portfolio/builder` — 40/60 split, 3-zone left, 7-tab right, cascade timeline |
| `surfaces/screener.css` | 412 | `/screener`, `/screener/research` — filter rail + results grid + Fund Focus |
| `surfaces/macro.css` | 643 | `/macro` — regime matrix, mini-cards, Asset Drawer |

Every bundle-native reference (`var(--netz-*)`, `var(--term-*)`, `var(--fg-*)`, `var(--up/down/warn/accent)`, `var(--t-size-*)`, `var(--tr-caps)`, `var(--ease)`) rewritten to either an existing `--ii-*` token or a new `--ii-terminal-*` namespaced slot. Comment prose mentioning legacy names stripped by the scanner before leak-detection.

### Typography

* Added IBM Plex Sans/Mono weights **300** and **700** (bundle uses the full 300..700 range; only 400/500/600 were bundled before).
* Added **Montserrat 400/600/700** for the brand-display slot.
* IBM Plex has no `@fontsource-variable/*` package on npm (tried; 404) — static weights used.
* New `--ii-font-terminal-{sans,mono,display}` vars in `typography.css`. `surfaces/terminal.css` rebinds `--ii-font-{sans,mono}` through these so the façade auto-flips.

### Façade rewire — `packages/investintell-ui/src/lib/tokens/terminal.css`

Every `--terminal-*` slot value rewritten from hex to `var(--ii-*)`. Slot names preserved — consumers unchanged. Light theme redeclarations retained for higher-contrast white-mode fidelity. `--terminal-accent-amber-dim` now derived via `color-mix(in srgb, var(--ii-brand-primary) 45%, transparent)` so it tracks accent swaps automatically.

### Scanner — Invariant E

`scripts/check-terminal-tokens-sync.mjs` gains a fifth invariant scoped to `packages/investintell-ui/src/lib/styles/surfaces/*.css`:

> Every rule must (a) override a base `--ii-*` token, (b) define a new `--ii-terminal-*` namespaced token, or (c) live inside a `[data-surface="..."]` block. Bare `--netz-*`, `--term-*`, `--fg-*`, `--up`, `--down` leaks FAIL.

```
[token-sync] OK — 82 CSS tokens, 22 readVar references, 19 DEFAULT_TOKENS keys
  are in sync; forbidden-pattern + surface-isolation scans passed.
```

### X2 debt cleanup

1. **`hideWorkflowStepper` prop on `TerminalShell`** — II Terminal's TopNav already renders F1..F6 workflow tabs, so the legacy `TerminalBreadcrumb` (SCREENER > TERMINAL > MACRO > BUILDER) was double-nav. Shell now gates the breadcrumb row and collapses the 28px grid-row when the prop is true. Wealth's (terminal)/ routes keep the default (false).

2. **Relative `/api/` fetches → api-client**. Three offenders:
   * `EntityAnalyticsVitrine.svelte` — `fetch('/api/v1/wealth/entity-analytics/...')` → `api.get('/wealth/entity-analytics/...')`
   * `FundFactSheetContent.svelte` — manual `${apiBase}/wealth/...` + Bearer → api-client
   * `OperationalRiskCard.svelte` — relative → api-client
   
   All now use `createClientApiClient(getToken)` with `VITE_API_BASE_URL` resolution + Clerk bearer. Vite proxy intentionally NOT added — does not survive Railway prod.

3. **`.env.example` clarity** — explicit warning that placeholder `DEV_TOKEN` produces 401.

## Verification

Build gates (local):

```
pnpm -F @investintell/ui build          ✓
pnpm -F ii-terminal build               ✓ 41.84s
pnpm -F netz-wealth-os build            ✓ 51.28s
pnpm -F netz-credit-intelligence build  ✓ 27.63s
node scripts/check-terminal-tokens-sync.mjs — OK
```

Regression check (code-level): `grep -rn 'fetch(["\x27]/api/' frontends/terminal/src/` returns zero hits.

## Out of scope (deferred)

- Remove "Netz" from product chrome → X4
- Promote shell components to `@investintell/ii-terminal-core` → X5
- DNS + Railway deploy → X6
- Delete wealth `(terminal)/**` → X7
- Wealth blue re-skin (separate sprint)

## Test plan

- [ ] `make dev-terminal` + `make dev-wealth` + backend up
- [ ] Open `:5175/live`, `/allocation`, `/screener`, `/macro` — verify navy-deep background, IBM Plex Sans/Mono in DevTools computed styles, orange accent on hover/active
- [ ] Open `:5174/portfolio/live` — verify blue palette unchanged (not navy/orange)
- [ ] DevTools Network on :5175 — zero calls to `:5176/api/...`; all API calls hit `:8000`
- [ ] `/live` shows only the F1..F6 TopNav — no secondary breadcrumb stepper row
- [ ] 4 side-by-side bundle-HTML vs terminal-dev screenshots attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)