### PR TITLE
feat(ii-terminal): X5a create @investintell/ii-terminal-core package

### DIFF
--- a/packages/ii-terminal-core/.gitignore
+++ b/packages/ii-terminal-core/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/ii-terminal-core/package.json
+++ b/packages/ii-terminal-core/package.json
@@ -51,6 +51,7 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "peerDependencies": {
+    "@sveltejs/kit": "^2.0.0",
     "svelte": "^5.0.0",
     "@investintell/ui": "workspace:*"
   },

--- a/packages/ii-terminal-core/package.json
+++ b/packages/ii-terminal-core/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@investintell/ii-terminal-core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "InvestIntell Terminal — shared components, stores, state, types, and utilities promoted from wealth for reuse by frontends/terminal.",
+  "svelte": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist", "src"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./components/*": {
+      "types": "./dist/components/*",
+      "svelte": "./dist/components/*",
+      "default": "./dist/components/*"
+    },
+    "./stores/*": {
+      "types": "./dist/stores/*.d.ts",
+      "svelte": "./dist/stores/*.js",
+      "default": "./dist/stores/*.js"
+    },
+    "./state/*": {
+      "types": "./dist/state/*.d.ts",
+      "svelte": "./dist/state/*.js",
+      "default": "./dist/state/*.js"
+    },
+    "./types/*": {
+      "types": "./dist/types/*.d.ts",
+      "default": "./dist/types/*.js"
+    },
+    "./utils/*": {
+      "types": "./dist/utils/*.d.ts",
+      "default": "./dist/utils/*.js"
+    },
+    "./api/*": {
+      "types": "./dist/api/*.d.ts",
+      "default": "./dist/api/*.js"
+    }
+  },
+  "scripts": {
+    "build": "svelte-package -i ./src/lib -o ./dist",
+    "prepublishOnly": "pnpm build",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "peerDependencies": {
+    "svelte": "^5.0.0",
+    "@investintell/ui": "workspace:*"
+  },
+  "dependencies": {
+    "@investintell/ui": "workspace:*"
+  },
+  "devDependencies": {
+    "@sveltejs/package": "^2.0.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/ii-terminal-core/package.json
+++ b/packages/ii-terminal-core/package.json
@@ -39,6 +39,10 @@
     "./api/*": {
       "types": "./dist/api/*.d.ts",
       "default": "./dist/api/*.js"
+    },
+    "./constants/*": {
+      "types": "./dist/constants/*.d.ts",
+      "default": "./dist/constants/*.js"
     }
   },
   "scripts": {

--- a/packages/ii-terminal-core/scripts/rewrite-imports.py
+++ b/packages/ii-terminal-core/scripts/rewrite-imports.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Rewrite $wealth/* imports to relative paths within ii-terminal-core.
+
+Mapping rules (source $wealth/* path → package subsystem):
+  $wealth/components/screener/terminal/* → components/screener-terminal/*
+  $wealth/components/*                   → components/*
+  $wealth/stores/*                       → stores/*
+  $wealth/state/*                        → state/*
+  $wealth/types/*                        → types/*
+  $wealth/utils/*                        → utils/*
+  $wealth/util/*                         → utils/*          (singular to plural)
+  $wealth/api/*                          → api/*
+  $wealth/constants/*                    → constants/*
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PKG_ROOT = Path(__file__).resolve().parent.parent
+LIB_ROOT = PKG_ROOT / "src" / "lib"
+
+# Ordered remap — longest prefix first.
+PREFIX_MAP: list[tuple[str, str]] = [
+    ("$wealth/components/screener/terminal/", "components/screener-terminal/"),
+    ("$wealth/components/", "components/"),
+    ("$wealth/stores/", "stores/"),
+    ("$wealth/state/", "state/"),
+    ("$wealth/types/", "types/"),
+    ("$wealth/utils/", "utils/"),
+    ("$wealth/util/", "utils/"),
+    ("$wealth/api/", "api/"),
+    ("$wealth/constants/", "constants/"),
+]
+
+IMPORT_RE = re.compile(r"""((?:from|import)\s*\(?\s*['"])(\$wealth/[^'"]+)(['"]\)?)""")
+
+def relative_path(from_file: Path, target_subpath: str) -> str:
+    """Compute relative path from from_file's dir to LIB_ROOT/target_subpath."""
+    target = LIB_ROOT / target_subpath
+    rel = Path(target).relative_to(LIB_ROOT)
+    # walk from from_file.parent up to LIB_ROOT, then down to target
+    up = len(from_file.parent.relative_to(LIB_ROOT).parts)
+    if up == 0:
+        prefix = "./"
+    else:
+        prefix = "../" * up
+    return prefix + str(rel).replace("\\", "/")
+
+
+def rewrite_spec(from_file: Path, spec: str) -> str:
+    """spec is a $wealth/foo/bar path. Return relative path string."""
+    for w_prefix, pkg_prefix in PREFIX_MAP:
+        if spec.startswith(w_prefix):
+            tail = spec[len(w_prefix):]
+            target_subpath = pkg_prefix + tail
+            return relative_path(from_file, target_subpath)
+    return spec  # unchanged — caller will detect leftover
+
+
+def process_file(path: Path) -> int:
+    text = path.read_text(encoding="utf-8")
+    changes = [0]
+
+    def repl(m: re.Match[str]) -> str:
+        pre, spec, post = m.group(1), m.group(2), m.group(3)
+        new_spec = rewrite_spec(path, spec)
+        if new_spec != spec:
+            changes[0] += 1
+        return pre + new_spec + post
+
+    new_text = IMPORT_RE.sub(repl, text)
+    if new_text != text:
+        path.write_text(new_text, encoding="utf-8")
+    return changes[0]
+
+
+def main() -> int:
+    total = 0
+    files_changed = 0
+    exts = {".svelte", ".ts", ".tsx", ".js", ".mjs"}
+    for p in LIB_ROOT.rglob("*"):
+        if p.is_file() and p.suffix in exts:
+            n = process_file(p)
+            if n:
+                files_changed += 1
+                total += n
+
+    # Verify zero leftovers.
+    leftover_files: list[Path] = []
+    leftover_re = re.compile(r"""['"]\$wealth/""")
+    for p in LIB_ROOT.rglob("*"):
+        if p.is_file() and p.suffix in exts:
+            if leftover_re.search(p.read_text(encoding="utf-8")):
+                leftover_files.append(p)
+
+    print(f"Rewrote {total} imports across {files_changed} files")
+    if leftover_files:
+        print(f"LEFTOVER $wealth/ refs in {len(leftover_files)} files:")
+        for p in leftover_files[:20]:
+            print(f"  {p.relative_to(PKG_ROOT)}")
+        return 1
+    print("Zero $wealth/ leftovers.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/ii-terminal-core/src/lib/api/client.ts
+++ b/packages/ii-terminal-core/src/lib/api/client.ts
@@ -1,0 +1,25 @@
+/**
+ * Wealth-specific API client wrappers.
+ * Re-exports @investintell/ui factories with wealth backend base URL.
+ */
+
+import {
+	createServerApiClient as createServer,
+	createClientApiClient as createClient,
+	setAuthRedirectHandler,
+	setConflictHandler,
+} from "@investintell/ui/utils";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+/** Server-side API client (for +page.server.ts / +layout.server.ts). */
+export function createServerApiClient(token: string) {
+	return createServer(API_BASE, token);
+}
+
+/** Client-side API client (for browser components). */
+export function createClientApiClient(getToken: () => Promise<string>) {
+	return createClient(API_BASE, getToken);
+}
+
+export { setAuthRedirectHandler, setConflictHandler };

--- a/packages/ii-terminal-core/src/lib/components/allocation/AllocationDonut.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/AllocationDonut.svelte
@@ -13,12 +13,12 @@
 		formatPercent,
 		readTerminalTokens,
 	} from "@investintell/ui";
-	import GenericEChart from "$wealth/components/charts/GenericEChart.svelte";
+	import GenericEChart from "../../components/charts/GenericEChart.svelte";
 	import {
 		blockFamily,
 		type BlockFamily,
 		type StrategicAllocationBlock,
-	} from "$wealth/types/allocation-page";
+	} from "../../types/allocation-page";
 
 	interface Props {
 		blocks: StrategicAllocationBlock[];

--- a/packages/ii-terminal-core/src/lib/components/allocation/AllocationDonut.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/AllocationDonut.svelte
@@ -1,0 +1,95 @@
+<!--
+  PR-A26.3 Section C — Donut chart of the approved target weights,
+  grouped visually by block family (equity / fixed income / alt /
+  cash). When no approval exists, renders an empty-state hint instead
+  of a broken donut.
+
+  PR-4b — family colors resolved via readTerminalTokens() dataviz
+  palette; empty-state re-skinned with terminal tokens.
+-->
+<script lang="ts">
+	import {
+		formatNumber,
+		formatPercent,
+		readTerminalTokens,
+	} from "@investintell/ui";
+	import GenericEChart from "$wealth/components/charts/GenericEChart.svelte";
+	import {
+		blockFamily,
+		type BlockFamily,
+		type StrategicAllocationBlock,
+	} from "$wealth/types/allocation-page";
+
+	interface Props {
+		blocks: StrategicAllocationBlock[];
+		hasActiveApproval: boolean;
+	}
+	let { blocks, hasActiveApproval }: Props = $props();
+
+	let options = $derived.by(() => {
+		const tokens = readTerminalTokens();
+		// Pull family colors from the terminal dataviz palette so the
+		// donut inherits the same colorblind-safe ordering used by the
+		// rest of the terminal surface (tokens.dataviz is 8 slots).
+		const familyColor: Record<BlockFamily, string> = {
+			equity: tokens.dataviz[6] ?? tokens.accentCyan, // cobalt
+			fixed_income: tokens.statusSuccess, // success green
+			alternatives: tokens.accentAmber, // amber
+			cash: tokens.fgTertiary, // muted grey
+		};
+
+		const data = blocks
+			.filter((b) => (b.target_weight ?? 0) > 0)
+			.map((b) => ({
+				name: b.block_name,
+				value: b.target_weight ?? 0,
+				itemStyle: { color: familyColor[blockFamily(b.block_id)] },
+			}));
+
+		return {
+			tooltip: {
+				trigger: "item",
+				formatter: (params: {
+					name: string;
+					value: number;
+					percent: number;
+				}) =>
+					`${params.name}<br/>${formatPercent(params.value)} (${formatNumber(params.percent, 1)}%)`,
+			},
+			legend: { show: false },
+			series: [
+				{
+					name: "Strategic Allocation",
+					type: "pie",
+					radius: ["45%", "75%"],
+					avoidLabelOverlap: true,
+					label: { show: false },
+					labelLine: { show: false },
+					data,
+				},
+			],
+		};
+	});
+</script>
+
+{#if hasActiveApproval}
+	<GenericEChart {options} height={260} />
+{:else}
+	<div class="empty-state">Awaiting first approval.</div>
+{/if}
+
+<style>
+	.empty-state {
+		height: 260px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border: 1px dashed var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel-sunken);
+		color: var(--terminal-fg-tertiary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/allocation/AllocationTable.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/AllocationTable.svelte
@@ -1,0 +1,263 @@
+<!--
+  AllocationTable — hierarchical L1 (Geography) / L2 (Asset Class) table
+  with columns per risk profile. Used in strategic, tactical, and effective tabs.
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+	import type { BlockMeta, AllocationRow } from "./types";
+
+	type ProfileKey = string;
+
+	type GroupedRow = {
+		block_id: string;
+		display_name: string;
+		geography: string;
+		asset_class: string;
+		values: Record<ProfileKey, number>;
+	};
+
+	type TabMode = "strategic" | "tactical" | "effective";
+
+	interface Props {
+		blocks: BlockMeta[];
+		/** Map of profileKey -> array of { block_id, weight } */
+		data: Record<ProfileKey, AllocationRow[]>;
+		profiles: ProfileKey[];
+		profileLabels: Record<ProfileKey, string>;
+		mode: TabMode;
+	}
+
+	let { blocks, data, profiles, profileLabels, mode }: Props = $props();
+
+	// Build grouped rows: geography -> asset_class -> block rows
+	type GeoGroup = {
+		geography: string;
+		rows: GroupedRow[];
+	};
+
+	let groupedData = $derived.by((): GeoGroup[] => {
+		// Merge block metadata with allocation data
+		const rowMap = new Map<string, GroupedRow>();
+
+		for (const block of blocks) {
+			rowMap.set(block.block_id, {
+				block_id: block.block_id,
+				display_name: block.display_name,
+				geography: block.geography,
+				asset_class: block.asset_class,
+				values: {},
+			});
+		}
+
+		// Fill in values from each profile's data
+		for (const profile of profiles) {
+			const profileData = data[profile] ?? [];
+			for (const item of profileData) {
+				const row = rowMap.get(item.block_id);
+				if (row) {
+					row.values[profile] = item.weight;
+				}
+			}
+		}
+
+		// Group by geography
+		const geoMap = new Map<string, GroupedRow[]>();
+		for (const row of rowMap.values()) {
+			// Only include rows that have at least one non-zero value
+			const hasValue = profiles.some((p) => (row.values[p] ?? 0) !== 0);
+			if (!hasValue) continue;
+
+			const group = geoMap.get(row.geography) ?? [];
+			group.push(row);
+			geoMap.set(row.geography, group);
+		}
+
+		// Sort geographies and rows within each group
+		const groups: GeoGroup[] = [];
+		for (const [geography, rows] of [...geoMap.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+			rows.sort((a, b) => a.asset_class.localeCompare(b.asset_class));
+			groups.push({ geography, rows });
+		}
+
+		return groups;
+	});
+
+	let isEmpty = $derived(groupedData.length === 0);
+
+	function formatValue(value: number | undefined, tabMode: TabMode): string {
+		if (value === undefined || value === null) return "—";
+		if (tabMode === "tactical") {
+			if (Math.abs(value) < 0.00005) return "—";
+			const sign = value >= 0 ? "+" : "";
+			return `${sign}${formatPercent(value, 1, "en-US")}`;
+		}
+		return formatPercent(value, 1, "en-US");
+	}
+
+	function tacticalColor(value: number | undefined): string {
+		if (value === undefined || value === null || Math.abs(value) < 0.00005) return "";
+		return value > 0 ? "at-val--positive" : "at-val--negative";
+	}
+</script>
+
+{#if isEmpty}
+	<div class="at-empty">
+		{#if mode === "strategic"}
+			No strategic allocation configured. Set allocation targets to begin.
+		{:else if mode === "tactical"}
+			No tactical tilts active.
+		{:else}
+			No effective allocation computed.
+		{/if}
+	</div>
+{:else}
+	<div class="at-wrapper">
+		<table class="at-table">
+			<thead>
+				<tr>
+					<th class="at-th at-th--block">Block</th>
+					{#each profiles as profile (profile)}
+						<th class="at-th at-th--value">{profileLabels[profile] ?? profile}</th>
+					{/each}
+				</tr>
+			</thead>
+			<tbody>
+				{#each groupedData as group (group.geography)}
+					<!-- L1 Geography group header -->
+					<tr class="at-group-row">
+						<td class="at-group-label" colspan={profiles.length + 1}>
+							{group.geography}
+						</td>
+					</tr>
+					<!-- L2 Asset Class rows -->
+					{#each group.rows as row (row.block_id)}
+						<tr class="at-data-row">
+							<td class="at-cell at-cell--block">
+								<span class="at-block-name">{row.display_name}</span>
+								<span class="at-block-class">{row.asset_class}</span>
+							</td>
+							{#each profiles as profile (profile)}
+								{@const val = row.values[profile]}
+								<td
+									class="at-cell at-cell--value {mode === 'tactical' ? tacticalColor(val) : ''}"
+								>
+									{formatValue(val, mode)}
+								</td>
+							{/each}
+						</tr>
+					{/each}
+				{/each}
+			</tbody>
+		</table>
+	</div>
+{/if}
+
+<style>
+	.at-empty {
+		padding: var(--ii-space-stack-xl, 48px);
+		text-align: center;
+		color: var(--ii-text-muted);
+		font-size: var(--ii-text-small, 0.8125rem);
+	}
+
+	.at-wrapper {
+		border: 1px solid var(--ii-border-subtle);
+		border-radius: var(--ii-radius-md, 12px);
+		overflow: hidden;
+	}
+
+	.at-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: var(--ii-text-small, 0.8125rem);
+	}
+
+	.at-th {
+		padding: var(--ii-space-stack-2xs, 6px) var(--ii-space-inline-sm, 12px);
+		text-align: left;
+		font-size: var(--ii-text-label, 0.75rem);
+		font-weight: 600;
+		color: var(--ii-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.02em;
+		background: var(--ii-surface-alt);
+		border-bottom: 1px solid var(--ii-border-subtle);
+	}
+
+	.at-th--value {
+		text-align: right;
+		min-width: 100px;
+	}
+
+	.at-th--block {
+		min-width: 200px;
+	}
+
+	/* L1 Geography group header */
+	.at-group-row {
+		background: var(--ii-surface-alt);
+	}
+
+	.at-group-label {
+		padding: var(--ii-space-stack-2xs, 6px) var(--ii-space-inline-sm, 12px);
+		font-size: var(--ii-text-label, 0.75rem);
+		font-weight: 700;
+		color: var(--ii-text-secondary);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		border-bottom: 1px solid var(--ii-border-subtle);
+		border-top: 1px solid var(--ii-border-subtle);
+	}
+
+	/* L2 data rows */
+	.at-data-row {
+		border-bottom: 1px solid var(--ii-border-subtle);
+	}
+
+	.at-data-row:last-child {
+		border-bottom: none;
+	}
+
+	.at-cell {
+		padding: var(--ii-space-stack-2xs, 6px) var(--ii-space-inline-sm, 12px);
+		vertical-align: middle;
+	}
+
+	.at-cell--block {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.at-block-name {
+		font-weight: 500;
+		color: var(--ii-text-primary);
+	}
+
+	.at-block-class {
+		font-size: var(--ii-text-label, 0.75rem);
+		color: var(--ii-text-muted);
+	}
+
+	.at-cell--value {
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+		font-weight: 600;
+		color: var(--ii-text-primary);
+	}
+
+	/* Tactical colors */
+	.at-val--positive {
+		color: var(--ii-success);
+	}
+
+	.at-val--negative {
+		color: var(--ii-danger);
+	}
+
+	@media (max-width: 640px) {
+		.at-th--value {
+			min-width: 70px;
+		}
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/allocation/ApprovalHistoryTable.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/ApprovalHistoryTable.svelte
@@ -18,7 +18,7 @@
 	import type {
 		AllocationProfile,
 		ApprovalHistoryResponse,
-	} from "$wealth/types/allocation-page";
+	} from "../../types/allocation-page";
 
 	interface Props {
 		profile: AllocationProfile;

--- a/packages/ii-terminal-core/src/lib/components/allocation/ApprovalHistoryTable.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/ApprovalHistoryTable.svelte
@@ -1,0 +1,343 @@
+<!--
+  PR-A26.3 Section G — Approval history table.
+
+  Collapsible, offset/limit pagination via refetch through the API
+  client. Active/Superseded badge computed from is_active server-side.
+
+  PR-4b — terminal-density re-skin. All colors via --terminal-*;
+  row heights respect [data-density] via --t-row-height.
+-->
+<script lang="ts">
+	import { formatDateTime, formatPercent } from "@investintell/ui";
+	import {
+		CheckCircle2,
+		AlertTriangle,
+		ChevronDown,
+		ChevronRight,
+	} from "lucide-svelte";
+	import type {
+		AllocationProfile,
+		ApprovalHistoryResponse,
+	} from "$wealth/types/allocation-page";
+
+	interface Props {
+		profile: AllocationProfile;
+		history: ApprovalHistoryResponse;
+		apiGet: <T>(path: string) => Promise<T>;
+	}
+	let { profile, history, apiGet }: Props = $props();
+
+	let expanded = $state(false);
+	let offset = $state(0);
+	const limit = 5;
+	let override = $state<ApprovalHistoryResponse | null>(null);
+	const current = $derived(override ?? history);
+	let loading = $state(false);
+	let errorMsg = $state<string | null>(null);
+
+	async function fetchPage(nextOffset: number): Promise<void> {
+		loading = true;
+		errorMsg = null;
+		try {
+			const resp = await apiGet<ApprovalHistoryResponse>(
+				`/portfolio/profiles/${profile}/approval-history?limit=${limit}&offset=${nextOffset}`,
+			);
+			override = resp;
+			offset = nextOffset;
+		} catch (err) {
+			errorMsg = err instanceof Error ? err.message : "Failed to load";
+		} finally {
+			loading = false;
+		}
+	}
+
+	function truncate(text: string | null, n = 60): string {
+		if (!text) return "—";
+		return text.length > n ? `${text.slice(0, n)}…` : text;
+	}
+
+	const canPrev = $derived(offset > 0);
+	const canNext = $derived(offset + limit < current.total);
+</script>
+
+<section class="approval-history">
+	<button
+		type="button"
+		class="approval-history__toggle"
+		onclick={() => (expanded = !expanded)}
+		aria-expanded={expanded}
+	>
+		{#if expanded}
+			<ChevronDown class="w-4 h-4" />
+		{:else}
+			<ChevronRight class="w-4 h-4" />
+		{/if}
+		<h2 class="approval-history__title">Approval History</h2>
+		<span class="approval-history__count">({current.total})</span>
+	</button>
+
+	{#if expanded}
+		<div class="approval-history__body">
+			{#if errorMsg}
+				<p class="approval-history__error">{errorMsg}</p>
+			{/if}
+
+			{#if current.entries.length === 0}
+				<p class="approval-history__empty">No approvals yet.</p>
+			{:else}
+				<div class="history-table-wrap">
+					<table class="history-table">
+						<thead>
+							<tr>
+								<th class="align-left">Status</th>
+								<th class="align-left">Approved At</th>
+								<th class="align-left">Approved By</th>
+								<th class="align-right">CVaR</th>
+								<th class="align-right">Expected Return</th>
+								<th class="align-center">Feasible</th>
+								<th class="align-left">Message</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each current.entries as entry (entry.approval_id)}
+								<tr>
+									<td class="align-left">
+										{#if entry.is_active}
+											<span class="status-pill status-pill--active">Active</span>
+										{:else}
+											<span class="status-pill status-pill--superseded"
+												>Superseded</span
+											>
+										{/if}
+									</td>
+									<td class="align-left">{formatDateTime(entry.approved_at)}</td>
+									<td class="align-left">{entry.approved_by}</td>
+									<td class="align-right numeric">
+										{entry.cvar_at_approval !== null
+											? formatPercent(entry.cvar_at_approval)
+											: "—"}
+									</td>
+									<td class="align-right numeric">
+										{entry.expected_return_at_approval !== null
+											? formatPercent(entry.expected_return_at_approval)
+											: "—"}
+									</td>
+									<td class="align-center">
+										{#if entry.cvar_feasible_at_approval}
+											<span class="icon icon--ok">
+												<CheckCircle2 class="w-4 h-4" />
+											</span>
+										{:else}
+											<span class="icon icon--warn">
+												<AlertTriangle class="w-4 h-4" />
+											</span>
+										{/if}
+									</td>
+									<td
+										class="align-left muted"
+										title={entry.operator_message ?? ""}
+									>
+										{truncate(entry.operator_message)}
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+
+			<div class="approval-history__pager">
+				<button
+					type="button"
+					class="pager-btn"
+					disabled={!canPrev || loading}
+					onclick={() => void fetchPage(Math.max(0, offset - limit))}
+				>
+					Previous
+				</button>
+				<span class="pager-label">
+					{offset + 1}–{Math.min(
+						offset + current.entries.length,
+						current.total,
+					)} of {current.total}
+				</span>
+				<button
+					type="button"
+					class="pager-btn"
+					disabled={!canNext || loading}
+					onclick={() => void fetchPage(offset + limit)}
+				>
+					Next
+				</button>
+			</div>
+		</div>
+	{/if}
+</section>
+
+<style>
+	.approval-history {
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-primary);
+	}
+	.approval-history__toggle {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		background: transparent;
+		border: none;
+		padding: var(--terminal-space-3) var(--terminal-space-4);
+		color: var(--terminal-fg-secondary);
+		font-family: var(--terminal-font-mono);
+		text-align: left;
+		cursor: pointer;
+	}
+	.approval-history__toggle:hover,
+	.approval-history__toggle:focus-visible {
+		color: var(--terminal-fg-primary);
+		outline: none;
+	}
+	.approval-history__title {
+		font-size: var(--terminal-text-12);
+		font-weight: 500;
+		margin: 0;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.approval-history__count {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+	.approval-history__body {
+		border-top: var(--terminal-border-hairline);
+		padding: var(--terminal-space-3);
+	}
+	.approval-history__error {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-status-error);
+		margin: 0 0 var(--terminal-space-2);
+	}
+	.approval-history__empty {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-tertiary);
+		text-align: center;
+		padding: var(--terminal-space-6) 0;
+		margin: 0;
+	}
+
+	.history-table-wrap {
+		overflow-x: auto;
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel-raised);
+	}
+	.history-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: var(--terminal-text-11);
+		font-family: var(--terminal-font-mono);
+	}
+	.history-table thead tr {
+		background: var(--terminal-bg-panel-sunken);
+	}
+	.history-table th {
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		font-weight: 500;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.history-table tbody tr {
+		border-top: var(--terminal-border-hairline);
+		height: var(--t-row-height);
+	}
+	.history-table td {
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		color: var(--terminal-fg-primary);
+	}
+	.align-left {
+		text-align: left;
+	}
+	.align-right {
+		text-align: right;
+	}
+	.align-center {
+		text-align: center;
+	}
+	.numeric {
+		font-variant-numeric: tabular-nums;
+	}
+	.muted {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.status-pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0 var(--terminal-space-2);
+		border: var(--terminal-border-hairline);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.status-pill--active {
+		color: var(--terminal-status-success);
+		border-color: var(--terminal-status-success);
+	}
+	.status-pill--superseded {
+		color: var(--terminal-fg-tertiary);
+		border-color: var(--terminal-fg-muted);
+	}
+
+	.icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
+	.icon--ok {
+		color: var(--terminal-status-success);
+	}
+	.icon--warn {
+		color: var(--terminal-status-warn);
+	}
+
+	.approval-history__pager {
+		margin-top: var(--terminal-space-3);
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: var(--terminal-space-2);
+	}
+	.pager-btn {
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		border: var(--terminal-border-hairline);
+		background: transparent;
+		color: var(--terminal-fg-tertiary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		transition: color var(--terminal-motion-tick)
+				var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.pager-btn:hover:not(:disabled),
+	.pager-btn:focus-visible:not(:disabled) {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+		outline: none;
+	}
+	.pager-btn:disabled {
+		color: var(--terminal-fg-disabled);
+		border-color: var(--terminal-fg-disabled);
+		cursor: not-allowed;
+		opacity: 0.4;
+	}
+	.pager-label {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/allocation/BLOCK_INSTRUMENTS.ts
+++ b/packages/ii-terminal-core/src/lib/components/allocation/BLOCK_INSTRUMENTS.ts
@@ -1,0 +1,57 @@
+/**
+ * Static instrument mapping per allocation block.
+ * V1: hardcoded. V2: replace with GET /allocation/blocks/{id}/instruments
+ * Keys MUST match block_id from /blended-benchmarks/blocks.
+ */
+import type { BlockInstrument } from "./types";
+
+export const BLOCK_INSTRUMENTS: Record<string, BlockInstrument[]> = {
+	na_equity_large: [
+		{ ticker: "SPY", name: "iShares S&P 500 ETF", weight: 1.0 },
+	],
+	na_equity_growth: [
+		{ ticker: "QQQ", name: "Invesco QQQ Trust", weight: 1.0 },
+	],
+	na_equity_value: [
+		{ ticker: "IWD", name: "iShares Russell 1000 Value ETF", weight: 1.0 },
+	],
+	na_equity_small: [
+		{ ticker: "IWM", name: "iShares Russell 2000 ETF", weight: 1.0 },
+	],
+	dm_europe_equity: [
+		{ ticker: "VGK", name: "Vanguard FTSE Europe ETF", weight: 1.0 },
+	],
+	dm_asia_equity: [
+		{ ticker: "EWJ", name: "iShares MSCI Japan ETF", weight: 1.0 },
+	],
+	em_equity: [
+		{ ticker: "EEM", name: "iShares MSCI Emerging Markets ETF", weight: 1.0 },
+	],
+	fi_us_aggregate: [
+		{ ticker: "AGG", name: "iShares Core US Aggregate ETF", weight: 1.0 },
+	],
+	fi_us_treasury: [
+		{ ticker: "IEF", name: "iShares 7-10Y Treasury Bond ETF", weight: 1.0 },
+	],
+	fi_us_tips: [
+		{ ticker: "TIP", name: "iShares TIPS Bond ETF", weight: 1.0 },
+	],
+	fi_us_high_yield: [
+		{ ticker: "HYG", name: "iShares iBoxx HY Corp Bond ETF", weight: 1.0 },
+	],
+	fi_em_debt: [
+		{ ticker: "EMB", name: "iShares JPM EM Bond ETF", weight: 1.0 },
+	],
+	alt_real_estate: [
+		{ ticker: "VNQ", name: "Vanguard Real Estate ETF", weight: 1.0 },
+	],
+	alt_commodities: [
+		{ ticker: "DJP", name: "iPath Bloomberg Commodity ETN", weight: 1.0 },
+	],
+	alt_gold: [
+		{ ticker: "GLD", name: "SPDR Gold Shares", weight: 1.0 },
+	],
+	cash: [
+		{ ticker: "SHV", name: "iShares Short Treasury Bond ETF", weight: 1.0 },
+	],
+};

--- a/packages/ii-terminal-core/src/lib/components/allocation/CascadeTimeline.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/CascadeTimeline.svelte
@@ -1,0 +1,295 @@
+<!--
+  CascadeTimeline.svelte
+  ======================
+
+  Horizontal 3-phase cascade visualization for the PR-A12 RU LP cascade.
+  Ships two modes:
+
+    • mode="live"    — streamed during propose SSE. Parent seeds the
+                        phases array with three pending entries and
+                        mutates status in place as ``optimizer_phase_complete``
+                        arrives (phase, status, objective_value).
+                        Coverage is unknown mid-stream; the bar hides.
+
+    • mode="settled" — rendered by ProposalReviewPanel after the run
+                        completes. Parent reads ``phase_attempts`` and
+                        ``coverage`` from the LatestProposalResponse
+                        (surfaced by PR-4a backend extension).
+
+  Winner highlighting: the phase whose key matches the resolved winning
+  phase (derived client-side from the array for settled mode, from the
+  most-recent succeeded phase for live) renders with accent tone.
+
+  Coverage bar thresholds match PR-A14 operator signals:
+    • < 20% → critical (hard-fail territory)
+    • < 50% → warn
+    • ≥ 50% → success
+
+  Source: docs/plans/2026-04-19-netz-terminal-parity-builder-macro-screener.md §B.6.
+-->
+<script lang="ts">
+	import type {
+		CascadePhaseAttempt,
+		CoverageSummary,
+	} from "$wealth/types/allocation-page";
+
+	export type CascadeTimelineMode = "live" | "settled";
+
+	interface Props {
+		phases: CascadePhaseAttempt[];
+		winnerSignal?: string | null;
+		coverage?: CoverageSummary | null;
+		mode?: CascadeTimelineMode;
+		class?: string;
+	}
+
+	let {
+		phases,
+		winnerSignal = null,
+		coverage = null,
+		mode = "settled",
+		class: className,
+	}: Props = $props();
+
+	const PHASE_LABELS: Record<string, string> = {
+		phase_1_ru_max_return: "Phase 1 · Max Return",
+		phase_2_ru_robust: "Phase 2 · Robust",
+		phase_3_min_cvar: "Phase 3 · Min Tail Risk",
+	};
+
+	const PHASE_ORDER: readonly string[] = [
+		"phase_1_ru_max_return",
+		"phase_2_ru_robust",
+		"phase_3_min_cvar",
+	];
+
+	type PhaseStatus = "pending" | "running" | "succeeded" | "failed" | "skipped" | "unknown";
+
+	const STATUS_MAP: Record<string, PhaseStatus> = {
+		pending: "pending",
+		running: "running",
+		in_progress: "running",
+		succeeded: "succeeded",
+		success: "succeeded",
+		optimal: "succeeded",
+		failed: "failed",
+		error: "failed",
+		skipped: "skipped",
+	};
+
+	function normalizeStatus(raw: string | null | undefined): PhaseStatus {
+		if (!raw) return "unknown";
+		return STATUS_MAP[raw.toLowerCase()] ?? "unknown";
+	}
+
+	const orderedPhases = $derived.by(() => {
+		const byKey = new Map(phases.map((p) => [p.phase, p]));
+		return PHASE_ORDER.map((key) => {
+			const found = byKey.get(key);
+			return (
+				found ?? {
+					phase: key,
+					status: mode === "live" ? "pending" : "unknown",
+					solver: null,
+					wall_ms: 0,
+					objective_value: null,
+					cvar_within_limit: null,
+				}
+			);
+		});
+	});
+
+	const winningPhaseKey = $derived.by(() => {
+		for (let i = orderedPhases.length - 1; i >= 0; i--) {
+			if (normalizeStatus(orderedPhases[i]!.status) === "succeeded") {
+				return orderedPhases[i]!.phase;
+			}
+		}
+		return null;
+	});
+
+	function coverageTone(pct: number | null | undefined): "success" | "warn" | "critical" {
+		if (pct === null || pct === undefined) return "success";
+		if (pct < 0.2) return "critical";
+		if (pct < 0.5) return "warn";
+		return "success";
+	}
+
+	const coveragePct = $derived(coverage?.pct_covered ?? null);
+	const coverageToneClass = $derived(coverageTone(coveragePct));
+	const coverageWidth = $derived(
+		coveragePct !== null ? `${Math.max(0, Math.min(1, coveragePct)) * 100}%` : "0%",
+	);
+</script>
+
+<div class="cascade-timeline {className ?? ''}" data-mode={mode}>
+	<ol class="cascade-timeline__row" aria-label="Cascade phase timeline">
+		{#each orderedPhases as phase, idx (phase.phase)}
+			{@const status = normalizeStatus(phase.status)}
+			{@const isWinner = winningPhaseKey === phase.phase}
+			<li
+				class="cascade-timeline__phase"
+				data-status={status}
+				class:cascade-timeline__phase--winner={isWinner}
+			>
+				<span class="cascade-timeline__phase-index">{idx + 1}</span>
+				<span class="cascade-timeline__phase-label"
+					>{PHASE_LABELS[phase.phase] ?? phase.phase}</span
+				>
+				<span class="cascade-timeline__phase-status">{status}</span>
+			</li>
+		{/each}
+	</ol>
+
+	{#if coverage && coveragePct !== null}
+		<div class="cascade-timeline__coverage" data-tone={coverageToneClass}>
+			<div class="cascade-timeline__coverage-bar">
+				<div
+					class="cascade-timeline__coverage-fill"
+					style="width: {coverageWidth}"
+					role="progressbar"
+					aria-valuenow={Math.round(coveragePct * 100)}
+					aria-valuemin="0"
+					aria-valuemax="100"
+					aria-label="Universe coverage"
+				></div>
+			</div>
+			<span class="cascade-timeline__coverage-label">
+				UNIVERSE COVERAGE ·
+				<span class="cascade-timeline__coverage-value"
+					>{Math.round(coveragePct * 100)}%</span
+				>
+				{#if coverage.missing_blocks?.length}
+					· {coverage.missing_blocks.length} block{coverage.missing_blocks.length === 1 ? "" : "s"} pending
+				{/if}
+			</span>
+		</div>
+	{/if}
+
+	{#if winnerSignal && mode === "settled"}
+		<p class="cascade-timeline__winner-signal">
+			WINNER SIGNAL: <strong>{winnerSignal}</strong>
+		</p>
+	{/if}
+</div>
+
+<style>
+	.cascade-timeline {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.cascade-timeline__row {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: var(--terminal-space-2);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.cascade-timeline__phase {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel-raised);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	[data-mode="live"] .cascade-timeline__phase[data-status="pending"] {
+		border-style: dashed;
+	}
+	[data-mode="live"] .cascade-timeline__phase[data-status="running"] {
+		border-color: var(--terminal-accent-cyan);
+		color: var(--terminal-accent-cyan);
+	}
+
+	.cascade-timeline__phase[data-status="succeeded"] {
+		color: var(--terminal-status-success);
+		border-color: var(--terminal-status-success);
+	}
+	.cascade-timeline__phase[data-status="failed"] {
+		color: var(--terminal-status-error);
+		border-color: var(--terminal-status-error);
+	}
+	.cascade-timeline__phase[data-status="skipped"] {
+		color: var(--terminal-fg-tertiary);
+		border-color: var(--terminal-fg-muted);
+	}
+	.cascade-timeline__phase[data-status="unknown"] {
+		color: var(--terminal-fg-tertiary);
+		border-style: dashed;
+	}
+
+	.cascade-timeline__phase--winner {
+		background: var(--terminal-bg-panel-sunken);
+		box-shadow: inset 0 0 0 1px var(--terminal-accent-amber);
+	}
+	.cascade-timeline__phase--winner .cascade-timeline__phase-label {
+		color: var(--terminal-accent-amber);
+	}
+
+	.cascade-timeline__phase-index {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+	.cascade-timeline__phase-label {
+		font-size: var(--terminal-text-12);
+		color: var(--terminal-fg-primary);
+		line-height: var(--terminal-leading-tight);
+	}
+	.cascade-timeline__phase-status {
+		font-size: var(--terminal-text-10);
+	}
+
+	.cascade-timeline__coverage {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+	}
+	.cascade-timeline__coverage-bar {
+		height: 3px;
+		background: var(--terminal-fg-muted);
+		overflow: hidden;
+	}
+	.cascade-timeline__coverage-fill {
+		height: 100%;
+		transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+	}
+	[data-tone="success"] .cascade-timeline__coverage-fill {
+		background: var(--terminal-status-success);
+	}
+	[data-tone="warn"] .cascade-timeline__coverage-fill {
+		background: var(--sev-warn);
+	}
+	[data-tone="critical"] .cascade-timeline__coverage-fill {
+		background: var(--sev-critical);
+	}
+	.cascade-timeline__coverage-label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+	.cascade-timeline__coverage-value {
+		color: var(--terminal-fg-primary);
+	}
+
+	.cascade-timeline__winner-signal {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		margin: 0;
+	}
+	.cascade-timeline__winner-signal strong {
+		color: var(--terminal-fg-primary);
+		font-weight: inherit;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/allocation/CascadeTimeline.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/CascadeTimeline.svelte
@@ -31,7 +31,7 @@
 	import type {
 		CascadePhaseAttempt,
 		CoverageSummary,
-	} from "$wealth/types/allocation-page";
+	} from "../../types/allocation-page";
 
 	export type CascadeTimelineMode = "live" | "settled";
 

--- a/packages/ii-terminal-core/src/lib/components/allocation/IpsSummaryStrip.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/IpsSummaryStrip.svelte
@@ -1,0 +1,101 @@
+<!--
+  IpsSummaryStrip.svelte
+  ======================
+
+  Dense identifier bar for the allocation page. Answers "which IPS am
+  I looking at" in a single horizontal strip; complements the numerical
+  KPI row below. All pills are read-only.
+
+  Reads data already returned by ``GET /portfolio/profiles/{profile}/
+  strategic-allocation``; no new endpoint.
+
+  Source: docs/plans/2026-04-19-netz-terminal-parity-builder-macro-screener.md §B.7.
+-->
+<script lang="ts">
+	import {
+		TerminalPill,
+		formatPercent,
+		formatRelativeDate,
+	} from "@investintell/ui";
+	import type { AllocationProfile } from "$wealth/types/allocation-page";
+
+	interface Props {
+		cvarLimit: number | null;
+		lastApprovedAt: string | null;
+		lastApprovedBy: string | null;
+		profile: AllocationProfile;
+		cadenceLabel?: string;
+		class?: string;
+	}
+
+	let {
+		cvarLimit,
+		lastApprovedAt,
+		lastApprovedBy,
+		profile,
+		cadenceLabel = "Quarterly review",
+		class: className,
+	}: Props = $props();
+
+	const PROFILE_PILL_LABEL: Record<AllocationProfile, string> = {
+		conservative: "Conservative",
+		moderate: "Moderate",
+		growth: "Growth",
+	};
+
+	const cvarPillLabel = $derived(
+		cvarLimit !== null ? `CVaR ≤ ${formatPercent(cvarLimit)}` : "CVaR ≤ —",
+	);
+
+	const approvedPillLabel = $derived.by(() => {
+		if (!lastApprovedAt) return "Never approved";
+		const relative = formatRelativeDate(lastApprovedAt);
+		if (lastApprovedBy) return `Approved ${relative} · ${lastApprovedBy}`;
+		return `Approved ${relative}`;
+	});
+</script>
+
+<div class="ips-summary-strip {className ?? ''}" role="group" aria-label="IPS summary">
+	<span class="ips-summary-strip__label">IPS SUMMARY</span>
+	<div class="ips-summary-strip__pills">
+		<TerminalPill
+			label={`Profile: ${PROFILE_PILL_LABEL[profile]}`}
+			tone="neutral"
+			size="xs"
+		/>
+		<TerminalPill
+			label={cvarPillLabel}
+			tone={cvarLimit !== null ? "accent" : "neutral"}
+			size="xs"
+		/>
+		<TerminalPill
+			label={approvedPillLabel}
+			tone={lastApprovedAt ? "success" : "neutral"}
+			size="xs"
+		/>
+		<TerminalPill label={cadenceLabel} tone="neutral" size="xs" />
+	</div>
+</div>
+
+<style>
+	.ips-summary-strip {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding: var(--terminal-space-2) 0;
+		border-top: var(--terminal-border-hairline);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+	}
+	.ips-summary-strip__label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+	.ips-summary-strip__pills {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--terminal-space-2);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/allocation/IpsSummaryStrip.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/IpsSummaryStrip.svelte
@@ -17,7 +17,7 @@
 		formatPercent,
 		formatRelativeDate,
 	} from "@investintell/ui";
-	import type { AllocationProfile } from "$wealth/types/allocation-page";
+	import type { AllocationProfile } from "../../types/allocation-page";
 
 	interface Props {
 		cvarLimit: number | null;

--- a/packages/ii-terminal-core/src/lib/components/allocation/OverrideBandsEditor.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/OverrideBandsEditor.svelte
@@ -1,0 +1,347 @@
+<!--
+  PR-A26.3 Section F — Override bands editor modal.
+
+  Validation: at least one of min/max when saving; min <= max when
+  both given; rationale required (min 10 chars) when setting bounds.
+  Clear Override bypasses rationale and posts both-NULL.
+
+  PR-4b — terminal-density re-skin. Modal shell + inputs + actions
+  consume --terminal-* tokens. No Tailwind semantic colors.
+-->
+<script lang="ts">
+	import { formatNumber, formatPercent } from "@investintell/ui";
+	import type {
+		AllocationProfile,
+		SetOverrideRequest,
+		StrategicAllocationBlock,
+	} from "$wealth/types/allocation-page";
+
+	interface Props {
+		profile: AllocationProfile;
+		block: StrategicAllocationBlock;
+		onClose: () => void;
+		onSaved: () => Promise<void> | void;
+		apiPost: <T>(path: string, body: unknown) => Promise<T>;
+	}
+	let { profile, block, onClose, onSaved, apiPost }: Props = $props();
+
+	function toPctString(v: number | null): string {
+		return v !== null ? formatNumber(v * 100, 2, "en-US") : "";
+	}
+
+	let overrideMinRaw = $state("");
+	let overrideMaxRaw = $state("");
+
+	$effect(() => {
+		overrideMinRaw = toPctString(block.override_min);
+		overrideMaxRaw = toPctString(block.override_max);
+	});
+	let rationale = $state("");
+	let saving = $state(false);
+	let errorMsg = $state<string | null>(null);
+
+	function parseOrNull(raw: string): number | null {
+		const trimmed = raw.trim();
+		if (trimmed === "") return null;
+		const n = Number(trimmed);
+		if (!Number.isFinite(n)) return null;
+		return n / 100;
+	}
+
+	async function save(): Promise<void> {
+		errorMsg = null;
+		const min = parseOrNull(overrideMinRaw);
+		const max = parseOrNull(overrideMaxRaw);
+		if (min === null && max === null) {
+			errorMsg =
+				"Provide at least one bound or use Clear Override to remove the override.";
+			return;
+		}
+		if (min !== null && (min < 0 || min > 1)) {
+			errorMsg = "Override min must be between 0 and 100%.";
+			return;
+		}
+		if (max !== null && (max < 0 || max > 1)) {
+			errorMsg = "Override max must be between 0 and 100%.";
+			return;
+		}
+		if (min !== null && max !== null && min > max) {
+			errorMsg = "Override min must be less than or equal to override max.";
+			return;
+		}
+		if (rationale.trim().length < 10) {
+			errorMsg = "Rationale must be at least 10 characters.";
+			return;
+		}
+
+		saving = true;
+		try {
+			const body: SetOverrideRequest = {
+				block_id: block.block_id,
+				override_min: min,
+				override_max: max,
+				rationale: rationale.trim(),
+			};
+			await apiPost(`/portfolio/profiles/${profile}/set-override`, body);
+			await onSaved();
+			onClose();
+		} catch (err) {
+			errorMsg = err instanceof Error ? err.message : "Save failed";
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function clear(): Promise<void> {
+		errorMsg = null;
+		saving = true;
+		try {
+			const body: SetOverrideRequest = {
+				block_id: block.block_id,
+				override_min: null,
+				override_max: null,
+				rationale: rationale.trim() || "Override cleared",
+			};
+			await apiPost(`/portfolio/profiles/${profile}/set-override`, body);
+			await onSaved();
+			onClose();
+		} catch (err) {
+			errorMsg = err instanceof Error ? err.message : "Clear failed";
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<div
+	class="modal-backdrop"
+	role="dialog"
+	aria-modal="true"
+	aria-labelledby="override-editor-title"
+>
+	<div class="modal">
+		<header class="modal__header">
+			<h3 id="override-editor-title" class="modal__title">
+				Edit Override — {block.block_name}
+			</h3>
+			<p class="modal__subtitle">
+				Current target: {block.target_weight !== null
+					? formatPercent(block.target_weight)
+					: "—"}. Override takes effect on next proposal. Current holdings are
+				unaffected.
+			</p>
+		</header>
+
+		<div class="modal__fields">
+			<label class="field">
+				<span class="field__label">Override Min (%)</span>
+				<input
+					type="number"
+					min="0"
+					max="100"
+					step="0.1"
+					class="field__input"
+					bind:value={overrideMinRaw}
+					placeholder="e.g. 5"
+				/>
+			</label>
+			<label class="field">
+				<span class="field__label">Override Max (%)</span>
+				<input
+					type="number"
+					min="0"
+					max="100"
+					step="0.1"
+					class="field__input"
+					bind:value={overrideMaxRaw}
+					placeholder="e.g. 15"
+				/>
+			</label>
+			<label class="field">
+				<span class="field__label">Rationale (min 10 chars)</span>
+				<textarea
+					rows="3"
+					class="field__textarea"
+					bind:value={rationale}
+					placeholder="Why is this override needed?"
+				></textarea>
+			</label>
+		</div>
+
+		{#if errorMsg}
+			<p class="modal__error">{errorMsg}</p>
+		{/if}
+
+		<footer class="modal__footer">
+			<button
+				type="button"
+				class="action action--destructive-ghost"
+				onclick={() => void clear()}
+				disabled={saving}
+			>
+				Clear Override
+			</button>
+			<div class="modal__footer-right">
+				<button
+					type="button"
+					class="action action--ghost"
+					onclick={onClose}
+					disabled={saving}
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					class="action action--primary"
+					onclick={() => void save()}
+					disabled={saving}
+				>
+					{saving ? "Saving…" : "Save Override"}
+				</button>
+			</div>
+		</footer>
+	</div>
+</div>
+
+<style>
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: var(--terminal-z-modal);
+		background: var(--terminal-bg-scrim);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: var(--terminal-space-4);
+	}
+	.modal {
+		width: 100%;
+		max-width: 480px;
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		padding: var(--terminal-space-4);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-primary);
+	}
+	.modal__header {
+		margin-bottom: var(--terminal-space-3);
+	}
+	.modal__title {
+		font-size: var(--terminal-text-14);
+		font-weight: 500;
+		margin: 0;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-primary);
+	}
+	.modal__subtitle {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		margin: var(--terminal-space-1) 0 0;
+		line-height: var(--terminal-leading-snug);
+	}
+
+	.modal__fields {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-3);
+	}
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+	}
+	.field__label {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.field__input,
+	.field__textarea {
+		width: 100%;
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		background: var(--terminal-bg-panel-sunken);
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-12);
+		font-variant-numeric: tabular-nums;
+	}
+	.field__input:focus-visible,
+	.field__textarea:focus-visible {
+		outline: none;
+		border-color: var(--terminal-accent-amber);
+	}
+	.field__textarea {
+		resize: vertical;
+		min-height: 72px;
+	}
+
+	.modal__error {
+		margin-top: var(--terminal-space-3);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-status-error);
+	}
+
+	.modal__footer {
+		margin-top: var(--terminal-space-4);
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--terminal-space-2);
+	}
+	.modal__footer-right {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+
+	.action {
+		display: inline-flex;
+		align-items: center;
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		transition: color var(--terminal-motion-tick)
+				var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.action:disabled {
+		color: var(--terminal-fg-disabled);
+		border-color: var(--terminal-fg-disabled);
+		cursor: not-allowed;
+	}
+	.action--ghost {
+		color: var(--terminal-fg-tertiary);
+	}
+	.action--ghost:hover:not(:disabled),
+	.action--ghost:focus-visible:not(:disabled) {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+		outline: none;
+	}
+	.action--primary {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+	.action--primary:hover:not(:disabled),
+	.action--primary:focus-visible:not(:disabled) {
+		background: var(--terminal-bg-panel-sunken);
+		outline: none;
+	}
+	.action--destructive-ghost {
+		color: var(--terminal-status-error);
+		border-color: transparent;
+	}
+	.action--destructive-ghost:hover:not(:disabled),
+	.action--destructive-ghost:focus-visible:not(:disabled) {
+		border-color: var(--terminal-status-error);
+		outline: none;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/allocation/OverrideBandsEditor.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/OverrideBandsEditor.svelte
@@ -14,7 +14,7 @@
 		AllocationProfile,
 		SetOverrideRequest,
 		StrategicAllocationBlock,
-	} from "$wealth/types/allocation-page";
+	} from "../../types/allocation-page";
 
 	interface Props {
 		profile: AllocationProfile;

--- a/packages/ii-terminal-core/src/lib/components/allocation/ProposalReviewPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/ProposalReviewPanel.svelte
@@ -1,0 +1,574 @@
+<!--
+  PR-A26.3 Section D — Proposal Review Panel.
+
+  Shows a pending propose-mode run as a diff vs the current approved
+  Strategic. Approve is atomic; an infeasible proposal opens a confirm
+  modal before POSTing with ``confirm_cvar_infeasible = true``.
+
+  Dismiss is cosmetic in v1 — the panel hides locally, the DB run
+  persists. Running a new propose supersedes it.
+
+  PR-4b — terminal re-skin. ECharts bar colors now resolved via
+  ``readTerminalTokens()`` (no hex in script). All surfaces use
+  ``--terminal-*`` custom properties; no Tailwind semantic colors.
+-->
+<script lang="ts">
+	import {
+		formatDateTime,
+		formatNumber,
+		formatPercent,
+		readTerminalTokens,
+	} from "@investintell/ui";
+	import { CheckCircle2, AlertTriangle } from "lucide-svelte";
+	import GenericEChart from "$wealth/components/charts/GenericEChart.svelte";
+	import CascadeTimeline from "./CascadeTimeline.svelte";
+	import type {
+		AllocationProfile,
+		ApproveProposalRequest,
+		LatestProposalResponse,
+		StrategicAllocationBlock,
+	} from "$wealth/types/allocation-page";
+
+	interface Props {
+		profile: AllocationProfile;
+		proposal: LatestProposalResponse;
+		strategicBlocks: StrategicAllocationBlock[];
+		onApproved: () => Promise<void> | void;
+		apiPost: <T>(path: string, body: unknown) => Promise<T>;
+	}
+
+	let { profile, proposal, strategicBlocks, onApproved, apiPost }: Props =
+		$props();
+
+	let expanded = $state(false);
+	let approving = $state(false);
+	let showConfirmInfeasible = $state(false);
+	let dismissed = $state(false);
+	let errorMsg = $state<string | null>(null);
+
+	const nameByBlock = $derived(
+		new Map(strategicBlocks.map((b) => [b.block_id, b.block_name])),
+	);
+	const currentByBlock = $derived(
+		new Map(strategicBlocks.map((b) => [b.block_id, b.target_weight ?? 0])),
+	);
+
+	const diffs = $derived(
+		proposal.proposed_bands.map((b) => {
+			const current = currentByBlock.get(b.block_id) ?? 0;
+			return {
+				block_id: b.block_id,
+				block_name: nameByBlock.get(b.block_id) ?? b.block_id,
+				current,
+				proposed: b.target_weight,
+				delta: b.target_weight - current,
+			};
+		}),
+	);
+
+	const diffChartOptions = $derived.by(() => {
+		const tokens = readTerminalTokens();
+		const sorted = [...diffs].sort((a, b) => a.delta - b.delta);
+		return {
+			tooltip: {
+				trigger: "axis",
+				axisPointer: { type: "shadow" },
+				formatter: (arr: { name: string; value: number }[]) => {
+					const p = arr[0];
+					if (!p) return "";
+					return `${p.name}<br/>Delta: ${formatPercent(p.value, 2)}`;
+				},
+			},
+			grid: { left: 140, right: 20, top: 10, bottom: 30 },
+			xAxis: {
+				type: "value",
+				axisLabel: { formatter: (v: number) => formatPercent(v, 0) },
+			},
+			yAxis: {
+				type: "category",
+				data: sorted.map((d) => d.block_name),
+				axisLabel: { fontSize: 11 },
+			},
+			series: [
+				{
+					type: "bar",
+					data: sorted.map((d) => ({
+						value: d.delta,
+						itemStyle: {
+							color: d.delta >= 0 ? tokens.statusSuccess : tokens.statusError,
+						},
+					})),
+				},
+			],
+		};
+	});
+
+	const isInfeasible = $derived(!proposal.proposal_metrics.cvar_feasible);
+
+	async function doApprove(confirmInfeasible: boolean): Promise<void> {
+		approving = true;
+		errorMsg = null;
+		try {
+			const body: ApproveProposalRequest = {
+				confirm_cvar_infeasible: confirmInfeasible,
+				operator_message: null,
+			};
+			await apiPost(
+				`/portfolio/profiles/${profile}/approve-proposal/${proposal.run_id}`,
+				body,
+			);
+			showConfirmInfeasible = false;
+			await onApproved();
+		} catch (err) {
+			errorMsg = err instanceof Error ? err.message : "Approval failed";
+		} finally {
+			approving = false;
+		}
+	}
+
+	function onApproveClick(): void {
+		if (isInfeasible) {
+			showConfirmInfeasible = true;
+			return;
+		}
+		void doApprove(false);
+	}
+</script>
+
+{#if !dismissed}
+	<section class="proposal-panel">
+		<header class="proposal-panel__header">
+			<div class="proposal-panel__title-block">
+				<h2 class="proposal-panel__title">Pending Proposal</h2>
+				<p class="proposal-panel__subtitle">
+					Generated {formatDateTime(proposal.requested_at)}
+				</p>
+			</div>
+			{#if isInfeasible}
+				<span class="status-pill status-pill--warn">
+					<AlertTriangle class="w-3 h-3" /> CVaR infeasible
+				</span>
+			{:else}
+				<span class="status-pill status-pill--ok">
+					<CheckCircle2 class="w-3 h-3" /> Feasible
+				</span>
+			{/if}
+		</header>
+
+		<dl class="metrics-grid">
+			<div class="metric">
+				<dt class="metric__label">Proposed E[r]</dt>
+				<dd class="metric__value">
+					{proposal.proposal_metrics.expected_return !== null
+						? formatPercent(proposal.proposal_metrics.expected_return)
+						: "—"}
+				</dd>
+			</div>
+			<div class="metric">
+				<dt class="metric__label">Proposed CVaR</dt>
+				<dd class="metric__value">
+					{proposal.proposal_metrics.expected_cvar !== null
+						? formatPercent(proposal.proposal_metrics.expected_cvar)
+						: "—"}
+				</dd>
+			</div>
+			<div class="metric">
+				<dt class="metric__label">Target CVaR</dt>
+				<dd class="metric__value">
+					{proposal.proposal_metrics.target_cvar !== null
+						? formatPercent(proposal.proposal_metrics.target_cvar)
+						: "—"}
+				</dd>
+			</div>
+			<div class="metric">
+				<dt class="metric__label">Sharpe</dt>
+				<dd class="metric__value">
+					{proposal.proposal_metrics.expected_sharpe !== null
+						? formatNumber(proposal.proposal_metrics.expected_sharpe, 2)
+						: "—"}
+				</dd>
+			</div>
+		</dl>
+
+		{#if proposal.phase_attempts.length > 0}
+			<div class="proposal-panel__cascade">
+				<CascadeTimeline
+					phases={proposal.phase_attempts}
+					winnerSignal={proposal.winner_signal}
+					coverage={proposal.coverage}
+					mode="settled"
+				/>
+			</div>
+		{/if}
+
+		<div class="proposal-panel__chart">
+			<GenericEChart options={diffChartOptions} height={420} />
+		</div>
+
+		<div class="proposal-panel__diff">
+			<button
+				type="button"
+				class="proposal-panel__diff-toggle"
+				onclick={() => (expanded = !expanded)}
+			>
+				{expanded ? "Hide" : "Show"} block-by-block diff
+			</button>
+			{#if expanded}
+				<div class="diff-table-wrap">
+					<table class="diff-table">
+						<thead>
+							<tr>
+								<th class="align-left">Asset Class</th>
+								<th class="align-right">Current</th>
+								<th class="align-right">Proposed</th>
+								<th class="align-right">Delta</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each diffs as row (row.block_id)}
+								<tr>
+									<td class="align-left">{row.block_name}</td>
+									<td class="align-right numeric">
+										{formatPercent(row.current)}
+									</td>
+									<td class="align-right numeric">
+										{formatPercent(row.proposed)}
+									</td>
+									<td
+										class="align-right numeric"
+										class:delta-up={row.delta > 0}
+										class:delta-down={row.delta < 0}
+									>
+										{row.delta >= 0 ? "+" : ""}{formatPercent(row.delta)}
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</div>
+
+		{#if errorMsg}
+			<p class="proposal-panel__error">{errorMsg}</p>
+		{/if}
+
+		<footer class="proposal-panel__footer">
+			<button
+				type="button"
+				class="action action--ghost"
+				onclick={() => (dismissed = true)}
+			>
+				Dismiss proposal
+			</button>
+			<button
+				type="button"
+				class="action action--primary"
+				onclick={onApproveClick}
+				disabled={approving}
+			>
+				{approving ? "Approving…" : "Approve Allocation"}
+			</button>
+		</footer>
+	</section>
+
+	{#if showConfirmInfeasible}
+		<div
+			class="modal-backdrop"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="confirm-infeasible-title"
+		>
+			<div class="modal">
+				<h3 id="confirm-infeasible-title" class="modal__title">
+					Proposal did not reach CVaR target
+				</h3>
+				<p class="modal__body">
+					The optimizer could not meet the configured CVaR limit of
+					<strong>
+						{proposal.proposal_metrics.target_cvar !== null
+							? formatPercent(proposal.proposal_metrics.target_cvar)
+							: "—"}
+					</strong>; best achievable was
+					<strong>
+						{proposal.proposal_metrics.expected_cvar !== null
+							? formatPercent(proposal.proposal_metrics.expected_cvar)
+							: "—"}
+					</strong>. Approving accepts a Strategic IPS that cannot meet the
+					target. Continue anyway?
+				</p>
+				<div class="modal__footer">
+					<button
+						type="button"
+						class="action action--ghost"
+						onclick={() => (showConfirmInfeasible = false)}
+						disabled={approving}
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="action action--destructive"
+						onclick={() => void doApprove(true)}
+						disabled={approving}
+					>
+						{approving ? "Approving…" : "Confirm Approval"}
+					</button>
+				</div>
+			</div>
+		</div>
+	{/if}
+{/if}
+
+<style>
+	.proposal-panel {
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+		padding: var(--terminal-space-4);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-primary);
+	}
+	.proposal-panel__header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: var(--terminal-space-3);
+		margin-bottom: var(--terminal-space-3);
+	}
+	.proposal-panel__title {
+		font-size: var(--terminal-text-14);
+		font-weight: 500;
+		color: var(--terminal-fg-primary);
+		margin: 0;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.proposal-panel__subtitle {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		margin: var(--terminal-space-1) 0 0;
+	}
+	.status-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border: var(--terminal-border-hairline);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.status-pill--ok {
+		color: var(--terminal-status-success);
+		border-color: var(--terminal-status-success);
+	}
+	.status-pill--warn {
+		color: var(--terminal-status-warn);
+		border-color: var(--terminal-status-warn);
+	}
+
+	.metrics-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: var(--terminal-space-3);
+		margin: 0 0 var(--terminal-space-3);
+	}
+	@media (min-width: 640px) {
+		.metrics-grid {
+			grid-template-columns: repeat(4, 1fr);
+		}
+	}
+	.metric {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+	}
+	.metric__label {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		margin: 0;
+	}
+	.metric__value {
+		font-size: var(--terminal-text-14);
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+		margin: 0;
+	}
+
+	.proposal-panel__cascade,
+	.proposal-panel__chart {
+		margin-bottom: var(--terminal-space-4);
+	}
+
+	.proposal-panel__diff {
+		margin-bottom: var(--terminal-space-4);
+	}
+	.proposal-panel__diff-toggle {
+		background: transparent;
+		border: none;
+		color: var(--terminal-accent-amber);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		padding: 0;
+	}
+	.proposal-panel__diff-toggle:hover,
+	.proposal-panel__diff-toggle:focus-visible {
+		text-decoration: underline;
+		outline: none;
+	}
+
+	.diff-table-wrap {
+		margin-top: var(--terminal-space-2);
+		overflow-x: auto;
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel-raised);
+	}
+	.diff-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: var(--terminal-text-11);
+		font-family: var(--terminal-font-mono);
+	}
+	.diff-table thead tr {
+		background: var(--terminal-bg-panel-sunken);
+	}
+	.diff-table th {
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		font-weight: 500;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.diff-table td {
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		border-top: var(--terminal-border-hairline);
+		height: var(--t-row-height);
+		color: var(--terminal-fg-primary);
+	}
+	.align-left {
+		text-align: left;
+	}
+	.align-right {
+		text-align: right;
+	}
+	.numeric {
+		font-variant-numeric: tabular-nums;
+	}
+	.delta-up {
+		color: var(--terminal-status-success);
+	}
+	.delta-down {
+		color: var(--terminal-status-error);
+	}
+
+	.proposal-panel__error {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-status-error);
+		margin: 0 0 var(--terminal-space-2);
+	}
+
+	.proposal-panel__footer {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--terminal-space-3);
+	}
+
+	.action {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border: var(--terminal-border-hairline);
+		background: transparent;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		transition: border-color var(--terminal-motion-tick)
+				var(--terminal-motion-easing-out),
+			color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.action:disabled {
+		color: var(--terminal-fg-disabled);
+		border-color: var(--terminal-fg-disabled);
+		cursor: not-allowed;
+	}
+	.action--ghost {
+		color: var(--terminal-fg-tertiary);
+	}
+	.action--ghost:hover:not(:disabled),
+	.action--ghost:focus-visible:not(:disabled) {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+		outline: none;
+	}
+	.action--primary {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+	.action--primary:hover:not(:disabled),
+	.action--primary:focus-visible:not(:disabled) {
+		background: var(--terminal-bg-panel-sunken);
+		outline: none;
+	}
+	.action--destructive {
+		color: var(--terminal-status-error);
+		border-color: var(--terminal-status-error);
+	}
+	.action--destructive:hover:not(:disabled),
+	.action--destructive:focus-visible:not(:disabled) {
+		background: var(--terminal-bg-panel-sunken);
+		outline: none;
+	}
+
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: var(--terminal-z-modal);
+		background: var(--terminal-bg-scrim);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: var(--terminal-space-4);
+	}
+	.modal {
+		width: 100%;
+		max-width: 480px;
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		padding: var(--terminal-space-4);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-primary);
+	}
+	.modal__title {
+		font-size: var(--terminal-text-14);
+		font-weight: 500;
+		margin: 0 0 var(--terminal-space-2);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.modal__body {
+		font-size: var(--terminal-text-12);
+		color: var(--terminal-fg-secondary);
+		margin: 0 0 var(--terminal-space-4);
+		line-height: var(--terminal-leading-normal);
+	}
+	.modal__body strong {
+		color: var(--terminal-fg-primary);
+		font-weight: inherit;
+	}
+	.modal__footer {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: var(--terminal-space-2);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/allocation/ProposalReviewPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/ProposalReviewPanel.svelte
@@ -20,14 +20,14 @@
 		readTerminalTokens,
 	} from "@investintell/ui";
 	import { CheckCircle2, AlertTriangle } from "lucide-svelte";
-	import GenericEChart from "$wealth/components/charts/GenericEChart.svelte";
+	import GenericEChart from "../../components/charts/GenericEChart.svelte";
 	import CascadeTimeline from "./CascadeTimeline.svelte";
 	import type {
 		AllocationProfile,
 		ApproveProposalRequest,
 		LatestProposalResponse,
 		StrategicAllocationBlock,
-	} from "$wealth/types/allocation-page";
+	} from "../../types/allocation-page";
 
 	interface Props {
 		profile: AllocationProfile;

--- a/packages/ii-terminal-core/src/lib/components/allocation/ProposeButton.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/ProposeButton.svelte
@@ -1,0 +1,216 @@
+<!--
+  PR-A26.3 Section E — Propose CTA panel with SSE progress.
+
+  Click → POST /propose-allocation → open SSE stream via fetch +
+  ReadableStream (never EventSource, per CLAUDE.md) → map event types
+  to human-readable progress lines → refetch latest-proposal on
+  completion. User can navigate away; the propose run completes in
+  the DB regardless.
+
+  PR-4a — the SSE stream drives a live CascadeTimeline inside the
+  progress area. The three phase entries are seeded on propose start
+  and mutated in place as ``optimizer_phase_complete`` events arrive
+  (see §G.BUILDER.4 — mutate in place, don't remount the component).
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+	import { Loader2, Wand2 } from "lucide-svelte";
+	import CascadeTimeline from "./CascadeTimeline.svelte";
+	import type {
+		AllocationProfile,
+		CascadePhaseAttempt,
+		JobCreatedResponse,
+	} from "$wealth/types/allocation-page";
+
+	interface Props {
+		profile: AllocationProfile;
+		cvarLimit: number;
+		onCompleted: () => Promise<void> | void;
+		apiPost: <T>(path: string, body?: unknown) => Promise<T>;
+		getToken: () => Promise<string>;
+		apiBase: string;
+	}
+
+	let {
+		profile,
+		cvarLimit,
+		onCompleted,
+		apiPost,
+		getToken,
+		apiBase,
+	}: Props = $props();
+
+	const LIVE_PHASES: readonly string[] = [
+		"phase_1_ru_max_return",
+		"phase_2_ru_robust",
+		"phase_3_min_cvar",
+	];
+
+	function seedPhases(): CascadePhaseAttempt[] {
+		return LIVE_PHASES.map((phase) => ({
+			phase,
+			status: "pending",
+			solver: null,
+			wall_ms: 0,
+			objective_value: null,
+			cvar_within_limit: null,
+		}));
+	}
+
+	let running = $state(false);
+	let statusText = $state("");
+	let errorMsg = $state<string | null>(null);
+	let livePhases = $state<CascadePhaseAttempt[]>([]);
+
+	const EVENT_LABELS: Record<string, string> = {
+		propose_started: "Preparing universe…",
+		optimizer_started: "Optimizing…",
+		optimizer_phase_complete: "Optimizer phase complete",
+		propose_ready: "Proposal ready",
+		propose_cvar_infeasible: "Proposal ready (CVaR infeasible)",
+		completed: "Finalizing…",
+	};
+
+	function applyPhaseEvent(rawPayload: string): void {
+		if (!rawPayload) return;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(rawPayload);
+		} catch {
+			return;
+		}
+		if (!parsed || typeof parsed !== "object") return;
+		const record = parsed as Record<string, unknown>;
+		const phase = typeof record.phase === "string" ? record.phase : null;
+		const status = typeof record.status === "string" ? record.status : null;
+		if (!phase || !status) return;
+		const idx = livePhases.findIndex((p) => p.phase === phase);
+		if (idx === -1) return;
+		livePhases[idx] = {
+			...livePhases[idx]!,
+			status,
+			objective_value:
+				typeof record.objective_value === "number"
+					? record.objective_value
+					: livePhases[idx]!.objective_value,
+		};
+	}
+
+	async function streamProgress(sseUrl: string): Promise<void> {
+		const token = await getToken();
+		const absolute = sseUrl.startsWith("http")
+			? sseUrl
+			: new URL(sseUrl.replace(/^\//, ""), apiBase.replace(/\/$/, "") + "/").toString();
+		const resp = await fetch(absolute, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "text/event-stream",
+			},
+		});
+		if (!resp.ok || !resp.body) {
+			throw new Error(`SSE stream failed (${resp.status})`);
+		}
+
+		const reader = resp.body.getReader();
+		const decoder = new TextDecoder();
+		let buffer = "";
+
+		while (running) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+			const lines = buffer.split(/\n\n/);
+			buffer = lines.pop() ?? "";
+			for (const chunk of lines) {
+				let eventName = "message";
+				const dataLines: string[] = [];
+				for (const line of chunk.split("\n")) {
+					if (line.startsWith("event:")) eventName = line.slice(6).trim();
+					else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+				}
+				const label = EVENT_LABELS[eventName];
+				if (label) statusText = label;
+				if (eventName === "optimizer_phase_complete") {
+					applyPhaseEvent(dataLines.join("\n"));
+				}
+				if (
+					eventName === "completed" ||
+					eventName === "propose_ready" ||
+					eventName === "propose_cvar_infeasible"
+				) {
+					try {
+						reader.cancel();
+					} catch {
+						/* noop */
+					}
+					return;
+				}
+				if (eventName === "error" || eventName === "failed") {
+					const payload = dataLines.join("\n");
+					throw new Error(payload || "Propose failed");
+				}
+			}
+		}
+	}
+
+	async function propose(): Promise<void> {
+		running = true;
+		errorMsg = null;
+		statusText = "Starting…";
+		livePhases = seedPhases();
+		try {
+			const resp = await apiPost<JobCreatedResponse>(
+				`/portfolio/profiles/${profile}/propose-allocation`,
+				{},
+			);
+			await streamProgress(resp.sse_url);
+			statusText = "Proposal complete";
+			await onCompleted();
+		} catch (err) {
+			errorMsg = err instanceof Error ? err.message : "Propose failed";
+		} finally {
+			running = false;
+		}
+	}
+</script>
+
+<section class="rounded-lg border border-border bg-card p-5">
+	<div class="flex items-start gap-3 mb-3">
+		<span class="p-2 rounded-md bg-primary/10 text-primary">
+			<Wand2 class="w-4 h-4" />
+		</span>
+		<div>
+			<h2 class="text-base font-medium text-foreground">Generate New Proposal</h2>
+			<p class="text-sm text-muted-foreground mt-1">
+				The optimizer will propose a CVaR-optimal allocation given your current
+				<strong>{formatPercent(cvarLimit)}</strong> risk limit and any active overrides.
+			</p>
+		</div>
+	</div>
+
+	<button
+		type="button"
+		class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
+		onclick={() => void propose()}
+		disabled={running}
+	>
+		{#if running}
+			<Loader2 class="w-4 h-4 animate-spin" />
+			<span>Proposing…</span>
+		{:else}
+			<span>Propose Allocation</span>
+		{/if}
+	</button>
+
+	{#if running || statusText}
+		<p class="mt-3 text-xs text-muted-foreground">{statusText}</p>
+	{/if}
+	{#if livePhases.length > 0}
+		<div class="mt-3">
+			<CascadeTimeline phases={livePhases} mode="live" />
+		</div>
+	{/if}
+	{#if errorMsg}
+		<p class="mt-2 text-xs text-destructive">{errorMsg}</p>
+	{/if}
+</section>

--- a/packages/ii-terminal-core/src/lib/components/allocation/ProposeButton.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/ProposeButton.svelte
@@ -20,7 +20,7 @@
 		AllocationProfile,
 		CascadePhaseAttempt,
 		JobCreatedResponse,
-	} from "$wealth/types/allocation-page";
+	} from "../../types/allocation-page";
 
 	interface Props {
 		profile: AllocationProfile;

--- a/packages/ii-terminal-core/src/lib/components/allocation/RegimeContextStrip.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/RegimeContextStrip.svelte
@@ -1,0 +1,91 @@
+<!--
+  RegimeContextStrip.svelte
+  =========================
+
+  Read-only regime context for the allocation page. Renders the current
+  global regime + stress score as two pills. The macro regime window is
+  not exposed by ``GET /macro/regime`` (GlobalRegimeRead has no ``window``
+  field) so it is intentionally omitted; keep this component honest.
+
+  Data arrives via the page loader (``+page.server.ts``) fetching
+  ``/macro/regime`` in parallel; null when the endpoint is unavailable
+  (404 when the regime_detection worker has never run, transient 5xx)
+  and the component renders nothing so it never blocks page load.
+
+  Source: docs/plans/2026-04-19-netz-terminal-parity-builder-macro-screener.md §B.8.
+-->
+<script lang="ts">
+	import { TerminalPill, formatPercent } from "@investintell/ui";
+
+	interface RegimeContextStripData {
+		regime: string | null;
+		stressScore: number | null;
+	}
+
+	interface Props {
+		data: RegimeContextStripData | null;
+		class?: string;
+	}
+
+	let { data, class: className }: Props = $props();
+
+	function regimeTone(regime: string | null): "neutral" | "success" | "warn" | "error" {
+		if (!regime) return "neutral";
+		const upper = regime.toUpperCase();
+		if (upper.includes("CRISIS") || upper.includes("RISK_OFF")) return "error";
+		if (upper.includes("CAUTION") || upper.includes("TRANSITION")) return "warn";
+		if (upper.includes("RISK_ON") || upper.includes("EXPANSION")) return "success";
+		return "neutral";
+	}
+
+	function stressTone(
+		score: number | null,
+	): "neutral" | "success" | "warn" | "error" {
+		if (score === null) return "neutral";
+		if (score >= 0.75) return "error";
+		if (score >= 0.5) return "warn";
+		if (score >= 0.25) return "neutral";
+		return "success";
+	}
+</script>
+
+{#if data && data.regime}
+	<div class="regime-context-strip {className ?? ''}" role="group" aria-label="Macro regime context">
+		<span class="regime-context-strip__label">MACRO CONTEXT</span>
+		<div class="regime-context-strip__pills">
+			<TerminalPill
+				label={`Regime: ${data.regime}`}
+				tone={regimeTone(data.regime)}
+				size="xs"
+			/>
+			{#if data.stressScore !== null}
+				<TerminalPill
+					label={`Stress: ${formatPercent(data.stressScore)}`}
+					tone={stressTone(data.stressScore)}
+					size="xs"
+				/>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.regime-context-strip {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding: var(--terminal-space-2) 0;
+		font-family: var(--terminal-font-mono);
+	}
+	.regime-context-strip__label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+	.regime-context-strip__pills {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--terminal-space-2);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/allocation/StrategicAllocationTable.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/StrategicAllocationTable.svelte
@@ -13,7 +13,7 @@
 <script lang="ts">
 	import { formatPercent } from "@investintell/ui";
 	import { Pencil } from "lucide-svelte";
-	import type { StrategicAllocationBlock } from "$wealth/types/allocation-page";
+	import type { StrategicAllocationBlock } from "../../types/allocation-page";
 
 	interface Props {
 		blocks: StrategicAllocationBlock[];

--- a/packages/ii-terminal-core/src/lib/components/allocation/StrategicAllocationTable.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/StrategicAllocationTable.svelte
@@ -1,0 +1,170 @@
+<!--
+  PR-A26.3 Section C — Strategic Allocation table.
+
+  18 rows × 5 cols per feedback_datagrid_vs_viewer (4-6 cols max). Row
+  clicks are inert (no drill-down in v1); Edit Override emits an event
+  the page handler wires to the modal.
+
+  PR-4b — terminal-density re-skin. All colors pulled from
+  ``--terminal-*`` custom properties; row heights respect
+  ``[data-density]`` via ``--t-row-height``. No cursor:pointer on
+  data cells (§G.BUILDER.3) — only the Edit affordance is interactive.
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+	import { Pencil } from "lucide-svelte";
+	import type { StrategicAllocationBlock } from "$wealth/types/allocation-page";
+
+	interface Props {
+		blocks: StrategicAllocationBlock[];
+		onEditOverride: (block: StrategicAllocationBlock) => void;
+	}
+	let { blocks, onEditOverride }: Props = $props();
+
+	function rangeLabel(lo: number | null, hi: number | null): string {
+		if (lo === null && hi === null) return "—";
+		const lStr = lo !== null ? formatPercent(lo) : "—";
+		const hStr = hi !== null ? formatPercent(hi) : "—";
+		return `${lStr} – ${hStr}`;
+	}
+</script>
+
+<div class="strategic-allocation">
+	<table>
+		<thead>
+			<tr>
+				<th class="align-left">Asset Class</th>
+				<th class="align-right">
+					<span title="Approved target weight from last IPS approval.">Target</span>
+				</th>
+				<th class="align-right">
+					<span title="Tolerance before rebalance triggers.">Drift Band</span>
+				</th>
+				<th class="align-right">
+					<span title="Operator-set constraint for the next proposal.">Override</span>
+				</th>
+				<th class="align-right">Actions</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each blocks as block (block.block_id)}
+				<tr class:excluded={block.excluded_from_portfolio}>
+					<td class="align-left name">
+						<div class="name-cell">
+							<span>{block.block_name}</span>
+							{#if block.excluded_from_portfolio}
+								<span class="excluded-pill">Excluded</span>
+							{/if}
+						</div>
+					</td>
+					<td class="align-right numeric">
+						{block.target_weight !== null
+							? formatPercent(block.target_weight)
+							: "—"}
+					</td>
+					<td class="align-right numeric muted">
+						{rangeLabel(block.drift_min, block.drift_max)}
+					</td>
+					<td class="align-right numeric muted">
+						{rangeLabel(block.override_min, block.override_max)}
+					</td>
+					<td class="align-right">
+						<button
+							type="button"
+							class="edit-btn"
+							onclick={() => onEditOverride(block)}
+							title="Edit override for this block"
+							aria-label="Edit override for {block.block_name}"
+						>
+							<Pencil class="w-3 h-3" />
+							<span>Edit</span>
+						</button>
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>
+
+<style>
+	.strategic-allocation {
+		overflow-x: auto;
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel-raised);
+	}
+	table {
+		width: 100%;
+		border-collapse: collapse;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-12);
+	}
+	thead tr {
+		background: var(--terminal-bg-panel-sunken);
+	}
+	thead th {
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		font-weight: 500;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.align-left {
+		text-align: left;
+	}
+	.align-right {
+		text-align: right;
+	}
+	tbody tr {
+		border-top: var(--terminal-border-hairline);
+		height: var(--t-row-height);
+	}
+	tbody tr.excluded {
+		opacity: 0.5;
+	}
+	tbody td {
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		color: var(--terminal-fg-primary);
+		line-height: var(--terminal-leading-tight);
+	}
+	.numeric {
+		font-variant-numeric: tabular-nums;
+	}
+	.muted {
+		color: var(--terminal-fg-tertiary);
+	}
+	.name-cell {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+	.excluded-pill {
+		font-size: var(--terminal-text-10);
+		padding: 0 var(--terminal-space-2);
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.edit-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border: var(--terminal-border-hairline);
+		background: transparent;
+		color: var(--terminal-accent-amber);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		transition: border-color var(--terminal-motion-tick)
+			var(--terminal-motion-easing-out);
+	}
+	.edit-btn:hover,
+	.edit-btn:focus-visible {
+		border-color: var(--terminal-accent-amber);
+		outline: none;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/allocation/types.ts
+++ b/packages/ii-terminal-core/src/lib/components/allocation/types.ts
@@ -1,0 +1,17 @@
+export type BlockInstrument = {
+	ticker: string;
+	name: string;
+	weight: number;
+};
+
+export type BlockMeta = {
+	block_id: string;
+	display_name: string;
+	geography: string;
+	asset_class: string;
+};
+
+export type AllocationRow = {
+	block_id: string;
+	weight: number;
+};

--- a/packages/ii-terminal-core/src/lib/components/analytics/entity/EntityAnalyticsVitrine.svelte
+++ b/packages/ii-terminal-core/src/lib/components/analytics/entity/EntityAnalyticsVitrine.svelte
@@ -2,7 +2,7 @@
 	import { getContext, onMount } from "svelte";
 	import { formatNumber } from "@investintell/ui";
 	import { ChartContainer } from "@investintell/ui/charts";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../../api/client";
 	import ScoreCompositionPanel from "./ScoreCompositionPanel.svelte";
 
 	interface Props {

--- a/packages/ii-terminal-core/src/lib/components/analytics/entity/EntityAnalyticsVitrine.svelte
+++ b/packages/ii-terminal-core/src/lib/components/analytics/entity/EntityAnalyticsVitrine.svelte
@@ -1,0 +1,512 @@
+<script lang="ts">
+	import { getContext, onMount } from "svelte";
+	import { formatNumber } from "@investintell/ui";
+	import { ChartContainer } from "@investintell/ui/charts";
+	import { createClientApiClient } from "$wealth/api/client";
+	import ScoreCompositionPanel from "./ScoreCompositionPanel.svelte";
+
+	interface Props {
+		id: string;
+	}
+
+	let { id }: Props = $props();
+
+	// Component State
+	let data = $state<any>(null);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	// Auth-aware API client — fixes X2 smoke regression where the
+	// terminal app (different dev port) hit its own origin on a
+	// relative /api/v1 path and 404'd. api-client resolves against
+	// VITE_API_BASE_URL and attaches the Clerk bearer token.
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	// Fetch Data
+	$effect(() => {
+		if (!id) return;
+		loading = true;
+		error = null;
+
+		api
+			.get<any>(`/wealth/entity-analytics/${id}`)
+			.then(d => {
+				data = d;
+				loading = false;
+			})
+			.catch(e => {
+				error = e instanceof Error ? e.message : String(e);
+				loading = false;
+			});
+	});
+
+	// Formatting helper
+	function f(val: number | null | undefined, fmt: 'percent' | 'decimal' | 'bps' = 'decimal', decimals = 2) {
+		if (val == null) return "-";
+		if (fmt === 'percent') return formatNumber(val * 100, decimals) + "%";
+		if (fmt === 'bps') return formatNumber(val * 10000, 0);
+		return formatNumber(val, decimals);
+	}
+
+	function f_mil(val: number | null | undefined): string {
+		if (val == null) return "-";
+		return formatNumber(val / 1000000, 2);
+	}
+
+	// Base ECharts Configuration — cinematic reactor animation
+	const baseChartOptions = {
+		backgroundColor: "transparent",
+		animation: true,
+		animationDuration: 1500,
+		animationEasing: "cubicOut",
+		animationDelay: (idx: number) => idx * 10,
+		grid: { top: "10%", bottom: "10%", left: "10%", right: "5%" },
+		tooltip: {
+			trigger: "axis",
+			axisPointer: { type: "cross", crossStyle: { color: "#666" } },
+			backgroundColor: "#000",
+			borderColor: "#333",
+			borderWidth: 1,
+			textStyle: { fontFamily: "monospace", fontSize: 11, color: "#fff" },
+			borderRadius: 0,
+		},
+		textStyle: { fontFamily: "monospace" },
+		xAxis: {
+			axisLabel: { fontFamily: "monospace", fontSize: 10, color: "#9ca3af" },
+			splitLine: { show: true, lineStyle: { type: "dashed", color: "#333", width: 1 } },
+			axisLine: { lineStyle: { color: "#444" } }
+		},
+		yAxis: {
+			axisLabel: { fontFamily: "monospace", fontSize: 10, color: "#9ca3af" },
+			splitLine: { show: true, lineStyle: { type: "dashed", color: "#333", width: 1 } },
+			axisLine: { lineStyle: { color: "#444" } }
+		}
+	};
+
+	// Drawdown Analysis Options
+	let drawdownOption = $derived.by(() => {
+		if (!data?.drawdown?.series) return null;
+		return {
+			...baseChartOptions,
+			xAxis: { ...baseChartOptions.xAxis, type: "category", data: data.drawdown.dates || [] },
+			yAxis: { ...baseChartOptions.yAxis, type: "value", max: 0 },
+			series: [{
+				type: "line",
+				data: data.drawdown.series,
+				areaStyle: { color: "rgba(220, 38, 38, 0.2)" }, // Red translucent
+				lineStyle: { color: "#dc2626", width: 1 },
+				symbol: "none",
+				step: false
+			}]
+		};
+	});
+
+	// Capture Ratios Options
+	let captureOption = $derived.by(() => {
+		if (!data?.capture?.down || !data?.capture?.up) return null;
+		return {
+			...baseChartOptions,
+			tooltip: {
+				...baseChartOptions.tooltip,
+				trigger: "item",
+				formatter: (p: any) => `Down: ${p.value[0]}<br/>Up: ${p.value[1]}`
+			},
+			xAxis: { ...baseChartOptions.xAxis, type: "value", name: "Down Capture", nameLocation: "middle", nameGap: 20, nameTextStyle: { fontSize: 10, fontFamily: "monospace" } },
+			yAxis: { ...baseChartOptions.yAxis, type: "value", name: "Up Capture", nameLocation: "middle", nameGap: 30, nameTextStyle: { fontSize: 10, fontFamily: "monospace" } },
+			series: [
+				{
+					type: "scatter",
+					data: [[data.capture.down, data.capture.up]],
+					symbolSize: 8,
+					itemStyle: { color: "#fff" }
+				},
+				{
+					type: "line",
+					data: [[0, 0], [200, 200]],
+					lineStyle: { color: "#555", type: "dashed", width: 1 },
+					symbol: "none",
+					silent: true
+				}
+			]
+		};
+	});
+
+	// Rolling Returns Options
+	let rollingOption = $derived.by(() => {
+		if (!data?.rolling) return null;
+		return {
+			...baseChartOptions,
+			legend: { show: true, textStyle: { color: "#fff", fontFamily: "monospace", fontSize: 10 }, icon: "rect" },
+			xAxis: { ...baseChartOptions.xAxis, type: "category", data: data.rolling.dates || [] },
+			yAxis: { ...baseChartOptions.yAxis, type: "value" },
+			series: [
+				{ name: "3m", type: "line", data: data.rolling.series_3m, smooth: false, symbol: "none", lineStyle: { width: 1 } },
+				{ name: "6m", type: "line", data: data.rolling.series_6m, smooth: false, symbol: "none", lineStyle: { width: 1 } },
+				{ name: "1y", type: "line", data: data.rolling.series_1y, smooth: false, symbol: "none", lineStyle: { width: 1 } }
+			]
+		};
+	});
+
+	// Return Distribution Options
+	let distributionOption = $derived.by(() => {
+		if (!data?.distribution) return null;
+		return {
+			...baseChartOptions,
+			xAxis: { ...baseChartOptions.xAxis, type: "category", data: data.distribution.bins || [] },
+			yAxis: { ...baseChartOptions.yAxis, type: "value" },
+			series: [{
+				type: "bar",
+				data: data.distribution.frequencies || [],
+				itemStyle: { color: "#4b5563", borderRadius: 0 },
+				markLine: {
+					symbol: "none",
+					data: [
+						{ xAxis: data.distribution.var_95?.toString() || "", lineStyle: { color: "#ef4444", type: "solid" }, label: { formatter: "VaR", color: "#ef4444", fontSize: 9 } },
+						{ xAxis: data.distribution.cvar_95?.toString() || "", lineStyle: { color: "#b91c1c", type: "dashed" }, label: { formatter: "CVaR", color: "#b91c1c", fontSize: 9 } }
+					]
+				}
+			}]
+		};
+	});
+
+</script>
+
+<div class="vitrine-wrapper">
+	<!-- TAIL RISK STRIP (Header) -->
+	<header class="tail-strip">
+		<div class="strip-item">
+			<span class="label">STARR</span>
+			<span class="value">{f(data?.tail?.starr, 'decimal', 3)}</span>
+		</div>
+		<div class="strip-item">
+			<span class="label">Rachev Ratio</span>
+			<span class="value">{f(data?.tail?.rachev, 'decimal', 3)}</span>
+		</div>
+		<div class="strip-item">
+			<span class="label">ETL 95%</span>
+			<span class="value">{f(data?.tail?.etl_95, 'percent', 2)}</span>
+		</div>
+		<div class="strip-item">
+			<span class="label">JB p-value</span>
+			<span class="value">{f(data?.tail?.jb_p_value, 'decimal', 4)}</span>
+		</div>
+	</header>
+
+	{#if loading}
+		<div class="status-box">LOADING ENTITY DNA...</div>
+	{:else if error}
+		<div class="status-box text-red-500">ERR: {error}</div>
+	{:else}
+		<main class="grid-layout">
+
+			<!-- 0. Score Composition (first module — answers "is this fund good and WHY") -->
+			<ScoreCompositionPanel {id} />
+
+			<!-- 1. Risk Statistics Table -->
+			<section class="module">
+				<h2 class="module-title">RISK STATISTICS</h2>
+				<table class="data-table">
+					<tbody>
+						<tr><td>Beta</td><td class="num">{f(data?.risk?.beta)}</td></tr>
+						<tr><td>Alpha</td><td class="num">{f(data?.risk?.alpha, 'bps')} bps</td></tr>
+						<tr><td>Tracking Error</td><td class="num">{f(data?.risk?.tracking_error, 'percent')}</td></tr>
+						<tr><td>Calmar Ratio</td><td class="num">{f(data?.risk?.calmar)}</td></tr>
+						<tr><td>Sharpe Ratio</td><td class="num">{f(data?.risk?.sharpe)}</td></tr>
+						<tr><td>Sortino Ratio</td><td class="num">{f(data?.risk?.sortino)}</td></tr>
+					</tbody>
+				</table>
+			</section>
+
+			<!-- 2. Drawdown Analysis -->
+			<section class="module">
+				<h2 class="module-title">UNDERWATER DRAWDOWN</h2>
+				<div class="chart-wrapper">
+					{#if drawdownOption}
+						<ChartContainer option={drawdownOption} height={150} ariaLabel="Drawdown Chart" />
+					{:else}
+						<div class="empty-state">-</div>
+					{/if}
+				</div>
+				<table class="data-table mt-2">
+					<thead>
+						<tr><th>Depth</th><th>Duration</th><th>Recovery</th></tr>
+					</thead>
+					<tbody>
+						{#each (data?.drawdown?.worst_periods || []).slice(0,3) as period}
+							<tr>
+								<td class="num">{f(period.depth, 'percent')}</td>
+								<td class="num">{period.duration || "-"}d</td>
+								<td class="num">{period.recovery || "-"}d</td>
+							</tr>
+						{/each}
+						{#if !data?.drawdown?.worst_periods?.length}
+							<tr><td colspan="3" class="text-center">-</td></tr>
+						{/if}
+					</tbody>
+				</table>
+			</section>
+
+			<!-- 3. Capture Ratios -->
+			<section class="module">
+				<h2 class="module-title">CAPTURE RATIOS</h2>
+				<div class="chart-wrapper">
+					{#if captureOption}
+						<ChartContainer option={captureOption} height={200} ariaLabel="Capture Ratios Scatter" />
+					{:else}
+						<div class="empty-state">-</div>
+					{/if}
+				</div>
+			</section>
+
+			<!-- 4. Rolling Returns -->
+			<section class="module">
+				<h2 class="module-title">ROLLING RETURNS</h2>
+				<div class="chart-wrapper">
+					{#if rollingOption}
+						<ChartContainer option={rollingOption} height={200} ariaLabel="Rolling Returns Chart" />
+					{:else}
+						<div class="empty-state">-</div>
+					{/if}
+				</div>
+			</section>
+
+			<!-- 5. Return Distribution -->
+			<section class="module">
+				<h2 class="module-title">RETURN DISTRIBUTION</h2>
+				<div class="chart-wrapper">
+					{#if distributionOption}
+						<ChartContainer option={distributionOption} height={200} ariaLabel="Return Distribution Histogram" />
+					{:else}
+						<div class="empty-state">-</div>
+					{/if}
+				</div>
+			</section>
+
+			<!-- 6. eVestment Statistics -->
+			<section class="module evestment">
+				<h2 class="module-title">EVESTMENT GRID</h2>
+				<div class="ev-grid">
+					<div class="ev-group">
+						<div class="ev-group-title">Absolute Return</div>
+						<div class="ev-row"><span>Ann. Return</span><span class="num">{f(data?.evestment?.abs_return?.annualized, 'percent')}</span></div>
+						<div class="ev-row"><span>Best Month</span><span class="num">{f(data?.evestment?.abs_return?.best_month, 'percent')}</span></div>
+					</div>
+					<div class="ev-group">
+						<div class="ev-group-title">Absolute Risk</div>
+						<div class="ev-row"><span>Ann. Risk</span><span class="num">{f(data?.evestment?.abs_risk?.annualized, 'percent')}</span></div>
+						<div class="ev-row"><span>Max Drawdown</span><span class="num">{f(data?.evestment?.abs_risk?.max_dd, 'percent')}</span></div>
+					</div>
+					<div class="ev-group">
+						<div class="ev-group-title">Risk-Adjusted</div>
+						<div class="ev-row"><span>Info Ratio</span><span class="num">{f(data?.evestment?.risk_adj?.info_ratio)}</span></div>
+						<div class="ev-row"><span>Treynor</span><span class="num">{f(data?.evestment?.risk_adj?.treynor)}</span></div>
+					</div>
+					<div class="ev-group">
+						<div class="ev-group-title">Proficiency & Regr.</div>
+						<div class="ev-row"><span>Up/Down Ratio</span><span class="num">{f(data?.evestment?.proficiency?.up_down_ratio)}</span></div>
+						<div class="ev-row"><span>R-Squared</span><span class="num">{f(data?.evestment?.regression?.r_squared)}</span></div>
+					</div>
+				</div>
+			</section>
+
+			<!-- 7. Alternative Data: Insider Sentiment -->
+			<section class="module">
+				<h2 class="module-title">[ ALTERNATIVE DATA: INSIDER SENTIMENT ]</h2>
+				<div class="flex-1 flex flex-col justify-center items-center gap-4 py-4 h-full min-h-[150px]">
+					{#if !data?.insider_data || data?.insider_data?.insider_sentiment_score === 50.0 || data?.insider_data?.insider_sentiment_score == null}
+						<span class="text-gray-500 font-mono text-center">NO MATERIAL INSIDER ACTIVITY</span>
+					{:else}
+						{@const score = data.insider_data.insider_sentiment_score}
+						{#if score < 40}
+							<span class="text-[#ef4444] font-mono animate-pulse text-center">[ HEAVY DISTRIBUTION ]</span>
+						{:else if score > 60}
+							<span class="text-[#22c55e] font-mono text-center">[ ACCUMULATION ]</span>
+						{:else}
+							<span class="text-gray-300 font-mono text-center">[ NEUTRAL FLOW ]</span>
+						{/if}
+						<div class="w-full flex flex-col gap-2 mt-4 text-xs font-mono" style="max-width: 200px;">
+							<div class="flex justify-between border-b border-dotted border-[#222] pb-1">
+								<span class="text-gray-500">BUY VOL:</span>
+								<span class="text-gray-300 text-right w-24">$ {f_mil(data.insider_data.insider_summary?.buy_value)} M</span>
+							</div>
+							<div class="flex justify-between">
+								<span class="text-gray-500">SELL VOL:</span>
+								<span class="text-gray-300 text-right w-24">$ {f_mil(data.insider_data.insider_summary?.sell_value)} M</span>
+							</div>
+						</div>
+					{/if}
+				</div>
+			</section>
+
+		</main>
+	{/if}
+</div>
+
+<style>
+	/* Brutalist Design System - Financial Quant */
+	.vitrine-wrapper {
+		background-color: #000;
+		color: #e5e7eb;
+		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+		font-size: 0.75rem; /* text-xs */
+		display: flex;
+		flex-direction: column;
+		border: 1px solid #333;
+	}
+
+	.tail-strip {
+		display: flex;
+		flex-wrap: wrap;
+		border-bottom: 1px solid #333;
+		background-color: #0a0a0a;
+	}
+
+	.strip-item {
+		flex: 1;
+		min-width: 120px;
+		display: flex;
+		flex-direction: column;
+		padding: 8px 12px;
+		border-right: 1px solid #333;
+	}
+
+	.strip-item:last-child {
+		border-right: none;
+	}
+
+	.strip-item .label {
+		color: #6b7280;
+		text-transform: uppercase;
+		font-size: 0.65rem;
+		letter-spacing: 0.05em;
+	}
+
+	.strip-item .value {
+		font-size: 0.875rem; /* text-sm */
+		font-weight: 700;
+		color: #f3f4f6;
+		margin-top: 2px;
+	}
+
+	.status-box {
+		padding: 24px;
+		text-align: center;
+		color: #9ca3af;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
+
+	/* CSS Grid responsive with 1px gap acting as hard borders */
+	.grid-layout {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 1px;
+		background-color: #333; /* border color */
+	}
+
+	@media (min-width: 768px) {
+		.grid-layout { grid-template-columns: repeat(2, 1fr); }
+	}
+
+	@media (min-width: 1280px) {
+		.grid-layout { grid-template-columns: repeat(3, 1fr); }
+	}
+
+	.module {
+		background-color: #000;
+		padding: 16px;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.module-title {
+		font-size: 0.7rem;
+		font-weight: 700;
+		color: #9ca3af;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin-bottom: 12px;
+		border-bottom: 1px solid #222;
+		padding-bottom: 4px;
+	}
+
+	.data-table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	.data-table th, .data-table td {
+		padding: 6px 0;
+		border-bottom: 1px solid #111;
+		color: #d1d5db;
+	}
+
+	.data-table th {
+		text-align: left;
+		color: #6b7280;
+		font-weight: normal;
+		font-size: 0.65rem;
+		text-transform: uppercase;
+	}
+
+	.data-table .num {
+		text-align: right;
+	}
+
+	.data-table tbody tr:last-child td {
+		border-bottom: none;
+	}
+
+	.chart-wrapper {
+		flex: 1;
+		min-height: 150px;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+	}
+
+	.empty-state {
+		text-align: center;
+		color: #4b5563;
+	}
+
+	/* eVestment Grid */
+	.ev-grid {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	.ev-group-title {
+		color: #6b7280;
+		font-size: 0.65rem;
+		text-transform: uppercase;
+		margin-bottom: 4px;
+	}
+
+	.ev-row {
+		display: flex;
+		justify-content: space-between;
+		padding: 4px 0;
+		border-bottom: 1px dotted #222;
+	}
+	
+	.ev-row:last-child {
+		border-bottom: none;
+	}
+
+	.ev-row .num {
+		text-align: right;
+		color: #d1d5db;
+	}
+
+	.mt-2 { margin-top: 8px; }
+	.text-center { text-align: center; }
+	.text-red-500 { color: #ef4444; }
+
+	/* Spanning rules for larger items if needed */
+	.evestment {
+		grid-row: span 2;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/charts/GenericEChart.svelte
+++ b/packages/ii-terminal-core/src/lib/components/charts/GenericEChart.svelte
@@ -1,0 +1,41 @@
+<!--
+  Generic ECharts Wrapper — Uses bundled echarts from @investintell/ui.
+  Handles init, reactive option updates, resize, and cleanup.
+-->
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { echarts } from '@investintell/ui/charts/echarts-setup';
+
+    let { options, height = 400, theme = 'light' } = $props();
+
+    let chartDom: HTMLElement;
+    let chartInstance: ReturnType<typeof echarts.init> | null = null;
+
+    $effect(() => {
+        if (chartDom && options) {
+            if (!chartInstance) {
+                chartInstance = echarts.init(chartDom, theme, { renderer: 'svg' });
+            }
+            chartInstance.setOption(options, true);
+        }
+    });
+
+    onMount(() => {
+        const resizeHandler = () => {
+            chartInstance?.resize();
+        };
+        window.addEventListener('resize', resizeHandler);
+
+        return () => {
+            window.removeEventListener('resize', resizeHandler);
+            chartInstance?.dispose();
+            chartInstance = null;
+        };
+    });
+</script>
+
+<div
+    bind:this={chartDom}
+    style:height="{height}px"
+    style:width="100%"
+></div>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/AchievableReturnBandChart.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/AchievableReturnBandChart.svelte
@@ -1,0 +1,159 @@
+<!--
+  AchievableReturnBandChart — PR-A13 presentational chart that shows the
+  two-point achievable return band (lower / upper) produced by the RU CVaR
+  cascade (PR-A12). The vertical dashed marker sits at the operator's
+  current CVaR limit; the shaded x-axis area (0 → min_achievable_cvar)
+  marks the universe's infeasible region.
+
+  Institutional UX discipline:
+    - No inline hex literals; colours resolved from @netz/ui CSS
+      custom properties via getComputedStyle (ECharts cannot parse
+      var(--…)).
+    - Fixed pixel height — Layout Cage pattern (feedback_layout_cage_pattern.md).
+      Parent must not rely on ``height: 100%``.
+    - Empty-band fallback renders a placeholder div at the same height so
+      the panel doesn't reflow when a band is not yet available.
+-->
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { formatPercent } from "@investintell/ui";
+	import GenericEChart from "$wealth/components/charts/GenericEChart.svelte";
+	import type { AchievableReturnBand } from "$wealth/types/cascade-telemetry";
+
+	interface Props {
+		band: AchievableReturnBand | null;
+		cvarLimit: number;
+		minAchievableCvar: number | null;
+		height?: number;
+	}
+
+	let { band, cvarLimit, minAchievableCvar, height = 220 }: Props = $props();
+
+	// Resolve tokens once on mount — ECharts options must receive concrete
+	// colour strings. Re-reading on every $derived would bust the cache.
+	let tokens = $state({ primary: "", warning: "", border: "", muted: "" });
+
+	onMount(() => {
+		const cs = getComputedStyle(document.documentElement);
+		tokens = {
+			primary: cs.getPropertyValue("--terminal-accent-amber").trim() || "#d19a2f",
+			warning: cs.getPropertyValue("--terminal-status-warning").trim() || "#c29840",
+			border: cs.getPropertyValue("--terminal-fg-muted").trim() || "#888888",
+			muted: cs.getPropertyValue("--terminal-fg-secondary").trim() || "#b8b8b8",
+		};
+	});
+
+	const chartOptions = $derived.by(() => {
+		if (!band) return null;
+		const series: unknown[] = [
+			{
+				type: "line",
+				name: "Achievable band",
+				showSymbol: true,
+				symbolSize: 10,
+				data: [
+					[band.lower_at_cvar, band.lower],
+					[band.upper_at_cvar, band.upper],
+				],
+				lineStyle: { color: tokens.primary, width: 2 },
+				itemStyle: { color: tokens.primary },
+			},
+			{
+				type: "line",
+				data: [],
+				markLine: {
+					symbol: "none",
+					silent: true,
+					lineStyle: { color: tokens.warning, type: "dashed", width: 1 },
+					label: {
+						formatter: formatPercent(cvarLimit, 2),
+						color: tokens.warning,
+					},
+					data: [{ xAxis: cvarLimit }],
+				},
+			},
+		];
+		if (minAchievableCvar !== null && minAchievableCvar > 0) {
+			series.push({
+				type: "line",
+				data: [],
+				markArea: {
+					silent: true,
+					itemStyle: { color: tokens.border, opacity: 0.12 },
+					data: [[{ xAxis: 0 }, { xAxis: minAchievableCvar }]],
+				},
+			});
+		}
+		return {
+			grid: { left: 56, right: 16, top: 16, bottom: 36, containLabel: true },
+			xAxis: {
+				type: "value",
+				name: "Tail loss (95% CVaR)",
+				nameLocation: "middle",
+				nameGap: 24,
+				nameTextStyle: { color: tokens.muted, fontSize: 11 },
+				axisLabel: {
+					formatter: (v: number) => formatPercent(v, 1),
+					color: tokens.muted,
+					fontSize: 10,
+				},
+				axisLine: { lineStyle: { color: tokens.border } },
+				splitLine: { show: false },
+			},
+			yAxis: {
+				type: "value",
+				name: "Expected return",
+				nameTextStyle: { color: tokens.muted, fontSize: 11 },
+				axisLabel: {
+					formatter: (v: number) => formatPercent(v, 1),
+					color: tokens.muted,
+					fontSize: 10,
+				},
+				axisLine: { lineStyle: { color: tokens.border } },
+				splitLine: { lineStyle: { color: tokens.border, opacity: 0.25 } },
+			},
+			tooltip: {
+				trigger: "axis",
+				axisPointer: { type: "cross" },
+				formatter: (params: unknown) => {
+					const arr = params as Array<{ value: [number, number] }>;
+					const first = arr?.[0];
+					if (!first) return "";
+					const [x, y] = first.value;
+					return `Tail loss ${formatPercent(x, 2)}<br/>Return ${formatPercent(y, 2)}`;
+				},
+			},
+			series,
+		};
+	});
+</script>
+
+<div class="arbc-root" style:height="{height}px">
+	{#if band && chartOptions}
+		<GenericEChart options={chartOptions} {height} />
+	{:else}
+		<div class="arbc-empty" role="status">
+			<p class="arbc-empty__msg">Run a construction to see the achievable return band.</p>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.arbc-root {
+		width: 100%;
+	}
+	.arbc-empty {
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border: 1px dashed var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel);
+	}
+	.arbc-empty__msg {
+		margin: 0;
+		font-size: 12px;
+		color: var(--terminal-fg-muted);
+		font-family: var(--terminal-font-mono);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/AchievableReturnBandChart.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/AchievableReturnBandChart.svelte
@@ -17,8 +17,8 @@
 <script lang="ts">
 	import { onMount } from "svelte";
 	import { formatPercent } from "@investintell/ui";
-	import GenericEChart from "$wealth/components/charts/GenericEChart.svelte";
-	import type { AchievableReturnBand } from "$wealth/types/cascade-telemetry";
+	import GenericEChart from "../../components/charts/GenericEChart.svelte";
+	import type { AchievableReturnBand } from "../../types/cascade-telemetry";
 
 	interface Props {
 		band: AchievableReturnBand | null;

--- a/packages/ii-terminal-core/src/lib/components/portfolio/live/workbench-state.ts
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/live/workbench-state.ts
@@ -1,0 +1,17 @@
+/**
+ * Terminal workbench state — Phase 2 Terminal Grid Shell.
+ *
+ * Stripped to portfolio selection only. The old WorkbenchTool /
+ * tab-based state machine was removed along with WorkbenchToolRibbon
+ * and LivePortfolioSidebar. The terminal grid is a fixed 4-zone
+ * layout with no tab switching.
+ *
+ * Source-of-truth discipline (DL15 — Zero localStorage):
+ *   The parent +page.svelte reads the selected portfolio from
+ *   ``page.url.searchParams.get("portfolio")`` and writes it back
+ *   via ``goto({replaceState, noScroll, keepFocus})``. This module
+ *   exports pure types — there is NO in-module $state, no store.
+ */
+
+/** Context key for the terminal-scoped MarketDataStore. */
+export const TERMINAL_MARKET_DATA_KEY = "netz:terminal:marketDataStore";

--- a/packages/ii-terminal-core/src/lib/components/screener-terminal/FilterChipRow.svelte
+++ b/packages/ii-terminal-core/src/lib/components/screener-terminal/FilterChipRow.svelte
@@ -1,0 +1,353 @@
+<!--
+	FilterChipRow — horizontal strip of applied-filter pills above the
+	datagrid.
+
+	Stateless by design: chips are derived from `filters` inline; every
+	removal is routed through `onFiltersChange` so the URL remains the
+	single source of truth (see plan §G.SCREENER risk 3 — chip removal
+	and rail checkbox must not diverge).
+-->
+<script module lang="ts">
+	export interface DerivedChip {
+		key: string;
+		label: string;
+		value: string;
+		onRemove: () => void;
+	}
+</script>
+
+<script lang="ts">
+	import { formatCompactCurrency } from "@investintell/ui";
+	import type { FilterState } from "./TerminalScreenerFilters.svelte";
+
+	interface Props {
+		filters: FilterState;
+		onFiltersChange: (next: FilterState) => void;
+	}
+
+	let { filters, onFiltersChange }: Props = $props();
+
+	const FUND_UNIVERSE_LABELS: Record<string, string> = {
+		mutual_fund: "Mutual",
+		etf: "ETF",
+		closed_end: "CEF",
+		interval_fund: "Interval",
+		bdc: "BDC",
+		money_market: "MMF",
+		hedge_fund: "Hedge",
+		private_fund: "Private",
+		private_equity_fund: "PE",
+		ucits: "UCITS",
+	};
+
+	function remove(key: string, value: string): () => void {
+		return () => {
+			const next: FilterState = {
+				...filters,
+				fundUniverse: new Set(filters.fundUniverse),
+				strategies: new Set(filters.strategies),
+				geographies: new Set(filters.geographies),
+				managerNames: [...filters.managerNames],
+			};
+			switch (key) {
+				case "fundUniverse":
+					next.fundUniverse.delete(value);
+					break;
+				case "strategy":
+					next.strategies.delete(value);
+					break;
+				case "geography":
+					next.geographies.delete(value);
+					break;
+				case "manager":
+					next.managerNames = next.managerNames.filter((n) => n !== value);
+					break;
+				case "aum":
+					next.aumMin = 0;
+					next.aumMax = 0;
+					break;
+				case "return1y":
+					next.returnMin = -999;
+					next.returnMax = 999;
+					break;
+				case "expense":
+					next.expenseMax = 10;
+					break;
+				case "elite":
+					next.eliteOnly = false;
+					break;
+				case "sharpe":
+					next.sharpeMin = "";
+					next.sharpeMax = "";
+					break;
+				case "drawdown":
+					next.drawdownMinPct = "";
+					next.drawdownMaxPct = "";
+					break;
+				case "vol":
+					next.volatilityMax = "";
+					break;
+				case "return10y":
+					next.return10yMin = "";
+					next.return10yMax = "";
+					break;
+			}
+			onFiltersChange(next);
+		};
+	}
+
+	function rangeLabel(lo: number | string | null, hi: number | string | null, suffix: string): string {
+		const loStr = lo !== null && lo !== "" && !(typeof lo === "number" && (lo === 0 || lo === -999)) ? String(lo) : "";
+		const hiStr = hi !== null && hi !== "" && !(typeof hi === "number" && (hi === 0 || hi === 999)) ? String(hi) : "";
+		if (loStr && hiStr) return `${loStr}${suffix}–${hiStr}${suffix}`;
+		if (loStr) return `≥${loStr}${suffix}`;
+		if (hiStr) return `≤${hiStr}${suffix}`;
+		return "";
+	}
+
+	const chips = $derived.by<DerivedChip[]>(() => {
+		const out: DerivedChip[] = [];
+
+		for (const v of filters.fundUniverse) {
+			out.push({
+				key: `fundUniverse:${v}`,
+				label: "Type",
+				value: FUND_UNIVERSE_LABELS[v] ?? v,
+				onRemove: remove("fundUniverse", v),
+			});
+		}
+		for (const v of filters.strategies) {
+			out.push({
+				key: `strategy:${v}`,
+				label: "Strategy",
+				value: v,
+				onRemove: remove("strategy", v),
+			});
+		}
+		for (const v of filters.geographies) {
+			out.push({
+				key: `geography:${v}`,
+				label: "Geo",
+				value: v,
+				onRemove: remove("geography", v),
+			});
+		}
+		for (const v of filters.managerNames) {
+			out.push({
+				key: `manager:${v}`,
+				label: "Manager",
+				value: v,
+				onRemove: remove("manager", v),
+			});
+		}
+		if (filters.eliteOnly) {
+			out.push({
+				key: "elite",
+				label: "Tier",
+				value: "Elite only",
+				onRemove: remove("elite", ""),
+			});
+		}
+		if (filters.aumMin > 0 || filters.aumMax > 0) {
+			const lo = filters.aumMin > 0 ? formatCompactCurrency(filters.aumMin) : "";
+			const hi = filters.aumMax > 0 ? formatCompactCurrency(filters.aumMax) : "";
+			let value: string;
+			if (lo && hi) value = `${lo}–${hi}`;
+			else if (lo) value = `≥${lo}`;
+			else value = `≤${hi}`;
+			out.push({ key: "aum", label: "AUM", value, onRemove: remove("aum", "") });
+		}
+		const ret1y = rangeLabel(
+			filters.returnMin > -999 ? filters.returnMin : null,
+			filters.returnMax < 999 ? filters.returnMax : null,
+			"%",
+		);
+		if (ret1y) {
+			out.push({ key: "return1y", label: "1Y Return", value: ret1y, onRemove: remove("return1y", "") });
+		}
+		if (filters.expenseMax < 10) {
+			out.push({
+				key: "expense",
+				label: "Fee",
+				value: `≤${filters.expenseMax}%`,
+				onRemove: remove("expense", ""),
+			});
+		}
+		const sharpe = rangeLabel(filters.sharpeMin || null, filters.sharpeMax || null, "");
+		if (sharpe) out.push({ key: "sharpe", label: "Sharpe", value: sharpe, onRemove: remove("sharpe", "") });
+		const dd = rangeLabel(filters.drawdownMinPct || null, filters.drawdownMaxPct || null, "%");
+		if (dd) out.push({ key: "drawdown", label: "Drawdown", value: dd, onRemove: remove("drawdown", "") });
+		if (filters.volatilityMax) {
+			out.push({
+				key: "vol",
+				label: "Vol",
+				value: `≤${filters.volatilityMax}%`,
+				onRemove: remove("vol", ""),
+			});
+		}
+		const ret10y = rangeLabel(filters.return10yMin || null, filters.return10yMax || null, "%");
+		if (ret10y) out.push({ key: "return10y", label: "10Y Return", value: ret10y, onRemove: remove("return10y", "") });
+
+		return out;
+	});
+
+	function clearAll() {
+		onFiltersChange({
+			fundUniverse: new Set(),
+			strategies: new Set(),
+			geographies: new Set(),
+			aumMin: 0,
+			aumMax: 0,
+			returnMin: -999,
+			returnMax: 999,
+			expenseMax: 10,
+			eliteOnly: false,
+			managerNames: [],
+			sharpeMin: "",
+			sharpeMax: "",
+			drawdownMinPct: "",
+			drawdownMaxPct: "",
+			volatilityMax: "",
+			return10yMin: "",
+			return10yMax: "",
+		});
+	}
+</script>
+
+{#if chips.length > 0}
+	<div class="chip-row" role="region" aria-label="Applied filters">
+		<span class="chip-row__label">FILTERS</span>
+		<ul class="chip-row__list">
+			{#each chips as chip (chip.key)}
+				<li class="chip-row__item">
+					<button
+						type="button"
+						class="chip"
+						aria-label={`Remove ${chip.label} ${chip.value}`}
+						onclick={chip.onRemove}
+					>
+						<span class="chip__label">{chip.label}</span>
+						<span class="chip__sep">·</span>
+						<span class="chip__value">{chip.value}</span>
+						<span class="chip__x" aria-hidden="true">×</span>
+					</button>
+				</li>
+			{/each}
+		</ul>
+		<button type="button" class="chip-row__clear" onclick={clearAll}>CLEAR ALL</button>
+	</div>
+{/if}
+
+<style>
+	.chip-row {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+		min-height: 28px;
+		overflow-x: auto;
+		overflow-y: hidden;
+		scrollbar-width: thin;
+		white-space: nowrap;
+	}
+
+	.chip-row__label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		flex-shrink: 0;
+	}
+
+	.chip-row__list {
+		display: flex;
+		gap: var(--terminal-space-2);
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		flex: 1;
+		min-width: 0;
+	}
+
+	.chip-row__item {
+		display: inline-flex;
+		flex-shrink: 0;
+	}
+
+	.chip {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		padding: 2px var(--terminal-space-2);
+		height: 20px;
+		background: var(--terminal-bg-panel-raised);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		color: var(--terminal-fg-secondary);
+		font-family: inherit;
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		line-height: 1;
+		cursor: pointer;
+		white-space: nowrap;
+	}
+	.chip:hover {
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+	}
+	.chip:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.chip__label {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+	.chip:hover .chip__label {
+		color: var(--terminal-accent-amber);
+	}
+	.chip__sep {
+		color: var(--terminal-fg-tertiary);
+	}
+	.chip__value {
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+	.chip:hover .chip__value {
+		color: var(--terminal-accent-amber);
+	}
+	.chip__x {
+		margin-left: var(--terminal-space-1);
+		color: var(--terminal-fg-tertiary);
+		font-size: var(--terminal-text-11);
+	}
+	.chip:hover .chip__x {
+		color: var(--terminal-accent-amber);
+	}
+
+	.chip-row__clear {
+		margin-left: auto;
+		background: transparent;
+		border: none;
+		color: var(--terminal-fg-tertiary);
+		font-family: inherit;
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		padding: 0 var(--terminal-space-2);
+		flex-shrink: 0;
+	}
+	.chip-row__clear:hover {
+		color: var(--terminal-accent-amber);
+	}
+	.chip-row__clear:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalDataGrid.svelte
+++ b/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalDataGrid.svelte
@@ -1,0 +1,845 @@
+<!--
+  TerminalDataGrid — virtualized high-density scrollable catalog grid.
+  CSS Grid layout with role="grid" ARIA for accessibility.
+  Only renders visible rows (~50) from a potentially 9k+ dataset.
+  Fixed ROW_HEIGHT=32px, overscan buffer of 5 rows above/below viewport.
+-->
+<script module lang="ts">
+	export interface ScreenerAsset {
+		id: string;                 // external_id from /screener/catalog
+		/**
+		 * Global instruments_universe UUID. Populated by the backend via
+		 * ticker/ISIN lookup when the fund has NAV history; null for
+		 * rows not yet imported into instruments_universe.
+		 */
+		instrumentId: string | null;
+		ticker: string | null;
+		name: string;
+		fundType: string;           // raw fund_type key
+		universeLabel: string;      // pretty label for fund_type
+		strategy: string | null;    // strategy_label
+		geography: string | null;   // investment_geography
+		domicile: string | null;
+		currency: string | null;
+		managerName: string | null;
+		managerId: string | null;
+		aum: number | null;
+		expenseRatioPct: number | null;  // Already in human % (0.85 = 0.85%)
+		ret1y: number | null;            // Already in human % (5.0 = 5%)
+		ret10y: number | null;           // Already in human % (8.0 = 8%)
+		managerScore: number | null;     // Composite score 0-100
+		blendedMomentumScore: number | null; // Pre-computed 0-100 (RSI + Bollinger + NAV + flow)
+		inceptionDate: string | null;
+		isin: string | null;
+		navStatus: string | null;   // available | pending_import | unavailable | null
+		eliteFlag: boolean;
+		inUniverse: boolean;
+		approvalStatus?: string | null;
+		universe?: string | null;
+	}
+</script>
+
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatNumber, readTerminalTokens, TerminalMiniSparkline } from "@investintell/ui";
+	import { focusTrigger } from "$wealth/components/terminal/focus-mode/focus-trigger";
+	import { createClientApiClient } from "$wealth/api/client";
+
+	const ROW_HEIGHT = 32;
+	const OVERSCAN = 5;
+	const SPARKLINE_W = 48;
+	const SPARKLINE_H = 16;
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	interface Props {
+		assets: ScreenerAsset[];
+		total: number;
+		loading: boolean;
+		errorMessage: string | null;
+		selectedId: string | null;
+		highlightedIndex: number;
+		isLoadingMore: boolean;
+		hasMore: boolean;
+		fetchGeneration: number;
+		/** Map of instrument_id → monthly NAV series for the MiniSparkline column. Shell owns the fetch. */
+		sparklineMap?: Map<string, number[]>;
+		onSelect: (asset: ScreenerAsset) => void;
+		onHighlight: (index: number) => void;
+		onApprove: (asset: ScreenerAsset) => Promise<void>;
+		onQueueDD: (asset: ScreenerAsset) => Promise<void>;
+		onLoadMore: () => void;
+	}
+
+	let {
+		assets,
+		total,
+		loading,
+		errorMessage,
+		selectedId,
+		highlightedIndex,
+		isLoadingMore,
+		hasMore,
+		fetchGeneration,
+		sparklineMap,
+		onSelect,
+		onHighlight,
+		onApprove,
+		onQueueDD,
+		onLoadMore,
+	}: Props = $props();
+
+	const EMPTY_SPARKLINE: readonly number[] = [];
+
+	function sparklineFor(asset: ScreenerAsset): readonly number[] {
+		if (!sparklineMap || !asset.instrumentId) return EMPTY_SPARKLINE;
+		return sparklineMap.get(asset.instrumentId) ?? EMPTY_SPARKLINE;
+	}
+
+	function momentumTone(score: number | null): "high" | "mid" | "low" | "none" {
+		if (score == null) return "none";
+		if (score >= 70) return "high";
+		if (score >= 40) return "mid";
+		return "low";
+	}
+
+	// ── Type badge map ────────────────────────────────
+	const TYPE_BADGES: Record<string, { label: string; title: string }> = {
+		mutual_fund:  { label: "MF",    title: "Mutual Fund" },
+		registered_us: { label: "MF",   title: "Mutual Fund" },
+		etf:          { label: "ETF",   title: "Exchange-Traded Fund" },
+		closed_end:   { label: "CEF",   title: "Closed-End Fund" },
+		interval_fund: { label: "INT",  title: "Interval Fund" },
+		bdc:          { label: "BDC",   title: "Business Development Company" },
+		money_market: { label: "MMF",   title: "Money Market Fund" },
+		hedge_fund:   { label: "HF",    title: "Hedge Fund" },
+		private_fund: { label: "PRIV",  title: "Private Fund" },
+		private_equity_fund: { label: "PE", title: "Private Equity Fund" },
+		ucits:        { label: "UCITS", title: "UCITS (European)" },
+		ucits_eu:     { label: "UCITS", title: "UCITS (European)" },
+	};
+
+	function getTypeBadge(asset: ScreenerAsset): { label: string; title: string } {
+		return TYPE_BADGES[asset.universe ?? asset.fundType] ?? TYPE_BADGES[asset.fundType] ?? { label: asset.universeLabel, title: asset.fundType };
+	}
+
+	// ── Action column state ────────────────────────────
+	const LIQUID_UNIVERSES = new Set(["registered_us", "etf", "ucits_eu", "money_market"]);
+	let actionPending = $state(new Set<string>());
+
+	// ── Virtual scroll state ───────────────────────────
+	let scrollContainer: HTMLDivElement | undefined = $state();
+	let viewportHeight = $state(600);
+	let scrollTop = $state(0);
+
+	// ── Sort state ────────────────────────────────────────
+	type SortDirection = "asc" | "desc" | null;
+	type SortableColumn =
+		| "ticker"
+		| "name"
+		| "fundType"
+		| "strategy"
+		| "geography"
+		| "aum"
+		| "ret1y"
+		| "ret10y"
+		| "expenseRatioPct"
+		| "managerScore"
+		| "blendedMomentumScore";
+
+	let sortColumn = $state<SortableColumn | null>(null);
+	let sortDirection = $state<SortDirection>(null);
+
+	function toggleSort(col: SortableColumn) {
+		if (sortColumn !== col) {
+			sortColumn = col;
+			sortDirection = "desc";
+		} else if (sortDirection === "desc") {
+			sortDirection = "asc";
+		} else {
+			sortColumn = null;
+			sortDirection = null;
+		}
+		if (scrollContainer) {
+			scrollContainer.scrollTop = 0;
+			scrollTop = 0;
+		}
+	}
+
+	const SORTABLE_COLUMNS: Record<SortableColumn, "numeric" | "text"> = {
+		ticker: "text",
+		name: "text",
+		fundType: "text",
+		strategy: "text",
+		geography: "text",
+		aum: "numeric",
+		ret1y: "numeric",
+		ret10y: "numeric",
+		expenseRatioPct: "numeric",
+		managerScore: "numeric",
+		blendedMomentumScore: "numeric",
+	};
+
+	function sortCaret(col: SortableColumn): string {
+		if (sortColumn !== col) return "";
+		return sortDirection === "asc" ? " \u25B2" : " \u25BC";
+	}
+
+	// ── Sorted asset derivation ───────────────────────────
+	const sortedAssets = $derived.by(() => {
+		if (!sortColumn || !sortDirection) return assets;
+
+		const col = sortColumn;
+		const dir = sortDirection;
+		const colType = SORTABLE_COLUMNS[col];
+
+		return [...assets].sort((a, b) => {
+			const aVal = a[col];
+			const bVal = b[col];
+
+			if (aVal == null && bVal == null) return 0;
+			if (aVal == null) return 1;
+			if (bVal == null) return -1;
+
+			let cmp: number;
+			if (colType === "numeric") {
+				cmp = (aVal as number) - (bVal as number);
+			} else {
+				cmp = String(aVal).localeCompare(String(bVal), undefined, { sensitivity: "base" });
+			}
+
+			return dir === "asc" ? cmp : -cmp;
+		});
+	});
+
+	const totalHeight = $derived(sortedAssets.length * ROW_HEIGHT);
+	const visibleCount = $derived(Math.ceil(viewportHeight / ROW_HEIGHT));
+	const startIndex = $derived(Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN));
+	const endIndex = $derived(
+		Math.min(sortedAssets.length, Math.floor(scrollTop / ROW_HEIGHT) + visibleCount + OVERSCAN),
+	);
+	const visibleAssets = $derived(sortedAssets.slice(startIndex, endIndex));
+	const offsetY = $derived(startIndex * ROW_HEIGHT);
+
+	let loadMoreDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function handleScroll() {
+		if (!scrollContainer) return;
+		scrollTop = scrollContainer.scrollTop;
+
+		// Infinite scroll: load more when within 5 rows of the data boundary
+		const distanceFromBottom = scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight;
+		const threshold = ROW_HEIGHT * 5;
+		if (distanceFromBottom < threshold && hasMore && !isLoadingMore) {
+			if (loadMoreDebounce) clearTimeout(loadMoreDebounce);
+			loadMoreDebounce = setTimeout(() => onLoadMore(), 100);
+		}
+	}
+
+	// Measure viewport height on mount and resize
+	$effect(() => {
+		if (!scrollContainer) return;
+		const ro = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				viewportHeight = entry.contentRect.height;
+			}
+		});
+		ro.observe(scrollContainer);
+		viewportHeight = scrollContainer.clientHeight;
+		return () => ro.disconnect();
+	});
+
+	// Scroll to highlighted row when it changes (keyboard navigation)
+	export function scrollToIndex(index: number) {
+		if (!scrollContainer || index < 0 || index >= sortedAssets.length) return;
+		const rowTop = index * ROW_HEIGHT;
+		const rowBottom = rowTop + ROW_HEIGHT;
+		const viewTop = scrollContainer.scrollTop;
+		const viewBottom = viewTop + viewportHeight;
+		if (rowTop < viewTop) {
+			scrollContainer.scrollTop = rowTop;
+		} else if (rowBottom > viewBottom) {
+			scrollContainer.scrollTop = rowBottom - viewportHeight;
+		}
+	}
+
+	// Reset scroll only on filter change (new generation), NOT on append
+	$effect(() => {
+		void fetchGeneration;
+		sortColumn = null;
+		sortDirection = null;
+		if (scrollContainer) {
+			scrollContainer.scrollTop = 0;
+			scrollTop = 0;
+		}
+	});
+
+	// ── Formatters ─────────────────────────────────────
+	function fmtPct(v: number | null, decimals: number = 2): string {
+		if (v == null) return "\u2014";
+		return formatNumber(v, decimals) + "%";
+	}
+
+	function fmtNum(v: number | null, decimals: number = 2): string {
+		if (v == null) return "\u2014";
+		return formatNumber(v, decimals);
+	}
+
+	function fmtAum(v: number | null): string {
+		if (v == null || v <= 0) return "\u2014";
+		if (v >= 1e12) return formatNumber(v / 1e12, 2) + "T";
+		if (v >= 1e9) return formatNumber(v / 1e9, 1) + "B";
+		if (v >= 1e6) return formatNumber(v / 1e6, 0) + "M";
+		return formatNumber(v, 0);
+	}
+
+	function retClass(v: number | null): string {
+		if (v == null) return "";
+		if (v > 0) return "pos";
+		if (v < 0) return "neg";
+		return "";
+	}
+
+	// ── Sparkline rendering ────────────────────────────
+	interface SparklinePoint {
+		month: string;
+		nav_close: number;
+	}
+
+	let sparklineCache = $state(new Map<string, number[]>());
+	let sparklineDebounce: ReturnType<typeof setTimeout> | null = null;
+	let lastFetchedIds = "";
+
+	function drawSparkline(canvas: HTMLCanvasElement, values: number[]) {
+		const ctx = canvas.getContext("2d");
+		if (!ctx || values.length < 2) return;
+
+		const dpr = window.devicePixelRatio || 1;
+		canvas.width = SPARKLINE_W * dpr;
+		canvas.height = SPARKLINE_H * dpr;
+		ctx.scale(dpr, dpr);
+		ctx.clearRect(0, 0, SPARKLINE_W, SPARKLINE_H);
+
+		const min = Math.min(...values);
+		const max = Math.max(...values);
+		const range = max - min || 1;
+		const step = SPARKLINE_W / (values.length - 1);
+
+		// Color: green if positive trend, red if negative
+		const last = values[values.length - 1] ?? 0;
+		const first = values[0] ?? 0;
+		const delta = last - first;
+		const tk = readTerminalTokens();
+		ctx.strokeStyle = delta > 0 ? tk.statusSuccess : delta < 0 ? tk.statusError : tk.fgTertiary;
+		ctx.lineWidth = 1;
+		ctx.beginPath();
+		for (let i = 0; i < values.length; i++) {
+			const x = Math.round(i * step);
+			const v = values[i] ?? 0;
+			const y = Math.round(SPARKLINE_H - ((v - min) / range) * (SPARKLINE_H - 2) - 1);
+			if (i === 0) ctx.moveTo(x, y);
+			else ctx.lineTo(x, y);
+		}
+		ctx.stroke();
+	}
+
+	// Sparkline use:action for canvas elements
+	function sparklineAction(canvas: HTMLCanvasElement, instrumentId: string | null) {
+		function render() {
+			if (!instrumentId) return;
+			const values = sparklineCache.get(instrumentId);
+			if (values && values.length >= 2) {
+				drawSparkline(canvas, values);
+			}
+		}
+		render();
+		return {
+			update(newId: string | null) {
+				instrumentId = newId;
+				render();
+			},
+			destroy() {},
+		};
+	}
+
+	// Sparkline batch fetch removed from DataGrid — SCORE column replaced
+	// sparkline rendering. The drawSparkline() function and sparklineAction()
+	// are kept for other consumers (FocusMode vitrine, portfolio workbench).
+</script>
+
+<div class="dg-root">
+	<!-- Header row (sticky, outside scroll container) -->
+	<div class="dg-header" role="row" aria-rowindex={1}>
+		<button class="dg-th dg-th-sort dg-col-ticker" class:dg-th-active={sortColumn === "ticker"} onclick={() => toggleSort("ticker")}>Ticker{sortCaret("ticker")}</button>
+		<button class="dg-th dg-th-sort dg-col-name" class:dg-th-active={sortColumn === "name"} onclick={() => toggleSort("name")}>Name{sortCaret("name")}</button>
+		<button class="dg-th dg-th-sort dg-col-type" class:dg-th-active={sortColumn === "fundType"} onclick={() => toggleSort("fundType")}>Type{sortCaret("fundType")}</button>
+		<button class="dg-th dg-th-sort dg-col-strategy" class:dg-th-active={sortColumn === "strategy"} onclick={() => toggleSort("strategy")}>Strategy{sortCaret("strategy")}</button>
+		<button class="dg-th dg-th-sort dg-col-geo" class:dg-th-active={sortColumn === "geography"} onclick={() => toggleSort("geography")}>Geo{sortCaret("geography")}</button>
+		<button class="dg-th dg-th-sort dg-col-aum dg-right" class:dg-th-active={sortColumn === "aum"} onclick={() => toggleSort("aum")}>AUM{sortCaret("aum")}</button>
+		<button class="dg-th dg-th-sort dg-col-ret dg-right" class:dg-th-active={sortColumn === "ret1y"} onclick={() => toggleSort("ret1y")}>1Y Ret{sortCaret("ret1y")}</button>
+		<button class="dg-th dg-th-sort dg-col-ret dg-right" class:dg-th-active={sortColumn === "ret10y"} onclick={() => toggleSort("ret10y")}>10Y Ret{sortCaret("ret10y")}</button>
+		<button class="dg-th dg-th-sort dg-col-er dg-right" class:dg-th-active={sortColumn === "expenseRatioPct"} onclick={() => toggleSort("expenseRatioPct")}>ER%{sortCaret("expenseRatioPct")}</button>
+		<button class="dg-th dg-th-sort dg-col-score dg-right" class:dg-th-active={sortColumn === "managerScore"} onclick={() => toggleSort("managerScore")}>Score{sortCaret("managerScore")}</button>
+		<button class="dg-th dg-th-sort dg-col-mom dg-right" class:dg-th-active={sortColumn === "blendedMomentumScore"} onclick={() => toggleSort("blendedMomentumScore")}>Mom{sortCaret("blendedMomentumScore")}</button>
+		<span class="dg-th dg-col-spark dg-center">Trend</span>
+		<span class="dg-th dg-col-action dg-center">Action</span>
+	</div>
+
+	<!-- Virtualized scroll area -->
+	<div
+		class="dg-scroll"
+		role="grid"
+		aria-rowcount={assets.length + 1}
+		aria-label="Screener instrument grid"
+		bind:this={scrollContainer}
+		onscroll={handleScroll}
+		tabindex={0}
+	>
+		<!-- Spacer for total scroll height + indicator -->
+		<div class="dg-spacer" style="height: {totalHeight + (assets.length > 0 ? 24 : 0)}px;">
+			<!-- Positioned visible rows -->
+			<div class="dg-rows" style="transform: translateY({offsetY}px);">
+				{#each visibleAssets as asset, vi (asset.id)}
+					{@const globalIndex = startIndex + vi}
+					<div
+						class="dg-row"
+						class:selected={selectedId === asset.id}
+						class:highlighted={highlightedIndex === globalIndex}
+						class:zebra={globalIndex % 2 === 1}
+						role="row"
+						aria-rowindex={globalIndex + 2}
+						aria-selected={selectedId === asset.id}
+						style="height: {ROW_HEIGHT}px;"
+						use:focusTrigger={{ entityKind: "fund", entityId: asset.id, entityLabel: asset.name }}
+						onclick={() => onSelect(asset)}
+					>
+						<span class="dg-td dg-col-ticker dg-ticker" title={asset.ticker ?? asset.isin ?? ""}>
+							{asset.ticker ?? asset.isin ?? "\u2014"}
+						</span>
+						<span class="dg-td dg-col-name dg-name" title={asset.name}>{asset.name}</span>
+						<span class="dg-td dg-col-type">
+							<span class="dg-type-badges">
+								<span class="dg-type-badge" title={getTypeBadge(asset).title}>{getTypeBadge(asset).label}</span>
+								{#if asset.eliteFlag}<span class="dg-elite-inline" title="ELITE — top in strategy">ELITE</span>{/if}
+							</span>
+						</span>
+						<span class="dg-td dg-col-strategy dg-strategy" title={asset.strategy ?? ""}>
+							{asset.strategy ?? "\u2014"}
+						</span>
+						<span class="dg-td dg-col-geo dg-geo">{asset.geography ?? "\u2014"}</span>
+						<span class="dg-td dg-col-aum dg-right dg-num">{fmtAum(asset.aum)}</span>
+						<span class="dg-td dg-col-ret dg-right dg-num {retClass(asset.ret1y)}">{fmtPct(asset.ret1y)}</span>
+						<span class="dg-td dg-col-ret dg-right dg-num {retClass(asset.ret10y)}">{fmtPct(asset.ret10y)}</span>
+						<span class="dg-td dg-col-er dg-right dg-num">{fmtPct(asset.expenseRatioPct)}</span>
+						<span class="dg-td dg-col-score dg-right dg-num"
+							class:score-high={asset.managerScore != null && asset.managerScore >= 70}
+							class:score-mid={asset.managerScore != null && asset.managerScore >= 40 && asset.managerScore < 70}
+							class:score-low={asset.managerScore != null && asset.managerScore < 40}
+						>
+							{asset.managerScore != null ? fmtNum(asset.managerScore, 1) : "\u2014"}
+						</span>
+						<span
+							class="dg-td dg-col-mom dg-right dg-num dg-mom-{momentumTone(asset.blendedMomentumScore)}"
+							title="Blended momentum (RSI + Bollinger + NAV + flow)"
+						>
+							{asset.blendedMomentumScore != null ? fmtNum(asset.blendedMomentumScore, 0) : "\u2014"}
+						</span>
+						<span class="dg-td dg-col-spark dg-center">
+							<TerminalMiniSparkline
+								data={[...sparklineFor(asset)]}
+								width={60}
+								height={18}
+								ariaLabel="12mo NAV trend"
+							/>
+						</span>
+						<span class="dg-td dg-col-action dg-center">
+							{#if asset.inUniverse}
+								<span class="dg-action-label dg-action-approved">APPROVED</span>
+							{:else if asset.approvalStatus === "pending" || actionPending.has(asset.id)}
+								<span class="dg-action-label dg-action-pending">PENDING</span>
+							{:else if LIQUID_UNIVERSES.has(asset.universe ?? asset.fundType)}
+								<button
+									class="dg-action-btn dg-action-approve"
+									onclick={async (e) => {
+										e.stopPropagation();
+										actionPending = new Set([...actionPending, asset.id]);
+										await onApprove(asset);
+									}}
+								>
+									APPROVE
+								</button>
+							{:else}
+								<button
+									class="dg-action-btn dg-action-dd"
+									onclick={async (e) => {
+										e.stopPropagation();
+										actionPending = new Set([...actionPending, asset.id]);
+										await onQueueDD(asset);
+									}}
+								>
+									+ DD
+								</button>
+							{/if}
+						</span>
+					</div>
+				{/each}
+
+				{#if assets.length === 0 && !loading && !errorMessage}
+					<div class="dg-empty" role="row">
+						No instruments match the current filters.
+					</div>
+				{/if}
+			</div>
+
+			{#if isLoadingMore}
+				<div class="dg-loading-more" style="top: {totalHeight}px;">
+					LOADING PAGE {Math.ceil(assets.length / 200) + 1}...
+				</div>
+			{/if}
+
+			{#if !hasMore && assets.length > 0 && !loading}
+				<div class="dg-end-of-catalog" style="top: {totalHeight}px;">
+					END OF CATALOG — {formatNumber(assets.length, 0)} instruments loaded
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	<div class="dg-footer">
+		{#if errorMessage}
+			<span class="dg-footer-err">{errorMessage}</span>
+		{:else if loading}
+			<span>Loading&hellip;</span>
+		{:else if isLoadingMore}
+			<span>Showing {formatNumber(assets.length, 0)} of {formatNumber(total, 0)} instruments — loading...</span>
+		{:else if !hasMore && assets.length > 0}
+			<span>Showing {formatNumber(assets.length, 0)} of {formatNumber(total, 0)} instruments — complete</span>
+		{:else}
+			<span>
+				Showing {formatNumber(assets.length, 0)} of {formatNumber(total, 0)} instruments
+			</span>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.dg-root {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		overflow: hidden;
+		background: var(--terminal-bg-void);
+		font-family: var(--terminal-font-mono);
+		font-size: 11px;
+		color: var(--terminal-fg-primary);
+	}
+
+	/* ── Grid column template (shared by header + rows) ── */
+	.dg-header,
+	.dg-row {
+		display: grid;
+		grid-template-columns:
+			72px                  /* ticker — fixed, always visible */
+			minmax(100px, 1fr)    /* name — flex absorbs remaining space */
+			90px                  /* type badges (MF/ETF + ELITE) */
+			110px                 /* strategy — fixed */
+			36px                  /* geo — 2-letter code */
+			72px                  /* aum — right-aligned, compact format */
+			60px                  /* 1y ret — right-aligned */
+			60px                  /* 10y ret — right-aligned */
+			48px                  /* er% — right-aligned */
+			56px                  /* score — right-aligned numeral */
+			48px                  /* blended momentum — right-aligned */
+			64px                  /* trend sparkline — center, 60x18 */
+			72px;                 /* action — APPROVE/+DD button */
+		column-gap: 2px;
+		align-items: center;
+	}
+
+	/* ── Header ───────────────────────────────────────── */
+	.dg-header {
+		flex-shrink: 0;
+		z-index: 2;
+		background: var(--terminal-bg-panel-sunken);
+		border-bottom: 1px solid var(--terminal-fg-disabled);
+	}
+
+	.dg-th {
+		padding: 6px 6px;
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		white-space: nowrap;
+		user-select: none;
+	}
+
+	/* ── Sortable headers ────────────────────────────────── */
+	.dg-th-sort {
+		background: none;
+		border: none;
+		cursor: pointer;
+		text-align: left;
+		transition: color 80ms ease;
+	}
+	.dg-th-sort:hover {
+		color: var(--terminal-fg-secondary);
+	}
+	.dg-th-sort.dg-right {
+		text-align: right;
+	}
+	.dg-th-active {
+		color: var(--terminal-accent-amber) !important;
+	}
+
+	/* ── Scroll container ─────────────────────────────── */
+	.dg-scroll {
+		flex: 1;
+		overflow-y: auto;
+		overflow-x: auto;
+		min-height: 0;
+		outline: none;
+	}
+
+	.dg-spacer {
+		position: relative;
+		width: 100%;
+	}
+
+	.dg-rows {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+	}
+
+	/* ── Rows ─────────────────────────────────────────── */
+	.dg-row {
+		cursor: pointer;
+		transition: background 80ms ease;
+	}
+	.dg-row:hover {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 6%, transparent);
+	}
+	.dg-row.selected {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 10%, transparent);
+	}
+	.dg-row.highlighted {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 14%, transparent);
+		outline: 1px solid color-mix(in srgb, var(--terminal-accent-cyan) 30%, transparent);
+		outline-offset: -1px;
+	}
+	.dg-row.zebra {
+		background: color-mix(in srgb, var(--terminal-fg-primary) 1.2%, transparent);
+	}
+	.dg-row.zebra:hover {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 6%, transparent);
+	}
+	.dg-row.zebra.selected {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 10%, transparent);
+	}
+	.dg-row.zebra.highlighted {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 14%, transparent);
+	}
+
+	/* ── Cells ────────────────────────────────────────── */
+	.dg-td {
+		padding: 5px 6px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.dg-right { text-align: right; }
+	.dg-center { text-align: center; }
+
+	.dg-ticker {
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+	}
+
+	.dg-name {
+		color: var(--terminal-fg-secondary);
+	}
+
+	/* ── Type badges ────────────────────────────────── */
+	.dg-type-badges {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	.dg-type-badge {
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary, #5a6577);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		padding: 1px 4px;
+		white-space: nowrap;
+	}
+
+	.dg-elite-inline {
+		font-family: var(--terminal-font-mono);
+		font-size: 8px;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		color: var(--terminal-accent-amber, #f59e0b);
+		border: 1px solid rgba(245, 158, 11, 0.35);
+		padding: 1px 4px;
+		white-space: nowrap;
+	}
+
+	.dg-strategy {
+		color: var(--terminal-fg-secondary);
+		font-size: 10px;
+	}
+
+	.dg-geo {
+		color: var(--terminal-fg-tertiary);
+		font-size: 10px;
+	}
+
+	.dg-num {
+		font-variant-numeric: tabular-nums;
+		font-weight: 500;
+	}
+
+	.pos { color: var(--terminal-status-success); }
+	.neg { color: var(--terminal-status-error); }
+
+	/* Score color coding */
+	.score-high { color: var(--terminal-status-success); }
+	.score-mid { color: var(--terminal-accent-amber); }
+	.score-low { color: var(--terminal-status-error); }
+
+	/* Blended momentum tone — same palette as score, distinct class
+	   namespace so the two tiers can diverge without a cascade clash. */
+	.dg-mom-high { color: var(--terminal-status-success); }
+	.dg-mom-mid { color: var(--terminal-accent-amber); }
+	.dg-mom-low { color: var(--terminal-status-error); }
+	.dg-mom-none { color: var(--terminal-fg-tertiary); }
+
+	/* Spark column — cell centers the SVG inside the 64px column. */
+	.dg-col-spark {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.dg-empty {
+		padding: 32px;
+		text-align: center;
+		color: var(--terminal-fg-tertiary);
+		font-size: 11px;
+		font-style: italic;
+	}
+
+	/* ── Sparkline ───────────────────────────────────── */
+	.dg-sparkline {
+		display: block;
+		width: 48px;
+		height: 16px;
+	}
+
+	.dg-spark-empty {
+		color: var(--terminal-fg-tertiary);
+		font-size: 10px;
+	}
+
+	/* ── (old ticker badges removed — moved to TYPE column) ── */
+
+	/* ── Action column ────────────────────────────────── */
+	.dg-action-btn {
+		background: transparent;
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		padding: 2px 6px;
+		cursor: pointer;
+		transition: all 80ms ease;
+		text-transform: uppercase;
+	}
+	.dg-action-approve {
+		border: 1px solid color-mix(in srgb, var(--terminal-accent-amber) 35%, transparent);
+		color: var(--terminal-accent-amber);
+	}
+	.dg-action-approve:hover {
+		background: color-mix(in srgb, var(--terminal-accent-amber) 8%, transparent);
+		color: var(--terminal-accent-amber);
+	}
+	.dg-action-dd {
+		border: 1px solid color-mix(in srgb, var(--terminal-accent-cyan) 25%, transparent);
+		color: var(--terminal-accent-cyan);
+	}
+	.dg-action-dd:hover {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 8%, transparent);
+		color: var(--terminal-accent-cyan);
+	}
+	.dg-action-label {
+		font-family: var(--terminal-font-mono);
+		font-size: 8px;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+	.dg-action-approved {
+		color: var(--terminal-status-success);
+	}
+	.dg-action-pending {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	/* ── Infinite scroll indicators ───────────────────── */
+	.dg-loading-more {
+		position: absolute;
+		left: 0;
+		right: 0;
+		height: 24px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-family: var(--terminal-font-mono);
+		font-size: 10px;
+		letter-spacing: 0.06em;
+		color: var(--terminal-fg-tertiary);
+		animation: dg-pulse 1.2s ease-in-out infinite;
+	}
+
+	.dg-end-of-catalog {
+		position: absolute;
+		left: 0;
+		right: 0;
+		height: 24px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-family: var(--terminal-font-mono);
+		font-size: 10px;
+		letter-spacing: 0.06em;
+		color: var(--terminal-fg-muted);
+	}
+
+	@keyframes dg-pulse {
+		0%, 100% { opacity: 0.5; }
+		50% { opacity: 1; }
+	}
+
+	/* ── Footer ───────────────────────────────────────── */
+	.dg-footer {
+		flex-shrink: 0;
+		padding: 4px 10px;
+		font-size: 10px;
+		color: var(--terminal-fg-tertiary);
+		border-top: 1px solid var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel-sunken);
+	}
+	.dg-footer-err {
+		color: var(--terminal-status-error);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalDataGrid.svelte
+++ b/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalDataGrid.svelte
@@ -42,8 +42,8 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { formatNumber, readTerminalTokens, TerminalMiniSparkline } from "@investintell/ui";
-	import { focusTrigger } from "$wealth/components/terminal/focus-mode/focus-trigger";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { focusTrigger } from "../../components/terminal/focus-mode/focus-trigger";
+	import { createClientApiClient } from "../../api/client";
 
 	const ROW_HEIGHT = 32;
 	const OVERSCAN = 5;

--- a/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalScreenerFilters.svelte
+++ b/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalScreenerFilters.svelte
@@ -50,7 +50,7 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { formatNumber } from "@investintell/ui";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../api/client";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 	const api = createClientApiClient(getToken);

--- a/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalScreenerFilters.svelte
+++ b/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalScreenerFilters.svelte
@@ -1,0 +1,897 @@
+<!--
+  TerminalScreenerFilters — left panel, collapsible sections.
+
+  Drives the `/screener/catalog` backend query directly. Every option
+  here maps 1:1 to a backend query parameter — the filtering happens
+  server-side on the TimescaleDB-backed materialized view.
+-->
+<script module lang="ts">
+	export interface FilterState {
+		fundUniverse: Set<string>;   // fund_universe: mutual_fund,etf,closed_end,bdc,money_market,hedge_fund,private_fund,ucits
+		strategies: Set<string>;     // strategy_label
+		geographies: Set<string>;    // investment_geography
+		aumMin: number;              // USD absolute, 0 = no filter
+		aumMax: number;              // USD absolute, 0 = no filter
+		returnMin: number;           // % annualised 1Y, null/-999 = no filter
+		returnMax: number;           // % annualised 1Y, 999 = no filter
+		expenseMax: number;          // % annual fee, 10 = no filter
+		eliteOnly: boolean;          // ELITE-flagged funds only
+		managerNames: string[];      // multi-select exact manager names
+		sharpeMin: string;           // Sharpe ratio (1Y) min — string for input binding
+		sharpeMax: string;
+		drawdownMinPct: string;      // Positive %, converted to negative for backend
+		drawdownMaxPct: string;
+		volatilityMax: string;       // Annualized vol (1Y)
+		return10yMin: string;        // % annualised 10Y
+		return10yMax: string;
+	}
+
+	export const DEFAULT_FILTERS: FilterState = {
+		fundUniverse: new Set<string>(),
+		strategies: new Set<string>(),
+		geographies: new Set<string>(),
+		aumMin: 0,
+		aumMax: 0,
+		returnMin: -999,
+		returnMax: 999,
+		expenseMax: 10,
+		eliteOnly: false,
+		managerNames: [],
+		sharpeMin: "",
+		sharpeMax: "",
+		drawdownMinPct: "",
+		drawdownMaxPct: "",
+		volatilityMax: "",
+		return10yMin: "",
+		return10yMax: "",
+	};
+</script>
+
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatNumber } from "@investintell/ui";
+	import { createClientApiClient } from "$wealth/api/client";
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	interface Props {
+		filters: FilterState;
+		onFiltersChange: (filters: FilterState) => void;
+	}
+
+	let { filters, onFiltersChange }: Props = $props();
+
+	// ── Manager typeahead ────────────────────────────────
+	let managerQuery = $state("");
+	let managerSuggestions = $state<string[]>([]);
+	let managerDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function fetchManagerSuggestions() {
+		if (managerDebounce) clearTimeout(managerDebounce);
+		if (managerQuery.length < 2) {
+			managerSuggestions = [];
+			return;
+		}
+		managerDebounce = setTimeout(async () => {
+			try {
+				const results = await api.get<string[]>("/screener/managers", {
+					q: managerQuery,
+					limit: "10",
+				});
+				// Exclude already-selected managers
+				managerSuggestions = results.filter(
+					(n) => !filters.managerNames.includes(n),
+				);
+			} catch {
+				managerSuggestions = [];
+			}
+		}, 200);
+	}
+
+	function addManager(name: string) {
+		if (!filters.managerNames.includes(name)) {
+			onFiltersChange({
+				...filters,
+				managerNames: [...filters.managerNames, name],
+			});
+		}
+		managerQuery = "";
+		managerSuggestions = [];
+	}
+
+	function removeManager(name: string) {
+		onFiltersChange({
+			...filters,
+			managerNames: filters.managerNames.filter((n) => n !== name),
+		});
+	}
+
+	// Universe labels mirror the CatalogFilters backend contract.
+	const FUND_UNIVERSE: { key: string; label: string }[] = [
+		{ key: "mutual_fund",  label: "Mutual Fund" },
+		{ key: "etf",          label: "ETF" },
+		{ key: "closed_end",   label: "Closed-End" },
+		{ key: "interval_fund",label: "Interval" },
+		{ key: "bdc",          label: "BDC" },
+		{ key: "money_market", label: "Money Market" },
+		{ key: "hedge_fund",   label: "Hedge Fund" },
+		{ key: "private_fund", label: "Private Fund" },
+		{ key: "ucits",        label: "UCITS (EU)" },
+	];
+
+	// Subset of the most common strategy_label values — the full list is
+	// ~37 categories, we surface the ones that matter most to asset
+	// allocators first.
+	const STRATEGIES = [
+		"Equity",
+		"Fixed Income",
+		"Multi-Asset",
+		"Money Market",
+		"Alternatives",
+		"Real Estate",
+		"Commodities",
+		"Private Credit",
+		"Infrastructure",
+		"Long/Short Equity",
+		"Buyout",
+		"Venture Capital",
+	];
+
+	const GEOGRAPHIES = [
+		"US",
+		"Europe",
+		"Emerging Markets",
+		"Asia Pacific",
+		"Global",
+		"Latin America",
+	];
+
+	let sectionOpen = $state({ manager: false, universe: false, strategy: false, geography: false, metrics: false });
+
+	// Active filter counts for collapsed section badges
+	const activeManagerCount = $derived(filters.managerNames.length);
+	const activeUniverseCount = $derived(filters.fundUniverse.size);
+	const activeStrategyCount = $derived(filters.strategies.size);
+	const activeGeographyCount = $derived(filters.geographies.size);
+	const activeMetricsCount = $derived(
+		(filters.aumMin > 0 ? 1 : 0) +
+		(filters.aumMax > 0 ? 1 : 0) +
+		(filters.sharpeMin !== "" ? 1 : 0) +
+		(filters.sharpeMax !== "" ? 1 : 0) +
+		(filters.drawdownMinPct !== "" ? 1 : 0) +
+		(filters.drawdownMaxPct !== "" ? 1 : 0) +
+		(filters.volatilityMax !== "" ? 1 : 0) +
+		(filters.expenseMax < 10 ? 1 : 0) +
+		(filters.returnMin > -999 ? 1 : 0) +
+		(filters.returnMax < 999 ? 1 : 0) +
+		(filters.return10yMin !== "" ? 1 : 0) +
+		(filters.return10yMax !== "" ? 1 : 0)
+	);
+
+	function expandAll() {
+		sectionOpen = { manager: true, universe: true, strategy: true, geography: true, metrics: true };
+	}
+	function collapseAll() {
+		sectionOpen = { manager: false, universe: false, strategy: false, geography: false, metrics: false };
+	}
+
+	function toggleUniverse(key: string) {
+		const next = new Set(filters.fundUniverse);
+		if (next.has(key)) next.delete(key);
+		else next.add(key);
+		onFiltersChange({ ...filters, fundUniverse: next });
+	}
+
+	function toggleStrategy(key: string) {
+		const next = new Set(filters.strategies);
+		if (next.has(key)) next.delete(key);
+		else next.add(key);
+		onFiltersChange({ ...filters, strategies: next });
+	}
+
+	function toggleGeography(key: string) {
+		const next = new Set(filters.geographies);
+		if (next.has(key)) next.delete(key);
+		else next.add(key);
+		onFiltersChange({ ...filters, geographies: next });
+	}
+
+	function setRange<K extends "aumMin" | "aumMax" | "returnMin" | "returnMax" | "expenseMax">(field: K, value: number) {
+		onFiltersChange({ ...filters, [field]: value });
+	}
+
+	function toggleEliteOnly() {
+		onFiltersChange({ ...filters, eliteOnly: !filters.eliteOnly });
+	}
+
+	// ── Debounced metric input handler ────────────────────
+	type MetricKey = "sharpeMin" | "sharpeMax" | "drawdownMinPct" | "drawdownMaxPct" | "volatilityMax" | "return10yMin" | "return10yMax";
+	let metricDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function debouncedMetric(field: MetricKey, value: string) {
+		if (metricDebounce) clearTimeout(metricDebounce);
+		metricDebounce = setTimeout(() => {
+			onFiltersChange({ ...filters, [field]: value });
+		}, 500);
+	}
+
+	function clearAll() {
+		managerQuery = "";
+		managerSuggestions = [];
+		onFiltersChange({
+			fundUniverse: new Set(),
+			strategies: new Set(),
+			geographies: new Set(),
+			aumMin: 0,
+			aumMax: 0,
+			returnMin: -999,
+			returnMax: 999,
+			expenseMax: 10,
+			eliteOnly: false,
+			managerNames: [],
+			sharpeMin: "",
+			sharpeMax: "",
+			drawdownMinPct: "",
+			drawdownMaxPct: "",
+			volatilityMax: "",
+			return10yMin: "",
+			return10yMax: "",
+		});
+	}
+
+	// AUM slider uses log10 ticks: 0 → $0, 6 → $1M, 9 → $1B, 12 → $1T.
+	function aumToLog(n: number): number {
+		if (n <= 0) return 0;
+		return Math.log10(Math.max(1, n));
+	}
+	function logToAum(l: number): number {
+		if (l <= 0) return 0;
+		return Math.pow(10, l);
+	}
+	function fmtAum(n: number): string {
+		if (n <= 0) return "any";
+		if (n >= 1e12) return "$" + formatNumber(n / 1e12, 1) + "T";
+		if (n >= 1e9) return "$" + formatNumber(n / 1e9, 1) + "B";
+		if (n >= 1e6) return "$" + formatNumber(n / 1e6, 0) + "M";
+		return "$" + formatNumber(n, 0);
+	}
+
+	const aumLogValue = $derived(aumToLog(filters.aumMin));
+</script>
+
+<div class="sf-root">
+	<div class="sf-header">
+		<span class="sf-title">FILTERS</span>
+		<div class="sf-header-actions">
+			<button class="sf-action" onclick={expandAll} title="Expand all sections">ALL</button>
+			<button class="sf-action" onclick={collapseAll} title="Collapse all sections">NONE</button>
+			<button class="sf-clear" onclick={clearAll}>Clear</button>
+		</div>
+	</div>
+
+	<div class="sf-elite-chip-row">
+		<button
+			class="sf-elite-chip"
+			class:sf-elite-chip--active={filters.eliteOnly}
+			onclick={toggleEliteOnly}
+		>
+			ELITE
+		</button>
+	</div>
+
+	<div class="sf-scroll">
+		<!-- Manager typeahead -->
+		<div class="sf-section">
+			<button
+				class="sf-section-toggle"
+				onclick={() => (sectionOpen.manager = !sectionOpen.manager)}
+			>
+				<span class="sf-section-arrow" class:open={sectionOpen.manager}>&#9656;</span>
+				MANAGER
+				{#if activeManagerCount > 0}<span class="sf-active-count">{activeManagerCount}</span>{/if}
+			</button>
+			{#if sectionOpen.manager}
+				<div class="sf-section-body">
+					<div class="sf-manager-typeahead">
+						<input
+							type="text"
+							class="sf-manager-input"
+							placeholder="Search managers..."
+							bind:value={managerQuery}
+							oninput={fetchManagerSuggestions}
+						/>
+						{#if managerSuggestions.length > 0}
+							<ul class="sf-manager-suggestions" role="listbox">
+								{#each managerSuggestions as name (name)}
+									<li
+										role="option"
+										class="sf-manager-suggestion"
+										onclick={() => addManager(name)}
+									>
+										{name}
+									</li>
+								{/each}
+							</ul>
+						{/if}
+						{#if filters.managerNames.length > 0}
+							<div class="sf-manager-chips">
+								{#each filters.managerNames as name (name)}
+									<span class="sf-manager-chip">
+										{name}
+										<button
+											class="sf-manager-chip-x"
+											onclick={() => removeManager(name)}
+											aria-label="Remove {name}"
+										>x</button>
+									</span>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Universe -->
+		<div class="sf-section">
+			<button
+				class="sf-section-toggle"
+				onclick={() => (sectionOpen.universe = !sectionOpen.universe)}
+			>
+				<span class="sf-section-arrow" class:open={sectionOpen.universe}>&#9656;</span>
+				UNIVERSE
+				{#if activeUniverseCount > 0}<span class="sf-active-count">{activeUniverseCount}</span>{/if}
+			</button>
+			{#if sectionOpen.universe}
+				<div class="sf-section-body">
+					<div class="sf-check-grid">
+						{#each FUND_UNIVERSE as u}
+							<label class="sf-check">
+								<input
+									type="checkbox"
+									checked={filters.fundUniverse.has(u.key)}
+									onchange={() => toggleUniverse(u.key)}
+								/>
+								<span class="sf-check-label">{u.label}</span>
+							</label>
+						{/each}
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Strategy -->
+		<div class="sf-section">
+			<button
+				class="sf-section-toggle"
+				onclick={() => (sectionOpen.strategy = !sectionOpen.strategy)}
+			>
+				<span class="sf-section-arrow" class:open={sectionOpen.strategy}>&#9656;</span>
+				STRATEGY
+				{#if activeStrategyCount > 0}<span class="sf-active-count">{activeStrategyCount}</span>{/if}
+			</button>
+			{#if sectionOpen.strategy}
+				<div class="sf-section-body">
+					<div class="sf-check-grid">
+						{#each STRATEGIES as s}
+							<label class="sf-check">
+								<input
+									type="checkbox"
+									checked={filters.strategies.has(s)}
+									onchange={() => toggleStrategy(s)}
+								/>
+								<span class="sf-check-label">{s}</span>
+							</label>
+						{/each}
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Geography -->
+		<div class="sf-section">
+			<button
+				class="sf-section-toggle"
+				onclick={() => (sectionOpen.geography = !sectionOpen.geography)}
+			>
+				<span class="sf-section-arrow" class:open={sectionOpen.geography}>&#9656;</span>
+				GEOGRAPHY
+				{#if activeGeographyCount > 0}<span class="sf-active-count">{activeGeographyCount}</span>{/if}
+			</button>
+			{#if sectionOpen.geography}
+				<div class="sf-section-body">
+					<div class="sf-check-grid">
+						{#each GEOGRAPHIES as g}
+							<label class="sf-check">
+								<input
+									type="checkbox"
+									checked={filters.geographies.has(g)}
+									onchange={() => toggleGeography(g)}
+								/>
+								<span class="sf-check-label">{g}</span>
+							</label>
+						{/each}
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Metrics -->
+		<div class="sf-section">
+			<button
+				class="sf-section-toggle"
+				onclick={() => (sectionOpen.metrics = !sectionOpen.metrics)}
+			>
+				<span class="sf-section-arrow" class:open={sectionOpen.metrics}>&#9656;</span>
+				METRICS
+				{#if activeMetricsCount > 0}<span class="sf-active-count">{activeMetricsCount}</span>{/if}
+			</button>
+			{#if sectionOpen.metrics}
+				<div class="sf-section-body">
+					<div class="sf-range-group">
+						<div class="sf-range-header">
+							<span>Min AUM</span>
+							<span class="sf-range-value">{fmtAum(filters.aumMin)}</span>
+						</div>
+						<input
+							type="range"
+							min={0}
+							max={12}
+							step={0.1}
+							value={aumLogValue}
+							oninput={(e) => setRange("aumMin", logToAum(+e.currentTarget.value))}
+							class="sf-slider"
+						/>
+					</div>
+
+					<div class="sf-metric-row">
+						<span class="sf-metric-label">SHARPE (1Y)</span>
+						<div class="sf-metric-inputs">
+							<input type="number" step="0.1" placeholder="min" class="sf-metric-input" value={filters.sharpeMin}
+								oninput={(e) => debouncedMetric("sharpeMin", e.currentTarget.value)} />
+							<span class="sf-metric-sep">&mdash;</span>
+							<input type="number" step="0.1" placeholder="max" class="sf-metric-input" value={filters.sharpeMax}
+								oninput={(e) => debouncedMetric("sharpeMax", e.currentTarget.value)} />
+						</div>
+					</div>
+
+					<div class="sf-metric-row">
+						<span class="sf-metric-label">MAX DRAWDOWN (%)</span>
+						<div class="sf-metric-inputs">
+							<input type="number" step="1" placeholder="min" class="sf-metric-input" value={filters.drawdownMinPct}
+								oninput={(e) => debouncedMetric("drawdownMinPct", e.currentTarget.value)} />
+							<span class="sf-metric-sep">&mdash;</span>
+							<input type="number" step="1" placeholder="max" class="sf-metric-input" value={filters.drawdownMaxPct}
+								oninput={(e) => debouncedMetric("drawdownMaxPct", e.currentTarget.value)} />
+						</div>
+					</div>
+
+					<div class="sf-metric-row">
+						<span class="sf-metric-label">VOLATILITY (MAX)</span>
+						<div class="sf-metric-inputs">
+							<input type="number" step="0.01" placeholder="max" class="sf-metric-input" value={filters.volatilityMax}
+								oninput={(e) => debouncedMetric("volatilityMax", e.currentTarget.value)} />
+						</div>
+					</div>
+
+					<div class="sf-metric-row">
+						<span class="sf-metric-label">EXPENSE RATIO (MAX %)</span>
+						<div class="sf-metric-inputs">
+							<input type="number" step="0.05" placeholder="max" class="sf-metric-input"
+								value={filters.expenseMax >= 10 ? "" : String(filters.expenseMax)}
+								oninput={(e) => {
+									const v = e.currentTarget.value;
+									setRange("expenseMax", v === "" ? 10 : +v);
+								}} />
+						</div>
+					</div>
+
+					<div class="sf-metric-row">
+						<span class="sf-metric-label">1Y RETURN (%)</span>
+						<div class="sf-metric-inputs">
+							<input type="number" step="1" placeholder="min" class="sf-metric-input"
+								value={filters.returnMin <= -999 ? "" : String(filters.returnMin)}
+								oninput={(e) => {
+									const v = e.currentTarget.value;
+									setRange("returnMin", v === "" ? -999 : +v);
+								}} />
+							<span class="sf-metric-sep">&mdash;</span>
+							<input type="number" step="1" placeholder="max" class="sf-metric-input"
+								value={filters.returnMax >= 999 ? "" : String(filters.returnMax)}
+								oninput={(e) => {
+									const v = e.currentTarget.value;
+									setRange("returnMax", v === "" ? 999 : +v);
+								}} />
+						</div>
+					</div>
+
+					<div class="sf-metric-row">
+						<span class="sf-metric-label">10Y RETURN (%)</span>
+						<div class="sf-metric-inputs">
+							<input type="number" step="1" placeholder="min" class="sf-metric-input" value={filters.return10yMin}
+								oninput={(e) => debouncedMetric("return10yMin", e.currentTarget.value)} />
+							<span class="sf-metric-sep">&mdash;</span>
+							<input type="number" step="1" placeholder="max" class="sf-metric-input" value={filters.return10yMax}
+								oninput={(e) => debouncedMetric("return10yMax", e.currentTarget.value)} />
+						</div>
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.sf-root {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--terminal-bg-panel);
+		border-right: 1px solid var(--terminal-fg-muted);
+		font-family: var(--terminal-font-mono);
+		font-size: 11px;
+		color: var(--terminal-fg-primary);
+	}
+
+	.sf-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 10px 12px 8px;
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		flex-shrink: 0;
+	}
+
+	.sf-title {
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.sf-header-actions {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.sf-action {
+		font-size: 9px;
+		color: var(--terminal-fg-tertiary);
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
+		font-family: var(--terminal-font-mono);
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+	.sf-action:hover {
+		color: var(--terminal-fg-secondary);
+	}
+
+	.sf-clear {
+		font-size: 10px;
+		color: var(--terminal-accent-cyan);
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
+		font-family: inherit;
+	}
+	.sf-clear:hover {
+		color: var(--terminal-accent-cyan);
+	}
+
+	.sf-elite-chip-row {
+		padding: 8px 12px;
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		flex-shrink: 0;
+	}
+
+	.sf-elite-chip {
+		font-family: var(--terminal-font-mono);
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		padding: 4px 12px;
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+		cursor: pointer;
+		transition: all 80ms ease;
+	}
+	.sf-elite-chip:hover {
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+	}
+	.sf-elite-chip--active {
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+		background: color-mix(in srgb, var(--terminal-accent-amber) 8%, transparent);
+	}
+
+	.sf-scroll {
+		flex: 1;
+		overflow-y: auto;
+		overflow-x: hidden;
+		min-height: 0;
+	}
+
+	.sf-section {
+		border-bottom: 1px solid var(--terminal-fg-disabled);
+	}
+
+	.sf-section-toggle {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		width: 100%;
+		padding: 8px 12px;
+		background: none;
+		border: none;
+		color: var(--terminal-fg-secondary);
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		cursor: pointer;
+		font-family: inherit;
+		text-align: left;
+	}
+	.sf-section-toggle:hover {
+		color: var(--terminal-fg-primary);
+	}
+
+	.sf-section-arrow {
+		font-size: 9px;
+		transition: transform 120ms ease;
+		display: inline-block;
+	}
+	.sf-section-arrow.open {
+		transform: rotate(90deg);
+	}
+
+	.sf-active-count {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 16px;
+		height: 16px;
+		border-radius: var(--terminal-radius-none);
+		background: var(--terminal-accent-cyan);
+		color: var(--terminal-fg-inverted);
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 700;
+		margin-left: 4px;
+		padding: 0 3px;
+	}
+
+	.sf-section-body {
+		padding: 0 12px 10px;
+	}
+
+	.sf-check-grid {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.sf-check {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 2px 0;
+		cursor: pointer;
+	}
+	.sf-check input[type="checkbox"] {
+		width: 12px;
+		height: 12px;
+		accent-color: var(--terminal-accent-cyan);
+		margin: 0;
+		flex-shrink: 0;
+	}
+
+	.sf-check-label {
+		font-size: 11px;
+		color: var(--terminal-fg-secondary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	/* ── Metric range inputs ─────────────────────────── */
+	.sf-metric-row {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+		margin-bottom: 8px;
+	}
+
+	.sf-metric-label {
+		font-size: 10px;
+		font-weight: 600;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.sf-metric-inputs {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	.sf-metric-input {
+		flex: 1;
+		min-width: 0;
+		width: 56px;
+		background: transparent;
+		border: 1px solid var(--terminal-fg-disabled);
+		border-radius: 0;
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
+		font-size: 11px;
+		padding: 4px 6px;
+		text-align: right;
+		outline: none;
+		box-sizing: border-box;
+		-moz-appearance: textfield;
+	}
+	.sf-metric-input::-webkit-inner-spin-button,
+	.sf-metric-input::-webkit-outer-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+	.sf-metric-input::placeholder {
+		color: var(--terminal-fg-muted);
+		text-align: right;
+	}
+	.sf-metric-input:focus {
+		border-color: color-mix(in srgb, var(--terminal-accent-cyan) 40%, transparent);
+	}
+
+	.sf-metric-sep {
+		color: var(--terminal-fg-muted);
+		font-size: 10px;
+		flex-shrink: 0;
+	}
+
+	/* ── Manager typeahead ────────────────────────────── */
+	.sf-manager-typeahead {
+		position: relative;
+	}
+
+	.sf-manager-input {
+		width: 100%;
+		background: transparent;
+		border: 1px solid var(--terminal-fg-disabled);
+		border-radius: 0;
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
+		font-size: 11px;
+		padding: 5px 8px;
+		outline: none;
+		box-sizing: border-box;
+	}
+	.sf-manager-input::placeholder {
+		color: var(--terminal-fg-muted);
+	}
+	.sf-manager-input:focus {
+		border-color: color-mix(in srgb, var(--terminal-accent-cyan) 40%, transparent);
+	}
+
+	.sf-manager-suggestions {
+		position: absolute;
+		left: 0;
+		right: 0;
+		z-index: 20;
+		background: var(--terminal-bg-overlay);
+		border: 1px solid var(--terminal-fg-disabled);
+		border-top: none;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		max-height: 200px;
+		overflow-y: auto;
+	}
+
+	.sf-manager-suggestion {
+		padding: 5px 8px;
+		font-size: 11px;
+		color: var(--terminal-fg-secondary);
+		cursor: pointer;
+	}
+	.sf-manager-suggestion:hover {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 8%, transparent);
+		color: var(--terminal-fg-primary);
+	}
+
+	.sf-manager-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		margin-top: 6px;
+	}
+
+	.sf-manager-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		font-family: var(--terminal-font-mono);
+		font-size: 10px;
+		color: var(--terminal-accent-cyan);
+		border: 1px solid color-mix(in srgb, var(--terminal-accent-cyan) 30%, transparent);
+		padding: 2px 6px;
+		white-space: nowrap;
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.sf-manager-chip-x {
+		background: none;
+		border: none;
+		color: var(--terminal-accent-cyan);
+		font-size: 10px;
+		cursor: pointer;
+		padding: 0;
+		line-height: 1;
+		font-family: var(--terminal-font-mono);
+		opacity: 0.6;
+	}
+	.sf-manager-chip-x:hover {
+		opacity: 1;
+	}
+
+	/* ── Range sliders ─────────────────────────────────── */
+	.sf-range-group {
+		margin-bottom: 10px;
+	}
+
+	.sf-range-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 4px;
+		color: var(--terminal-fg-secondary);
+		font-size: 10px;
+	}
+
+	.sf-range-value {
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.sf-slider {
+		width: 100%;
+		-webkit-appearance: none;
+		appearance: none;
+		height: 3px;
+		background: var(--terminal-bg-panel-raised);
+		border-radius: var(--terminal-radius-none);
+		outline: none;
+	}
+	.sf-slider::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		appearance: none;
+		width: 10px;
+		height: 10px;
+		border-radius: var(--terminal-radius-none);
+		background: var(--terminal-accent-cyan);
+		cursor: pointer;
+		border: none;
+	}
+	.sf-slider::-moz-range-thumb {
+		width: 10px;
+		height: 10px;
+		border-radius: var(--terminal-radius-none);
+		background: var(--terminal-accent-cyan);
+		cursor: pointer;
+		border: none;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalScreenerShell.svelte
+++ b/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalScreenerShell.svelte
@@ -22,7 +22,7 @@
 	import { SvelteMap } from "svelte/reactivity";
 	import { goto } from "$app/navigation";
 	import { resolve } from "$app/paths";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../api/client";
 	import TerminalScreenerFilters, {
 		type FilterState,
 	} from "./TerminalScreenerFilters.svelte";

--- a/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalScreenerShell.svelte
+++ b/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalScreenerShell.svelte
@@ -1,0 +1,667 @@
+<!--
+  TerminalScreenerShell — 2-column high-density screener grid.
+
+  Grid topology:
+    ┌──────────┬─────────────────────────────────────┐
+    │          │                                     │
+    │ FILTERS  │            DATA GRID                │
+    │ (280px)  │             (1fr)                   │
+    │          │                                     │
+    └──────────┴─────────────────────────────────────┘
+
+  Data source: `/screener/catalog` (materialized view mv_unified_funds
+  over SEC N-CEN/XBRL, ESMA Fund Register, and hedge/private fund
+  tables). Filters drive the backend query directly — all filtering,
+  sorting and pagination happen server-side.
+
+  Debounced fetch (250ms) with AbortController to cancel in-flight
+  requests when the user drags a slider.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { SvelteMap } from "svelte/reactivity";
+	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
+	import { createClientApiClient } from "$wealth/api/client";
+	import TerminalScreenerFilters, {
+		type FilterState,
+	} from "./TerminalScreenerFilters.svelte";
+	import TerminalDataGrid, { type ScreenerAsset } from "./TerminalDataGrid.svelte";
+	import FilterChipRow from "./FilterChipRow.svelte";
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	const HREF_BUILDER = resolve("/portfolio/builder");
+
+	interface Props {
+		filters: FilterState;
+		onFiltersChange: (filters: FilterState) => void;
+	}
+
+	let { filters, onFiltersChange }: Props = $props();
+
+	// ── Universe labels ──────────────────────��──────────
+	const FUND_TYPE_LABELS: Record<string, string> = {
+		mutual_fund: "Mutual",
+		etf: "ETF",
+		closed_end: "CEF",
+		interval_fund: "Interval",
+		bdc: "BDC",
+		money_market: "MMF",
+		hedge_fund: "Hedge",
+		private_fund: "Private",
+		private_equity_fund: "PE",
+		ucits: "UCITS",
+		unknown: "—",
+	};
+
+	// ── Backend catalog item shape (subset we consume) ──
+	interface UnifiedFundItem {
+		external_id: string;
+		instrument_id: string | null;
+		universe: string;
+		name: string;
+		ticker: string | null;
+		isin: string | null;
+		fund_type: string;
+		strategy_label: string | null;
+		investment_geography: string | null;
+		domicile: string | null;
+		currency: string | null;
+		manager_name: string | null;
+		manager_id: string | null;
+		aum: number | null;
+		inception_date: string | null;
+		expense_ratio_pct: number | null;
+		avg_annual_return_1y: number | null;
+		avg_annual_return_10y: number | null;
+		elite_flag: boolean | null;
+		manager_score: number | null;
+		blended_momentum_score: number | null;
+		in_universe: boolean;
+		approval_status?: string | null;
+		disclosure?: { nav_status?: string | null };
+	}
+
+	interface UnifiedCatalogPage {
+		items: UnifiedFundItem[];
+		total: number;
+		page: number;
+		page_size: number;
+		has_next: boolean;
+		next_cursor: string | null;
+	}
+
+	function toAsset(raw: UnifiedFundItem): ScreenerAsset {
+		return {
+			id: raw.external_id,
+			instrumentId: raw.instrument_id,
+			ticker: raw.ticker,
+			name: raw.name,
+			fundType: raw.fund_type,
+			universeLabel: FUND_TYPE_LABELS[raw.fund_type] ?? raw.fund_type,
+			strategy: raw.strategy_label,
+			geography: raw.investment_geography,
+			domicile: raw.domicile,
+			currency: raw.currency,
+			managerName: raw.manager_name,
+			managerId: raw.manager_id,
+			aum: raw.aum,
+			expenseRatioPct: raw.expense_ratio_pct != null ? raw.expense_ratio_pct * 100 : null,
+			ret1y: raw.avg_annual_return_1y != null ? raw.avg_annual_return_1y * 100 : null,
+			ret10y: raw.avg_annual_return_10y != null ? raw.avg_annual_return_10y * 100 : null,
+			managerScore: raw.manager_score,
+			blendedMomentumScore: raw.blended_momentum_score,
+			inceptionDate: raw.inception_date,
+			isin: raw.isin,
+			navStatus: raw.disclosure?.nav_status ?? null,
+			eliteFlag: raw.elite_flag === true,
+			inUniverse: raw.in_universe === true,
+			approvalStatus: raw.approval_status ?? null,
+			universe: raw.universe,
+		};
+	}
+
+	// ── State ───────────────────────────────────────────
+	let assets = $state<ScreenerAsset[]>([]);
+	let total = $state(0);
+	let loading = $state(false);
+	let errorMessage = $state<string | null>(null);
+	let selectedId = $state<string | null>(null);
+	let highlightedIndex = $state(-1);
+
+	// ── Infinite scroll state ────────────────────────────
+	let nextCursor = $state<string | null>(null);
+	let isLoadingMore = $state(false);
+	/** Generation counter — increments on every fresh fetch (filter change). */
+	let fetchGeneration = $state(0);
+
+	// ── Sparkline batch fetch ───────────────────────────
+	/**
+	 * Keyed by instrument_id (UUID). Populated after each catalog fetch
+	 * from POST /screener/sparklines. Passed down to TerminalDataGrid;
+	 * the grid's MiniSparkline column reads by row.instrumentId.
+	 *
+	 * Stored as a Map (not a plain Record) so the prop reference
+	 * changes when the fetch completes — triggers downstream $derived
+	 * reactivity cleanly.
+	 */
+	let sparklineMap = $state<Map<string, number[]>>(new Map());
+	let sparklineFetchId = 0;
+
+	interface SparklineResponsePoint {
+		month: string;
+		nav_close: number;
+		return_1m?: number | null;
+	}
+
+	async function refreshSparklines(currentAssets: ScreenerAsset[]) {
+		const ids = currentAssets
+			.map((a) => a.instrumentId)
+			.filter((id): id is string => id !== null);
+		if (ids.length === 0) {
+			sparklineMap = new Map();
+			return;
+		}
+		const fetchId = ++sparklineFetchId;
+		// Endpoint caps at 100 IDs per call; chunk in parallel and merge.
+		const CHUNK = 100;
+		const chunks: string[][] = [];
+		for (let i = 0; i < ids.length; i += CHUNK) {
+			chunks.push(ids.slice(i, i + CHUNK));
+		}
+		try {
+			const results = await Promise.all(
+				chunks.map((chunk) =>
+					api.post<Record<string, SparklineResponsePoint[]>>(
+						"/screener/sparklines",
+						{ instrument_ids: chunk, months: 12 },
+					),
+				),
+			);
+			if (fetchId !== sparklineFetchId) return; // stale
+			const next = new SvelteMap<string, number[]>();
+			for (const chunkResult of results) {
+				for (const [iid, points] of Object.entries(chunkResult)) {
+					if (!Array.isArray(points) || points.length < 2) continue;
+					next.set(
+						iid,
+						points.map((p) => p.nav_close),
+					);
+				}
+			}
+			sparklineMap = next;
+		} catch {
+			// Non-fatal: sparklines are decorative — MiniSparkline renders
+			// empty svg when no data is present.
+		}
+	}
+
+
+	// ── Query builder ──────────────���────────────────────
+	function buildQuery(f: FilterState): Record<string, string> {
+		const q: Record<string, string> = {
+			page: "1",
+			page_size: "200",
+			sort: "aum_desc",
+			in_universe: "true", // Always filter to NAV-populated funds — non-negotiable data-quality gate
+		};
+		if (f.eliteOnly) q.elite_only = "true";
+		if (f.fundUniverse.size > 0) q.fund_universe = [...f.fundUniverse].join(",");
+		if (f.strategies.size > 0) q.strategy_label = [...f.strategies].join(",");
+		if (f.geographies.size > 0) q.investment_geography = [...f.geographies].join(",");
+		if (f.aumMin > 0) q.aum_min = String(f.aumMin);
+		if (f.aumMax > 0) q.aum_max = String(f.aumMax);
+		if (f.returnMin > -999) q.min_return_1y = String(f.returnMin);
+		if (f.returnMax < 999) q.return_1y_max = String(f.returnMax / 100);
+		if (f.expenseMax < 10) q.max_expense_ratio = String(f.expenseMax);
+		if (f.managerNames.length > 0) q.manager_names = f.managerNames.join(",");
+
+		// Expanded metric filters
+		if (f.sharpeMin) q.sharpe_min = f.sharpeMin;
+		if (f.sharpeMax) q.sharpe_max = f.sharpeMax;
+		if (f.volatilityMax) q.volatility_max = f.volatilityMax;
+		if (f.return10yMin) q.return_10y_min = f.return10yMin;
+		if (f.return10yMax) q.return_10y_max = f.return10yMax;
+
+		// Drawdown: user enters positive % (e.g. 15 = 15%), backend expects negative decimal
+		// "No worse than 15%" → max_drawdown_min = -0.15 (floor)
+		// "At least 5% drawdown" → max_drawdown_max = -0.05 (ceiling)
+		if (f.drawdownMaxPct) q.max_drawdown_min = String(-Math.abs(+f.drawdownMaxPct) / 100);
+		if (f.drawdownMinPct) q.max_drawdown_max = String(-Math.abs(+f.drawdownMinPct) / 100);
+
+		return q;
+	}
+
+	// ── Debounced reactive fetch ────────────────────────
+	let debounceHandle: ReturnType<typeof setTimeout> | null = null;
+	let currentFetchId = 0;
+	let retryTrigger = $state(0);
+
+	function retryFetch() {
+		errorMessage = null;
+		retryTrigger++;
+	}
+
+	$effect(() => {
+		// Track filters + retryTrigger to trigger re-runs
+		const snapshot = buildQuery(filters);
+		void retryTrigger; // reactive dependency for retry
+
+		if (debounceHandle) clearTimeout(debounceHandle);
+		debounceHandle = setTimeout(async () => {
+			const fetchId = ++currentFetchId;
+			loading = true;
+			errorMessage = null;
+			// Reset infinite scroll state on fresh fetch
+			nextCursor = null;
+			isLoadingMore = false;
+			fetchGeneration++;
+
+			try {
+				const page = await api.get<UnifiedCatalogPage>("/screener/catalog", snapshot);
+				if (fetchId !== currentFetchId) return; // stale
+				assets = page.items.map(toAsset);
+				total = page.total;
+				nextCursor = page.next_cursor;
+
+				// Drop selection if it fell out of the current result set
+				if (selectedId && !assets.some((a) => a.id === selectedId)) {
+					selectedId = null;
+				}
+
+				// Fire-and-forget sparkline fetch — decorative overlay,
+				// must not block the catalog render.
+				void refreshSparklines(assets);
+			} catch (err) {
+				if (fetchId !== currentFetchId) return;
+				assets = [];
+				total = 0;
+				nextCursor = null;
+				const raw = err instanceof Error ? err.message : "Failed to load catalog";
+				// Truncate verbose backend tracebacks to first meaningful line
+				const firstLine = raw.split("\n")[0] ?? raw;
+				errorMessage = firstLine.length > 200 ? firstLine.slice(0, 200) + "..." : firstLine;
+			} finally {
+				if (fetchId === currentFetchId) loading = false;
+			}
+		}, 250);
+
+		return () => {
+			if (debounceHandle) clearTimeout(debounceHandle);
+		};
+	});
+
+	// ── Infinite scroll: load next page ─────────────────
+	async function loadMore() {
+		if (!nextCursor || isLoadingMore || loading) return;
+		isLoadingMore = true;
+		try {
+			const snapshot = buildQuery(filters);
+			snapshot.cursor = nextCursor;
+			delete snapshot.page; // keyset mode — no offset
+			const page = await api.get<UnifiedCatalogPage>("/screener/catalog", snapshot);
+			const newAssets = page.items.map(toAsset);
+			assets = [...assets, ...newAssets];
+			// Keep the initial total (page 1) — keyset cursor changes the
+			// windowed count on subsequent pages due to WHERE clause shift.
+			nextCursor = page.next_cursor;
+			// Refresh sparkline map for the combined asset set.
+			void refreshSparklines(assets);
+		} catch {
+			// Non-fatal: user can keep scrolling to retry
+		} finally {
+			isLoadingMore = false;
+		}
+	}
+
+	function handleSelect(asset: ScreenerAsset) {
+		selectedId = asset.id;
+	}
+
+	function handleHighlight(index: number) {
+		highlightedIndex = index;
+	}
+
+	// ── Action handlers (approve / DD queue) ────────────
+	let toastMessage = $state<{ text: string; type: "success" | "warn" | "info" } | null>(null);
+	let toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function showToast(text: string, type: "success" | "warn" | "info") {
+		toastMessage = { text, type };
+		if (toastTimer) clearTimeout(toastTimer);
+		toastTimer = setTimeout(() => { toastMessage = null; }, 3000);
+	}
+
+	async function handleApprove(asset: ScreenerAsset) {
+		if (!asset.instrumentId) {
+			showToast("Fund not yet in instruments universe", "warn");
+			return;
+		}
+		try {
+			const resp = await api.post<{ approved: string[]; rejected_dd_required: string[] }>(
+				"/universe/fast-approve",
+				{ instrument_ids: [asset.instrumentId] },
+			);
+			if (resp.rejected_dd_required.length > 0) {
+				showToast("DD report required for this fund type", "warn");
+				return;
+			}
+			showToast("Fund approved to universe", "success");
+			// Update locally
+			const idx = assets.findIndex((a) => a.id === asset.id);
+			if (idx >= 0) {
+				assets[idx] = { ...assets[idx], inUniverse: true } as ScreenerAsset;
+			}
+		} catch {
+			showToast("Failed to approve fund", "warn");
+		}
+	}
+
+	// ── DataGrid ref for scrollToIndex ──────────────────
+	let dataGridRef: TerminalDataGrid | undefined = $state();
+	let filtersEl: HTMLDivElement | undefined = $state();
+	let rootEl: HTMLDivElement | undefined = $state();
+
+	// ── Keyboard shortcuts ──────────────────────────────
+	function handleKeydown(e: KeyboardEvent) {
+		// Don't fire when typing in inputs
+		const target = e.target as HTMLElement;
+		if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.tagName === "SELECT") {
+			if (e.key === "Escape") {
+				target.blur();
+				e.preventDefault();
+			}
+			return;
+		}
+
+		switch (e.key) {
+			case "/": {
+				e.preventDefault();
+				// Focus first interactive element in filter panel
+				const input = filtersEl?.querySelector("input, button");
+				if (input instanceof HTMLElement) input.focus();
+				break;
+			}
+			case "ArrowDown": {
+				e.preventDefault();
+				const next = Math.min(highlightedIndex + 1, assets.length - 1);
+				highlightedIndex = next;
+				dataGridRef?.scrollToIndex(next);
+				break;
+			}
+			case "ArrowUp": {
+				e.preventDefault();
+				const prev = Math.max(highlightedIndex - 1, 0);
+				highlightedIndex = prev;
+				dataGridRef?.scrollToIndex(prev);
+				break;
+			}
+			case "Enter": {
+				if (highlightedIndex >= 0 && highlightedIndex < assets.length) {
+					const asset = assets[highlightedIndex];
+					if (asset) {
+						selectedId = asset.id;
+						// Dispatch focustrigger event for FocusMode (bubbles to page)
+						rootEl?.dispatchEvent(
+							new CustomEvent("focustrigger", {
+								bubbles: true,
+								detail: { entityKind: "fund", entityId: asset.id, entityLabel: asset.name },
+							}),
+						);
+					}
+				}
+				break;
+			}
+			case "u": {
+				if (highlightedIndex >= 0 && highlightedIndex < assets.length) {
+					const asset = assets[highlightedIndex];
+					if (asset && !asset.inUniverse && asset.approvalStatus !== "pending") {
+						handleApprove(asset);
+					}
+				}
+				break;
+			}
+			case "d": {
+				if (highlightedIndex >= 0 && highlightedIndex < assets.length) {
+					const asset = assets[highlightedIndex];
+					if (asset && !asset.inUniverse && asset.approvalStatus !== "pending") {
+						handleQueueDD(asset);
+					}
+				}
+				break;
+			}
+			case "e": {
+				e.preventDefault();
+				onFiltersChange({ ...filters, eliteOnly: !filters.eliteOnly });
+				break;
+			}
+			case "b": {
+				if (highlightedIndex >= 0 && highlightedIndex < assets.length) {
+					const asset = assets[highlightedIndex];
+					if (asset && asset.inUniverse) {
+						goto(HREF_BUILDER);
+					} else {
+						showToast("Fund must be approved to universe first", "warn");
+					}
+				}
+				break;
+			}
+		}
+	}
+
+	async function handleQueueDD(asset: ScreenerAsset) {
+		if (!asset.instrumentId) {
+			showToast("Fund not yet in instruments universe", "warn");
+			return;
+		}
+		try {
+			await api.post("/dd-reports/funds/" + asset.instrumentId);
+			showToast("DD report queued", "info");
+			// Update locally
+			const idx = assets.findIndex((a) => a.id === asset.id);
+			if (idx >= 0) {
+				assets[idx] = { ...assets[idx], approvalStatus: "pending" } as ScreenerAsset;
+			}
+		} catch {
+			showToast("Failed to queue DD report", "warn");
+		}
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="ts-root" onkeydown={handleKeydown} bind:this={rootEl}>
+	<div class="ts-zone ts-filters" aria-label="Screener filters" bind:this={filtersEl}>
+		<TerminalScreenerFilters {filters} {onFiltersChange} />
+	</div>
+	<div class="ts-zone ts-datagrid" aria-label="Instrument data grid">
+		{#if errorMessage}
+			<div class="sep-panel">
+				<div class="sep-header">
+					<span class="sep-code">[ ERR ]</span>
+					<span class="sep-title">SCREENER DATA ERROR</span>
+				</div>
+				<div class="sep-body">
+					<p class="sep-message">{errorMessage}</p>
+					<p class="sep-hint">The screener encountered a data error. This may be caused by a backend timeout, a malformed response, or a network issue.</p>
+				</div>
+				<div class="sep-actions">
+					<button class="sep-btn" onclick={retryFetch}>[ RETRY ]</button>
+					<button class="sep-btn sep-btn--reload" onclick={() => location.reload()}>[ RELOAD PAGE ]</button>
+				</div>
+			</div>
+		{:else}
+			<FilterChipRow {filters} {onFiltersChange} />
+			<svelte:boundary>
+				<TerminalDataGrid
+					bind:this={dataGridRef}
+					{assets}
+					{total}
+					{loading}
+					errorMessage={null}
+					{selectedId}
+					{highlightedIndex}
+					{isLoadingMore}
+					hasMore={nextCursor !== null}
+					{fetchGeneration}
+					{sparklineMap}
+					onSelect={handleSelect}
+					onHighlight={handleHighlight}
+					onApprove={handleApprove}
+					onQueueDD={handleQueueDD}
+					onLoadMore={loadMore}
+				/>
+				{#snippet failed(error, reset)}
+					<div class="sep-panel">
+						<div class="sep-header">
+							<span class="sep-code">[ ERR ]</span>
+							<span class="sep-title">SCREENER RENDER ERROR</span>
+						</div>
+						<div class="sep-body">
+							<p class="sep-message">{(error as Error)?.message ?? "An unexpected rendering error occurred"}</p>
+							<p class="sep-hint">The screener grid encountered a rendering crash. Try retrying or reloading the page.</p>
+						</div>
+						<div class="sep-actions">
+							<button class="sep-btn" onclick={reset}>[ RETRY ]</button>
+							<button class="sep-btn sep-btn--reload" onclick={() => location.reload()}>[ RELOAD PAGE ]</button>
+						</div>
+					</div>
+				{/snippet}
+			</svelte:boundary>
+		{/if}
+	</div>
+
+	{#if toastMessage}
+		<div class="ts-toast ts-toast--{toastMessage.type}">{toastMessage.text}</div>
+	{/if}
+</div>
+
+<style>
+	.ts-root {
+		display: grid;
+		grid-template-areas: "filters datagrid";
+		grid-template-columns: 280px 1fr;
+		grid-template-rows: 1fr;
+		gap: 2px;
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+		background: var(--terminal-bg-void);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.ts-zone {
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.ts-filters { grid-area: filters; }
+	.ts-datagrid {
+		grid-area: datagrid;
+		display: flex;
+		flex-direction: column;
+	}
+	.ts-datagrid :global(> *) {
+		flex-shrink: 0;
+	}
+	.ts-datagrid :global(> .dg-root) {
+		flex: 1 1 auto;
+		min-height: 0;
+	}
+
+	/* ── Error panel ─────────────────────────────────── */
+	.sep-panel {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		gap: var(--terminal-space-6, 24px);
+		padding: var(--terminal-space-6, 24px);
+		font-family: var(--terminal-font-mono, "JetBrains Mono", monospace);
+		color: var(--terminal-status-error, #ef4444);
+	}
+
+	.sep-header {
+		display: flex;
+		align-items: baseline;
+		gap: var(--terminal-space-3, 12px);
+	}
+
+	.sep-code {
+		font-size: var(--terminal-text-20, 20px);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps, 0.06em);
+	}
+
+	.sep-title {
+		font-size: var(--terminal-text-14, 14px);
+		letter-spacing: var(--terminal-tracking-caps, 0.06em);
+		color: var(--terminal-fg-secondary, #8a94a6);
+	}
+
+	.sep-body {
+		text-align: center;
+		max-width: 480px;
+	}
+
+	.sep-message {
+		font-size: var(--terminal-text-11, 11px);
+		color: var(--terminal-fg-primary, #e2e8f0);
+		margin: 0 0 var(--terminal-space-2, 8px);
+	}
+
+	.sep-hint {
+		font-size: var(--terminal-text-11, 11px);
+		color: var(--terminal-fg-tertiary, #5a6577);
+		margin: 0;
+	}
+
+	.sep-actions {
+		display: flex;
+		gap: var(--terminal-space-4, 16px);
+	}
+
+	.sep-btn {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		border-radius: 0;
+		color: var(--terminal-fg-primary, #e2e8f0);
+		font-family: var(--terminal-font-mono, "JetBrains Mono", monospace);
+		font-size: var(--terminal-text-11, 11px);
+		letter-spacing: var(--terminal-tracking-caps, 0.06em);
+		padding: var(--terminal-space-2, 8px) var(--terminal-space-4, 16px);
+		cursor: pointer;
+	}
+
+	.sep-btn:hover {
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+	}
+
+	.sep-btn--reload:hover {
+		border-color: var(--terminal-status-warn, #f59e0b);
+		color: var(--terminal-status-warn, #f59e0b);
+	}
+
+	/* ── Toast ────────────────────────────────────────── */
+	.ts-toast {
+		position: absolute;
+		bottom: 16px;
+		left: 50%;
+		transform: translateX(-50%);
+		padding: 6px 16px;
+		font-family: var(--terminal-font-mono);
+		font-size: 11px;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-overlay);
+		z-index: 10;
+	}
+	.ts-toast--success { color: var(--terminal-status-success); border-color: color-mix(in srgb, var(--terminal-status-success) 30%, transparent); }
+	.ts-toast--warn { color: var(--terminal-accent-amber); border-color: color-mix(in srgb, var(--terminal-accent-amber) 30%, transparent); }
+	.ts-toast--info { color: var(--terminal-accent-cyan); border-color: color-mix(in srgb, var(--terminal-accent-cyan) 30%, transparent); }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/allocation/ImpactPreview.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/allocation/ImpactPreview.svelte
@@ -8,7 +8,7 @@
   import { goto } from "$app/navigation";
   import { resolve } from "$app/paths";
   import { formatNumber, formatPercent, createTerminalChartOptions } from "@investintell/ui";
-  import TerminalChart from "$wealth/components/terminal/charts/TerminalChart.svelte";
+  import TerminalChart from "../../../components/terminal/charts/TerminalChart.svelte";
 
   interface EffectiveEntry {
     name: string;

--- a/packages/ii-terminal-core/src/lib/components/terminal/allocation/ImpactPreview.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/allocation/ImpactPreview.svelte
@@ -1,0 +1,363 @@
+<!--
+  ImpactPreview.svelte — right-side panel showing effective allocation
+  visualization, regime state, simulation trigger, and builder link.
+
+  Terminal-native: no hex, no radius, mono font, TerminalChart only.
+-->
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { resolve } from "$app/paths";
+  import { formatNumber, formatPercent, createTerminalChartOptions } from "@investintell/ui";
+  import TerminalChart from "$wealth/components/terminal/charts/TerminalChart.svelte";
+
+  interface EffectiveEntry {
+    name: string;
+    weight: number;
+  }
+
+  interface SimResult {
+    proposedCvar: number | null;
+    cvarLimit: number | null;
+    cvarUtilization: number | null;
+    cvarDelta: number | null;
+    withinLimit: boolean;
+    warnings: string[];
+  }
+
+  interface ImpactPreviewProps {
+    effective: EffectiveEntry[];
+    regime: string;
+    simulationResult: SimResult | null;
+    onSimulate: () => void;
+    isSimulating: boolean;
+  }
+
+  let { effective, regime, simulationResult, onSimulate, isSimulating }: ImpactPreviewProps =
+    $props();
+
+  // Regime label sanitization + color mapping
+  const REGIME_MAP: Record<string, { label: string; colorVar: string }> = {
+    REGIME_NORMAL: { label: "Normal", colorVar: "var(--terminal-status-ok)" },
+    normal: { label: "Normal", colorVar: "var(--terminal-status-ok)" },
+    REGIME_RISK_ON: { label: "Risk On", colorVar: "var(--terminal-accent-cyan)" },
+    risk_on: { label: "Risk On", colorVar: "var(--terminal-accent-cyan)" },
+    REGIME_RISK_OFF: { label: "Risk Off", colorVar: "var(--terminal-accent-amber)" },
+    risk_off: { label: "Risk Off", colorVar: "var(--terminal-accent-amber)" },
+    REGIME_CRISIS: { label: "Crisis", colorVar: "var(--terminal-status-error)" },
+    crisis: { label: "Crisis", colorVar: "var(--terminal-status-error)" },
+  };
+
+  const regimeDisplay = $derived(REGIME_MAP[regime] ?? { label: regime, colorVar: "var(--terminal-fg-muted)" });
+
+  // Stacked bar chart for effective allocation
+  const chartOption = $derived.by(() => {
+    if (effective.length === 0) return null;
+
+    const sorted = [...effective].sort((a, b) => b.weight - a.weight);
+    const data = sorted.map((e) => ({
+      name: e.name,
+      value: +(e.weight * 100).toFixed(1),
+    }));
+
+    return createTerminalChartOptions({
+      series: [
+        {
+          type: "bar",
+          data: data.map((d) => d.value),
+          barWidth: 16,
+          label: {
+            show: true,
+            position: "right",
+            formatter: "{c}%",
+            fontSize: 10,
+          },
+        },
+      ],
+      xAxis: {
+        type: "value",
+        min: 0,
+        max: 100,
+        axisLabel: {
+          formatter: "{value}%",
+        },
+      },
+      yAxis: {
+        type: "category",
+        data: data.map((d) => d.name),
+        inverse: true,
+        axisLabel: {
+          fontSize: 10,
+          width: 80,
+          overflow: "truncate",
+        },
+      },
+      slot: "secondary",
+      showLegend: false,
+    });
+  });
+
+  function handleBuilderNav() {
+    goto(resolve("/portfolio/builder") + "?alloc=default");
+  }
+</script>
+
+<div class="ip-root">
+  <!-- Regime badge -->
+  <div class="ip-regime">
+    <span class="ip-regime-label">REGIME</span>
+    <span class="ip-regime-value" style:color={regimeDisplay.colorVar}>
+      {regimeDisplay.label}
+    </span>
+  </div>
+
+  <!-- Effective allocation chart -->
+  <div class="ip-chart">
+    {#if chartOption}
+      <TerminalChart option={chartOption} ariaLabel="Effective allocation breakdown" />
+    {:else}
+      <div class="ip-empty">No allocation data</div>
+    {/if}
+  </div>
+
+  <!-- Simulation section -->
+  <div class="ip-sim">
+    <button
+      type="button"
+      class="ip-sim-btn"
+      disabled={isSimulating}
+      onclick={onSimulate}
+      title="Simulation requires portfolio instruments — block-level simulation coming soon"
+    >
+      {isSimulating ? "SIMULATING..." : "SIMULATE"}
+    </button>
+
+    {#if simulationResult}
+      <div class="ip-sim-results">
+        {#if simulationResult.proposedCvar !== null}
+          <div class="ip-sim-row">
+            <span class="ip-sim-label">CVaR (95%, 3M)</span>
+            <span class="ip-sim-value">
+              {formatPercent(simulationResult.proposedCvar, 2)}
+            </span>
+          </div>
+        {/if}
+        {#if simulationResult.cvarUtilization !== null}
+          <div class="ip-sim-row">
+            <span class="ip-sim-label">Risk Budget Used</span>
+            <span class="ip-sim-value">
+              {formatNumber(simulationResult.cvarUtilization, 1)}%
+            </span>
+          </div>
+        {/if}
+        {#if simulationResult.cvarDelta !== null}
+          <div class="ip-sim-row">
+            <span class="ip-sim-label">Risk Change</span>
+            <span
+              class="ip-sim-value"
+              class:ip-sim-value--positive={simulationResult.cvarDelta > 0}
+              class:ip-sim-value--negative={simulationResult.cvarDelta < 0}
+            >
+              {simulationResult.cvarDelta > 0 ? "+" : ""}
+              {formatPercent(simulationResult.cvarDelta, 3)}
+            </span>
+          </div>
+        {/if}
+        <div class="ip-sim-row">
+          <span class="ip-sim-label">Within Limit</span>
+          <span
+            class="ip-sim-value"
+            class:ip-sim-value--ok={simulationResult.withinLimit}
+            class:ip-sim-value--breach={!simulationResult.withinLimit}
+          >
+            {simulationResult.withinLimit ? "YES" : "NO"}
+          </span>
+        </div>
+        {#if simulationResult.warnings.length > 0}
+          <div class="ip-sim-warnings">
+            {#each simulationResult.warnings as warn}
+              <p class="ip-sim-warn">{warn}</p>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </div>
+
+  <!-- Builder navigation -->
+  <div class="ip-nav">
+    <button type="button" class="ip-builder-btn" onclick={handleBuilderNav}>
+      -&gt; BUILDER
+    </button>
+  </div>
+</div>
+
+<style>
+  .ip-root {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-3);
+    height: 100%;
+    font-family: var(--terminal-font-mono);
+  }
+
+  .ip-regime {
+    display: flex;
+    align-items: baseline;
+    gap: var(--terminal-space-2);
+    padding: var(--terminal-space-2) 0;
+    border-bottom: var(--terminal-border-hairline);
+    flex-shrink: 0;
+  }
+
+  .ip-regime-label {
+    font-size: var(--terminal-text-10);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-muted);
+  }
+
+  .ip-regime-value {
+    font-size: var(--terminal-text-14);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .ip-chart {
+    flex: 1;
+    min-height: 120px;
+    max-height: 300px;
+  }
+
+  .ip-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    font-size: var(--terminal-text-11);
+    color: var(--terminal-fg-muted);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .ip-sim {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-2);
+    flex-shrink: 0;
+  }
+
+  .ip-sim-btn {
+    width: 100%;
+    height: 28px;
+    background: transparent;
+    border: var(--terminal-border-hairline);
+    border-radius: var(--terminal-radius-none);
+    color: var(--terminal-accent-cyan);
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    cursor: pointer;
+    transition:
+      border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+      background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .ip-sim-btn:hover:not(:disabled) {
+    border-color: var(--terminal-accent-cyan);
+    background: var(--terminal-bg-panel-raised);
+  }
+
+  .ip-sim-btn:disabled {
+    color: var(--terminal-fg-muted);
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .ip-sim-results {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-1);
+    padding: var(--terminal-space-2);
+    border: var(--terminal-border-hairline);
+  }
+
+  .ip-sim-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: var(--terminal-text-11);
+  }
+
+  .ip-sim-label {
+    color: var(--terminal-fg-muted);
+    font-size: var(--terminal-text-10);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .ip-sim-value {
+    font-variant-numeric: tabular-nums;
+    color: var(--terminal-fg-primary);
+    font-weight: 600;
+  }
+
+  .ip-sim-value--positive {
+    color: var(--terminal-status-error);
+  }
+
+  .ip-sim-value--negative {
+    color: var(--terminal-status-ok);
+  }
+
+  .ip-sim-value--ok {
+    color: var(--terminal-status-ok);
+  }
+
+  .ip-sim-value--breach {
+    color: var(--terminal-status-error);
+  }
+
+  .ip-sim-warnings {
+    padding-top: var(--terminal-space-1);
+    border-top: var(--terminal-border-hairline);
+  }
+
+  .ip-sim-warn {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-muted);
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  .ip-nav {
+    flex-shrink: 0;
+    padding-top: var(--terminal-space-2);
+    border-top: var(--terminal-border-hairline);
+  }
+
+  .ip-builder-btn {
+    width: 100%;
+    height: 32px;
+    background: transparent;
+    border: var(--terminal-border-hairline);
+    border-radius: var(--terminal-radius-none);
+    color: var(--terminal-accent-amber);
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-11);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    cursor: pointer;
+    transition:
+      border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+      background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .ip-builder-btn:hover {
+    border-color: var(--terminal-accent-amber);
+    background: var(--terminal-bg-panel-raised);
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/allocation/WeightsEditor.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/allocation/WeightsEditor.svelte
@@ -1,0 +1,346 @@
+<!--
+  WeightsEditor.svelte — editable strategic + tactical allocation table.
+
+  Terminal-native: mono font, hairline borders, zero radius.
+  Weights display as 0–100% but backend stores as 0–1 decimals.
+  Total validation: sum of strategic weights must equal 100 (tolerance 0.1).
+-->
+<script lang="ts">
+  import { formatNumber } from "@investintell/ui";
+
+  interface BlockRow {
+    blockId: string;
+    name: string;
+    strategicWeight: number;
+    tacticalOverweight: number;
+  }
+
+  interface RegimeSuggestion {
+    blockId: string;
+    suggestedWeight: number;
+  }
+
+  interface WeightsEditorProps {
+    blocks: BlockRow[];
+    regimeSuggestions: RegimeSuggestion[] | null;
+    onSave: (
+      strategic: Array<{ blockId: string; weight: number }>,
+      tactical: Array<{ blockId: string; overweight: number }>,
+    ) => void;
+    isSaving: boolean;
+  }
+
+  let { blocks, regimeSuggestions, onSave, isSaving }: WeightsEditorProps = $props();
+
+  // Local editable state: display as 0-100 scale
+  let editRows = $state<Array<{
+    blockId: string;
+    name: string;
+    strategic: number;
+    tactical: number;
+    originalStrategic: number;
+    originalTactical: number;
+  }>>([]);
+
+  // Sync from props when blocks change
+  $effect(() => {
+    editRows = blocks.map((b) => ({
+      blockId: b.blockId,
+      name: b.name,
+      strategic: b.strategicWeight * 100,
+      tactical: b.tacticalOverweight * 100,
+      originalStrategic: b.strategicWeight * 100,
+      originalTactical: b.tacticalOverweight * 100,
+    }));
+  });
+
+  const strategicTotal = $derived(
+    editRows.reduce((sum, r) => sum + r.strategic, 0),
+  );
+
+  const totalValid = $derived(Math.abs(strategicTotal - 100) < 0.1);
+  const hasChanges = $derived(
+    editRows.some(
+      (r) =>
+        Math.abs(r.strategic - r.originalStrategic) > 0.001 ||
+        Math.abs(r.tactical - r.originalTactical) > 0.001,
+    ),
+  );
+
+  const canSave = $derived(totalValid && hasChanges && !isSaving);
+
+  function getRegimeSuggestion(blockId: string): number | null {
+    if (!regimeSuggestions) return null;
+    const s = regimeSuggestions.find((r) => r.blockId === blockId);
+    return s ? s.suggestedWeight * 100 : null;
+  }
+
+  function handleSave() {
+    if (!canSave) return;
+    onSave(
+      editRows.map((r) => ({ blockId: r.blockId, weight: r.strategic / 100 })),
+      editRows.map((r) => ({ blockId: r.blockId, overweight: r.tactical / 100 })),
+    );
+  }
+
+  function isModified(current: number, original: number): boolean {
+    return Math.abs(current - original) > 0.001;
+  }
+</script>
+
+<div class="we-root">
+  <div class="we-table">
+    <div class="we-header">
+      <span class="we-col we-col--name">Block</span>
+      <span class="we-col we-col--num">Strategic %</span>
+      <span class="we-col we-col--num">Tactical +/-</span>
+      <span class="we-col we-col--num">Effective %</span>
+      <span class="we-col we-col--num">Regime Sug.</span>
+    </div>
+
+    {#each editRows as row, i (row.blockId)}
+      {@const effective = row.strategic + row.tactical}
+      {@const suggestion = getRegimeSuggestion(row.blockId)}
+      <div class="we-row">
+        <span class="we-col we-col--name">{row.name}</span>
+        <span class="we-col we-col--num">
+          <input
+            type="number"
+            class="we-input"
+            class:we-input--modified={isModified(row.strategic, row.originalStrategic)}
+            min="0"
+            max="100"
+            step="0.1"
+            bind:value={row.strategic}
+          />
+        </span>
+        <span class="we-col we-col--num">
+          <input
+            type="number"
+            class="we-input we-input--tactical"
+            class:we-input--modified={isModified(row.tactical, row.originalTactical)}
+            min="-50"
+            max="50"
+            step="0.1"
+            bind:value={row.tactical}
+          />
+        </span>
+        <span
+          class="we-col we-col--num we-effective"
+          class:we-effective--warn={effective < 0 || effective > 100}
+        >
+          {formatNumber(effective, 1)}%
+        </span>
+        <span class="we-col we-col--num we-suggestion">
+          {#if suggestion !== null}
+            {formatNumber(suggestion, 1)}%
+          {:else}
+            --
+          {/if}
+        </span>
+      </div>
+    {/each}
+
+    <div class="we-total" class:we-total--error={!totalValid}>
+      <span class="we-col we-col--name">TOTAL</span>
+      <span class="we-col we-col--num we-total-value">
+        {formatNumber(strategicTotal, 1)}%
+      </span>
+      <span class="we-col we-col--num"></span>
+      <span class="we-col we-col--num we-total-value">
+        {formatNumber(
+          editRows.reduce((s, r) => s + r.strategic + r.tactical, 0),
+          1,
+        )}%
+      </span>
+      <span class="we-col we-col--num"></span>
+    </div>
+  </div>
+
+  <div class="we-actions">
+    {#if !totalValid}
+      <span class="we-validation-msg">Strategic weights must sum to 100%</span>
+    {/if}
+    <button
+      type="button"
+      class="we-save-btn"
+      disabled={!canSave}
+      onclick={handleSave}
+    >
+      {isSaving ? "SAVING..." : "SAVE WEIGHTS"}
+    </button>
+  </div>
+</div>
+
+<style>
+  .we-root {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-3);
+    height: 100%;
+    font-family: var(--terminal-font-mono);
+  }
+
+  .we-table {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .we-header {
+    display: flex;
+    align-items: center;
+    height: 28px;
+    padding: 0 var(--terminal-space-2);
+    border-bottom: var(--terminal-border-hairline);
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-muted);
+    flex-shrink: 0;
+  }
+
+  .we-row {
+    display: flex;
+    align-items: center;
+    height: 36px;
+    padding: 0 var(--terminal-space-2);
+    border-bottom: var(--terminal-border-hairline);
+    font-size: var(--terminal-text-11);
+    color: var(--terminal-fg-secondary);
+  }
+
+  .we-row:hover {
+    background: var(--terminal-bg-panel-raised);
+  }
+
+  .we-col {
+    display: flex;
+    align-items: center;
+  }
+
+  .we-col--name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--terminal-fg-primary);
+    font-weight: 600;
+  }
+
+  .we-col--num {
+    width: 110px;
+    flex-shrink: 0;
+    justify-content: flex-end;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .we-input {
+    width: 72px;
+    height: 24px;
+    padding: 0 var(--terminal-space-2);
+    background: var(--terminal-bg-void);
+    border: var(--terminal-border-hairline);
+    border-radius: var(--terminal-radius-none);
+    color: var(--terminal-fg-primary);
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-11);
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+    outline: none;
+  }
+
+  .we-input:focus {
+    border-color: var(--terminal-accent-amber);
+  }
+
+  .we-input--modified {
+    color: var(--terminal-accent-cyan);
+  }
+
+  .we-input--tactical {
+    width: 64px;
+  }
+
+  .we-effective {
+    color: var(--terminal-fg-primary);
+  }
+
+  .we-effective--warn {
+    color: var(--terminal-status-error);
+  }
+
+  .we-suggestion {
+    color: var(--terminal-fg-muted);
+    font-style: italic;
+  }
+
+  .we-total {
+    display: flex;
+    align-items: center;
+    height: 32px;
+    padding: 0 var(--terminal-space-2);
+    border-top: 1px solid var(--terminal-fg-muted);
+    font-size: var(--terminal-text-11);
+    font-weight: 700;
+    color: var(--terminal-fg-primary);
+    flex-shrink: 0;
+  }
+
+  .we-total--error {
+    color: var(--terminal-status-error);
+  }
+
+  .we-total-value {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .we-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--terminal-space-3);
+    padding: var(--terminal-space-2) 0;
+    flex-shrink: 0;
+  }
+
+  .we-validation-msg {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-status-error);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .we-save-btn {
+    height: 28px;
+    padding: 0 var(--terminal-space-4);
+    background: transparent;
+    border: var(--terminal-border-hairline);
+    border-radius: var(--terminal-radius-none);
+    color: var(--terminal-accent-amber);
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    cursor: pointer;
+    transition:
+      border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+      background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .we-save-btn:hover:not(:disabled) {
+    border-color: var(--terminal-accent-amber);
+    background: var(--terminal-bg-panel-raised);
+  }
+
+  .we-save-btn:disabled {
+    color: var(--terminal-fg-muted);
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/ActivationBar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/ActivationBar.svelte
@@ -7,7 +7,7 @@
 <script lang="ts">
 	import { fly } from "svelte/transition";
 	import { svelteTransitionFor } from "@investintell/ui";
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import { workspace } from "../../../state/portfolio-workspace.svelte";
 	import ConsequenceDialog from "./ConsequenceDialog.svelte";
 
 	interface Props {

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/ActivationBar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/ActivationBar.svelte
@@ -1,0 +1,141 @@
+<!--
+  ActivationBar — Zone F fixed footer in the Builder right column.
+
+  Appears ONLY when: runPhase === "done" AND allTabsVisited === true.
+  Two buttons: Save as Draft + Activate Portfolio (opens ConsequenceDialog).
+-->
+<script lang="ts">
+	import { fly } from "svelte/transition";
+	import { svelteTransitionFor } from "@investintell/ui";
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import ConsequenceDialog from "./ConsequenceDialog.svelte";
+
+	interface Props {
+		allTabsVisited: boolean;
+	}
+
+	let { allTabsVisited }: Props = $props();
+
+	const visible = $derived(workspace.runPhase === "done" && allTabsVisited);
+
+	let showDialog = $state(false);
+	let successBanner = $state(false);
+
+	async function handleSaveDraft() {
+		// Draft is the current state — no explicit save needed beyond
+		// the already-persisted construction run. This is a UX affordance
+		// to reassure PMs their work is saved.
+	}
+
+	function handleActivateClick() {
+		showDialog = true;
+	}
+
+	function handleDialogClose() {
+		showDialog = false;
+	}
+
+	function handleActivateSuccess() {
+		showDialog = false;
+		successBanner = true;
+	}
+</script>
+
+{#if visible}
+	<div class="ab-bar" in:fly={{ y: 12, ...svelteTransitionFor("tail", { duration: "update" }) }}>
+		<button type="button" class="ab-btn ab-btn--secondary" onclick={handleSaveDraft}>
+			Save as Draft
+		</button>
+		<button type="button" class="ab-btn ab-btn--primary" onclick={handleActivateClick}>
+			Activate Portfolio
+		</button>
+	</div>
+{/if}
+
+{#if successBanner}
+	<div class="ab-success">
+		Portfolio activated &mdash;
+		<a href="/live" class="ab-success-link">view in Live Workbench</a>
+	</div>
+{/if}
+
+{#if showDialog}
+	<ConsequenceDialog
+		onclose={handleDialogClose}
+		onsuccess={handleActivateSuccess}
+	/>
+{/if}
+
+<style>
+	.ab-bar {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: var(--terminal-space-2);
+		height: 48px;
+		padding: 0 var(--terminal-space-3);
+		border-top: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+		flex-shrink: 0;
+	}
+
+	.ab-btn {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		border-radius: var(--terminal-radius-none);
+		cursor: pointer;
+		transition:
+			background var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.ab-btn--secondary {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.ab-btn--secondary:hover {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+	}
+
+	.ab-btn--primary {
+		background: var(--terminal-accent-amber);
+		border: 1px solid var(--terminal-accent-amber);
+		color: var(--terminal-bg-void);
+	}
+
+	.ab-btn--primary:hover {
+		opacity: 0.9;
+	}
+
+	.ab-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.ab-success {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--terminal-space-1);
+		height: 36px;
+		background: var(--terminal-status-success);
+		color: var(--terminal-bg-void);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.ab-success-link {
+		color: var(--terminal-bg-void);
+		text-decoration: underline;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/AdvisorTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/AdvisorTab.svelte
@@ -1,0 +1,410 @@
+<!--
+  AdvisorTab — Zone E ADVISOR tab of the Builder results panel.
+
+  Migrated from ConstructionNarrative.svelte, restyled for terminal.
+  Renders: headline, key points, ex-ante metrics strip, holding changes,
+  advisor notes. All text plain institutional — no markdown rendering.
+-->
+<script lang="ts">
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import { formatNumber, formatPercent } from "@investintell/ui";
+
+	const run = $derived(workspace.constructionRun);
+	// PR-A5 B.5 — phase gating: distinguish idle vs in-flight.
+	const isIdle = $derived(run === null && workspace.runPhase === "idle");
+	const isInFlight = $derived(
+		run === null &&
+			workspace.runPhase !== "idle" &&
+			workspace.runPhase !== "done" &&
+			workspace.runPhase !== "error" &&
+			workspace.runPhase !== "cancelled",
+	);
+	const narrative = $derived(run?.narrative ?? null);
+	const metrics = $derived(run?.ex_ante_metrics ?? null);
+	const deltas = $derived(run?.ex_ante_vs_previous ?? null);
+	const advisor = $derived(run?.advisor ?? null);
+	const holdingChanges = $derived(narrative?.holding_changes ?? []);
+
+	/** Sanitized metric labels for the stat slabs. */
+	const METRIC_DISPLAY: Array<{
+		key: string;
+		label: string;
+		format: (v: number) => string;
+	}> = [
+		{ key: "cvar_95", label: "Tail Loss (95%)", format: (v) => formatPercent(v, 2) },
+		{ key: "expected_return", label: "Expected Return", format: (v) => formatPercent(v, 2) },
+		{
+			key: "portfolio_volatility",
+			label: "Tracking Error",
+			format: (v) => formatPercent(v, 2),
+		},
+		{ key: "sharpe_ratio", label: "Sharpe Ratio", format: (v) => formatNumber(v, 2) },
+	];
+
+	const advisorEntries = $derived.by(() => {
+		if (!advisor || typeof advisor !== "object") return [];
+		return Object.entries(advisor as Record<string, unknown>).filter(
+			([, v]) => v !== null && v !== undefined && typeof v !== "object",
+		);
+	});
+
+	function formatAdvisorValue(key: string, value: unknown): string {
+		if (value === null || value === undefined) return "\u2014";
+		if (typeof value === "number") {
+			if (key.includes("pct") || key.includes("gap") || key.includes("cvar")) {
+				return formatPercent(value, 2);
+			}
+			return formatNumber(value, 4);
+		}
+		if (typeof value === "boolean") return value ? "yes" : "no";
+		if (typeof value === "string") return value;
+		return String(value);
+	}
+
+	/** Map raw backend keys to institutional display labels. */
+	const ADVISOR_KEY_LABELS: Record<string, string> = {
+		portfolio_id: "Portfolio",
+		profile: "Profile",
+		current_cvar_95: "Current Tail Loss (95%)",
+		cvar_limit: "Tail Loss Limit",
+		cvar_gap: "Risk Budget Gap",
+		detail_endpoint: "Detail Endpoint",
+		note: "Note",
+	};
+
+	function advisorKeyLabel(key: string): string {
+		return ADVISOR_KEY_LABELS[key] ?? key.replace(/_/g, " ");
+	}
+</script>
+
+<svelte:boundary>
+	<div class="at-root">
+		{#if isIdle}
+			<div class="at-empty">Aguardando construction run</div>
+		{:else if isInFlight}
+			<div class="at-skeleton" aria-busy="true">
+				<div class="at-skeleton-line at-skeleton-line--wide"></div>
+				<div class="at-skeleton-line"></div>
+				<div class="at-skeleton-line at-skeleton-line--narrow"></div>
+			</div>
+		{:else if !run}
+			<div class="at-empty">Run construction to see advisor analysis</div>
+		{:else if !narrative}
+			<div class="at-empty">No narrative in this construction run</div>
+		{:else}
+			<!-- Headline -->
+			{#if narrative.headline}
+				<h3 class="at-headline">{narrative.headline}</h3>
+			{/if}
+
+			<!-- Key points -->
+			{#if narrative.key_points && narrative.key_points.length > 0}
+				<ul class="at-points">
+					{#each narrative.key_points as point, i (i)}
+						<li class="at-point">{point}</li>
+					{/each}
+				</ul>
+			{/if}
+
+			<!-- Ex-ante metrics strip -->
+			{#if metrics}
+				<div class="at-metrics">
+					{#each METRIC_DISPLAY as m (m.key)}
+						{@const value = metrics[m.key]}
+						{@const delta = deltas?.[m.key]}
+						<div class="at-stat">
+							<span class="at-stat-label">{m.label}</span>
+							<span class="at-stat-value">
+								{value != null ? m.format(value) : "\u2014"}
+							</span>
+							{#if delta != null && delta !== 0}
+								<span
+									class="at-stat-delta"
+									class:at-stat-delta--pos={delta > 0}
+									class:at-stat-delta--neg={delta < 0}
+								>
+									{delta > 0 ? "+" : ""}{formatNumber(delta * 100, 2)}pp
+								</span>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			{/if}
+
+			<!-- Holding changes -->
+			{#if holdingChanges.length > 0}
+				<section class="at-changes">
+					<header class="at-section-kicker">Holding Changes</header>
+					<table class="at-changes-table">
+						<thead>
+							<tr>
+								<th scope="col">Fund</th>
+								<th scope="col" class="at-num">From</th>
+								<th scope="col" class="at-num">To</th>
+								<th scope="col" class="at-num">Delta</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each holdingChanges as change (change.instrument_id)}
+								<tr>
+									<td class="at-fund-name">{change.name}</td>
+									<td class="at-num">
+										{change.prev_weight != null
+											? formatPercent(change.prev_weight, 2)
+											: "\u2014"}
+									</td>
+									<td class="at-num">{formatPercent(change.next_weight, 2)}</td>
+									<td
+										class="at-num"
+										class:at-delta-pos={change.delta > 0}
+										class:at-delta-neg={change.delta < 0}
+									>
+										{change.delta > 0 ? "+" : ""}{formatPercent(change.delta, 2)}
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</section>
+			{/if}
+
+			<!-- Advisor notes -->
+			{#if advisorEntries.length > 0}
+				<section class="at-advisor">
+					<header class="at-section-kicker">Construction Notes</header>
+					<dl class="at-advisor-grid">
+						{#each advisorEntries as [key, value] (key)}
+							<div class="at-advisor-item">
+								<dt class="at-advisor-key">{advisorKeyLabel(key)}</dt>
+								<dd class="at-advisor-value">{formatAdvisorValue(key, value)}</dd>
+							</div>
+						{/each}
+					</dl>
+				</section>
+			{/if}
+		{/if}
+	</div>
+
+	{#snippet failed(err: unknown)}
+		<div class="at-empty">Advisor panel failed to render</div>
+	{/snippet}
+</svelte:boundary>
+
+<style>
+	.at-root {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-4);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.at-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 200px;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-11);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	/* ── Headline ─────────────────────────────────────── */
+
+	.at-headline {
+		margin: 0;
+		font-size: var(--terminal-text-14);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		line-height: var(--terminal-leading-snug);
+	}
+
+	/* ── Key points ───────────────────────────────────── */
+
+	.at-points {
+		margin: 0;
+		padding-left: var(--terminal-space-4);
+		list-style: disc;
+	}
+
+	.at-point {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		line-height: var(--terminal-leading-normal);
+		margin-bottom: var(--terminal-space-1);
+	}
+
+	/* ── Metrics strip ────────────────────────────────── */
+
+	.at-metrics {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-2) 0;
+		border-top: var(--terminal-border-hairline);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.at-stat {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.at-stat-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.at-stat-value {
+		font-size: var(--terminal-text-14);
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		color: var(--terminal-fg-primary);
+	}
+
+	.at-stat-delta {
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.at-stat-delta--pos {
+		color: var(--terminal-status-success);
+	}
+
+	.at-stat-delta--neg {
+		color: var(--terminal-status-error);
+	}
+
+	/* ── Holding changes ──────────────────────────────── */
+
+	.at-section-kicker {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		margin-bottom: var(--terminal-space-2);
+	}
+
+	.at-changes-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: var(--terminal-text-11);
+	}
+
+	.at-changes-table th,
+	.at-changes-table td {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+		text-align: left;
+	}
+
+	.at-changes-table thead th {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.at-fund-name {
+		color: var(--terminal-fg-primary);
+		font-weight: 600;
+		max-width: 200px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.at-num {
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.at-delta-pos {
+		color: var(--terminal-status-success);
+	}
+
+	.at-delta-neg {
+		color: var(--terminal-status-error);
+	}
+
+	/* ── Advisor notes ────────────────────────────────── */
+
+	.at-advisor {
+		padding: var(--terminal-space-3);
+		border: var(--terminal-border-hairline);
+	}
+
+	.at-advisor-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: var(--terminal-space-2) var(--terminal-space-4);
+		margin: 0;
+	}
+
+	.at-advisor-item {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.at-advisor-key {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: capitalize;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.at-advisor-value {
+		margin: 0;
+		font-size: var(--terminal-text-12);
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		color: var(--terminal-fg-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	/* ── PR-A5 B.5 — shimmer skeleton ────────────────── */
+
+	.at-skeleton {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-4);
+	}
+
+	.at-skeleton-line {
+		height: 12px;
+		background: linear-gradient(
+			90deg,
+			var(--terminal-bg-panel-raised) 0%,
+			var(--terminal-fg-muted) 50%,
+			var(--terminal-bg-panel-raised) 100%
+		);
+		background-size: 200% 100%;
+		animation: at-shimmer 1.4s linear infinite;
+		opacity: 0.4;
+	}
+
+	.at-skeleton-line--wide {
+		width: 80%;
+	}
+
+	.at-skeleton-line--narrow {
+		width: 45%;
+	}
+
+	@keyframes at-shimmer {
+		0% { background-position: 200% 0; }
+		100% { background-position: -200% 0; }
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/AdvisorTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/AdvisorTab.svelte
@@ -6,7 +6,7 @@
   advisor notes. All text plain institutional — no markdown rendering.
 -->
 <script lang="ts">
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import { workspace } from "../../../state/portfolio-workspace.svelte";
 	import { formatNumber, formatPercent } from "@investintell/ui";
 
 	const run = $derived(workspace.constructionRun);

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/BacktestTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/BacktestTab.svelte
@@ -1,0 +1,323 @@
+<!--
+  BacktestTab — BACKTEST tab in the Builder results panel.
+
+  Equity curve (NAV line chart) + drawdown underwater chart + metrics sidebar.
+  Period selector (1Y/3Y/5Y/10Y) re-fetches from nav-history endpoint.
+  Data sourced from workspace.backtestData.
+-->
+<script lang="ts">
+	import { formatNumber, formatPercent, createTerminalChartOptions, readTerminalTokens } from "@investintell/ui";
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import TerminalChart from "$wealth/components/terminal/charts/TerminalChart.svelte";
+	import type { EChartsOption } from "echarts";
+
+	const PERIODS = ["1Y", "3Y", "5Y", "10Y"] as const;
+	type Period = (typeof PERIODS)[number];
+	let activePeriod = $state<Period>("5Y");
+
+	// Fetch on mount
+	$effect(() => {
+		if (workspace.portfolioId && !workspace.backtestData && !workspace.isLoadingBacktest) {
+			workspace.fetchBacktestData(activePeriod);
+		}
+	});
+
+	function selectPeriod(p: Period) {
+		activePeriod = p;
+		workspace.fetchBacktestData(p);
+	}
+
+	const data = $derived(workspace.backtestData);
+	const metrics = $derived(data?.metrics ?? null);
+	const isEmpty = $derived(!data || data.dates.length === 0);
+
+	// PR-A5 B.5 — phase gating for the pre-run empty states.
+	const run = $derived(workspace.constructionRun);
+	const isIdle = $derived(
+		run === null && workspace.runPhase === "idle" && isEmpty,
+	);
+	const isInFlight = $derived(
+		run === null &&
+			workspace.runPhase !== "idle" &&
+			workspace.runPhase !== "done" &&
+			workspace.runPhase !== "error" &&
+			workspace.runPhase !== "cancelled" &&
+			isEmpty,
+	);
+
+	// Equity curve chart option
+	const navOption = $derived.by<EChartsOption>(() => {
+		if (isEmpty || !data) return createTerminalChartOptions({ series: [] });
+		const tokens = readTerminalTokens();
+		return createTerminalChartOptions({
+			series: [
+				{
+					type: "line",
+					name: "NAV",
+					data: data.dates.map((d, i) => [d, data.nav_series[i]]),
+					showSymbol: false,
+					lineStyle: { width: 1.5, color: tokens.accentAmber },
+					itemStyle: { color: tokens.accentAmber },
+					areaStyle: { color: tokens.accentAmber, opacity: 0.08 },
+				},
+			],
+			slot: "primary",
+		});
+	});
+
+	// Drawdown chart option
+	const ddOption = $derived.by<EChartsOption>(() => {
+		if (isEmpty || !data) return createTerminalChartOptions({ series: [] });
+		const tokens = readTerminalTokens();
+		return createTerminalChartOptions({
+			series: [
+				{
+					type: "line",
+					name: "Drawdown",
+					data: data.dates.map((d, i) => [d, data.drawdown_series[i]]),
+					showSymbol: false,
+					lineStyle: { width: 1, color: tokens.statusError },
+					itemStyle: { color: tokens.statusError },
+					areaStyle: { color: tokens.statusError, opacity: 0.2 },
+				},
+			],
+			yAxis: {
+				type: "value" as const,
+				axisLabel: {
+					formatter: (v: number) => formatPercent(v, 0),
+				},
+			},
+			slot: "secondary",
+		});
+	});
+
+	function metricColor(value: number | null, threshold: number, invert: boolean = false): string {
+		if (value === null) return "var(--terminal-fg-muted)";
+		const bad = invert ? value > threshold : value < threshold;
+		return bad ? "var(--terminal-status-error)" : "var(--terminal-status-success)";
+	}
+</script>
+
+<div class="bt-root">
+	{#if isIdle && !workspace.isLoadingBacktest}
+		<div class="bt-empty">Aguardando construction run</div>
+	{:else if isInFlight && !workspace.isLoadingBacktest}
+		<div class="bt-skeleton" aria-busy="true">
+			<div class="bt-skeleton-line bt-skeleton-line--wide"></div>
+			<div class="bt-skeleton-line"></div>
+			<div class="bt-skeleton-line bt-skeleton-line--narrow"></div>
+		</div>
+	{:else if isEmpty && !workspace.isLoadingBacktest}
+		<div class="bt-empty">Run the NAV synthesizer to see historical performance</div>
+	{:else}
+		<div class="bt-layout">
+			<div class="bt-charts">
+				<div class="bt-chart-label">Equity Curve</div>
+				<TerminalChart
+					option={navOption}
+					height={180}
+					loading={workspace.isLoadingBacktest}
+					empty={isEmpty}
+					emptyMessage="NO NAV DATA"
+					ariaLabel="Portfolio equity curve"
+				/>
+				<div class="bt-chart-label">Drawdown</div>
+				<TerminalChart
+					option={ddOption}
+					height={140}
+					loading={workspace.isLoadingBacktest}
+					empty={isEmpty}
+					emptyMessage="NO DRAWDOWN DATA"
+					ariaLabel="Portfolio drawdown underwater chart"
+				/>
+				<!-- Period selector -->
+				<div class="bt-period-bar">
+					{#each PERIODS as p (p)}
+						<button
+							type="button"
+							class="bt-period-btn"
+							class:bt-period-btn--active={activePeriod === p}
+							onclick={() => selectPeriod(p)}
+						>
+							{p}
+						</button>
+					{/each}
+				</div>
+			</div>
+
+			<!-- Metrics sidebar -->
+			<div class="bt-metrics">
+				<div class="bt-metric">
+					<div class="bt-metric-label">Sharpe Ratio</div>
+					<div class="bt-metric-value">
+						{metrics?.sharpe != null ? formatNumber(metrics.sharpe, 2) : "\u2014"}
+					</div>
+				</div>
+				<div class="bt-metric">
+					<div class="bt-metric-label">Maximum Drawdown</div>
+					<div
+						class="bt-metric-value"
+						style="color: {metricColor(metrics?.max_dd ?? null, -0.10)}"
+					>
+						{metrics?.max_dd != null ? formatPercent(metrics.max_dd, 1) : "\u2014"}
+					</div>
+				</div>
+				<div class="bt-metric">
+					<div class="bt-metric-label">Annualized Return</div>
+					<div
+						class="bt-metric-value"
+						style="color: {metricColor(metrics?.ann_return ?? null, 0, true)}"
+					>
+						{metrics?.ann_return != null ? formatPercent(metrics.ann_return, 1) : "\u2014"}
+					</div>
+				</div>
+				<div class="bt-metric">
+					<div class="bt-metric-label">Calmar Ratio</div>
+					<div class="bt-metric-value">
+						{metrics?.calmar != null ? formatNumber(metrics.calmar, 2) : "\u2014"}
+					</div>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.bt-root {
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.bt-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 300px;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-12);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.bt-layout {
+		display: grid;
+		grid-template-columns: 1fr 120px;
+		gap: 0;
+	}
+
+	.bt-charts {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+	}
+
+	.bt-chart-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		padding: var(--terminal-space-1) 0;
+	}
+
+	.bt-period-bar {
+		display: flex;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-2) 0;
+	}
+
+	.bt-period-btn {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-tertiary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		cursor: pointer;
+		border-radius: var(--terminal-radius-none);
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.bt-period-btn:hover {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+
+	.bt-period-btn--active {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.bt-period-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	/* Metrics sidebar */
+	.bt-metrics {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-4);
+		padding: var(--terminal-space-4) var(--terminal-space-2);
+		border-left: var(--terminal-border-hairline);
+	}
+
+	.bt-metric {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.bt-metric-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-muted);
+	}
+
+	.bt-metric-value {
+		font-size: var(--terminal-text-14);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+	}
+
+	/* ── PR-A5 B.5 — shimmer skeleton ────────────────── */
+
+	.bt-skeleton {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-4);
+	}
+
+	.bt-skeleton-line {
+		height: 12px;
+		background: linear-gradient(
+			90deg,
+			var(--terminal-bg-panel-raised) 0%,
+			var(--terminal-fg-muted) 50%,
+			var(--terminal-bg-panel-raised) 100%
+		);
+		background-size: 200% 100%;
+		animation: bt-shimmer 1.4s linear infinite;
+		opacity: 0.4;
+	}
+
+	.bt-skeleton-line--wide {
+		width: 80%;
+	}
+
+	.bt-skeleton-line--narrow {
+		width: 45%;
+	}
+
+	@keyframes bt-shimmer {
+		0% { background-position: 200% 0; }
+		100% { background-position: -200% 0; }
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/BacktestTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/BacktestTab.svelte
@@ -7,8 +7,8 @@
 -->
 <script lang="ts">
 	import { formatNumber, formatPercent, createTerminalChartOptions, readTerminalTokens } from "@investintell/ui";
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
-	import TerminalChart from "$wealth/components/terminal/charts/TerminalChart.svelte";
+	import { workspace } from "../../../state/portfolio-workspace.svelte";
+	import TerminalChart from "../../../components/terminal/charts/TerminalChart.svelte";
 	import type { EChartsOption } from "echarts";
 
 	const PERIODS = ["1Y", "3Y", "5Y", "10Y"] as const;

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/CascadeTimeline.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/CascadeTimeline.svelte
@@ -1,0 +1,384 @@
+<!--
+  CascadeTimeline — Zone D of the Builder results panel.
+
+  Pure Svelte 5 + CSS component (NOT ECharts). Renders the 5-phase
+  optimizer cascade as horizontal pills with a connector rail.
+
+  States: pending → running (amber pulse) → succeeded (green) → failed (red) → skipped (ghost).
+  Connector rail fills left-to-right as phases complete.
+-->
+<script lang="ts">
+	import type { CascadePhase } from "$wealth/state/portfolio-workspace.svelte";
+	import type { BuildPhase } from "$wealth/types/portfolio-build";
+	import { formatNumber } from "@investintell/ui";
+
+	interface Props {
+		phases: CascadePhase[];
+		/** PR-A5 A.8 — 0..1 build progress. Visible while a build is in-flight. */
+		runProgress?: number;
+		/** PR-A5 A.8 — whether the thin progress bar should render. */
+		showProgress?: boolean;
+		/** PR-A5 B.2 — current pipeline phase (drives the upper strip). */
+		pipelinePhase?: BuildPhase | "IDLE";
+		/** PR-A5 B.2 — whether the pipeline phase has entered a terminal error state. */
+		pipelineErrored?: boolean;
+	}
+
+	let {
+		phases,
+		runProgress = 0,
+		showProgress = false,
+		pipelinePhase = "IDLE",
+		pipelineErrored = false,
+	}: Props = $props();
+
+	// PR-A5 B.2 — pipeline strip: 5 chips mapping each top-level phase.
+	const PIPELINE_STRIP: ReadonlyArray<{ key: BuildPhase; label: string }> = [
+		{ key: "FACTOR_MODELING", label: "FACTOR MODEL" },
+		{ key: "SHRINKAGE", label: "COVARIANCE" },
+		{ key: "SOCP_OPTIMIZATION", label: "OPTIMIZER" },
+		{ key: "BACKTESTING", label: "BACKTEST" },
+		{ key: "COMPLETED", label: "COMPLETE" },
+	];
+
+	type StripStatus = "pending" | "running" | "succeeded" | "failed" | "skipped";
+
+	const currentIdx = $derived.by(() => {
+		const idx = PIPELINE_STRIP.findIndex((c) => c.key === pipelinePhase);
+		return idx;
+	});
+
+	const stripStatuses = $derived.by<StripStatus[]>(() => {
+		return PIPELINE_STRIP.map((chip, i) => {
+			if (pipelinePhase === "COMPLETED") return "succeeded";
+			if (pipelineErrored) {
+				if (currentIdx < 0) return "failed";
+				if (i < currentIdx) return "succeeded";
+				if (i === currentIdx) return "failed";
+				return "skipped";
+			}
+			if (currentIdx < 0) return "pending";
+			if (i < currentIdx) return "succeeded";
+			if (i === currentIdx) return "running";
+			return "pending";
+		});
+	});
+
+	const progressPct = $derived(Math.max(0, Math.min(1, runProgress)) * 100);
+
+	/** Index of the last completed (succeeded/failed) phase for connector fill. */
+	const lastCompletedIdx = $derived.by(() => {
+		let last = -1;
+		for (let i = 0; i < phases.length; i++) {
+			const phase = phases[i];
+			if (phase && (phase.status === "succeeded" || phase.status === "failed")) last = i;
+		}
+		return last;
+	});
+
+	/** Connector fill percentage (0-100). */
+	const fillPct = $derived(
+		phases.length > 0 && lastCompletedIdx >= 0
+			? ((lastCompletedIdx + 1) / phases.length) * 100
+			: 0,
+	);
+</script>
+
+<div class="ct-root" role="group" aria-label="Construction phase timeline">
+	<!-- PR-A5 B.2 — pipeline phase strip (coarse top-level). -->
+	<div class="ct-strip" aria-label="Pipeline phases">
+		{#each PIPELINE_STRIP as chip, i (chip.key)}
+			<div
+				class="ct-strip-chip ct-strip-chip--{stripStatuses[i]}"
+				aria-current={stripStatuses[i] === "running" ? "step" : undefined}
+			>
+				<span class="ct-strip-label">{chip.label}</span>
+			</div>
+			{#if i < PIPELINE_STRIP.length - 1}
+				<span class="ct-strip-sep" aria-hidden="true">&rarr;</span>
+			{/if}
+		{/each}
+	</div>
+
+	<!-- Connector rail -->
+	<div class="ct-rail">
+		<div class="ct-rail-bg"></div>
+		<div class="ct-rail-fill" style:width="{fillPct}%"></div>
+	</div>
+
+	<!-- Phase pills -->
+	<div class="ct-pills">
+		{#each phases as phase, i (phase.key)}
+			<div
+				class="ct-pill ct-pill--{phase.status}"
+				aria-current={phase.status === "running" ? "step" : undefined}
+			>
+				<div class="ct-pill-icon">
+					{#if phase.status === "succeeded"}
+						<span class="ct-icon-check" aria-hidden="true">&#x2713;</span>
+					{:else if phase.status === "failed"}
+						<span class="ct-icon-x" aria-hidden="true">&#x2717;</span>
+					{:else if phase.status === "running"}
+						<span class="ct-icon-dot" aria-hidden="true">&#x25CF;</span>
+					{:else}
+						<span class="ct-icon-dot ct-icon-dot--dim" aria-hidden="true">&#x25CB;</span>
+					{/if}
+				</div>
+				<span class="ct-pill-label">{phase.label}</span>
+				{#if phase.status === "succeeded" && phase.objectiveValue != null}
+					<span class="ct-pill-value">{formatNumber(phase.objectiveValue, 4)}</span>
+				{/if}
+			</div>
+		{/each}
+	</div>
+
+	{#if showProgress}
+		<!-- PR-A5 A.8 — thin 2px run-progress bar under the pills. -->
+		<div
+			class="ct-progress"
+			role="progressbar"
+			aria-valuenow={Math.round(progressPct)}
+			aria-valuemin="0"
+			aria-valuemax="100"
+			aria-label="Construction progress"
+		>
+			<div class="ct-progress-fill" style:width="{progressPct}%"></div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.ct-root {
+		position: relative;
+		min-height: 160px;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		padding: var(--terminal-space-4) var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		box-sizing: border-box;
+	}
+
+	/* ── Connector rail ──────────────────────────────── */
+
+	.ct-rail {
+		position: absolute;
+		top: 50%;
+		left: var(--terminal-space-3);
+		right: var(--terminal-space-3);
+		height: 2px;
+		transform: translateY(-1px);
+		pointer-events: none;
+	}
+
+	.ct-rail-bg {
+		position: absolute;
+		inset: 0;
+		background: var(--terminal-fg-muted);
+	}
+
+	.ct-rail-fill {
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 100%;
+		background: var(--terminal-status-success);
+		transition: width 0.4s cubic-bezier(0.33, 1, 0.68, 1);
+	}
+
+	/* ── Pills container ─────────────────────────────── */
+
+	.ct-pills {
+		position: relative;
+		display: flex;
+		justify-content: space-between;
+		gap: var(--terminal-space-1);
+		z-index: 1;
+	}
+
+	/* ── Individual pill ─────────────────────────────── */
+
+	.ct-pill {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		flex: 1;
+		min-width: 0;
+		padding: var(--terminal-space-2);
+		border: 1px solid var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel);
+		transition:
+			border-color 0.3s ease,
+			opacity 0.3s ease;
+	}
+
+	/* States */
+
+	.ct-pill--pending {
+		opacity: 0.35;
+		border-color: var(--terminal-fg-muted);
+		color: var(--terminal-fg-muted);
+	}
+
+	.ct-pill--running {
+		opacity: 1;
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+		animation: ct-pulse 1.5s ease-in-out infinite;
+	}
+
+	.ct-pill--succeeded {
+		opacity: 1;
+		border-color: var(--terminal-status-success);
+		color: var(--terminal-fg-primary);
+	}
+
+	.ct-pill--failed {
+		opacity: 1;
+		border-color: var(--terminal-status-error);
+		color: var(--terminal-status-error);
+	}
+
+	.ct-pill--failed .ct-pill-label {
+		text-decoration: line-through;
+	}
+
+	.ct-pill--skipped {
+		opacity: 0.25;
+		border-style: dashed;
+		border-color: var(--terminal-fg-muted);
+		color: var(--terminal-fg-muted);
+	}
+
+	.ct-pill--skipped .ct-pill-label {
+		font-style: italic;
+	}
+
+	/* ── Pill internals ──────────────────────────────── */
+
+	.ct-pill-icon {
+		font-size: var(--terminal-text-14);
+		line-height: 1;
+	}
+
+	.ct-icon-check {
+		color: var(--terminal-status-success);
+	}
+
+	.ct-icon-x {
+		color: var(--terminal-status-error);
+	}
+
+	.ct-icon-dot {
+		color: var(--terminal-accent-amber);
+	}
+
+	.ct-icon-dot--dim {
+		color: var(--terminal-fg-muted);
+	}
+
+	.ct-pill-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		text-align: center;
+		line-height: var(--terminal-leading-tight);
+	}
+
+	.ct-pill-value {
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+		color: var(--terminal-fg-secondary);
+	}
+
+	/* ── Thin progress bar (PR-A5 A.8) ───────────────── */
+
+	.ct-progress {
+		position: relative;
+		margin-top: var(--terminal-space-2);
+		height: 2px;
+		background: var(--terminal-border-hairline, var(--terminal-fg-muted));
+		overflow: hidden;
+	}
+
+	.ct-progress-fill {
+		height: 100%;
+		background: var(--terminal-accent, var(--terminal-accent-amber));
+		transition: width 0.3s cubic-bezier(0.33, 1, 0.68, 1);
+	}
+
+	/* ── Pulse animation ─────────────────────────────── */
+
+	@keyframes ct-pulse {
+		0%, 100% { opacity: 1; }
+		50% { opacity: 0.5; }
+	}
+
+	/* ── Pipeline strip (PR-A5 B.2) ──────────────────── */
+
+	.ct-strip {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		margin-bottom: var(--terminal-space-2);
+		padding-bottom: var(--terminal-space-2);
+		border-bottom: 1px dashed var(--terminal-fg-muted);
+	}
+
+	.ct-strip-chip {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		height: 24px;
+		padding: 0 var(--terminal-space-2);
+		border: 1px solid var(--terminal-fg-muted);
+		background: transparent;
+		transition:
+			border-color 0.3s ease,
+			color 0.3s ease,
+			opacity 0.3s ease;
+	}
+
+	.ct-strip-chip--pending {
+		opacity: 0.45;
+		color: var(--terminal-fg-muted);
+	}
+
+	.ct-strip-chip--running {
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+		animation: ct-pulse 1.5s ease-in-out infinite;
+	}
+
+	.ct-strip-chip--succeeded {
+		border-color: var(--terminal-status-success);
+		color: var(--terminal-fg-primary);
+	}
+
+	.ct-strip-chip--failed {
+		border-color: var(--terminal-status-error);
+		color: var(--terminal-status-error);
+	}
+
+	.ct-strip-chip--skipped {
+		opacity: 0.35;
+		border-style: dashed;
+		color: var(--terminal-fg-muted);
+	}
+
+	.ct-strip-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		line-height: 1;
+	}
+
+	.ct-strip-sep {
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-10);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/CascadeTimeline.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/CascadeTimeline.svelte
@@ -8,8 +8,8 @@
   Connector rail fills left-to-right as phases complete.
 -->
 <script lang="ts">
-	import type { CascadePhase } from "$wealth/state/portfolio-workspace.svelte";
-	import type { BuildPhase } from "$wealth/types/portfolio-build";
+	import type { CascadePhase } from "../../../state/portfolio-workspace.svelte";
+	import type { BuildPhase } from "../../../types/portfolio-build";
 	import { formatNumber } from "@investintell/ui";
 
 	interface Props {

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/ConsequenceDialog.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/ConsequenceDialog.svelte
@@ -6,7 +6,7 @@
   Focus trap: Tab cycling within dialog. ESC closes.
 -->
 <script lang="ts">
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import { workspace } from "../../../state/portfolio-workspace.svelte";
 
 	interface Props {
 		onclose: () => void;

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/ConsequenceDialog.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/ConsequenceDialog.svelte
@@ -1,0 +1,271 @@
+<!--
+  ConsequenceDialog — typed ACTIVATE confirmation modal.
+
+  Terminal styling: dark bg, hairline border, no radius.
+  Type "ACTIVATE" to enable the confirm button.
+  Focus trap: Tab cycling within dialog. ESC closes.
+-->
+<script lang="ts">
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+
+	interface Props {
+		onclose: () => void;
+		onsuccess: () => void;
+	}
+
+	let { onclose, onsuccess }: Props = $props();
+
+	let confirmText = $state("");
+	let errorMessage = $state<string | null>(null);
+	let isSubmitting = $state(false);
+
+	const canConfirm = $derived(confirmText === "ACTIVATE");
+
+	let dialogEl: HTMLDivElement | undefined = $state();
+	let inputEl: HTMLInputElement | undefined = $state();
+
+	// Auto-focus input on mount
+	$effect(() => {
+		if (inputEl) inputEl.focus();
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === "Escape") {
+			e.preventDefault();
+			onclose();
+			return;
+		}
+		if (e.key === "Enter" && canConfirm && !isSubmitting) {
+			e.preventDefault();
+			handleConfirm();
+			return;
+		}
+		// Focus trap
+		if (e.key === "Tab" && dialogEl) {
+			const focusable = dialogEl.querySelectorAll<HTMLElement>(
+				'input, button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+			);
+			if (focusable.length === 0) return;
+			const first = focusable[0] as HTMLElement | undefined;
+			const last = focusable[focusable.length - 1] as HTMLElement | undefined;
+			if (!first || !last) return;
+			if (e.shiftKey && document.activeElement === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && document.activeElement === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
+	}
+
+	async function handleConfirm() {
+		if (!canConfirm || isSubmitting) return;
+		isSubmitting = true;
+		errorMessage = null;
+
+		try {
+			await workspace.activatePortfolio();
+			onsuccess();
+		} catch (err) {
+			errorMessage = err instanceof Error ? err.message : "Activation failed";
+		} finally {
+			isSubmitting = false;
+		}
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div
+	class="cd-overlay"
+	role="dialog"
+	aria-modal="true"
+	aria-label="Activate Portfolio"
+	onkeydown={handleKeydown}
+	bind:this={dialogEl}
+>
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="cd-backdrop" onclick={onclose}></div>
+	<div class="cd-panel">
+		<h2 class="cd-title">Activate Portfolio</h2>
+
+		<p class="cd-warning">
+			This will move the portfolio to LIVE status. Active portfolios
+			are monitored daily for drift and trigger alerts.
+		</p>
+
+		<label class="cd-label" for="cd-confirm-input">
+			Type ACTIVATE to confirm
+		</label>
+		<input
+			id="cd-confirm-input"
+			type="text"
+			class="cd-input"
+			bind:value={confirmText}
+			bind:this={inputEl}
+			placeholder="ACTIVATE"
+			autocomplete="off"
+			spellcheck="false"
+		/>
+
+		{#if errorMessage}
+			<div class="cd-error">{errorMessage}</div>
+		{/if}
+
+		<div class="cd-actions">
+			<button type="button" class="cd-btn cd-btn--cancel" onclick={onclose} disabled={isSubmitting}>
+				Cancel
+			</button>
+			<button
+				type="button"
+				class="cd-btn cd-btn--confirm"
+				onclick={handleConfirm}
+				disabled={!canConfirm || isSubmitting}
+			>
+				{isSubmitting ? "Activating..." : "Activate"}
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.cd-overlay {
+		position: fixed;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: var(--terminal-z-overlay, 1000);
+	}
+
+	.cd-backdrop {
+		position: absolute;
+		inset: 0;
+		background: var(--terminal-bg-void);
+		opacity: 0.85;
+	}
+
+	.cd-panel {
+		position: relative;
+		width: 420px;
+		max-width: 90vw;
+		padding: var(--terminal-space-6);
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-primary);
+	}
+
+	.cd-title {
+		font-size: 16px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		margin: 0 0 var(--terminal-space-4);
+		color: var(--terminal-accent-amber);
+	}
+
+	.cd-warning {
+		font-size: var(--terminal-text-12);
+		color: var(--terminal-fg-secondary);
+		line-height: 1.6;
+		margin: 0 0 var(--terminal-space-4);
+	}
+
+	.cd-label {
+		display: block;
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		margin-bottom: var(--terminal-space-1);
+	}
+
+	.cd-input {
+		width: 100%;
+		height: 32px;
+		background: var(--terminal-bg-panel-sunken, var(--terminal-bg-void));
+		color: var(--terminal-fg-primary);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-12);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		padding: 0 var(--terminal-space-2);
+		box-sizing: border-box;
+	}
+
+	.cd-input:focus {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.cd-input::placeholder {
+		color: var(--terminal-fg-muted);
+		font-weight: 400;
+	}
+
+	.cd-error {
+		margin-top: var(--terminal-space-2);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		background: var(--terminal-bg-panel-raised);
+		border-left: 2px solid var(--terminal-status-error);
+		color: var(--terminal-status-error);
+		font-size: var(--terminal-text-11);
+	}
+
+	.cd-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--terminal-space-2);
+		margin-top: var(--terminal-space-4);
+	}
+
+	.cd-btn {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		border-radius: var(--terminal-radius-none);
+		cursor: pointer;
+		transition:
+			background var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			opacity var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.cd-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.cd-btn--cancel {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.cd-btn--cancel:hover:not(:disabled) {
+		color: var(--terminal-fg-primary);
+	}
+
+	.cd-btn--confirm {
+		background: var(--terminal-accent-amber);
+		border: 1px solid var(--terminal-accent-amber);
+		color: var(--terminal-bg-void);
+	}
+
+	.cd-btn--confirm:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.cd-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/MonteCarloTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/MonteCarloTab.svelte
@@ -1,0 +1,199 @@
+<!--
+  MonteCarloTab — MONTE CARLO tab in the Builder results panel.
+
+  Single chart: stacked area bands for percentile ranges (p5-p95)
+  with solid p50 median line. Horizons: 12m, 36m, 60m.
+  Data sourced from workspace.monteCarloData.
+-->
+<script lang="ts">
+	import { formatNumber, formatPercent, createTerminalChartOptions, readTerminalTokens } from "@investintell/ui";
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import TerminalChart from "$wealth/components/terminal/charts/TerminalChart.svelte";
+	import type { EChartsOption } from "echarts";
+
+	// Fetch on mount
+	$effect(() => {
+		if (workspace.portfolioId && !workspace.monteCarloData && !workspace.isLoadingMonteCarlo) {
+			workspace.fetchMonteCarlo();
+		}
+	});
+
+	const data = $derived(workspace.monteCarloData);
+	const bars = $derived(data?.confidence_bars ?? []);
+	const isEmpty = $derived(!data || bars.length === 0);
+
+	const chartOption = $derived.by<EChartsOption>(() => {
+		if (isEmpty || bars.length === 0) {
+			return createTerminalChartOptions({ series: [] });
+		}
+
+		const tokens = readTerminalTokens();
+
+		// X-axis: months from horizons
+		const horizonLabels = bars.map((b) => b.horizon);
+
+		// Build stacked area bands using 4 stacked invisible-base series:
+		// The technique: stack from bottom up, each series value = band height.
+		// p5 base (invisible), p5→p25 band, p25→p50 band, p50→p75 band, p75→p95 band.
+		const barsRef = bars;
+		const p5Values = barsRef.map((b) => b.pct_5);
+		const p25Values = barsRef.map((b) => b.pct_25);
+		const p50Values = barsRef.map((b) => b.pct_50);
+		const p75Values = barsRef.map((b) => b.pct_75);
+		const p95Values = barsRef.map((b) => b.pct_95);
+
+		const bandColor = tokens.accentCyan;
+
+		return createTerminalChartOptions({
+			xAxis: {
+				type: "category" as const,
+				data: horizonLabels,
+				boundaryGap: false,
+			},
+			yAxis: {
+				type: "value" as const,
+				axisLabel: {
+					formatter: (v: number) => formatPercent(v, 0),
+				},
+			},
+			series: [
+				// Invisible base: p5
+				{
+					type: "line",
+					name: "p5-base",
+					stack: "mc-band",
+					data: p5Values,
+					lineStyle: { opacity: 0 },
+					areaStyle: { opacity: 0 },
+					showSymbol: false,
+					silent: true,
+				},
+				// Band: p5 → p25
+				{
+					type: "line",
+					name: "5th - 25th",
+					stack: "mc-band",
+					data: p25Values.map((v, i) => v - (p5Values[i] ?? 0)),
+					lineStyle: { opacity: 0 },
+					areaStyle: { color: bandColor, opacity: 0.08 },
+					showSymbol: false,
+					silent: true,
+				},
+				// Band: p25 → p50
+				{
+					type: "line",
+					name: "25th - 50th",
+					stack: "mc-band",
+					data: p50Values.map((v, i) => v - (p25Values[i] ?? 0)),
+					lineStyle: { opacity: 0 },
+					areaStyle: { color: bandColor, opacity: 0.15 },
+					showSymbol: false,
+					silent: true,
+				},
+				// Band: p50 → p75
+				{
+					type: "line",
+					name: "50th - 75th",
+					stack: "mc-band",
+					data: p75Values.map((v, i) => v - (p50Values[i] ?? 0)),
+					lineStyle: { opacity: 0 },
+					areaStyle: { color: bandColor, opacity: 0.22 },
+					showSymbol: false,
+					silent: true,
+				},
+				// Band: p75 → p95
+				{
+					type: "line",
+					name: "75th - 95th",
+					stack: "mc-band",
+					data: p95Values.map((v, i) => v - (p75Values[i] ?? 0)),
+					lineStyle: { opacity: 0 },
+					areaStyle: { color: bandColor, opacity: 0.30 },
+					showSymbol: false,
+					silent: true,
+				},
+				// Solid median line (non-stacked)
+				{
+					type: "line",
+					name: "Median",
+					data: p50Values,
+					showSymbol: true,
+					symbolSize: 6,
+					lineStyle: { width: 2, color: tokens.accentAmber },
+					itemStyle: { color: tokens.accentAmber },
+				},
+			],
+			showLegend: false,
+			tooltipFormatter: (params: unknown) => {
+				if (!Array.isArray(params) || params.length === 0) return "";
+				const idx = (params[0] as { dataIndex: number }).dataIndex;
+				if (idx == null || idx >= barsRef.length) return "";
+				const bar = barsRef[idx];
+				if (!bar) return "";
+				const lines = [
+					`<b>${bar.horizon}</b>`,
+					`95th: ${formatPercent(bar.pct_95, 1)}`,
+					`75th: ${formatPercent(bar.pct_75, 1)}`,
+					`Median: ${formatPercent(bar.pct_50, 1)}`,
+					`25th: ${formatPercent(bar.pct_25, 1)}`,
+					`5th: ${formatPercent(bar.pct_5, 1)}`,
+				];
+				return lines.join("<br>");
+			},
+			slot: "primary",
+		});
+	});
+</script>
+
+<div class="mc-root">
+	{#if isEmpty && !workspace.isLoadingMonteCarlo}
+		<div class="mc-empty">Run construction to simulate future outcomes</div>
+	{:else}
+		<div class="mc-header">
+			<span class="mc-title">
+				Monte Carlo Simulation
+				{#if data}
+					({formatNumber(data.n_simulations, 0)} paths)
+				{/if}
+			</span>
+		</div>
+		<TerminalChart
+			option={chartOption}
+			height={360}
+			loading={workspace.isLoadingMonteCarlo}
+			empty={isEmpty}
+			emptyMessage="INSUFFICIENT DATA"
+			ariaLabel="Monte Carlo percentile band chart"
+		/>
+	{/if}
+</div>
+
+<style>
+	.mc-root {
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.mc-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 300px;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-12);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.mc-header {
+		padding: var(--terminal-space-1) 0 var(--terminal-space-2);
+	}
+
+	.mc-title {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/MonteCarloTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/MonteCarloTab.svelte
@@ -7,8 +7,8 @@
 -->
 <script lang="ts">
 	import { formatNumber, formatPercent, createTerminalChartOptions, readTerminalTokens } from "@investintell/ui";
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
-	import TerminalChart from "$wealth/components/terminal/charts/TerminalChart.svelte";
+	import { workspace } from "../../../state/portfolio-workspace.svelte";
+	import TerminalChart from "../../../components/terminal/charts/TerminalChart.svelte";
 	import type { EChartsOption } from "echarts";
 
 	// Fetch on mount

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/RegimeContextStrip.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/RegimeContextStrip.svelte
@@ -1,0 +1,225 @@
+<!--
+  RegimeContextStrip — Zone A of the Builder command panel.
+
+  Shows current TAA regime badge, stress score bar, effective band
+  ranges (equity/FI/alt/cash), and universe count. 120px fixed height.
+  Pure presentational — no workspace dependency.
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+	import {
+		taaRegimeLabel,
+		taaRegimeColor,
+		taaRegimePosture,
+	} from "$wealth/types/taa";
+	import type { RegimeBands } from "$wealth/types/taa";
+
+	interface Props {
+		regimeBands: RegimeBands | null;
+	}
+
+	let { regimeBands }: Props = $props();
+
+	// Derive band entries for the 4 main asset classes
+	interface BandRow {
+		label: string;
+		min: number;
+		center: number | null;
+		max: number;
+	}
+
+	const BAND_ORDER: Record<string, string> = {
+		equity: "Equity",
+		fi: "Fixed Income",
+		alt: "Alternatives",
+		cash: "Cash",
+	};
+
+	const bandRows = $derived.by<BandRow[]>(() => {
+		if (!regimeBands?.effective_bands) return [];
+		const rows: BandRow[] = [];
+		// Aggregate effective_bands by asset class prefix
+		const agg: Record<string, { min: number; center: number; max: number }> = {};
+		for (const [blockId, band] of Object.entries(regimeBands.effective_bands)) {
+			let cls = "other";
+			if (blockId.startsWith("na_equity") || blockId.startsWith("dm_") || blockId.startsWith("em_") || blockId.startsWith("intl_equity")) cls = "equity";
+			else if (blockId.startsWith("fi_")) cls = "fi";
+			else if (blockId.startsWith("alt_")) cls = "alt";
+			else if (blockId === "cash") cls = "cash";
+
+			const entry = agg[cls] ?? (agg[cls] = { min: 0, center: 0, max: 0 });
+			entry.min += band.min;
+			entry.center += band.center ?? (band.min + band.max) / 2;
+			entry.max += band.max;
+		}
+		for (const [key, label] of Object.entries(BAND_ORDER)) {
+			const a = agg[key];
+			if (!a) continue;
+			rows.push({ label, min: a.min, center: a.center, max: a.max });
+		}
+		return rows;
+	});
+
+	const universeCount = $derived.by(() => {
+		if (!regimeBands?.effective_bands) return { instruments: 0, classes: 0 };
+		const keys = Object.keys(regimeBands.effective_bands);
+		return { instruments: keys.length, classes: Object.keys(BAND_ORDER).length };
+	});
+
+	const regimeColor = $derived(
+		regimeBands ? taaRegimeColor(regimeBands.raw_regime) : "var(--terminal-fg-muted)",
+	);
+</script>
+
+<div class="rcs-root">
+	{#if regimeBands}
+		<div class="rcs-header">
+			<span class="rcs-badge" style="background: {regimeColor}; color: var(--terminal-fg-inverted);">
+				{taaRegimeLabel(regimeBands.raw_regime)}
+			</span>
+			<span class="rcs-posture">{taaRegimePosture(regimeBands.raw_regime)}</span>
+		</div>
+
+		<div class="rcs-stress">
+			<span class="rcs-stress-label">STRESS</span>
+			<div class="rcs-stress-track">
+				<div
+					class="rcs-stress-fill"
+					style="width: {regimeBands.stress_score ?? 0}%; background: {regimeColor};"
+				></div>
+			</div>
+			<span class="rcs-stress-value">{regimeBands.stress_score ?? 0}</span>
+		</div>
+
+		<div class="rcs-bands">
+			{#each bandRows as row (row.label)}
+				<div class="rcs-band-row">
+					<span class="rcs-band-label">{row.label}</span>
+					<span class="rcs-band-range">
+						{formatPercent(row.min, 1)} <span class="rcs-band-arrow">&rarr;</span>
+						{formatPercent(row.center ?? row.min, 1)} <span class="rcs-band-arrow">&rarr;</span>
+						{formatPercent(row.max, 1)}
+					</span>
+				</div>
+			{/each}
+		</div>
+
+		<div class="rcs-universe">
+			{universeCount.instruments} blocks across {universeCount.classes} classes
+		</div>
+	{:else}
+		<div class="rcs-empty">Regime data unavailable</div>
+	{/if}
+</div>
+
+<style>
+	.rcs-root {
+		height: 120px;
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		box-sizing: border-box;
+		overflow: hidden;
+	}
+
+	.rcs-header {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+
+	.rcs-badge {
+		display: inline-block;
+		padding: 1px 6px;
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.rcs-posture {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rcs-stress {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+
+	.rcs-stress-label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		min-width: 40px;
+	}
+
+	.rcs-stress-track {
+		flex: 1;
+		height: 4px;
+		background: var(--terminal-fg-muted);
+	}
+
+	.rcs-stress-fill {
+		height: 100%;
+		transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+	}
+
+	.rcs-stress-value {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		min-width: 24px;
+		text-align: right;
+	}
+
+	.rcs-bands {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.rcs-band-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		font-size: var(--terminal-text-10);
+	}
+
+	.rcs-band-label {
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rcs-band-range {
+		color: var(--terminal-fg-primary);
+		font-weight: 600;
+	}
+
+	.rcs-band-arrow {
+		color: var(--terminal-fg-muted);
+	}
+
+	.rcs-universe {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rcs-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-11);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/RegimeContextStrip.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/RegimeContextStrip.svelte
@@ -11,8 +11,8 @@
 		taaRegimeLabel,
 		taaRegimeColor,
 		taaRegimePosture,
-	} from "$wealth/types/taa";
-	import type { RegimeBands } from "$wealth/types/taa";
+	} from "../../../types/taa";
+	import type { RegimeBands } from "../../../types/taa";
 
 	interface Props {
 		regimeBands: RegimeBands | null;

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/RegimeTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/RegimeTab.svelte
@@ -1,0 +1,612 @@
+<!--
+  RegimeTab — REGIME tab in the Builder results panel (right column).
+
+  Three sections:
+  1. Regime History Chart (S&P500 line + colored markArea bands per regime)
+  2. Regime Metadata Panel (badge, stress bar, signal breakdown table)
+  3. Allocation Bands Summary (Equity/FI/Alt/Cash min→center→max)
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import {
+		createTerminalChartOptions,
+		readTerminalTokens,
+		formatPercent,
+		formatNumber,
+		formatDate,
+	} from "@investintell/ui";
+	import TerminalChart from "$wealth/components/terminal/charts/TerminalChart.svelte";
+	import { createClientApiClient } from "$wealth/api/client";
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import {
+		taaRegimeLabel,
+		taaRegimeColor,
+		taaRegimePosture,
+	} from "$wealth/types/taa";
+	import type { RegimeBands } from "$wealth/types/taa";
+	import type { EChartsOption } from "echarts";
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	// ── Regime overlay data ─────────────────────────────────────
+
+	interface RegimeOverlay {
+		dates: string[];
+		spy_values: number[];
+		regime_bands: Array<{ start: string; end: string; regime: string }>;
+		period: string;
+	}
+
+	const PERIODS = ["1Y", "2Y", "3Y", "5Y"] as const;
+	type Period = (typeof PERIODS)[number];
+
+	let period = $state<Period>("3Y");
+	let overlay = $state<RegimeOverlay | null>(null);
+	let loading = $state(true);
+
+	async function fetchOverlay() {
+		loading = true;
+		try {
+			const res = await api.get(`/allocation/regime-overlay?period=${period}`);
+			overlay = res as RegimeOverlay;
+		} catch (e) {
+			console.error("Failed to fetch regime overlay", e);
+			overlay = null;
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		// Track period reactively — reads period inside the effect body
+		const _p = period;
+		void fetchOverlay();
+	});
+
+	// ── Current regime (from existing endpoint) ──────────────────
+
+	interface GlobalRegime {
+		as_of_date: string;
+		raw_regime: string;
+		stress_score: number | null;
+		signal_details: Record<string, string>;
+	}
+
+	let currentRegime = $state<GlobalRegime | null>(null);
+
+	$effect(() => {
+		(async () => {
+			try {
+				const res = await api.get("/allocation/regime");
+				currentRegime = res as GlobalRegime;
+			} catch {
+				currentRegime = null;
+			}
+		})();
+	});
+
+	// ── Chart options ────────────────────────────────────────────
+
+	const REGIME_COLORS: Record<string, { label: string }> = {
+		RISK_ON: { label: "Expansion" },
+		RISK_OFF: { label: "Defensive" },
+		CRISIS: { label: "Stress" },
+		INFLATION: { label: "Inflation" },
+	};
+
+	function regimeChartColor(regime: string): string {
+		const tokens = readTerminalTokens();
+		const map: Record<string, string> = {
+			RISK_ON: tokens.statusSuccess,
+			RISK_OFF: tokens.statusWarn,
+			CRISIS: tokens.statusError,
+			INFLATION: tokens.accentViolet,
+		};
+		return map[regime] ?? tokens.fgMuted;
+	}
+
+	const chartOption = $derived.by<EChartsOption>(() => {
+		if (!overlay || overlay.dates.length === 0) {
+			return createTerminalChartOptions({
+				series: [],
+				showLegend: false,
+			});
+		}
+
+		const tokens = readTerminalTokens();
+
+		const markAreaData = overlay.regime_bands.map((band) => {
+			const pair: [Record<string, unknown>, Record<string, unknown>] = [
+				{
+					xAxis: band.start,
+					itemStyle: {
+						color: regimeChartColor(band.regime),
+						opacity: 0.12,
+					},
+				},
+				{ xAxis: band.end },
+			];
+			return pair;
+		});
+
+		return createTerminalChartOptions({
+			series: [
+				{
+					type: "line",
+					name: "S&P 500",
+					data: overlay.dates.map((d, i) => [d, overlay!.spy_values[i]]),
+					lineStyle: { width: 1.5, color: tokens.accentAmber },
+					itemStyle: { color: tokens.accentAmber },
+					symbol: "none",
+					smooth: false,
+					markArea: {
+						silent: true,
+						data: markAreaData,
+					},
+				},
+			],
+			yAxis: {
+				type: "value",
+				axisLabel: { formatter: (v: number) => formatNumber(v, 0) },
+			},
+			showLegend: false,
+		});
+	});
+
+	// ── Signal breakdown parsing ─────────────────────────────────
+
+	const SIGNAL_LABELS: Record<string, string> = {
+		vix: "VIX",
+		yield_curve_spread: "Yield Curve",
+		cpi_yoy: "CPI YoY",
+		sahm_rule: "Sahm Rule",
+		hy_oas: "HY OAS",
+		baa_spread: "Baa Spread",
+		fed_funds_delta_6m: "Fed Funds Delta",
+		dxy_zscore: "DXY Z-Score",
+		energy_shock: "Energy Shock",
+		cfnai: "CFNAI",
+	};
+
+	interface SignalRow {
+		key: string;
+		label: string;
+		value: string;
+		status: string;
+	}
+
+	function parseSignalDetails(details: Record<string, string>): SignalRow[] {
+		const rows: SignalRow[] = [];
+		for (const [key, raw] of Object.entries(details)) {
+			if (key === "composite_stress" || key === "decision") continue;
+			const label = SIGNAL_LABELS[key];
+			if (!label) continue;
+
+			// Try to extract numeric value and parenthetical status
+			const numMatch = raw.match(/[=:]?\s*([\d.\-]+)/);
+			const statusMatch = raw.match(/\(([^)]+)\)/);
+			rows.push({
+				key,
+				label,
+				value: numMatch?.[1] ?? raw,
+				status: statusMatch?.[1] ?? raw,
+			});
+		}
+		return rows;
+	}
+
+	const signalRows = $derived(
+		currentRegime?.signal_details ? parseSignalDetails(currentRegime.signal_details) : [],
+	);
+
+	const decisionText = $derived(currentRegime?.signal_details?.["decision"] ?? null);
+
+	// ── Regime duration from overlay ─────────────────────────────
+
+	const regimeDurationDays = $derived.by(() => {
+		if (!overlay?.regime_bands.length) return null;
+		const last = overlay.regime_bands.at(-1);
+		if (!last) return null;
+		const days = Math.ceil(
+			(new Date(last.end).getTime() - new Date(last.start).getTime()) / 86400000,
+		);
+		return days;
+	});
+
+	// ── Allocation bands from workspace ──────────────────────────
+
+	const regimeBands: RegimeBands | null = $derived(workspace.regimeBands ?? null);
+
+	const BAND_ORDER: Record<string, string> = {
+		equity: "Equity",
+		fi: "Fixed Income",
+		alt: "Alternatives",
+		cash: "Cash",
+	};
+
+	interface BandRow {
+		label: string;
+		min: number;
+		center: number | null;
+		max: number;
+	}
+
+	const bandRows = $derived.by<BandRow[]>(() => {
+		if (!regimeBands?.effective_bands) return [];
+		const agg: Record<string, { min: number; center: number; max: number }> = {};
+		for (const [blockId, band] of Object.entries(regimeBands.effective_bands)) {
+			let cls = "other";
+			if (
+				blockId.startsWith("na_equity") ||
+				blockId.startsWith("dm_") ||
+				blockId.startsWith("em_") ||
+				blockId.startsWith("intl_equity")
+			)
+				cls = "equity";
+			else if (blockId.startsWith("fi_")) cls = "fi";
+			else if (blockId.startsWith("alt_")) cls = "alt";
+			else if (blockId === "cash") cls = "cash";
+
+			const entry = agg[cls] ?? (agg[cls] = { min: 0, center: 0, max: 0 });
+			entry.min += band.min;
+			entry.center += band.center ?? (band.min + band.max) / 2;
+			entry.max += band.max;
+		}
+		const rows: BandRow[] = [];
+		for (const [key, label] of Object.entries(BAND_ORDER)) {
+			const a = agg[key];
+			if (!a) continue;
+			rows.push({ label, min: a.min, center: a.center, max: a.max });
+		}
+		return rows;
+	});
+</script>
+
+<div class="rt-root">
+	<!-- Section 1: Regime History Chart -->
+	<div class="rt-section">
+		<div class="rt-section-header">
+			<span class="rt-section-title">REGIME HISTORY</span>
+			<div class="rt-period-group">
+				{#each PERIODS as p (p)}
+					<button
+						type="button"
+						class="rt-period-btn"
+						class:rt-period-btn--active={period === p}
+						onclick={() => { period = p; }}
+					>
+						{p}
+					</button>
+				{/each}
+			</div>
+		</div>
+
+		<TerminalChart
+			option={chartOption}
+			height={300}
+			ariaLabel="S&P 500 with regime classification overlay"
+			empty={!overlay || overlay.dates.length === 0}
+			emptyMessage="NO REGIME DATA"
+			{loading}
+		/>
+	</div>
+
+	<!-- Section 2: Regime Metadata Panel -->
+	<div class="rt-section">
+		<div class="rt-section-header">
+			<span class="rt-section-title">CURRENT REGIME</span>
+		</div>
+
+		{#if currentRegime}
+			<div class="rt-meta-row">
+				<span
+					class="rt-badge"
+					style="background: {taaRegimeColor(currentRegime.raw_regime)}; color: var(--terminal-fg-inverted);"
+				>
+					{taaRegimeLabel(currentRegime.raw_regime)}
+				</span>
+				<span class="rt-meta-date">as of {formatDate(currentRegime.as_of_date)}</span>
+				{#if regimeDurationDays !== null}
+					<span class="rt-meta-duration">{regimeDurationDays}d</span>
+				{/if}
+			</div>
+
+			<div class="rt-stress">
+				<span class="rt-stress-label">STRESS</span>
+				<div class="rt-stress-track">
+					<div
+						class="rt-stress-fill"
+						style="width: {currentRegime.stress_score ?? 0}%; background: {taaRegimeColor(currentRegime.raw_regime)};"
+					></div>
+				</div>
+				<span class="rt-stress-value">{currentRegime.stress_score ?? 0}/100</span>
+			</div>
+
+			<!-- Signal breakdown table -->
+			{#if signalRows.length > 0}
+				<table class="rt-signal-table">
+					<thead>
+						<tr>
+							<th class="rt-sig-th">Signal</th>
+							<th class="rt-sig-th rt-sig-th--right">Value</th>
+							<th class="rt-sig-th rt-sig-th--right">Status</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each signalRows as row (row.key)}
+							<tr class="rt-sig-row">
+								<td class="rt-sig-td">{row.label}</td>
+								<td class="rt-sig-td rt-sig-td--right rt-sig-td--mono">{row.value}</td>
+								<td class="rt-sig-td rt-sig-td--right rt-sig-td--status">{row.status}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			{/if}
+
+			{#if decisionText}
+				<div class="rt-decision">{decisionText}</div>
+			{/if}
+		{:else}
+			<div class="rt-empty">Regime data unavailable</div>
+		{/if}
+	</div>
+
+	<!-- Section 3: Allocation Bands Summary -->
+	<div class="rt-section">
+		<div class="rt-section-header">
+			<span class="rt-section-title">ALLOCATION BANDS</span>
+		</div>
+
+		{#if bandRows.length > 0}
+			<div class="rt-bands">
+				{#each bandRows as row (row.label)}
+					<div class="rt-band-row">
+						<span class="rt-band-label">{row.label}</span>
+						<span class="rt-band-range">
+							{formatPercent(row.min, 1)}
+							<span class="rt-band-arrow">&rarr;</span>
+							{formatPercent(row.center ?? row.min, 1)}
+							<span class="rt-band-arrow">&rarr;</span>
+							{formatPercent(row.max, 1)}
+						</span>
+					</div>
+				{/each}
+			</div>
+
+			{#if regimeBands}
+				<div class="rt-posture">{taaRegimePosture(regimeBands.raw_regime)}</div>
+			{/if}
+		{:else}
+			<div class="rt-empty">No allocation band data</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.rt-root {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-3);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.rt-section {
+		border-bottom: var(--terminal-border-hairline);
+		padding-bottom: var(--terminal-space-2);
+	}
+
+	.rt-section:last-child {
+		border-bottom: none;
+	}
+
+	.rt-section-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: var(--terminal-space-2);
+	}
+
+	.rt-section-title {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	/* Period selector */
+	.rt-period-group {
+		display: flex;
+		gap: 1px;
+	}
+
+	.rt-period-btn {
+		padding: 2px 8px;
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		cursor: pointer;
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.rt-period-btn:hover {
+		color: var(--terminal-accent-amber);
+	}
+
+	.rt-period-btn--active {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+
+	/* Metadata panel */
+	.rt-meta-row {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		margin-bottom: var(--terminal-space-2);
+	}
+
+	.rt-badge {
+		display: inline-block;
+		padding: 1px 6px;
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.rt-meta-date {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rt-meta-duration {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		color: var(--terminal-fg-secondary);
+	}
+
+	/* Stress bar */
+	.rt-stress {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		margin-bottom: var(--terminal-space-2);
+	}
+
+	.rt-stress-label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		min-width: 40px;
+	}
+
+	.rt-stress-track {
+		flex: 1;
+		height: 4px;
+		background: var(--terminal-fg-muted);
+	}
+
+	.rt-stress-fill {
+		height: 100%;
+		transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+	}
+
+	.rt-stress-value {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		min-width: 48px;
+		text-align: right;
+	}
+
+	/* Signal table */
+	.rt-signal-table {
+		width: 100%;
+		border-collapse: collapse;
+		margin-bottom: var(--terminal-space-2);
+	}
+
+	.rt-sig-th {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		text-align: left;
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.rt-sig-th--right {
+		text-align: right;
+	}
+
+	.rt-sig-row {
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.rt-sig-td {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: var(--terminal-text-11);
+	}
+
+	.rt-sig-td--right {
+		text-align: right;
+	}
+
+	.rt-sig-td--mono {
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+
+	.rt-sig-td--status {
+		color: var(--terminal-fg-tertiary);
+		font-size: var(--terminal-text-10);
+	}
+
+	/* Decision footnote */
+	.rt-decision {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-left: 2px solid var(--terminal-fg-muted);
+	}
+
+	/* Allocation bands */
+	.rt-bands {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.rt-band-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+	}
+
+	.rt-band-label {
+		font-size: var(--terminal-text-10);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rt-band-range {
+		color: var(--terminal-fg-primary);
+		font-weight: 600;
+	}
+
+	.rt-band-arrow {
+		color: var(--terminal-fg-muted);
+	}
+
+	.rt-posture {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		margin-top: var(--terminal-space-1);
+	}
+
+	.rt-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 60px;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-11);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/RegimeTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/RegimeTab.svelte
@@ -15,15 +15,15 @@
 		formatNumber,
 		formatDate,
 	} from "@investintell/ui";
-	import TerminalChart from "$wealth/components/terminal/charts/TerminalChart.svelte";
-	import { createClientApiClient } from "$wealth/api/client";
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import TerminalChart from "../../../components/terminal/charts/TerminalChart.svelte";
+	import { createClientApiClient } from "../../../api/client";
+	import { workspace } from "../../../state/portfolio-workspace.svelte";
 	import {
 		taaRegimeLabel,
 		taaRegimeColor,
 		taaRegimePosture,
-	} from "$wealth/types/taa";
-	import type { RegimeBands } from "$wealth/types/taa";
+	} from "../../../types/taa";
+	import type { RegimeBands } from "../../../types/taa";
 	import type { EChartsOption } from "echarts";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/RiskTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/RiskTab.svelte
@@ -10,9 +10,9 @@
   createTerminalChartOptions).
 -->
 <script lang="ts">
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import { workspace } from "../../../state/portfolio-workspace.svelte";
 	import { formatNumber, readTerminalTokens, createTerminalChartOptions } from "@investintell/ui";
-	import TerminalChart from "$wealth/components/terminal/charts/TerminalChart.svelte";
+	import TerminalChart from "../../../components/terminal/charts/TerminalChart.svelte";
 	import type { EChartsOption } from "echarts";
 	import {
 		translateKappa,
@@ -21,7 +21,7 @@
 		translateFactorCoverage,
 		translateRSquaredMedian,
 		type TranslatedMetric,
-	} from "$wealth/util/metric-translators";
+	} from "../../../utils/metric-translators";
 
 	const run = $derived(workspace.constructionRun);
 	const funds = $derived(workspace.funds);

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/RiskTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/RiskTab.svelte
@@ -1,0 +1,389 @@
+<!--
+  RiskTab — Zone E RISK tab of the Builder results panel.
+
+  Two sections:
+    A) CVaR contribution — 48px horizontal stacked bar
+    B) Factor exposure — horizontal bar chart
+
+  Uses TerminalChart with raw EChartsOption (the stacked bar and
+  horizontal bar layouts need custom grid/tooltip not covered by
+  createTerminalChartOptions).
+-->
+<script lang="ts">
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import { formatNumber, readTerminalTokens, createTerminalChartOptions } from "@investintell/ui";
+	import TerminalChart from "$wealth/components/terminal/charts/TerminalChart.svelte";
+	import type { EChartsOption } from "echarts";
+	import {
+		translateKappa,
+		translateShrinkageLambda,
+		translateRegime,
+		translateFactorCoverage,
+		translateRSquaredMedian,
+		type TranslatedMetric,
+	} from "$wealth/util/metric-translators";
+
+	const run = $derived(workspace.constructionRun);
+	const funds = $derived(workspace.funds);
+
+	// ── PR-A5 B.3 — in-flight chip strip from buildMetrics ──────
+	const factorMetrics = $derived(workspace.buildMetrics.factor);
+	const shrinkageMetrics = $derived(workspace.buildMetrics.shrinkage);
+	const inFlightPhase = $derived(
+		workspace.runPhase === "factor_modeling" || workspace.runPhase === "shrinkage",
+	);
+
+	type Chip = TranslatedMetric & { rawTitle?: string };
+
+	const chips = $derived.by<Chip[]>(() => {
+		const out: Chip[] = [];
+		if (factorMetrics) {
+			const effRaw = factorMetrics.k_factors_effective;
+			const totRaw = factorMetrics.k_factors;
+			if (typeof effRaw === "number" && typeof totRaw === "number") {
+				out.push({
+					...translateFactorCoverage(effRaw, totRaw),
+					rawTitle: `k_factors_effective=${effRaw}, k_factors=${totRaw}`,
+				});
+			}
+			const regime = factorMetrics.regime;
+			if (typeof regime === "string") {
+				out.push({ ...translateRegime(regime), rawTitle: `regime=${regime}` });
+			}
+			const kappa = factorMetrics.kappa;
+			if (typeof kappa === "number") {
+				out.push({
+					...translateKappa(kappa),
+					rawTitle: `kappa=${formatNumber(kappa, 0)}`,
+				});
+			}
+			const r2 = factorMetrics.r_squared_p50;
+			if (typeof r2 === "number") {
+				out.push({
+					...translateRSquaredMedian(r2),
+					rawTitle: `r_squared_p50=${formatNumber(r2, 3)}`,
+				});
+			}
+		}
+		if (shrinkageMetrics) {
+			const lambda = shrinkageMetrics.shrinkage_lambda;
+			if (typeof lambda === "number") {
+				out.push({
+					...translateShrinkageLambda(lambda),
+					rawTitle: `shrinkage_lambda=${formatNumber(lambda, 4)}`,
+				});
+			}
+		}
+		return out;
+	});
+
+	const showChips = $derived(chips.length > 0);
+
+	/** Sanitized factor category labels (PC1/PC2/PC3 → Market/Style/Sector). */
+	const FACTOR_LABELS: Record<string, string> = {
+		PC1: "Market Factor",
+		PC2: "Style Factor",
+		PC3: "Sector Factor",
+	};
+
+	// ── Section A: CVaR Contribution ────────────────────────
+
+	const cvarContributions = $derived.by<Array<{ name: string; value: number }>>(() => {
+		if (!run?.ex_ante_metrics || !run.weights_proposed) return [];
+		const totalCvar = run.ex_ante_metrics.cvar_95;
+		if (totalCvar == null || totalCvar === 0) return [];
+
+		const entries: Array<{ name: string; value: number }> = [];
+		for (const fund of funds) {
+			const w = run.weights_proposed[fund.instrument_id] ?? 0;
+			if (w > 0.001) {
+				entries.push({
+					name: fund.fund_name || fund.instrument_id,
+					value: Math.abs(w * totalCvar),
+				});
+			}
+		}
+		return entries.sort((a, b) => b.value - a.value);
+	});
+
+	const hasCvar = $derived(cvarContributions.length > 0);
+
+	const cvarOption = $derived.by<EChartsOption>(() => {
+		if (!hasCvar) return {};
+		const tk = readTerminalTokens();
+		const total = cvarContributions.reduce((sum, c) => sum + c.value, 0);
+
+		const base = createTerminalChartOptions({
+			slot: "secondary",
+			disableAnimation: true,
+			showXAxisLabels: false,
+			showYAxisLabels: false,
+			xAxis: { type: "value" as const, show: false, max: total },
+			yAxis: { type: "category" as const, show: false, data: ["Tail Loss"] },
+			series: cvarContributions.map((c, i) => ({
+				type: "bar" as const,
+				stack: "cvar",
+				barWidth: "100%",
+				data: [c.value],
+				name: c.name,
+				itemStyle: { color: tk.dataviz[i % tk.dataviz.length] },
+			})),
+		});
+		return { ...base, grid: { left: 0, right: 0, top: 0, bottom: 0 } };
+	});
+
+	// ── Section B: Factor Exposure ──────────────────────────
+
+	const factorExposures = $derived.by<Array<{ label: string; value: number }>>(() => {
+		const fe = run?.factor_exposure;
+		if (!fe || typeof fe !== "object") return [];
+
+		const inner = (fe as Record<string, unknown>).exposures ?? fe;
+		if (!inner || typeof inner !== "object") return [];
+
+		return Object.entries(inner as Record<string, unknown>)
+			.filter(([, v]) => typeof v === "number")
+			.map(([key, v]) => ({
+				label: FACTOR_LABELS[key] ?? key,
+				value: v as number,
+			}))
+			.sort((a, b) => Math.abs(b.value) - Math.abs(a.value));
+	});
+
+	const hasFactors = $derived(factorExposures.length > 0);
+
+	const factorOption = $derived.by<EChartsOption>(() => {
+		if (!hasFactors) return {};
+		const tk = readTerminalTokens();
+
+		const labels = factorExposures.map((e) => e.label);
+		const values = factorExposures.map((e) => Math.round(e.value * 1000) / 1000);
+
+		const base = createTerminalChartOptions({
+			slot: "secondary",
+			disableAnimation: true,
+			xAxis: {
+				type: "value" as const,
+				axisLabel: {
+					formatter: (v: number) => formatNumber(v, 1),
+				},
+			},
+			yAxis: {
+				type: "category" as const,
+				data: labels,
+				inverse: true,
+				axisLabel: { fontWeight: 600 as const },
+				axisTick: { show: false },
+				axisLine: { show: false },
+			},
+			series: [
+				{
+					type: "bar" as const,
+					barWidth: "55%",
+					data: values.map((v) => ({
+						value: v,
+						itemStyle: {
+							color: v >= 0 ? tk.accentCyan : tk.accentAmber,
+						},
+					})),
+					label: {
+						show: true,
+						position: "right" as const,
+						fontSize: tk.text10,
+						fontWeight: 600 as const,
+						color: tk.fgPrimary,
+					},
+					markLine: {
+						silent: true,
+						symbol: "none" as const,
+						data: [{ xAxis: 0 }],
+						lineStyle: { color: tk.fgTertiary, type: "solid" as const, width: 1 },
+						label: { show: false },
+					},
+				},
+			],
+		});
+
+		return { ...base, grid: { left: 130, right: 50, top: 12, bottom: 24 } };
+	});
+
+	const hasData = $derived(hasCvar || hasFactors);
+</script>
+
+<svelte:boundary>
+	<div class="rt-root">
+		{#if showChips}
+			<!-- PR-A5 B.3 — phase-aware chip strip, pinned above the charts. -->
+			<section class="rt-chips" aria-label="Risk model diagnostics">
+				{#each chips as chip, i (i)}
+					<span class="rt-chip rt-chip--{chip.tone}" title={chip.rawTitle ?? ""}>
+						{chip.label}
+					</span>
+				{/each}
+			</section>
+		{/if}
+
+		{#if !run}
+			{#if inFlightPhase}
+				<div class="rt-skeleton" aria-busy="true">
+					<div class="rt-skeleton-line rt-skeleton-line--wide"></div>
+					<div class="rt-skeleton-line"></div>
+					<div class="rt-skeleton-line rt-skeleton-line--narrow"></div>
+				</div>
+			{:else}
+				<div class="rt-empty">Run construction to see risk analysis</div>
+			{/if}
+		{:else if !hasData}
+			<div class="rt-empty">No risk data in this construction run</div>
+		{:else}
+			{#if hasCvar}
+				<section class="rt-section">
+					<header class="rt-section-header">
+						<span class="rt-kicker">Risk Contribution</span>
+						<span class="rt-subtitle">Tail Loss (95% confidence) by position</span>
+					</header>
+					<TerminalChart option={cvarOption} height={48} ariaLabel="Tail loss contribution stacked bar" />
+				</section>
+			{/if}
+
+			{#if hasFactors}
+				<section class="rt-section">
+					<header class="rt-section-header">
+						<span class="rt-kicker">Factor Decomposition</span>
+						<span class="rt-subtitle">Portfolio factor exposures</span>
+					</header>
+					<TerminalChart option={factorOption} height={200} ariaLabel="Factor exposure horizontal bar" />
+				</section>
+			{/if}
+		{/if}
+	</div>
+
+	{#snippet failed(err: unknown)}
+		<div class="rt-empty">Risk panel failed to render</div>
+	{/snippet}
+</svelte:boundary>
+
+<style>
+	.rt-root {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-4);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.rt-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 200px;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-11);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rt-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+	}
+
+	.rt-section-header {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.rt-kicker {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rt-subtitle {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+	}
+
+	/* ── PR-A5 B.3 — diagnostics chip strip ─────────────── */
+
+	.rt-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--terminal-space-2);
+		padding-bottom: var(--terminal-space-2);
+		border-bottom: 1px dashed var(--terminal-fg-muted);
+	}
+
+	.rt-chip {
+		display: inline-flex;
+		align-items: center;
+		padding: 4px 8px;
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		border: 1px solid var(--terminal-fg-muted);
+		border-radius: 2px;
+		background: var(--terminal-bg-panel-raised);
+		font-family: var(--terminal-font-mono);
+		white-space: nowrap;
+	}
+
+	.rt-chip--success {
+		border-color: var(--terminal-status-success);
+		color: var(--terminal-fg-primary);
+	}
+
+	.rt-chip--neutral {
+		border-color: var(--terminal-fg-muted);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.rt-chip--warning {
+		border-color: var(--terminal-status-warn);
+		color: var(--terminal-status-warn);
+	}
+
+	.rt-chip--danger {
+		border-color: var(--terminal-status-error);
+		color: var(--terminal-status-error);
+	}
+
+	/* ── PR-A5 B.3/B.5 — shimmer skeleton ─────────────── */
+
+	.rt-skeleton {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-4) 0;
+	}
+
+	.rt-skeleton-line {
+		height: 12px;
+		background: linear-gradient(
+			90deg,
+			var(--terminal-bg-panel-raised) 0%,
+			var(--terminal-fg-muted) 50%,
+			var(--terminal-bg-panel-raised) 100%
+		);
+		background-size: 200% 100%;
+		animation: rt-shimmer 1.4s linear infinite;
+		opacity: 0.4;
+	}
+
+	.rt-skeleton-line--wide {
+		width: 80%;
+	}
+
+	.rt-skeleton-line--narrow {
+		width: 45%;
+	}
+
+	@keyframes rt-shimmer {
+		0% { background-position: 200% 0; }
+		100% { background-position: -200% 0; }
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/RunControls.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/RunControls.svelte
@@ -1,0 +1,420 @@
+<!--
+  RunControls — Zone C of the Builder command panel.
+
+  "Run Construction" button with state machine driven by
+  workspace.runPhase. Compare dropdown stub for Session 3.
+-->
+<script lang="ts">
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+
+	interface Props {
+		onRunComplete?: () => void;
+	}
+
+	let { onRunComplete }: Props = $props();
+
+	const phase = $derived(workspace.runPhase);
+	const hasPortfolio = $derived(workspace.portfolioId !== null);
+	const runError = $derived(workspace.runError);
+	const dedupedNotice = $derived(workspace.buildDedupedNotice);
+
+	/**
+	 * PR-A5 A.11 — Error UX matrix, rendered inline in the RunControls
+	 * footer. The backend already sanitises ``message`` server-side; we
+	 * just map HTTP-level failures (captured as Error.message by the
+	 * api client) onto the spec's verbatim strings. SSE ERROR/CANCELLED
+	 * are already driven by _applyBuildEvent so runError carries the
+	 * sanitised sentence directly.
+	 */
+	const errorLine = $derived.by((): { text: string; cta: string | null } | null => {
+		if (phase === "cancelled") {
+			return { text: "Construction cancelled.", cta: null };
+		}
+		if (phase !== "error") return null;
+		const msg = runError ?? "";
+		// HTTP 400 invalid UUID
+		if (/\b400\b/.test(msg) && /uuid|invalid/i.test(msg)) {
+			return {
+				text: "Portfolio identifier is invalid. Refresh and re-select.",
+				cta: "Refresh",
+			};
+		}
+		// HTTP 403 — cross-tenant stream vs RBAC distinction
+		if (/\b403\b/.test(msg)) {
+			if (/stream/i.test(msg)) {
+				return { text: "Build stream unavailable. Please re-open the Builder.", cta: "Reopen" };
+			}
+			return {
+				text: "You are not authorised to run a construction. Contact an IC member.",
+				cta: null,
+			};
+		}
+		// HTTP 504 / 120s client-timeout surfaces as AbortError → "Construction exceeded 120s"
+		if (/\b504\b/.test(msg) || /timeout|exceeded/i.test(msg)) {
+			return {
+				text:
+					"Construction exceeded 120s. Review your calibration (regime override, shrinkage, turnover cap) and try again.",
+				cta: "Re-run",
+			};
+		}
+		// Stream disconnect
+		if (/stream closed|lost connection|reconnect/i.test(msg)) {
+			return {
+				text: "Lost connection to the build stream. Reconnecting\u2026",
+				cta: "Reopen",
+			};
+		}
+		// Default: render sanitised backend message verbatim (never re-format).
+		return { text: msg || "Construction failed.", cta: "Re-run" };
+	});
+
+	function handleErrorCta() {
+		if (!errorLine?.cta) return;
+		if (errorLine.cta === "Refresh" || errorLine.cta === "Reopen") {
+			window.location.reload();
+			return;
+		}
+		void handleRun();
+	}
+
+	const buttonLabel = $derived.by(() => {
+		switch (phase) {
+			case "running":
+			case "factor_modeling":
+			case "shrinkage":
+			case "optimizer":
+			case "stress":
+			case "deduped":
+				return "Building\u2026";
+			case "done":
+				return "Complete";
+			case "error":
+				return "Re-run";
+			case "cancelled":
+				// A.6 — cancelled uses neutral wording + neutral style.
+				return "Run again";
+			default:
+				return "Run Construction";
+		}
+	});
+
+	const inFlight = $derived(
+		phase === "running" ||
+			phase === "factor_modeling" ||
+			phase === "shrinkage" ||
+			phase === "optimizer" ||
+			phase === "stress" ||
+			phase === "deduped",
+	);
+
+	const isDisabled = $derived(!hasPortfolio || inFlight);
+
+	// PR-A5 D.2 — belt-and-suspenders: we also key the disabled attribute
+	// on the same set so synchronous double-clicks within a frame become
+	// a no-op even before the async runBuildJob resolves.
+	const showCancel = $derived(inFlight);
+	let cancelRequested = $state(false);
+	let cancelWarningTimerId: ReturnType<typeof setTimeout> | null = null;
+	let cancelWarningActive = $state(false);
+
+	async function handleCancel() {
+		if (!inFlight || cancelRequested) return;
+		cancelRequested = true;
+		// D.5 — if no CANCELLED event within 30s, surface a soft warning.
+		if (cancelWarningTimerId !== null) clearTimeout(cancelWarningTimerId);
+		cancelWarningTimerId = setTimeout(() => {
+			cancelWarningActive = true;
+		}, 30_000);
+		await workspace.cancelActiveBuild();
+	}
+
+	$effect(() => {
+		// Reset cancel guards when we leave an in-flight state.
+		if (!inFlight) {
+			cancelRequested = false;
+			cancelWarningActive = false;
+			if (cancelWarningTimerId !== null) {
+				clearTimeout(cancelWarningTimerId);
+				cancelWarningTimerId = null;
+			}
+		}
+	});
+
+	const statusClass = $derived.by(() => {
+		switch (phase) {
+			case "running":
+			case "factor_modeling":
+			case "shrinkage":
+			case "optimizer":
+			case "stress":
+			case "deduped":
+				return "rc-btn--running";
+			case "done":
+				return "rc-btn--done";
+			case "error":
+				return "rc-btn--error";
+			case "cancelled":
+				// A.6 — neutral, NOT red.
+				return "rc-btn--cancelled";
+			default:
+				return "";
+		}
+	});
+
+	async function handleRun() {
+		if (isDisabled) return;
+		const result = await workspace.runBuildJob();
+		if (result && onRunComplete) {
+			onRunComplete();
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === "Enter" && !isDisabled) {
+			e.preventDefault();
+			handleRun();
+		}
+	}
+</script>
+
+<div class="rc-root">
+	<div class="rc-row">
+		<button
+			type="button"
+			class="rc-btn {statusClass}"
+			disabled={isDisabled}
+			onclick={handleRun}
+			onkeydown={handleKeydown}
+			aria-label={buttonLabel}
+		>
+			{#if phase === "done"}
+				<span class="rc-check">&check;</span>
+			{/if}
+			{buttonLabel}
+		</button>
+
+		{#if showCancel}
+			<!-- PR-A5 A.9 — secondary CANCEL, only while in-flight. -->
+			<button
+				type="button"
+				class="rc-cancel"
+				onclick={handleCancel}
+				disabled={cancelRequested}
+				aria-label="Cancel construction"
+			>
+				{cancelRequested ? "Cancelling\u2026" : "Cancel"}
+			</button>
+		{/if}
+	</div>
+
+	<select class="rc-compare" aria-label="Compare with previous run">
+		<option value="last">Compare with: Last run</option>
+	</select>
+
+	{#if dedupedNotice}
+		<!-- PR-A5 A.4.3 — transient notice while advisory-lock loser follows the primary stream. -->
+		<div class="rc-notice" role="status">{dedupedNotice}</div>
+	{/if}
+
+	{#if cancelWarningActive}
+		<!-- PR-A5 D.5 — 30s soft warning if no CANCELLED event arrives. -->
+		<div class="rc-notice rc-notice--warn" role="status">
+			Cancellation accepted but no confirmation received. Refresh to re-sync.
+		</div>
+	{/if}
+
+	{#if errorLine}
+		<!-- PR-A5 A.11 — inline error footer with recovery CTA. -->
+		<div class="rc-error" role="alert">
+			<span class="rc-error-text">{errorLine.text}</span>
+			{#if errorLine.cta}
+				<button type="button" class="rc-error-cta" onclick={handleErrorCta}>
+					{errorLine.cta}
+				</button>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.rc-root {
+		min-height: 80px;
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-2);
+		border-top: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		box-sizing: border-box;
+	}
+
+	.rc-row {
+		display: flex;
+		align-items: stretch;
+		gap: var(--terminal-space-2);
+		width: 100%;
+	}
+
+	.rc-row .rc-btn {
+		flex: 1;
+	}
+
+	.rc-cancel {
+		flex: 0 0 auto;
+		min-width: 96px;
+		padding: 0 var(--terminal-space-3);
+		background: var(--terminal-bg-panel-sunken);
+		color: var(--terminal-fg-primary);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+
+	.rc-cancel:hover:not(:disabled) {
+		opacity: 0.85;
+	}
+
+	.rc-cancel:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.rc-cancel:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.rc-notice {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-secondary);
+		line-height: var(--terminal-leading-tight);
+		padding: var(--terminal-space-1) 0;
+	}
+
+	.rc-notice--warn {
+		color: var(--terminal-accent-amber);
+	}
+
+	.rc-error {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-status-error);
+		line-height: var(--terminal-leading-tight);
+		padding: var(--terminal-space-1) 0;
+	}
+
+	.rc-error-text {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.rc-error-cta {
+		flex: 0 0 auto;
+		padding: 0 var(--terminal-space-2);
+		height: 24px;
+		background: transparent;
+		color: var(--terminal-status-error);
+		border: 1px solid var(--terminal-status-error);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+
+	.rc-error-cta:hover {
+		opacity: 0.8;
+	}
+
+	.rc-error-cta:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.rc-btn {
+		height: 32px;
+		width: 100%;
+		background: var(--terminal-accent-amber);
+		color: var(--terminal-bg-base, var(--terminal-bg-void));
+		border: none;
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		transition:
+			background var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			opacity var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.rc-btn:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.rc-btn:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.rc-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.rc-btn--running {
+		animation: rc-pulse 1.5s ease-in-out infinite;
+	}
+
+	.rc-btn--done {
+		background: var(--terminal-status-success);
+	}
+
+	.rc-btn--error {
+		background: var(--terminal-status-error);
+		color: var(--terminal-fg-primary);
+	}
+
+	.rc-btn--cancelled {
+		background: var(--terminal-bg-panel-sunken);
+		color: var(--terminal-fg-primary);
+		border: var(--terminal-border-hairline);
+	}
+
+	.rc-check {
+		margin-right: var(--terminal-space-1);
+	}
+
+	@keyframes rc-pulse {
+		0%, 100% { opacity: 1; }
+		50% { opacity: 0.6; }
+	}
+
+	.rc-compare {
+		height: 24px;
+		width: 100%;
+		background: var(--terminal-bg-panel-sunken);
+		color: var(--terminal-fg-secondary);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		padding: 0 var(--terminal-space-2);
+		cursor: pointer;
+	}
+
+	.rc-compare:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/RunControls.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/RunControls.svelte
@@ -5,7 +5,7 @@
   workspace.runPhase. Compare dropdown stub for Session 3.
 -->
 <script lang="ts">
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import { workspace } from "../../../state/portfolio-workspace.svelte";
 
 	interface Props {
 		onRunComplete?: () => void;

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/StressTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/StressTab.svelte
@@ -1,0 +1,265 @@
+<!--
+  StressTab — Zone E STRESS tab of the Builder results panel.
+
+  Displays the 4 parametric stress scenario results from the last
+  construction run. Terminal-styled table with sanitized scenario names.
+  No custom shock form (deferred to Session 3+).
+-->
+<script lang="ts">
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import type { ConstructionStressResult } from "$wealth/state/portfolio-workspace.svelte";
+	import { formatPercent } from "@investintell/ui";
+
+	/** Sanitized scenario names per Appendix D. */
+	const SCENARIO_LABELS: Record<string, string> = {
+		gfc_2008: "Global Financial Crisis",
+		covid_2020: "COVID",
+		taper_2013: "Taper Tantrum",
+		rate_shock_200bps: "Rate Shock",
+	};
+
+	const run = $derived(workspace.constructionRun);
+	const stressResults = $derived(run?.stress_results ?? []);
+
+	// ── PR-A5 B.4 — in-flight scenario grid (before run loads) ──
+	const inFlight = $derived(workspace.runPhase === "stress");
+	const backtestMetrics = $derived(workspace.buildMetrics.backtest);
+	const liveScenarioResults = $derived.by<Record<string, unknown> | null>(() => {
+		if (!backtestMetrics) return null;
+		const raw = backtestMetrics.scenario_results;
+		if (raw && typeof raw === "object") return raw as Record<string, unknown>;
+		return null;
+	});
+	const STRESS_KEYS: ReadonlyArray<string> = [
+		"gfc_2008",
+		"covid_2020",
+		"taper_2013",
+		"rate_shock_200bps",
+	];
+	function isScenarioDone(key: string): boolean {
+		return !!liveScenarioResults && liveScenarioResults[key] != null;
+	}
+
+	interface StressRow {
+		scenario: string;
+		label: string;
+		navImpact: number | null;
+		worstBlock: string | null;
+		bestBlock: string | null;
+		severity: "high" | "medium" | "low" | "none";
+	}
+
+	const rows = $derived.by<StressRow[]>(() => {
+		return stressResults.map((r: ConstructionStressResult) => {
+			const label = SCENARIO_LABELS[r.scenario] ?? r.scenario;
+			const navImpact = r.nav_impact_pct;
+			const blocks = r.per_block_impact ?? {};
+			const blockEntries = Object.entries(blocks);
+
+			let worstBlock: string | null = null;
+			let bestBlock: string | null = null;
+			if (blockEntries.length > 0) {
+				const sorted = [...blockEntries].sort((a, b) => a[1] - b[1]);
+				const worst = sorted[0];
+				const best = sorted[sorted.length - 1];
+				if (worst) worstBlock = worst[0];
+				if (best) bestBlock = best[0];
+			}
+
+			let severity: StressRow["severity"] = "none";
+			if (navImpact != null) {
+				const abs = Math.abs(navImpact);
+				if (abs > 0.05) severity = "high";
+				else if (abs > 0.02) severity = "medium";
+				else severity = "low";
+			}
+
+			return { scenario: r.scenario, label, navImpact, worstBlock, bestBlock, severity };
+		});
+	});
+</script>
+
+<svelte:boundary>
+	<div class="st-root">
+		{#if !run && inFlight}
+			<!-- PR-A5 B.4 — live scenario grid while BACKTESTING runs. -->
+			<section class="st-live" aria-label="Cenários em execução">
+				<header class="st-live-header">Executando 4 cenários de stress…</header>
+				<div class="st-live-grid">
+					{#each STRESS_KEYS as key (key)}
+						{@const done = isScenarioDone(key)}
+						<div class="st-live-cell" class:st-live-cell--done={done}>
+							<span
+								class="st-live-icon"
+								class:st-live-icon--done={done}
+								aria-hidden="true"
+							>{done ? "\u2713" : "\u25CF"}</span>
+							<span class="st-live-label">{SCENARIO_LABELS[key]}</span>
+						</div>
+					{/each}
+				</div>
+			</section>
+		{:else if !run}
+			<div class="st-empty">Run construction to see stress analysis</div>
+		{:else if rows.length === 0}
+			<div class="st-empty">No active stress scenarios in this run</div>
+		{:else}
+			<table class="st-table">
+				<thead>
+					<tr>
+						<th scope="col">Scenario</th>
+						<th scope="col" class="st-num">Portfolio Impact</th>
+						<th scope="col">Worst Block</th>
+						<th scope="col">Best Block</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each rows as row (row.scenario)}
+						<tr>
+							<td class="st-scenario">{row.label}</td>
+							<td class="st-num st-impact st-impact--{row.severity}">
+								{row.navImpact != null ? formatPercent(row.navImpact, 1) : "\u2014"}
+							</td>
+							<td class="st-block">{row.worstBlock ?? "\u2014"}</td>
+							<td class="st-block">{row.bestBlock ?? "\u2014"}</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		{/if}
+	</div>
+
+	{#snippet failed(err: unknown)}
+		<div class="st-empty">Stress panel failed to render</div>
+	{/snippet}
+</svelte:boundary>
+
+<style>
+	.st-root {
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.st-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 200px;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-11);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.st-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: var(--terminal-text-11);
+	}
+
+	.st-table th,
+	.st-table td {
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+		text-align: left;
+		vertical-align: middle;
+	}
+
+	.st-table thead th {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.st-scenario {
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+
+	.st-num {
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.st-block {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.st-impact--high {
+		color: var(--terminal-status-error);
+	}
+
+	.st-impact--medium {
+		color: var(--terminal-status-warn);
+	}
+
+	.st-impact--low {
+		color: var(--terminal-status-success);
+	}
+
+	.st-impact--none {
+		color: var(--terminal-fg-muted);
+	}
+
+	/* ── PR-A5 B.4 — in-flight scenario grid ──────────── */
+
+	.st-live {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-3);
+		padding: var(--terminal-space-4);
+	}
+
+	.st-live-header {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		animation: st-live-pulse 1.5s ease-in-out infinite;
+	}
+
+	.st-live-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: var(--terminal-space-2);
+	}
+
+	.st-live-cell {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border: 1px solid var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel-raised);
+		font-size: var(--terminal-text-11);
+	}
+
+	.st-live-cell--done {
+		border-color: var(--terminal-status-success);
+	}
+
+	.st-live-icon {
+		display: inline-flex;
+		width: 16px;
+		font-size: var(--terminal-text-12);
+		color: var(--terminal-fg-muted);
+	}
+
+	.st-live-icon--done {
+		color: var(--terminal-status-success);
+	}
+
+	.st-live-label {
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+
+	@keyframes st-live-pulse {
+		0%, 100% { opacity: 1; }
+		50% { opacity: 0.5; }
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/StressTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/StressTab.svelte
@@ -6,8 +6,8 @@
   No custom shock form (deferred to Session 3+).
 -->
 <script lang="ts">
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
-	import type { ConstructionStressResult } from "$wealth/state/portfolio-workspace.svelte";
+	import { workspace } from "../../../state/portfolio-workspace.svelte";
+	import type { ConstructionStressResult } from "../../../state/portfolio-workspace.svelte";
 	import { formatPercent } from "@investintell/ui";
 
 	/** Sanitized scenario names per Appendix D. */

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/WeightsTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/WeightsTab.svelte
@@ -7,9 +7,9 @@
 -->
 <script lang="ts">
 	import { formatPercent, formatNumber } from "@investintell/ui";
-	import { BLOCK_GROUPS, blockDisplay, groupDisplay } from "$wealth/constants/blocks";
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
-	import AchievableReturnBandChart from "$wealth/components/portfolio/AchievableReturnBandChart.svelte";
+	import { BLOCK_GROUPS, blockDisplay, groupDisplay } from "../../../constants/blocks";
+	import { workspace } from "../../../state/portfolio-workspace.svelte";
+	import AchievableReturnBandChart from "../../../components/portfolio/AchievableReturnBandChart.svelte";
 
 	// ── Build 3-level tree (same logic as BuilderTable, DnD stripped) ──
 

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/WeightsTab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/WeightsTab.svelte
@@ -1,0 +1,524 @@
+<!--
+  WeightsTab — WEIGHTS tab in the Builder results panel (right column).
+
+  Read-only display of proposed weights grouped by asset class.
+  Tree structure: Group -> Block -> Fund. No drag-drop.
+  Data sourced from workspace.funds / workspace.fundsByBlock.
+-->
+<script lang="ts">
+	import { formatPercent, formatNumber } from "@investintell/ui";
+	import { BLOCK_GROUPS, blockDisplay, groupDisplay } from "$wealth/constants/blocks";
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import AchievableReturnBandChart from "$wealth/components/portfolio/AchievableReturnBandChart.svelte";
+
+	// ── Build 3-level tree (same logic as BuilderTable, DnD stripped) ──
+
+	const GROUP_ORDER = ["CASH & EQUIVALENTS", "EQUITIES", "FIXED INCOME", "ALTERNATIVES"];
+
+	interface TreeFund {
+		instrument_id: string;
+		fund_name: string;
+		block_id: string;
+		score: number | null;
+		weight: number;
+		ticker?: string | null;
+	}
+
+	interface TreeBlock {
+		blockId: string;
+		displayLabel: string;
+		funds: TreeFund[];
+		weight: number;
+	}
+
+	interface TreeGroup {
+		name: string;
+		displayName: string;
+		blocks: TreeBlock[];
+		totalWeight: number;
+		fundCount: number;
+	}
+
+	const activeBlockIds = $derived.by<Set<string>>(() => {
+		const blocks = new Set<string>();
+		for (const f of workspace.funds) blocks.add(f.block_id);
+		return blocks;
+	});
+
+	const tree = $derived.by<TreeGroup[]>(() => {
+		const groupMap = new Map<string, TreeGroup>();
+
+		for (const [groupName, blockIds] of Object.entries(BLOCK_GROUPS)) {
+			const blocks: TreeBlock[] = [];
+			for (const blockId of blockIds) {
+				if (!activeBlockIds.has(blockId)) continue;
+				const rawFunds = (workspace.fundsByBlock[blockId] ?? []) as TreeFund[];
+				const weight = rawFunds.reduce((s, f) => s + (f.weight ?? 0), 0);
+				blocks.push({
+					blockId,
+					displayLabel: blockDisplay(blockId),
+					funds: rawFunds,
+					weight,
+				});
+			}
+			if (blocks.length === 0) continue;
+
+			groupMap.set(groupName, {
+				name: groupName,
+				displayName: groupDisplay(groupName),
+				blocks,
+				totalWeight: blocks.reduce((s, b) => s + b.weight, 0),
+				fundCount: blocks.reduce((s, b) => s + b.funds.length, 0),
+			});
+		}
+
+		// Catch unmapped blocks
+		const mappedBlockIds = new Set(Object.values(BLOCK_GROUPS).flat());
+		const unmapped: TreeBlock[] = [];
+		for (const blockId of activeBlockIds) {
+			if (mappedBlockIds.has(blockId)) continue;
+			const rawFunds = (workspace.fundsByBlock[blockId] ?? []) as TreeFund[];
+			unmapped.push({
+				blockId,
+				displayLabel: blockDisplay(blockId),
+				funds: rawFunds,
+				weight: rawFunds.reduce((s, f) => s + (f.weight ?? 0), 0),
+			});
+		}
+		if (unmapped.length > 0) {
+			groupMap.set("OTHER", {
+				name: "OTHER",
+				displayName: groupDisplay("OTHER"),
+				blocks: unmapped,
+				totalWeight: unmapped.reduce((s, b) => s + b.weight, 0),
+				fundCount: unmapped.reduce((s, b) => s + b.funds.length, 0),
+			});
+		}
+
+		const result: TreeGroup[] = [];
+		for (const key of GROUP_ORDER) {
+			const g = groupMap.get(key);
+			if (g) {
+				result.push(g);
+				groupMap.delete(key);
+			}
+		}
+		for (const g of groupMap.values()) result.push(g);
+		return result;
+	});
+
+	const hasRun = $derived(workspace.constructionRun !== null);
+
+	// PR-A13 — echo the achievable return band from the completed run so the
+	// operator can see their delivered return against the modeled band.
+	const echoBand = $derived(
+		workspace.constructionRun?.cascade_telemetry?.achievable_return_band ?? null,
+	);
+	const echoMinCvar = $derived(
+		workspace.constructionRun?.cascade_telemetry?.min_achievable_cvar ?? null,
+	);
+	const echoCvarLimit = $derived.by<number>(() => {
+		const snap = workspace.constructionRun?.calibration_snapshot as
+			| { cvar_limit?: number }
+			| null;
+		return typeof snap?.cvar_limit === "number" ? snap.cvar_limit : 0.05;
+	});
+	const realizedReturn = $derived.by<number | null>(() => {
+		const metrics = workspace.constructionRun?.ex_ante_metrics ?? null;
+		const r = metrics?.expected_return ?? metrics?.ann_return ?? null;
+		return typeof r === "number" ? r : null;
+	});
+	const realizedWithinBand = $derived.by<boolean | null>(() => {
+		if (realizedReturn === null || !echoBand) return null;
+		return realizedReturn >= echoBand.lower && realizedReturn <= echoBand.upper;
+	});
+
+	// ── Run diff data for Previous column (Session 3) ──
+	// Fetch diff when a construction run completes
+	$effect(() => {
+		const run = workspace.constructionRun;
+		if (run?.run_id && !workspace.runDiff && !workspace.isLoadingDiff) {
+			workspace.fetchRunDiff(run.run_id);
+		}
+	});
+
+	const diffData = $derived(workspace.runDiff?.weight_delta ?? null);
+
+	function previousWeight(instrumentId: string, currentWeight: number): string {
+		if (!diffData) return "\u2014";
+		const entry = diffData[instrumentId];
+		if (!entry) return "\u2014";
+		return formatWeight(entry.from);
+	}
+
+	// ── Collapse state ──
+	let collapsedGroup = $state<Record<string, boolean>>({});
+
+	function toggleGroup(name: string) {
+		collapsedGroup[name] = !collapsedGroup[name];
+	}
+
+	// ── Delta formatting ──
+	function deltaColor(weight: number): string {
+		if (weight > 0.0001) return "var(--terminal-status-success)";
+		if (weight < -0.0001) return "var(--terminal-status-error)";
+		return "var(--terminal-fg-muted)";
+	}
+
+	function formatDelta(weight: number): string {
+		if (Math.abs(weight) < 0.0001) return "\u2014";
+		const sign = weight > 0 ? "+" : "";
+		return sign + formatPercent(weight, 2);
+	}
+
+	function formatWeight(value: number): string {
+		return formatPercent(value, 2);
+	}
+
+	function formatScore(value: number | null | undefined): string {
+		if (value == null || value === 0) return "\u2014";
+		return formatNumber(value, 0);
+	}
+</script>
+
+<div class="wt-root">
+	{#if hasRun && echoBand}
+		<section class="wt-band-echo" aria-label="Achievable return band">
+			<header class="wt-band-echo__header">
+				<h4 class="wt-band-echo__title">Achievable return band</h4>
+				{#if realizedReturn !== null && realizedWithinBand !== null}
+					<span
+						class="wt-band-echo__chip"
+						class:wt-band-echo__chip--within={realizedWithinBand}
+						class:wt-band-echo__chip--below={!realizedWithinBand}
+					>
+						{#if realizedWithinBand}
+							Delivered {formatPercent(realizedReturn, 2)} — within band
+						{:else}
+							Delivered {formatPercent(realizedReturn, 2)} — below modeled band
+						{/if}
+					</span>
+				{/if}
+			</header>
+			<AchievableReturnBandChart
+				band={echoBand}
+				cvarLimit={echoCvarLimit}
+				minAchievableCvar={echoMinCvar}
+				height={180}
+			/>
+		</section>
+	{/if}
+	{#if tree.length === 0}
+		<div class="wt-empty">
+			{#if hasRun}
+				No instruments in portfolio
+			{:else}
+				Run construction to see proposed weights
+			{/if}
+		</div>
+	{:else}
+		<table class="wt-table" aria-label="Proposed portfolio weights">
+			<thead>
+				<tr>
+					<th class="wt-th wt-th-name">Fund</th>
+					<th class="wt-th wt-th-num">Score</th>
+					<th class="wt-th wt-th-num">Weight</th>
+					<th class="wt-th wt-th-num">Previous</th>
+					<th class="wt-th wt-th-num">Delta</th>
+				</tr>
+			</thead>
+
+			{#each tree as group (group.name)}
+				{@const isCollapsed = collapsedGroup[group.name] ?? false}
+				<tbody>
+					<tr
+						class="wt-group-row"
+						role="button"
+						tabindex="0"
+						onclick={() => toggleGroup(group.name)}
+						onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleGroup(group.name); } }}
+					>
+						<td class="wt-group-name" colspan="3">
+							<span class="wt-chevron" class:wt-chevron--open={!isCollapsed}>&rsaquo;</span>
+							{group.displayName}
+							<span class="wt-group-count">({group.fundCount})</span>
+						</td>
+						<td class="wt-group-weight" colspan="2">
+							{formatWeight(group.totalWeight)}
+						</td>
+					</tr>
+
+					{#if !isCollapsed}
+						{#each group.blocks as block (block.blockId)}
+							<tr class="wt-block-row">
+								<td class="wt-block-name" colspan="3">
+									{block.displayLabel}
+								</td>
+								<td class="wt-block-weight" colspan="2">
+									{formatWeight(block.weight)}
+								</td>
+							</tr>
+
+							{#each block.funds as fund (fund.instrument_id)}
+								<tr class="wt-fund-row">
+									<td class="wt-fund-name">
+										<span class="wt-fund-label">{fund.fund_name}</span>
+										{#if fund.ticker}
+											<span class="wt-fund-ticker">{fund.ticker}</span>
+										{/if}
+									</td>
+									<td class="wt-fund-num">{formatScore(fund.score)}</td>
+									<td class="wt-fund-num">{formatWeight(fund.weight)}</td>
+									<td class="wt-fund-num wt-fund-ghost">{previousWeight(fund.instrument_id, fund.weight)}</td>
+									<td class="wt-fund-num">
+										<span class="wt-delta" style="color: {deltaColor(fund.weight)}">
+											{formatDelta(fund.weight)}
+										</span>
+										{#if Math.abs(fund.weight) > 0.0001}
+											<div class="wt-delta-bar">
+												<div
+													class="wt-delta-fill"
+													style="width: {Math.min(Math.abs(fund.weight) * 500, 100)}%; background: {deltaColor(fund.weight)};"
+												></div>
+											</div>
+										{/if}
+									</td>
+								</tr>
+							{/each}
+						{/each}
+					{/if}
+				</tbody>
+			{/each}
+
+			<tfoot>
+				<tr class="wt-total-row">
+					<td class="wt-total-label" colspan="2">Total</td>
+					<td class="wt-total-value">{formatWeight(workspace.totalWeight)}</td>
+					<td class="wt-total-value wt-fund-ghost">&mdash;</td>
+					<td class="wt-total-value"></td>
+				</tr>
+			</tfoot>
+		</table>
+	{/if}
+</div>
+
+<style>
+	.wt-root {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.wt-band-echo {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 12px 0 16px 0;
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		margin-bottom: 12px;
+	}
+	.wt-band-echo__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+	}
+	.wt-band-echo__title {
+		margin: 0;
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--terminal-fg-primary);
+	}
+	.wt-band-echo__chip {
+		font-size: 10px;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		padding: 2px 8px;
+		border: 1px solid var(--terminal-fg-muted);
+		border-radius: 2px;
+	}
+	.wt-band-echo__chip--within {
+		color: var(--terminal-status-success);
+		border-color: var(--terminal-status-success);
+	}
+	.wt-band-echo__chip--below {
+		color: var(--terminal-status-warning);
+		border-color: var(--terminal-status-warning);
+	}
+
+	.wt-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 200px;
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-12);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.wt-table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	.wt-th {
+		position: sticky;
+		top: 0;
+		background: var(--terminal-bg-panel);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		text-align: left;
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		border-bottom: var(--terminal-border-hairline);
+		z-index: 1;
+	}
+
+	.wt-th-num {
+		text-align: right;
+		width: 80px;
+	}
+
+	.wt-th-name {
+		width: auto;
+	}
+
+	/* Group row */
+	.wt-group-row {
+		cursor: pointer;
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.wt-group-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.wt-group-name {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-weight: 700;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-primary);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.wt-chevron {
+		display: inline-block;
+		width: 12px;
+		transition: transform var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.wt-chevron--open {
+		transform: rotate(90deg);
+	}
+
+	.wt-group-count {
+		color: var(--terminal-fg-tertiary);
+		font-weight: 400;
+		margin-left: var(--terminal-space-1);
+	}
+
+	.wt-group-weight {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		text-align: right;
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+	}
+
+	/* Block row */
+	.wt-block-row {
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.wt-block-name {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		padding-left: var(--terminal-space-6);
+		font-weight: 600;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-secondary);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.wt-block-weight {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		text-align: right;
+		font-weight: 600;
+		color: var(--terminal-fg-secondary);
+	}
+
+	/* Fund row */
+	.wt-fund-row {
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.wt-fund-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.wt-fund-name {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		padding-left: var(--terminal-space-8);
+	}
+
+	.wt-fund-label {
+		color: var(--terminal-fg-primary);
+	}
+
+	.wt-fund-ticker {
+		margin-left: var(--terminal-space-1);
+		color: var(--terminal-fg-tertiary);
+		font-size: var(--terminal-text-10);
+	}
+
+	.wt-fund-num {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		text-align: right;
+	}
+
+	.wt-fund-ghost {
+		color: var(--terminal-fg-muted);
+	}
+
+	.wt-delta {
+		font-weight: 600;
+	}
+
+	.wt-delta-bar {
+		margin-top: 2px;
+		height: 2px;
+		background: var(--terminal-fg-muted);
+		width: 60px;
+		margin-left: auto;
+	}
+
+	.wt-delta-fill {
+		height: 100%;
+		transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+	}
+
+	/* Total row */
+	.wt-total-row {
+		border-top: var(--terminal-border-strong);
+	}
+
+	.wt-total-label {
+		padding: var(--terminal-space-2);
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-primary);
+	}
+
+	.wt-total-value {
+		padding: var(--terminal-space-2);
+		text-align: right;
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/charts/TerminalChart.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/charts/TerminalChart.svelte
@@ -1,0 +1,228 @@
+<!--
+	TerminalChart.svelte
+	====================
+
+	Source of truth: docs/plans/2026-04-11-terminal-unification-master-plan.md §1.2, §1.4, Appendix G
+
+	THE ONLY Svelte component allowed to import ECharts directly
+	inside `frontends/wealth/src/`. Every pattern wrapper
+	(TerminalLineChart, TerminalHeatmap, TerminalTreemap, …)
+	composes `TerminalChart` under the hood; every surface under
+	`(terminal)/` renders through those wrappers. ESLint enforces
+	this — see frontends/eslint.config.js `no-restricted-imports`.
+
+	Responsibilities:
+	  - Lifecycle: `echarts.init` on mount, `dispose` on destroy.
+	  - ResizeObserver for fluid panels (LayoutCage is fixed but
+	    split panes and focus mode resize dynamically).
+	  - Rebinds `setOption` on reactive `option` updates.
+	  - Exposes the `echarts` instance via `bindable` so pattern
+	    wrappers can call `setOption({ replaceMerge })` for live
+	    streams without paying the cost of a full notMerge.
+	  - Renderer selection (canvas/svg) is controlled by the
+	    caller so heatmaps/scatter stay on canvas and small
+	    sparklines stay on svg.
+
+	This wrapper never bakes aesthetic decisions. Callers build
+	option objects through `createTerminalChartOptions()` from
+	@investintell/ui and pass them down.
+-->
+<script lang="ts">
+	import { onMount } from "svelte";
+	// TerminalChart is the single authorized direct consumer of
+	// the `echarts` module inside the wealth frontend.
+	import * as echarts from "echarts/core";
+	import {
+		LineChart,
+		BarChart,
+		ScatterChart,
+		HeatmapChart,
+		TreemapChart,
+		CandlestickChart,
+		RadarChart,
+		CustomChart,
+	} from "echarts/charts";
+	import {
+		GridComponent,
+		TooltipComponent,
+		LegendComponent,
+		DataZoomComponent,
+		VisualMapComponent,
+		MarkLineComponent,
+		MarkAreaComponent,
+		MarkPointComponent,
+		DatasetComponent,
+		TransformComponent,
+	} from "echarts/components";
+	import { CanvasRenderer, SVGRenderer } from "echarts/renderers";
+	import type { EChartsOption } from "echarts";
+
+	echarts.use([
+		LineChart,
+		BarChart,
+		ScatterChart,
+		HeatmapChart,
+		TreemapChart,
+		CandlestickChart,
+		RadarChart,
+		CustomChart,
+		GridComponent,
+		TooltipComponent,
+		LegendComponent,
+		DataZoomComponent,
+		VisualMapComponent,
+		MarkLineComponent,
+		MarkAreaComponent,
+		MarkPointComponent,
+		DatasetComponent,
+		TransformComponent,
+		CanvasRenderer,
+		SVGRenderer,
+	]);
+
+	interface Props {
+		/** Full ECharts option object — normally built via createTerminalChartOptions. */
+		option: EChartsOption;
+		/** Render backend: canvas (heroes, heatmaps) or svg (sparklines, radar). */
+		renderer?: "canvas" | "svg";
+		/** Height in pixels. Width is 100% of the parent container. */
+		height?: number;
+		/** ARIA label for assistive tech (charts are rendered on canvas). */
+		ariaLabel?: string;
+		/** Empty state toggle. When true, hides the chart and shows an ASCII placeholder. */
+		empty?: boolean;
+		emptyMessage?: string;
+		/** Loading toggle. Terminal-native CSS hatching — no spinner. */
+		loading?: boolean;
+		/** Bindable ECharts instance (for live setOption calls from pattern wrappers). */
+		instance?: echarts.ECharts | undefined;
+	}
+
+	let {
+		option,
+		renderer = "canvas",
+		height = 320,
+		ariaLabel = "Terminal chart",
+		empty = false,
+		emptyMessage = "NO DATA",
+		loading = false,
+		instance = $bindable(),
+	}: Props = $props();
+
+	let hostEl: HTMLDivElement | undefined = $state();
+
+	/*
+	 * ============================================================
+	 * DO NOT CONVERT `lastOption` TO `$state` — REACTIVITY TRAP
+	 * ============================================================
+	 *
+	 * `lastOption` is a PLAIN module-local variable on purpose. It
+	 * exists ONLY to short-circuit the `$effect` below when the
+	 * caller passes the same option reference twice.
+	 *
+	 * IF YOU WRAP THIS IN `$state`, THE FOLLOWING HAPPENS:
+	 *
+	 *   1. `$state` deeply proxies the EChartsOption object.
+	 *   2. The proxy is no longer reference-equal to the raw
+	 *      `option` prop the caller passed in (`option === lastOption`
+	 *      becomes permanently false).
+	 *   3. The `$effect` re-reads `lastOption` on every assignment,
+	 *      establishes a reactive dependency on it, and rebinds the
+	 *      ECharts instance via `setOption` on EVERY tick.
+	 *   4. ECharts triggers an internal redraw, which mutates the
+	 *      bound `instance` prop (`$bindable`), which re-runs the
+	 *      effect → INFINITE LOOP, browser tab freezes.
+	 *
+	 * This pattern is load-bearing for the entire `(terminal)/`
+	 * chart pipeline. The Phase 1 audit (2026-04-11) flagged it as
+	 * the #1 risk for future refactors. Leave it as a plain `let`.
+	 * ============================================================
+	 */
+	let lastOption: EChartsOption | null = null;
+
+	onMount(() => {
+		if (!hostEl) return;
+		instance = echarts.init(hostEl, null, { renderer });
+		const ro = new ResizeObserver(() => instance?.resize());
+		ro.observe(hostEl);
+		return () => {
+			ro.disconnect();
+			instance?.dispose();
+			instance = undefined;
+		};
+	});
+
+	$effect(() => {
+		if (!instance || empty || loading) return;
+		if (option === lastOption) return;
+		lastOption = option;
+		instance.setOption(option, { notMerge: true });
+	});
+</script>
+
+<div class="terminal-chart" style:height="{height}px">
+	{#if loading}
+		<div class="terminal-chart__state terminal-chart__state--loading" aria-hidden="true">
+			<span class="terminal-chart__state-label">█ LOADING</span>
+		</div>
+	{/if}
+
+	{#if empty && !loading}
+		<div class="terminal-chart__state terminal-chart__state--empty" aria-hidden="true">
+			<span class="terminal-chart__state-label">[ {emptyMessage} ]</span>
+		</div>
+	{/if}
+
+	<div
+		bind:this={hostEl}
+		class="terminal-chart__host"
+		role="img"
+		aria-label={ariaLabel}
+		style:visibility={empty || loading ? "hidden" : "visible"}
+	></div>
+</div>
+
+<style>
+	.terminal-chart {
+		position: relative;
+		width: 100%;
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.terminal-chart__host {
+		width: 100%;
+		height: 100%;
+	}
+
+	.terminal-chart__state {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: var(--terminal-z-panel);
+		background: var(--terminal-bg-panel);
+		color: var(--terminal-fg-tertiary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.terminal-chart__state--loading {
+		background-image: repeating-linear-gradient(
+			45deg,
+			transparent 0 6px,
+			var(--terminal-bg-panel-raised) 6px 8px
+		);
+	}
+
+	.terminal-chart__state-label {
+		padding: var(--terminal-space-2) var(--terminal-space-4);
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/charts/TerminalLineChart.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/charts/TerminalLineChart.svelte
@@ -1,0 +1,103 @@
+<!--
+	TerminalLineChart.svelte
+	========================
+
+	Reference pattern wrapper from Appendix A #1 (NAV time series).
+	All other pattern wrappers (TerminalHeatmap, TerminalTreemap,
+	TerminalDistribution, TerminalRollingBand, TerminalCandlestick,
+	TerminalRadar) should follow this exact composition:
+
+	  1. Accept a minimal, domain-shaped prop surface (time-series
+	     tuples, labels, title) — never raw ECharts option objects.
+	  2. Build an option via `createTerminalChartOptions()`.
+	  3. Delegate rendering to <TerminalChart />.
+	  4. Never import `echarts` directly.
+	  5. Never write hex, inline duration literals, or Intl.* calls.
+
+	Consumers:
+	  - Live Workbench NAV strip
+	  - Builder preview
+	  - Focus Mode fund hero chart
+	  - Screener sparkline grid (via a thin sparkline variant)
+-->
+<script lang="ts">
+	import { createTerminalChartOptions, type ChoreoSlot } from "@investintell/ui";
+	import type { EChartsOption } from "echarts";
+	import TerminalChart from "./TerminalChart.svelte";
+
+	/** One continuous series. */
+	export interface TerminalLineSeries {
+		name: string;
+		/** Array of [ms-epoch, value] tuples. Monotonic time expected. */
+		data: ReadonlyArray<readonly [number, number]>;
+		/**
+		 * 0-indexed color slot from the terminal dataviz palette. When
+		 * omitted, ECharts assigns sequential colors from the factory.
+		 */
+		colorSlot?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+		/** Draw as smoothed area (NAV hero) rather than plain line. */
+		area?: boolean;
+	}
+
+	interface Props {
+		series: ReadonlyArray<TerminalLineSeries>;
+		height?: number;
+		/** Choreo slot for the reveal animation. Defaults to `primary`. */
+		slot?: ChoreoSlot;
+		/** Render backend. Heroes stay on canvas; tiny strips can use svg. */
+		renderer?: "canvas" | "svg";
+		/** Hide x-axis ticks/labels (use for ticker-strip mode). */
+		compact?: boolean;
+		/** Show legend (usually false — panel headers label the series). */
+		showLegend?: boolean;
+		ariaLabel?: string;
+		empty?: boolean;
+		loading?: boolean;
+	}
+
+	const {
+		series,
+		height = 320,
+		slot = "primary",
+		renderer = "canvas",
+		compact = false,
+		showLegend = false,
+		ariaLabel = "Time series",
+		empty = false,
+		loading = false,
+	}: Props = $props();
+
+	const option = $derived<EChartsOption>(
+		createTerminalChartOptions({
+			slot,
+			showXAxisLabels: !compact,
+			showYAxisLabels: !compact,
+			showLegend,
+			series: series.map((s) => ({
+				name: s.name,
+				type: "line" as const,
+				showSymbol: false,
+				smooth: true,
+				sampling: "lttb" as const,
+				progressive: 2000,
+				progressiveThreshold: 4000,
+				lineStyle: { width: s.area ? 1.25 : 1.5 },
+				areaStyle: s.area ? { opacity: 0.14 } : undefined,
+				// ECharts wants mutable tuples; our prop surface is readonly.
+				// The factory never mutates data — this cast is contract-safe.
+				data: s.data.map((pt) => [pt[0], pt[1]] as [number, number]),
+				...(s.colorSlot !== undefined ? { colorBy: "series" as const, seriesIndex: s.colorSlot } : {}),
+			})),
+		}),
+	);
+</script>
+
+<TerminalChart
+	{option}
+	{renderer}
+	{height}
+	{ariaLabel}
+	{empty}
+	{loading}
+	emptyMessage="NO SERIES"
+/>

--- a/packages/ii-terminal-core/src/lib/components/terminal/data/KeyValueStrip.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/data/KeyValueStrip.svelte
@@ -1,0 +1,76 @@
+<!--
+  KeyValueStrip — horizontal strip of key-value pairs.
+
+  Extracted from MacroRegimePanel rows and AdvisorTab metrics.
+  Consistent spacing, monospace, tabular-nums.
+-->
+<script lang="ts">
+  interface KVItem {
+    key: string;
+    value: string;
+    /** Optional color override for the value text. */
+    valueColor?: string;
+  }
+
+  interface Props {
+    items: KVItem[];
+    /** Direction of the strip. Default: horizontal row. */
+    direction?: "row" | "column";
+  }
+
+  let {
+    items,
+    direction = "row",
+  }: Props = $props();
+</script>
+
+<div class="kv-root" class:kv-root--column={direction === "column"}>
+  {#each items as item (item.key)}
+    <div class="kv-pair">
+      <span class="kv-key">{item.key}</span>
+      <span
+        class="kv-value"
+        style:color={item.valueColor ?? "var(--terminal-fg-primary)"}
+      >
+        {item.value}
+      </span>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .kv-root {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--terminal-space-3);
+    font-family: var(--terminal-font-mono);
+  }
+
+  .kv-root--column {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .kv-pair {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--terminal-space-2);
+  }
+
+  .kv-key {
+    font-size: var(--terminal-text-10);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-tertiary);
+    white-space: nowrap;
+  }
+
+  .kv-value {
+    font-size: var(--terminal-text-11);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/data/LiveDot.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/data/LiveDot.svelte
@@ -1,0 +1,67 @@
+<!--
+  LiveDot — 6px status indicator dot.
+
+  Extracted from TerminalStatusBar inline dots and DriftMonitorPanel
+  drift state indicators. Four status states mapping to terminal tokens.
+  Optional pulse animation for live/streaming contexts.
+-->
+<script lang="ts">
+  type DotStatus = "success" | "warn" | "error" | "muted";
+
+  interface Props {
+    status?: DotStatus;
+    /** Enable pulse animation (for live streaming indicators). */
+    pulse?: boolean;
+    /** Optional accessible label. */
+    label?: string;
+  }
+
+  let {
+    status = "muted",
+    pulse = false,
+    label,
+  }: Props = $props();
+
+  const colorMap: Record<DotStatus, string> = {
+    success: "var(--terminal-status-success)",
+    warn: "var(--terminal-status-warn)",
+    error: "var(--terminal-status-error)",
+    muted: "var(--terminal-fg-muted)",
+  };
+
+  const resolvedColor = $derived(colorMap[status]);
+</script>
+
+<span
+  class="ld-dot"
+  class:ld-dot--pulse={pulse}
+  style:background={resolvedColor}
+  style:box-shadow={status !== "muted" ? `0 0 8px ${resolvedColor}` : "none"}
+  role={label ? "status" : undefined}
+  aria-label={label}
+></span>
+
+<style>
+  .ld-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    flex-shrink: 0;
+    vertical-align: middle;
+  }
+
+  .ld-dot--pulse {
+    animation: ld-pulse 1.8s ease-in-out infinite;
+  }
+
+  @keyframes ld-pulse {
+    0%, 100% { opacity: 0.45; }
+    50% { opacity: 1; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ld-dot--pulse {
+      animation: none;
+    }
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/data/StatSlab.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/data/StatSlab.svelte
@@ -1,0 +1,80 @@
+<!--
+  StatSlab — label + value + optional delta indicator.
+
+  Extracted from PortfolioSummary KPI rows and BacktestTab metrics.
+  Monospace typography, tabular-nums, terminal tokens only.
+-->
+<script lang="ts">
+  interface Props {
+    label: string;
+    value: string;
+    /** Optional delta string (e.g. "+2.4%"). */
+    delta?: string | null;
+    /** Color for the delta text. Maps to terminal status/accent tokens. */
+    deltaColor?: "success" | "warn" | "error" | "muted" | "cyan" | "amber";
+  }
+
+  let {
+    label,
+    value,
+    delta = null,
+    deltaColor = "muted",
+  }: Props = $props();
+
+  const colorMap: Record<string, string> = {
+    success: "var(--terminal-status-success)",
+    warn: "var(--terminal-status-warn)",
+    error: "var(--terminal-status-error)",
+    muted: "var(--terminal-fg-muted)",
+    cyan: "var(--terminal-accent-cyan)",
+    amber: "var(--terminal-accent-amber)",
+  };
+
+  const resolvedColor = $derived(colorMap[deltaColor] ?? colorMap.muted);
+</script>
+
+<div class="ss-root">
+  <span class="ss-label">{label}</span>
+  <div class="ss-value-row">
+    <span class="ss-value">{value}</span>
+    {#if delta}
+      <span class="ss-delta" style:color={resolvedColor}>{delta}</span>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .ss-root {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-family: var(--terminal-font-mono);
+  }
+
+  .ss-label {
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-tertiary);
+  }
+
+  .ss-value-row {
+    display: flex;
+    align-items: baseline;
+    gap: var(--terminal-space-2);
+  }
+
+  .ss-value {
+    font-size: var(--terminal-text-14);
+    font-weight: 600;
+    color: var(--terminal-fg-primary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .ss-delta {
+    font-size: var(--terminal-text-11);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/dd/DDApprovalDialog.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/dd/DDApprovalDialog.svelte
@@ -1,0 +1,238 @@
+<!--
+  DDApprovalDialog — terminal-native confirmation dialog for DD approve/reject.
+
+  Renders a scrim overlay with a centered dialog box. Textarea requires
+  minimum 10 characters. Terminal tokens only — no shadcn, no hex values.
+-->
+<script lang="ts">
+	interface DDApprovalDialogProps {
+		mode: "approve" | "reject";
+		isOpen: boolean;
+		isSubmitting: boolean;
+		error: string | null;
+		onSubmit: (text: string) => void;
+		onCancel: () => void;
+	}
+
+	let {
+		mode,
+		isOpen,
+		isSubmitting,
+		error,
+		onSubmit,
+		onCancel,
+	}: DDApprovalDialogProps = $props();
+
+	let text = $state("");
+
+	const isApprove = $derived(mode === "approve");
+	const title = $derived(isApprove ? "Approve DD Report" : "Reject DD Report");
+	const body = $derived(
+		isApprove
+			? "Approving this report will add the fund to the Approved Universe."
+			: "This report will be returned to draft status.",
+	);
+	const confirmLabel = $derived(isApprove ? "CONFIRM APPROVAL" : "CONFIRM REJECTION");
+	const confirmColor = $derived(
+		isApprove ? "var(--terminal-status-success)" : "var(--terminal-status-error)",
+	);
+	const placeholder = $derived(
+		isApprove ? "Rationale for approval (min 10 chars)" : "Reason for rejection (min 10 chars)",
+	);
+	const isValid = $derived(text.trim().length >= 10);
+
+	function handleSubmit() {
+		if (!isValid || isSubmitting) return;
+		onSubmit(text.trim());
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === "Escape") {
+			e.preventDefault();
+			onCancel();
+		}
+	}
+
+	// Reset text when dialog opens
+	$effect(() => {
+		if (isOpen) {
+			text = "";
+		}
+	});
+</script>
+
+{#if isOpen}
+	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+	<div
+		class="dad-scrim"
+		role="dialog"
+		aria-modal="true"
+		aria-label={title}
+		onkeydown={handleKeydown}
+	>
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="dad-backdrop" onclick={onCancel} onkeydown={handleKeydown}></div>
+		<div class="dad-dialog">
+			<div class="dad-title">{title}</div>
+			<div class="dad-body">{body}</div>
+
+			<textarea
+				class="dad-textarea"
+				bind:value={text}
+				{placeholder}
+				rows={4}
+				disabled={isSubmitting}
+			></textarea>
+
+			{#if !isValid && text.length > 0}
+				<div class="dad-hint">Minimum 10 characters required ({text.trim().length}/10)</div>
+			{/if}
+
+			{#if error}
+				<div class="dad-error">{error}</div>
+			{/if}
+
+			<div class="dad-actions">
+				<button
+					class="dad-btn dad-btn--confirm"
+					style:border-color={confirmColor}
+					style:color={confirmColor}
+					type="button"
+					disabled={!isValid || isSubmitting}
+					onclick={handleSubmit}
+				>
+					{#if isSubmitting}
+						SUBMITTING...
+					{:else}
+						{confirmLabel}
+					{/if}
+				</button>
+				<button
+					class="dad-btn dad-btn--cancel"
+					type="button"
+					disabled={isSubmitting}
+					onclick={onCancel}
+				>
+					CANCEL
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.dad-scrim {
+		position: fixed;
+		inset: 0;
+		z-index: 9000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.dad-backdrop {
+		position: absolute;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.7);
+	}
+
+	.dad-dialog {
+		position: relative;
+		z-index: 1;
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-3);
+		width: 480px;
+		max-width: 90vw;
+		padding: var(--terminal-space-4);
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.dad-title {
+		font-size: var(--terminal-text-13);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.dad-body {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		line-height: 1.5;
+	}
+
+	.dad-textarea {
+		width: 100%;
+		min-height: 80px;
+		padding: var(--terminal-space-2);
+		background: var(--terminal-bg-surface);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-primary);
+		resize: vertical;
+	}
+
+	.dad-textarea:focus {
+		outline: var(--terminal-border-focus);
+		outline-offset: -1px;
+	}
+
+	.dad-textarea:disabled {
+		opacity: 0.5;
+	}
+
+	.dad-hint {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+
+	.dad-error {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-status-error);
+		font-weight: 600;
+	}
+
+	.dad-actions {
+		display: flex;
+		gap: var(--terminal-space-2);
+		justify-content: flex-end;
+	}
+
+	.dad-btn {
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		background: transparent;
+		border: 1px solid;
+		border-radius: var(--terminal-radius-none);
+		cursor: pointer;
+		transition: opacity var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.dad-btn:disabled {
+		opacity: 0.35;
+		cursor: not-allowed;
+	}
+
+	.dad-btn--cancel {
+		border-color: var(--terminal-fg-secondary);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.dad-btn--confirm:hover:not(:disabled) {
+		opacity: 0.8;
+	}
+
+	.dad-btn--cancel:hover:not(:disabled) {
+		opacity: 0.8;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/dd/DDChapterSection.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/dd/DDChapterSection.svelte
@@ -7,10 +7,10 @@
 -->
 <script lang="ts">
 	import { formatDateTime } from "@investintell/ui";
-	import LiveDot from "$wealth/components/terminal/data/LiveDot.svelte";
-	import KeyValueStrip from "$wealth/components/terminal/data/KeyValueStrip.svelte";
-	import { chapterTitle } from "$wealth/types/dd-report";
-	import { renderMarkdown, flattenObject } from "$wealth/utils/render-markdown";
+	import LiveDot from "../../../components/terminal/data/LiveDot.svelte";
+	import KeyValueStrip from "../../../components/terminal/data/KeyValueStrip.svelte";
+	import { chapterTitle } from "../../../types/dd-report";
+	import { renderMarkdown, flattenObject } from "../../../utils/render-markdown";
 
 	interface DDChapterSectionProps {
 		chapterTag: string;

--- a/packages/ii-terminal-core/src/lib/components/terminal/dd/DDChapterSection.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/dd/DDChapterSection.svelte
@@ -1,0 +1,379 @@
+<!--
+  DDChapterSection — collapsible chapter section for DD report viewer.
+
+  Renders chapter header with critic badge + LiveDot, expandable body
+  with rendered markdown, quant_data KeyValueStrip, and evidence refs.
+  Terminal tokens only — no shadcn, no hex values.
+-->
+<script lang="ts">
+	import { formatDateTime } from "@investintell/ui";
+	import LiveDot from "$wealth/components/terminal/data/LiveDot.svelte";
+	import KeyValueStrip from "$wealth/components/terminal/data/KeyValueStrip.svelte";
+	import { chapterTitle } from "$wealth/types/dd-report";
+	import { renderMarkdown, flattenObject } from "$wealth/utils/render-markdown";
+
+	interface DDChapterSectionProps {
+		chapterTag: string;
+		chapterOrder: number;
+		contentMd: string | null;
+		evidenceRefs: Record<string, unknown> | null;
+		quantData: Record<string, unknown> | null;
+		criticIterations: number;
+		criticStatus: string;
+		generatedAt: string | null;
+		isGenerating: boolean;
+		defaultOpen: boolean;
+	}
+
+	let {
+		chapterTag,
+		chapterOrder,
+		contentMd,
+		evidenceRefs,
+		quantData,
+		criticIterations,
+		criticStatus,
+		generatedAt,
+		isGenerating,
+		defaultOpen,
+	}: DDChapterSectionProps = $props();
+
+	// eslint-disable-next-line -- defaultOpen is intentionally captured once as initial value
+	let isOpen = $state(defaultOpen);
+
+	const displayTitle = $derived(`${chapterOrder}. ${chapterTitle(chapterTag)}`);
+
+	const CRITIC_MAP: Record<string, { label: string; color: string }> = {
+		accepted: { label: "CRITIC: PASS", color: "var(--terminal-status-success)" },
+		escalated: { label: "CRITIC: FAIL", color: "var(--terminal-status-error)" },
+		pending: { label: "CRITIC: PENDING", color: "var(--terminal-fg-muted)" },
+	};
+
+	const criticBadge = $derived(CRITIC_MAP[criticStatus] ?? { label: criticStatus.toUpperCase(), color: "var(--terminal-fg-muted)" });
+
+	const hasQuant = $derived(quantData !== null && Object.keys(quantData).length > 0);
+	const hasEvidence = $derived(evidenceRefs !== null && Object.keys(evidenceRefs).length > 0);
+
+	const quantItems = $derived(
+		hasQuant
+			? flattenObject(quantData!).map((item) => ({
+					key: item.key,
+					value: item.value,
+				}))
+			: [],
+	);
+
+	const evidenceList = $derived(
+		hasEvidence
+			? Object.entries(evidenceRefs!).map(([key, val]) => ({
+					key,
+					value: typeof val === "string" ? val : JSON.stringify(val),
+				}))
+			: [],
+	);
+
+	function toggle() {
+		isOpen = !isOpen;
+	}
+</script>
+
+<div class="dcs-root">
+	<button
+		class="dcs-header"
+		type="button"
+		onclick={toggle}
+		aria-expanded={isOpen}
+	>
+		<span class="dcs-chevron" class:dcs-chevron--open={isOpen}></span>
+		<span class="dcs-title">{displayTitle}</span>
+		<span class="dcs-badges">
+			<span class="dcs-critic" style:color={criticBadge.color}>{criticBadge.label}</span>
+			{#if isGenerating}
+				<LiveDot status="warn" pulse label="Generating chapter" />
+			{/if}
+		</span>
+	</button>
+
+	{#if isOpen}
+		<div class="dcs-body">
+			{#if isGenerating && !contentMd}
+				<div class="dcs-generating">Generating chapter content...</div>
+			{:else}
+				<div class="dcs-content">
+					{@html renderMarkdown(contentMd)}
+				</div>
+			{/if}
+
+			{#if hasQuant}
+				<div class="dcs-section">
+					<div class="dcs-section-label">QUANTITATIVE DATA</div>
+					<KeyValueStrip items={quantItems} direction="column" />
+				</div>
+			{/if}
+
+			{#if hasEvidence}
+				<div class="dcs-section">
+					<div class="dcs-section-label">EVIDENCE</div>
+					<div class="dcs-evidence-list">
+						{#each evidenceList as ref (ref.key)}
+							<div class="dcs-evidence-item">
+								<span class="dcs-evidence-key">{ref.key}</span>
+								{#if ref.value.startsWith("http")}
+									<a
+										class="dcs-evidence-link"
+										href={ref.value}
+										target="_blank"
+										rel="noopener noreferrer"
+									>{ref.value}</a>
+								{:else}
+									<span class="dcs-evidence-value">{ref.value}</span>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				</div>
+			{/if}
+
+			<div class="dcs-footer">
+				<span class="dcs-footer-item">Critic iterations: {criticIterations}</span>
+				{#if generatedAt}
+					<span class="dcs-footer-item">{formatDateTime(generatedAt)}</span>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dcs-root {
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.dcs-header {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		width: 100%;
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		background: var(--terminal-bg-surface);
+		border: none;
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		text-align: left;
+		cursor: pointer;
+		transition: background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.dcs-header:hover {
+		background: var(--terminal-bg-panel);
+	}
+
+	.dcs-header:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -1px;
+	}
+
+	.dcs-chevron {
+		display: inline-block;
+		width: 0;
+		height: 0;
+		flex-shrink: 0;
+		border-top: 4px solid transparent;
+		border-bottom: 4px solid transparent;
+		border-left: 5px solid var(--terminal-fg-tertiary);
+		transition: transform var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.dcs-chevron--open {
+		transform: rotate(90deg);
+	}
+
+	.dcs-title {
+		flex: 1;
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+
+	.dcs-badges {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+
+	.dcs-critic {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.dcs-body {
+		padding: var(--terminal-space-3);
+		border-top: var(--terminal-border-hairline);
+	}
+
+	.dcs-generating {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		font-style: italic;
+		padding: var(--terminal-space-2) 0;
+	}
+
+	.dcs-content {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-primary);
+		line-height: 1.65;
+	}
+
+	/* Terminal-native overrides for rendered markdown */
+	.dcs-content :global(h1),
+	.dcs-content :global(h2),
+	.dcs-content :global(h3) {
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.dcs-content :global(h1) {
+		font-size: var(--terminal-text-13);
+		margin: var(--terminal-space-3) 0 var(--terminal-space-2);
+	}
+
+	.dcs-content :global(h2) {
+		font-size: var(--terminal-text-12);
+		margin: var(--terminal-space-3) 0 var(--terminal-space-2);
+	}
+
+	.dcs-content :global(h3) {
+		font-size: var(--terminal-text-11);
+		margin: var(--terminal-space-2) 0 var(--terminal-space-1);
+	}
+
+	.dcs-content :global(p) {
+		margin: 0 0 var(--terminal-space-2);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.dcs-content :global(ul),
+	.dcs-content :global(ol) {
+		margin: 0 0 var(--terminal-space-2);
+		padding-left: var(--terminal-space-4);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.dcs-content :global(li) {
+		margin: 0 0 var(--terminal-space-1);
+	}
+
+	.dcs-content :global(strong) {
+		color: var(--terminal-fg-primary);
+	}
+
+	.dcs-content :global(code) {
+		font-family: var(--terminal-font-mono);
+		background: var(--terminal-bg-surface);
+		padding: 1px 4px;
+		border-radius: var(--terminal-radius-none);
+	}
+
+	.dcs-content :global(table) {
+		width: 100%;
+		border-collapse: collapse;
+		margin: var(--terminal-space-2) 0;
+		font-size: var(--terminal-text-10);
+	}
+
+	.dcs-content :global(th),
+	.dcs-content :global(td) {
+		border: var(--terminal-border-hairline);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		text-align: left;
+	}
+
+	.dcs-content :global(th) {
+		background: var(--terminal-bg-surface);
+		font-weight: 700;
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.dcs-content :global(blockquote) {
+		border-left: 2px solid var(--terminal-accent-amber);
+		margin: 0 0 var(--terminal-space-2);
+		padding-left: var(--terminal-space-3);
+		color: var(--terminal-fg-muted);
+	}
+
+	.dcs-content :global(hr) {
+		border: none;
+		border-top: var(--terminal-border-hairline);
+		margin: var(--terminal-space-3) 0;
+	}
+
+	.dcs-content :global(a) {
+		color: var(--terminal-accent-cyan);
+		text-decoration: underline;
+	}
+
+	.dcs-section {
+		margin-top: var(--terminal-space-3);
+		padding-top: var(--terminal-space-3);
+		border-top: var(--terminal-border-hairline);
+	}
+
+	.dcs-section-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		margin-bottom: var(--terminal-space-2);
+	}
+
+	.dcs-evidence-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+	}
+
+	.dcs-evidence-item {
+		display: flex;
+		gap: var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+	}
+
+	.dcs-evidence-key {
+		color: var(--terminal-fg-tertiary);
+		flex-shrink: 0;
+	}
+
+	.dcs-evidence-link {
+		color: var(--terminal-accent-cyan);
+		text-decoration: underline;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.dcs-evidence-value {
+		color: var(--terminal-fg-secondary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.dcs-footer {
+		display: flex;
+		gap: var(--terminal-space-3);
+		margin-top: var(--terminal-space-3);
+		padding-top: var(--terminal-space-2);
+		border-top: var(--terminal-border-hairline);
+	}
+
+	.dcs-footer-item {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/dd/DDQueueCard.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/dd/DDQueueCard.svelte
@@ -1,0 +1,171 @@
+<!--
+  DDQueueCard — terminal-native kanban card for a single DD report.
+
+  Renders as a keyboard-accessible <button> with instrument label,
+  status badge, version, confidence score, and decision anchor.
+  Terminal tokens only — no shadcn, no hex values.
+-->
+<script lang="ts">
+	import { formatDateTime, formatPercent } from "@investintell/ui";
+	import LiveDot from "$wealth/components/terminal/data/LiveDot.svelte";
+
+	interface DDQueueCardProps {
+		id: string;
+		instrumentId: string;
+		instrumentLabel: string | null;
+		status: string;
+		version: number;
+		confidenceScore: number | null;
+		decisionAnchor: string | null;
+		createdAt: string;
+		approvedAt: string | null;
+		onClick: () => void;
+	}
+
+	let {
+		instrumentLabel,
+		status,
+		version,
+		confidenceScore,
+		decisionAnchor,
+		createdAt,
+		onClick,
+	}: DDQueueCardProps = $props();
+
+	const STATUS_LABELS: Record<string, string> = {
+		draft: "Queued",
+		generating: "Generating...",
+		pending_approval: "Pending Review",
+		approved: "Approved",
+		rejected: "Rejected",
+		failed: "Failed",
+	};
+
+	const STATUS_COLORS: Record<string, string> = {
+		draft: "var(--terminal-fg-secondary)",
+		generating: "var(--terminal-accent-amber)",
+		pending_approval: "var(--terminal-accent-cyan)",
+		approved: "var(--terminal-status-success)",
+		rejected: "var(--terminal-status-error)",
+		failed: "var(--terminal-status-error)",
+	};
+
+	const ANCHOR_LABELS: Record<string, { text: string; color: string }> = {
+		APPROVE: { text: "Recommend Approve", color: "var(--terminal-status-success)" },
+		REJECT: { text: "Recommend Reject", color: "var(--terminal-status-error)" },
+		CONDITIONAL: { text: "Conditional", color: "var(--terminal-accent-amber)" },
+	};
+
+	const statusLabel = $derived(STATUS_LABELS[status] ?? status);
+	const statusColor = $derived(STATUS_COLORS[status] ?? "var(--terminal-fg-secondary)");
+	const isGenerating = $derived(status === "generating");
+	const anchor = $derived(decisionAnchor ? ANCHOR_LABELS[decisionAnchor] ?? null : null);
+</script>
+
+<button
+	class="dqc-card"
+	type="button"
+	onclick={onClick}
+	aria-label={`${instrumentLabel ?? "Unknown Fund"} — ${statusLabel}`}
+>
+	<span class="dqc-label">{instrumentLabel ?? "Unknown Fund"}</span>
+
+	<span class="dqc-meta">
+		<span class="dqc-version">v{version}</span>
+		<span class="dqc-status" style:color={statusColor}>{statusLabel}</span>
+		{#if isGenerating}
+			<LiveDot status="warn" pulse label="Generating" />
+		{/if}
+	</span>
+
+	<span class="dqc-date">{formatDateTime(createdAt)}</span>
+
+	{#if confidenceScore !== null || anchor}
+		<span class="dqc-bottom">
+			{#if confidenceScore !== null}
+				<span class="dqc-conf">CONF: {formatPercent(confidenceScore / 100, 0)}</span>
+			{/if}
+			{#if anchor}
+				<span class="dqc-anchor" style:color={anchor.color}>{anchor.text}</span>
+			{/if}
+		</span>
+	{/if}
+</button>
+
+<style>
+	.dqc-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		width: 100%;
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		background: var(--terminal-bg-surface);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		text-align: left;
+		cursor: pointer;
+		transition: border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.dqc-card:hover {
+		border-color: var(--terminal-accent-amber);
+	}
+
+	.dqc-card:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -1px;
+	}
+
+	.dqc-label {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.dqc-meta {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+	}
+
+	.dqc-version {
+		color: var(--terminal-fg-tertiary);
+		font-weight: 600;
+	}
+
+	.dqc-status {
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.dqc-date {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+
+	.dqc-bottom {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+	}
+
+	.dqc-conf {
+		font-weight: 600;
+		color: var(--terminal-fg-secondary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.dqc-anchor {
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/dd/DDQueueCard.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/dd/DDQueueCard.svelte
@@ -7,7 +7,7 @@
 -->
 <script lang="ts">
 	import { formatDateTime, formatPercent } from "@investintell/ui";
-	import LiveDot from "$wealth/components/terminal/data/LiveDot.svelte";
+	import LiveDot from "../../../components/terminal/data/LiveDot.svelte";
 
 	interface DDQueueCardProps {
 		id: string;

--- a/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/FocusMode.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/FocusMode.svelte
@@ -1,0 +1,449 @@
+<!--
+	FocusMode.svelte — generic entity focus primitive.
+	==================================================
+
+	Source of truth: docs/plans/2026-04-11-terminal-unification-master-plan.md
+		§1.3 FocusMode primitive, Appendix B §4, Appendix G file structure.
+
+	Generalization of the Phase 4.2 FundWarRoomModal. Accepts any
+	entity kind (fund / portfolio / manager / sector / regime) and
+	composes the brutalist 95vw × 95vh cage via snippets:
+
+	  • reactor  — main centerpiece, staggered with the `primary` slot.
+	  • rail     — optional 220px metadata strip, `secondary` slot.
+	  • actions  — optional top-right action cluster, defaults to
+	               a single [ ESC · CLOSE ] pill.
+
+	FocusMode does NOT own the inner cascade of a reactor's modules —
+	the consumer's snippet is responsible for its own stagger. This
+	primitive animates only four elements: scrim, top bar, reactor
+	wrapper, rail wrapper. All four motion sites route through
+	svelteTransitionFor from @investintell/ui.
+
+	URL state is NOT owned by this primitive. The caller owns URL
+	deep-link contracts (see Part C / TerminalShell).
+-->
+<script lang="ts">
+	import type { Snippet } from "svelte";
+	import { fade, fly } from "svelte/transition";
+	import { svelteTransitionFor } from "@investintell/ui";
+
+	export type FocusModeEntityKind =
+		| "fund"
+		| "portfolio"
+		| "manager"
+		| "sector"
+		| "regime";
+
+	interface FocusModeProps {
+		entityKind: FocusModeEntityKind;
+		entityId: string;
+		entityLabel: string;
+		reactor: Snippet;
+		rail?: Snippet;
+		actions?: Snippet;
+		onClose: () => void;
+	}
+
+	let {
+		entityKind,
+		entityId,
+		entityLabel,
+		reactor,
+		rail,
+		actions,
+		onClose,
+	}: FocusModeProps = $props();
+
+	let frameEl: HTMLDivElement | undefined = $state();
+
+	const timestamp = buildTimestamp();
+
+	function buildTimestamp(): string {
+		// Terminal timestamp — ISO 8601 minute precision, UTC. Not a
+		// user-facing value, so it does not route through @investintell/ui
+		// formatters (those handle locale/currency/date, not raw ISO).
+		const now = new Date();
+		const iso = now.toISOString();
+		return iso.replace("T", " ").slice(0, 19) + "Z";
+	}
+
+	function kindLabel(kind: FocusModeEntityKind): string {
+		switch (kind) {
+			case "fund":
+				return "FUND";
+			case "portfolio":
+				return "PORTFOLIO";
+			case "manager":
+				return "MANAGER";
+			case "sector":
+				return "SECTOR";
+			case "regime":
+				return "ENVIRONMENT";
+		}
+	}
+
+	// Body scroll lock — restore on unmount.
+	$effect(() => {
+		if (typeof document === "undefined") return;
+		const previous = document.body.style.overflow;
+		document.body.style.overflow = "hidden";
+		return () => {
+			document.body.style.overflow = previous;
+		};
+	});
+
+	// Keyboard handling — ESC closes, remove on unmount.
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const handler = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				event.preventDefault();
+				onClose();
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => {
+			window.removeEventListener("keydown", handler);
+		};
+	});
+
+	// Focus lifecycle — move focus inside the frame on mount, restore
+	// on unmount. Pairs with the Tab trap $effect below to implement
+	// the full WAI-ARIA dialog focus contract (aria-modal="true").
+	$effect(() => {
+		if (typeof document === "undefined") return;
+		const previouslyFocused = document.activeElement as HTMLElement | null;
+		// Defer one microtask so the DOM is painted before querying.
+		const task = queueMicrotask(() => {
+			if (!frameEl) return;
+			const target = queryFocusables(frameEl)[0] ?? frameEl;
+			target.focus({ preventScroll: true });
+		});
+		return () => {
+			// queueMicrotask returns undefined so `task` is unused; kept
+			// for symmetry if the scheduling strategy changes.
+			void task;
+			if (previouslyFocused && typeof previouslyFocused.focus === "function") {
+				previouslyFocused.focus({ preventScroll: true });
+			}
+		};
+	});
+
+	// Tab trap — cycle keyboard focus within the frame on Tab and
+	// Shift+Tab, wrapping around at the edges. Satisfies the WAI-ARIA
+	// dialog pattern for aria-modal="true": keyboard focus must not
+	// escape to the inert background content. Defense-in-depth with
+	// the initial-focus $effect above.
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const handler = (event: KeyboardEvent) => {
+			if (event.key !== "Tab" || !frameEl) return;
+			const focusables = queryFocusables(frameEl);
+			if (focusables.length === 0) {
+				// No focusables inside the modal — park focus on the frame
+				// itself (tabindex="-1") so focus cannot leak out.
+				event.preventDefault();
+				frameEl.focus({ preventScroll: true });
+				return;
+			}
+			// Non-null assertions safe: length === 0 case already returned above.
+			const first = focusables[0]!;
+			const last = focusables[focusables.length - 1]!;
+			const active = document.activeElement as HTMLElement | null;
+			const outsideFrame = !active || !frameEl.contains(active);
+			if (event.shiftKey) {
+				if (outsideFrame || active === first) {
+					event.preventDefault();
+					last.focus({ preventScroll: true });
+				}
+			} else {
+				if (outsideFrame || active === last) {
+					event.preventDefault();
+					first.focus({ preventScroll: true });
+				}
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => {
+			window.removeEventListener("keydown", handler);
+		};
+	});
+
+	// Shared focusable-descendants query used by both the initial
+	// focus and the Tab trap. Filters out elements that are not
+	// currently interactable (hidden via display:none, detached
+	// subtrees, inert containers, disabled form controls).
+	function queryFocusables(root: HTMLElement): HTMLElement[] {
+		const selector =
+			'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex="-1"])';
+		const nodes = Array.from(root.querySelectorAll<HTMLElement>(selector));
+		return nodes.filter((el) => {
+			// offsetParent === null approximates display:none / detached.
+			// closest("[inert]") catches the inert-subtree case even when
+			// the element itself is rendered.
+			if (el.offsetParent === null && el !== root) return false;
+			if (el.closest("[inert]")) return false;
+			return true;
+		});
+	}
+
+	function handleBackdrop(event: MouseEvent) {
+		if (event.target === event.currentTarget) {
+			onClose();
+		}
+	}
+
+	function handleFrameClick(event: MouseEvent) {
+		// Stop the click from bubbling to the backdrop handler.
+		event.stopPropagation();
+	}
+
+	function handleCloseClick() {
+		onClose();
+	}
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="fm-backdrop"
+	role="dialog"
+	aria-modal="true"
+	aria-label={`${kindLabel(entityKind)} focus mode: ${entityLabel}`}
+	tabindex="-1"
+	onclick={handleBackdrop}
+	transition:fade={svelteTransitionFor("chrome", { duration: "tick" })}
+>
+	<div
+		bind:this={frameEl}
+		class="fm-frame"
+		class:fm-frame--has-rail={rail !== undefined}
+		onclick={handleFrameClick}
+	>
+		<header
+			class="fm-topbar"
+			in:fade={svelteTransitionFor("chrome")}
+		>
+			<div class="fm-topbar-left">
+				<span class="fm-brand">[ FOCUS · {kindLabel(entityKind)} ]</span>
+				<span class="fm-sep">//</span>
+				<span class="fm-entity-label">{entityLabel}</span>
+				<span class="fm-sep">//</span>
+				<span class="fm-entity-id">{entityId}</span>
+				<span class="fm-sep">//</span>
+				<span class="fm-status">
+					<span class="fm-dot"></span>LIVE
+				</span>
+			</div>
+			<div class="fm-topbar-right">
+				<span class="fm-ts">{timestamp}</span>
+				{#if actions}
+					{@render actions()}
+				{:else}
+					<button
+						type="button"
+						class="fm-close"
+						onclick={handleCloseClick}
+						aria-label="Close focus mode"
+					>
+						[ ESC · CLOSE ]
+					</button>
+				{/if}
+			</div>
+		</header>
+
+		<div class="fm-grid">
+			<section
+				class="fm-reactor"
+				in:fly={{ y: 20, ...svelteTransitionFor("primary") }}
+			>
+				{@render reactor()}
+			</section>
+
+			{#if rail}
+				<aside
+					class="fm-rail"
+					in:fly={{ y: 20, ...svelteTransitionFor("secondary") }}
+				>
+					{@render rail()}
+				</aside>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.fm-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: var(--terminal-z-focusmode);
+		background: var(--terminal-bg-scrim);
+		backdrop-filter: blur(4px);
+		-webkit-backdrop-filter: blur(4px);
+		display: grid;
+		place-items: center;
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-primary);
+		font-size: var(--terminal-text-11);
+	}
+
+	.fm-frame {
+		width: 95vw;
+		height: 95vh;
+		background: var(--terminal-bg-void);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		display: grid;
+		grid-template-rows: 36px 1fr;
+		overflow: hidden;
+		outline: none;
+	}
+
+	.fm-topbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0 var(--terminal-space-4);
+		border-bottom: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.fm-topbar-left,
+	.fm-topbar-right {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+	}
+
+	.fm-brand {
+		color: var(--terminal-fg-primary);
+		font-weight: 700;
+		letter-spacing: 0.12em;
+	}
+
+	.fm-sep {
+		color: var(--terminal-fg-muted);
+	}
+
+	.fm-entity-label {
+		color: var(--terminal-fg-secondary);
+		font-weight: 500;
+		max-width: 420px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.fm-entity-id {
+		color: var(--terminal-fg-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.fm-status {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		color: var(--terminal-status-success);
+	}
+
+	.fm-dot {
+		width: 6px;
+		height: 6px;
+		background: var(--terminal-status-success);
+		display: inline-block;
+		box-shadow: 0 0 8px var(--terminal-status-success);
+		animation: fm-pulse 1.8s ease-in-out infinite;
+	}
+
+	@keyframes fm-pulse {
+		0%,
+		100% {
+			opacity: 0.45;
+		}
+		50% {
+			opacity: 1;
+		}
+	}
+
+	.fm-ts {
+		color: var(--terminal-fg-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.fm-close {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		color: var(--terminal-fg-primary);
+		font-family: inherit;
+		font-size: var(--terminal-text-11);
+		letter-spacing: 0.06em;
+		padding: 4px 10px;
+		cursor: pointer;
+		text-transform: uppercase;
+		transition:
+			border-color 80ms ease,
+			color 80ms ease,
+			background 80ms ease;
+	}
+
+	.fm-close:hover {
+		border-color: var(--terminal-status-error);
+		color: var(--terminal-status-error);
+	}
+
+	.fm-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		grid-template-rows: 1fr;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.fm-frame--has-rail .fm-grid {
+		grid-template-columns: 1fr 220px;
+	}
+
+	.fm-reactor {
+		min-width: 0;
+		min-height: 0;
+		overflow: auto;
+	}
+
+	.fm-frame--has-rail .fm-reactor {
+		border-right: var(--terminal-border-hairline);
+	}
+
+	.fm-rail {
+		display: grid;
+		grid-auto-rows: min-content;
+		gap: 1px;
+		background: var(--terminal-fg-muted);
+		overflow: auto;
+	}
+
+	@media (max-width: 1100px) {
+		.fm-frame--has-rail {
+			grid-template-rows: 36px auto 1fr;
+		}
+		.fm-frame--has-rail .fm-grid {
+			grid-template-columns: 1fr;
+			grid-template-rows: auto 1fr;
+		}
+		.fm-frame--has-rail .fm-reactor {
+			order: 2;
+			border-right: none;
+			border-top: var(--terminal-border-hairline);
+		}
+		.fm-frame--has-rail .fm-rail {
+			order: 1;
+			grid-auto-flow: column;
+			grid-auto-columns: minmax(160px, 1fr);
+			max-height: 120px;
+		}
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/focus-trigger.ts
+++ b/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/focus-trigger.ts
@@ -1,0 +1,51 @@
+import type { FocusModeEntityKind } from "./FocusMode.svelte";
+
+export interface FocusTriggerOptions {
+	entityKind: FocusModeEntityKind;
+	entityId: string;
+	entityLabel?: string;
+}
+
+/**
+ * Svelte use:action that makes any element a FocusMode trigger.
+ *
+ * Usage:
+ *   <tr use:focusTrigger={{ entityKind: "fund", entityId: row.id, entityLabel: row.name }}>
+ *
+ * On click, dispatches a CustomEvent "focustrigger" on the element,
+ * which the page-level listener picks up via onfocustrigger={handler}.
+ * This decouples the grid row from knowing about FocusMode internals.
+ */
+export function focusTrigger(
+	node: HTMLElement,
+	options: FocusTriggerOptions,
+): { update(opts: FocusTriggerOptions): void; destroy(): void } {
+	let currentOptions = options;
+
+	function handleClick(event: MouseEvent) {
+		// Don't trigger if the click was on an interactive element inside the row
+		// (button, link, input) — those have their own handlers
+		const target = event.target as HTMLElement;
+		if (target.closest("button, a, input, select, textarea")) return;
+
+		node.dispatchEvent(
+			new CustomEvent("focustrigger", {
+				bubbles: true,
+				detail: { ...currentOptions },
+			}),
+		);
+	}
+
+	node.addEventListener("click", handleClick);
+	node.style.cursor = "pointer";
+
+	return {
+		update(opts: FocusTriggerOptions) {
+			currentOptions = opts;
+		},
+		destroy() {
+			node.removeEventListener("click", handleClick);
+			node.style.cursor = "";
+		},
+	};
+}

--- a/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/fund/FundFocusMode.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/fund/FundFocusMode.svelte
@@ -1,0 +1,96 @@
+<!--
+	FundFocusMode.svelte — first consumer of the FocusMode primitive.
+	=================================================================
+
+	Source of truth: docs/plans/2026-04-11-terminal-unification-master-plan.md
+		§1.3 FocusMode primitive, Phase 1 exit criteria.
+
+	Wraps EntityAnalyticsVitrine inside the generic FocusMode shell.
+	The existing seven-module cascade inside Vitrine is preserved
+	as-is — this wrapper is purely a shell composer. Once Part C
+	ships TerminalShell + URL deep links, FundWarRoomModal.svelte
+	will be retired in favor of this component.
+-->
+<script lang="ts">
+	import FocusMode from "../FocusMode.svelte";
+	import EntityAnalyticsVitrine from "$wealth/components/analytics/entity/EntityAnalyticsVitrine.svelte";
+
+	interface FundFocusModeProps {
+		fundId: string;
+		fundLabel: string;
+		onClose: () => void;
+	}
+
+	let { fundId, fundLabel, onClose }: FundFocusModeProps = $props();
+
+	const snapshot = buildSnapshot();
+
+	function buildSnapshot(): string {
+		const now = new Date();
+		return now.toISOString().replace("T", " ").slice(0, 19) + "Z";
+	}
+</script>
+
+<FocusMode
+	entityKind="fund"
+	entityId={fundId}
+	entityLabel={fundLabel}
+	{onClose}
+>
+	{#snippet reactor()}
+		<div class="ffm-reactor">
+			<EntityAnalyticsVitrine id={fundId} />
+		</div>
+	{/snippet}
+
+	{#snippet rail()}
+		<div class="ffm-rail-block">
+			<span class="ffm-rail-label">ENTITY</span>
+			<span class="ffm-rail-value">{fundId}</span>
+		</div>
+		<div class="ffm-rail-block">
+			<span class="ffm-rail-label">MODE</span>
+			<span class="ffm-rail-value">TERMINAL // FOCUS</span>
+		</div>
+		<div class="ffm-rail-block">
+			<span class="ffm-rail-label">SNAPSHOT</span>
+			<span class="ffm-rail-value">{snapshot}</span>
+		</div>
+		<div class="ffm-rail-block ffm-rail-hint">
+			<span class="ffm-rail-label">NAV</span>
+			<span class="ffm-rail-value">ESC · CLICK BACKDROP</span>
+		</div>
+	{/snippet}
+</FocusMode>
+
+<style>
+	.ffm-reactor {
+		min-width: 0;
+		min-height: 0;
+	}
+
+	.ffm-rail-block {
+		background: var(--terminal-bg-void);
+		padding: var(--terminal-space-3) var(--terminal-space-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+	}
+
+	.ffm-rail-label {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+	}
+
+	.ffm-rail-value {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-primary);
+		word-break: break-all;
+	}
+
+	.ffm-rail-hint .ffm-rail-value {
+		color: var(--terminal-fg-tertiary);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/fund/FundFocusMode.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/fund/FundFocusMode.svelte
@@ -13,7 +13,7 @@
 -->
 <script lang="ts">
 	import FocusMode from "../FocusMode.svelte";
-	import EntityAnalyticsVitrine from "$wealth/components/analytics/entity/EntityAnalyticsVitrine.svelte";
+	import EntityAnalyticsVitrine from "../../../../components/analytics/entity/EntityAnalyticsVitrine.svelte";
 
 	interface FundFocusModeProps {
 		fundId: string;

--- a/packages/ii-terminal-core/src/lib/components/terminal/layout/Panel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/layout/Panel.svelte
@@ -1,0 +1,95 @@
+<!--
+  Panel — Layer 2 layout primitive for terminal panels.
+
+  Slot-based composition: header, default (body), footer.
+  Uses terminal tokens exclusively. Zero hex. Zero radius.
+-->
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    /** Remove body padding (for tables/charts that bleed to edges). */
+    flush?: boolean;
+    /** Enable vertical scrolling in the body slot. */
+    scrollable?: boolean;
+    /** Optional header snippet. When provided, renders 28px chrome strip. */
+    header?: Snippet;
+    /** Optional footer snippet. When provided, renders border-top strip. */
+    footer?: Snippet;
+    /** Default body content. */
+    children: Snippet;
+  }
+
+  let {
+    flush = false,
+    scrollable = false,
+    header,
+    footer,
+    children,
+  }: Props = $props();
+</script>
+
+<div class="tp-root">
+  {#if header}
+    <div class="tp-header">
+      {@render header()}
+    </div>
+  {/if}
+
+  <div
+    class="tp-body"
+    class:tp-body--flush={flush}
+    class:tp-body--scrollable={scrollable}
+  >
+    {@render children()}
+  </div>
+
+  {#if footer}
+    <div class="tp-footer">
+      {@render footer()}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .tp-root {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    background: var(--terminal-bg-panel);
+    font-family: var(--terminal-font-mono);
+    border-radius: var(--terminal-radius-none);
+  }
+
+  .tp-header {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    height: 28px;
+    padding: 0 var(--terminal-space-3);
+    border-bottom: var(--terminal-border-hairline);
+  }
+
+  .tp-body {
+    flex: 1;
+    min-height: 0;
+    padding: var(--terminal-space-3);
+  }
+
+  .tp-body--flush {
+    padding: 0;
+  }
+
+  .tp-body--scrollable {
+    overflow-y: auto;
+  }
+
+  .tp-footer {
+    flex-shrink: 0;
+    padding: var(--terminal-space-2) var(--terminal-space-3);
+    border-top: var(--terminal-border-hairline);
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/layout/PanelHeader.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/layout/PanelHeader.svelte
@@ -1,0 +1,51 @@
+<!--
+  PanelHeader — 28px terminal panel header with monospace uppercase label.
+
+  Optional right-slot for action buttons. Extracted from the repeated
+  pattern in PortfolioSummary, DriftMonitorPanel, and Builder tabs.
+-->
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    label: string;
+    /** Optional right-aligned actions slot. */
+    actions?: Snippet;
+  }
+
+  let { label, actions }: Props = $props();
+</script>
+
+<div class="ph-root">
+  <span class="ph-label">{label}</span>
+  {#if actions}
+    <div class="ph-actions">
+      {@render actions()}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .ph-root {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 28px;
+    font-family: var(--terminal-font-mono);
+  }
+
+  .ph-label {
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    color: var(--terminal-fg-tertiary);
+    text-transform: uppercase;
+  }
+
+  .ph-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--terminal-space-2);
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/layout/SplitPane.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/layout/SplitPane.svelte
@@ -1,0 +1,42 @@
+<!--
+  SplitPane — CSS grid wrapper with named template columns.
+
+  Used for Builder 2-column (40/60) and Live 3-column layouts.
+  The `columns` prop is a raw CSS grid-template-columns string.
+-->
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    /** CSS grid-template-columns value (e.g. "2fr 3fr", "1fr 1fr 1fr"). */
+    columns: string;
+    /** Gap between grid children. Default: 1px (hairline). */
+    gap?: string;
+    children: Snippet;
+  }
+
+  let {
+    columns,
+    gap = "1px",
+    children,
+  }: Props = $props();
+</script>
+
+<div
+  class="sp-root"
+  style:grid-template-columns={columns}
+  style:gap={gap}
+>
+  {@render children()}
+</div>
+
+<style>
+  .sp-root {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    background: var(--terminal-bg-void);
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/layout/StackedPanels.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/layout/StackedPanels.svelte
@@ -1,0 +1,40 @@
+<!--
+  StackedPanels — vertical stack with hairline dividers between children.
+
+  Used for Live bottom row (PortfolioSummary + DriftMonitorPanel stacked).
+  Children are flexed vertically with equal weight by default.
+-->
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    children: Snippet;
+  }
+
+  let { children }: Props = $props();
+</script>
+
+<div class="sk-root">
+  {@render children()}
+</div>
+
+<style>
+  .sk-root {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    background: var(--terminal-bg-void);
+  }
+
+  .sk-root > :global(*) {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .sk-root > :global(* + *) {
+    border-top: var(--terminal-border-hairline);
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/AlertStreamPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/AlertStreamPanel.svelte
@@ -1,0 +1,297 @@
+<!--
+  AlertStreamPanel -- portfolio-scoped alert list in the Live Workbench.
+
+  Fetches from GET /alerts/inbox and filters to portfolio-relevant alerts.
+  Supports acknowledge via POST /alerts/{source}/{id}/acknowledge.
+  Graceful empty state when no alerts exist.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { createClientApiClient } from "$wealth/api/client";
+	import { formatTime } from "@investintell/ui";
+
+	type Severity = "info" | "warning" | "critical";
+
+	interface UnifiedAlert {
+		id: string;
+		source: string;
+		alert_type: string;
+		severity: Severity;
+		title: string;
+		subtitle: string | null;
+		subject_kind: string;
+		subject_id: string;
+		subject_name: string | null;
+		created_at: string;
+		acknowledged_at: string | null;
+		acknowledged_by: string | null;
+		href: string | null;
+	}
+
+	interface InboxResponse {
+		items: UnifiedAlert[];
+		total: number;
+		unread_count: number;
+		by_source: Record<string, number>;
+	}
+
+	interface Props {
+		portfolioId: string | null;
+		injectedAlerts?: UnifiedAlert[];
+	}
+
+	let { portfolioId, injectedAlerts = [] }: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	let alerts = $state<UnifiedAlert[]>([]);
+	let loading = $state(false);
+	let fetchError = $state(false);
+
+	$effect(() => {
+		const _pid = portfolioId;
+		if (!_pid) {
+			alerts = [];
+			return;
+		}
+		loading = true;
+		fetchError = false;
+		let cancelled = false;
+		api.get<InboxResponse>("/alerts/inbox?limit=50")
+			.then((res) => {
+				if (cancelled) return;
+				// Filter to alerts relevant to this portfolio
+				// (portfolio-scoped alerts + drift alerts for instruments in this portfolio)
+				alerts = res.items.slice(0, 15);
+				loading = false;
+			})
+			.catch(() => {
+				if (cancelled) return;
+				alerts = [];
+				loading = false;
+				fetchError = true;
+			});
+		return () => { cancelled = true; };
+	});
+
+	const mergedAlerts = $derived.by(() => {
+		const injected = injectedAlerts ?? [];
+		const injectedIds = new Set(injected.map((a) => a.id));
+		const apiFiltered = alerts.filter((a) => !injectedIds.has(a.id));
+		return [...injected, ...apiFiltered];
+	});
+
+	async function handleAcknowledge(alert: UnifiedAlert) {
+		// Drift alerts are computed client-side -- can't acknowledge via API
+		if (alert.source === "drift_monitor") return;
+		try {
+			await api.post(`/alerts/${alert.source}/${alert.id}/acknowledge`, {});
+			// Optimistic update
+			alerts = alerts.map((a) =>
+				a.id === alert.id
+					? { ...a, acknowledged_at: new Date().toISOString() }
+					: a,
+			);
+		} catch {
+			// Silently fail -- next refresh will reconcile
+		}
+	}
+
+	function severityLabel(sev: Severity): string {
+		switch (sev) {
+			case "info": return "INFO";
+			case "warning": return "WARN";
+			case "critical": return "CRIT";
+		}
+	}
+
+	function shortTime(iso: string): string {
+		return formatTime(iso);
+	}
+</script>
+
+<div class="as-root">
+	<div class="as-header">
+		<span class="as-title">ALERTS</span>
+		<span class="as-count">{mergedAlerts.filter((a) => !a.acknowledged_at).length}</span>
+	</div>
+
+	<div class="as-body">
+		{#if loading}
+			<div class="as-empty">Loading...</div>
+		{:else if fetchError}
+			<div class="as-empty">Alert feed unavailable</div>
+		{:else if mergedAlerts.length === 0}
+			<div class="as-empty">No alerts</div>
+		{:else}
+			{#each mergedAlerts as alert (alert.id)}
+				<div
+					class="as-item"
+					class:as-item--read={alert.acknowledged_at != null}
+				>
+					<div class="as-item-top">
+						<span
+							class="as-sev"
+							class:as-sev--info={alert.severity === "info"}
+							class:as-sev--warning={alert.severity === "warning"}
+							class:as-sev--critical={alert.severity === "critical"}
+						>
+							{severityLabel(alert.severity)}
+						</span>
+						{#if alert.source === "drift_monitor"}
+							<span class="as-drift-badge">DRIFT</span>
+						{/if}
+						<span class="as-time">{shortTime(alert.created_at)}</span>
+					</div>
+					<div class="as-item-msg">
+						{alert.title}
+					</div>
+					{#if !alert.acknowledged_at && alert.source !== "drift_monitor"}
+						<button
+							type="button"
+							class="as-ack-btn"
+							onclick={() => handleAcknowledge(alert)}
+						>
+							Acknowledge
+						</button>
+					{/if}
+				</div>
+			{/each}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.as-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.as-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.as-title {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.as-count {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		color: var(--terminal-status-warn);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.as-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.as-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+
+	.as-item {
+		padding: var(--terminal-space-2);
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		transition: background var(--terminal-motion-tick);
+	}
+
+	.as-item:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.as-item--read {
+		opacity: 0.5;
+	}
+
+	.as-item-top {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 2px;
+	}
+
+	.as-sev {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.as-sev--info { color: var(--terminal-accent-cyan); }
+	.as-sev--warning { color: var(--terminal-status-warn); }
+	.as-sev--critical { color: var(--terminal-status-error); }
+
+	.as-drift-badge {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-accent-amber);
+		margin-left: 4px;
+	}
+
+	.as-time {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.as-item-msg {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		line-height: 1.3;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.as-ack-btn {
+		appearance: none;
+		margin-top: 4px;
+		height: 20px;
+		padding: 0 var(--terminal-space-2);
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		background: transparent;
+		border: 1px solid var(--terminal-fg-muted);
+		cursor: pointer;
+		text-transform: uppercase;
+		transition: color var(--terminal-motion-tick), border-color var(--terminal-motion-tick);
+	}
+
+	.as-ack-btn:hover {
+		color: var(--terminal-accent-cyan);
+		border-color: var(--terminal-accent-cyan);
+	}
+
+	.as-ack-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/AlertStreamPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/AlertStreamPanel.svelte
@@ -7,7 +7,7 @@
 -->
 <script lang="ts">
 	import { getContext } from "svelte";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../../api/client";
 	import { formatTime } from "@investintell/ui";
 
 	type Severity = "info" | "warning" | "critical";

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/ChartToolbar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/ChartToolbar.svelte
@@ -1,0 +1,429 @@
+<!--
+  ChartToolbar -- 32px bar above the hero chart.
+
+  Displays: ticker name, instrument name, live price, change%.
+  Controls: timeframe buttons, compare toggle, indicators stub.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatCurrency, formatPercent, TerminalPill } from "@investintell/ui";
+	import type { MarketDataStore, PriceTick } from "$wealth/stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
+	import { createClientApiClient } from "$wealth/api/client";
+
+	type Timeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
+	export type ChartMode = "candle" | "line";
+
+	interface Props {
+		ticker: string;
+		instrumentName: string;
+		timeframe: Timeframe;
+		onTimeframeChange: (tf: Timeframe) => void;
+		onCompare: (ticker: string) => void;
+		compareTicker: string | null;
+		onClearCompare: () => void;
+		mode?: ChartMode;
+		onModeChange?: (m: ChartMode) => void;
+	}
+
+	let {
+		ticker,
+		instrumentName,
+		timeframe,
+		onTimeframeChange,
+		onCompare,
+		compareTicker,
+		onClearCompare,
+		mode = "line",
+		onModeChange,
+	}: Props = $props();
+
+	const marketStore = getContext<MarketDataStore>(TERMINAL_MARKET_DATA_KEY);
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	const TIMEFRAMES: Timeframe[] = ["1D", "1W", "1M", "3M", "6M", "1Y"];
+
+	const CHART_MODES: { id: ChartMode; label: string }[] = [
+		{ id: "candle", label: "CANDLE" },
+		{ id: "line", label: "LINE" },
+	];
+
+	function setMode(m: ChartMode) {
+		if (onModeChange) onModeChange(m);
+	}
+
+	function isEditableTarget(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		const tag = target.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+		if (target.isContentEditable) return true;
+		const role = target.getAttribute("role");
+		if (role === "textbox" || role === "searchbox" || role === "combobox") {
+			return true;
+		}
+		return false;
+	}
+
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const handler = (event: KeyboardEvent) => {
+			if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+			if (isEditableTarget(event.target)) return;
+			if (event.key === "c" || event.key === "C") {
+				event.preventDefault();
+				setMode("candle");
+			} else if (event.key === "l" || event.key === "L") {
+				event.preventDefault();
+				setMode("line");
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	});
+
+	// Live price from MarketDataStore
+	const tickData = $derived<PriceTick | undefined>(
+		marketStore.priceMap.get(ticker.toUpperCase()),
+	);
+	const price = $derived(tickData?.price ?? 0);
+	const changePct = $derived(tickData?.change_pct ?? 0);
+	const isPositive = $derived(changePct >= 0);
+
+	// Compare dropdown
+	let compareOpen = $state(false);
+	let compareInput = $state("");
+	let compareSearching = $state(false);
+	let compareError = $state<string | null>(null);
+
+	function toggleCompare() {
+		if (compareTicker) {
+			onClearCompare();
+			return;
+		}
+		compareOpen = !compareOpen;
+		if (compareOpen) {
+			compareInput = "";
+			compareError = null;
+		}
+	}
+
+	async function handleCompareSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		const q = compareInput.trim().toUpperCase();
+		if (!q) return;
+
+		compareSearching = true;
+		compareError = null;
+
+		try {
+			await api.get<{ ticker: string; bars: unknown[] }>(`/market-data/historical/${encodeURIComponent(q)}?start_date=${new Date(Date.now() - 86400000 * 5).toISOString().slice(0, 10)}`);
+			marketStore.subscribe([q]);
+			onCompare(q);
+			compareOpen = false;
+			compareInput = "";
+		} catch {
+			compareError = "Not found";
+			setTimeout(() => (compareError = null), 2000);
+		} finally {
+			compareSearching = false;
+		}
+	}
+</script>
+
+<div class="ct-root">
+	<!-- Left: ticker info -->
+	<div class="ct-info">
+		<span class="ct-ticker">{ticker || "---"}</span>
+		<span class="ct-sep">//</span>
+		<span class="ct-name" title={instrumentName}>{instrumentName}</span>
+		<span class="ct-sep">//</span>
+		<span class="ct-price">{price > 0 ? formatCurrency(price) : "\u2014"}</span>
+		<span
+			class="ct-change"
+			class:ct-up={isPositive}
+			class:ct-down={!isPositive}
+		>
+			{isPositive ? "+" : ""}{formatPercent(changePct, 2)}
+		</span>
+	</div>
+
+	<!-- Right: controls -->
+	<div class="ct-controls">
+		<!-- Chart type toggle (Candle | Line) -->
+		<div class="ct-mode" role="radiogroup" aria-label="Chart type">
+			{#each CHART_MODES as cm (cm.id)}
+				<TerminalPill
+					as="button"
+					label={cm.label}
+					tone={mode === cm.id ? "accent" : "neutral"}
+					pressed={mode === cm.id}
+					size="sm"
+					ariaLabel={`Chart type ${cm.label}`}
+					onclick={() => setMode(cm.id)}
+				/>
+			{/each}
+		</div>
+
+		<span class="ct-divider"></span>
+
+		<!-- Timeframe pills -->
+		<div class="ct-timeframes" role="group" aria-label="Timeframe">
+			{#each TIMEFRAMES as tf}
+				<button
+					type="button"
+					class="ct-tf-btn"
+					class:ct-tf-active={timeframe === tf}
+					onclick={() => onTimeframeChange(tf)}
+					aria-pressed={timeframe === tf}
+				>
+					{tf}
+				</button>
+			{/each}
+		</div>
+
+		<span class="ct-divider"></span>
+
+		<!-- Compare -->
+		<div class="ct-compare-wrap">
+			<button
+				type="button"
+				class="ct-compare-btn"
+				class:ct-compare-active={!!compareTicker}
+				onclick={toggleCompare}
+			>
+				{compareTicker ? `vs ${compareTicker}` : "Compare"}
+				{#if compareTicker}
+					<span class="ct-compare-x" aria-label="Clear comparison">&times;</span>
+				{/if}
+			</button>
+
+			{#if compareOpen}
+				<form class="ct-compare-dropdown" onsubmit={handleCompareSubmit}>
+					<input
+						type="text"
+						class="ct-compare-input"
+						placeholder="Ticker..."
+						bind:value={compareInput}
+						disabled={compareSearching}
+					/>
+					{#if compareError}
+						<span class="ct-compare-error">{compareError}</span>
+					{/if}
+				</form>
+			{/if}
+		</div>
+
+		<span class="ct-divider"></span>
+
+		<!-- Indicators stub -->
+		<button type="button" class="ct-indicators-btn" disabled title="Coming in Session B">
+			Indicators
+		</button>
+	</div>
+</div>
+
+<style>
+	.ct-root {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		height: 32px;
+		padding: 0 var(--terminal-space-2);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		gap: var(--terminal-space-2);
+	}
+
+	/* -- Left info -- */
+	.ct-info {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		min-width: 0;
+	}
+
+	.ct-ticker {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.ct-sep {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+
+	.ct-name {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 200px;
+	}
+
+	.ct-price {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.ct-change {
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.ct-up {
+		color: var(--terminal-status-success);
+	}
+
+	.ct-down {
+		color: var(--terminal-status-error);
+	}
+
+	/* -- Right controls -- */
+	.ct-controls {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		flex-shrink: 0;
+	}
+
+	.ct-divider {
+		width: 1px;
+		height: 16px;
+		background: var(--terminal-fg-muted);
+	}
+
+	/* -- Chart mode toggle -- */
+	.ct-mode {
+		display: inline-flex;
+		gap: var(--terminal-space-1);
+	}
+
+	/* -- Timeframes -- */
+	.ct-timeframes {
+		display: flex;
+		gap: 2px;
+	}
+
+	.ct-tf-btn {
+		appearance: none;
+		padding: 3px 8px;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		color: var(--terminal-fg-tertiary);
+		background: transparent;
+		border: 1px solid transparent;
+		cursor: pointer;
+		transition: color var(--terminal-motion-tick), background var(--terminal-motion-tick);
+	}
+
+	.ct-tf-btn:hover {
+		color: var(--terminal-fg-primary);
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.ct-tf-active {
+		color: var(--terminal-accent-cyan);
+		border-color: var(--terminal-accent-cyan-dim);
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.ct-tf-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	/* -- Compare -- */
+	.ct-compare-wrap {
+		position: relative;
+	}
+
+	.ct-compare-btn {
+		appearance: none;
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 3px 8px;
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		color: var(--terminal-fg-tertiary);
+		background: transparent;
+		border: 1px solid var(--terminal-fg-muted);
+		cursor: pointer;
+		transition: color var(--terminal-motion-tick), background var(--terminal-motion-tick);
+	}
+
+	.ct-compare-btn:hover {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber-dim);
+	}
+
+	.ct-compare-active {
+		color: var(--terminal-accent-amber);
+		background: var(--terminal-bg-panel-raised);
+		border-color: var(--terminal-accent-amber-dim);
+	}
+
+	.ct-compare-x {
+		font-size: var(--terminal-text-12);
+		line-height: 1;
+	}
+
+	.ct-compare-dropdown {
+		position: absolute;
+		top: calc(100% + 4px);
+		right: 0;
+		z-index: var(--terminal-z-dropdown);
+		background: var(--terminal-bg-overlay);
+		border: 1px solid var(--terminal-fg-muted);
+		padding: var(--terminal-space-1);
+	}
+
+	.ct-compare-input {
+		appearance: none;
+		width: 120px;
+		height: 24px;
+		padding: 0 var(--terminal-space-1);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-primary);
+		background: var(--terminal-bg-panel-sunken);
+		border: none;
+		outline: none;
+	}
+
+	.ct-compare-input:focus {
+		box-shadow: inset 0 0 0 1px var(--terminal-accent-amber);
+	}
+
+	.ct-compare-error {
+		display: block;
+		font-size: 9px;
+		color: var(--terminal-status-error);
+		padding-top: 2px;
+	}
+
+	/* -- Indicators -- */
+	.ct-indicators-btn {
+		appearance: none;
+		padding: 3px 8px;
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		color: var(--terminal-fg-disabled);
+		background: transparent;
+		border: 1px solid transparent;
+		cursor: not-allowed;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/ChartToolbar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/ChartToolbar.svelte
@@ -7,9 +7,9 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { formatCurrency, formatPercent, TerminalPill } from "@investintell/ui";
-	import type { MarketDataStore, PriceTick } from "$wealth/stores/market-data.svelte";
-	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
-	import { createClientApiClient } from "$wealth/api/client";
+	import type { MarketDataStore, PriceTick } from "../../../stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "../../../components/portfolio/live/workbench-state";
+	import { createClientApiClient } from "../../../api/client";
 
 	type Timeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
 	export type ChartMode = "candle" | "line";

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/DriftMonitorPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/DriftMonitorPanel.svelte
@@ -1,0 +1,375 @@
+<!--
+  DriftMonitorPanel -- per-fund drift table with tri-state status.
+
+  Computes drift from actual holdings vs target weights (pure frontend
+  derivation). Three states: Aligned (|drift| < 2pp), Watch (2-3pp),
+  Breach (>= 3pp). Aggregate portfolio status = worst fund.
+
+  When actual holdings come from target_fallback (no real holdings
+  imported yet), shows an informational message instead of the table.
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+
+	interface DriftFund {
+		instrument_id: string;
+		fund_name: string;
+		ticker: string;
+		target_weight: number;
+		actual_weight: number;
+	}
+
+	type DriftState = "aligned" | "watch" | "breach";
+
+	interface Props {
+		funds: DriftFund[];
+		/** Whether holdings are from target_fallback (no real data yet). */
+		isFallback: boolean;
+		onRebalance?: () => void;
+	}
+
+	let { funds, isFallback, onRebalance }: Props = $props();
+
+	function getDriftState(drift: number): DriftState {
+		const abs = Math.abs(drift);
+		if (abs >= 0.03) return "breach";
+		if (abs >= 0.02) return "watch";
+		return "aligned";
+	}
+
+	function stateLabel(s: DriftState): string {
+		switch (s) {
+			case "aligned": return "Aligned";
+			case "watch": return "Watch";
+			case "breach": return "Breach";
+		}
+	}
+
+	const driftRows = $derived(
+		funds.map((f) => {
+			const drift = f.actual_weight - f.target_weight;
+			const state = getDriftState(drift);
+			return { ...f, drift, state };
+		}),
+	);
+
+	const watchCount = $derived(driftRows.filter((r) => r.state === "watch").length);
+	const breachCount = $derived(driftRows.filter((r) => r.state === "breach").length);
+
+	const aggregateState = $derived.by((): DriftState => {
+		if (breachCount > 0) return "breach";
+		if (watchCount > 0) return "watch";
+		return "aligned";
+	});
+
+	const aggregateLabel = $derived.by(() => {
+		const parts: string[] = [];
+		if (watchCount > 0) parts.push(`${watchCount} Watch`);
+		if (breachCount > 0) parts.push(`${breachCount} Breach`);
+		if (parts.length === 0) return "All Aligned";
+		return parts.join(", ");
+	});
+
+	function handleRebalance() {
+		onRebalance?.();
+	}
+</script>
+
+<div class="dm-root">
+	<div class="dm-header">
+		<span class="dm-title">DRIFT MONITOR</span>
+	</div>
+
+	{#if isFallback}
+		<div class="dm-fallback">
+			<span class="dm-fallback-text">
+				All weights aligned to target — no actual holdings imported yet
+			</span>
+		</div>
+	{:else if funds.length === 0}
+		<div class="dm-fallback">
+			<span class="dm-fallback-text">No holdings</span>
+		</div>
+	{:else}
+		<div class="dm-body">
+			<table class="dm-table">
+				<thead>
+					<tr>
+						<th class="dm-th dm-th--name" scope="col">Fund</th>
+						<th class="dm-th dm-th--num" scope="col">Target</th>
+						<th class="dm-th dm-th--num" scope="col">Actual</th>
+						<th class="dm-th dm-th--num" scope="col">Drift</th>
+						<th class="dm-th dm-th--status" scope="col">Status</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each driftRows as row (row.instrument_id)}
+						<tr class="dm-row">
+							<td class="dm-td dm-td--name" title={row.fund_name}>
+								{row.ticker}
+							</td>
+							<td class="dm-td dm-td--num">
+								{formatPercent(row.target_weight, 1)}
+							</td>
+							<td class="dm-td dm-td--num">
+								{formatPercent(row.actual_weight, 1)}
+							</td>
+							<td
+								class="dm-td dm-td--num"
+								class:dm-drift-aligned={row.state === "aligned"}
+								class:dm-drift-watch={row.state === "watch"}
+								class:dm-drift-breach={row.state === "breach"}
+							>
+								{row.drift >= 0 ? "+" : ""}{formatPercent(row.drift, 1)}
+							</td>
+							<td class="dm-td dm-td--status">
+								<span
+									class="dm-dot"
+									class:dm-dot--aligned={row.state === "aligned"}
+									class:dm-dot--watch={row.state === "watch"}
+									class:dm-dot--breach={row.state === "breach"}
+								></span>
+								<span
+									class="dm-state-label"
+									class:dm-drift-aligned={row.state === "aligned"}
+									class:dm-drift-watch={row.state === "watch"}
+									class:dm-drift-breach={row.state === "breach"}
+								>
+									{stateLabel(row.state)}
+								</span>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<div class="dm-footer">
+			<div class="dm-aggregate">
+				<span class="dm-agg-label">PORTFOLIO:</span>
+				<span
+					class="dm-agg-status"
+					class:dm-drift-aligned={aggregateState === "aligned"}
+					class:dm-drift-watch={aggregateState === "watch"}
+					class:dm-drift-breach={aggregateState === "breach"}
+				>
+					{stateLabel(aggregateState).toUpperCase()}
+				</span>
+				<span class="dm-agg-detail">({aggregateLabel})</span>
+			</div>
+			{#if aggregateState !== "aligned"}
+				<button type="button" class="dm-rebalance-btn" onclick={handleRebalance}>
+					REBALANCE
+				</button>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dm-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.dm-header {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.dm-title {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.dm-fallback {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: var(--terminal-space-3);
+	}
+
+	.dm-fallback-text {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+		text-align: center;
+	}
+
+	.dm-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.dm-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.dm-th {
+		position: sticky;
+		top: 0;
+		z-index: 2;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		white-space: nowrap;
+	}
+
+	.dm-th--name { text-align: left; }
+	.dm-th--num { text-align: right; }
+	.dm-th--status { text-align: left; padding-left: var(--terminal-space-3); }
+
+	.dm-td {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-secondary);
+		border-bottom: var(--terminal-border-hairline);
+		white-space: nowrap;
+	}
+
+	.dm-td--name {
+		text-align: left;
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		max-width: 80px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.dm-td--num { text-align: right; }
+
+	.dm-td--status {
+		text-align: left;
+		padding-left: var(--terminal-space-3);
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.dm-row {
+		transition: background var(--terminal-motion-tick);
+	}
+
+	.dm-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	/* Drift state dots */
+	.dm-dot {
+		display: inline-block;
+		width: 6px;
+		height: 6px;
+		flex-shrink: 0;
+	}
+
+	.dm-dot--aligned {
+		background: var(--terminal-status-success);
+		border-radius: 50%;
+	}
+
+	.dm-dot--watch {
+		background: var(--terminal-status-warn);
+		border-radius: 50%;
+		/* Half-circle effect via clip-path */
+		clip-path: inset(0 50% 0 0);
+		box-shadow: inset 0 0 0 1px var(--terminal-status-warn);
+		width: 6px;
+	}
+
+	.dm-dot--breach {
+		background: transparent;
+		border: 1px solid var(--terminal-status-error);
+		border-radius: 50%;
+	}
+
+	.dm-state-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+	}
+
+	/* Drift colors */
+	.dm-drift-aligned { color: var(--terminal-status-success); }
+	.dm-drift-watch { color: var(--terminal-status-warn); }
+	.dm-drift-breach { color: var(--terminal-status-error); }
+
+	/* Footer */
+	.dm-footer {
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-top: var(--terminal-border-hairline);
+		gap: var(--terminal-space-2);
+	}
+
+	.dm-aggregate {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+	}
+
+	.dm-agg-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.dm-agg-status {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.dm-agg-detail {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+
+	.dm-rebalance-btn {
+		appearance: none;
+		height: 22px;
+		padding: 0 var(--terminal-space-2);
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-accent-amber);
+		background: transparent;
+		border: 1px solid var(--terminal-accent-amber-dim);
+		cursor: pointer;
+		transition: background var(--terminal-motion-tick), border-color var(--terminal-motion-tick);
+	}
+
+	.dm-rebalance-btn:hover {
+		background: var(--terminal-bg-panel-raised);
+		border-color: var(--terminal-accent-amber);
+	}
+
+	.dm-rebalance-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/HoldingsTable.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/HoldingsTable.svelte
@@ -1,0 +1,260 @@
+<!--
+  HoldingsTable -- portfolio positions with live prices.
+
+  Bottom-right panel. Columns: Fund, Ticker, Weight, Target,
+  Drift, Price, Change. Row click selects ticker for chart.
+  Sticky header, scrollable body.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatPercent, formatCurrency } from "@investintell/ui";
+	import type { MarketDataStore, PriceTick } from "$wealth/stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
+
+	export interface HoldingRow {
+		instrument_id: string;
+		fund_name: string;
+		ticker: string;
+		weight: number;
+		target_weight: number;
+	}
+
+	interface Props {
+		holdings: HoldingRow[];
+		selectedTicker: string | null;
+		onSelect: (ticker: string) => void;
+	}
+
+	let { holdings, selectedTicker, onSelect }: Props = $props();
+
+	const marketStore = getContext<MarketDataStore>(TERMINAL_MARKET_DATA_KEY);
+
+	function getTickData(ticker: string): PriceTick | undefined {
+		return marketStore.priceMap.get(ticker.toUpperCase());
+	}
+
+	function driftStatus(drift: number): "aligned" | "watch" | "breach" {
+		const abs = Math.abs(drift);
+		if (abs >= 0.03) return "breach";
+		if (abs >= 0.02) return "watch";
+		return "aligned";
+	}
+</script>
+
+<div class="ht-root">
+	<div class="ht-header">
+		<span class="ht-label">HOLDINGS</span>
+		<span class="ht-count">{holdings.length}</span>
+	</div>
+
+	<div class="ht-body">
+		<table class="ht-table">
+			<thead>
+				<tr>
+					<th class="ht-th ht-th--name" scope="col">Fund</th>
+					<th class="ht-th ht-th--ticker" scope="col">Ticker</th>
+					<th class="ht-th ht-th--num" scope="col">Weight</th>
+					<th class="ht-th ht-th--num" scope="col">Target</th>
+					<th class="ht-th ht-th--num" scope="col">Drift</th>
+					<th class="ht-th ht-th--num" scope="col">Price</th>
+					<th class="ht-th ht-th--num" scope="col">Change</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each holdings as h (h.instrument_id)}
+					{@const tick = getTickData(h.ticker)}
+					{@const drift = h.weight - h.target_weight}
+					{@const ds = driftStatus(drift)}
+					{@const changePct = tick?.change_pct ?? 0}
+					<!-- svelte-ignore a11y_click_events_have_key_events -->
+					<tr
+						class="ht-row"
+						class:ht-row--selected={selectedTicker?.toUpperCase() === h.ticker.toUpperCase()}
+						onclick={() => onSelect(h.ticker)}
+					>
+						<td class="ht-td ht-td--name" title={h.fund_name}>{h.fund_name}</td>
+						<td class="ht-td ht-td--ticker">{h.ticker}</td>
+						<td class="ht-td ht-td--num">{formatPercent(h.weight, 1)}</td>
+						<td class="ht-td ht-td--num ht-muted">{formatPercent(h.target_weight, 1)}</td>
+						<td
+							class="ht-td ht-td--num"
+							class:ht-drift-aligned={ds === "aligned"}
+							class:ht-drift-watch={ds === "watch"}
+							class:ht-drift-breach={ds === "breach"}
+						>
+							{drift >= 0 ? "+" : ""}{formatPercent(drift, 2)}
+						</td>
+						<td class="ht-td ht-td--num">
+							{tick?.price ? formatCurrency(tick.price) : "\u2014"}
+						</td>
+						<td
+							class="ht-td ht-td--num"
+							class:ht-up={changePct >= 0}
+							class:ht-down={changePct < 0}
+						>
+							{changePct !== 0 ? formatPercent(changePct, 2) : "\u2014"}
+						</td>
+					</tr>
+				{/each}
+
+				{#if holdings.length === 0}
+					<tr>
+						<td class="ht-td ht-empty" colspan="7">No holdings</td>
+					</tr>
+				{/if}
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<style>
+	.ht-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.ht-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.ht-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.ht-count {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.ht-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.ht-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-variant-numeric: tabular-nums;
+	}
+
+	/* -- Headers -- */
+	.ht-th {
+		position: sticky;
+		top: 0;
+		z-index: 2;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		white-space: nowrap;
+	}
+
+	.ht-th--name {
+		text-align: left;
+	}
+
+	.ht-th--ticker {
+		text-align: left;
+	}
+
+	.ht-th--num {
+		text-align: right;
+	}
+
+	/* -- Cells -- */
+	.ht-td {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-secondary);
+		border-bottom: var(--terminal-border-hairline);
+		white-space: nowrap;
+	}
+
+	.ht-td--name {
+		text-align: left;
+		font-size: var(--terminal-text-11);
+		font-weight: 500;
+		color: var(--terminal-fg-primary);
+		max-width: 200px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.ht-td--ticker {
+		text-align: left;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.ht-td--num {
+		text-align: right;
+	}
+
+	.ht-muted {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.ht-empty {
+		text-align: center;
+		padding: var(--terminal-space-6);
+		color: var(--terminal-fg-muted);
+	}
+
+	/* -- Row interaction -- */
+	.ht-row {
+		cursor: pointer;
+		transition: background var(--terminal-motion-tick);
+	}
+
+	.ht-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.ht-row--selected {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	/* -- Drift colors -- */
+	.ht-drift-aligned {
+		color: var(--terminal-status-success);
+	}
+
+	.ht-drift-watch {
+		color: var(--terminal-status-warn);
+	}
+
+	.ht-drift-breach {
+		color: var(--terminal-status-error);
+	}
+
+	/* -- P&L colors -- */
+	.ht-up {
+		color: var(--terminal-status-success);
+	}
+
+	.ht-down {
+		color: var(--terminal-status-error);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/HoldingsTable.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/HoldingsTable.svelte
@@ -8,8 +8,8 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { formatPercent, formatCurrency } from "@investintell/ui";
-	import type { MarketDataStore, PriceTick } from "$wealth/stores/market-data.svelte";
-	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
+	import type { MarketDataStore, PriceTick } from "../../../stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "../../../components/portfolio/live/workbench-state";
 
 	export interface HoldingRow {
 		instrument_id: string;

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/MacroRegimePanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/MacroRegimePanel.svelte
@@ -8,7 +8,7 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { formatPercent, formatNumber, formatBps } from "@investintell/ui";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../../api/client";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 	const api = createClientApiClient(getToken);

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/MacroRegimePanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/MacroRegimePanel.svelte
@@ -1,0 +1,215 @@
+<!--
+  MacroRegimePanel -- key macro indicators from FRED via macro_data.
+
+  Fetches latest values for VIX, CPI, DXY, 10Y, IG/HY spreads,
+  Fed Funds, Unemployment from GET /macro/fred?series_id={id}.
+  Shows value + directional change arrow.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatPercent, formatNumber, formatBps } from "@investintell/ui";
+	import { createClientApiClient } from "$wealth/api/client";
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	interface Indicator {
+		label: string;
+		seriesId: string;
+		suffix: string;
+		/** true = rising is danger (VIX, spreads), false = rising is positive */
+		riseIsWarning: boolean;
+	}
+
+	const INDICATORS: Indicator[] = [
+		{ label: "VIX", seriesId: "VIXCLS", suffix: "", riseIsWarning: true },
+		{ label: "CPI (YoY)", seriesId: "CPI_YOY", suffix: "%", riseIsWarning: true },
+		{ label: "DXY", seriesId: "DTWEXBGS", suffix: "", riseIsWarning: false },
+		{ label: "10Y YIELD", seriesId: "DGS10", suffix: "%", riseIsWarning: false },
+		{ label: "IG SPREAD", seriesId: "BAA10Y", suffix: "bp", riseIsWarning: true },
+		{ label: "HY SPREAD", seriesId: "BAMLH0A0HYM2", suffix: "bp", riseIsWarning: true },
+		{ label: "FED FUNDS", seriesId: "DFF", suffix: "%", riseIsWarning: false },
+		{ label: "UNEMPLOYMENT", seriesId: "UNRATE", suffix: "%", riseIsWarning: true },
+	];
+
+	interface IndicatorValue {
+		value: number | null;
+		change: number | null;
+	}
+
+	let values = $state<Map<string, IndicatorValue>>(new Map());
+	let loading = $state(true);
+
+	$effect(() => {
+		let cancelled = false;
+		loading = true;
+
+		const fetches = INDICATORS.map(async (ind) => {
+			try {
+				const res = await api.get<{
+					series_id: string;
+					data: Array<{ obs_date: string; value: number }>;
+				}>(`/macro/fred?series_id=${encodeURIComponent(ind.seriesId)}`);
+
+				if (cancelled) return;
+
+				const data = res.data;
+				if (data.length === 0) {
+					values.set(ind.seriesId, { value: null, change: null });
+					return;
+				}
+
+				const latestPoint = data[data.length - 1];
+				const prevPoint = data.length >= 2 ? data[data.length - 2] : undefined;
+				const latest = latestPoint?.value ?? null;
+				const prev = prevPoint?.value ?? null;
+				const change = latest != null && prev != null ? latest - prev : null;
+
+				values = new Map(values).set(ind.seriesId, { value: latest, change });
+			} catch {
+				if (!cancelled) {
+					values = new Map(values).set(ind.seriesId, { value: null, change: null });
+				}
+			}
+		});
+
+		Promise.all(fetches).then(() => {
+			if (!cancelled) loading = false;
+		});
+
+		return () => { cancelled = true; };
+	});
+
+	function formatVal(v: number | null, suffix: string): string {
+		if (v == null) return "\u2014";
+		if (suffix === "%") return formatPercent(v / 100, 1);
+		if (suffix === "bp") return formatBps(v / 100);
+		return formatNumber(v, 1);
+	}
+
+	function changeArrow(change: number | null): string {
+		if (change == null || Math.abs(change) < 0.001) return "\u2500";
+		return change > 0 ? "\u25B2" : "\u25BC";
+	}
+
+	function changeClass(change: number | null, riseIsWarning: boolean): string {
+		if (change == null || Math.abs(change) < 0.001) return "mr-neutral";
+		if (change > 0) return riseIsWarning ? "mr-warn" : "mr-good";
+		return riseIsWarning ? "mr-good" : "mr-warn";
+	}
+
+	function formatChange(change: number | null, suffix: string): string {
+		if (change == null) return "";
+		if (suffix === "bp") return `${change > 0 ? "+" : ""}${Math.round(change * 100)}`;
+		if (suffix === "%") return `${change > 0 ? "+" : ""}${formatNumber(Math.abs(change), 1)}`;
+		return `${change > 0 ? "+" : ""}${formatNumber(Math.abs(change), 1)}`;
+	}
+</script>
+
+<div class="mr-root">
+	<div class="mr-header">
+		<span class="mr-label">MARKET CONDITIONS</span>
+	</div>
+
+	<div class="mr-body">
+		{#each INDICATORS as ind (ind.seriesId)}
+			{@const v = values.get(ind.seriesId)}
+			{@const val = v?.value ?? null}
+			{@const chg = v?.change ?? null}
+			<div class="mr-row">
+				<span class="mr-key">{ind.label}</span>
+				<span class="mr-val">
+					{formatVal(val, ind.suffix)}
+				</span>
+				<span class="mr-change {changeClass(chg, ind.riseIsWarning)}">
+					{changeArrow(chg)} {formatChange(chg, ind.suffix)}
+				</span>
+			</div>
+		{/each}
+	</div>
+</div>
+
+<style>
+	.mr-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.mr-header {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.mr-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.mr-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		padding: var(--terminal-space-1) 0;
+	}
+
+	.mr-row {
+		display: grid;
+		grid-template-columns: 1fr auto auto;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding: 3px var(--terminal-space-2);
+		height: 24px;
+	}
+
+	.mr-key {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.mr-val {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+		white-space: nowrap;
+	}
+
+	.mr-change {
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+		min-width: 48px;
+		white-space: nowrap;
+	}
+
+	.mr-good {
+		color: var(--terminal-status-success);
+	}
+
+	.mr-warn {
+		color: var(--terminal-status-error);
+	}
+
+	.mr-neutral {
+		color: var(--terminal-fg-muted);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/NewsFeed.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/NewsFeed.svelte
@@ -8,7 +8,7 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { formatTime } from "@investintell/ui";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../../api/client";
 
 	interface Props {
 		tickers: string[];

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/NewsFeed.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/NewsFeed.svelte
@@ -1,0 +1,224 @@
+<!--
+  NewsFeed -- right-column panel showing Tiingo editorial headlines.
+
+  Fetches from GET /market-data/news?tickers={csv}&limit=20.
+  Shows tag-colored pills (MACRO, FUND, MARKET, ALERT),
+  publication time, and 2-line headline.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatTime } from "@investintell/ui";
+	import { createClientApiClient } from "$wealth/api/client";
+
+	interface Props {
+		tickers: string[];
+	}
+
+	let { tickers }: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	interface NewsItem {
+		id: number | string | null;
+		title: string;
+		description: string;
+		url: string;
+		source: string;
+		published_at: string;
+		tickers: string[];
+		tags: string[];
+	}
+
+	let items = $state<NewsItem[]>([]);
+	let loading = $state(true);
+	let error = $state(false);
+
+	function classifyTag(item: NewsItem): string {
+		const tags = item.tags.map((t) => t.toLowerCase());
+		const title = item.title.toLowerCase();
+		if (tags.includes("alert") || title.includes("alert") || title.includes("warning")) return "ALERT";
+		if (tags.includes("macro") || title.includes("fed") || title.includes("inflation") || title.includes("gdp") || title.includes("cpi")) return "MACRO";
+		if (tags.includes("fund") || title.includes("etf") || title.includes("fund")) return "FUND";
+		return "MARKET";
+	}
+
+	function displayTime(iso: string): string {
+		return formatTime(iso);
+	}
+
+	$effect(() => {
+		const t = tickers;
+		let cancelled = false;
+		loading = true;
+		error = false;
+
+		const params = new URLSearchParams({ limit: "20" });
+		if (t.length > 0) {
+			params.set("tickers", t.join(","));
+		}
+
+		api.get<{ items: NewsItem[]; count: number }>(`/market-data/news?${params.toString()}`)
+			.then((res) => {
+				if (!cancelled) {
+					items = res.items;
+					loading = false;
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					items = [];
+					loading = false;
+					error = true;
+				}
+			});
+
+		return () => { cancelled = true; };
+	});
+</script>
+
+<div class="nf-root">
+	<div class="nf-header">
+		<span class="nf-label">NEWS FEED</span>
+		<span class="nf-count">{items.length}</span>
+	</div>
+
+	<div class="nf-body">
+		{#if loading}
+			<div class="nf-empty">Loading...</div>
+		{:else if error}
+			<div class="nf-empty">News feed -- coming soon</div>
+		{:else if items.length === 0}
+			<div class="nf-empty">No recent headlines</div>
+		{:else}
+			{#each items as item (item.id ?? item.title)}
+				{@const tag = classifyTag(item)}
+				<a
+					class="nf-item"
+					href={item.url}
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<div class="nf-meta">
+						<span class="nf-time">{displayTime(item.published_at)}</span>
+						<span class="nf-tag nf-tag--{tag.toLowerCase()}">{tag}</span>
+					</div>
+					<span class="nf-headline">{item.title}</span>
+				</a>
+			{/each}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.nf-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.nf-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.nf-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.nf-count {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.nf-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.nf-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 80px;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+	}
+
+	.nf-item {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		cursor: pointer;
+		text-decoration: none;
+		transition: background var(--terminal-motion-tick);
+	}
+
+	.nf-item:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.nf-meta {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.nf-time {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.nf-tag {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: 1px 4px;
+	}
+
+	.nf-tag--macro {
+		color: var(--terminal-accent-cyan);
+	}
+
+	.nf-tag--fund {
+		color: var(--terminal-status-success);
+	}
+
+	.nf-tag--market {
+		color: var(--terminal-accent-amber);
+	}
+
+	.nf-tag--alert {
+		color: var(--terminal-status-error);
+	}
+
+	.nf-headline {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		line-height: var(--terminal-leading-snug);
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/PortfolioSummary.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/PortfolioSummary.svelte
@@ -1,0 +1,221 @@
+<!--
+  PortfolioSummary -- vertical KPI panel to the left of Holdings.
+
+  Shows: status badge, AUM, return (1Y), drift status,
+  instrument count, last rebalance date, rebalance button.
+-->
+<script lang="ts">
+	import { formatAUM, formatPercent, formatDate } from "@investintell/ui";
+	import LiveDot from "$wealth/components/terminal/data/LiveDot.svelte";
+
+	interface Props {
+		status: string;
+		state: string;
+		aum: number;
+		returnPct: number | null;
+		driftStatus: "aligned" | "watch" | "breach";
+		instrumentCount: number;
+		lastRebalance: string | null;
+		onRebalance?: () => void;
+	}
+
+	let {
+		status,
+		state,
+		aum,
+		returnPct,
+		driftStatus,
+		instrumentCount,
+		lastRebalance,
+		onRebalance,
+	}: Props = $props();
+
+	const isLive = $derived(state === "live");
+	const isPaused = $derived(state === "paused");
+
+	const driftLabel = $derived.by(() => {
+		switch (driftStatus) {
+			case "aligned":
+				return "Aligned";
+			case "watch":
+				return "Watch";
+			case "breach":
+				return "Breach";
+			default:
+				return "Unknown";
+		}
+	});
+
+	function handleRebalance() {
+		onRebalance?.();
+	}
+</script>
+
+<div class="ps-root">
+	<div class="ps-header">
+		<span class="ps-label">PORTFOLIO</span>
+	</div>
+
+	<div class="ps-body">
+		<div class="ps-row">
+			<span class="ps-key">STATUS</span>
+			<span class="ps-val ps-status">
+				<LiveDot
+					status={isLive ? "success" : isPaused ? "warn" : "muted"}
+					pulse={isLive}
+					label="Portfolio state"
+				/>
+				{isLive ? "LIVE" : isPaused ? "PAUSED" : state.toUpperCase()}
+			</span>
+		</div>
+
+		<div class="ps-row">
+			<span class="ps-key">AUM</span>
+			<span class="ps-val">{formatAUM(aum)}</span>
+		</div>
+
+		<div class="ps-row">
+			<span class="ps-key">RETURN (1Y)</span>
+			<span
+				class="ps-val"
+				class:ps-up={returnPct != null && returnPct >= 0}
+				class:ps-down={returnPct != null && returnPct < 0}
+			>
+				{returnPct != null ? formatPercent(returnPct, 1, "en-US", true) : "\u2014"}
+			</span>
+		</div>
+
+		<div class="ps-row">
+			<span class="ps-key">DRIFT</span>
+			<span
+				class="ps-val"
+				class:ps-drift-aligned={driftStatus === "aligned"}
+				class:ps-drift-watch={driftStatus === "watch"}
+				class:ps-drift-breach={driftStatus === "breach"}
+			>
+				{driftLabel}
+			</span>
+		</div>
+
+		<div class="ps-row">
+			<span class="ps-key">INSTRUMENTS</span>
+			<span class="ps-val">{instrumentCount}</span>
+		</div>
+
+		<div class="ps-row">
+			<span class="ps-key">LAST REBALANCE</span>
+			<span class="ps-val">{lastRebalance ? formatDate(lastRebalance, "short") : "\u2014"}</span>
+		</div>
+	</div>
+
+	{#if driftStatus !== "aligned"}
+		<div class="ps-footer">
+			<button type="button" class="ps-rebalance-btn" onclick={handleRebalance}>
+				REBALANCE
+			</button>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.ps-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono), "JetBrains Mono", "SF Mono", monospace;
+		border-right: var(--terminal-border-hairline);
+	}
+
+	.ps-header {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+		height: 24px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.ps-label {
+		font-family: var(--terminal-font-mono), "JetBrains Mono", "SF Mono", monospace;
+		font-size: var(--terminal-text-9);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.ps-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		padding: var(--terminal-space-2);
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+	}
+
+	.ps-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.ps-key {
+		font-family: var(--terminal-font-mono), "JetBrains Mono", "SF Mono", monospace;
+		font-size: var(--terminal-text-9);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.ps-val {
+		font-family: var(--terminal-font-mono), "JetBrains Mono", "SF Mono", monospace;
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.ps-status {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	.ps-up { color: var(--terminal-status-success); }
+	.ps-down { color: var(--terminal-status-error); }
+	.ps-drift-aligned { color: var(--terminal-status-success); }
+	.ps-drift-watch { color: var(--terminal-status-warn); }
+	.ps-drift-breach { color: var(--terminal-status-error); }
+
+	.ps-footer {
+		flex-shrink: 0;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-top: var(--terminal-border-hairline);
+	}
+
+	.ps-rebalance-btn {
+		width: 100%;
+		height: 24px;
+		background: var(--terminal-accent-amber);
+		color: var(--terminal-bg-void);
+		border: none;
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-9);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+
+	.ps-rebalance-btn:hover { opacity: 0.9; }
+
+	.ps-rebalance-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/PortfolioSummary.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/PortfolioSummary.svelte
@@ -6,7 +6,7 @@
 -->
 <script lang="ts">
 	import { formatAUM, formatPercent, formatDate } from "@investintell/ui";
-	import LiveDot from "$wealth/components/terminal/data/LiveDot.svelte";
+	import LiveDot from "../../../components/terminal/data/LiveDot.svelte";
 
 	interface Props {
 		status: string;

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/RebalanceFocusMode.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/RebalanceFocusMode.svelte
@@ -8,8 +8,8 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { formatPercent, formatCurrency } from "@investintell/ui";
-	import { createClientApiClient } from "$wealth/api/client";
-	import FocusMode from "$wealth/components/terminal/focus-mode/FocusMode.svelte";
+	import { createClientApiClient } from "../../../api/client";
+	import FocusMode from "../../../components/terminal/focus-mode/FocusMode.svelte";
 	import TradeConfirmation from "./TradeConfirmation.svelte";
 
 	interface Props {

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/RebalanceFocusMode.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/RebalanceFocusMode.svelte
@@ -1,0 +1,771 @@
+<!--
+  RebalanceFocusMode — full-screen overlay for rebalance trade proposals.
+
+  Uses FocusMode primitive. Calls POST /rebalance/preview to get
+  SuggestedTrade[], displays in 2-column layout (trades + impact),
+  then executes via POST /execute-trades with optimistic lock.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatPercent, formatCurrency } from "@investintell/ui";
+	import { createClientApiClient } from "$wealth/api/client";
+	import FocusMode from "$wealth/components/terminal/focus-mode/FocusMode.svelte";
+	import TradeConfirmation from "./TradeConfirmation.svelte";
+
+	interface Props {
+		portfolioId: string;
+		portfolioName: string;
+		holdings: Array<{
+			instrument_id: string;
+			fund_name: string;
+			block_id: string;
+			weight: number;
+		}>;
+		holdingsVersion: number;
+		totalAum: number;
+		onClose: () => void;
+		onSuccess: () => void;
+	}
+
+	let {
+		portfolioId,
+		portfolioName,
+		holdings,
+		holdingsVersion,
+		totalAum,
+		onClose,
+		onSuccess,
+	}: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	// ---- State ----
+
+	interface SuggestedTrade {
+		instrument_id: string;
+		fund_name: string;
+		block_id: string;
+		action: "BUY" | "SELL" | "HOLD";
+		current_weight: number;
+		target_weight: number;
+		delta_weight: number;
+		current_value: number;
+		target_value: number;
+		trade_value: number;
+		estimated_quantity: number;
+	}
+
+	interface PreviewResponse {
+		portfolio_id: string;
+		portfolio_name: string;
+		profile: string;
+		total_aum: number;
+		cash_available: number;
+		total_trades: number;
+		estimated_turnover_pct: number;
+		trades: SuggestedTrade[];
+		weight_comparison: Array<{ block_id: string; current_weight: number; target_weight: number; delta: number }>;
+		cvar_95_projected: number | null;
+		cvar_limit: number | null;
+		cvar_warning: boolean;
+	}
+
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let preview = $state<PreviewResponse | null>(null);
+	let showConfirmation = $state(false);
+	let executing = $state(false);
+	let executionError = $state<string | null>(null);
+
+	// ---- Instrument ticker map ----
+
+	let instrumentMap = $state<Map<string, string>>(new Map());
+
+	$effect(() => {
+		let cancelled = false;
+		api.get<Array<{ instrument_id: string; ticker: string | null; name: string }>>(
+			"/instruments",
+		)
+			.then((instruments) => {
+				if (cancelled) return;
+				const m = new Map<string, string>();
+				for (const inst of instruments) {
+					if (inst.ticker) {
+						m.set(inst.instrument_id, inst.ticker);
+					}
+				}
+				instrumentMap = m;
+			})
+			.catch(() => {});
+		return () => { cancelled = true; };
+	});
+
+	function resolveTicker(instrumentId: string): string {
+		return instrumentMap.get(instrumentId) ?? instrumentId.slice(0, 8);
+	}
+
+	// ---- Fetch preview on mount ----
+
+	$effect(() => {
+		const _pid = portfolioId;
+		let cancelled = false;
+		loading = true;
+		error = null;
+
+		// Build current_holdings payload from actual holdings
+		const currentHoldings = holdings.map((h) => ({
+			instrument_id: h.instrument_id,
+			quantity: h.weight * totalAum,
+			current_price: 1.0,
+		}));
+
+		api.post<PreviewResponse>(
+			`/model-portfolios/${_pid}/rebalance/preview`,
+			{
+				total_aum: totalAum > 0 ? totalAum : undefined,
+				cash_available: 0,
+				current_holdings: currentHoldings,
+			},
+		)
+			.then((res) => {
+				if (!cancelled) {
+					preview = res;
+					loading = false;
+				}
+			})
+			.catch((err) => {
+				if (!cancelled) {
+					error = err instanceof Error ? err.message : "Failed to compute rebalance preview";
+					loading = false;
+				}
+			});
+
+		return () => { cancelled = true; };
+	});
+
+	// ---- Derived data ----
+
+	const sortedTrades = $derived.by(() => {
+		if (!preview) return [];
+		return [...preview.trades].sort(
+			(a, b) => Math.abs(b.delta_weight) - Math.abs(a.delta_weight),
+		);
+	});
+
+	const buys = $derived(sortedTrades.filter((t) => t.action === "BUY"));
+	const sells = $derived(sortedTrades.filter((t) => t.action === "SELL"));
+	const holds = $derived(sortedTrades.filter((t) => t.action === "HOLD"));
+
+	const totalBuyValue = $derived(
+		sortedTrades.filter((t) => t.action === "BUY").reduce((s, t) => s + t.trade_value, 0),
+	);
+	const totalSellValue = $derived(
+		sortedTrades.filter((t) => t.action === "SELL").reduce((s, t) => s + Math.abs(t.trade_value), 0),
+	);
+	const netFlow = $derived(totalBuyValue - totalSellValue);
+
+	const turnoverClass = $derived.by(() => {
+		if (!preview) return "";
+		if (preview.estimated_turnover_pct > 0.20) return "rfm-val--danger";
+		if (preview.estimated_turnover_pct > 0.10) return "rfm-val--warn";
+		return "";
+	});
+
+	// ---- Actions ----
+
+	function handleSubmitProposal() {
+		showConfirmation = true;
+	}
+
+	async function handleExecute() {
+		if (executing || !preview) return;
+		executing = true;
+		executionError = null;
+
+		const tickets = preview.trades
+			.filter((t) => t.action !== "HOLD")
+			.map((t) => ({
+				instrument_id: t.instrument_id,
+				action: t.action,
+				delta_weight: Math.abs(t.delta_weight),
+			}));
+
+		if (tickets.length === 0) {
+			executionError = "No trades to execute (all positions are HOLD).";
+			executing = false;
+			return;
+		}
+
+		try {
+			await api.post(`/model-portfolios/${portfolioId}/execute-trades`, {
+				tickets,
+				expected_version: holdingsVersion,
+			});
+			onSuccess();
+		} catch (err: unknown) {
+			if (err instanceof Error && err.name === "ConflictError") {
+				executionError = "Portfolio was modified by another user. Refresh and retry.";
+			} else {
+				executionError = err instanceof Error ? err.message : "Trade execution failed";
+			}
+		} finally {
+			executing = false;
+		}
+	}
+
+	function handleConfirmationClose() {
+		showConfirmation = false;
+	}
+</script>
+
+<FocusMode
+	entityKind="portfolio"
+	entityId={portfolioId}
+	entityLabel={portfolioName}
+	onClose={onClose}
+>
+	{#snippet reactor()}
+		<div class="rfm-content">
+			{#if loading}
+				<div class="rfm-loading">
+					<span class="rfm-loading-text">COMPUTING REBALANCE...</span>
+				</div>
+			{:else if error}
+				<div class="rfm-error">
+					<span class="rfm-error-label">ERROR</span>
+					<span class="rfm-error-msg">{error}</span>
+					<button type="button" class="rfm-retry" onclick={onClose}>CLOSE</button>
+				</div>
+			{:else if preview}
+				<div class="rfm-grid">
+					<!-- Left: Proposed Trades -->
+					<div class="rfm-trades-panel">
+						<div class="rfm-panel-header">
+							<span class="rfm-panel-title">PROPOSED TRADES</span>
+						</div>
+						<div class="rfm-trades-body">
+							<table class="rfm-table">
+								<thead>
+									<tr>
+										<th class="rfm-th rfm-th--name">Fund</th>
+										<th class="rfm-th rfm-th--ticker">Ticker</th>
+										<th class="rfm-th rfm-th--action">Action</th>
+										<th class="rfm-th rfm-th--num">Current</th>
+										<th class="rfm-th rfm-th--num">Target</th>
+										<th class="rfm-th rfm-th--num">Weight Change</th>
+										<th class="rfm-th rfm-th--num">Trade Value</th>
+									</tr>
+								</thead>
+								<tbody>
+									{#each sortedTrades as trade (trade.instrument_id)}
+										<tr class="rfm-row">
+											<td class="rfm-td rfm-td--name" title={trade.fund_name}>
+												{trade.fund_name}
+											</td>
+											<td class="rfm-td rfm-td--ticker">
+												{resolveTicker(trade.instrument_id)}
+											</td>
+											<td class="rfm-td rfm-td--action">
+												<span
+													class="rfm-badge"
+													class:rfm-badge--buy={trade.action === "BUY"}
+													class:rfm-badge--sell={trade.action === "SELL"}
+													class:rfm-badge--hold={trade.action === "HOLD"}
+												>
+													{trade.action}
+												</span>
+											</td>
+											<td class="rfm-td rfm-td--num">
+												{formatPercent(trade.current_weight, 1)}
+											</td>
+											<td class="rfm-td rfm-td--num">
+												{formatPercent(trade.target_weight, 1)}
+											</td>
+											<td
+												class="rfm-td rfm-td--num"
+												class:rfm-delta--pos={trade.delta_weight > 0}
+												class:rfm-delta--neg={trade.delta_weight < 0}
+											>
+												{trade.delta_weight > 0 ? "+" : ""}{formatPercent(trade.delta_weight, 2)}
+											</td>
+											<td class="rfm-td rfm-td--num">
+												{formatCurrency(Math.abs(trade.trade_value))}
+											</td>
+										</tr>
+									{/each}
+								</tbody>
+							</table>
+						</div>
+						<div class="rfm-trades-footer">
+							{sortedTrades.length} trades ({buys.length} BUY, {sells.length} SELL, {holds.length} HOLD)
+						</div>
+					</div>
+
+					<!-- Right: Impact Analysis -->
+					<div class="rfm-impact-panel">
+						<div class="rfm-panel-header">
+							<span class="rfm-panel-title">IMPACT ANALYSIS</span>
+						</div>
+						<div class="rfm-impact-body">
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Turnover</span>
+								<span class="rfm-metric-val {turnoverClass}">
+									{formatPercent(preview.estimated_turnover_pct, 1)}
+								</span>
+							</div>
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Tail Loss (95% confidence)</span>
+								<span class="rfm-metric-val">
+									{preview.cvar_95_projected != null
+										? formatPercent(preview.cvar_95_projected, 1)
+										: "\u2014"}
+								</span>
+							</div>
+							{#if preview.cvar_warning}
+								<div class="rfm-warning">
+									Risk limit approaching
+								</div>
+							{/if}
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Trades</span>
+								<span class="rfm-metric-val">{preview.total_trades}</span>
+							</div>
+
+							<div class="rfm-divider"></div>
+
+							<div class="rfm-section-label">TRADE VALUES</div>
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Total BUY</span>
+								<span class="rfm-metric-val rfm-val--success">
+									{formatCurrency(totalBuyValue)}
+								</span>
+							</div>
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Total SELL</span>
+								<span class="rfm-metric-val rfm-val--danger">
+									{formatCurrency(totalSellValue)}
+								</span>
+							</div>
+							<div class="rfm-metric">
+								<span class="rfm-metric-key">Net Flow</span>
+								<span
+									class="rfm-metric-val"
+									class:rfm-val--success={netFlow >= 0}
+									class:rfm-val--danger={netFlow < 0}
+								>
+									{formatCurrency(netFlow)}
+								</span>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- Confirmation bar -->
+				<div class="rfm-confirm-bar">
+					<div class="rfm-confirm-text">
+						This will generate trade orders for the active portfolio.
+						Execution is simulated &mdash; no real broker orders will be placed.
+					</div>
+
+					{#if executionError}
+						<div class="rfm-exec-error">{executionError}</div>
+					{/if}
+
+					<div class="rfm-confirm-actions">
+						<button type="button" class="rfm-btn rfm-btn--cancel" onclick={onClose}>
+							CANCEL
+						</button>
+						<button
+							type="button"
+							class="rfm-btn rfm-btn--submit"
+							onclick={handleSubmitProposal}
+							disabled={executing || sortedTrades.filter((t) => t.action !== "HOLD").length === 0}
+						>
+							SUBMIT PROPOSAL
+						</button>
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/snippet}
+</FocusMode>
+
+{#if showConfirmation && preview}
+	<TradeConfirmation
+		tradeCount={sortedTrades.filter((t) => t.action !== "HOLD").length}
+		buyCount={buys.length}
+		sellCount={sells.length}
+		turnoverPct={preview.estimated_turnover_pct}
+		{executing}
+		errorMessage={executionError}
+		onClose={handleConfirmationClose}
+		onConfirm={handleExecute}
+	/>
+{/if}
+
+<style>
+	.rfm-content {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		min-height: 0;
+		font-family: var(--terminal-font-mono);
+	}
+
+	/* Loading */
+	.rfm-loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex: 1;
+	}
+
+	.rfm-loading-text {
+		font-size: var(--terminal-text-14);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-accent-amber);
+		animation: rfm-pulse 1.4s ease-in-out infinite;
+	}
+
+	@keyframes rfm-pulse {
+		0%, 100% { opacity: 0.4; }
+		50% { opacity: 1; }
+	}
+
+	/* Error */
+	.rfm-error {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: var(--terminal-space-3);
+		flex: 1;
+	}
+
+	.rfm-error-label {
+		font-size: var(--terminal-text-12);
+		font-weight: 700;
+		color: var(--terminal-status-error);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rfm-error-msg {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		max-width: 500px;
+		text-align: center;
+	}
+
+	.rfm-retry {
+		appearance: none;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-primary);
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		cursor: pointer;
+	}
+
+	/* 2-column grid */
+	.rfm-grid {
+		display: grid;
+		grid-template-columns: 1fr 320px;
+		gap: 1px;
+		flex: 1;
+		min-height: 0;
+		background: var(--terminal-fg-muted);
+	}
+
+	/* Panel headers */
+	.rfm-panel-header {
+		display: flex;
+		align-items: center;
+		height: 32px;
+		padding: 0 var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+		flex-shrink: 0;
+	}
+
+	.rfm-panel-title {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	/* Trades panel */
+	.rfm-trades-panel {
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+	}
+
+	.rfm-trades-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.rfm-trades-footer {
+		flex-shrink: 0;
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border-top: var(--terminal-border-hairline);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	/* Table */
+	.rfm-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.rfm-th {
+		position: sticky;
+		top: 0;
+		z-index: 2;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		white-space: nowrap;
+	}
+
+	.rfm-th--name { text-align: left; }
+	.rfm-th--ticker { text-align: left; }
+	.rfm-th--action { text-align: center; }
+	.rfm-th--num { text-align: right; }
+
+	.rfm-td {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-secondary);
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		white-space: nowrap;
+	}
+
+	.rfm-td--name {
+		text-align: left;
+		font-size: var(--terminal-text-11);
+		font-weight: 500;
+		color: var(--terminal-fg-primary);
+		max-width: 220px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.rfm-td--ticker {
+		text-align: left;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rfm-td--action {
+		text-align: center;
+	}
+
+	.rfm-td--num {
+		text-align: right;
+	}
+
+	.rfm-row {
+		transition: background var(--terminal-motion-tick);
+	}
+
+	.rfm-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	/* Action badges */
+	.rfm-badge {
+		display: inline-block;
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		padding: 1px 6px;
+		text-transform: uppercase;
+	}
+
+	.rfm-badge--buy {
+		color: var(--terminal-bg-void);
+		background: var(--terminal-status-success);
+	}
+
+	.rfm-badge--sell {
+		color: var(--terminal-bg-void);
+		background: var(--terminal-status-error);
+	}
+
+	.rfm-badge--hold {
+		color: var(--terminal-fg-tertiary);
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	/* Delta colors */
+	.rfm-delta--pos {
+		color: var(--terminal-status-success);
+	}
+
+	.rfm-delta--neg {
+		color: var(--terminal-status-error);
+	}
+
+	/* Impact panel */
+	.rfm-impact-panel {
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+	}
+
+	.rfm-impact-body {
+		flex: 1;
+		padding: var(--terminal-space-3);
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-3);
+		overflow-y: auto;
+	}
+
+	.rfm-metric {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.rfm-metric-key {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rfm-metric-val {
+		font-size: var(--terminal-text-12);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.rfm-val--warn {
+		color: var(--terminal-status-warn);
+	}
+
+	.rfm-val--danger {
+		color: var(--terminal-status-error);
+	}
+
+	.rfm-val--success {
+		color: var(--terminal-status-success);
+	}
+
+	.rfm-warning {
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-left: 2px solid var(--terminal-status-warn);
+		background: var(--terminal-bg-panel-raised);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-status-warn);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rfm-divider {
+		height: 1px;
+		background: var(--terminal-fg-muted);
+	}
+
+	.rfm-section-label {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-muted);
+		text-transform: uppercase;
+	}
+
+	/* Confirmation bar */
+	.rfm-confirm-bar {
+		flex-shrink: 0;
+		padding: var(--terminal-space-3) var(--terminal-space-4);
+		border-top: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+	}
+
+	.rfm-confirm-text {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		margin-bottom: var(--terminal-space-3);
+		line-height: 1.5;
+	}
+
+	.rfm-exec-error {
+		margin-bottom: var(--terminal-space-2);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-left: 2px solid var(--terminal-status-error);
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-status-error);
+		font-size: var(--terminal-text-11);
+	}
+
+	.rfm-confirm-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--terminal-space-2);
+	}
+
+	.rfm-btn {
+		appearance: none;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: var(--terminal-space-1) var(--terminal-space-4);
+		cursor: pointer;
+		transition:
+			background var(--terminal-motion-tick),
+			opacity var(--terminal-motion-tick);
+	}
+
+	.rfm-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.rfm-btn--cancel {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.rfm-btn--cancel:hover:not(:disabled) {
+		color: var(--terminal-fg-primary);
+	}
+
+	.rfm-btn--submit {
+		background: var(--terminal-accent-amber);
+		border: 1px solid var(--terminal-accent-amber);
+		color: var(--terminal-bg-void);
+	}
+
+	.rfm-btn--submit:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.rfm-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/TradeConfirmation.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/TradeConfirmation.svelte
@@ -1,0 +1,246 @@
+<!--
+  TradeConfirmation — simple confirmation dialog before trade execution.
+
+  Lighter than ConsequenceDialog (no typed ACTIVATE). ESC closes,
+  Enter confirms. Amber "Execute" button.
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+
+	interface Props {
+		tradeCount: number;
+		buyCount: number;
+		sellCount: number;
+		turnoverPct: number;
+		executing: boolean;
+		errorMessage: string | null;
+		onClose: () => void;
+		onConfirm: () => void;
+	}
+
+	let {
+		tradeCount,
+		buyCount,
+		sellCount,
+		turnoverPct,
+		executing,
+		errorMessage,
+		onClose,
+		onConfirm,
+	}: Props = $props();
+
+	let dialogEl: HTMLDivElement | undefined = $state();
+
+	// Auto-focus the dialog on mount
+	$effect(() => {
+		if (dialogEl) dialogEl.focus();
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === "Escape") {
+			e.preventDefault();
+			onClose();
+			return;
+		}
+		if (e.key === "Enter" && !executing) {
+			e.preventDefault();
+			onConfirm();
+			return;
+		}
+		// Focus trap
+		if (e.key === "Tab" && dialogEl) {
+			const focusable = dialogEl.querySelectorAll<HTMLElement>(
+				"button:not([disabled])",
+			);
+			if (focusable.length === 0) return;
+			const first = focusable[0] as HTMLElement | undefined;
+			const last = focusable[focusable.length - 1] as HTMLElement | undefined;
+			if (!first || !last) return;
+			if (e.shiftKey && document.activeElement === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && document.activeElement === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div
+	class="tc-overlay"
+	role="dialog"
+	aria-modal="true"
+	aria-label="Confirm trade execution"
+	onkeydown={handleKeydown}
+	bind:this={dialogEl}
+	tabindex="-1"
+>
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="tc-backdrop" onclick={onClose}></div>
+	<div class="tc-panel">
+		<h2 class="tc-title">Execute {tradeCount} trades?</h2>
+
+		<div class="tc-details">
+			<div class="tc-row">
+				<span class="tc-key">{buyCount} BUY orders, {sellCount} SELL orders</span>
+			</div>
+			<div class="tc-row">
+				<span class="tc-key">Estimated turnover:</span>
+				<span class="tc-val">{formatPercent(turnoverPct, 1)}</span>
+			</div>
+			<div class="tc-row">
+				<span class="tc-key">Execution:</span>
+				<span class="tc-val tc-val--muted">Simulated</span>
+			</div>
+		</div>
+
+		{#if errorMessage}
+			<div class="tc-error">{errorMessage}</div>
+		{/if}
+
+		<div class="tc-actions">
+			<button type="button" class="tc-btn tc-btn--cancel" onclick={onClose} disabled={executing}>
+				Cancel
+			</button>
+			<button
+				type="button"
+				class="tc-btn tc-btn--execute"
+				onclick={onConfirm}
+				disabled={executing}
+			>
+				{executing ? "Executing..." : "Execute"}
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.tc-overlay {
+		position: fixed;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: calc(var(--terminal-z-focusmode, 900) + 10);
+		outline: none;
+	}
+
+	.tc-backdrop {
+		position: absolute;
+		inset: 0;
+		background: var(--terminal-bg-void);
+		opacity: 0.85;
+	}
+
+	.tc-panel {
+		position: relative;
+		width: 400px;
+		max-width: 90vw;
+		padding: var(--terminal-space-6);
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-primary);
+	}
+
+	.tc-title {
+		font-size: 16px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+		margin: 0 0 var(--terminal-space-4);
+		color: var(--terminal-accent-amber);
+	}
+
+	.tc-details {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		margin-bottom: var(--terminal-space-4);
+	}
+
+	.tc-row {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+
+	.tc-key {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.tc-val {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.tc-val--muted {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.tc-error {
+		margin-bottom: var(--terminal-space-3);
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		border-left: 2px solid var(--terminal-status-error);
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-status-error);
+		font-size: var(--terminal-text-11);
+	}
+
+	.tc-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--terminal-space-2);
+	}
+
+	.tc-btn {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		border-radius: var(--terminal-radius-none);
+		cursor: pointer;
+		transition:
+			background var(--terminal-motion-tick),
+			opacity var(--terminal-motion-tick);
+	}
+
+	.tc-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.tc-btn--cancel {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.tc-btn--cancel:hover:not(:disabled) {
+		color: var(--terminal-fg-primary);
+	}
+
+	.tc-btn--execute {
+		background: var(--terminal-accent-amber);
+		border: 1px solid var(--terminal-accent-amber);
+		color: var(--terminal-bg-void);
+	}
+
+	.tc-btn--execute:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.tc-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/TradeLog.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/TradeLog.svelte
@@ -7,7 +7,7 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { formatPercent, formatTime } from "@investintell/ui";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../../api/client";
 
 	interface Props {
 		portfolioId: string | null;

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/TradeLog.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/TradeLog.svelte
@@ -1,0 +1,242 @@
+<!--
+  TradeLog -- recent trade tickets for the active portfolio.
+
+  Fetches from GET /model-portfolios/{id}/trade-tickets?page_size=20.
+  Shows ticker, BUY/SELL badge, delta weight, and execution time.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatPercent, formatTime } from "@investintell/ui";
+	import { createClientApiClient } from "$wealth/api/client";
+
+	interface Props {
+		portfolioId: string | null;
+	}
+
+	let { portfolioId }: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	/** Instrument ID -> ticker map for resolution */
+	let instrumentMap = $state<Map<string, string>>(new Map());
+
+	interface TradeTicket {
+		id: string;
+		instrument_id: string;
+		action: string;
+		delta_weight: number;
+		executed_at: string;
+		execution_venue: string | null;
+		fill_status: string;
+	}
+
+	let tickets = $state<TradeTicket[]>([]);
+	let loading = $state(true);
+
+	// Fetch instrument map for ticker resolution
+	$effect(() => {
+		const _pid = portfolioId;
+		if (!_pid) return;
+		let cancelled = false;
+		api.get<Array<{ instrument_id: string; ticker: string | null; name: string }>>(
+			"/instruments",
+		)
+			.then((instruments) => {
+				if (cancelled) return;
+				const m = new Map<string, string>();
+				for (const inst of instruments) {
+					if (inst.ticker) {
+						m.set(inst.instrument_id, inst.ticker);
+					}
+				}
+				instrumentMap = m;
+			})
+			.catch(() => {});
+		return () => { cancelled = true; };
+	});
+
+	$effect(() => {
+		const pid = portfolioId;
+		let cancelled = false;
+		loading = true;
+
+		if (!pid) {
+			tickets = [];
+			loading = false;
+			return;
+		}
+
+		api.get<{
+			items: TradeTicket[];
+			total: number;
+			page: number;
+			page_size: number;
+			has_next: boolean;
+		}>(`/model-portfolios/${pid}/trade-tickets?page_size=20`)
+			.then((res) => {
+				if (!cancelled) {
+					tickets = res.items;
+					loading = false;
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					tickets = [];
+					loading = false;
+				}
+			});
+
+		return () => { cancelled = true; };
+	});
+
+	function displayTime(iso: string): string {
+		return formatTime(iso);
+	}
+
+	function resolveTicker(instrumentId: string): string {
+		return instrumentMap.get(instrumentId) ?? instrumentId.slice(0, 8);
+	}
+</script>
+
+<div class="tl-root">
+	<div class="tl-header">
+		<span class="tl-label">TRADE LOG</span>
+		<span class="tl-count">{tickets.length}</span>
+	</div>
+
+	<div class="tl-body">
+		{#if loading}
+			<div class="tl-empty">Loading...</div>
+		{:else if tickets.length === 0}
+			<div class="tl-empty">No trades executed</div>
+		{:else}
+			{#each tickets as t (t.id)}
+				{@const isBuy = t.action.toLowerCase() === "buy"}
+				<div class="tl-row">
+					<span class="tl-ticker">{resolveTicker(t.instrument_id)}</span>
+					<span class="tl-badge" class:tl-badge--buy={isBuy} class:tl-badge--sell={!isBuy}>
+						{t.action.toUpperCase()}
+					</span>
+					<span class="tl-delta" class:tl-delta--buy={isBuy} class:tl-delta--sell={!isBuy}>
+						{isBuy ? "+" : ""}{formatPercent(t.delta_weight, 1)}
+					</span>
+					<span class="tl-time">{displayTime(t.executed_at)}</span>
+				</div>
+			{/each}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.tl-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.tl-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.tl-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.tl-count {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.tl-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.tl-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 80px;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+	}
+
+	.tl-row {
+		display: grid;
+		grid-template-columns: 1fr auto auto auto;
+		align-items: center;
+		gap: 6px;
+		padding: var(--terminal-space-1) var(--terminal-space-2);
+		height: 28px;
+		border-bottom: 1px solid var(--terminal-fg-muted);
+	}
+
+	.tl-ticker {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		letter-spacing: var(--terminal-tracking-caps);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.tl-badge {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		padding: 1px 6px;
+		white-space: nowrap;
+	}
+
+	.tl-badge--buy {
+		color: var(--terminal-bg-void);
+		background: var(--terminal-status-success);
+	}
+
+	.tl-badge--sell {
+		color: var(--terminal-bg-void);
+		background: var(--terminal-status-error);
+	}
+
+	.tl-delta {
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+		white-space: nowrap;
+	}
+
+	.tl-delta--buy {
+		color: var(--terminal-status-success);
+	}
+
+	.tl-delta--sell {
+		color: var(--terminal-status-error);
+	}
+
+	.tl-time {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/Watchlist.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/Watchlist.svelte
@@ -1,0 +1,331 @@
+<!--
+  Watchlist -- left panel of the Live Workbench.
+
+  Shows portfolio holdings as live tickers with prices from
+  MarketDataStore. Footer has a ticker search input to look up
+  any Tiingo-available instrument via REST quote endpoint.
+
+  Layout: 240px fixed-width sidebar, scrollable items, sticky
+  header + footer.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatPercent, formatCurrency } from "@investintell/ui";
+	import type { MarketDataStore, PriceTick } from "$wealth/stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
+	import { createClientApiClient } from "$wealth/api/client";
+
+	export interface WatchlistItem {
+		ticker: string;
+		name: string;
+		instrument_id: string;
+		weight: number;
+	}
+
+	interface Props {
+		items: WatchlistItem[];
+		selectedTicker: string | null;
+		onSelect: (ticker: string) => void;
+		portfolioName: string;
+	}
+
+	let { items, selectedTicker, onSelect, portfolioName }: Props = $props();
+
+	const marketStore = getContext<MarketDataStore>(TERMINAL_MARKET_DATA_KEY);
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	// Ad-hoc tickers added via search (not part of portfolio)
+	let adHocItems = $state<WatchlistItem[]>([]);
+	let searchQuery = $state("");
+	let searching = $state(false);
+	let searchError = $state<string | null>(null);
+
+	const allItems = $derived([...items, ...adHocItems]);
+
+	function getTickData(ticker: string): PriceTick | undefined {
+		return marketStore.priceMap.get(ticker.toUpperCase());
+	}
+
+	async function handleSearch(e: SubmitEvent) {
+		e.preventDefault();
+		const q = searchQuery.trim().toUpperCase();
+		if (!q) return;
+
+		// Already in the list?
+		if (allItems.some((i) => i.ticker.toUpperCase() === q)) {
+			onSelect(q);
+			searchQuery = "";
+			return;
+		}
+
+		searching = true;
+		searchError = null;
+
+		try {
+			const res = await api.get<{
+				ticker: string;
+				interval: string;
+				bars: Array<{ timestamp: string; close: number | null }>;
+				source: string;
+			}>(`/market-data/historical/${encodeURIComponent(q)}?start_date=${new Date(Date.now() - 86400000 * 5).toISOString().slice(0, 10)}`);
+			adHocItems = [
+				...adHocItems,
+				{
+					ticker: res.ticker ?? q,
+					name: q,
+					instrument_id: "",
+					weight: 0,
+				},
+			];
+			marketStore.subscribe([res.ticker ?? q]);
+			onSelect(res.ticker ?? q);
+			searchQuery = "";
+		} catch {
+			searchError = "Ticker not found";
+			setTimeout(() => (searchError = null), 2000);
+		} finally {
+			searching = false;
+		}
+	}
+</script>
+
+<div class="wl-root">
+	<!-- Header -->
+	<div class="wl-header">
+		<span class="wl-label">WATCHLIST</span>
+		<span class="wl-portfolio" title={portfolioName}>{portfolioName}</span>
+	</div>
+
+	<!-- Items -->
+	<div class="wl-items">
+		{#each allItems as item (item.ticker)}
+			{@const tick = getTickData(item.ticker)}
+			{@const price = tick?.price ?? 0}
+			{@const changePct = tick?.change_pct ?? 0}
+			{@const isPositive = changePct >= 0}
+			<!-- svelte-ignore a11y_click_events_have_key_events -->
+			<button
+				type="button"
+				class="wl-row"
+				class:wl-row--selected={selectedTicker?.toUpperCase() === item.ticker.toUpperCase()}
+				onclick={() => onSelect(item.ticker)}
+			>
+				<div class="wl-row-left">
+					<span class="wl-ticker">{item.ticker}</span>
+					<span class="wl-name" title={item.name}>{item.name}</span>
+					{#if item.weight > 0}
+						<span class="wl-weight">{formatPercent(item.weight, 1)}</span>
+					{/if}
+				</div>
+				<div class="wl-row-right">
+					<span
+						class="wl-change"
+						class:wl-up={isPositive}
+						class:wl-down={!isPositive}
+					>
+						{isPositive ? "\u25B2" : "\u25BC"}
+						{formatPercent(Math.abs(changePct), 2)}
+					</span>
+					<span class="wl-price">
+						{price > 0 ? formatCurrency(price) : "\u2014"}
+					</span>
+				</div>
+			</button>
+		{/each}
+
+		{#if allItems.length === 0}
+			<div class="wl-empty">No instruments</div>
+		{/if}
+	</div>
+
+	<!-- Footer: search -->
+	<form class="wl-search" onsubmit={handleSearch}>
+		<input
+			type="text"
+			class="wl-search-input"
+			placeholder="Search ticker..."
+			bind:value={searchQuery}
+			disabled={searching}
+		/>
+		{#if searchError}
+			<span class="wl-search-error">{searchError}</span>
+		{/if}
+	</form>
+</div>
+
+<style>
+	.wl-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-height: 0;
+		overflow: hidden;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	/* -- Header -- */
+	.wl-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-shrink: 0;
+		height: 28px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.wl-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.wl-portfolio {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+		max-width: 120px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	/* -- Items -- */
+	.wl-items {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.wl-row {
+		appearance: none;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		height: 36px;
+		padding: 0 var(--terminal-space-2);
+		background: transparent;
+		border: none;
+		border-bottom: 1px solid var(--terminal-fg-muted);
+		border-left: 2px solid transparent;
+		cursor: pointer;
+		transition: background var(--terminal-motion-tick);
+		text-align: left;
+	}
+
+	.wl-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.wl-row--selected {
+		background: var(--terminal-bg-panel-raised);
+		border-left-color: var(--terminal-accent-amber);
+	}
+
+	.wl-row-left {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		min-width: 0;
+	}
+
+	.wl-ticker {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.wl-name {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 110px;
+	}
+
+	.wl-weight {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+
+	.wl-row-right {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 1px;
+		flex-shrink: 0;
+	}
+
+	.wl-change {
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.wl-up {
+		color: var(--terminal-status-success);
+	}
+
+	.wl-down {
+		color: var(--terminal-status-error);
+	}
+
+	.wl-price {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.wl-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 80px;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+	}
+
+	/* -- Search footer -- */
+	.wl-search {
+		flex-shrink: 0;
+		height: 28px;
+		border-top: var(--terminal-border-hairline);
+		position: relative;
+	}
+
+	.wl-search-input {
+		appearance: none;
+		width: 100%;
+		height: 100%;
+		padding: 0 var(--terminal-space-2);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-primary);
+		background: var(--terminal-bg-panel-sunken);
+		border: none;
+		outline: none;
+	}
+
+	.wl-search-input::placeholder {
+		color: var(--terminal-fg-muted);
+	}
+
+	.wl-search-input:focus {
+		box-shadow: inset 0 0 0 1px var(--terminal-accent-amber);
+	}
+
+	.wl-search-error {
+		position: absolute;
+		top: -20px;
+		left: var(--terminal-space-2);
+		font-size: 9px;
+		color: var(--terminal-status-error);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/Watchlist.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/Watchlist.svelte
@@ -11,9 +11,9 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { formatPercent, formatCurrency } from "@investintell/ui";
-	import type { MarketDataStore, PriceTick } from "$wealth/stores/market-data.svelte";
-	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
-	import { createClientApiClient } from "$wealth/api/client";
+	import type { MarketDataStore, PriceTick } from "../../../stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "../../../components/portfolio/live/workbench-state";
+	import { createClientApiClient } from "../../../api/client";
 
 	export interface WatchlistItem {
 		ticker: string;

--- a/packages/ii-terminal-core/src/lib/components/terminal/macro/CommitteeReviewFeed.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/macro/CommitteeReviewFeed.svelte
@@ -1,0 +1,127 @@
+<!--
+  CommitteeReviewFeed — scrollable feed of macro committee reviews.
+
+  Shows date, status badge, and truncated summary for each review.
+  Terminal tokens only.
+-->
+<script lang="ts">
+  import { formatDate } from "@investintell/ui/utils";
+
+  interface Review {
+    id: string;
+    status: string;
+    createdAt: string;
+    summary: string;
+  }
+
+  interface Props {
+    reviews: Review[];
+    onClickReview?: (id: string) => void;
+  }
+
+  let { reviews, onClickReview }: Props = $props();
+
+  const STATUS_COLORS: Record<string, string> = {
+    approved: "var(--terminal-status-success)",
+    pending: "var(--terminal-accent-amber)",
+    rejected: "var(--terminal-status-error)",
+  };
+
+  function statusColor(s: string): string {
+    return STATUS_COLORS[s] ?? "var(--terminal-fg-secondary)";
+  }
+
+  function truncate(text: string, max: number): string {
+    if (text.length <= max) return text;
+    return text.slice(0, max) + "\u2026";
+  }
+</script>
+
+<div class="cf-root">
+  {#each reviews as review (review.id)}
+    <button
+      type="button"
+      class="cf-card"
+      onclick={() => onClickReview?.(review.id)}
+    >
+      <div class="cf-card-header">
+        <span class="cf-date">{formatDate(new Date(review.createdAt), "medium")}</span>
+        <span class="cf-status" style:color={statusColor(review.status)} style:border-color={statusColor(review.status)}>
+          {review.status.toUpperCase()}
+        </span>
+      </div>
+      <p class="cf-summary">{truncate(review.summary, 200)}</p>
+    </button>
+  {:else}
+    <span class="cf-empty">No committee reviews</span>
+  {/each}
+</div>
+
+<style>
+  .cf-root {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-2);
+    overflow-y: auto;
+    height: 100%;
+    font-family: var(--terminal-font-mono);
+  }
+
+  .cf-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-1);
+    padding: var(--terminal-space-2) var(--terminal-space-3);
+    background: var(--terminal-bg-panel);
+    border: var(--terminal-border-hairline);
+    cursor: pointer;
+    text-align: left;
+    font-family: var(--terminal-font-mono);
+    transition: border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .cf-card:hover {
+    border-color: var(--terminal-accent-amber);
+  }
+
+  .cf-card:focus-visible {
+    outline: var(--terminal-border-focus);
+    outline-offset: -2px;
+  }
+
+  .cf-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--terminal-space-2);
+  }
+
+  .cf-date {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .cf-status {
+    font-size: var(--terminal-text-10);
+    font-weight: 600;
+    letter-spacing: var(--terminal-tracking-caps);
+    padding: 1px 4px;
+    border: 1px solid;
+  }
+
+  .cf-summary {
+    font-size: var(--terminal-text-11);
+    color: var(--terminal-fg-secondary);
+    line-height: var(--terminal-leading-normal);
+    margin: 0;
+  }
+
+  .cf-empty {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-muted);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    padding: var(--terminal-space-3);
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/macro/RegimeMatrix.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/macro/RegimeMatrix.svelte
@@ -1,0 +1,348 @@
+<!--
+	RegimeMatrix — 4x4 simulation grid (plan §B.4).
+
+	Rows = stress axis (top: LOW_STRESS → bottom: CRISIS).
+	Cols = growth axis (left: CONTRACTION → right: OVERHEAT).
+
+	The user drags the active pin into any cell to preview the regime
+	as-if. State is held in a page-local `MacroSimulationStore` — this
+	component never writes to the global `pinnedRegime` store, never
+	posts to the backend. Reset clears the simulation. A persistent
+	SIMULATION banner makes the mode unmistakable.
+
+	Accessibility: pointer drag primary; keyboard as fallback —
+	arrow keys move the simulation cell, Enter/Space commits, Escape
+	clears.
+-->
+<script lang="ts">
+	import {
+		STRESS_LABELS,
+		GROWTH_LABELS,
+		type RegimeCell,
+	} from "./macro-simulation-store.svelte";
+
+	interface Props {
+		/** The real regime label (e.g. "RISK_OFF"). Rendered as context. */
+		activeRegime: string;
+		/** Current simulated cell, or null for no simulation. */
+		simulatedCell: RegimeCell | null;
+		/** Called on any simulation change — drag drop, keyboard, or reset. */
+		onSimulate: (cell: RegimeCell | null) => void;
+	}
+
+	let { activeRegime, simulatedCell, onSimulate }: Props = $props();
+
+	const ROWS = STRESS_LABELS.length;
+	const COLS = GROWTH_LABELS.length;
+
+	let gridEl: HTMLDivElement | null = $state(null);
+	let draggingFrom = $state<RegimeCell | null>(null);
+	let hoverCell = $state<RegimeCell | null>(null);
+
+	const pinCell = $derived<RegimeCell>(simulatedCell ?? { row: 0, col: 0 });
+
+	function cellsEqual(a: RegimeCell, b: RegimeCell): boolean {
+		return a.row === b.row && a.col === b.col;
+	}
+
+	function handlePointerDownCell(row: number, col: number, event: PointerEvent) {
+		event.preventDefault();
+		draggingFrom = { row, col };
+		hoverCell = { row, col };
+		(event.target as HTMLElement).setPointerCapture(event.pointerId);
+	}
+
+	function handlePointerMove(event: PointerEvent) {
+		if (!draggingFrom || !gridEl) return;
+		const target = document.elementFromPoint(event.clientX, event.clientY);
+		const cellEl = target?.closest<HTMLElement>("[data-cell]");
+		if (!cellEl || !gridEl.contains(cellEl)) return;
+		const row = Number(cellEl.dataset.row);
+		const col = Number(cellEl.dataset.col);
+		if (Number.isFinite(row) && Number.isFinite(col)) {
+			hoverCell = { row, col };
+		}
+	}
+
+	function handlePointerUp() {
+		if (!draggingFrom) return;
+		// Tap or drag both commit the hovered cell; if the user never
+		// moved, hoverCell === draggingFrom so tap-to-simulate works.
+		const target = hoverCell ?? draggingFrom;
+		onSimulate(target);
+		draggingFrom = null;
+		hoverCell = null;
+	}
+
+	function handleReset() {
+		onSimulate(null);
+	}
+
+	function handleGridKeydown(event: KeyboardEvent) {
+		if (event.key === "Escape") {
+			if (simulatedCell) {
+				event.preventDefault();
+				onSimulate(null);
+			}
+			return;
+		}
+		const base = simulatedCell ?? { row: 0, col: 0 };
+		let next: RegimeCell | null = null;
+		switch (event.key) {
+			case "ArrowUp":
+				next = { row: Math.max(0, base.row - 1), col: base.col };
+				break;
+			case "ArrowDown":
+				next = { row: Math.min(ROWS - 1, base.row + 1), col: base.col };
+				break;
+			case "ArrowLeft":
+				next = { row: base.row, col: Math.max(0, base.col - 1) };
+				break;
+			case "ArrowRight":
+				next = { row: base.row, col: Math.min(COLS - 1, base.col + 1) };
+				break;
+			case "Enter":
+			case " ":
+				next = base;
+				break;
+			default:
+				return;
+		}
+		event.preventDefault();
+		onSimulate(next);
+	}
+</script>
+
+<div class="rm-root">
+	<header class="rm-header">
+		<span class="rm-title">REGIME MATRIX</span>
+		<span class="rm-context">ACTIVE {activeRegime}</span>
+		<button
+			type="button"
+			class="rm-reset"
+			onclick={handleReset}
+			disabled={simulatedCell === null}
+			aria-label="Reset regime simulation"
+		>
+			RESET
+		</button>
+	</header>
+
+	{#if simulatedCell}
+		<div class="rm-banner" role="status" aria-live="polite">
+			SIMULATION — DOES NOT PERSIST
+		</div>
+	{/if}
+
+	<div class="rm-axes">
+		<span class="rm-axis rm-axis--rows">STRESS ↓</span>
+		<span class="rm-axis rm-axis--cols">GROWTH →</span>
+	</div>
+
+	<div
+		bind:this={gridEl}
+		class="rm-grid"
+		role="grid"
+		aria-label="Regime simulation matrix"
+		tabindex="0"
+		onpointermove={handlePointerMove}
+		onpointerup={handlePointerUp}
+		onpointercancel={handlePointerUp}
+		onkeydown={handleGridKeydown}
+	>
+		{#each Array(ROWS) as _, r (r)}
+			<div class="rm-row" role="row">
+				{#each Array(COLS) as _, c (c)}
+					{@const isSim = simulatedCell !== null && cellsEqual(simulatedCell, { row: r, col: c })}
+					{@const isHover = hoverCell !== null && cellsEqual(hoverCell, { row: r, col: c })}
+					{@const isPinOrigin = simulatedCell === null && r === 0 && c === 0}
+					<button
+						type="button"
+						class="rm-cell"
+						class:rm-cell--sim={isSim}
+						class:rm-cell--hover={isHover}
+						class:rm-cell--origin={isPinOrigin}
+						data-cell="1"
+						data-row={r}
+						data-col={c}
+						role="gridcell"
+						aria-selected={isSim}
+						aria-label="Stress {STRESS_LABELS[r]} growth {GROWTH_LABELS[c]}"
+						onpointerdown={(e) => handlePointerDownCell(r, c, e)}
+					>
+						{#if isSim}
+							<span class="rm-pin" aria-hidden="true">●</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+		{/each}
+	</div>
+
+	<div class="rm-labels">
+		<span class="rm-label rm-label--stress-lo">{STRESS_LABELS[0]}</span>
+		<span class="rm-label rm-label--stress-hi">{STRESS_LABELS[ROWS - 1]}</span>
+		<span class="rm-label rm-label--growth-lo">{GROWTH_LABELS[0]}</span>
+		<span class="rm-label rm-label--growth-hi">{GROWTH_LABELS[COLS - 1]}</span>
+	</div>
+
+	{#if simulatedCell}
+		<footer class="rm-footer">
+			<span class="rm-sim-coords">
+				{STRESS_LABELS[pinCell.row]} · {GROWTH_LABELS[pinCell.col]}
+			</span>
+		</footer>
+	{/if}
+</div>
+
+<style>
+	.rm-root {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-3);
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.rm-header {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+	}
+	.rm-title {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-primary);
+		text-transform: uppercase;
+	}
+	.rm-context {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+		margin-left: auto;
+	}
+	.rm-reset {
+		padding: 2px var(--terminal-space-2);
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+		font-family: inherit;
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		cursor: pointer;
+	}
+	.rm-reset:disabled {
+		color: var(--terminal-fg-disabled);
+		border-color: var(--terminal-fg-disabled);
+		cursor: not-allowed;
+	}
+	.rm-reset:not(:disabled):hover {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+
+	.rm-banner {
+		padding: 2px var(--terminal-space-2);
+		background: var(--terminal-bg-panel-sunken);
+		border-left: 3px solid var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rm-axes {
+		display: flex;
+		justify-content: space-between;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.rm-grid {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: 2px;
+		background: var(--terminal-bg-panel-sunken);
+		touch-action: none;
+	}
+	.rm-grid:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.rm-row {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 2px;
+	}
+
+	.rm-cell {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		aspect-ratio: 1 / 1;
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-tertiary);
+		font-family: inherit;
+		font-size: var(--terminal-text-14);
+		cursor: grab;
+		transition:
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.rm-cell:active {
+		cursor: grabbing;
+	}
+	.rm-cell--origin {
+		border-color: var(--terminal-fg-secondary);
+	}
+	.rm-cell--hover {
+		border-color: var(--terminal-accent-amber);
+		background: var(--terminal-bg-panel-raised);
+	}
+	.rm-cell--sim {
+		border-color: var(--terminal-accent-amber);
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-accent-amber);
+	}
+	.rm-cell:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -1px;
+	}
+
+	.rm-pin {
+		color: var(--terminal-accent-amber);
+		font-size: var(--terminal-text-14);
+		line-height: 1;
+	}
+
+	.rm-labels {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+	.rm-label--stress-lo { grid-column: 1; }
+	.rm-label--stress-hi { grid-column: 2; text-align: right; }
+	.rm-label--growth-lo { grid-column: 1; }
+	.rm-label--growth-hi { grid-column: 2; text-align: right; }
+
+	.rm-footer {
+		display: flex;
+		justify-content: flex-end;
+	}
+	.rm-sim-coords {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-accent-amber);
+		letter-spacing: var(--terminal-tracking-caps);
+		font-variant-numeric: tabular-nums;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/macro/RegionalHealthTile.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/macro/RegionalHealthTile.svelte
@@ -1,0 +1,146 @@
+<!--
+  RegionalHealthTile — regional macro health tile for the macro desk.
+
+  Displays composite score and dimension progress bars for a single
+  region (US / EU / JP / EM). No regime badge. Terminal tokens only.
+-->
+<script lang="ts">
+  import { formatNumber } from "@investintell/ui/utils";
+
+  interface DimensionScore {
+    name: string;
+    score: number;
+  }
+
+  interface Props {
+    region: string;
+    compositeScore: number;
+    dimensions: DimensionScore[];
+  }
+
+  let { region, compositeScore, dimensions }: Props = $props();
+
+  const DIMENSION_LABELS: Record<string, string> = {
+    growth: "Growth",
+    inflation: "Inflation",
+    employment: "Employment",
+    financial_conditions: "Fin. Conditions",
+  };
+
+  function dimensionLabel(raw: string): string {
+    return DIMENSION_LABELS[raw] ?? raw.replace(/_/g, " ");
+  }
+</script>
+
+<div class="rht-root">
+  <div class="rht-header">
+    <span class="rht-region">{region}</span>
+  </div>
+
+  <div class="rht-score">
+    <span class="rht-score-value">{formatNumber(compositeScore, 0)}</span>
+    <span class="rht-score-unit">/100</span>
+  </div>
+
+  <div class="rht-dimensions">
+    {#each dimensions as dim (dim.name)}
+      <div class="rht-dim">
+        <span class="rht-dim-label">{dimensionLabel(dim.name)}</span>
+        <div class="rht-dim-bar">
+          <div class="rht-dim-fill" style:width="{Math.min(100, Math.max(0, dim.score))}%"></div>
+        </div>
+        <span class="rht-dim-value">{formatNumber(dim.score, 0)}</span>
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .rht-root {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-3);
+    padding: var(--terminal-space-3);
+    background: var(--terminal-bg-panel);
+    border: var(--terminal-border-hairline);
+    font-family: var(--terminal-font-mono);
+    height: 100%;
+  }
+
+  .rht-header {
+    display: flex;
+    align-items: center;
+  }
+
+  .rht-region {
+    font-size: var(--terminal-text-12);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-primary);
+  }
+
+  .rht-score {
+    display: flex;
+    align-items: baseline;
+    gap: 2px;
+  }
+
+  .rht-score-value {
+    font-size: var(--terminal-text-24);
+    font-weight: 700;
+    color: var(--terminal-accent-amber);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .rht-score-unit {
+    font-size: var(--terminal-text-11);
+    color: var(--terminal-fg-tertiary);
+  }
+
+  .rht-dimensions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-2);
+  }
+
+  .rht-dim {
+    display: grid;
+    grid-template-columns: 90px 1fr 24px;
+    align-items: center;
+    gap: var(--terminal-space-2);
+  }
+
+  .rht-dim-label {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-secondary);
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .rht-dim-bar {
+    height: 4px;
+    background: var(--terminal-fg-muted);
+    position: relative;
+  }
+
+  .rht-dim-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: var(--terminal-accent-amber);
+    transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+  }
+
+  .rht-dim-value {
+    font-size: var(--terminal-text-10);
+    font-weight: 600;
+    color: var(--terminal-fg-secondary);
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/macro/SignalBreakdown.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/macro/SignalBreakdown.svelte
@@ -1,0 +1,209 @@
+<!--
+  SignalBreakdown — two-column signal panel for regime stress decomposition.
+
+  Left: financial signals. Right: real economy signals.
+  Each row shows label, raw value, stress bar, and weight amplification.
+  Terminal tokens only. No hex. No radius.
+-->
+<script lang="ts">
+  import { formatNumber } from "@investintell/ui/utils";
+
+  interface RegimeSignalRead {
+    key: string;
+    label: string;
+    raw_value: number | null;
+    unit: string;
+    stress_score: number;
+    weight_base: number;
+    weight_effective: number;
+    category: "financial" | "real_economy";
+    fred_series: string | null;
+  }
+
+  interface Props {
+    signals: RegimeSignalRead[];
+  }
+
+  let { signals }: Props = $props();
+
+  const financialSignals = $derived(
+    signals
+      .filter((s) => s.category === "financial")
+      .sort((a, b) => b.weight_effective - a.weight_effective),
+  );
+
+  const realEconSignals = $derived(
+    signals
+      .filter((s) => s.category === "real_economy")
+      .sort((a, b) => b.weight_effective - a.weight_effective),
+  );
+
+  function stressColor(score: number): string {
+    if (score < 33) return "var(--terminal-status-ok, var(--terminal-status-success))";
+    if (score < 66) return "var(--terminal-accent-amber)";
+    return "var(--terminal-status-error)";
+  }
+
+  function formatRawValue(value: number | null, unit: string): string {
+    if (value == null) return "--";
+    const formatted = formatNumber(value, 2);
+    if (unit === "%") return formatted + "%";
+    if (unit) return formatted + unit;
+    return formatted;
+  }
+
+  function weightColor(base: number, effective: number): string {
+    if (effective > base * 1.2) return "var(--terminal-accent-amber)";
+    return "var(--terminal-fg-muted)";
+  }
+</script>
+
+<div class="sb-root">
+  <div class="sb-column">
+    <span class="sb-column-header">FINANCIAL SIGNALS ({financialSignals.length})</span>
+    {#each financialSignals as sig (sig.key)}
+      {@const color = stressColor(sig.stress_score)}
+      <div class="sb-row">
+        <div class="sb-row-top">
+          <span class="sb-label">{sig.label.toUpperCase()}</span>
+          <span class="sb-value">{formatRawValue(sig.raw_value, sig.unit)}</span>
+          <span class="sb-stress" style:color={color}>{formatNumber(sig.stress_score, 0)}/100</span>
+        </div>
+        <div class="sb-row-bottom">
+          <div class="sb-bar">
+            <div
+              class="sb-bar-fill"
+              style:width="{Math.min(100, Math.max(0, sig.stress_score))}%"
+              style:background={color}
+            ></div>
+          </div>
+          <span class="sb-weight" style:color={weightColor(sig.weight_base, sig.weight_effective)}>
+            w: {formatNumber(sig.weight_base, 2)} &rarr; {formatNumber(sig.weight_effective, 2)}
+          </span>
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  <div class="sb-column">
+    <span class="sb-column-header">REAL ECONOMY SIGNALS ({realEconSignals.length})</span>
+    {#each realEconSignals as sig (sig.key)}
+      {@const color = stressColor(sig.stress_score)}
+      <div class="sb-row">
+        <div class="sb-row-top">
+          <span class="sb-label">{sig.label.toUpperCase()}</span>
+          <span class="sb-value">{formatRawValue(sig.raw_value, sig.unit)}</span>
+          <span class="sb-stress" style:color={color}>{formatNumber(sig.stress_score, 0)}/100</span>
+        </div>
+        <div class="sb-row-bottom">
+          <div class="sb-bar">
+            <div
+              class="sb-bar-fill"
+              style:width="{Math.min(100, Math.max(0, sig.stress_score))}%"
+              style:background={color}
+            ></div>
+          </div>
+          <span class="sb-weight" style:color={weightColor(sig.weight_base, sig.weight_effective)}>
+            w: {formatNumber(sig.weight_base, 2)} &rarr; {formatNumber(sig.weight_effective, 2)}
+          </span>
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .sb-root {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--terminal-space-4);
+    padding: var(--terminal-space-3);
+    background: var(--terminal-bg-panel);
+    border: var(--terminal-border-hairline);
+    font-family: var(--terminal-font-mono);
+    flex-shrink: 0;
+  }
+
+  .sb-column {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-3);
+  }
+
+  .sb-column-header {
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    color: var(--terminal-fg-tertiary);
+    text-transform: uppercase;
+    padding-bottom: var(--terminal-space-1);
+    border-bottom: var(--terminal-border-hairline);
+  }
+
+  .sb-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .sb-row-top {
+    display: flex;
+    align-items: baseline;
+    gap: var(--terminal-space-2);
+  }
+
+  .sb-label {
+    width: 120px;
+    flex-shrink: 0;
+    font-size: var(--terminal-text-10);
+    font-weight: 600;
+    letter-spacing: var(--terminal-tracking-caps);
+    color: var(--terminal-fg-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .sb-value {
+    flex: 1;
+    text-align: right;
+    font-size: var(--terminal-text-11);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--terminal-fg-primary);
+  }
+
+  .sb-stress {
+    flex-shrink: 0;
+    font-size: var(--terminal-text-10);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .sb-row-bottom {
+    display: flex;
+    align-items: center;
+    gap: var(--terminal-space-2);
+  }
+
+  .sb-bar {
+    flex: 1;
+    height: 4px;
+    background: var(--terminal-fg-muted);
+    position: relative;
+  }
+
+  .sb-bar-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+  }
+
+  .sb-weight {
+    flex-shrink: 0;
+    font-size: var(--terminal-text-10);
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/macro/SparklineWall.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/macro/SparklineWall.svelte
@@ -1,0 +1,216 @@
+<!--
+	SparklineWall — grid of macro indicator mini sparklines.
+
+	Each cell: indicator name, latest FRED value + REST-origin trend
+	arrow, and the 12-month mini sparkline rendered via the shared
+	TerminalMiniSparkline primitive. Indicators with a Tiingo proxy
+	(VIXCLS→VXX, DTWEXBGS→UUP, DGS10→IEF) surface an additional
+	"LIVE" pill — the proxy tick is NOT merged into the sparkline,
+	because the series units don't line up (see macro-sparkline-
+	adapter.ts header). The FRED number stays authoritative; the
+	proxy is a freshness signal.
+-->
+<script lang="ts">
+	import { getContext, onDestroy } from "svelte";
+	import {
+		TerminalMiniSparkline,
+		formatNumber,
+	} from "@investintell/ui";
+	import type { MarketDataStore } from "$wealth/stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
+	import {
+		proxyFor,
+		PROXY_SYMBOLS,
+	} from "./macro-sparkline-adapter";
+
+	export interface MacroIndicator {
+		/** Optional FRED series id — required for Tiingo proxy lookup. */
+		seriesId?: string;
+		name: string;
+		currentValue: number;
+		previousValue: number;
+		history: Array<{ date: string; value: number }>;
+		unit: string;
+	}
+
+	interface Props {
+		indicators: MacroIndicator[];
+	}
+
+	let { indicators }: Props = $props();
+
+	const marketData = getContext<MarketDataStore | undefined>(
+		TERMINAL_MARKET_DATA_KEY,
+	);
+
+	// Subscribe once for the three proxy symbols. MarketDataStore
+	// dedupes existing subscriptions, so this is safe even when
+	// another page (e.g. /portfolio/live) has already subscribed.
+	let subscribedOnMount = false;
+	$effect(() => {
+		if (!marketData || subscribedOnMount) return;
+		marketData.subscribe([...PROXY_SYMBOLS]);
+		subscribedOnMount = true;
+	});
+	onDestroy(() => {
+		// Let the store manage refcount — we only unsubscribe the
+		// symbols we added. If another consumer still needs them,
+		// MarketDataStore keeps them live.
+		marketData?.unsubscribe([...PROXY_SYMBOLS]);
+	});
+
+	function trendArrow(current: number, previous: number): string {
+		if (current > previous) return "\u25B2";
+		if (current < previous) return "\u25BC";
+		return "\u25C6";
+	}
+
+	function trendColor(current: number, previous: number): string {
+		if (current > previous) return "var(--terminal-status-success)";
+		if (current < previous) return "var(--terminal-status-error)";
+		return "var(--terminal-fg-secondary)";
+	}
+
+	function formatUnit(value: number, unit: string): string {
+		if (unit === "%") return formatNumber(value, 1) + "%";
+		if (unit === "bps") return formatNumber(value, 0) + " bps";
+		if (unit === "idx") return formatNumber(value, 1);
+		return formatNumber(value, 2);
+	}
+
+	function liveProxyPrice(seriesId: string | undefined): number | null {
+		if (!seriesId || !marketData) return null;
+		const symbol = proxyFor(seriesId);
+		if (!symbol) return null;
+		return marketData.priceMap.get(symbol)?.price ?? null;
+	}
+
+	function sparklineValues(history: MacroIndicator["history"]): number[] {
+		return history.map((pt) => pt.value);
+	}
+</script>
+
+<div class="sw-root">
+	{#each indicators as ind (ind.name)}
+		{@const livePx = liveProxyPrice(ind.seriesId)}
+		<div class="sw-cell" class:sw-cell--live={livePx !== null}>
+			<div class="sw-meta">
+				<div class="sw-name-row">
+					<span class="sw-name">{ind.name}</span>
+					{#if livePx !== null}
+						<span class="sw-live" title="Live proxy tick — not merged into sparkline">
+							LIVE
+						</span>
+					{/if}
+				</div>
+				<div class="sw-value-row">
+					<span class="sw-value">{formatUnit(ind.currentValue, ind.unit)}</span>
+					<span class="sw-arrow" style:color={trendColor(ind.currentValue, ind.previousValue)}>
+						{trendArrow(ind.currentValue, ind.previousValue)}
+					</span>
+				</div>
+				{#if livePx !== null && ind.seriesId}
+					<span class="sw-proxy">
+						{proxyFor(ind.seriesId)} {formatNumber(livePx, 2)}
+					</span>
+				{/if}
+			</div>
+			{#if ind.history.length > 1}
+				<div class="sw-chart">
+					<TerminalMiniSparkline
+						data={sparklineValues(ind.history)}
+						width={120}
+						height={28}
+						ariaLabel="{ind.name} sparkline"
+					/>
+				</div>
+			{/if}
+		</div>
+	{/each}
+</div>
+
+<style>
+	.sw-root {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: var(--terminal-space-2);
+		font-family: var(--terminal-font-mono);
+		width: 100%;
+	}
+
+	.sw-cell {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		padding: var(--terminal-space-2);
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+	}
+	.sw-cell--live {
+		border-color: var(--terminal-accent-amber-dim);
+	}
+
+	.sw-meta {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.sw-name-row {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+	}
+
+	.sw-name {
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.sw-live {
+		padding: 0 4px;
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-accent-amber);
+		border: 1px solid var(--terminal-accent-amber);
+		line-height: 1.4;
+	}
+
+	.sw-value-row {
+		display: flex;
+		align-items: baseline;
+		gap: var(--terminal-space-1);
+	}
+
+	.sw-value {
+		font-size: var(--terminal-text-12);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.sw-arrow {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+	}
+
+	.sw-proxy {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-accent-amber);
+		font-variant-numeric: tabular-nums;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.sw-chart {
+		display: flex;
+		justify-content: flex-start;
+		min-height: 0;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/macro/SparklineWall.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/macro/SparklineWall.svelte
@@ -16,8 +16,8 @@
 		TerminalMiniSparkline,
 		formatNumber,
 	} from "@investintell/ui";
-	import type { MarketDataStore } from "$wealth/stores/market-data.svelte";
-	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
+	import type { MarketDataStore } from "../../../stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "../../../components/portfolio/live/workbench-state";
 	import {
 		proxyFor,
 		PROXY_SYMBOLS,

--- a/packages/ii-terminal-core/src/lib/components/terminal/macro/StressHero.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/macro/StressHero.svelte
@@ -1,0 +1,251 @@
+<!--
+  StressHero — full-width stress score banner for the macro desk.
+
+  Displays global regime stress score as a horizontal bar with
+  dynamic weight category breakdown and regime pin/proceed actions.
+  Terminal tokens only. No hex. No radius.
+-->
+<script lang="ts">
+  import { formatNumber, formatShortDate } from "@investintell/ui/utils";
+
+  interface Props {
+    stressScore: number;
+    regimeLabel: string;
+    asOfDate: string;
+    financialEffWeight: number;
+    realEconEffWeight: number;
+    isPinned: boolean;
+    onPin: () => void;
+    onUnpin: () => void;
+    onProceedToAlloc: () => void;
+  }
+
+  let {
+    stressScore,
+    regimeLabel,
+    asOfDate,
+    financialEffWeight,
+    realEconEffWeight,
+    isPinned,
+    onPin,
+    onUnpin,
+    onProceedToAlloc,
+  }: Props = $props();
+
+  function stressColor(score: number): string {
+    if (score < 33) return "var(--terminal-status-ok, var(--terminal-status-success))";
+    if (score < 66) return "var(--terminal-accent-amber)";
+    return "var(--terminal-status-error)";
+  }
+
+  const fillColor = $derived(stressColor(stressScore));
+  const fillPct = $derived(Math.min(100, Math.max(0, stressScore)));
+
+  const financialPct = $derived(
+    financialEffWeight + realEconEffWeight > 0
+      ? formatNumber((financialEffWeight / (financialEffWeight + realEconEffWeight)) * 100, 0)
+      : "0"
+  );
+
+  const realEconPct = $derived(
+    financialEffWeight + realEconEffWeight > 0
+      ? formatNumber((realEconEffWeight / (financialEffWeight + realEconEffWeight)) * 100, 0)
+      : "0"
+  );
+</script>
+
+<div class="sh-root">
+  <div class="sh-top">
+    <div class="sh-score-group">
+      <span class="sh-score" style:color={fillColor}>{formatNumber(stressScore, 0)}</span>
+      <span class="sh-regime">{regimeLabel.toUpperCase()}</span>
+    </div>
+    <span class="sh-date">as of {formatShortDate(new Date(asOfDate))}</span>
+  </div>
+
+  <div class="sh-bar-wrap">
+    <div class="sh-bar">
+      <div class="sh-bar-fill" style:width="{fillPct}%" style:background={fillColor}></div>
+    </div>
+    <div class="sh-bar-ticks">
+      <div class="sh-tick" style:left="33%"></div>
+      <div class="sh-tick" style:left="66%"></div>
+    </div>
+    <span class="sh-bar-label">/100</span>
+  </div>
+
+  <div class="sh-bottom">
+    <div class="sh-weights">
+      <span class="sh-weight">FINANCIAL {financialPct}%</span>
+      <span class="sh-weight">REAL ECONOMY {realEconPct}%</span>
+    </div>
+    <div class="sh-actions">
+      {#if isPinned}
+        <button type="button" class="sh-btn sh-btn--active" onclick={onUnpin}>UNPIN</button>
+      {:else}
+        <button type="button" class="sh-btn" onclick={onPin}>PIN REGIME</button>
+      {/if}
+      <button type="button" class="sh-btn sh-btn--proceed" onclick={onProceedToAlloc}>
+        PROCEED TO BUILDER &rarr;
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .sh-root {
+    display: flex;
+    flex-direction: column;
+    gap: var(--terminal-space-2);
+    padding: var(--terminal-space-3) var(--terminal-space-4);
+    background: var(--terminal-bg-panel);
+    border: var(--terminal-border-hairline);
+    font-family: var(--terminal-font-mono);
+    flex-shrink: 0;
+  }
+
+  .sh-top {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+
+  .sh-score-group {
+    display: flex;
+    align-items: baseline;
+    gap: var(--terminal-space-3);
+  }
+
+  .sh-score {
+    font-size: 32px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+
+  .sh-regime {
+    font-size: var(--terminal-text-16, 16px);
+    font-weight: 700;
+    letter-spacing: var(--terminal-tracking-caps);
+    color: var(--terminal-fg-primary);
+  }
+
+  .sh-date {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-muted);
+    letter-spacing: var(--terminal-tracking-caps);
+  }
+
+  .sh-bar-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: var(--terminal-space-2);
+  }
+
+  .sh-bar {
+    flex: 1;
+    height: 6px;
+    background: var(--terminal-fg-muted);
+    position: relative;
+  }
+
+  .sh-bar-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    transition: width var(--terminal-motion-update) var(--terminal-motion-easing-out);
+  }
+
+  .sh-bar-ticks {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 40px;
+    height: 6px;
+    pointer-events: none;
+  }
+
+  .sh-tick {
+    position: absolute;
+    top: -2px;
+    width: 1px;
+    height: 10px;
+    background: var(--terminal-fg-tertiary);
+  }
+
+  .sh-bar-label {
+    font-size: var(--terminal-text-10);
+    color: var(--terminal-fg-muted);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+
+  .sh-bottom {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .sh-weights {
+    display: flex;
+    gap: var(--terminal-space-4);
+  }
+
+  .sh-weight {
+    font-size: var(--terminal-text-10);
+    font-weight: 600;
+    letter-spacing: var(--terminal-tracking-caps);
+    color: var(--terminal-fg-tertiary);
+  }
+
+  .sh-actions {
+    display: flex;
+    gap: var(--terminal-space-2);
+  }
+
+  .sh-btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px var(--terminal-space-2);
+    background: transparent;
+    border: var(--terminal-border-hairline);
+    border-radius: 0;
+    font-family: var(--terminal-font-mono);
+    font-size: var(--terminal-text-10);
+    font-weight: 600;
+    letter-spacing: var(--terminal-tracking-caps);
+    text-transform: uppercase;
+    color: var(--terminal-fg-secondary);
+    cursor: pointer;
+    transition:
+      border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+      color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+  }
+
+  .sh-btn:hover {
+    border-color: var(--terminal-accent-amber);
+    color: var(--terminal-accent-amber);
+  }
+
+  .sh-btn--active {
+    border-color: var(--terminal-accent-cyan);
+    color: var(--terminal-accent-cyan);
+  }
+
+  .sh-btn--active:hover {
+    border-color: var(--terminal-status-error);
+    color: var(--terminal-status-error);
+  }
+
+  .sh-btn--proceed {
+    border-color: var(--terminal-accent-cyan);
+    color: var(--terminal-accent-cyan);
+  }
+
+  .sh-btn--proceed:hover {
+    border-color: var(--terminal-fg-primary);
+    color: var(--terminal-fg-primary);
+  }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/macro/macro-simulation-store.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/components/terminal/macro/macro-simulation-store.svelte.ts
@@ -1,0 +1,78 @@
+/**
+ * Page-scoped macro regime simulation store.
+ *
+ * Deliberately isolated under `lib/components/terminal/macro/` (NOT
+ * `$wealth/state/*`) per plan §M5 so that importing it from anywhere
+ * else in the app is visibly wrong in code review — the simulation
+ * must never leak into `pinnedRegime` (which is the global TopNav
+ * indicator) or into any backend call.
+ *
+ * Zero persistence. Zero network. In-memory `$state` only. Reload
+ * resets the matrix to "no simulation."
+ */
+
+export interface RegimeCell {
+	/** 0-indexed row (stress axis). */
+	row: number;
+	/** 0-indexed column (growth axis). */
+	col: number;
+}
+
+export interface MacroSimulationStore {
+	readonly cell: RegimeCell | null;
+	readonly label: string | null;
+	setCell(next: RegimeCell | null): void;
+	reset(): void;
+}
+
+/**
+ * Canonical 4x4 regime grid labels.
+ *
+ * Rows (top → bottom) climb in stress: LOW_STRESS, NORMAL, ELEVATED,
+ * CRISIS. Cols (left → right) traverse growth: CONTRACTION, SLOWDOWN,
+ * EXPANSION, OVERHEAT. The intersection is the simulated regime.
+ *
+ * Labels are derived, never authored — UI reads from here to avoid
+ * drift between the pin label on the Hero and the tooltip on the
+ * matrix cell.
+ */
+export const STRESS_LABELS = [
+	"LOW_STRESS",
+	"NORMAL",
+	"ELEVATED",
+	"CRISIS",
+] as const;
+
+export const GROWTH_LABELS = [
+	"CONTRACTION",
+	"SLOWDOWN",
+	"EXPANSION",
+	"OVERHEAT",
+] as const;
+
+export function labelFor(cell: RegimeCell): string {
+	const stress = STRESS_LABELS[cell.row] ?? "UNKNOWN";
+	const growth = GROWTH_LABELS[cell.col] ?? "UNKNOWN";
+	return `${stress} · ${growth}`;
+}
+
+export function createMacroSimulationStore(): MacroSimulationStore {
+	let cell = $state<RegimeCell | null>(null);
+
+	const label = $derived(cell ? labelFor(cell) : null);
+
+	return {
+		get cell() {
+			return cell;
+		},
+		get label() {
+			return label;
+		},
+		setCell(next: RegimeCell | null) {
+			cell = next;
+		},
+		reset() {
+			cell = null;
+		},
+	};
+}

--- a/packages/ii-terminal-core/src/lib/components/terminal/macro/macro-sparkline-adapter.ts
+++ b/packages/ii-terminal-core/src/lib/components/terminal/macro/macro-sparkline-adapter.ts
@@ -1,0 +1,47 @@
+/**
+ * FRED series → Tiingo proxy symbol map (plan §B.3).
+ *
+ * Only series where a liquid, continuously-quoted ETF proxy exists
+ * are mapped. Everything else stays REST-only — the 5-min FRED poll
+ * remains the authoritative source for the macro indicator.
+ *
+ * IMPORTANT — the proxy is NOT unit-equivalent to the FRED series:
+ *  - VIXCLS (spot VIX index) ≈ VXX (S&P500 VIX Short-Term ETF). VXX
+ *    has roll-yield decay; the sparkline number is NOT the VIX.
+ *  - DTWEXBGS (Fed broad trade-weighted dollar index) ≠ UUP (USD vs
+ *    6-currency basket ETF). Directionally correlated, absolutely
+ *    different scale.
+ *  - DGS10 (10-year Treasury yield, %) vs IEF (7-10yr Treasury ETF
+ *    price, USD). Inversely correlated — an IEF price tick UP is a
+ *    DGS10 yield tick DOWN.
+ *
+ * Therefore the consumer (SparklineWall) uses proxy data ONLY for a
+ * "LIVE" badge + timestamp surface, never to replace the FRED value
+ * or to append into the historical sparkline array. The underlying
+ * macro number stays canonical; the proxy is a freshness signal.
+ */
+
+const SERIES_TO_SYMBOL: Record<string, string> = {
+	VIXCLS: "VXX",
+	DTWEXBGS: "UUP",
+	DGS10: "IEF",
+};
+
+export function proxyFor(seriesId: string): string | null {
+	return SERIES_TO_SYMBOL[seriesId] ?? null;
+}
+
+/**
+ * Reverse lookup — which FRED series does a Tiingo symbol proxy?
+ * Used by `SparklineWall` to route incoming WS ticks back to the
+ * right indicator cell without re-scanning the full mapping.
+ */
+export function seriesForProxy(symbol: string): string | null {
+	const upper = symbol.toUpperCase();
+	for (const [series, proxy] of Object.entries(SERIES_TO_SYMBOL)) {
+		if (proxy === upper) return series;
+	}
+	return null;
+}
+
+export const PROXY_SYMBOLS: readonly string[] = Object.values(SERIES_TO_SYMBOL);

--- a/packages/ii-terminal-core/src/lib/components/terminal/runtime/stream.ts
+++ b/packages/ii-terminal-core/src/lib/components/terminal/runtime/stream.ts
@@ -1,0 +1,283 @@
+/**
+ * createTerminalStream — unified SSE runtime primitive for (terminal)/.
+ * ====================================================================
+ *
+ * Source of truth: docs/plans/2026-04-11-terminal-unification-master-plan.md
+ *   §Appendix G (runtime/stream.ts), §2 rule 7 (no browser-native SSE API).
+ *
+ * Every streaming surface inside (terminal)/ — construction runs, live
+ * prices, alerts, drift events, macro flashes — consumes this factory.
+ * One primitive, one reconnect policy, one SSR contract.
+ *
+ * Why handroll SSE framing? The browser-native SSE API cannot carry
+ * custom headers, and Clerk JWT must travel in the Authorization
+ * header. We use fetch() + ReadableStream and parse SSE frames by
+ * hand so auth headers ride along.
+ *
+ * Why not @investintell/ui's createSSEStream? That one is a
+ * Svelte-aware runes-based helper that accumulates events into a
+ * $state array. The terminal runtime needs a leaner, framework-free
+ * factory whose handle is safe to hold inside a $effect closure
+ * without creating a reactive dependency on every incoming frame.
+ */
+
+export interface TerminalStreamOptions<T> {
+	url: string;
+	onMessage: (event: T) => void;
+	onError?: (error: Error) => void;
+	onOpen?: () => void;
+	onClose?: () => void;
+	headers?: Record<string, string>;
+	signal?: AbortSignal;
+	reconnect?: boolean;
+	maxReconnectDelayMs?: number;
+	initialReconnectDelayMs?: number;
+}
+
+export type TerminalStreamStatus = "connecting" | "open" | "closed" | "error";
+
+export interface TerminalStreamHandle {
+	readonly status: TerminalStreamStatus;
+	readonly lastEventAt: number | null;
+	close(): void;
+}
+
+const DEFAULT_INITIAL_DELAY = 1_000;
+const DEFAULT_MAX_DELAY = 30_000;
+const JITTER_SPREAD_MS = 400;
+
+/**
+ * Build a terminal SSE handle. On the server the factory returns a
+ * frozen no-op handle so callers can invoke it from a component body
+ * without guarding on `typeof window`; the real connection is mounted
+ * by the caller's $effect on the client.
+ */
+export function createTerminalStream<T>(
+	options: TerminalStreamOptions<T>,
+): TerminalStreamHandle {
+	if (typeof window === "undefined") {
+		return Object.freeze({
+			get status(): TerminalStreamStatus {
+				return "closed";
+			},
+			get lastEventAt(): number | null {
+				return null;
+			},
+			close() {
+				/* no-op on server */
+			},
+		});
+	}
+
+	const reconnectEnabled = options.reconnect !== false;
+	const initialDelayMs = options.initialReconnectDelayMs ?? DEFAULT_INITIAL_DELAY;
+	const maxDelayMs = options.maxReconnectDelayMs ?? DEFAULT_MAX_DELAY;
+
+	let status: TerminalStreamStatus = "connecting";
+	let lastEventAt: number | null = null;
+	let reconnectAttempt = 0;
+	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	let abortController: AbortController | null = null;
+	let explicitlyClosed = false;
+
+	const upstreamSignal = options.signal;
+	const upstreamAbortHandler = () => {
+		explicitlyClosed = true;
+		teardown();
+		status = "closed";
+	};
+	if (upstreamSignal) {
+		if (upstreamSignal.aborted) {
+			explicitlyClosed = true;
+			status = "closed";
+			return Object.freeze({
+				get status() {
+					return status;
+				},
+				get lastEventAt() {
+					return lastEventAt;
+				},
+				close() {
+					/* already closed */
+				},
+			});
+		}
+		upstreamSignal.addEventListener("abort", upstreamAbortHandler, { once: true });
+	}
+
+	function teardown() {
+		if (reconnectTimer !== null) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+		}
+		if (abortController !== null) {
+			abortController.abort();
+			abortController = null;
+		}
+	}
+
+	function dispatchError(err: unknown) {
+		if (explicitlyClosed) return;
+		const wrapped =
+			err instanceof Error ? err : new Error(typeof err === "string" ? err : "stream error");
+		status = "error";
+		try {
+			options.onError?.(wrapped);
+		} catch {
+			/* swallow consumer errors so the stream does not crash the page */
+		}
+	}
+
+	function scheduleReconnect() {
+		if (!reconnectEnabled || explicitlyClosed) {
+			status = "closed";
+			try {
+				options.onClose?.();
+			} catch {
+				/* swallow */
+			}
+			return;
+		}
+		/* exponential backoff — see Stability Guardrails P6 fault-tolerant principle */
+		const base = Math.min(initialDelayMs * Math.pow(2, reconnectAttempt), maxDelayMs);
+		const jitter = (Math.random() - 0.5) * JITTER_SPREAD_MS;
+		const delay = Math.max(0, base + jitter);
+		reconnectAttempt += 1;
+		status = "connecting";
+		reconnectTimer = setTimeout(() => {
+			reconnectTimer = null;
+			void connect();
+		}, delay);
+	}
+
+	async function connect() {
+		if (explicitlyClosed) return;
+		abortController = new AbortController();
+
+		const headers: Record<string, string> = {
+			Accept: "text/event-stream",
+			...(options.headers ?? {}),
+		};
+
+		try {
+			const response = await fetch(options.url, {
+				method: "GET",
+				headers,
+				credentials: "include",
+				signal: abortController.signal,
+			});
+
+			if (!response.ok) {
+				throw new Error(`stream http ${response.status}`);
+			}
+			if (!response.body) {
+				throw new Error("stream missing body");
+			}
+
+			status = "open";
+			reconnectAttempt = 0;
+			try {
+				options.onOpen?.();
+			} catch {
+				/* swallow */
+			}
+
+			const reader = response.body.getReader();
+			const decoder = new TextDecoder("utf-8");
+			let buffer = "";
+
+			while (true) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+				buffer = drainFrames(buffer);
+			}
+
+			// Stream closed by server — attempt reconnect unless caller closed us.
+			if (!explicitlyClosed) {
+				scheduleReconnect();
+			} else {
+				status = "closed";
+			}
+		} catch (err) {
+			if (explicitlyClosed) {
+				status = "closed";
+				return;
+			}
+			if ((err as { name?: string })?.name === "AbortError") {
+				status = "closed";
+				return;
+			}
+			dispatchError(err);
+			scheduleReconnect();
+		}
+	}
+
+	function drainFrames(buffer: string): string {
+		let remaining = buffer;
+		while (true) {
+			const terminator = remaining.indexOf("\n\n");
+			if (terminator === -1) return remaining;
+			const frame = remaining.slice(0, terminator);
+			remaining = remaining.slice(terminator + 2);
+			handleFrame(frame);
+		}
+	}
+
+	function handleFrame(frame: string) {
+		if (frame.length === 0) return;
+		const lines = frame.split(/\r?\n/);
+		const dataLines: string[] = [];
+		for (const line of lines) {
+			if (line.length === 0) continue;
+			if (line.startsWith(":")) continue; // comment / heartbeat
+			if (line.startsWith("data:")) {
+				dataLines.push(line.slice(5).replace(/^\s/, ""));
+			}
+			// `event:` / `id:` / `retry:` are tolerated but ignored; the
+			// terminal runtime carries event type inside the JSON payload.
+		}
+		if (dataLines.length === 0) return;
+		const raw = dataLines.join("\n");
+		let parsed: T;
+		try {
+			parsed = JSON.parse(raw) as T;
+		} catch (err) {
+			dispatchError(err);
+			return;
+		}
+		lastEventAt = Date.now();
+		try {
+			options.onMessage(parsed);
+		} catch (err) {
+			dispatchError(err);
+		}
+	}
+
+	void connect();
+
+	const handle: TerminalStreamHandle = Object.freeze({
+		get status() {
+			return status;
+		},
+		get lastEventAt() {
+			return lastEventAt;
+		},
+		close() {
+			if (explicitlyClosed) return;
+			explicitlyClosed = true;
+			teardown();
+			if (upstreamSignal) {
+				upstreamSignal.removeEventListener("abort", upstreamAbortHandler);
+			}
+			status = "closed";
+			try {
+				options.onClose?.();
+			} catch {
+				/* swallow */
+			}
+		},
+	});
+
+	return handle;
+}

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/AlertTicker.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/AlertTicker.svelte
@@ -27,7 +27,7 @@
 	import {
 		createTerminalStream,
 		type TerminalStreamHandle,
-	} from "$wealth/components/terminal/runtime/stream";
+	} from "../../../components/terminal/runtime/stream";
 
 	type AlertSeverity = "info" | "warn" | "error" | "critical";
 

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/AlertTicker.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/AlertTicker.svelte
@@ -1,0 +1,261 @@
+<!--
+	AlertTicker.svelte — streaming alert marquee primitive.
+	=======================================================
+
+	Source of truth: docs/plans/2026-04-11-terminal-unification-master-plan.md
+		§1.4 TerminalShell, Phase 5 alerts stream.
+
+	Horizontal marquee of the 5 most recent portfolio alerts. Mounts
+	inside TerminalStatusBar's ticker snippet slot. When a `streamUrl`
+	prop is provided, subscribes via `createTerminalStream` and
+	coalesces events into a reactive snapshot via
+	`createTickBuffer` from @investintell/ui/runtime (satisfies the
+	Stability Guardrails P2 Batched requirement). When omitted, the
+	ticker renders a STANDBY placeholder.
+
+	Part C scope: TerminalShell passes `streamUrl=undefined` because
+	the backend `/alerts/stream` endpoint is Phase 5 territory. The
+	component is ready to consume the stream the moment that endpoint
+	ships — no further changes required.
+-->
+<script lang="ts">
+	import { onDestroy } from "svelte";
+	import {
+		createTickBuffer,
+		type TickBuffer,
+	} from "@investintell/ui/runtime";
+	import {
+		createTerminalStream,
+		type TerminalStreamHandle,
+	} from "$wealth/components/terminal/runtime/stream";
+
+	type AlertSeverity = "info" | "warn" | "error" | "critical";
+
+	interface AlertEvent {
+		id: string;
+		severity: AlertSeverity;
+		title: string;
+		/** ISO 8601 timestamp emitted by the backend. */
+		timestamp: string;
+	}
+
+	interface AlertTickerProps {
+		/**
+		 * URL of the SSE endpoint. Optional — when omitted (Part C
+		 * default), the component renders a static STANDBY state
+		 * without subscribing. Phase 5 wires this to
+		 * `/alerts/stream` when the backend endpoint ships.
+		 */
+		streamUrl?: string;
+	}
+
+	let { streamUrl }: AlertTickerProps = $props();
+
+	const MAX_EVENTS = 5;
+
+	// Coalesce incoming alerts into a bounded reactive snapshot.
+	// Last-write-wins per alert id so backend replays do not explode
+	// the buffer. Interval clock at 500 ms gives a human-legible
+	// cadence without burning raf budget — tickers do not need 60fps.
+	const buffer: TickBuffer<AlertEvent> = createTickBuffer<AlertEvent>({
+		keyOf: (evt) => evt.id,
+		maxKeys: MAX_EVENTS * 4,
+		evictionPolicy: "drop_oldest",
+		clock: { intervalMs: 500 },
+	});
+
+	let handle: TerminalStreamHandle | null = null;
+	let connectionStatus = $state<"idle" | "connecting" | "open" | "error">(
+		"idle",
+	);
+
+	$effect(() => {
+		const url = streamUrl;
+		if (!url) {
+			connectionStatus = "idle";
+			return;
+		}
+		connectionStatus = "connecting";
+		const localHandle = createTerminalStream<AlertEvent>({
+			url,
+			onOpen: () => {
+				connectionStatus = "open";
+			},
+			onMessage: (evt) => {
+				buffer.write(evt);
+			},
+			onError: () => {
+				connectionStatus = "error";
+			},
+			onClose: () => {
+				connectionStatus = "idle";
+			},
+		});
+		handle = localHandle;
+		return () => {
+			localHandle.close();
+			handle = null;
+		};
+	});
+
+	onDestroy(() => {
+		handle?.close();
+		buffer.dispose();
+	});
+
+	const sortedEvents = $derived.by<AlertEvent[]>(() => {
+		const snapshot = buffer.snapshot;
+		if (snapshot.size === 0) return [];
+		// Newest first. Timestamps are ISO 8601 — lexicographic sort
+		// matches chronological sort for same-timezone data.
+		return Array.from(snapshot.values())
+			.sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1))
+			.slice(0, MAX_EVENTS);
+	});
+
+	const hasEvents = $derived(sortedEvents.length > 0);
+
+	function severityClass(sev: AlertSeverity): string {
+		return `at-sev at-sev--${sev}`;
+	}
+
+	function severityLabel(sev: AlertSeverity): string {
+		switch (sev) {
+			case "info":
+				return "INFO";
+			case "warn":
+				return "WARN";
+			case "error":
+				return "ERR";
+			case "critical":
+				return "CRIT";
+		}
+	}
+
+	function shortTimestamp(iso: string): string {
+		// ISO 8601 → HH:MM:SS extraction. Acceptable without the
+		// @investintell/ui formatter since this is a raw machine
+		// value, not a locale-sensitive user-facing date.
+		if (iso.length < 19) return iso;
+		return iso.substring(11, 19);
+	}
+</script>
+
+<div class="at-track" role="status" aria-live="polite" aria-atomic="false">
+	{#if hasEvents}
+		<div class="at-scroll">
+			{#each sortedEvents as evt (evt.id)}
+				<span class="at-entry">
+					<span class={severityClass(evt.severity)}>
+						<span class="at-dot"></span>
+						<span class="at-sev-label">{severityLabel(evt.severity)}</span>
+					</span>
+					<span class="at-ts">{shortTimestamp(evt.timestamp)}</span>
+					<span class="at-sep">·</span>
+					<span class="at-title">{evt.title}</span>
+				</span>
+			{/each}
+		</div>
+	{:else}
+		<span class="at-standby">
+			STANDBY — alert stream {connectionStatus === "connecting"
+				? "connecting…"
+				: connectionStatus === "error"
+					? "offline"
+					: "not connected"}
+		</span>
+	{/if}
+</div>
+
+<style>
+	.at-track {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		overflow: hidden;
+		white-space: nowrap;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-secondary);
+	}
+
+	.at-scroll {
+		display: inline-flex;
+		gap: var(--terminal-space-4);
+		min-width: 0;
+	}
+
+	.at-entry {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+	}
+
+	.at-sev {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		font-weight: 700;
+	}
+
+	.at-sev--info {
+		color: var(--terminal-accent-cyan);
+	}
+	.at-sev--warn {
+		color: var(--terminal-status-warn);
+	}
+	.at-sev--error,
+	.at-sev--critical {
+		color: var(--terminal-status-error);
+	}
+
+	.at-dot {
+		display: inline-block;
+		width: 5px;
+		height: 5px;
+		background: currentColor;
+		box-shadow: 0 0 6px currentColor;
+	}
+
+	.at-sev-label {
+		font-size: var(--terminal-text-10);
+	}
+
+	.at-ts {
+		color: var(--terminal-fg-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.at-sep {
+		color: var(--terminal-fg-muted);
+	}
+
+	.at-title {
+		color: var(--terminal-fg-secondary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.at-standby {
+		color: var(--terminal-fg-muted);
+		animation: at-pulse 2.4s ease-in-out infinite;
+	}
+
+	@keyframes at-pulse {
+		0%,
+		100% {
+			opacity: 0.45;
+		}
+		50% {
+			opacity: 1;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.at-standby {
+			animation: none;
+		}
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/CommandPalette.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/CommandPalette.svelte
@@ -1,0 +1,445 @@
+<!--
+	CommandPalette.svelte — Cmd+K launcher overlay.
+	===============================================
+
+	Source of truth: docs/plans/2026-04-11-terminal-unification-master-plan.md
+		§1.4 TerminalShell, Appendix B navigation flow.
+
+	WAI-ARIA combobox overlay with listbox results. Seeded with 8 go-to
+	navigation commands (3 active, 5 pending) matching the TerminalTopNav
+	tab catalog. Pending commands stay visible so users see the full
+	terminal vision.
+
+	Full-viewport backdrop (var(--terminal-bg-scrim)), centered 640px
+	frame, brutalist chrome, auto-focus on open, focus restore on close,
+	body scroll lock, ESC/Enter/↑/↓ keyboard handling, simple substring
+	filter on label + hint.
+
+	Navigation uses `const target = resolve("/..."); await goto(target);`
+	per the svelte/no-navigation-without-resolve rule — the AST matcher
+	only accepts a plain Identifier passed to goto.
+
+	Z-index var(--terminal-z-palette) = 70, above FocusMode (60) so the
+	palette can open inside an active focus mode.
+-->
+<script lang="ts">
+	import { fade, fly } from "svelte/transition";
+	import { svelteTransitionFor } from "@investintell/ui";
+	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
+
+	interface CommandPaletteProps {
+		/** Bindable. TerminalShell toggles this from Cmd+K. */
+		open: boolean;
+	}
+
+	let { open = $bindable() }: CommandPaletteProps = $props();
+
+	type CommandStatus = "active" | "pending";
+
+	interface Command {
+		id: string;
+		label: string;
+		hint: string;
+		status: CommandStatus;
+		action: () => void | Promise<void>;
+	}
+
+	// ─────────────────────────────────────────────────────────────
+	// Active command actions — extracted-const resolve() pattern.
+	// ─────────────────────────────────────────────────────────────
+
+	async function gotoScreener() {
+		const target = resolve("/screener");
+		await goto(target);
+	}
+
+	async function gotoLive() {
+		const target = resolve("/live");
+		await goto(target);
+	}
+
+	async function gotoResearch() {
+		const target = resolve("/screener/research");
+		await goto(target);
+	}
+
+	// Pending actions are intentional no-ops. Triggering a pending
+	// command plays a shake animation on its row and keeps the palette
+	// open so the user sees the "not yet wired" signal.
+	function pendingAction() {
+		/* no-op — see handleEnter for UX feedback */
+	}
+
+	const COMMANDS: ReadonlyArray<Command> = [
+		{ id: "nav.screener", label: "Go to Screener",        hint: "g s", status: "active",  action: gotoScreener },
+		{ id: "nav.live",     label: "Go to Live Workbench",  hint: "g l", status: "active",  action: gotoLive },
+		{ id: "nav.research", label: "Go to Research",        hint: "g r", status: "active",  action: gotoResearch },
+		{ id: "nav.macro",    label: "Go to Macro Desk",      hint: "g m", status: "pending", action: pendingAction },
+		{ id: "nav.alloc",    label: "Go to Allocation",      hint: "g a", status: "pending", action: pendingAction },
+		{ id: "nav.builder",  label: "Go to Portfolio Builder", hint: "g p", status: "pending", action: pendingAction },
+		{ id: "nav.alerts",   label: "Go to Alerts",          hint: "g n", status: "pending", action: pendingAction },
+		{ id: "nav.dd",       label: "Go to DD Queue",        hint: "g d", status: "pending", action: pendingAction },
+	];
+
+	let query = $state("");
+	let highlightedIndex = $state(0);
+	let inputEl: HTMLInputElement | undefined = $state();
+	let frameEl: HTMLDivElement | undefined = $state();
+	let shakeKey = $state(0);
+
+	const filtered = $derived.by<Command[]>(() => {
+		const q = query.trim().toLowerCase();
+		if (q.length === 0) return [...COMMANDS];
+		return COMMANDS.filter(
+			(c) =>
+				c.label.toLowerCase().includes(q) ||
+				c.hint.toLowerCase().includes(q),
+		);
+	});
+
+	$effect(() => {
+		// Clamp the highlighted index whenever the filtered list shrinks.
+		if (filtered.length === 0) {
+			highlightedIndex = 0;
+			return;
+		}
+		if (highlightedIndex >= filtered.length) {
+			highlightedIndex = filtered.length - 1;
+		}
+	});
+
+	// Focus lifecycle — mirror FocusMode's pattern: restore focus on
+	// close, body scroll lock while open.
+	$effect(() => {
+		if (!open) return;
+		if (typeof document === "undefined") return;
+		const previousOverflow = document.body.style.overflow;
+		document.body.style.overflow = "hidden";
+		const previouslyFocused = document.activeElement as HTMLElement | null;
+		query = "";
+		highlightedIndex = 0;
+		queueMicrotask(() => {
+			inputEl?.focus({ preventScroll: true });
+		});
+		return () => {
+			document.body.style.overflow = previousOverflow;
+			if (
+				previouslyFocused &&
+				typeof previouslyFocused.focus === "function"
+			) {
+				previouslyFocused.focus({ preventScroll: true });
+			}
+		};
+	});
+
+	function handleBackdropClick(event: MouseEvent) {
+		if (event.target === event.currentTarget) {
+			open = false;
+		}
+	}
+
+	function handleFrameClick(event: MouseEvent) {
+		event.stopPropagation();
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === "Escape") {
+			event.preventDefault();
+			open = false;
+			return;
+		}
+		if (event.key === "ArrowDown") {
+			event.preventDefault();
+			if (filtered.length === 0) return;
+			highlightedIndex = (highlightedIndex + 1) % filtered.length;
+			return;
+		}
+		if (event.key === "ArrowUp") {
+			event.preventDefault();
+			if (filtered.length === 0) return;
+			highlightedIndex =
+				(highlightedIndex - 1 + filtered.length) % filtered.length;
+			return;
+		}
+		if (event.key === "Enter") {
+			event.preventDefault();
+			handleEnter();
+			return;
+		}
+	}
+
+	function handleEnter() {
+		const command = filtered[highlightedIndex];
+		if (!command) return;
+		if (command.status === "pending") {
+			// Visual shake feedback — increment key so the row remounts
+			// its animation.
+			shakeKey += 1;
+			return;
+		}
+		const result = command.action();
+		if (result && typeof (result as Promise<void>).then === "function") {
+			(result as Promise<void>).then(
+				() => {
+					open = false;
+				},
+				() => {
+					/* swallow navigation errors — palette stays open so
+					   the user can retry */
+				},
+			);
+		} else {
+			open = false;
+		}
+	}
+
+	function handleOptionClick(index: number) {
+		highlightedIndex = index;
+		handleEnter();
+	}
+
+	const optionIdFor = (id: string) => `cp-option-${id}`;
+
+	const listboxId = "terminal-command-palette-listbox";
+	const inputId = "terminal-command-palette-input";
+</script>
+
+{#if open}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<div
+		class="cp-backdrop"
+		role="presentation"
+		onclick={handleBackdropClick}
+		transition:fade={svelteTransitionFor("chrome", { duration: "tick" })}
+	>
+		<div
+			bind:this={frameEl}
+			class="cp-frame"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Command palette"
+			tabindex="-1"
+			onclick={handleFrameClick}
+			in:fly={{ y: -12, ...svelteTransitionFor("chrome", { duration: "tick" }) }}
+		>
+			<header class="cp-header">
+				<span class="cp-prompt">⌘</span>
+				<input
+					bind:this={inputEl}
+					bind:value={query}
+					id={inputId}
+					class="cp-input"
+					type="text"
+					placeholder="Type a command or search..."
+					autocomplete="off"
+					autocorrect="off"
+					autocapitalize="off"
+					spellcheck="false"
+					role="combobox"
+					aria-expanded="true"
+					aria-controls={listboxId}
+					aria-activedescendant={(() => {
+						const current = filtered[highlightedIndex];
+						return current ? optionIdFor(current.id) : undefined;
+					})()}
+					onkeydown={handleKeydown}
+				/>
+			</header>
+
+			<ul id={listboxId} class="cp-list" role="listbox">
+				{#each filtered as cmd, i (cmd.id)}
+					{@const isHighlighted = i === highlightedIndex}
+					{@const shouldShake =
+						isHighlighted && cmd.status === "pending" && shakeKey > 0}
+					<!-- svelte-ignore a11y_click_events_have_key_events -->
+					<li
+						id={optionIdFor(cmd.id)}
+						class="cp-option"
+						class:cp-option--highlighted={isHighlighted}
+						class:cp-option--pending={cmd.status === "pending"}
+						class:cp-option--shake={shouldShake}
+						role="option"
+						aria-selected={isHighlighted}
+						onclick={() => handleOptionClick(i)}
+						onmouseenter={() => (highlightedIndex = i)}
+					>
+						<span class="cp-option-label">{cmd.label}</span>
+						<span class="cp-option-right">
+							{#if cmd.status === "pending"}
+								<span class="cp-option-badge">PENDING</span>
+							{/if}
+							<span class="cp-option-hint">{cmd.hint}</span>
+						</span>
+					</li>
+				{:else}
+					<li class="cp-empty">NO MATCHES</li>
+				{/each}
+			</ul>
+
+			<footer class="cp-footer">
+				<span class="cp-footer-count">{filtered.length} results</span>
+				<span class="cp-footer-keys">↑↓ navigate · ⏎ select · ESC close</span>
+			</footer>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.cp-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: var(--terminal-z-palette);
+		background: var(--terminal-bg-scrim);
+		backdrop-filter: blur(3px);
+		-webkit-backdrop-filter: blur(3px);
+		display: grid;
+		place-items: start center;
+		padding-top: 14vh;
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-primary);
+	}
+
+	.cp-frame {
+		width: 640px;
+		max-width: calc(100vw - var(--terminal-space-8));
+		max-height: 60vh;
+		background: var(--terminal-bg-void);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		display: grid;
+		grid-template-rows: auto 1fr auto;
+		overflow: hidden;
+		box-shadow: 0 0 0 1px var(--terminal-fg-muted);
+	}
+
+	.cp-header {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding: var(--terminal-space-3) var(--terminal-space-4);
+		border-bottom: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+	}
+
+	.cp-prompt {
+		color: var(--terminal-accent-amber);
+		font-size: var(--terminal-text-14);
+		font-weight: 700;
+	}
+
+	.cp-input {
+		flex: 1;
+		background: transparent;
+		border: none;
+		outline: none;
+		color: var(--terminal-fg-primary);
+		font-family: inherit;
+		font-size: var(--terminal-text-14);
+		letter-spacing: 0;
+	}
+
+	.cp-input::placeholder {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.cp-list {
+		list-style: none;
+		margin: 0;
+		padding: var(--terminal-space-1) 0;
+		overflow-y: auto;
+		min-height: 0;
+	}
+
+	.cp-option {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--terminal-space-4);
+		padding: var(--terminal-space-2) var(--terminal-space-4);
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-secondary);
+		cursor: pointer;
+		border-left: 2px solid transparent;
+	}
+
+	.cp-option--highlighted {
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-fg-primary);
+		border-left-color: var(--terminal-accent-amber);
+	}
+
+	.cp-option--pending {
+		color: var(--terminal-fg-muted);
+	}
+
+	.cp-option--pending.cp-option--highlighted {
+		color: var(--terminal-fg-tertiary);
+		border-left-color: var(--terminal-status-warn);
+	}
+
+	.cp-option--shake {
+		animation: cp-shake 240ms ease-in-out;
+	}
+
+	.cp-option-label {
+		font-weight: 600;
+	}
+
+	.cp-option-right {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+
+	.cp-option-badge {
+		padding: 1px 4px;
+		font-size: var(--terminal-text-10);
+		letter-spacing: 0.08em;
+		color: var(--terminal-fg-tertiary);
+		border: 1px solid var(--terminal-fg-muted);
+	}
+
+	.cp-option-hint {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: 0.06em;
+	}
+
+	.cp-empty {
+		padding: var(--terminal-space-6) var(--terminal-space-4);
+		text-align: center;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.cp-footer {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: var(--terminal-space-2) var(--terminal-space-4);
+		border-top: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	@keyframes cp-shake {
+		0%, 100% { transform: translateX(0); }
+		20% { transform: translateX(-4px); }
+		40% { transform: translateX(4px); }
+		60% { transform: translateX(-3px); }
+		80% { transform: translateX(3px); }
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.cp-option--shake {
+			animation: none;
+		}
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/LayoutCage.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/LayoutCage.svelte
@@ -1,0 +1,63 @@
+<!--
+	LayoutCage.svelte — canonical 24px black-margin frame.
+	======================================================
+
+	Source of truth: docs/plans/2026-04-11-terminal-unification-master-plan.md
+		§1.4 TerminalShell + layer taxonomy, Appendix G file structure.
+
+	Replaces the ad-hoc `calc(100vh - 88px)` + `padding: 24px` pattern
+	that was scattered across every (terminal) page and layout file
+	(see memory/feedback_layout_cage_pattern.md for the incident
+	that produced this rule).
+
+	Pure presentational primitive: fills its grid cell (TerminalShell
+	owns the viewport math and hands the cage a constrained height
+	via its grid layout) and paints a var(--terminal-space-6) black
+	margin on all sides. Children decide their own inner overflow.
+
+	No state, no effects, no derivations. Do NOT add chrome-height
+	math here — that is TerminalShell's job.
+-->
+<script lang="ts">
+	import type { Snippet } from "svelte";
+
+	interface LayoutCageProps {
+		children: Snippet;
+		/**
+		 * Optional class hook for consumers that need to compose their
+		 * own layout modifiers (e.g., grid / flex setup) on top of the
+		 * cage frame.
+		 */
+		class?: string;
+		/**
+		 * Density variant. "standard" (24px padding) for narrative
+		 * surfaces; "compact" (8px) for data-dense grids.
+		 */
+		density?: "standard" | "compact";
+	}
+
+	let { children, class: className = "", density = "standard" }: LayoutCageProps = $props();
+</script>
+
+<div class="lc-cage lc-cage--{density} {className}">
+	{@render children()}
+</div>
+
+<style>
+	.lc-cage {
+		position: relative;
+		box-sizing: border-box;
+		width: 100%;
+		height: 100%;
+		background: var(--terminal-bg-void);
+		overflow: hidden;
+	}
+
+	.lc-cage--standard {
+		padding: var(--terminal-space-6); /* 24px — narrative surfaces */
+	}
+
+	.lc-cage--compact {
+		padding: var(--terminal-space-2); /* 8px — data-dense surfaces */
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalBreadcrumb.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalBreadcrumb.svelte
@@ -1,0 +1,143 @@
+<!--
+	TerminalBreadcrumb.svelte
+	=========================
+
+	28px persistent row rendered BETWEEN TerminalTopNav and LayoutCage.
+	Segments: Screener → Terminal → Macro → Builder. Each is an <a>
+	with SvelteKit preload. Active segment matches page.route.id.
+
+	Keyboard: Alt+1..4 jumps to each segment. Ignored when focus is in
+	an editable field. Namespace does not collide with CommandPalette
+	go-to sequences (g-prefix) or palette shortcut (Cmd+K).
+
+	Source: docs/plans/2026-04-18-netz-terminal-parity.md §A.4, §C.1.
+-->
+<script lang="ts">
+	import { page } from "$app/state";
+	import { goto } from "$app/navigation";
+
+	interface Segment {
+		key: string;
+		label: string;
+		href: string;
+		/** Path prefix used to resolve the active state against page.route.id. */
+		match: string;
+	}
+
+	const segments: Segment[] = [
+		{ key: "screener", label: "SCREENER", href: "/screener", match: "/screener" },
+		{ key: "terminal", label: "TERMINAL", href: "/live", match: "/live" },
+		{ key: "macro", label: "MACRO", href: "/macro", match: "/macro" },
+		{ key: "builder", label: "BUILDER", href: "/portfolio/builder", match: "/portfolio/builder" },
+	];
+
+	const activeKey = $derived.by(() => {
+		const path = page.url.pathname;
+		for (const seg of segments) {
+			if (path.startsWith(seg.match)) return seg.key;
+		}
+		return null;
+	});
+
+	function isEditableTarget(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		const tag = target.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+		if (target.isContentEditable) return true;
+		const role = target.getAttribute("role");
+		if (role === "textbox" || role === "searchbox" || role === "combobox") {
+			return true;
+		}
+		return false;
+	}
+
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const handler = (event: KeyboardEvent) => {
+			if (!event.altKey || event.metaKey || event.ctrlKey || event.shiftKey) return;
+			if (isEditableTarget(event.target)) return;
+			const idx = Number.parseInt(event.key, 10);
+			if (Number.isNaN(idx) || idx < 1 || idx > segments.length) return;
+			event.preventDefault();
+			const target = segments[idx - 1];
+			if (!target) return;
+			// Route hrefs are string-typed here (mapped from segments[]),
+			// so resolve() type inference narrows to never. Cast keeps
+			// the runtime behavior identical and svelte-check quiet.
+			void goto(target.href as Parameters<typeof goto>[0]);
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	});
+</script>
+
+<nav class="tb-crumb" aria-label="Terminal sections">
+	{#each segments as seg, i (seg.key)}
+		{#if i > 0}
+			<span class="tb-sep" aria-hidden="true">›</span>
+		{/if}
+		<a
+			class="tb-link"
+			class:is-active={activeKey === seg.key}
+			href={seg.href}
+			data-sveltekit-preload-data="hover"
+			aria-current={activeKey === seg.key ? "page" : undefined}
+		>
+			<span class="tb-alt" aria-hidden="true">{i + 1}</span>
+			<span class="tb-label">{seg.label}</span>
+		</a>
+	{/each}
+</nav>
+
+<style>
+	.tb-crumb {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		height: var(--terminal-shell-breadcrumb-height, 28px);
+		padding: 0 var(--terminal-space-4);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		overflow: hidden;
+		white-space: nowrap;
+	}
+
+	.tb-link {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		text-decoration: none;
+		padding: 0 var(--terminal-space-2);
+		height: 100%;
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.tb-link:hover {
+		color: var(--terminal-fg-primary);
+	}
+	.tb-link.is-active {
+		color: var(--terminal-accent-amber);
+		border-bottom: 1px solid var(--terminal-accent-amber);
+	}
+	.tb-link:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -2px;
+	}
+
+	.tb-alt {
+		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-10);
+		font-variant-numeric: tabular-nums;
+	}
+	.tb-link.is-active .tb-alt {
+		color: var(--terminal-accent-amber-dim);
+	}
+
+	.tb-sep {
+		color: var(--terminal-fg-muted);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalContextRail.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalContextRail.svelte
@@ -1,0 +1,321 @@
+<!--
+	TerminalContextRail.svelte — entity-scoped right rail.
+	======================================================
+
+	Source of truth: docs/plans/2026-04-11-terminal-unification-master-plan.md
+		§1.4 TerminalShell, Appendix B navigation flow.
+
+	Right-side 280px rail that appears when the URL contains
+	`?entity=<kind>:<id>` and disappears entirely otherwise. Supports
+	fund / portfolio / manager / sector / regime entity kinds
+	(matching FocusMode.entityKind).
+
+	Snippet-based content composition: the caller passes a `content`
+	snippet typed with `Snippet<[{ kind, id }]>` so the rail renders
+	entity-specific metadata without the primitive knowing domain
+	details. A default card shows kind + id when no snippet is
+	provided.
+
+	Collapse to 32px sliver with a vertical CTX label preserving the
+	grid column width. TerminalShell owns the `[` / `]` keyboard
+	shortcuts and passes the `collapsed` state down as a prop — the
+	rail stays purely presentational.
+
+	Z-index var(--terminal-z-rail) = 20.
+-->
+<script lang="ts">
+	import type { Snippet } from "svelte";
+	import { fly } from "svelte/transition";
+	import { svelteTransitionFor } from "@investintell/ui";
+	import { pinnedRegime, type PinnedRegime } from "$wealth/state/pinned-regime.svelte";
+
+	export type TerminalContextRailEntityKind =
+		| "fund"
+		| "portfolio"
+		| "manager"
+		| "sector"
+		| "regime";
+
+	export interface TerminalContextRailEntity {
+		kind: TerminalContextRailEntityKind;
+		id: string;
+	}
+
+	interface TerminalContextRailProps {
+		/**
+		 * Currently-pinned entity. Null when no entity is in the URL;
+		 * in that case the component returns nothing.
+		 */
+		entity: TerminalContextRailEntity | null;
+		/**
+		 * Optional content snippet. If provided, the rail renders it
+		 * with the entity as parameter. If absent, a minimal default
+		 * card listing kind + id is rendered.
+		 */
+		content?: Snippet<[TerminalContextRailEntity]>;
+		/**
+		 * Collapsed state controlled externally. TerminalShell
+		 * handles the `[` / `]` keyboard shortcuts and flips this.
+		 */
+		collapsed: boolean;
+	}
+
+	let { entity, content, collapsed }: TerminalContextRailProps = $props();
+
+	const pinned = $derived(pinnedRegime.current);
+
+	const regimeColorClass = $derived.by(() => {
+		if (!pinned) return "";
+		switch (pinned.label) {
+			case "Normal": return "tcr-regime--ok";
+			case "Risk On": return "tcr-regime--cyan";
+			case "Risk Off": return "tcr-regime--amber";
+			case "Crisis": return "tcr-regime--error";
+			default: return "";
+		}
+	});
+
+	function kindLabel(kind: TerminalContextRailEntityKind): string {
+		switch (kind) {
+			case "fund":
+				return "FUND";
+			case "portfolio":
+				return "PORTFOLIO";
+			case "manager":
+				return "MANAGER";
+			case "sector":
+				return "SECTOR";
+			case "regime":
+				return "ENVIRONMENT";
+		}
+	}
+</script>
+
+{#if entity !== null}
+	{#if collapsed}
+		<aside class="tcr-rail tcr-rail--collapsed" aria-label="Context rail (collapsed)">
+			<span class="tcr-collapsed-label">CTX</span>
+		</aside>
+	{:else}
+		<aside
+			class="tcr-rail tcr-rail--expanded"
+			aria-label="Context rail"
+			in:fly={{ x: 16, ...svelteTransitionFor("secondary") }}
+		>
+			<header class="tcr-header">
+				<span class="tcr-brand">[ CTX · {kindLabel(entity.kind)} ]</span>
+				<span class="tcr-entity-id" title={entity.id}>{entity.id}</span>
+			</header>
+			<div class="tcr-body">
+				{#if pinned}
+					<div class="tcr-regime-section">
+						<div class="tcr-regime-row">
+							<span class="tcr-regime-label">REGIME</span>
+							<span class="tcr-regime-value {regimeColorClass}">{pinned.label}</span>
+						</div>
+						<div class="tcr-regime-row">
+							<span class="tcr-regime-label">REGION</span>
+							<span class="tcr-regime-detail">{pinned.region}</span>
+						</div>
+						<div class="tcr-regime-row">
+							<span class="tcr-regime-label">SCORE</span>
+							<span class="tcr-regime-detail">{pinned.score}/100</span>
+						</div>
+					</div>
+				{/if}
+				{#if content}
+					{@render content(entity)}
+				{:else}
+					<div class="tcr-default-card">
+						<div class="tcr-default-row">
+							<span class="tcr-default-label">KIND</span>
+							<span class="tcr-default-value">{kindLabel(entity.kind)}</span>
+						</div>
+						<div class="tcr-default-row">
+							<span class="tcr-default-label">ID</span>
+							<span class="tcr-default-value">{entity.id}</span>
+						</div>
+						<p class="tcr-default-hint">
+							Bind a <code>content</code> snippet to fill this rail with
+							entity-specific metadata.
+						</p>
+					</div>
+				{/if}
+			</div>
+		</aside>
+	{/if}
+{/if}
+
+<style>
+	.tcr-rail {
+		position: relative;
+		z-index: var(--terminal-z-rail);
+		background: var(--terminal-bg-panel);
+		border-left: var(--terminal-border-hairline);
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		box-sizing: border-box;
+		height: 100%;
+		overflow: hidden;
+	}
+
+	.tcr-rail--expanded {
+		width: 280px;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.tcr-rail--collapsed {
+		width: 32px;
+		display: flex;
+		align-items: flex-start;
+		justify-content: center;
+		padding-top: var(--terminal-space-4);
+	}
+
+	.tcr-collapsed-label {
+		writing-mode: vertical-rl;
+		transform: rotate(180deg);
+		font-size: var(--terminal-text-10);
+		letter-spacing: 0.18em;
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.tcr-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--terminal-space-2);
+		height: 32px;
+		padding: 0 var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel-raised);
+		flex-shrink: 0;
+	}
+
+	.tcr-brand {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-accent-amber);
+	}
+
+	.tcr-entity-id {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		font-variant-numeric: tabular-nums;
+		max-width: 140px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.tcr-body {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		padding: var(--terminal-space-3);
+	}
+
+	.tcr-default-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-3);
+		padding: var(--terminal-space-3);
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-void);
+	}
+
+	.tcr-default-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.tcr-default-label {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.tcr-default-value {
+		color: var(--terminal-fg-primary);
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		max-width: 180px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.tcr-default-hint {
+		margin: 0;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+		line-height: var(--terminal-leading-normal);
+	}
+
+	.tcr-default-hint code {
+		color: var(--terminal-fg-tertiary);
+		background: var(--terminal-bg-panel-raised);
+		padding: 0 3px;
+	}
+
+	/* ── Pinned regime section ────────────────────────── */
+
+	.tcr-regime-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-3);
+		margin-bottom: var(--terminal-space-3);
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-void);
+	}
+
+	.tcr-regime-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+
+	.tcr-regime-label {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.tcr-regime-value {
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+	}
+
+	.tcr-regime-detail {
+		color: var(--terminal-fg-secondary);
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.tcr-regime--ok {
+		color: var(--terminal-status-ok);
+	}
+
+	.tcr-regime--cyan {
+		color: var(--terminal-accent-cyan);
+	}
+
+	.tcr-regime--amber {
+		color: var(--terminal-accent-amber);
+	}
+
+	.tcr-regime--error {
+		color: var(--terminal-status-error);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalContextRail.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalContextRail.svelte
@@ -27,7 +27,7 @@
 	import type { Snippet } from "svelte";
 	import { fly } from "svelte/transition";
 	import { svelteTransitionFor } from "@investintell/ui";
-	import { pinnedRegime, type PinnedRegime } from "$wealth/state/pinned-regime.svelte";
+	import { pinnedRegime, type PinnedRegime } from "../../../state/pinned-regime.svelte";
 
 	export type TerminalContextRailEntityKind =
 		| "fund"

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalShell.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalShell.svelte
@@ -40,7 +40,7 @@
 	import { page } from "$app/state";
 	import { goto } from "$app/navigation";
 	import { resolve } from "$app/paths";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../../api/client";
 	import TerminalTopNav from "./TerminalTopNav.svelte";
 	import TerminalBreadcrumb from "./TerminalBreadcrumb.svelte";
 	import TerminalTweaksPanel from "./TerminalTweaksPanel.svelte";
@@ -48,9 +48,9 @@
 	import {
 		TERMINAL_TWEAKS_KEY,
 		type TerminalTweaks,
-	} from "$wealth/stores/terminal-tweaks.svelte";
-	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
-	import type { MarketDataStore, WsStatus } from "$wealth/stores/market-data.svelte";
+	} from "../../../stores/terminal-tweaks.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "../../../components/portfolio/live/workbench-state";
+	import type { MarketDataStore, WsStatus } from "../../../stores/market-data.svelte";
 	import type { TerminalStatusBarConnectionStatus } from "./TerminalStatusBar.svelte";
 	import TerminalContextRail, {
 		type TerminalContextRailEntity,

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalShell.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalShell.svelte
@@ -1,0 +1,456 @@
+<!--
+	TerminalShell.svelte — outermost shell composition.
+	====================================================
+
+	Source of truth: docs/plans/2026-04-11-terminal-unification-master-plan.md
+		§1.4 TerminalShell + layer taxonomy, Appendix B navigation flow,
+		Appendix C tokens, Appendix G file structure.
+
+	The persistent chrome of every terminal route. Composes:
+		• TerminalTopNav   (row 1, 32px)
+		• LayoutCage       (row 2, 1fr, wraps children snippet)
+		• TerminalContextRail  (column 2, 280px conditional)
+		• TerminalStatusBar (row 3, 28px)
+		• CommandPalette   (overlay, z=70)
+
+	Owns the global keyboard shortcuts:
+		• Cmd/Ctrl + K      → toggle CommandPalette
+		• `[` / `]`         → collapse / expand TerminalContextRail
+		• `g` + s/l/r/m/a/p/n/d  → go-to navigation (active routes fire
+		                       the matching command palette action;
+		                       pending routes toggle the palette open
+		                       so the user sees the pending badge)
+
+	Input-field detection: the global handler short-circuits when the
+	active element is an <input>, <textarea>, contenteditable, or
+	role="textbox" so typing inside a search field never triggers a
+	palette toggle or rail collapse.
+
+	Resolves build metadata (VITE_BUILD_SHA, VITE_ENV), Clerk user/org
+	placeholders (Phase 2+ will wire real Clerk context), and the
+	URL-pinned entity via $derived reading $app/state `page`. The
+	context rail only mounts when `?entity=<kind>:<id>` is in the URL
+	with a valid entity kind. Rail collapse is ephemeral $state, not
+	URL-persisted (feedback_echarts_no_localstorage.md: no browser
+	storage inside the terminal namespace).
+-->
+<script lang="ts">
+	import type { Snippet } from "svelte";
+	import { getContext } from "svelte";
+	import { page } from "$app/state";
+	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
+	import { createClientApiClient } from "$wealth/api/client";
+	import TerminalTopNav from "./TerminalTopNav.svelte";
+	import TerminalBreadcrumb from "./TerminalBreadcrumb.svelte";
+	import TerminalTweaksPanel from "./TerminalTweaksPanel.svelte";
+	import TerminalStatusBar from "./TerminalStatusBar.svelte";
+	import {
+		TERMINAL_TWEAKS_KEY,
+		type TerminalTweaks,
+	} from "$wealth/stores/terminal-tweaks.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
+	import type { MarketDataStore, WsStatus } from "$wealth/stores/market-data.svelte";
+	import type { TerminalStatusBarConnectionStatus } from "./TerminalStatusBar.svelte";
+	import TerminalContextRail, {
+		type TerminalContextRailEntity,
+		type TerminalContextRailEntityKind,
+	} from "./TerminalContextRail.svelte";
+	import CommandPalette from "./CommandPalette.svelte";
+	import AlertTicker from "./AlertTicker.svelte";
+	import LayoutCage from "./LayoutCage.svelte";
+
+	interface TerminalShellProps {
+		children: Snippet;
+		/** Density for the LayoutCage: "standard" (24px) or "compact" (8px). */
+		cageDensity?: "standard" | "compact";
+		/**
+		 * Hide the TerminalBreadcrumb workflow stepper row. The II Terminal
+		 * app (frontends/terminal/) sets this to `true` because its TopNav
+		 * already carries the workflow tabs (F1..F6) — rendering the
+		 * breadcrumb too produces a double-nav stack. Wealth's (terminal)/
+		 * routes keep the legacy default (false) while the shell lives in
+		 * both apps; X7 retires the wealth copy entirely.
+		 */
+		hideWorkflowStepper?: boolean;
+	}
+
+	let {
+		children,
+		cageDensity = "standard",
+		hideWorkflowStepper = false,
+	}: TerminalShellProps = $props();
+
+	// ─── Build metadata ─────────────────────────────────────────
+	// Exposed via vite `define` in frontends/wealth/vite.config.ts
+	// (commit 8). String literal fallbacks let the shell render
+	// cleanly before the config edit lands.
+	const buildShaRaw =
+		(import.meta.env.VITE_BUILD_SHA as string | undefined) ?? "local";
+	const buildSha = buildShaRaw.length > 7 ? buildShaRaw.slice(0, 7) : buildShaRaw;
+	const environment = (((import.meta.env.VITE_ENV as string | undefined) ??
+		"dev") as "dev" | "staging" | "prod");
+
+	// ─── Clerk context placeholders ─────────────────────────────
+	// Phase 2+ wires real Clerk user/org when the SvelteKit SDK
+	// stabilizes. Ship with placeholders per escape hatch #7.
+	const orgName = "II";
+	const userInitials = "AR";
+
+	// ─── Connection status ──────────────────────────────────────
+	// Aggregated from the terminal-scoped MarketDataStore WS state
+	// (context set by (terminal)/+layout.svelte). Routes without a
+	// market stream still see "connecting" as the bootstrap default.
+	const marketStore = getContext<MarketDataStore | undefined>(
+		TERMINAL_MARKET_DATA_KEY,
+	);
+
+	const WS_STATUS_MAP: Record<WsStatus, TerminalStatusBarConnectionStatus> = {
+		connecting: "connecting",
+		connected: "open",
+		reconnecting: "degraded",
+		disconnected: "closed",
+		error: "error",
+	};
+
+	const connectionStatus = $derived<TerminalStatusBarConnectionStatus>(
+		marketStore ? WS_STATUS_MAP[marketStore.status] : "connecting",
+	);
+
+	// ─── Tweaks (density / accent / theme) ─────────────────────
+	// Bound as data-attributes on the shell root so tokens shipped
+	// in @investintell/ui/tokens/terminal.css activate via attribute
+	// selectors. Store is populated by (terminal)/+layout.svelte.
+	const tweaks = getContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY);
+
+	// ─── DD queue badge count ───────────────────────────────────
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const ddApi = createClientApiClient(getToken);
+	let ddQueueCount = $state(0);
+
+	async function fetchDDQueueCount() {
+		try {
+			const res = await ddApi.get<{ counts: Record<string, number> }>("/dd-reports/queue");
+			ddQueueCount = (res.counts.pending ?? 0) + (res.counts.in_progress ?? 0);
+		} catch {
+			// Silently ignore — badge stays at 0.
+		}
+	}
+
+	$effect(() => {
+		fetchDDQueueCount();
+		const timer = setInterval(fetchDDQueueCount, 60_000);
+		return () => clearInterval(timer);
+	});
+
+	// ─── URL-pinned entity ──────────────────────────────────────
+	const KNOWN_KINDS: ReadonlyArray<TerminalContextRailEntityKind> = [
+		"fund",
+		"portfolio",
+		"manager",
+		"sector",
+		"regime",
+	];
+
+	const entity = $derived.by<TerminalContextRailEntity | null>(() => {
+		const raw = page.url.searchParams.get("entity");
+		if (!raw) return null;
+		const separator = raw.indexOf(":");
+		if (separator <= 0 || separator >= raw.length - 1) return null;
+		const kind = raw.slice(0, separator);
+		const id = raw.slice(separator + 1);
+		if (!KNOWN_KINDS.includes(kind as TerminalContextRailEntityKind)) return null;
+		return { kind: kind as TerminalContextRailEntityKind, id };
+	});
+
+	// ─── Ephemeral shell state ──────────────────────────────────
+	let railCollapsed = $state(false);
+	let paletteOpen = $state(false);
+
+	// Go-to navigation catalog (mirrors the CommandPalette action
+	// dispatch surface). `active` entries invoke goto via resolve();
+	// `pending` entries open the palette so the user sees the
+	// pending badge for that route.
+	async function navMacro() {
+		await goto(resolve("/macro"));
+	}
+
+	async function navAlloc() {
+		await goto(resolve("/allocation"));
+	}
+
+	async function navScreener() {
+		await goto(resolve("/screener"));
+	}
+
+	async function navDD() {
+		await goto(resolve("/dd"));
+	}
+
+	async function navBuilder() {
+		await goto(resolve("/portfolio/builder"));
+	}
+
+	async function navLive() {
+		await goto(resolve("/live"));
+	}
+
+	async function navResearch() {
+		await goto(resolve("/screener/research"));
+	}
+
+	async function navAlerts() {
+		await goto(resolve("/alerts"));
+	}
+
+	function openPalette() {
+		paletteOpen = true;
+	}
+
+	type GoToHandler = () => void | Promise<void>;
+
+	const GO_TO_SHORTCUTS: Readonly<Record<string, GoToHandler>> = {
+		m: navMacro,
+		a: navAlloc,
+		s: navScreener,
+		d: navDD,
+		p: navBuilder,
+		l: navLive,
+		r: navResearch,
+		n: navAlerts,
+	};
+
+	const GO_TO_WINDOW_MS = 800;
+
+	// ─── Global keyboard handler ────────────────────────────────
+	let goPrefixTimestamp: number | null = null;
+
+	function isEditableTarget(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		const tag = target.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
+			return true;
+		}
+		if (target.isContentEditable) return true;
+		const role = target.getAttribute("role");
+		if (role === "textbox" || role === "searchbox" || role === "combobox") {
+			return true;
+		}
+		return false;
+	}
+
+	$effect(() => {
+		if (typeof window === "undefined") return;
+
+		const handler = (event: KeyboardEvent) => {
+			// Cmd+K / Ctrl+K always wins — it works inside inputs too,
+			// because the palette is a global launcher and needs an
+			// escape hatch from any focused surface.
+			const isPaletteShortcut =
+				(event.metaKey || event.ctrlKey) &&
+				!event.shiftKey &&
+				!event.altKey &&
+				(event.key === "k" || event.key === "K");
+			if (isPaletteShortcut) {
+				event.preventDefault();
+				paletteOpen = !paletteOpen;
+				goPrefixTimestamp = null;
+				return;
+			}
+
+			// All remaining shortcuts short-circuit inside editable fields.
+			if (isEditableTarget(event.target)) {
+				goPrefixTimestamp = null;
+				return;
+			}
+
+			// Rail collapse — only plain brackets, no modifiers.
+			if (
+				(event.key === "[" || event.key === "]") &&
+				!event.metaKey &&
+				!event.ctrlKey &&
+				!event.altKey
+			) {
+				if (entity !== null) {
+					event.preventDefault();
+					railCollapsed = event.key === "[";
+				}
+				goPrefixTimestamp = null;
+				return;
+			}
+
+			// g-prefix go-to sequences.
+			if (
+				event.key === "g" &&
+				!event.metaKey &&
+				!event.ctrlKey &&
+				!event.altKey
+			) {
+				goPrefixTimestamp = Date.now();
+				return;
+			}
+
+			if (goPrefixTimestamp !== null) {
+				const elapsed = Date.now() - goPrefixTimestamp;
+				goPrefixTimestamp = null;
+				if (elapsed > GO_TO_WINDOW_MS) return;
+				const handlerFn = GO_TO_SHORTCUTS[event.key];
+				if (handlerFn) {
+					event.preventDefault();
+					const result = handlerFn();
+					if (
+						result &&
+						typeof (result as Promise<void>).then === "function"
+					) {
+						void (result as Promise<void>);
+					}
+				}
+				return;
+			}
+		};
+
+		window.addEventListener("keydown", handler);
+		return () => {
+			window.removeEventListener("keydown", handler);
+		};
+	});
+</script>
+
+{#snippet tickerSnippet()}
+	<AlertTicker />
+{/snippet}
+
+<div
+	class="ts-shell"
+	class:ts-shell--has-rail={entity !== null}
+	class:ts-shell--no-crumb={hideWorkflowStepper}
+	data-surface="terminal"
+	data-density={tweaks?.density ?? "standard"}
+	data-accent={tweaks?.accent ?? "amber"}
+	data-theme={tweaks?.theme ?? "dark"}
+>
+	<div class="ts-nav-row">
+		<TerminalTopNav
+			activePath={page.url.pathname}
+			onOpenPalette={openPalette}
+			{ddQueueCount}
+			{userInitials}
+			{orgName}
+		/>
+	</div>
+
+	{#if !hideWorkflowStepper}
+		<div class="ts-crumb-row">
+			<TerminalBreadcrumb />
+		</div>
+	{/if}
+
+	<main class="ts-content">
+		<LayoutCage density={cageDensity}>
+			{@render children()}
+		</LayoutCage>
+	</main>
+
+	{#if entity !== null}
+		<div class="ts-rail-col">
+			<TerminalContextRail {entity} collapsed={railCollapsed} />
+		</div>
+	{/if}
+
+	<div class="ts-status-row">
+		<TerminalStatusBar
+			{buildSha}
+			{environment}
+			{orgName}
+			{userInitials}
+			{connectionStatus}
+			ticker={tickerSnippet}
+		/>
+	</div>
+</div>
+
+<CommandPalette bind:open={paletteOpen} />
+<TerminalTweaksPanel />
+
+<style>
+	.ts-shell {
+		position: fixed;
+		inset: 0;
+		display: grid;
+		grid-template-rows: 32px var(--terminal-shell-breadcrumb-height, 28px) 1fr 28px;
+		grid-template-columns: 1fr;
+		grid-template-areas:
+			"nav"
+			"crumb"
+			"content"
+			"status";
+		height: 100dvh;
+		width: 100vw;
+		overflow: hidden;
+		background: var(--terminal-bg-void);
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
+		isolation: isolate;
+	}
+
+	/* II Terminal path — stepper hidden. Collapse the breadcrumb row
+	 * entirely so the content gets the full height back, including
+	 * the 28px previously reserved by --terminal-shell-breadcrumb. */
+	.ts-shell--no-crumb {
+		grid-template-rows: 32px 1fr 28px;
+		grid-template-areas:
+			"nav"
+			"content"
+			"status";
+	}
+
+	.ts-shell--has-rail {
+		grid-template-columns: 1fr 280px;
+		grid-template-areas:
+			"nav nav"
+			"crumb crumb"
+			"content rail"
+			"status status";
+	}
+
+	.ts-shell--has-rail.ts-shell--no-crumb {
+		grid-template-rows: 32px 1fr 28px;
+		grid-template-areas:
+			"nav nav"
+			"content rail"
+			"status status";
+	}
+
+	.ts-nav-row {
+		grid-area: nav;
+		min-width: 0;
+	}
+
+	.ts-crumb-row {
+		grid-area: crumb;
+		min-width: 0;
+	}
+
+	.ts-content {
+		grid-area: content;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+		display: flex;
+	}
+
+	.ts-rail-col {
+		grid-area: rail;
+		min-width: 0;
+		min-height: 0;
+	}
+
+	.ts-status-row {
+		grid-area: status;
+		min-width: 0;
+	}
+
+	:global(body:has(.ts-shell)) {
+		overflow: hidden;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalStatusBar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalStatusBar.svelte
@@ -1,0 +1,331 @@
+<!--
+	TerminalStatusBar.svelte — bottom chrome strip.
+	==============================================
+
+	Source of truth: docs/plans/2026-04-11-terminal-unification-master-plan.md
+		§1.4 TerminalShell + layer taxonomy, Appendix C tokens.
+
+	Fixed 28px bottom strip for the terminal shell. Three-zone grid:
+		• Left   — tenant brand (default II), build SHA, environment (dev/staging
+		           hidden on prod), org name, user initials.
+		• Center — optional `ticker` snippet slot (TerminalShell
+		           injects AlertTicker output here). STANDBY fallback
+		           when omitted.
+		• Right  — connection LiveDot (pulse animation, color-coded
+		           by stream state), UTC clock (tabular-nums, 1Hz
+		           tick via $effect + setInterval with cleanup).
+
+	Pure presentational primitive — build SHA, org name, user initials,
+	and connection status are passed in as props. TerminalShell resolves
+	these from import.meta.env + Clerk context + TerminalStream
+	aggregation.
+
+	Z-index var(--terminal-z-statusbar) = 30, above page content (10)
+	and rail (20), below modals (50), focus mode (60), and palette (70).
+-->
+<script lang="ts">
+	import type { Snippet } from "svelte";
+	import { formatMonoTime } from "@investintell/ui";
+
+	export type TerminalStatusBarConnectionStatus =
+		| "connecting"
+		| "open"
+		| "degraded"
+		| "closed"
+		| "error";
+
+	interface TerminalStatusBarProps {
+		/**
+		 * Build SHA string (7-char short form). Resolved via
+		 * `import.meta.env.VITE_BUILD_SHA` by TerminalShell. Empty
+		 * string or "local" is acceptable during dev bootstrap.
+		 */
+		buildSha: string;
+		/**
+		 * Environment label. Rendered for "dev" and "staging" only —
+		 * suppressed on "prod" to reduce visual noise on the
+		 * institutional surface.
+		 */
+		environment: "dev" | "staging" | "prod";
+		/**
+		 * Organization name (from Clerk org context). Empty string
+		 * allowed during bootstrap; bar shows an em-dash fallback.
+		 */
+		orgName: string;
+		/**
+		 * Current user initials (2 char mono). Empty string fallback.
+		 */
+		userInitials: string;
+		/**
+		 * Optional ticker content — a snippet provided by
+		 * TerminalShell that injects AlertTicker output. When omitted,
+		 * the ticker zone shows a subtle STANDBY placeholder.
+		 */
+		ticker?: Snippet;
+		/**
+		 * Connection status driving the LiveDot color. Parent
+		 * (TerminalShell) aggregates the state of all active
+		 * TerminalStream subscriptions and hands down the worst
+		 * status.
+		 */
+		connectionStatus: TerminalStatusBarConnectionStatus;
+	}
+
+	let {
+		buildSha,
+		environment,
+		orgName,
+		userInitials,
+		ticker,
+		connectionStatus,
+	}: TerminalStatusBarProps = $props();
+
+	let utcClock = $state("--:--:-- UTC");
+
+	// 1Hz UTC clock via the mono formatter from @investintell/ui. The
+	// formatter is tabular-safe (zero-padded HH:MM:SS) and locale-
+	// independent. `$effect` cleanup guarantees the interval stops
+	// when the shell unmounts.
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const tick = () => {
+			utcClock = formatMonoTime(new Date(), "utc");
+		};
+		tick();
+		const interval = window.setInterval(tick, 1000);
+		return () => {
+			window.clearInterval(interval);
+		};
+	});
+
+	const showEnvironmentBadge = $derived(
+		environment === "dev" || environment === "staging",
+	);
+
+	const displayBuildSha = $derived(buildSha.length > 0 ? buildSha : "local");
+	const displayOrgName = $derived(orgName.length > 0 ? orgName : "II");
+	const displayUserInitials = $derived(
+		userInitials.length > 0 ? userInitials : "—",
+	);
+
+	const connectionLabel = $derived(connectionStatusLabel(connectionStatus));
+
+	function connectionStatusLabel(
+		status: TerminalStatusBarConnectionStatus,
+	): string {
+		switch (status) {
+			case "open":
+				return "LIVE";
+			case "connecting":
+				return "LINK";
+			case "degraded":
+				return "DEGR";
+			case "closed":
+				return "DOWN";
+			case "error":
+				return "ERR";
+		}
+	}
+</script>
+
+<footer class="sb-bar" aria-label="Terminal status bar">
+	<div class="sb-cluster sb-cluster--left">
+		<span class="sb-brand">[ {displayOrgName} ]</span>
+		<span class="sb-sep">//</span>
+		<span class="sb-meta">
+			<span class="sb-meta-label">BUILD</span>
+			<span class="sb-meta-value">{displayBuildSha}</span>
+		</span>
+		{#if showEnvironmentBadge}
+			<span class="sb-sep">//</span>
+			<span class="sb-env sb-env--{environment}">{environment.toUpperCase()}</span>
+		{/if}
+		<span class="sb-sep">//</span>
+		<span class="sb-meta">
+			<span class="sb-meta-label">ORG</span>
+			<span class="sb-meta-value">{displayOrgName}</span>
+		</span>
+		<span class="sb-sep">//</span>
+		<span class="sb-meta">
+			<span class="sb-meta-label">USR</span>
+			<span class="sb-meta-value">{displayUserInitials}</span>
+		</span>
+	</div>
+
+	<div class="sb-cluster sb-cluster--center">
+		{#if ticker}
+			{@render ticker()}
+		{:else}
+			<span class="sb-standby">STANDBY</span>
+		{/if}
+	</div>
+
+	<div class="sb-cluster sb-cluster--right">
+		<span class="sb-conn sb-conn--{connectionStatus}">
+			<span class="sb-dot"></span>
+			<span class="sb-conn-label">{connectionLabel}</span>
+		</span>
+		<span class="sb-sep">//</span>
+		<span class="sb-clock">{utcClock}</span>
+	</div>
+</footer>
+
+<style>
+	.sb-bar {
+		position: relative;
+		z-index: var(--terminal-z-statusbar);
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		align-items: center;
+		gap: var(--terminal-space-4);
+		height: 28px;
+		padding: 0 var(--terminal-space-4);
+		background: var(--terminal-bg-panel);
+		border-top: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		box-sizing: border-box;
+	}
+
+	.sb-cluster {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		min-width: 0;
+	}
+
+	.sb-cluster--center {
+		justify-content: center;
+		overflow: hidden;
+		white-space: nowrap;
+	}
+
+	.sb-cluster--right {
+		justify-content: flex-end;
+	}
+
+	.sb-brand {
+		color: var(--terminal-fg-primary);
+		font-weight: 700;
+	}
+
+	.sb-sep {
+		color: var(--terminal-fg-muted);
+	}
+
+	.sb-meta {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 4px;
+	}
+
+	.sb-meta-label {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.sb-meta-value {
+		color: var(--terminal-fg-secondary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.sb-env {
+		padding: 1px var(--terminal-space-1);
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-primary);
+	}
+
+	.sb-env--dev {
+		border-color: var(--terminal-accent-cyan);
+		color: var(--terminal-accent-cyan);
+	}
+
+	.sb-env--staging {
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+	}
+
+	.sb-standby {
+		color: var(--terminal-fg-muted);
+		font-variant-numeric: tabular-nums;
+		animation: sb-pulse 2.4s ease-in-out infinite;
+	}
+
+	.sb-conn {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.sb-dot {
+		display: inline-block;
+		width: 6px;
+		height: 6px;
+		background: var(--terminal-status-neutral);
+		animation: sb-pulse 1.8s ease-in-out infinite;
+	}
+
+	.sb-conn--open .sb-dot {
+		background: var(--terminal-status-success);
+		box-shadow: 0 0 8px var(--terminal-status-success);
+	}
+
+	.sb-conn--open .sb-conn-label {
+		color: var(--terminal-status-success);
+	}
+
+	.sb-conn--connecting .sb-dot {
+		background: var(--terminal-accent-cyan);
+		box-shadow: 0 0 8px var(--terminal-accent-cyan);
+	}
+
+	.sb-conn--connecting .sb-conn-label {
+		color: var(--terminal-accent-cyan);
+	}
+
+	.sb-conn--degraded .sb-dot {
+		background: var(--terminal-status-warn);
+		box-shadow: 0 0 8px var(--terminal-status-warn);
+	}
+
+	.sb-conn--degraded .sb-conn-label {
+		color: var(--terminal-status-warn);
+	}
+
+	.sb-conn--closed .sb-dot,
+	.sb-conn--error .sb-dot {
+		background: var(--terminal-status-error);
+		box-shadow: 0 0 8px var(--terminal-status-error);
+	}
+
+	.sb-conn--closed .sb-conn-label,
+	.sb-conn--error .sb-conn-label {
+		color: var(--terminal-status-error);
+	}
+
+	.sb-clock {
+		color: var(--terminal-fg-secondary);
+		font-variant-numeric: tabular-nums;
+		letter-spacing: 0.04em;
+	}
+
+	@keyframes sb-pulse {
+		0%,
+		100% {
+			opacity: 0.45;
+		}
+		50% {
+			opacity: 1;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.sb-dot,
+		.sb-standby {
+			animation: none;
+		}
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalTopNav.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalTopNav.svelte
@@ -1,0 +1,659 @@
+<!--
+	TerminalTopNav.svelte — global navigation chrome.
+	=================================================
+
+	Source of truth: docs/plans/2026-04-19-ii-terminal-extraction.md
+		§X2 route move — institutional flow rewire.
+
+	F-key ordering (X2): six canonical tabs in institutional-lifecycle
+	order, Macro context flowing into Builder allocation flowing into
+	DD validation. No RESEARCH tab at top-level — research is scoped
+	under SCREENER (/screener/research).
+
+		F1  LIVE      /live
+		F2  SCREENER  /screener
+		F3  MACRO     /macro
+		F4  BUILDER   /allocation  (builder surface = allocation review)
+		F5  DD        /dd
+		F6  ALERTS    /alerts
+
+	Fixed 32px top chrome strip.
+
+	Shared across wealth and terminal during X2–X6. Wealth adds minimal
+	redirect shims for /live and /screener/research so the resolve()
+	typecheck passes in both apps: see
+	frontends/wealth/src/routes/(terminal)/live (redirects to
+	/portfolio/live) and frontends/wealth/src/routes/(app)/screener/
+	research (redirects to /research). The /screener F-key resolves to
+	wealth's existing (app)/screener page — legacy wealth-app screener —
+	during transition; canonical /screener lives on the terminal app.
+
+	This component has no keyboard handling of its own. Global shortcuts
+	(Cmd+K, rail [ / ], g-prefix go-to) live inside TerminalShell's
+	window keydown listener.
+-->
+<script lang="ts">
+	import { resolve } from "$app/paths";
+	import { goto } from "$app/navigation";
+	import { getContext, onDestroy } from "svelte";
+	import { createClientApiClient } from "$wealth/api/client";
+
+	// Resolved hrefs for the 6 F-key tabs. The lint rule
+	// `svelte/no-navigation-without-resolve` rejects any href that is
+	// not the direct return value of a plain Identifier argument to
+	// `resolve(...)`; hardcoding one identifier per route is the only
+	// pattern its AST matcher accepts.
+	const HREF_LIVE = resolve("/live");
+	const HREF_SCREENER = resolve("/screener");
+	const HREF_MACRO = resolve("/macro");
+	const HREF_BUILDER = resolve("/allocation");
+	const HREF_DD = resolve("/dd");
+	const HREF_ALERTS = resolve("/alerts");
+
+	interface PrimaryTab {
+		id: string;
+		label: string;
+		href: string;
+		fKey: number;
+	}
+
+	interface TerminalTopNavProps {
+		/**
+		 * Currently active pathname (from `$page.url.pathname`).
+		 * TopNav uses this to highlight the active tab.
+		 */
+		activePath: string;
+		/**
+		 * Callback fired when user clicks the command palette trigger.
+		 * TerminalShell wires this to toggle the CommandPalette overlay.
+		 */
+		onOpenPalette: () => void;
+		/**
+		 * Optional: unread alert count driving the alert pill badge.
+		 * Zero means no badge; non-zero renders a red circle with count.
+		 */
+		alertCount?: number;
+		/**
+		 * DD queue count (pending + in_progress). Drives a badge on
+		 * the DD tab when > 0.
+		 */
+		ddQueueCount?: number;
+		/**
+		 * User initials rendered inside the session chip. Two-char mono
+		 * expected; empty string fallback renders "—".
+		 */
+		userInitials: string;
+		/**
+		 * Organization name shown on the tenant switcher placeholder.
+		 * Empty string fallback renders "II" (InvestIntell product
+		 * default for unauthenticated / pre-hydration chrome).
+		 */
+		orgName: string;
+	}
+
+	let {
+		activePath,
+		onOpenPalette,
+		alertCount = 0,
+		ddQueueCount = 0,
+		userInitials,
+		orgName,
+	}: TerminalTopNavProps = $props();
+
+	// ─── Live regime from /allocation/regime ───────────────────
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const regimeApi = createClientApiClient(getToken);
+
+	interface GlobalRegimeRead {
+		regime: string;
+		confidence: number;
+		as_of_date: string | null;
+	}
+
+	let regimeLabel = $state("STANDBY");
+	let regimeLoaded = $state(false);
+
+	const REGIME_DISPLAY: Record<string, string> = {
+		REGIME_NORMAL: "Normal",
+		normal: "Normal",
+		REGIME_RISK_ON: "Risk On",
+		risk_on: "Risk On",
+		REGIME_RISK_OFF: "Risk Off",
+		risk_off: "Risk Off",
+		REGIME_CRISIS: "Crisis",
+		crisis: "Crisis",
+	};
+
+	function sanitizeRegime(raw: string): string {
+		return REGIME_DISPLAY[raw] ?? raw;
+	}
+
+	const regimeColorClass = $derived.by(() => {
+		switch (regimeLabel) {
+			case "Normal": return "tn-regime-value--ok";
+			case "Risk On": return "tn-regime-value--cyan";
+			case "Risk Off": return "tn-regime-value--amber";
+			case "Crisis": return "tn-regime-value--error";
+			default: return "";
+		}
+	});
+
+	async function fetchRegime() {
+		try {
+			const res = await regimeApi.get<GlobalRegimeRead>("/allocation/regime");
+			regimeLabel = sanitizeRegime(res.regime);
+			regimeLoaded = true;
+		} catch {
+			// Keep current label on failure
+		}
+	}
+
+	$effect(() => {
+		fetchRegime();
+		const timer = setInterval(fetchRegime, 5 * 60 * 1000);
+		return () => clearInterval(timer);
+	});
+
+	const PRIMARY_TABS: ReadonlyArray<PrimaryTab> = [
+		{ id: "live",     label: "LIVE",     href: HREF_LIVE,     fKey: 1 },
+		{ id: "screener", label: "SCREENER", href: HREF_SCREENER, fKey: 2 },
+		{ id: "macro",    label: "MACRO",    href: HREF_MACRO,    fKey: 3 },
+		{ id: "builder",  label: "BUILDER",  href: HREF_BUILDER,  fKey: 4 },
+		{ id: "dd",       label: "DD",       href: HREF_DD,       fKey: 5 },
+		{ id: "alerts",   label: "ALERTS",   href: HREF_ALERTS,   fKey: 6 },
+	];
+
+	function isHrefActive(href: string): boolean {
+		return (
+			href === HREF_LIVE ||
+			href === HREF_SCREENER ||
+			href === HREF_MACRO ||
+			href === HREF_BUILDER ||
+			href === HREF_DD ||
+			href === HREF_ALERTS
+		);
+	}
+
+	function activePathSegment(href: string): string {
+		if (href === HREF_LIVE) return "/live";
+		if (href === HREF_SCREENER) return "/screener";
+		if (href === HREF_MACRO) return "/macro";
+		if (href === HREF_BUILDER) return "/allocation";
+		if (href === HREF_DD) return "/dd";
+		if (href === HREF_ALERTS) return "/alerts";
+		return href;
+	}
+
+	function isActiveTab(tab: PrimaryTab): boolean {
+		if (!isHrefActive(tab.href)) return false;
+		return activePath.startsWith(activePathSegment(tab.href));
+	}
+
+	// Platform detection for the Cmd+K affordance. SSR-safe default to
+	// Ctrl, hydrate to Cmd on macOS when navigator becomes available.
+	let paletteHint = $state("Ctrl+K");
+	$effect(() => {
+		if (typeof navigator === "undefined") return;
+		const platform = navigator.platform ?? "";
+		const userAgent = navigator.userAgent ?? "";
+		const isMac = /Mac|iPhone|iPad|iPod/.test(platform) || /Mac OS X/.test(userAgent);
+		paletteHint = isMac ? "⌘K" : "Ctrl+K";
+	});
+
+	const displayUserInitials = $derived(
+		userInitials.length > 0 ? userInitials : "—",
+	);
+	const displayOrgName = $derived(orgName.length > 0 ? orgName : "II");
+
+	const alertBadgeLabel = $derived(
+		alertCount > 99 ? "99+" : String(alertCount),
+	);
+
+	function handleTenantClick() {
+		// Pending Clerk SDK resolution — no-op for X2. A later sprint
+		// wires the real org switcher when the SvelteKit SDK stabilizes
+		// (see CLAUDE.md §Clerk SvelteKit SDK Note).
+	}
+
+	function handleAlertClick() {
+		// Navigate to the alerts inbox route.
+		goto(HREF_ALERTS);
+	}
+
+	function handleSessionClick() {
+		// Clerk user menu — pending SDK. Same rationale as tenant
+		// switcher. No-op for X2.
+	}
+</script>
+
+<nav class="tn-nav" aria-label="Terminal primary navigation">
+	<div class="tn-brand">
+		<span class="tn-brand-mark">▣</span>
+		<span class="tn-brand-name">{displayOrgName} / TERMINAL</span>
+	</div>
+
+	<ul class="tn-tabs" role="list">
+		{#each PRIMARY_TABS as tab (tab.id)}
+			<li class="tn-tab-item">
+				{#if tab.id === "live"}
+					<a
+						class="tn-tab tn-tab--active"
+						class:tn-tab--current={isActiveTab(tab)}
+						href={HREF_LIVE}
+						data-sveltekit-preload-data="hover"
+					>
+						<span class="tn-tab-fkey">F{tab.fKey}</span>
+						<span class="tn-tab-label">{tab.label}</span>
+					</a>
+				{:else if tab.id === "screener"}
+					<a
+						class="tn-tab tn-tab--active"
+						class:tn-tab--current={isActiveTab(tab)}
+						href={HREF_SCREENER}
+						data-sveltekit-preload-data="hover"
+					>
+						<span class="tn-tab-fkey">F{tab.fKey}</span>
+						<span class="tn-tab-label">{tab.label}</span>
+					</a>
+				{:else if tab.id === "macro"}
+					<a
+						class="tn-tab tn-tab--active"
+						class:tn-tab--current={isActiveTab(tab)}
+						href={HREF_MACRO}
+						data-sveltekit-preload-data="hover"
+					>
+						<span class="tn-tab-fkey">F{tab.fKey}</span>
+						<span class="tn-tab-label">{tab.label}</span>
+					</a>
+				{:else if tab.id === "builder"}
+					<a
+						class="tn-tab tn-tab--active"
+						class:tn-tab--current={isActiveTab(tab)}
+						href={HREF_BUILDER}
+						data-sveltekit-preload-data="hover"
+					>
+						<span class="tn-tab-fkey">F{tab.fKey}</span>
+						<span class="tn-tab-label">{tab.label}</span>
+					</a>
+				{:else if tab.id === "dd"}
+					<a
+						class="tn-tab tn-tab--active"
+						class:tn-tab--current={isActiveTab(tab)}
+						href={HREF_DD}
+						data-sveltekit-preload-data="hover"
+					>
+						<span class="tn-tab-fkey">F{tab.fKey}</span>
+						<span class="tn-tab-label">{tab.label}</span>
+						{#if ddQueueCount > 0}
+							<span class="tn-dd-badge">{ddQueueCount > 99 ? "99+" : ddQueueCount}</span>
+						{/if}
+					</a>
+				{:else if tab.id === "alerts"}
+					<a
+						class="tn-tab tn-tab--active"
+						class:tn-tab--current={isActiveTab(tab)}
+						href={HREF_ALERTS}
+						data-sveltekit-preload-data="hover"
+					>
+						<span class="tn-tab-fkey">F{tab.fKey}</span>
+						<span class="tn-tab-label">{tab.label}</span>
+					</a>
+				{/if}
+			</li>
+		{/each}
+	</ul>
+
+	<div class="tn-right">
+		<button
+			type="button"
+			class="tn-palette-trigger"
+			onclick={onOpenPalette}
+			aria-label="Open command palette"
+		>
+			<span class="tn-palette-bracket">[</span>
+			<span class="tn-palette-hint">{paletteHint}</span>
+			<span class="tn-palette-bracket">]</span>
+		</button>
+
+		<span class="tn-regime" aria-live="polite">
+			<span class="tn-regime-label">REGIME</span>
+			<span class="tn-regime-value {regimeColorClass}">{regimeLabel}</span>
+		</span>
+
+		<button
+			type="button"
+			class="tn-tenant"
+			onclick={handleTenantClick}
+			title="Tenant switcher pending Clerk SDK"
+			aria-label={`Current organization ${displayOrgName}`}
+		>
+			<span class="tn-tenant-label">{displayOrgName}</span>
+			<span class="tn-tenant-caret">▾</span>
+		</button>
+
+		<button
+			type="button"
+			class="tn-alerts"
+			onclick={handleAlertClick}
+			aria-label={alertCount > 0 ? `${alertCount} unread alerts` : "Alerts inbox"}
+			title={alertCount > 0 ? `${alertCount} unread` : "Alerts inbox"}
+		>
+			<span class="tn-alerts-icon">△</span>
+			{#if alertCount > 0}
+				<span class="tn-alerts-badge">{alertBadgeLabel}</span>
+			{/if}
+		</button>
+
+		<button
+			type="button"
+			class="tn-session"
+			onclick={handleSessionClick}
+			aria-label="User session menu"
+			title="User menu pending Clerk SDK"
+		>
+			{displayUserInitials}
+		</button>
+	</div>
+</nav>
+
+<style>
+	.tn-nav {
+		position: relative;
+		z-index: var(--terminal-z-panel);
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		align-items: stretch;
+		gap: var(--terminal-space-4);
+		height: 32px;
+		padding: 0 var(--terminal-space-4);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		box-sizing: border-box;
+	}
+
+	.tn-brand {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding-right: var(--terminal-space-4);
+		border-right: var(--terminal-border-hairline);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-primary);
+		font-weight: 700;
+	}
+
+	.tn-brand-mark {
+		color: var(--terminal-accent-amber);
+		font-size: var(--terminal-text-12);
+	}
+
+	.tn-brand-name {
+		font-size: var(--terminal-text-10);
+		letter-spacing: 0.12em;
+	}
+
+	.tn-tabs {
+		display: flex;
+		align-items: stretch;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		gap: 0;
+		min-width: 0;
+	}
+
+	.tn-tab-item {
+		display: flex;
+		align-items: stretch;
+	}
+
+	.tn-tab {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		padding: 0 var(--terminal-space-3);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		text-decoration: none;
+		color: var(--terminal-fg-tertiary);
+		border-bottom: 2px solid transparent;
+		transition:
+			color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+		user-select: none;
+	}
+
+	.tn-tab--active {
+		cursor: pointer;
+	}
+
+	.tn-tab--active:hover {
+		color: var(--terminal-accent-amber);
+	}
+
+	.tn-tab--current {
+		color: var(--terminal-accent-amber);
+		border-bottom-color: var(--terminal-accent-amber);
+	}
+
+	.tn-tab--active:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -2px;
+	}
+
+	.tn-tab-fkey {
+		font-weight: 500;
+		color: var(--terminal-fg-muted);
+		letter-spacing: 0;
+	}
+
+	.tn-tab-label {
+		font-weight: 600;
+	}
+
+	.tn-right {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding-left: var(--terminal-space-4);
+		border-left: var(--terminal-border-hairline);
+	}
+
+	.tn-palette-trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		padding: 2px var(--terminal-space-2);
+		color: var(--terminal-fg-secondary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		cursor: pointer;
+		text-transform: uppercase;
+		transition:
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.tn-palette-trigger:hover {
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+	}
+
+	.tn-palette-trigger:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.tn-palette-bracket {
+		color: var(--terminal-fg-muted);
+	}
+
+	.tn-palette-hint {
+		font-weight: 600;
+	}
+
+	.tn-regime {
+		display: inline-flex;
+		align-items: baseline;
+		gap: var(--terminal-space-1);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-muted);
+		text-transform: uppercase;
+	}
+
+	.tn-regime-label {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.tn-regime-value {
+		font-weight: 600;
+	}
+
+	.tn-regime-value--ok {
+		color: var(--terminal-status-ok);
+	}
+
+	.tn-regime-value--cyan {
+		color: var(--terminal-accent-cyan);
+	}
+
+	.tn-regime-value--amber {
+		color: var(--terminal-accent-amber);
+	}
+
+	.tn-regime-value--error {
+		color: var(--terminal-status-error);
+	}
+
+	.tn-tenant {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-1);
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		padding: 2px var(--terminal-space-2);
+		color: var(--terminal-fg-secondary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		cursor: pointer;
+		text-transform: uppercase;
+		transition: border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.tn-tenant:hover {
+		border-color: var(--terminal-accent-cyan);
+		color: var(--terminal-accent-cyan);
+	}
+
+	.tn-tenant:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.tn-tenant-caret {
+		color: var(--terminal-fg-muted);
+	}
+
+	.tn-alerts {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
+		height: 22px;
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		color: var(--terminal-fg-secondary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-12);
+		cursor: pointer;
+		transition:
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.tn-alerts:hover {
+		border-color: var(--terminal-status-warn);
+		color: var(--terminal-status-warn);
+	}
+
+	.tn-alerts:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.tn-alerts-badge {
+		position: absolute;
+		top: -6px;
+		right: -8px;
+		min-width: 14px;
+		height: 14px;
+		padding: 0 3px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--terminal-status-error);
+		color: var(--terminal-fg-inverted);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0;
+		box-sizing: border-box;
+	}
+
+	.tn-session {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		letter-spacing: 0;
+		cursor: pointer;
+		text-transform: uppercase;
+		font-weight: 700;
+		transition: border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.tn-session:hover {
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+	}
+
+	.tn-session:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.tn-dd-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 14px;
+		height: 14px;
+		padding: 0 3px;
+		background: var(--terminal-accent-cyan);
+		color: var(--terminal-fg-inverted);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0;
+		box-sizing: border-box;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalTopNav.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalTopNav.svelte
@@ -36,7 +36,7 @@
 	import { resolve } from "$app/paths";
 	import { goto } from "$app/navigation";
 	import { getContext, onDestroy } from "svelte";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../../api/client";
 
 	// Resolved hrefs for the 6 F-key tabs. The lint rule
 	// `svelte/no-navigation-without-resolve` rejects any href that is

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalTweaksPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalTweaksPanel.svelte
@@ -1,0 +1,252 @@
+<!--
+	TerminalTweaksPanel.svelte
+	==========================
+
+	Floating gear button (bottom-right) + right-side drawer with density,
+	accent, and theme toggles. Reads/writes the terminal-tweaks store
+	wired via context at (terminal)/+layout.svelte.
+
+	Source: docs/plans/2026-04-18-netz-terminal-parity.md §C.2.
+
+	Keyboard: Shift+T toggles open/close. Ignored inside editable fields.
+	Mount location: TerminalShell root (OUTSIDE LayoutCage) so the drawer
+	is unaffected by the cage padding override pattern — see plan §H risk #4.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import {
+		TerminalAccentPicker,
+		TerminalDensityToggle,
+		TerminalPill,
+		TerminalThemeToggle,
+		TerminalKbd,
+	} from "@investintell/ui";
+	import {
+		TERMINAL_TWEAKS_KEY,
+		type TerminalTweaks,
+	} from "$wealth/stores/terminal-tweaks.svelte";
+
+	const tweaks = getContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY);
+
+	let open = $state(false);
+
+	function isEditableTarget(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		const tag = target.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+		if (target.isContentEditable) return true;
+		const role = target.getAttribute("role");
+		if (role === "textbox" || role === "searchbox" || role === "combobox") {
+			return true;
+		}
+		return false;
+	}
+
+	$effect(() => {
+		if (typeof window === "undefined") return;
+		const handler = (event: KeyboardEvent) => {
+			if (
+				event.shiftKey &&
+				!event.metaKey &&
+				!event.ctrlKey &&
+				!event.altKey &&
+				(event.key === "T" || event.key === "t")
+			) {
+				if (isEditableTarget(event.target)) return;
+				event.preventDefault();
+				open = !open;
+			} else if (event.key === "Escape" && open) {
+				open = false;
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	});
+</script>
+
+<button
+	type="button"
+	class="tweaks-fab"
+	aria-label="Open terminal tweaks (Shift+T)"
+	aria-expanded={open}
+	aria-controls="terminal-tweaks-drawer"
+	onclick={() => (open = !open)}
+>
+	<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+		<path
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.25"
+			d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Zm5.6 2.5a5.7 5.7 0 0 0-.1-1l1.3-1-1.3-2.3-1.6.5a5.6 5.6 0 0 0-1.7-1L9.8 1H7.2l-.4 1.7a5.6 5.6 0 0 0-1.7 1l-1.6-.5-1.3 2.3 1.3 1a5.7 5.7 0 0 0 0 2l-1.3 1 1.3 2.3 1.6-.5a5.6 5.6 0 0 0 1.7 1l.4 1.7h2.6l.4-1.7a5.6 5.6 0 0 0 1.7-1l1.6.5 1.3-2.3-1.3-1c.1-.3.1-.7.1-1Z"
+		/>
+	</svg>
+</button>
+
+{#if open}
+	<div
+		class="tweaks-scrim"
+		aria-hidden="true"
+		role="presentation"
+		onclick={() => (open = false)}
+		onkeydown={(e) => {
+			if (e.key === "Enter" || e.key === " ") open = false;
+		}}
+	></div>
+	<div
+		id="terminal-tweaks-drawer"
+		class="tweaks-drawer"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Terminal tweaks"
+		tabindex="-1"
+	>
+		<header class="tweaks-header">
+			<span class="tweaks-title">TWEAKS</span>
+			<span class="tweaks-shortcut">
+				<TerminalKbd keys={["Shift", "T"]} />
+			</span>
+			<button
+				type="button"
+				class="tweaks-close"
+				aria-label="Close"
+				onclick={() => (open = false)}
+			>
+				×
+			</button>
+		</header>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">DENSITY</div>
+			<TerminalDensityToggle
+				value={tweaks.density}
+				onChange={(v) => tweaks.setDensity(v)}
+			/>
+		</section>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">ACCENT</div>
+			<TerminalAccentPicker
+				value={tweaks.accent}
+				onChange={(v) => tweaks.setAccent(v)}
+			/>
+		</section>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">THEME</div>
+			<TerminalThemeToggle
+				value={tweaks.theme}
+				onChange={(v) => tweaks.setTheme(v)}
+			/>
+		</section>
+
+		<section class="tweaks-section">
+			<div class="tweaks-section__label">LIVE SIM</div>
+			<TerminalPill label="OFF" tone="neutral" size="sm" />
+		</section>
+	</div>
+{/if}
+
+<style>
+	.tweaks-fab {
+		position: fixed;
+		bottom: calc(var(--terminal-shell-statusbar-height) + var(--terminal-space-3));
+		right: var(--terminal-space-3);
+		z-index: var(--terminal-z-toast);
+		width: 32px;
+		height: 32px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-fg-secondary);
+		border: var(--terminal-border-hairline);
+		border-radius: var(--terminal-radius-none);
+		cursor: pointer;
+		transition: color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.tweaks-fab:hover {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+	.tweaks-fab:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.tweaks-scrim {
+		position: fixed;
+		inset: 0;
+		background: var(--terminal-bg-scrim);
+		z-index: calc(var(--terminal-z-toast) - 1);
+	}
+
+	.tweaks-drawer {
+		position: fixed;
+		top: var(--terminal-shell-topbar-height);
+		right: 0;
+		bottom: var(--terminal-shell-statusbar-height);
+		width: 320px;
+		background: var(--terminal-bg-panel);
+		border-left: var(--terminal-border-strong);
+		z-index: var(--terminal-z-toast);
+		padding: var(--terminal-space-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-6);
+		overflow-y: auto;
+		font-family: var(--terminal-font-mono);
+	}
+
+	.tweaks-header {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-3);
+		padding-bottom: var(--terminal-space-3);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.tweaks-title {
+		font-size: var(--terminal-text-11);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-primary);
+		text-transform: uppercase;
+		flex: 1;
+	}
+	.tweaks-shortcut {
+		display: inline-flex;
+	}
+	.tweaks-close {
+		width: 20px;
+		height: 20px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		background: transparent;
+		color: var(--terminal-fg-tertiary);
+		border: var(--terminal-border-hairline);
+		font-size: var(--terminal-text-14);
+		line-height: 1;
+		cursor: pointer;
+	}
+	.tweaks-close:hover {
+		color: var(--terminal-fg-primary);
+		border-color: var(--terminal-fg-secondary);
+	}
+	.tweaks-close:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+
+	.tweaks-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-2);
+	}
+	.tweaks-section__label {
+		font-size: var(--terminal-text-10);
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalTweaksPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/shell/TerminalTweaksPanel.svelte
@@ -24,7 +24,7 @@
 	import {
 		TERMINAL_TWEAKS_KEY,
 		type TerminalTweaks,
-	} from "$wealth/stores/terminal-tweaks.svelte";
+	} from "../../../stores/terminal-tweaks.svelte";
 
 	const tweaks = getContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY);
 

--- a/packages/ii-terminal-core/src/lib/constants/blocks.ts
+++ b/packages/ii-terminal-core/src/lib/constants/blocks.ts
@@ -1,0 +1,95 @@
+/** Block display labels — single source of truth for all allocation block IDs. */
+
+export const BLOCK_LABELS: Record<string, string> = {
+	na_equity_large: "NA Equity Large",
+	na_equity_growth: "NA Equity Growth",
+	na_equity_value: "NA Equity Value",
+	na_equity_small: "NA Equity Small",
+	dm_europe_equity: "DM Europe Equity",
+	dm_asia_equity: "DM Asia Equity",
+	em_equity: "Emerging Markets Equity",
+	fi_us_aggregate: "FI US Aggregate",
+	fi_us_treasury: "FI US Treasury",
+	fi_us_tips: "FI US TIPS",
+	fi_us_high_yield: "FI US High Yield",
+	fi_em_debt: "FI EM Debt",
+	fi_treasury: "Treasuries",
+	fi_credit_ig: "Credit IG",
+	fi_credit_hy: "Credit HY",
+	alt_real_estate: "Alt Real Estate",
+	alt_commodities: "Alt Commodities",
+	alt_gold: "Alt Gold",
+	alt_reits: "REITs",
+	intl_equity_dm: "Intl Equity DM",
+	intl_equity_em: "Intl Equity EM",
+	cash: "Cash",
+};
+
+export function blockLabel(blockId: string): string {
+	return BLOCK_LABELS[blockId] ?? blockId.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export const BLOCK_GROUPS: Record<string, string[]> = {
+	EQUITIES: ["na_equity_large", "na_equity_growth", "na_equity_value", "na_equity_small", "dm_europe_equity", "dm_asia_equity", "em_equity"],
+	"FIXED INCOME": ["fi_us_aggregate", "fi_us_treasury", "fi_us_tips", "fi_us_high_yield", "fi_em_debt"],
+	ALTERNATIVES: ["alt_real_estate", "alt_commodities", "alt_gold"],
+	"CASH & EQUIVALENTS": ["cash"],
+};
+
+// ── UX Glossary — human-readable labels for front-office display ─────
+// Intercepts raw DB keys before rendering. Backend stays agnotic.
+
+/** Asset class group names → executive display labels */
+export const GROUP_DISPLAY: Record<string, string> = {
+	EQUITIES: "Equities",
+	"FIXED INCOME": "Fixed Income",
+	ALTERNATIVES: "Alternatives",
+	"CASH & EQUIVALENTS": "Cash & Equivalents",
+	OTHER: "Other Instruments",
+};
+
+/** Block IDs → UX-friendly region/sub-class labels (no abbreviations) */
+export const BLOCK_DISPLAY: Record<string, string> = {
+	na_equity_large: "North America — Large Cap",
+	na_equity_growth: "North America — Growth",
+	na_equity_value: "North America — Value",
+	na_equity_small: "North America — Small Cap",
+	dm_europe_equity: "Developed Markets — Europe",
+	dm_asia_equity: "Developed Markets — Asia Pacific",
+	em_equity: "Emerging Markets",
+	fi_us_aggregate: "US Aggregate Bond",
+	fi_us_treasury: "US Treasury",
+	fi_us_tips: "US Inflation-Protected (TIPS)",
+	fi_us_high_yield: "US High Yield",
+	fi_em_debt: "Emerging Markets Debt",
+	fi_treasury: "Treasuries",
+	fi_credit_ig: "Investment Grade Credit",
+	fi_credit_hy: "High Yield Credit",
+	alt_real_estate: "Real Estate",
+	alt_commodities: "Commodities",
+	alt_gold: "Gold & Precious Metals",
+	alt_reits: "REITs",
+	intl_equity_dm: "International — Developed Markets",
+	intl_equity_em: "International — Emerging Markets",
+	cash: "Cash & Money Market",
+};
+
+/** Resolve UX-friendly block display name, fallback to blockLabel */
+export function blockDisplay(blockId: string): string {
+	return BLOCK_DISPLAY[blockId] ?? blockLabel(blockId);
+}
+
+/** Resolve UX-friendly group display name */
+export function groupDisplay(groupName: string): string {
+	return GROUP_DISPLAY[groupName] ?? groupName;
+}
+
+/** Portfolio display name overrides — sanitize aggressive language */
+export const PORTFOLIO_DISPLAY: Record<string, string> = {
+	"Aggressive Growth": "Strategic Growth",
+};
+
+/** Resolve portfolio display name with UX override */
+export function portfolioDisplayName(raw: string): string {
+	return PORTFOLIO_DISPLAY[raw] ?? raw;
+}

--- a/packages/ii-terminal-core/src/lib/constants/regime.ts
+++ b/packages/ii-terminal-core/src/lib/constants/regime.ts
@@ -1,0 +1,29 @@
+/** Regime display labels, colors, and CVaR multipliers — shared across dashboard and components. */
+
+export const regimeLabels: Record<string, string> = {
+	RISK_ON: "Expansion",
+	RISK_OFF: "Defensive",
+	INFLATION: "Inflation",
+	CRISIS: "Stress",
+};
+
+export const regimeColors: Record<string, string> = {
+	RISK_ON: "var(--ii-success)",
+	RISK_OFF: "var(--ii-warning)",
+	INFLATION: "var(--ii-brand-highlight)",
+	CRISIS: "var(--ii-danger)",
+};
+
+export const REGIME_CVAR_MULTIPLIER: Record<string, number> = {
+	RISK_ON: 1.00,
+	RISK_OFF: 0.85,
+	CRISIS: 0.70,
+	INFLATION: 0.90,
+};
+
+export function regimeMultiplierLabel(regime: string): string {
+	const m = REGIME_CVAR_MULTIPLIER[regime];
+	if (!m || m === 1.0) return "";
+	const pct = Math.round((1 - m) * 100);
+	return `Risk budget tightened by ${pct}%`;
+}

--- a/packages/ii-terminal-core/src/lib/index.ts
+++ b/packages/ii-terminal-core/src/lib/index.ts
@@ -1,0 +1,67 @@
+/**
+ * @investintell/ii-terminal-core — barrel
+ *
+ * Top-level exports for the most frequently-imported entry points.
+ * Deep imports (live/, builder/, allocation/, screener-terminal/,
+ * macro/, dd/, focus-mode/) remain available via subpath exports:
+ *   @investintell/ii-terminal-core/components/terminal/live/...
+ *   @investintell/ii-terminal-core/stores/market-data.svelte
+ *   @investintell/ii-terminal-core/types/portfolio-build
+ *   @investintell/ii-terminal-core/utils/sse-reader
+ *   @investintell/ii-terminal-core/constants/blocks
+ *   @investintell/ii-terminal-core/api/client
+ */
+
+// Shell
+export { default as TerminalShell } from "./components/terminal/shell/TerminalShell.svelte";
+export { default as TerminalTopNav } from "./components/terminal/shell/TerminalTopNav.svelte";
+export { default as TerminalStatusBar } from "./components/terminal/shell/TerminalStatusBar.svelte";
+export { default as TerminalBreadcrumb } from "./components/terminal/shell/TerminalBreadcrumb.svelte";
+export { default as TerminalContextRail } from "./components/terminal/shell/TerminalContextRail.svelte";
+export { default as TerminalTweaksPanel } from "./components/terminal/shell/TerminalTweaksPanel.svelte";
+export { default as LayoutCage } from "./components/terminal/shell/LayoutCage.svelte";
+export { default as AlertTicker } from "./components/terminal/shell/AlertTicker.svelte";
+export { default as CommandPalette } from "./components/terminal/shell/CommandPalette.svelte";
+
+// Focus mode
+export { default as FundFocusMode } from "./components/terminal/focus-mode/fund/FundFocusMode.svelte";
+
+// Stores
+export {
+	createMarketDataStore,
+	type MarketDataStore,
+	type MarketDataStoreConfig,
+	type PriceTick,
+	type HoldingSummary,
+	type DashboardSnapshot,
+	type WsStatus,
+} from "./stores/market-data.svelte";
+export {
+	createTerminalTweaks,
+	TERMINAL_TWEAKS_KEY,
+	type TerminalTweaks,
+} from "./stores/terminal-tweaks.svelte";
+
+// State
+export {
+	workspace,
+	PortfolioWorkspaceState,
+	type CascadePhase,
+	type ConstructionStressResult,
+	type ConstructionValidationResult,
+	type ConstructionNarrativeContent,
+	type StressResultView,
+	type UniverseFund,
+	type WorkspaceError,
+	type FactorContribution,
+	type FactorAnalysisResponse,
+} from "./state/portfolio-workspace.svelte";
+export { pinnedRegime, type PinnedRegime } from "./state/pinned-regime.svelte";
+
+// API
+export {
+	createClientApiClient,
+	createServerApiClient,
+	setAuthRedirectHandler,
+	setConflictHandler,
+} from "./api/client";

--- a/packages/ii-terminal-core/src/lib/state/pinned-regime.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/pinned-regime.svelte.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared reactive state for pinned regime.
+ *
+ * Written by macro desk [PIN REGIME] button, read by
+ * TerminalContextRail and any downstream surface that
+ * needs regime context (Builder, Screener, etc.).
+ *
+ * Module-level $state — singleton across the app.
+ * No localStorage (terminal namespace forbids it).
+ */
+
+export interface PinnedRegime {
+	label: string;
+	region: string;
+	score: number;
+}
+
+let current = $state<PinnedRegime | null>(null);
+
+export const pinnedRegime = {
+	get current() {
+		return current;
+	},
+	pin(regime: PinnedRegime) {
+		current = regime;
+	},
+	clear() {
+		current = null;
+	},
+};

--- a/packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts
@@ -1,0 +1,2214 @@
+/**
+ * Portfolio Workspace — Global state for the unified Portfolio Builder.
+ * Manages sidebar/main tab selection, active portfolio, and async operation flags.
+ * All API calls go through NetzApiClient (no mocks).
+ */
+
+import { v4 as uuidv4 } from "uuid";
+import { createClientApiClient } from "$wealth/api/client";
+import { BLOCK_LABELS } from "$wealth/constants/blocks";
+import { parseSseStream } from "$wealth/util/sse-reader";
+import type { BuildAccepted, BuildEvent, BuildPhase } from "$wealth/types/portfolio-build";
+import type {
+	ModelPortfolio,
+	NAVPoint,
+	ParametricStressRequest,
+	ParametricStressResult,
+	RebalancePreviewRequest,
+	RebalancePreviewResponse,
+	TrackRecord,
+	OverlapResult,
+	ConstructionAdvice,
+} from "$wealth/types/model-portfolio";
+import type {
+	AttributionResult,
+	StrategyDriftAlert,
+	CorrelationRegimeResult,
+	RiskBudgetResult,
+} from "$wealth/types/analytics";
+import type {
+	PortfolioCalibration,
+	PortfolioCalibrationUpdate,
+} from "$wealth/types/portfolio-calibration";
+import type {
+	PortfolioAlertCount,
+	UnifiedAlertInbox,
+} from "$wealth/types/alerts";
+import type {
+	CascadeTelemetry,
+	AchievableReturnBand,
+	OperatorSignal,
+	PreviewCvarResponse,
+} from "$wealth/types/cascade-telemetry";
+import type {
+	RegimeBands,
+	TaaHistory,
+	EffectiveAllocationWithRegime,
+} from "$wealth/types/taa";
+
+/**
+ * Phase 3 Run Construct response payload — flat dict returned from
+ * ``GET /model-portfolios/{portfolio_id}/runs/{run_id}``. Every field
+ * maps to a column on ``portfolio_construction_runs`` (DL4). Consumed
+ * by the ConstructionNarrative + Stress matrix components in Phase 4.
+ */
+export interface ConstructionRunPayload {
+	run_id: string;
+	portfolio_id: string;
+	status: "running" | "succeeded" | "failed" | "superseded";
+	as_of_date: string;
+	requested_by: string;
+	requested_at: string | null;
+	started_at: string | null;
+	completed_at: string | null;
+	wall_clock_ms: number | null;
+	failure_reason: string | null;
+	calibration_snapshot: Record<string, unknown> | null;
+	optimizer_trace: Record<string, unknown> | null;
+	binding_constraints: unknown;
+	regime_context: Record<string, unknown> | null;
+	statistical_inputs: Record<string, unknown> | null;
+	ex_ante_metrics: Record<string, number | null> | null;
+	ex_ante_vs_previous: Record<string, number | null> | null;
+	factor_exposure: Record<string, unknown> | null;
+	stress_results: ConstructionStressResult[] | null;
+	advisor: Record<string, unknown> | null;
+	validation: ConstructionValidationResult | null;
+	narrative: ConstructionNarrativeContent | null;
+	rationale_per_weight: Record<string, unknown> | null;
+	weights_proposed: Record<string, number> | null;
+	/**
+	 * PR-A11/A12 — cascade telemetry JSONB column. Drives the PR-A13
+	 * Risk Budget panel: achievable return band, operator signal, and
+	 * per-phase cascade trace.
+	 */
+	cascade_telemetry: CascadeTelemetry | null;
+}
+
+export interface ConstructionStressResult {
+	scenario: string;
+	scenario_kind: "preset" | "user_defined";
+	nav_impact_pct: number | null;
+	cvar_impact_pct: number | null;
+	per_block_impact: Record<string, number> | null;
+	per_instrument_impact: Record<string, number> | null;
+}
+
+export interface ConstructionValidationCheck {
+	id: string;
+	label: string;
+	severity: "block" | "warn";
+	passed: boolean;
+	value: number | null;
+	threshold: number | null;
+	explanation: string;
+}
+
+export interface ConstructionValidationResult {
+	passed: boolean;
+	checks: ConstructionValidationCheck[];
+	warnings: ConstructionValidationCheck[];
+}
+
+export interface ConstructionNarrativeContent {
+	headline?: string;
+	key_points?: string[];
+	constraint_story?: string;
+	holding_changes?: Array<{
+		instrument_id: string;
+		name: string;
+		prev_weight: number | null;
+		next_weight: number;
+		delta: number;
+	}>;
+	client_safe?: string;
+}
+
+/** Phase 3 Job-or-Stream 202 response from POST /{id}/construct. */
+export interface ConstructRunAccepted {
+	run_id: string;
+	portfolio_id: string;
+	status: "running" | "succeeded" | "failed" | "cached";
+	job_id: string;
+	stream_url: string;
+	run_url: string;
+}
+
+/**
+ * SSE event shape emitted by the ``construction_run_executor``.
+ * ``event`` is the sanitized type label (humanize_event_type output);
+ * the remaining keys are the event-specific payload.
+ */
+export interface ConstructRunEvent {
+	event: string;
+	run_id?: string;
+	portfolio_id?: string;
+	status?: string;
+	wall_clock_ms?: number;
+	reason?: string;
+	// Per-phase optimizer cascade fields
+	phase?: string;
+	phase_label?: string;
+	objective_value?: number | null;
+	// PR-A11 cascade_telemetry_completed payload
+	cascade_summary?: string | null;
+	operator_signal?: OperatorSignal | null;
+	min_achievable_cvar?: number | null;
+	achievable_return_band?: AchievableReturnBand | null;
+}
+
+/** Session 3 — NAV history response for Backtest tab. */
+export interface BacktestNavHistory {
+	portfolio_id: string;
+	dates: string[];
+	nav_series: number[];
+	drawdown_series: number[];
+	metrics: {
+		sharpe: number | null;
+		max_dd: number | null;
+		ann_return: number | null;
+		calmar: number | null;
+	};
+}
+
+/** Session 3 — Monte Carlo confidence bar entry. */
+export interface MonteCarloConfidenceBar {
+	horizon: string;
+	horizon_days: number;
+	pct_5: number;
+	pct_10: number;
+	pct_25: number;
+	pct_50: number;
+	pct_75: number;
+	pct_90: number;
+	pct_95: number;
+	mean: number;
+}
+
+/** Session 3 — Monte Carlo portfolio-scoped response. */
+export interface MonteCarloPortfolioResult {
+	portfolio_id: string;
+	n_simulations: number;
+	statistic: string;
+	percentiles: Record<string, number>;
+	mean: number;
+	median: number;
+	std: number;
+	historical_value: number;
+	confidence_bars: MonteCarloConfidenceBar[];
+}
+
+/** Session 3 — Construction run diff for WeightsTab ghost columns. */
+export interface ConstructionRunDiff {
+	portfolio_id: string;
+	run_id: string;
+	previous_run_id: string | null;
+	weight_delta: Record<string, { from: number; to: number; delta: number }>;
+	metrics_delta: Record<string, { from: number | null; to: number | null; delta: number | null }>;
+	status_delta_text: string;
+}
+
+/** Cascade phase state for the CascadeTimeline component. */
+export interface CascadePhase {
+	key: string;
+	label: string;
+	status: "pending" | "running" | "succeeded" | "failed" | "skipped";
+	objectiveValue?: number | null;
+}
+
+const DEFAULT_CASCADE_PHASES: CascadePhase[] = [
+	{ key: "primary", label: "Primary Objective", status: "pending" },
+	{ key: "robust", label: "Robust Optimization", status: "pending" },
+	{ key: "variance_capped", label: "Variance-Capped", status: "pending" },
+	{ key: "min_variance", label: "Minimum Variance", status: "pending" },
+	{ key: "heuristic", label: "Recovery", status: "pending" },
+];
+
+// ── Shock mapping: UI macro-shocks → per-block shocks ────────────────
+// The backend stress engine expects shocks keyed by allocation block_id.
+// We distribute the 3 UI macro-shocks (equity %, rates bps, credit bps)
+// to the relevant block IDs using historically-calibrated beta weights.
+
+const EQUITY_BLOCKS: Record<string, number> = {
+	na_equity_large: 1.0,
+	na_equity_small: 1.2,
+	intl_equity_dm: 0.9,
+	intl_equity_em: 1.3,
+	alt_reits: 0.7,
+};
+
+const RATES_BLOCKS: Record<string, number> = {
+	fi_treasury: -1.0,
+	fi_credit_ig: -0.6,
+	fi_credit_hy: -0.3,
+	alt_gold: 0.2,
+};
+
+const CREDIT_BLOCKS: Record<string, number> = {
+	fi_credit_ig: -0.5,
+	fi_credit_hy: -1.0,
+};
+
+/**
+ * Convert UI-level macro shocks to per-block shocks dict.
+ * - equity: percentage points (e.g. -20 → -0.20 base)
+ * - rates: basis points (e.g. 200 → +0.02 base, i.e. 2% rate move)
+ * - credit: basis points (e.g. 150 → +0.015 base, i.e. 1.5% spread move)
+ */
+export function mapMacroShocksToBlocks(equity: number, rates: number, credit: number): Record<string, number> {
+	const shocks: Record<string, number> = {};
+	const eqBase = equity / 100;   // -20% → -0.20
+	const rtBase = rates / 10000;  // 200bps → 0.02
+	const crBase = credit / 10000; // 150bps → 0.015
+
+	for (const [block, beta] of Object.entries(EQUITY_BLOCKS)) {
+		shocks[block] = (shocks[block] ?? 0) + eqBase * beta;
+	}
+	for (const [block, beta] of Object.entries(RATES_BLOCKS)) {
+		shocks[block] = (shocks[block] ?? 0) + rtBase * beta;
+	}
+	for (const [block, beta] of Object.entries(CREDIT_BLOCKS)) {
+		shocks[block] = (shocks[block] ?? 0) + crBase * beta;
+	}
+
+	// Round to 6 decimal places to avoid floating point noise
+	for (const k of Object.keys(shocks)) {
+		shocks[k] = Math.round(shocks[k]! * 1e6) / 1e6;
+	}
+
+	return shocks;
+}
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface StressResultView {
+	scenario: string;
+	portfolioDrop: number;
+	blockImpacts: Record<string, number>;
+	cvarStressed: number | null;
+	worstBlock: string | null;
+	bestBlock: string | null;
+}
+
+export interface UniverseFund {
+	instrument_id: string;
+	fund_name: string;
+	ticker: string | null;
+	block_id: string;
+	block_label: string;
+	asset_class: string | null;
+	geography: string | null;
+	instrument_type: string;
+	manager_score: number | null;
+	/**
+	 * Tier 1 density fields (Flexible Columns Layout spec §3.1).
+	 * Populated from fund_risk_metrics + nav_timeseries + correlation
+	 * service. `null` means the metric is not yet computed for this
+	 * instrument — the UI renders em-dash, never crashes.
+	 */
+	aum_usd: number | null;
+	expense_ratio: number | null;
+	return_3y_ann: number | null;
+	sharpe_1y: number | null;
+	max_drawdown_1y: number | null;
+	blended_momentum_score: number | null;
+	liquidity_tier: string | null;
+	correlation_to_portfolio: number | null;
+	/** Pre-computed lowercase search key: "name|ticker|block_label" */
+	_searchKey: string;
+}
+
+/** Raw shape from GET /universe (matches UniverseAssetRead). */
+interface UniverseApiItem {
+	instrument_id: string;
+	fund_name: string;
+	ticker: string | null;
+	block_id: string | null;
+	asset_class: string | null;
+	geography: string | null;
+	approval_status: string | null;
+	manager_score: number | null;
+	aum_usd: number | null;
+	expense_ratio: number | null;
+	return_3y_ann: number | null;
+	sharpe_1y: number | null;
+	max_drawdown_1y: number | null;
+	blended_momentum_score: number | null;
+	liquidity_tier: string | null;
+	correlation_to_portfolio: number | null;
+}
+
+export interface WorkspaceError {
+	action: string;
+	message: string;
+	timestamp: number;
+}
+
+export interface FactorContribution {
+	factor_label: string;
+	pct_contribution: number;
+}
+
+export interface FactorAnalysisResponse {
+	profile: string;
+	as_of_date: string;
+	systematic_risk_pct: number;
+	specific_risk_pct: number;
+	factor_contributions: FactorContribution[];
+	r_squared: number;
+	portfolio_factor_exposures: Record<string, number>;
+}
+
+export class PortfolioWorkspaceState {
+	/** Builder sub-pills: Models | Universe | Policy */
+	activeBuilderTab = $state<"models" | "universe" | "policy">("models");
+	/** Model detail sub-pills: Holdings | Factor Analysis | Stress Testing | Overlap | Rebalance | Reporting */
+	activeModelTab = $state<"overview" | "factor" | "stress" | "overlap" | "rebalance" | "reporting">("overview");
+	/** Analytics sub-pills: Attribution | Factor | Drift | Risk Budget */
+	activeAnalyticsTab = $state<"attribution" | "factor" | "drift" | "risk-budget">("attribution");
+	portfolio = $state<ModelPortfolio | null>(null);
+	localStress = $state.raw<StressResultView | null>(null);
+	localFactorAnalysis = $state.raw<FactorAnalysisResponse | null>(null);
+	localOverlap = $state.raw<OverlapResult | null>(null);
+	/** Synthesized NAV series from backend track-record endpoint. */
+	navSeries = $state<NAVPoint[]>([]);
+	isLoadingTrackRecord = $state(false);
+	isLoadingFactorAnalysis = $state(false);
+	isLoadingOverlap = $state(false);
+	isConstructing = $state(false);
+	isStressing = $state(false);
+	isRebalancing = $state(false);
+	isExecuting = $state(false);
+	rebalanceResult = $state.raw<RebalancePreviewResponse | null>(null);
+	isLoadingAdvice = $state(false);
+	advice = $state.raw<ConstructionAdvice | null>(null);
+	/** True after a fetchConstructionAdvice() attempt (success or failure) for the current portfolio. Reset on selectPortfolio(). */
+	adviceFetched = $state(false);
+	isActivating = $state(false);
+	lastError = $state.raw<WorkspaceError | null>(null);
+
+	/** Attribution analysis (Brinson-Fachler) for current portfolio profile. */
+	attribution = $state.raw<AttributionResult | null>(null);
+	isLoadingAttribution = $state(false);
+
+	/** Strategy drift alerts across instruments. */
+	driftAlerts = $state.raw<StrategyDriftAlert[]>([]);
+	isLoadingDrift = $state(false);
+
+	/** Correlation regime analysis (Marchenko-Pastur denoising). */
+	correlationRegime = $state.raw<CorrelationRegimeResult | null>(null);
+	isLoadingCorrelationRegime = $state(false);
+
+	/** Risk budget decomposition (on-demand). */
+	riskBudget = $state.raw<RiskBudgetResult | null>(null);
+	isLoadingRiskBudget = $state(false);
+
+	// ── Phase 4 — Calibration + Construction Narrative ────────────────
+	/**
+	 * Tiered calibration surface (DL5). Loaded on selectPortfolio().
+	 * The Builder's CalibrationPanel reads this as the source-of-truth
+	 * snapshot; editing happens in a local ``draft`` owned by the
+	 * panel and persisted via ``applyCalibration`` on Apply.
+	 */
+	calibration = $state.raw<PortfolioCalibration | null>(null);
+	isLoadingCalibration = $state(false);
+	isApplyingCalibration = $state(false);
+
+	// ── TAA (Tactical Asset Allocation) — Sprint 4 regime visualization ──
+	/** Current regime bands for the portfolio's profile. */
+	regimeBands = $state.raw<RegimeBands | null>(null);
+	isLoadingRegimeBands = $state(false);
+	/** 60-day TAA history for transition sparklines. */
+	taaHistory = $state.raw<TaaHistory | null>(null);
+	isLoadingTaaHistory = $state(false);
+	/** Effective allocation enriched with regime-adjusted bands per block. */
+	effectiveWithRegime = $state.raw<EffectiveAllocationWithRegime[] | null>(null);
+	isLoadingEffectiveWithRegime = $state(false);
+
+	/**
+	 * Phase 3 construct run payload for the current portfolio — loaded
+	 * either after a successful ``runConstructJob`` (via the SSE stream
+	 * terminal ``done`` event) or on-demand via ``loadConstructionRun``.
+	 * Empty means "no run yet" — ConstructionNarrative renders the
+	 * institutional empty state (DL4 + OD-26 strict).
+	 */
+	constructionRun = $state.raw<ConstructionRunPayload | null>(null);
+	isLoadingRun = $state(false);
+
+	/**
+	 * Run Construct SSE state — replaces the legacy ``isConstructing``
+	 * boolean. ``runPhase`` advances as the executor publishes events:
+	 *
+	 *   idle → running → optimizer → stress → done (or error)
+	 *
+	 * Phase 4 Task 4.5 Job-or-Stream wiring (DL18 P2). Consumed by
+	 * BuilderColumn / BuilderRightStack for the "Building…" pill + the
+	 * auto-switch to the Narrative tab on ``done``.
+	 */
+	runPhase = $state<
+		| "idle"
+		| "running"
+		| "factor_modeling"
+		| "shrinkage"
+		| "optimizer"
+		| "stress"
+		| "done"
+		| "error"
+		| "cancelled"
+		| "deduped"
+	>("idle");
+	runError = $state<string | null>(null);
+	private _activeRunAbort: AbortController | null = null;
+
+	/** Optimizer cascade phase states for the CascadeTimeline (Session 2). */
+	optimizerPhases = $state<CascadePhase[]>(structuredClone(DEFAULT_CASCADE_PHASES));
+
+	// ── PR-A5: Build pipeline (POST /portfolios/{id}/build) ────────────
+	/** 0…1 progress surfaced by _publish_phase. 0 when idle. */
+	runProgress = $state<number>(0);
+	/** Raw metrics payloads per pipeline phase, keyed by friendly name. */
+	buildMetrics = $state<{
+		factor: Record<string, unknown> | null;
+		shrinkage: Record<string, unknown> | null;
+		socp: Record<string, unknown> | null;
+		backtest: Record<string, unknown> | null;
+	}>({ factor: null, shrinkage: null, socp: null, backtest: null });
+	/** Transient notice surfaced when the advisory lock deduped our build. */
+	buildDedupedNotice = $state<string | null>(null);
+	private _activeBuildJobId: string | null = null;
+	private _activeBuildAbort: AbortController | null = null;
+	/** Idempotency-Key of the most recent build POST — retained for QA/dev re-run toggle only. */
+	private _lastIdempotencyKey: string | null = null;
+
+	// ── Session 3: Backtest + Monte Carlo state ──────────────────────
+	backtestData = $state.raw<BacktestNavHistory | null>(null);
+	isLoadingBacktest = $state(false);
+	monteCarloData = $state.raw<MonteCarloPortfolioResult | null>(null);
+	isLoadingMonteCarlo = $state(false);
+	/** Diff data for WeightsTab ghost columns. */
+	runDiff = $state.raw<ConstructionRunDiff | null>(null);
+	isLoadingDiff = $state(false);
+
+	/** Approved universe funds for DnD — loaded from API when portfolio is selected. */
+	universe = $state<UniverseFund[]>([]);
+
+	/**
+	 * Analytics column mode — drives Estado C of the Flexible Columns
+	 * Layout (design spec 2026-04-08). Three mutually-exclusive modes:
+	 *
+	 *   - `"fund"` → PM clicked a row in the Universe table; the 3rd
+	 *     column shows the drill-down for `selectedAnalyticsFund`.
+	 *   - `"portfolio"` → PM clicked "View Chart" in the Builder
+	 *     action bar; the 3rd column shows MainPortfolioChart (NAV
+	 *     synthesis) for the current portfolio. This was previously
+	 *     pinned to the top of the Builder column — moved here so
+	 *     the Builder has full vertical space for allocation blocks.
+	 *   - `null` → Estado B (2 columns only, 3rd column hidden).
+	 *
+	 * Reset rules:
+	 *   1. Cleared on `selectPortfolio()` (switching model starts fresh).
+	 *   2. Cleared on `resetBuilderEntry()` (re-entering /portfolio from
+	 *      another route — "reset ao voltar" rule).
+	 *   3. Cleared directly by the Analytics close button via
+	 *      `clearAnalytics()`.
+	 *
+	 * NOT armazenado como `layoutState`. The layout state is derived:
+	 *   analyticsMode !== null ? "three-col" : "two-col"
+	 */
+	analyticsMode = $state.raw<"fund" | "portfolio" | null>(null);
+
+	/**
+	 * The specific fund populating the Analytics column when
+	 * `analyticsMode === "fund"`. Ignored in `"portfolio"` mode.
+	 */
+	selectedAnalyticsFund = $state.raw<UniverseFund | null>(null);
+
+	/** Token provider — set once from +page.svelte via setGetToken(). */
+	private _getToken: (() => Promise<string>) | null = null;
+
+	/**
+	 * Generation counter — incremented on every selectPortfolio() call.
+	 * Async methods capture the value at start and bail if it changed,
+	 * preventing stale responses from overwriting current portfolio data.
+	 */
+	private _generation = 0;
+
+	portfolioId = $derived(this.portfolio?.id ?? null);
+	funds = $derived(this.portfolio?.fund_selection_schema?.funds ?? []);
+
+	/** Sum of all fund weights across all blocks (should be ~1.0 after construction). */
+	totalWeight = $derived(this.funds.reduce((sum, f) => sum + (f.weight ?? 0), 0));
+
+	/** True when total weight is outside the acceptable [0.98, 1.02] range. */
+	weightWarning = $derived(this.funds.length > 0 && (this.totalWeight < 0.98 || this.totalWeight > 1.02));
+
+	/** Optimizer metadata from the last construction result (if available). */
+	optimizationMeta = $derived(this.portfolio?.fund_selection_schema?.optimization ?? null);
+
+	/** True when the last construction violated the CVaR risk limit. */
+	cvarViolated = $derived(this.optimizationMeta?.cvar_within_limit === false);
+
+	/** Group current funds by block_id for drop-zone rendering */
+	fundsByBlock = $derived.by(() => {
+		const map: Record<string, any[]> = {};
+		for (const f of this.funds) {
+			(map[f.block_id] ??= []).push(f);
+		}
+		return map;
+	});
+
+	/** All distinct block IDs present in the portfolio */
+	activeBlocks = $derived(Object.keys(this.fundsByBlock));
+
+	setGetToken(fn: () => Promise<string>) {
+		this._getToken = fn;
+	}
+
+	private api() {
+		if (!this._getToken) throw new Error("Token provider not configured");
+		return createClientApiClient(this._getToken);
+	}
+
+	/**
+	 * Open the Analytics column in "fund" mode with the given fund.
+	 * Triggered by a row click in the Universe table.
+	 */
+	openAnalyticsForFund(fund: UniverseFund) {
+		this.selectedAnalyticsFund = fund;
+		this.analyticsMode = "fund";
+	}
+
+	/**
+	 * Open the Analytics column in "portfolio" mode showing the
+	 * MainPortfolioChart NAV synthesis. Triggered by the Builder
+	 * "View Chart" button.
+	 */
+	openAnalyticsForPortfolio() {
+		this.analyticsMode = "portfolio";
+	}
+
+	/** Close the Analytics column, collapsing back to Estado B. */
+	clearAnalytics() {
+		this.analyticsMode = null;
+		this.selectedAnalyticsFund = null;
+	}
+
+	/**
+	 * Reset layout-scoped state when the PM (re-)enters /portfolio
+	 * from another route. The 3rd column must always start closed
+	 * per the design spec §1.3 "Reset ao voltar" rule. Called from
+	 * `onMount` of `routes/(app)/portfolio/+page.svelte`.
+	 *
+	 * This is separate from `selectPortfolio()` because the PM may
+	 * re-enter with the same portfolio still selected — we don't
+	 * want to drop workspace state, only layout state.
+	 */
+	resetBuilderEntry() {
+		this.analyticsMode = null;
+		this.selectedAnalyticsFund = null;
+	}
+
+	selectPortfolio(p: ModelPortfolio) {
+		// Increment generation to invalidate any in-flight async loads
+		this._generation++;
+		// Cancel any in-flight construction run stream belonging to the
+		// previous portfolio — prevents stale SSE events from clobbering
+		// the newly-selected portfolio.
+		this._activeRunAbort?.abort();
+		this._activeRunAbort = null;
+
+		this.portfolio = p;
+		this.localStress = null;
+		this.localFactorAnalysis = null;
+		this.localOverlap = null;
+		this.rebalanceResult = null;
+		this.attribution = null;
+		this.driftAlerts = [];
+		this.correlationRegime = null;
+		this.riskBudget = null;
+		this.advice = null;
+		this.adviceFetched = false;
+		this.lastError = null;
+		this.navSeries = [];
+		// Phase 4 — calibration + run reset on portfolio switch
+		this.calibration = null;
+		this.constructionRun = null;
+		this.runPhase = "idle";
+		this.runError = null;
+		// Session 3 — reset backtest + monte carlo + diff state
+		this.backtestData = null;
+		this.monteCarloData = null;
+		this.runDiff = null;
+		// TAA Sprint 4 — reset regime visualization state
+		this.regimeBands = null;
+		this.taaHistory = null;
+		this.effectiveWithRegime = null;
+		// Switching models is a hard reset of the analytics context —
+		// the 3rd column closes and the PM starts fresh in Estado B.
+		this.analyticsMode = null;
+		this.selectedAnalyticsFund = null;
+		// Fire-and-forget: load track-record, factor analysis, attribution, drift,
+		// + Phase 4 calibration surface so the Builder right stack can render.
+		this.loadTrackRecord();
+		this.loadDriftAlerts();
+		this.loadCalibration();
+
+		if (p.profile) {
+			this.loadFactorAnalysis(p.profile);
+			this.loadAttribution(p.profile);
+			// TAA Sprint 4 — load regime bands + history for allocation visualization
+			this.loadRegimeBands(p.profile);
+			this.loadTaaHistory(p.profile);
+			this.loadEffectiveWithRegime(p.profile);
+			// Correlation regime requires constructed portfolio with fund data
+			if (p.fund_selection_schema?.funds?.length) {
+				this.loadCorrelationRegime(p.profile);
+			}
+		}
+		if (p.id) {
+			this.loadOverlap();
+		}
+	}
+
+	// ── Track-record loading (real API) ─────────────────────────────
+
+	/** Fetch synthesized NAV series from GET /model-portfolios/{id}/track-record. */
+	async loadTrackRecord() {
+		if (!this._getToken || !this.portfolioId) return;
+		const gen = this._generation;
+		this.isLoadingTrackRecord = true;
+
+		try {
+			const api = this.api();
+			const result = await api.get<TrackRecord>(
+				`/model-portfolios/${this.portfolioId}/track-record`,
+			);
+			if (gen !== this._generation) return; // stale — portfolio changed
+			this.navSeries = result.nav_series ?? [];
+		} catch (err) {
+			if (gen !== this._generation) return;
+			this.lastError = {
+				action: "track-record",
+				message: err instanceof Error ? err.message : "Failed to load track record",
+				timestamp: Date.now(),
+			};
+			this.navSeries = [];
+		} finally {
+			if (gen === this._generation) this.isLoadingTrackRecord = false;
+		}
+	}
+
+	async loadFactorAnalysis(profile: string) {
+		const gen = this._generation;
+		this.isLoadingFactorAnalysis = true;
+		try {
+			const api = this.api();
+			const result = await api.get<FactorAnalysisResponse>(
+				`/analytics/factor-analysis/${profile}`
+			);
+			if (gen !== this._generation) return;
+			this.localFactorAnalysis = result;
+			this.lastError = null;
+		} catch (err: any) {
+			if (gen !== this._generation) return;
+			console.error("loadFactorAnalysis error:", err);
+			this.lastError = {
+				action: "factor-analysis",
+				message: err.message || "Unknown error resolving factor analysis",
+				timestamp: Date.now()
+			};
+		} finally {
+			if (gen === this._generation) this.isLoadingFactorAnalysis = false;
+		}
+	}
+
+	// ── Overlap loading (real API) ──────────────────────────────────
+
+	async loadOverlap() {
+		if (!this._getToken || !this.portfolioId) return;
+		const gen = this._generation;
+		this.isLoadingOverlap = true;
+		try {
+			const api = this.api();
+			const result = await api.get<OverlapResult>(
+				`/model-portfolios/${this.portfolioId}/overlap`
+			);
+			if (gen !== this._generation) return;
+			this.localOverlap = result;
+		} catch (err: any) {
+			if (gen !== this._generation) return;
+			console.error("loadOverlap error:", err);
+			this.lastError = {
+				action: "overlap",
+				message: err.message || "Unknown error fetching overlaps",
+				timestamp: Date.now()
+			};
+			this.localOverlap = null;
+		} finally {
+			if (gen === this._generation) this.isLoadingOverlap = false;
+		}
+	}
+
+	// ── Attribution loading (Brinson-Fachler) ───────────────────────
+
+	async loadAttribution(profile: string) {
+		if (!this._getToken) return;
+		const gen = this._generation;
+		this.isLoadingAttribution = true;
+		try {
+			const api = this.api();
+			const result = await api.get<AttributionResult>(
+				`/analytics/attribution/${profile}`,
+			);
+			if (gen !== this._generation) return;
+			this.attribution = result;
+		} catch {
+			if (gen !== this._generation) return;
+			this.attribution = null;
+		} finally {
+			if (gen === this._generation) this.isLoadingAttribution = false;
+		}
+	}
+
+	// ── Drift alerts loading ────────────────────────────────────────
+
+	async loadDriftAlerts() {
+		if (!this._getToken) return;
+		const gen = this._generation;
+		this.isLoadingDrift = true;
+		try {
+			const api = this.api();
+			const result = await api.get<StrategyDriftAlert[]>(
+				"/analytics/strategy-drift/alerts",
+				{ limit: "50" },
+			);
+			if (gen !== this._generation) return;
+			this.driftAlerts = result;
+		} catch {
+			if (gen !== this._generation) return;
+			this.driftAlerts = [];
+		} finally {
+			if (gen === this._generation) this.isLoadingDrift = false;
+		}
+	}
+
+	// ── Correlation regime loading ──────────────────────────────────
+
+	async loadCorrelationRegime(profile: string) {
+		if (!this._getToken) return;
+		const gen = this._generation;
+		this.isLoadingCorrelationRegime = true;
+		try {
+			const api = this.api();
+			const result = await api.get<CorrelationRegimeResult>(
+				`/analytics/correlation-regime/${profile}`,
+				{ window_days: "60" },
+			);
+			if (gen !== this._generation) return;
+			this.correlationRegime = result;
+		} catch {
+			if (gen !== this._generation) return;
+			this.correlationRegime = null;
+		} finally {
+			if (gen === this._generation) this.isLoadingCorrelationRegime = false;
+		}
+	}
+
+	// ── Risk budget loading (on-demand) ─────────────────────────────
+
+	async loadRiskBudget() {
+		if (!this._getToken || !this.portfolio?.profile) return;
+		const gen = this._generation;
+		this.isLoadingRiskBudget = true;
+		try {
+			const api = this.api();
+			const result = await api.post<RiskBudgetResult>(
+				`/analytics/risk-budget/${this.portfolio.profile}`,
+				{},
+			);
+			if (gen !== this._generation) return;
+			this.riskBudget = result;
+		} catch {
+			if (gen !== this._generation) return;
+			this.riskBudget = null;
+		} finally {
+			if (gen === this._generation) this.isLoadingRiskBudget = false;
+		}
+	}
+
+	// ── Universe loading (real API) ──────────────────────────────────
+
+	/** True while universe is being fetched from API. */
+	isLoadingUniverse = $state(false);
+
+	/** Load approved universe funds from GET /universe.
+	 *
+	 * Passes the current Builder `funds` as `current_holdings` query
+	 * param so the backend can enrich each row with
+	 * `correlation_to_portfolio` on-the-fly (spec §3.4). When the
+	 * portfolio is empty, the param is omitted and every row's
+	 * correlation comes back `null`.
+	 */
+	async loadUniverse() {
+		if (!this._getToken) return;
+		this.isLoadingUniverse = true;
+
+		try {
+			const api = this.api();
+			// Send the list of currently allocated instrument IDs so
+			// the backend can correlate each candidate against this
+			// exact portfolio composition. The query param accepts
+			// comma-separated UUIDs; empty means "no portfolio context,
+			// return correlation_to_portfolio=null for everyone".
+			const holdingIds = this.funds
+				.map((f) => f.instrument_id)
+				.filter((id): id is string => !!id);
+			const qs = holdingIds.length > 0
+				? `?current_holdings=${holdingIds.join(",")}`
+				: "";
+			const result = await api.get<UniverseApiItem[]>(`/universe${qs}`);
+
+			this.universe = result.map((r) => {
+				const blockId = r.block_id ?? "unknown";
+				const label = BLOCK_LABELS[blockId] ?? blockId.replace(/_/g, " ");
+				const name = r.fund_name.toLowerCase();
+				const ticker = (r.ticker ?? "").toLowerCase();
+				return {
+					instrument_id: r.instrument_id,
+					fund_name: r.fund_name,
+					ticker: r.ticker ?? null,
+					block_id: blockId,
+					block_label: label,
+					asset_class: r.asset_class ?? null,
+					geography: r.geography ?? null,
+					instrument_type: r.asset_class ?? "fund",
+					manager_score: r.manager_score ?? null,
+					aum_usd: r.aum_usd ?? null,
+					expense_ratio: r.expense_ratio ?? null,
+					return_3y_ann: r.return_3y_ann ?? null,
+					sharpe_1y: r.sharpe_1y ?? null,
+					max_drawdown_1y: r.max_drawdown_1y ?? null,
+					blended_momentum_score: r.blended_momentum_score ?? null,
+					liquidity_tier: r.liquidity_tier ?? null,
+					correlation_to_portfolio: r.correlation_to_portfolio ?? null,
+					_searchKey: `${name}|${ticker}|${label.toLowerCase()}`,
+				};
+			});
+		} catch (err) {
+			this.lastError = {
+				action: "universe",
+				message: err instanceof Error ? err.message : "Failed to load universe",
+				timestamp: Date.now(),
+			};
+			this.universe = [];
+		} finally {
+			this.isLoadingUniverse = false;
+		}
+	}
+
+	/**
+	 * Add a fund from the universe into a specific allocation block.
+	 * Rejects if the fund's block_id doesn't match the target block.
+	 * Recalculates equal weights within the block after insertion.
+	 */
+	addFundToBlock(fund: UniverseFund, blockId: string): boolean {
+		if (!this.portfolio) return false;
+		if (fund.block_id !== blockId) return false;
+
+		// Initialize schema if missing
+		if (!this.portfolio.fund_selection_schema) {
+			this.portfolio = {
+				...this.portfolio,
+				fund_selection_schema: { profile: this.portfolio.profile, total_weight: 0, funds: [] },
+			};
+		}
+		const schema = this.portfolio.fund_selection_schema!;
+		if (!schema.funds) schema.funds = [];
+
+		// Reject duplicates
+		if (schema.funds.some((f) => f.instrument_id === fund.instrument_id)) return false;
+
+		// Add with temporary weight 0
+		schema.funds.push({
+			instrument_id: fund.instrument_id,
+			fund_name: fund.fund_name,
+			block_id: fund.block_id,
+			instrument_type: fund.instrument_type as any,
+			score: 0,
+			weight: 0,
+		});
+
+		// Recalculate equal weights within this block
+		const blockFunds = schema.funds.filter((f) => f.block_id === blockId);
+		const equalWeight = Math.round((1 / blockFunds.length) * 10000) / 10000;
+		for (const f of blockFunds) {
+			f.weight = equalWeight;
+		}
+
+		// Trigger reactivity
+		this.portfolio = { ...this.portfolio };
+		return true;
+	}
+
+	/**
+	 * Remove a fund from the allocation (reverse of addFundToBlock).
+	 *
+	 * The Portfolio Builder is a staging area — the portfolio is not
+	 * "live" until explicitly activated. Removing a fund here simply
+	 * takes it out of `fund_selection_schema.funds`, which makes the
+	 * UniverseTable's `isAllocated` check return `false` and the fund
+	 * appears re-enabled (full opacity, draggable) back in the
+	 * Approved Universe column. This is the user's primary undo
+	 * action while modelling.
+	 *
+	 * After removal, weights within the affected block are redistributed
+	 * equally across the remaining funds, matching the convention of
+	 * `addFundToBlock`. When the last fund in a block is removed, the
+	 * block weight falls to 0 naturally.
+	 *
+	 * Returns `true` if the fund was found and removed, `false` if not.
+	 */
+	removeFund(instrumentId: string): boolean {
+		if (!this.portfolio?.fund_selection_schema?.funds) return false;
+		const schema = this.portfolio.fund_selection_schema;
+		const idx = schema.funds.findIndex((f) => f.instrument_id === instrumentId);
+		if (idx === -1) return false;
+
+		const removed = schema.funds[idx]!;
+		schema.funds.splice(idx, 1);
+
+		// Re-equalise the weights in the block that just lost a fund.
+		const remainingInBlock = schema.funds.filter((f) => f.block_id === removed.block_id);
+		if (remainingInBlock.length > 0) {
+			const equalWeight = Math.round((1 / remainingInBlock.length) * 10000) / 10000;
+			for (const f of remainingInBlock) {
+				f.weight = equalWeight;
+			}
+		}
+
+		// Trigger reactivity
+		this.portfolio = { ...this.portfolio };
+		return true;
+	}
+
+	// ── Phase 4 — Calibration load / preview / apply ────────────────
+
+	/** Load the 63-input calibration surface for the active portfolio. */
+	async loadCalibration() {
+		if (!this._getToken || !this.portfolioId) return;
+		const gen = this._generation;
+		this.isLoadingCalibration = true;
+		try {
+			const api = this.api();
+			const result = await api.get<PortfolioCalibration>(
+				`/model-portfolios/${this.portfolioId}/calibration`,
+			);
+			if (gen !== this._generation) return;
+			this.calibration = result;
+		} catch (err) {
+			if (gen !== this._generation) return;
+			this.lastError = {
+				action: "calibration-load",
+				message: err instanceof Error ? err.message : "Failed to load calibration",
+				timestamp: Date.now(),
+			};
+			this.calibration = null;
+		} finally {
+			if (gen === this._generation) this.isLoadingCalibration = false;
+		}
+	}
+
+	/**
+	 * Persist a Builder CalibrationPanel Apply edit. Accepts the
+	 * partial update body and replaces ``this.calibration`` with the
+	 * post-update snapshot returned from the backend.
+	 *
+	 * DL5 — Apply is the ONLY persistence moment. Preview is never
+	 * reactive; it is only fired when the user presses the Preview
+	 * button in the panel (debounced client-side).
+	 */
+	async applyCalibration(patch: PortfolioCalibrationUpdate): Promise<PortfolioCalibration | null> {
+		if (!this._getToken || !this.portfolioId) return null;
+		this.isApplyingCalibration = true;
+		this.lastError = null;
+		try {
+			const api = this.api();
+			const result = await api.put<PortfolioCalibration>(
+				`/model-portfolios/${this.portfolioId}/calibration`,
+				patch,
+			);
+			this.calibration = result;
+			return result;
+		} catch (err) {
+			this.lastError = {
+				action: "calibration-apply",
+				message: err instanceof Error ? err.message : "Failed to apply calibration",
+				timestamp: Date.now(),
+			};
+			return null;
+		} finally {
+			this.isApplyingCalibration = false;
+		}
+	}
+
+	/**
+	 * PR-A13.2 — Live drag preview for the Builder risk budget slider.
+	 *
+	 * Calls ``POST /portfolios/{id}/preview-cvar`` to compute the
+	 * achievable_return_band for a probed cvar_limit without persisting
+	 * to portfolio_calibration. Backed by a 5-min Redis cache; cold wall
+	 * is ~4s on a typical universe, hot is ~12ms. The caller is
+	 * responsible for debouncing and for threading an AbortController
+	 * signal to cancel stale in-flight requests when the operator drags
+	 * past the quantized value.
+	 *
+	 * Returns ``null`` when no portfolio is selected or the token
+	 * provider isn't configured (matches the rest of the workspace loader
+	 * contract).
+	 */
+	async previewCvar(
+		cvarLimit: number,
+		signal?: AbortSignal,
+	): Promise<PreviewCvarResponse | null> {
+		if (!this._getToken || !this.portfolioId) return null;
+		const api = this.api();
+		return await api.post<PreviewCvarResponse>(
+			`/portfolios/${this.portfolioId}/preview-cvar`,
+			{ cvar_limit: cvarLimit },
+			{ signal, timeoutMs: 20_000 },
+		);
+	}
+
+	// ── TAA Sprint 4 — Regime visualization loaders ─────────────────
+
+	/** Load current regime bands for the portfolio's profile. Fails gracefully (no TAA data = null). */
+	async loadRegimeBands(profile: string) {
+		if (!this._getToken) return;
+		const gen = this._generation;
+		this.isLoadingRegimeBands = true;
+		try {
+			const api = this.api();
+			const result = await api.get<RegimeBands>(
+				`/allocation/${profile}/regime-bands`,
+			);
+			if (gen !== this._generation) return;
+			this.regimeBands = result;
+		} catch {
+			if (gen !== this._generation) return;
+			// 404 = worker hasn't run yet — graceful null, not an error
+			this.regimeBands = null;
+		} finally {
+			if (gen === this._generation) this.isLoadingRegimeBands = false;
+		}
+	}
+
+	/** Load 60-day TAA history for transition sparklines. */
+	async loadTaaHistory(profile: string, limit = 60) {
+		if (!this._getToken) return;
+		const gen = this._generation;
+		this.isLoadingTaaHistory = true;
+		try {
+			const api = this.api();
+			const result = await api.get<TaaHistory>(
+				`/allocation/${profile}/taa-history?limit=${limit}`,
+			);
+			if (gen !== this._generation) return;
+			this.taaHistory = result;
+		} catch {
+			if (gen !== this._generation) return;
+			this.taaHistory = null;
+		} finally {
+			if (gen === this._generation) this.isLoadingTaaHistory = false;
+		}
+	}
+
+	/** Load effective allocation with regime bands per block. */
+	async loadEffectiveWithRegime(profile: string) {
+		if (!this._getToken) return;
+		const gen = this._generation;
+		this.isLoadingEffectiveWithRegime = true;
+		try {
+			const api = this.api();
+			const result = await api.get<EffectiveAllocationWithRegime[]>(
+				`/allocation/${profile}/effective-with-regime`,
+			);
+			if (gen !== this._generation) return;
+			this.effectiveWithRegime = result;
+		} catch {
+			if (gen !== this._generation) return;
+			this.effectiveWithRegime = null;
+		} finally {
+			if (gen === this._generation) this.isLoadingEffectiveWithRegime = false;
+		}
+	}
+
+	// ── Phase 7 — Alerts Unification ────────────────────────────────
+
+	/**
+	 * Phase 7 Alerts Unification — global alerts inbox slice.
+	 *
+	 * The slice holds the latest UnifiedAlertInbox response from
+	 * GET /alerts/inbox plus loading + error state. The
+	 * GlobalAlertInbox bell icon dropdown subscribes via $derived;
+	 * the PortfolioSubNav 'Live' pill badge reads ``unread_count``
+	 * for the global indicator.
+	 *
+	 * Polling is opt-in: the layout component calls
+	 * ``startAlertsPolling()`` on mount and ``stopAlertsPolling()``
+	 * on destroy. Default interval is 60s — institutional cadence,
+	 * not real-time. SSE upgrade lands in a follow-up sprint when
+	 * the workers writing to portfolio_alerts ship.
+	 *
+	 * Per DL15 — zero localStorage. Read/unread state lives on the
+	 * backend ``acknowledged_at`` columns. The frontend's
+	 * "unread_count" is purely a re-fetch of /alerts/inbox after
+	 * any acknowledge call.
+	 */
+	alertsInbox = $state.raw<UnifiedAlertInbox | null>(null);
+	isLoadingAlerts = $state(false);
+	alertsError = $state<string | null>(null);
+
+	private _alertsPollHandle: ReturnType<typeof setInterval> | null = null;
+	private _alertsGen = 0;
+
+	/**
+	 * Fetch the unified alerts inbox. Idempotent — safe to call from
+	 * effects, on-mount hooks, or polling intervals.
+	 */
+	async loadAlertsInbox(opts: { unreadOnly?: boolean; limit?: number } = {}): Promise<void> {
+		if (!this._getToken) return;
+		const gen = ++this._alertsGen;
+		this.isLoadingAlerts = true;
+		this.alertsError = null;
+		try {
+			const api = this.api();
+			const params = new URLSearchParams();
+			if (opts.unreadOnly) params.set("unread_only", "true");
+			if (opts.limit) params.set("limit", String(opts.limit));
+			const qs = params.toString() ? `?${params.toString()}` : "";
+			const result = await api.get<UnifiedAlertInbox>(`/alerts/inbox${qs}`);
+			if (gen !== this._alertsGen) return;
+			this.alertsInbox = result;
+		} catch (err) {
+			if (gen !== this._alertsGen) return;
+			this.alertsError = err instanceof Error ? err.message : "Failed to load alerts";
+			// Do NOT clobber the existing alertsInbox on error — keeps
+			// the bell badge from blinking to zero on a transient failure.
+		} finally {
+			if (gen === this._alertsGen) this.isLoadingAlerts = false;
+		}
+	}
+
+	/**
+	 * Acknowledge a single alert. Re-fetches the inbox on success so
+	 * the bell badge updates without a separate refresh round trip.
+	 *
+	 * Per DL15 — the acknowledged state IS the backend write; the
+	 * frontend never persists read state to localStorage.
+	 */
+	async acknowledgeAlert(source: string, alertId: string): Promise<void> {
+		if (!this._getToken) return;
+		try {
+			const api = this.api();
+			await api.post(`/alerts/${source}/${alertId}/acknowledge`, {});
+			// Re-fetch the full inbox so unread_count + per-source
+			// counts both update. Cheaper than maintaining a local
+			// optimistic patch and avoids the consistency hazard of
+			// the polling tick racing with the local update.
+			await this.loadAlertsInbox();
+		} catch (err) {
+			this.alertsError = err instanceof Error ? err.message : "Failed to acknowledge alert";
+		}
+	}
+
+	/**
+	 * Start polling /alerts/inbox at the given interval. Idempotent —
+	 * calling twice does not stack intervals. The default 60s cadence
+	 * matches the institutional polling rhythm; faster polling should
+	 * wait for the SSE bridge in a follow-up sprint.
+	 */
+	startAlertsPolling(intervalMs = 60_000) {
+		this.stopAlertsPolling();
+		void this.loadAlertsInbox();
+		this._alertsPollHandle = setInterval(() => {
+			void this.loadAlertsInbox();
+		}, intervalMs);
+	}
+
+	/** Clear the polling interval — call from onDestroy hooks. */
+	stopAlertsPolling() {
+		if (this._alertsPollHandle !== null) {
+			clearInterval(this._alertsPollHandle);
+			this._alertsPollHandle = null;
+		}
+	}
+
+	/**
+	 * Per-portfolio open-alert count for the Phase 5 PortfolioSubNav
+	 * 'Live' pill badge. Returns 0 on any error so the badge falls
+	 * back to "no alerts" rather than blinking on transient failures.
+	 */
+	async fetchPortfolioAlertCount(portfolioId: string): Promise<number> {
+		if (!this._getToken) return 0;
+		try {
+			const api = this.api();
+			const result = await api.get<PortfolioAlertCount>(
+				`/alerts/portfolio/${portfolioId}/count`,
+			);
+			return result.open_count;
+		} catch {
+			return 0;
+		}
+	}
+
+	// ── Phase 6 Block B — Portfolio Analytics surface data ───────────
+
+	/**
+	 * Phase 6 Block B — separate data slice for the /portfolio/analytics
+	 * surface so it does not collide with the Builder's ``portfolio``
+	 * field. The shell renders charts against this slice; switching the
+	 * selected subject in the BottomTabDock triggers a fresh fetch via
+	 * ``loadAnalyticsSubject``.
+	 *
+	 * The slice carries:
+	 *   - portfolio: the selected ModelPortfolio detail (for state +
+	 *     fund_selection_schema + profile)
+	 *   - latestRun: the most recent persisted construction run with
+	 *     stress_results, factor_exposure, ex_ante_metrics
+	 *   - attribution / factor / correlationRegime / riskBudget:
+	 *     profile-keyed analytics responses (only populated when the
+	 *     portfolio is in "live" state — the existing routes require
+	 *     a live portfolio for that profile)
+	 *
+	 * Strict empty states per OD-26 — every field starts as null and
+	 * the chart components render an EmptyState when their slice is
+	 * missing. No fabricated values, no MOCK data.
+	 */
+	analyticsPortfolio = $state.raw<ModelPortfolio | null>(null);
+	analyticsLatestRun = $state.raw<ConstructionRunPayload | null>(null);
+	analyticsAttribution = $state.raw<AttributionResult | null>(null);
+	analyticsFactor = $state.raw<FactorAnalysisResponse | null>(null);
+	analyticsCorrelationRegime = $state.raw<CorrelationRegimeResult | null>(null);
+	analyticsRiskBudget = $state.raw<RiskBudgetResult | null>(null);
+	/** NAV series for the analytics-selected portfolio (separate from
+	 *  ``navSeries`` which tracks the Builder selection). */
+	analyticsNavSeries = $state.raw<NAVPoint[]>([]);
+	isLoadingAnalyticsSubject = $state(false);
+	analyticsSubjectError = $state<string | null>(null);
+
+	/** Generation counter to invalidate stale loadAnalyticsSubject responses. */
+	private _analyticsGen = 0;
+
+	/**
+	 * Load every analytics slice for a model portfolio. Called by the
+	 * /portfolio/analytics page when the user selects a subject in the
+	 * BottomTabDock or via the FilterRail subject list.
+	 *
+	 * Fetches in parallel:
+	 *   - GET /model-portfolios/{id}                      (detail)
+	 *   - GET /model-portfolios/{id}/runs/latest          (Phase 6 Block B)
+	 *   - GET /analytics/attribution/{profile}            (404 OK)
+	 *   - GET /analytics/factor-analysis/{profile}        (404 OK)
+	 *   - GET /analytics/correlation-regime/{profile}     (404 OK)
+	 *
+	 * Risk budget is on-demand only — the route is POST-based and
+	 * triggers heavy computation. The PM can request it from the
+	 * RiskAttributionBarChart card via a "Compute" CTA.
+	 *
+	 * 404 / 422 from the analytics routes are CAUGHT and surfaced as
+	 * null slices — the chart components render strict empty states
+	 * (OD-26). Only a 5xx on the portfolio detail call propagates as
+	 * an error message via ``analyticsSubjectError``.
+	 */
+	async loadAnalyticsSubject(portfolioId: string): Promise<void> {
+		if (!this._getToken) return;
+		const gen = ++this._analyticsGen;
+		this.isLoadingAnalyticsSubject = true;
+		this.analyticsSubjectError = null;
+
+		// Reset slices upfront so the shell shows loading skeletons
+		// instead of stale data from the previous subject.
+		this.analyticsPortfolio = null;
+		this.analyticsLatestRun = null;
+		this.analyticsAttribution = null;
+		this.analyticsFactor = null;
+		this.analyticsCorrelationRegime = null;
+		this.analyticsRiskBudget = null;
+		this.analyticsNavSeries = [];
+
+		try {
+			const api = this.api();
+			const portfolio = await api.get<ModelPortfolio>(
+				`/model-portfolios/${portfolioId}`,
+			);
+			if (gen !== this._analyticsGen) return;
+			this.analyticsPortfolio = portfolio;
+
+			// Latest run + NAV series are best-effort. NAV series feeds
+			// the Discovery NavHero / Drawdown chart adapters.
+			const [latestRun, trackRecord] = await Promise.all([
+				api
+					.get<ConstructionRunPayload | null>(
+						`/model-portfolios/${portfolioId}/runs/latest`,
+					)
+					.catch(() => null),
+				api
+					.get<TrackRecord>(`/model-portfolios/${portfolioId}/track-record`)
+					.catch(() => null),
+			]);
+			if (gen !== this._analyticsGen) return;
+			this.analyticsLatestRun = latestRun;
+			this.analyticsNavSeries = trackRecord?.nav_series ?? [];
+
+			// Profile-keyed analytics — only meaningful when the
+			// portfolio is in "live" state because the routes require
+			// a live model_portfolio for that profile.
+			const profile = portfolio.profile;
+			if (portfolio.state === "live" && profile) {
+				const [attribution, factor, correlationRegime] = await Promise.all([
+					api
+						.get<AttributionResult>(`/analytics/attribution/${profile}`)
+						.catch(() => null),
+					api
+						.get<FactorAnalysisResponse>(`/analytics/factor-analysis/${profile}`)
+						.catch(() => null),
+					api
+						.get<CorrelationRegimeResult>(
+							`/analytics/correlation-regime/${profile}?window_days=60`,
+						)
+						.catch(() => null),
+				]);
+				if (gen !== this._analyticsGen) return;
+				this.analyticsAttribution = attribution;
+				this.analyticsFactor = factor;
+				this.analyticsCorrelationRegime = correlationRegime;
+			}
+		} catch (err) {
+			if (gen !== this._analyticsGen) return;
+			this.analyticsSubjectError = err instanceof Error
+				? err.message
+				: "Failed to load analytics subject";
+		} finally {
+			if (gen === this._analyticsGen) {
+				this.isLoadingAnalyticsSubject = false;
+			}
+		}
+	}
+
+	/** Clear the analytics slice — called on route unmount. */
+	resetAnalyticsSubject() {
+		this._analyticsGen++;
+		this.analyticsPortfolio = null;
+		this.analyticsLatestRun = null;
+		this.analyticsAttribution = null;
+		this.analyticsFactor = null;
+		this.analyticsCorrelationRegime = null;
+		this.analyticsRiskBudget = null;
+		this.analyticsNavSeries = [];
+		this.analyticsSubjectError = null;
+		this.isLoadingAnalyticsSubject = false;
+	}
+
+	// ── Phase 5 Task 5.2 — State machine transitions ─────────────────
+
+	/**
+	 * POST /model-portfolios/{id}/transitions — apply a state-machine
+	 * action and refresh ``this.portfolio`` with the freshly-serialized
+	 * response (carrying new ``state``, ``state_changed_at``, and
+	 * ``allowed_actions``).
+	 *
+	 * The Builder action bar (Phase 5 Task 5.2) calls this directly.
+	 * Returns the updated portfolio so the caller can branch on
+	 * success/failure without re-reading the store.
+	 *
+	 * Per DL3 — never inspect ``state`` to decide whether to render
+	 * a button. The backend's ``allowed_actions`` is the only source
+	 * of truth for action visibility.
+	 */
+	async applyTransition(
+		action: string,
+		opts: { reason?: string; metadata?: Record<string, unknown> } = {},
+	): Promise<ModelPortfolio | null> {
+		if (!this._getToken || !this.portfolioId) return null;
+		this.lastError = null;
+		try {
+			const api = this.api();
+			const body: Record<string, unknown> = { action };
+			if (opts.reason && opts.reason.trim().length > 0) {
+				body.reason = opts.reason.trim();
+			}
+			if (opts.metadata && Object.keys(opts.metadata).length > 0) {
+				body.metadata = opts.metadata;
+			}
+			const updated = await api.post<ModelPortfolio>(
+				`/model-portfolios/${this.portfolioId}/transitions`,
+				body,
+			);
+			// Refresh the workspace's portfolio view so action buttons
+			// re-render against the new ``allowed_actions`` immediately.
+			this.portfolio = updated;
+			return updated;
+		} catch (err) {
+			this.lastError = {
+				action: `transition:${action}`,
+				message: err instanceof Error ? err.message : "Failed to apply transition",
+				timestamp: Date.now(),
+			};
+			return null;
+		}
+	}
+
+	// ── Phase 5 Task 5.1 — Create new portfolio (NewPortfolioDialog) ──
+
+	/**
+	 * POST /model-portfolios — create a new draft portfolio.
+	 *
+	 * The backend (Phase 5 Task 5.1 backend extension) hydrates the
+	 * response with ``allowed_actions`` from the state machine and
+	 * seeds the paired ``portfolio_calibration`` row with migration
+	 * 0100 defaults so the Builder can immediately render the
+	 * canonical ``[construct, archive]`` action set on success.
+	 *
+	 * Caller is responsible for navigating to the new portfolio —
+	 * this method only persists and returns the new row.
+	 */
+	async createPortfolio(payload: Record<string, unknown>): Promise<ModelPortfolio | null> {
+		if (!this._getToken) return null;
+		this.lastError = null;
+		try {
+			const api = this.api();
+			const created = await api.post<ModelPortfolio>(
+				"/model-portfolios",
+				payload,
+			);
+			return created;
+		} catch (err) {
+			this.lastError = {
+				action: "create-portfolio",
+				message: err instanceof Error ? err.message : "Failed to create portfolio",
+				timestamp: Date.now(),
+			};
+			return null;
+		}
+	}
+
+	// ── Phase 4 — Construction run loader ───────────────────────────
+
+	/** Fetch a persisted construction run by id into ``constructionRun``. */
+	async loadConstructionRun(runId: string) {
+		if (!this._getToken || !this.portfolioId) return;
+		const gen = this._generation;
+		this.isLoadingRun = true;
+		try {
+			const api = this.api();
+			const result = await api.get<ConstructionRunPayload>(
+				`/model-portfolios/${this.portfolioId}/runs/${runId}`,
+			);
+			if (gen !== this._generation) return;
+			this.constructionRun = result;
+		} catch (err) {
+			if (gen !== this._generation) return;
+			this.lastError = {
+				action: "run-load",
+				message: err instanceof Error ? err.message : "Failed to load construction run",
+				timestamp: Date.now(),
+			};
+			this.constructionRun = null;
+		} finally {
+			if (gen === this._generation) this.isLoadingRun = false;
+		}
+	}
+
+	// ── Construction Advisor (generation-guarded) ───────────────────────────
+
+	async fetchConstructionAdvice() {
+		if (!this._getToken || !this.portfolioId) return;
+		const gen = this._generation;
+		this.isLoadingAdvice = true;
+		this.advice = null;
+
+		try {
+			const api = this.api();
+			const result = await api.post<ConstructionAdvice>(
+				`/model-portfolios/${this.portfolioId}/construction-advice`,
+				{},
+			);
+			if (gen !== this._generation) return; // stale — portfolio changed
+			this.advice = result;
+		} catch (err) {
+			if (gen !== this._generation) return;
+			this.lastError = {
+				action: "construction-advice",
+				message: err instanceof Error ? err.message : "Failed to load construction advice",
+				timestamp: Date.now(),
+			};
+		} finally {
+			if (gen === this._generation) {
+				this.isLoadingAdvice = false;
+				this.adviceFetched = true;
+			}
+		}
+	}
+
+	// ── Portfolio Activation ────────────────────────────────────────────────
+
+	async activatePortfolio() {
+		if (!this._getToken || !this.portfolioId) return;
+		this.isActivating = true;
+		this.lastError = null;
+
+		try {
+			const api = this.api();
+			const result = await api.post<ModelPortfolio>(
+				`/model-portfolios/${this.portfolioId}/activate`,
+				{},
+			);
+			this.portfolio = result;
+			this.advice = null; // advisor no longer relevant after activation
+		} catch (err) {
+			this.lastError = {
+				action: "activate",
+				message: err instanceof Error ? err.message : "Portfolio activation failed",
+				timestamp: Date.now(),
+			};
+			throw err; // re-throw so ConsequenceDialog can handle
+		} finally {
+			this.isActivating = false;
+		}
+	}
+
+	// ── Construction & Live Rebalance ─────────────────────────────────────────
+
+	/**
+	 * Kick off a Phase 3 Job-or-Stream construction run (DL18 P2).
+	 *
+	 * @deprecated PR-A5 A.5/E.3 — use {@link runBuildJob} instead. Kept
+	 *   around only so the Phase 4 test harness keeps compiling until
+	 *   the legacy backend route ``/model-portfolios/{id}/construct`` is
+	 *   removed in PR-A7. No production call site should reach this
+	 *   method; grep ``frontends/wealth/src`` for ``runConstructJob`` —
+	 *   expect zero non-test hits (see Section E.3 audit).
+	 *
+	 * Flow (preserved verbatim for test compatibility):
+	 *   1. POST /model-portfolios/{id}/construct → 202 ConstructRunAccepted
+	 *   2. Open fetch()+ReadableStream SSE at stream_url (NEVER EventSource
+	 *      — Clerk JWT needs Authorization header, DL15).
+	 *   3. Advance runPhase on each event ('run_started' | 'optimizer_started'
+	 *      | 'stress_started').
+	 *   4. On terminal 'done', fetch the run detail via loadConstructionRun
+	 *      and transition runPhase → 'done'.
+	 *   5. On terminal 'error', set runError + runPhase → 'error'.
+	 */
+	async runConstructJob(): Promise<ConstructionRunPayload | null> {
+		if (!this._getToken || !this.portfolioId) return null;
+
+		// Cancel any in-flight stream if the user re-presses Run Construct.
+		this._activeRunAbort?.abort();
+		const abort = new AbortController();
+		this._activeRunAbort = abort;
+
+		this.runPhase = "running";
+		this.runError = null;
+		this.optimizerPhases = structuredClone(DEFAULT_CASCADE_PHASES);
+		this.isConstructing = true;
+		this.lastError = null;
+
+		try {
+			// ── 1. POST /construct → 202 ──
+			const api = this.api();
+			const accepted = await api.post<ConstructRunAccepted>(
+				`/model-portfolios/${this.portfolioId}/construct`,
+				undefined,
+				{ timeoutMs: 130_000 }, // backend bound is 120s + 10s margin
+			);
+
+			// If the worker completed synchronously (cached or very fast),
+			// skip the SSE dance and load the run immediately.
+			if (accepted.status === "succeeded" || accepted.status === "cached") {
+				await this.loadConstructionRun(accepted.run_id);
+				this.runPhase = "done";
+				return this.constructionRun;
+			}
+			if (accepted.status === "failed") {
+				this.runPhase = "error";
+				this.runError = "Construction failed before streaming started";
+				return null;
+			}
+
+			// ── 2. Stream SSE until terminal ──
+			// The backend emits stream_url as ``/api/v1/jobs/{id}/stream``.
+			// VITE_API_BASE_URL already contains the ``/api/v1`` suffix
+			// (e.g. http://localhost:8000/api/v1), so we strip that before
+			// concatenating the absolute stream path.
+			const token = await this._getToken();
+			const envBase =
+				(import.meta.env.VITE_API_BASE_URL as string | undefined) ??
+				"http://localhost:8000/api/v1";
+			const host = envBase.replace(/\/api\/v1\/?$/, "");
+			const streamUrl = accepted.stream_url.startsWith("http")
+				? accepted.stream_url
+				: `${host}${accepted.stream_url}`;
+
+			const res = await fetch(streamUrl, {
+				headers: {
+					Authorization: `Bearer ${token}`,
+					Accept: "text/event-stream",
+				},
+				signal: abort.signal,
+			});
+
+			const terminalBox: { event: ConstructRunEvent | null } = { event: null };
+
+			await parseSseStream(
+				res,
+				(raw) => {
+					const parsed = raw as ConstructRunEvent;
+					this._applyRunEvent(parsed);
+					const ev = parsed.event;
+					if (
+						ev === "done" || ev === "error" ||
+						ev === "Construction succeeded" ||
+						ev === "Construction failed" ||
+						ev === "Construction cancelled"
+					) {
+						terminalBox.event = parsed;
+						// Abort the reader — legacy behaviour kept intact
+						abort.abort();
+					}
+				},
+				abort.signal,
+			);
+
+			const terminal = terminalBox.event;
+			if (!terminal) {
+				this.runPhase = "error";
+				this.runError = "Stream closed before terminal event";
+				return null;
+			}
+
+			if (
+				terminal.event === "error" ||
+				terminal.event === "Construction failed" ||
+				terminal.event === "Construction cancelled"
+			) {
+				this.runPhase = "error";
+				this.runError = terminal.reason ?? "Construction failed";
+				return null;
+			}
+
+			// ── 3. Fetch the persisted run ──
+			const runId = terminal.run_id ?? accepted.run_id;
+			await this.loadConstructionRun(runId);
+			this.runPhase = "done";
+			// ── 4. Refresh TAA data (construction may update regime state) ──
+			const profile = this.portfolio?.profile;
+			if (profile) {
+				this.loadRegimeBands(profile);
+				this.loadTaaHistory(profile);
+				this.loadEffectiveWithRegime(profile);
+			}
+			return this.constructionRun;
+		} catch (err) {
+			if ((err as { name?: string } | null)?.name === "AbortError") {
+				return null;
+			}
+			this.runPhase = "error";
+			this.runError = err instanceof Error ? err.message : "Construction failed";
+			this.lastError = {
+				action: "construct",
+				message: this.runError,
+				timestamp: Date.now(),
+			};
+			return null;
+		} finally {
+			this.isConstructing = false;
+			if (this._activeRunAbort === abort) this._activeRunAbort = null;
+		}
+	}
+
+	/**
+	 * Legacy alias — delegates to the hardened runBuildJob (PR-A5 A.5).
+	 * Kept so external tests and older callers keep compiling.
+	 */
+	async constructPortfolio() {
+		await this.runBuildJob();
+	}
+
+	/**
+	 * PR-A5 A.10 — Best-effort cancel of the active build.
+	 *
+	 * Fires ``DELETE /api/v1/jobs/{job_id}`` and returns. We intentionally
+	 * do NOT abort the SSE reader client-side; the server emits a
+	 * ``CANCELLED`` terminal event which drives the phase transition
+	 * through _applyBuildEvent. This preserves the audit trail and
+	 * lets the `portfolio_construction_runs` row settle to status
+	 * ``cancelled`` via the worker's finally block.
+	 *
+	 * If the DELETE itself fails, we tolerate silently — the backend
+	 * tracker.is_cancellation_requested flag will win next poll. UX
+	 * surfaces a warning after 30s without confirmation (spec D.5);
+	 * that timer lives in RunControls, not here.
+	 */
+	async cancelActiveBuild(): Promise<void> {
+		const jobId = this._activeBuildJobId;
+		if (!jobId) return;
+		try {
+			await this.api().delete(`/jobs/${jobId}`, { timeoutMs: 5_000 });
+		} catch {
+			// Best-effort — the SSE CANCELLED event is authoritative.
+		}
+	}
+
+	/** Apply a single SSE event to ``runPhase`` and cascade timeline. */
+	private _applyRunEvent(ev: ConstructRunEvent) {
+		const e = ev.event;
+
+		// Run lifecycle — match both raw and sanitized labels
+		if (e === "run_started" || e === "Construction started") {
+			this.runPhase = "running";
+		} else if (e === "optimizer_started" || e === "Optimizer started") {
+			this.runPhase = "optimizer";
+		} else if (e === "stress_started" || e === "Stress tests started") {
+			this.runPhase = "stress";
+		} else if (e === "done" || e === "Construction succeeded") {
+			this.runPhase = "done";
+		} else if (e === "error" || e === "Construction failed" || e === "Construction cancelled") {
+			this.runPhase = "error";
+			this.runError = ev.reason ?? "Construction failed";
+		}
+
+		// PR-A13 — hydrate cascade_telemetry on the dedicated SSE event so the
+		// Risk Budget panel updates before the final REST GET arrives. The
+		// backend only emits the subset needed by the panel
+		// (cascade_summary / achievable_return_band / operator_signal /
+		// min_achievable_cvar). ``phase_attempts`` lands via loadConstructionRun.
+		if (e === "cascade_telemetry_completed" || e === "Cascade telemetry completed") {
+			const run = this.constructionRun;
+			const summary = (ev.cascade_summary ?? null) as
+				| CascadeTelemetry["cascade_summary"]
+				| null;
+			const nextTelemetry: CascadeTelemetry = {
+				phase_attempts: run?.cascade_telemetry?.phase_attempts ?? [],
+				cascade_summary: summary ?? "upstream_heuristic",
+				min_achievable_cvar: ev.min_achievable_cvar ?? null,
+				achievable_return_band: ev.achievable_return_band ?? null,
+				operator_signal: ev.operator_signal ?? null,
+			};
+			this.constructionRun = run
+				? { ...run, cascade_telemetry: nextTelemetry }
+				: run;
+		}
+
+		// Per-phase optimizer cascade events → update timeline pills
+		if (
+			(e === "optimizer_phase_complete" || e === "Optimizer phase completed") &&
+			ev.phase
+		) {
+			this.optimizerPhases = this.optimizerPhases.map((p) => {
+				if (p.key === ev.phase) {
+					return {
+						...p,
+						status: (ev.status as CascadePhase["status"]) ?? "succeeded",
+						objectiveValue: ev.objective_value ?? null,
+					};
+				}
+				return p;
+			});
+		}
+	}
+
+	// ── PR-A5: POST /portfolios/{id}/build (Job-or-Stream, hardened) ──
+	//
+	// Companion to runConstructJob (legacy /model-portfolios/{id}/construct).
+	// Endpoint is guarded by @idempotent + SingleFlightLock + advisory lock
+	// (builder.py) and RBAC-gated to IC members. We generate a fresh
+	// Idempotency-Key per click (spec A.11/D.1); double-clicks coalesce
+	// server-side to the same job_id (HTTP 202 cached) and the SSE stream
+	// of the second caller receives a DEDUPED event — see A.4.3.
+	async runBuildJob(): Promise<ConstructionRunPayload | null> {
+		if (!this._getToken || !this.portfolioId) return null;
+
+		// Cancel any in-flight BUILD stream if the user re-presses.
+		this._activeBuildAbort?.abort();
+		const abort = new AbortController();
+		this._activeBuildAbort = abort;
+
+		const idempotencyKey = uuidv4();
+		this._lastIdempotencyKey = idempotencyKey;
+
+		this.runPhase = "running";
+		this.runProgress = 0;
+		this.runError = null;
+		this.buildDedupedNotice = null;
+		this.optimizerPhases = structuredClone(DEFAULT_CASCADE_PHASES);
+		this.buildMetrics = { factor: null, shrinkage: null, socp: null, backtest: null };
+		this.isConstructing = true;
+		this.lastError = null;
+
+		try {
+			const api = this.api();
+			const accepted = await api.post<BuildAccepted>(
+				`/portfolios/${this.portfolioId}/build`,
+				undefined,
+				{ timeoutMs: 130_000, headers: { "Idempotency-Key": idempotencyKey } },
+			);
+			this._activeBuildJobId = accepted.job_id;
+
+			const token = await this._getToken();
+			const envBase =
+				(import.meta.env.VITE_API_BASE_URL as string | undefined) ??
+				"http://localhost:8000/api/v1";
+			const host = envBase.replace(/\/api\/v1\/?$/, "");
+			const streamUrl = accepted.stream_url.startsWith("http")
+				? accepted.stream_url
+				: `${host}${accepted.stream_url}`;
+
+			const res = await fetch(streamUrl, {
+				headers: {
+					Authorization: `Bearer ${token}`,
+					Accept: "text/event-stream",
+				},
+				signal: abort.signal,
+			});
+
+			const terminalBox: { event: BuildEvent | null } = { event: null };
+
+			await parseSseStream(
+				res,
+				(raw) => {
+					const parsed = raw as BuildEvent;
+					this._applyBuildEvent(parsed);
+					const phase = parsed.phase as BuildPhase | undefined;
+					if (phase === "COMPLETED" || phase === "ERROR" || phase === "CANCELLED") {
+						terminalBox.event = parsed;
+						abort.abort();
+					}
+					// DEDUPED is NOT terminal — see A.4.3. We keep reading the
+					// stream because the advisory-lock loser shares the same
+					// job_id and receives the full event sequence.
+				},
+				abort.signal,
+			);
+
+			const terminal = terminalBox.event;
+			if (!terminal) {
+				this.runPhase = "error";
+				this.runError = "Stream closed before terminal event";
+				return null;
+			}
+
+			if (terminal.phase === "ERROR") {
+				this.runPhase = "error";
+				this.runError = terminal.message ?? terminal.reason ?? "Construction failed";
+				return null;
+			}
+			if (terminal.phase === "CANCELLED") {
+				this.runPhase = "cancelled";
+				this.runError = null;
+				return null;
+			}
+
+			// COMPLETED → load the persisted run.
+			if (terminal.run_id) {
+				await this.loadConstructionRun(terminal.run_id);
+			}
+			this.runPhase = "done";
+			const profile = this.portfolio?.profile;
+			if (profile) {
+				this.loadRegimeBands(profile);
+				this.loadTaaHistory(profile);
+				this.loadEffectiveWithRegime(profile);
+			}
+			return this.constructionRun;
+		} catch (err) {
+			if ((err as { name?: string } | null)?.name === "AbortError") {
+				return null;
+			}
+			this.runPhase = "error";
+			this.runError = err instanceof Error ? err.message : "Construction failed";
+			this.lastError = {
+				action: "construct",
+				message: this.runError,
+				timestamp: Date.now(),
+			};
+			return null;
+		} finally {
+			this.isConstructing = false;
+			if (this._activeBuildAbort === abort) this._activeBuildAbort = null;
+			this._activeBuildJobId = null;
+		}
+	}
+
+	/**
+	 * Apply a single sanitised SSE event from /portfolios/{id}/build.
+	 *
+	 * Contract (PR-A5 A.4):
+	 *   - ``ev.phase`` drives the top-level runPhase transition.
+	 *   - ``ev.raw_type`` forwards optimizer cascade sub-phases for the
+	 *     existing CascadeTimeline pills (legacy ``_applyRunEvent`` path).
+	 *   - ``ev.metrics`` is stored raw on ``buildMetrics`` — translation
+	 *     into human chips is handled by metric-translators.ts (Section C).
+	 *   - ``ev.message`` is already sanitised server-side; NEVER
+	 *     re-sanitise here.
+	 */
+	private _applyBuildEvent(ev: BuildEvent): void {
+		// Progress first — backend may emit it on any event.
+		if (typeof ev.progress === "number" && Number.isFinite(ev.progress)) {
+			this.runProgress = Math.max(0, Math.min(1, ev.progress));
+		}
+
+		const phase = ev.phase as BuildPhase | undefined;
+		switch (phase) {
+			case "STARTED":
+				this.runPhase = "running";
+				this.runProgress = 0;
+				this.optimizerPhases = structuredClone(DEFAULT_CASCADE_PHASES);
+				break;
+			case "FACTOR_MODELING":
+				this.runPhase = "factor_modeling";
+				if (ev.metrics) this.buildMetrics = { ...this.buildMetrics, factor: ev.metrics };
+				break;
+			case "SHRINKAGE":
+				this.runPhase = "shrinkage";
+				if (ev.metrics) this.buildMetrics = { ...this.buildMetrics, shrinkage: ev.metrics };
+				break;
+			case "SOCP_OPTIMIZATION":
+				this.runPhase = "optimizer";
+				if (ev.metrics) this.buildMetrics = { ...this.buildMetrics, socp: ev.metrics };
+				break;
+			case "BACKTESTING":
+				this.runPhase = "stress";
+				if (ev.metrics) this.buildMetrics = { ...this.buildMetrics, backtest: ev.metrics };
+				break;
+			case "COMPLETED":
+				// runPhase flips to "done" in the caller after loadConstructionRun resolves
+				break;
+			case "ERROR":
+				this.runPhase = "error";
+				this.runError = ev.message ?? ev.reason ?? "Construction failed";
+				break;
+			case "CANCELLED":
+				this.runPhase = "cancelled";
+				this.runError = null;
+				break;
+			case "DEDUPED":
+				// A.4.3 — do NOT error. Surface a transient notice and keep
+				// the stream open; the advisory-lock loser still receives
+				// the full event sequence on the same job_id.
+				this.buildDedupedNotice =
+					"Another build is already running for this portfolio; following the live stream.";
+				break;
+			default:
+				// No phase ⇒ optimizer cascade sub-event. Fall through to
+				// raw_type handling below.
+				break;
+		}
+
+		// Optimizer cascade sub-phases (raw_type === "optimizer_phase_complete").
+		// Mirrors _applyRunEvent so the pills update regardless of whether the
+		// backend sent ``type`` sanitised or ``raw_type`` forwarded.
+		const rawType = ev.raw_type ?? ev.type;
+		if (
+			(rawType === "optimizer_phase_complete" ||
+				rawType === "Optimizer phase completed") &&
+			ev.phase &&
+			typeof ev.phase === "string"
+		) {
+			// ev.phase for optimizer sub-events is a cascade KEY (primary, robust, ...),
+			// not a pipeline phase. The two namespaces do not overlap.
+			const cascadeKey = ev.phase;
+			this.optimizerPhases = this.optimizerPhases.map((p) => {
+				if (p.key === cascadeKey) {
+					return {
+						...p,
+						status: (ev.status as CascadePhase["status"]) ?? "succeeded",
+						objectiveValue: ev.objective_value ?? null,
+					};
+				}
+				return p;
+			});
+		}
+	}
+
+	// ── Rebalance Preview (real API) ─────────────────────────────────
+
+	async runRebalancePreview(payload: RebalancePreviewRequest) {
+		if (!this.portfolioId) return;
+		this.isRebalancing = true;
+		this.lastError = null;
+
+		try {
+			const api = this.api();
+			const result = await api.post<RebalancePreviewResponse>(
+				`/model-portfolios/${this.portfolioId}/rebalance/preview`,
+				payload,
+				{ timeoutMs: 30_000 },
+			);
+			this.rebalanceResult = result;
+		} catch (err) {
+			this.lastError = {
+				action: "rebalance",
+				message: err instanceof Error ? err.message : "Rebalance preview failed",
+				timestamp: Date.now(),
+			};
+		} finally {
+			this.isRebalancing = false;
+		}
+	}
+
+	async executeTrades(payload: RebalancePreviewRequest) {
+		if (!this.portfolioId) return;
+		this.isExecuting = true;
+		this.lastError = null;
+
+		try {
+			const api = this.api();
+			// POST /model-portfolios/{id}/execute-trades
+			await api.post(
+				`/model-portfolios/${this.portfolioId}/execute-trades`,
+				payload,
+				{ timeoutMs: 30_000 },
+			);
+		} catch (err) {
+			this.lastError = {
+				action: "execute-trades",
+				message: err instanceof Error ? err.message : "Trade execution failed",
+				timestamp: Date.now(),
+			};
+			throw err;
+		} finally {
+			this.isExecuting = false;
+		}
+	}
+
+	// ── Parametric Stress Test (real API) ─────────────────────────────
+
+	// ── Session 3: Backtest NAV History ──────────────────────────────
+
+	async fetchBacktestData(period: string = "5Y") {
+		if (!this._getToken || !this.portfolioId) return;
+		const gen = this._generation;
+		this.isLoadingBacktest = true;
+
+		try {
+			const api = this.api();
+			const result = await api.get<BacktestNavHistory>(
+				`/model-portfolios/${this.portfolioId}/nav-history?period=${period}`,
+			);
+			if (gen !== this._generation) return;
+			this.backtestData = result;
+		} catch (err) {
+			if (gen !== this._generation) return;
+			this.lastError = {
+				action: "backtest",
+				message: err instanceof Error ? err.message : "Failed to load backtest data",
+				timestamp: Date.now(),
+			};
+		} finally {
+			if (gen === this._generation) {
+				this.isLoadingBacktest = false;
+			}
+		}
+	}
+
+	// ── Session 3: Monte Carlo ───────────────────────────────────────
+
+	async fetchMonteCarlo() {
+		if (!this._getToken || !this.portfolioId) return;
+		const gen = this._generation;
+		this.isLoadingMonteCarlo = true;
+
+		try {
+			const api = this.api();
+			const result = await api.post<MonteCarloPortfolioResult>(
+				`/model-portfolios/${this.portfolioId}/monte-carlo`,
+				{},
+				{ timeoutMs: 60_000 },
+			);
+			if (gen !== this._generation) return;
+			this.monteCarloData = result;
+		} catch (err) {
+			if (gen !== this._generation) return;
+			this.lastError = {
+				action: "monte-carlo",
+				message: err instanceof Error ? err.message : "Failed to run Monte Carlo simulation",
+				timestamp: Date.now(),
+			};
+		} finally {
+			if (gen === this._generation) {
+				this.isLoadingMonteCarlo = false;
+			}
+		}
+	}
+
+	// ── Session 3: Construction Run Diff ─────────────────────────────
+
+	async fetchRunDiff(runId: string) {
+		if (!this._getToken || !this.portfolioId) return;
+		const gen = this._generation;
+		this.isLoadingDiff = true;
+
+		try {
+			const api = this.api();
+			const result = await api.get<ConstructionRunDiff>(
+				`/model-portfolios/${this.portfolioId}/construction/runs/${runId}/diff`,
+			);
+			if (gen !== this._generation) return;
+			this.runDiff = result;
+		} catch {
+			if (gen !== this._generation) return;
+			// Graceful fallback — diff may not exist for first run
+			this.runDiff = null;
+		} finally {
+			if (gen === this._generation) {
+				this.isLoadingDiff = false;
+			}
+		}
+	}
+
+	async runStressTest(shocks: { equity: number; rates: number; credit: number }) {
+		if (!this.portfolioId) return;
+		this.isStressing = true;
+		this.lastError = null;
+
+		try {
+			const api = this.api();
+
+			// Map UI macro-shocks to per-block shocks (with unit conversion)
+			const blockShocks = mapMacroShocksToBlocks(shocks.equity, shocks.rates, shocks.credit);
+
+			const body: ParametricStressRequest = {
+				scenario_name: "custom",
+				shocks: blockShocks,
+			};
+
+			const result = await api.post<ParametricStressResult>(
+				`/model-portfolios/${this.portfolioId}/stress-test`,
+				body,
+				{ timeoutMs: 30_000 },
+			);
+
+			// Convert API response (decimals) to view model (percentages for display)
+			this.localStress = {
+				scenario: result.scenario_name,
+				portfolioDrop: result.nav_impact_pct * 100,
+				blockImpacts: Object.fromEntries(
+					Object.entries(result.block_impacts).map(([k, v]) => [k, v * 100]),
+				),
+				cvarStressed: result.cvar_stressed,
+				worstBlock: result.worst_block,
+				bestBlock: result.best_block,
+			};
+		} catch (err) {
+			this.lastError = {
+				action: "stress",
+				message: err instanceof Error ? err.message : "Stress test failed",
+				timestamp: Date.now(),
+			};
+		} finally {
+			this.isStressing = false;
+		}
+	}
+}
+
+export const workspace = new PortfolioWorkspaceState();

--- a/packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts
@@ -5,10 +5,10 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
-import { createClientApiClient } from "$wealth/api/client";
-import { BLOCK_LABELS } from "$wealth/constants/blocks";
-import { parseSseStream } from "$wealth/util/sse-reader";
-import type { BuildAccepted, BuildEvent, BuildPhase } from "$wealth/types/portfolio-build";
+import { createClientApiClient } from "../api/client";
+import { BLOCK_LABELS } from "../constants/blocks";
+import { parseSseStream } from "../utils/sse-reader";
+import type { BuildAccepted, BuildEvent, BuildPhase } from "../types/portfolio-build";
 import type {
 	ModelPortfolio,
 	NAVPoint,
@@ -19,32 +19,32 @@ import type {
 	TrackRecord,
 	OverlapResult,
 	ConstructionAdvice,
-} from "$wealth/types/model-portfolio";
+} from "../types/model-portfolio";
 import type {
 	AttributionResult,
 	StrategyDriftAlert,
 	CorrelationRegimeResult,
 	RiskBudgetResult,
-} from "$wealth/types/analytics";
+} from "../types/analytics";
 import type {
 	PortfolioCalibration,
 	PortfolioCalibrationUpdate,
-} from "$wealth/types/portfolio-calibration";
+} from "../types/portfolio-calibration";
 import type {
 	PortfolioAlertCount,
 	UnifiedAlertInbox,
-} from "$wealth/types/alerts";
+} from "../types/alerts";
 import type {
 	CascadeTelemetry,
 	AchievableReturnBand,
 	OperatorSignal,
 	PreviewCvarResponse,
-} from "$wealth/types/cascade-telemetry";
+} from "../types/cascade-telemetry";
 import type {
 	RegimeBands,
 	TaaHistory,
 	EffectiveAllocationWithRegime,
-} from "$wealth/types/taa";
+} from "../types/taa";
 
 /**
  * Phase 3 Run Construct response payload — flat dict returned from

--- a/packages/ii-terminal-core/src/lib/stores/market-data.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/stores/market-data.svelte.ts
@@ -1,0 +1,491 @@
+/**
+ * Market Data Store — WebSocket-primary, poll-fallback.
+ *
+ * Manages a WebSocket connection to `/api/v1/market-data/live/ws` for
+ * real-time price ticks. Follows the same resilience patterns as
+ * risk-store.svelte.ts:
+ *   - Heartbeat monitoring (45s timeout)
+ *   - Exponential backoff reconnection (1s → 30s cap, max 5 retries)
+ *   - Monotonic version counter (prevents stale data overwrites)
+ *   - No localStorage (in-memory only)
+ *
+ * Stability Guardrails (Phase 2 retrofit, §4.1 B1.7–B1.9)
+ * -------------------------------------------------------
+ * Every incoming price tick used to be written into a reactive
+ * `$state` object via `priceMap = { ...priceMap, [t.ticker]: t }`. At
+ * the Tiingo IEX firehose rate (hundreds of ticks/sec) this produced
+ * one full reactive invalidation per tick — the Dashboard tab froze
+ * within minutes (the §7.1 self-DDoS incident).
+ *
+ * The store now owns a single `createTickBuffer<PriceTick>` configured
+ * with `{ intervalMs: 250 }`. Writes go straight into the buffer
+ * (`buffer.write(tick)` — one `Map.set` call, no allocation, no
+ * reactive invalidation). The buffer's `snapshot` is itself a Svelte
+ * 5 `$state(new Map())` and the buffer's internal clock reassigns
+ * it exactly once per 250ms, producing four reactive updates per
+ * second regardless of tick volume. The store just exposes the
+ * snapshot directly through a getter — no mirror, no second timer,
+ * no defensive `flush()`.
+ *
+ * `holdings` is a `$derived` that fuses the static SSR-seeded
+ * composition with the live tick snapshot at read time, so consumers
+ * keep their existing API (`marketStore.holdings[i].price` is live)
+ * without ever touching a spread inside a WS handler.
+ *
+ * Declared once in (app)/+layout.svelte, shared via Svelte context.
+ */
+
+import { createTickBuffer, type TickBuffer } from "@investintell/ui/runtime";
+
+// ── Types ───────────────────────────────────────────────────
+
+export type WsStatus = "connecting" | "connected" | "reconnecting" | "disconnected" | "error";
+
+export interface PriceTick {
+	ticker: string;
+	price: number;
+	change: number;
+	change_pct: number;
+	volume: number | null;
+	aum_usd: number | null;
+	timestamp: string;
+	source: string;
+}
+
+export interface HoldingSummary {
+	instrument_id: string;
+	ticker: string;
+	name: string;
+	price: number;
+	change: number;
+	change_pct: number;
+	weight: number;
+	aum_usd: number | null;
+	asset_class: string;
+	currency: string;
+}
+
+export interface DashboardSnapshot {
+	holdings: HoldingSummary[];
+	total_aum: number;
+	total_return_pct: number | null;
+	as_of: string;
+}
+
+interface WsServerMessage {
+	type: "price" | "snapshot" | "pong" | "error" | "subscribed";
+	data: unknown;
+	timestamp: string;
+}
+
+export interface MarketDataStoreConfig {
+	getToken: () => Promise<string>;
+	apiBaseUrl?: string;
+	heartbeatTimeoutMs?: number;
+}
+
+export interface MarketDataStore {
+	// Reactive state (readonly to consumers)
+	readonly status: WsStatus;
+	/**
+	 * Live snapshot of all subscribed tickers, keyed by uppercase
+	 * ticker. The underlying `$state` is owned by the tick buffer
+	 * and reassigned at most once per 250ms regardless of inbound
+	 * tick volume. Consumers read via `priceMap.get(ticker)` —
+	 * never `priceMap[ticker]`.
+	 */
+	readonly priceMap: ReadonlyMap<string, PriceTick>;
+	readonly holdings: HoldingSummary[];
+	readonly totalAum: number;
+	readonly totalReturnPct: number | null;
+	readonly asOf: string | null;
+	readonly subscribedTickers: string[];
+	readonly error: string | null;
+	// Actions
+	start: () => void;
+	stop: () => void;
+	/**
+	 * Manually re-attempt connection after a permanent error (B1.9).
+	 * Resets the retry counter and dispatches a fresh `connect()`. The
+	 * store API previously had no escape from the "5 retries → error
+	 * forever" terminal state — `reconnect()` is the explicit recovery
+	 * lever the UI surfaces in `<svelte:boundary>` failed snippets.
+	 */
+	reconnect: () => void;
+	subscribe: (tickers: string[]) => void;
+	unsubscribe: (tickers: string[]) => void;
+	seedFromSSR: (snapshot: DashboardSnapshot) => void;
+}
+
+// ── Constants ───────────────────────────────────────────────
+
+const BACKOFF_BASE = 1000;
+const BACKOFF_MAX = 30_000;
+const MAX_RETRIES = 5;
+const DEFAULT_HEARTBEAT_TIMEOUT = 45_000;
+// Tabular UI cadence — 4 updates/sec, legible without "slot machine".
+// Aligned with the design spec §3.1 default for Dashboard surfaces.
+const TICK_FLUSH_INTERVAL_MS = 250;
+// Hard ceiling on simultaneously-tracked tickers. The screener catalog
+// page-size cap (200) is the upper bound the user can drive into the
+// buffer in one frame; 5000 leaves headroom for cross-page navigation
+// without dropping fresh data on the floor.
+const TICK_BUFFER_MAX_KEYS = 5000;
+
+// ── Store Factory ───────────────────────────────────────────
+
+export function createMarketDataStore(config: MarketDataStoreConfig): MarketDataStore {
+	const {
+		getToken,
+		apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1",
+		heartbeatTimeoutMs = DEFAULT_HEARTBEAT_TIMEOUT,
+	} = config;
+
+	// ── Reactive state ──────────────────────────────────────
+	let status = $state<WsStatus>("disconnected");
+
+	// SSR-seeded portfolio composition. Updated only by seedFromSSR —
+	// never per WebSocket tick. Live prices fold in via the `holdings`
+	// derived below.
+	let rawHoldings = $state<HoldingSummary[]>([]);
+
+	let totalAum = $state(0);
+	let asOf = $state<string | null>(null);
+	let subscribedTickers = $state<string[]>([]);
+	let error = $state<string | null>(null);
+
+	// ── Tick buffer ────────────────────────────────────────
+	// All inbound price ticks land here. The buffer owns its own
+	// reactive snapshot (`$state(new Map())`) and reassigns it on
+	// its internal 250ms clock — Svelte 5 propagates the change to
+	// every dependent `$derived` and template binding without any
+	// external mirror or polling.
+	const tickBuffer: TickBuffer<PriceTick> = createTickBuffer<PriceTick>({
+		keyOf: (t) => t.ticker.toUpperCase(),
+		clock: { intervalMs: TICK_FLUSH_INTERVAL_MS },
+		maxKeys: TICK_BUFFER_MAX_KEYS,
+		evictionPolicy: "drop_oldest",
+	});
+
+	// Live-fused holdings. Reads from `rawHoldings` (reactive) and
+	// `tickBuffer.snapshot` (reactive, owned by the buffer) so this
+	// re-runs once per buffer flush, not once per tick. Returns the
+	// same object reference for unchanged rows so downstream
+	// `{#each}` blocks don't churn DOM nodes.
+	const holdings = $derived.by((): HoldingSummary[] => {
+		if (rawHoldings.length === 0) return rawHoldings;
+		const snap = tickBuffer.snapshot;
+		if (snap.size === 0) return rawHoldings;
+		return rawHoldings.map((h) => {
+			const key = (h.ticker || "").toUpperCase();
+			if (!key) return h;
+			const tick = snap.get(key);
+			if (!tick) return h;
+			return {
+				...h,
+				price: tick.price,
+				change: tick.change,
+				change_pct: tick.change_pct,
+				aum_usd: tick.aum_usd ?? h.aum_usd,
+			};
+		});
+	});
+
+	const totalReturnPct = $derived.by((): number | null => {
+		if (holdings.length === 0) return null;
+		return holdings.reduce((sum, h) => sum + h.change_pct * h.weight, 0);
+	});
+
+	// ── Internal state ──────────────────────────────────────
+	let ws: WebSocket | null = null;
+	let retryCount = 0;
+	let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	let version = 0; // Monotonic — prevents stale overwrites
+	// Set, not array — dedup is O(1) and `pendingTickers` cannot grow
+	// linearly with subscribe/unsubscribe churn (B1.8).
+	const pendingTickers = new Set<string>();
+
+	// ── Heartbeat ───────────────────────────────────────────
+
+	function resetHeartbeat() {
+		if (heartbeatTimer) clearTimeout(heartbeatTimer);
+		heartbeatTimer = setTimeout(() => {
+			if (status === "connected") {
+				// No heartbeat/pong received — reconnect
+				ws?.close();
+				scheduleReconnect();
+			}
+		}, heartbeatTimeoutMs);
+	}
+
+	function clearHeartbeat() {
+		if (heartbeatTimer) {
+			clearTimeout(heartbeatTimer);
+			heartbeatTimer = null;
+		}
+	}
+
+	// ── Reconnection ────────────────────────────────────────
+
+	function scheduleReconnect() {
+		if (retryCount >= MAX_RETRIES) {
+			status = "error";
+			error = `WebSocket reconnection failed after ${MAX_RETRIES} retries`;
+			return;
+		}
+
+		status = "reconnecting";
+		const delay = Math.min(BACKOFF_BASE * 2 ** retryCount, BACKOFF_MAX);
+		retryCount++;
+
+		reconnectTimer = setTimeout(() => {
+			connect();
+		}, delay);
+	}
+
+	function clearReconnect() {
+		if (reconnectTimer) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+		}
+	}
+
+	// ── Message handling ────────────────────────────────────
+
+	function handleMessage(msg: WsServerMessage) {
+		resetHeartbeat();
+		version++;
+
+		switch (msg.type) {
+			case "price": {
+				const tick = msg.data as PriceTick;
+				if (tick?.ticker) {
+					// Single non-blocking write into the coalescing
+					// buffer. No spread, no allocation, no reactive
+					// invalidation — the snapshot mirror picks it up
+					// on the next flush tick.
+					tickBuffer.write(tick);
+				}
+				break;
+			}
+			case "subscribed": {
+				const data = msg.data as { tickers: string[] };
+				subscribedTickers = data?.tickers ?? [];
+				break;
+			}
+			case "pong":
+				// Heartbeat response — already handled by resetHeartbeat()
+				break;
+			case "error": {
+				const data = msg.data as { message?: string };
+				error = data?.message ?? "Unknown server error";
+				break;
+			}
+		}
+	}
+
+	// ── Connect ─────────────────────────────────────────────
+
+	async function connect() {
+		if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) {
+			return; // Already connected
+		}
+
+		status = "connecting";
+		error = null;
+
+		let token: string;
+		try {
+			token = await getToken();
+		} catch {
+			status = "error";
+			error = "Failed to retrieve auth token";
+			return;
+		}
+
+		// Preflight: verify backend is reachable before opening WebSocket.
+		// Avoids noisy browser console errors when backend is down.
+		try {
+			const healthUrl = apiBaseUrl.replace(/\/api\/v1$/, "") + "/health";
+			const health = await fetch(healthUrl, {
+				signal: AbortSignal.timeout(3000),
+			});
+			if (!health.ok) throw new Error("unhealthy");
+		} catch {
+			scheduleReconnect();
+			return;
+		}
+
+		// Build WS URL: http→ws, https→wss
+		const wsBase = apiBaseUrl.replace(/^http/, "ws");
+		const url = `${wsBase}/market-data/live/ws?token=${encodeURIComponent(token)}`;
+
+		try {
+			ws = new WebSocket(url);
+		} catch {
+			scheduleReconnect();
+			return;
+		}
+
+		ws.onopen = () => {
+			status = "connected";
+			retryCount = 0;
+			error = null;
+			resetHeartbeat();
+
+			// Subscribe to pending tickers
+			if (pendingTickers.size > 0) {
+				sendSubscribe(Array.from(pendingTickers));
+			}
+		};
+
+		ws.onmessage = (event) => {
+			try {
+				const msg = JSON.parse(event.data) as WsServerMessage;
+				handleMessage(msg);
+			} catch {
+				// Ignore unparseable messages
+			}
+		};
+
+		ws.onerror = () => {
+			// onclose will fire next — handle reconnect there
+		};
+
+		ws.onclose = (event) => {
+			clearHeartbeat();
+			ws = null;
+
+			if (event.code === 1008) {
+				// Auth failure — do not reconnect
+				status = "error";
+				error = "Authentication failed";
+				return;
+			}
+
+			if (status !== "disconnected") {
+				scheduleReconnect();
+			}
+		};
+	}
+
+	// ── Send helpers ────────────────────────────────────────
+
+	function sendSubscribe(tickers: string[]) {
+		if (ws?.readyState === WebSocket.OPEN) {
+			ws.send(JSON.stringify({ action: "subscribe", tickers }));
+		}
+	}
+
+	function sendUnsubscribe(tickers: string[]) {
+		if (ws?.readyState === WebSocket.OPEN) {
+			ws.send(JSON.stringify({ action: "unsubscribe", tickers }));
+		}
+	}
+
+	// ── Public API ──────────────────────────────────────────
+
+	function start() {
+		retryCount = 0;
+		connect();
+	}
+
+	function stop() {
+		status = "disconnected";
+		clearHeartbeat();
+		clearReconnect();
+		// Release the buffer's clock + visibility listener. The buffer
+		// is single-use after `dispose()`; the store instance is
+		// created once per layout mount and `stop()` runs on layout
+		// teardown, so this is the correct lifecycle moment.
+		tickBuffer.dispose();
+		if (ws) {
+			ws.onclose = null; // Prevent reconnect on intentional close
+			ws.close(1000, "Client disconnected");
+			ws = null;
+		}
+	}
+
+	function reconnect() {
+		// Recover from terminal "error" state — caller (typically a
+		// `<svelte:boundary>` failed snippet) decided the user wants
+		// another attempt. Clear the timers, reset the budget, fire
+		// off a fresh connect. The tick buffer is still alive (we
+		// only dispose it on `stop()`), so no buffer state needs
+		// rebuilding here.
+		clearReconnect();
+		clearHeartbeat();
+		retryCount = 0;
+		error = null;
+		status = "disconnected";
+		connect();
+	}
+
+	function subscribeTickers(tickers: string[]) {
+		const upper = tickers.map((t) => t.toUpperCase()).filter((t) => t.length > 0);
+		for (const t of upper) pendingTickers.add(t);
+		sendSubscribe(upper);
+	}
+
+	function unsubscribeTickers(tickers: string[]) {
+		const upper = tickers.map((t) => t.toUpperCase()).filter((t) => t.length > 0);
+		for (const t of upper) pendingTickers.delete(t);
+		sendUnsubscribe(upper);
+	}
+
+	function seedFromSSR(snapshot: DashboardSnapshot) {
+		rawHoldings = snapshot.holdings;
+		totalAum = snapshot.total_aum;
+		asOf = snapshot.as_of;
+
+		// Seed the buffer with the SSR prices so the first frame the
+		// user sees is correct even before the WebSocket warms up.
+		// `writeMany` performs one Map.set per ticker; the buffer's
+		// own clock will publish the resulting snapshot on the next
+		// flush tick. We force a single immediate `flush()` here so
+		// the SSR-rendered Dashboard does not flash empty between
+		// hydration and the first 250 ms tick.
+		const seedTicks: PriceTick[] = [];
+		for (const h of snapshot.holdings) {
+			if (!h.ticker) continue;
+			seedTicks.push({
+				ticker: h.ticker,
+				price: h.price,
+				change: h.change,
+				change_pct: h.change_pct,
+				volume: null,
+				aum_usd: h.aum_usd,
+				timestamp: snapshot.as_of,
+				source: "ssr",
+			});
+		}
+		if (seedTicks.length > 0) {
+			tickBuffer.writeMany(seedTicks);
+			tickBuffer.flush();
+		}
+
+		// Auto-subscribe to all holding tickers
+		pendingTickers.clear();
+		for (const h of snapshot.holdings) {
+			if (h.ticker) pendingTickers.add(h.ticker.toUpperCase());
+		}
+	}
+
+	return {
+		get status() { return status; },
+		get priceMap() { return tickBuffer.snapshot; },
+		get holdings() { return holdings; },
+		get totalAum() { return totalAum; },
+		get totalReturnPct() { return totalReturnPct; },
+		get asOf() { return asOf; },
+		get subscribedTickers() { return subscribedTickers; },
+		get error() { return error; },
+		start,
+		stop,
+		reconnect,
+		subscribe: subscribeTickers,
+		unsubscribe: unsubscribeTickers,
+		seedFromSSR,
+	};
+}

--- a/packages/ii-terminal-core/src/lib/stores/terminal-tweaks.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/stores/terminal-tweaks.svelte.ts
@@ -1,0 +1,56 @@
+/**
+ * Terminal runtime tweaks — density / accent / theme.
+ *
+ * In-memory only. No localStorage, no URL param. Resets on
+ * hard reload (confirmed trade-off per plan scope-decision #3:
+ * docs/plans/2026-04-18-netz-terminal-parity.md §0).
+ *
+ * Usage:
+ *   const tweaks = createTerminalTweaks();
+ *   setContext(TERMINAL_TWEAKS_KEY, tweaks);
+ *   ...
+ *   const tweaks = getContext<TerminalTweaks>(TERMINAL_TWEAKS_KEY);
+ *
+ * The TerminalShell binds `data-density`, `data-accent`, `data-theme`
+ * onto its root element so the @investintell/ui tokens shipped in
+ * PR-1 activate via attribute selectors.
+ */
+
+import type { Accent, Density, TerminalTheme } from "@investintell/ui";
+
+export const TERMINAL_TWEAKS_KEY = Symbol("netz:terminal-tweaks");
+
+export interface TerminalTweaks {
+	readonly density: Density;
+	readonly accent: Accent;
+	readonly theme: TerminalTheme;
+	setDensity(v: Density): void;
+	setAccent(v: Accent): void;
+	setTheme(v: TerminalTheme): void;
+}
+
+export function createTerminalTweaks(): TerminalTweaks {
+	let density = $state<Density>("standard");
+	let accent = $state<Accent>("amber");
+	let theme = $state<TerminalTheme>("dark");
+	return {
+		get density() {
+			return density;
+		},
+		get accent() {
+			return accent;
+		},
+		get theme() {
+			return theme;
+		},
+		setDensity(v) {
+			density = v;
+		},
+		setAccent(v) {
+			accent = v;
+		},
+		setTheme(v) {
+			theme = v;
+		},
+	};
+}

--- a/packages/ii-terminal-core/src/lib/types/alerts.ts
+++ b/packages/ii-terminal-core/src/lib/types/alerts.ts
@@ -1,0 +1,67 @@
+/**
+ * Phase 7 Alerts Unification — TS shapes mirroring the backend
+ * ``UnifiedAlertRead`` schema in
+ * ``backend/app/domains/wealth/schemas/alerts.py``.
+ *
+ * The frontend never branches on the source. Every alert flows
+ * through this single contract; only the backend aggregator knows
+ * about the underlying ``strategy_drift_alerts`` /
+ * ``portfolio_alerts`` tables.
+ *
+ * Per DL15: read/unread state lives on the backend's
+ * ``acknowledged_at`` columns. The GlobalAlertInbox never touches
+ * localStorage / sessionStorage.
+ */
+
+/** Canonical severity scale used by the unified API. */
+export type UnifiedSeverity = "info" | "warning" | "critical";
+
+/** Source table the alert came from. The frontend uses this only to
+ *  build the acknowledge URL — never to branch rendering logic. */
+export type UnifiedAlertSource = "drift" | "portfolio";
+
+/** What kind of entity the alert is about. Drives href + icon. */
+export type UnifiedSubjectKind = "instrument" | "portfolio";
+
+export interface UnifiedAlert {
+	/** Source row id. Combine with ``source`` for the acknowledge call. */
+	id: string;
+	source: UnifiedAlertSource;
+
+	/** Snake-case alert kind for icon / label routing. */
+	alert_type: string;
+
+	/** Normalized severity. */
+	severity: UnifiedSeverity;
+
+	/** 1-line headline. */
+	title: string;
+	subtitle: string | null;
+
+	/** Subject linkage. */
+	subject_kind: UnifiedSubjectKind;
+	subject_id: string;
+	subject_name: string | null;
+
+	/** Read state. */
+	created_at: string;
+	acknowledged_at: string | null;
+	acknowledged_by: string | null;
+
+	/** Drill-through href computed by the backend route layer. */
+	href: string | null;
+}
+
+/** Envelope returned by GET /alerts/inbox. */
+export interface UnifiedAlertInbox {
+	items: UnifiedAlert[];
+	total: number;
+	unread_count: number;
+	by_source: Record<string, number>;
+}
+
+/** Per-portfolio open count from GET /alerts/portfolio/{id}/count. */
+export interface PortfolioAlertCount {
+	portfolio_id: string;
+	open_count: number;
+}

--- a/packages/ii-terminal-core/src/lib/types/allocation-page.ts
+++ b/packages/ii-terminal-core/src/lib/types/allocation-page.ts
@@ -1,0 +1,147 @@
+/**
+ * PR-A26.3 — Allocation page types.
+ *
+ * Maps 1:1 to backend Pydantic schemas in
+ * ``backend/app/domains/wealth/schemas/model_portfolio.py``
+ * (StrategicAllocationResponse / ApprovalHistoryResponse and friends).
+ *
+ * Hand-maintained until ``make types`` (openapi-typescript) is wired
+ * into the frontend build — matches the pattern of model-portfolio.ts.
+ */
+
+export interface StrategicAllocationBlock {
+	block_id: string;
+	block_name: string;
+	target_weight: number | null;
+	drift_min: number | null;
+	drift_max: number | null;
+	override_min: number | null;
+	override_max: number | null;
+	excluded_from_portfolio: boolean;
+	approved_from_run_id: string | null;
+	approved_at: string | null;
+	approved_by: string | null;
+}
+
+export interface StrategicAllocationResponse {
+	organization_id: string;
+	profile: string;
+	cvar_limit: number;
+	has_active_approval: boolean;
+	last_approved_at: string | null;
+	last_approved_by: string | null;
+	blocks: StrategicAllocationBlock[];
+}
+
+export interface ApprovalHistoryEntry {
+	approval_id: string;
+	run_id: string;
+	approved_by: string;
+	approved_at: string;
+	superseded_at: string | null;
+	cvar_at_approval: number | null;
+	expected_return_at_approval: number | null;
+	cvar_feasible_at_approval: boolean;
+	operator_message: string | null;
+	is_active: boolean;
+}
+
+export interface ApprovalHistoryResponse {
+	organization_id: string;
+	profile: string;
+	total: number;
+	entries: ApprovalHistoryEntry[];
+}
+
+export interface ProposedBand {
+	block_id: string;
+	target_weight: number;
+	drift_min: number;
+	drift_max: number;
+	rationale: string | null;
+}
+
+export interface ProposalMetrics {
+	expected_return: number | null;
+	expected_cvar: number | null;
+	expected_sharpe: number | null;
+	target_cvar: number | null;
+	cvar_feasible: boolean;
+}
+
+/**
+ * PR-4a — surfaced from ``cascade_telemetry.phase_attempts``.
+ * Matches ``backend.app.domains.wealth.schemas.model_portfolio.CascadePhaseAttempt``.
+ */
+export interface CascadePhaseAttempt {
+	phase: string;
+	status: string;
+	solver: string | null;
+	wall_ms: number;
+	objective_value: number | null;
+	cvar_within_limit: boolean | null;
+}
+
+/**
+ * PR-4a — PR-A14 universe coverage summary.
+ * Matches ``backend.app.domains.wealth.schemas.model_portfolio.CoverageSummary``.
+ */
+export interface CoverageSummary {
+	pct_covered: number | null;
+	hard_fail: boolean;
+	n_total_blocks: number | null;
+	n_covered_blocks: number | null;
+	missing_blocks: string[];
+}
+
+export interface LatestProposalResponse {
+	run_id: string;
+	requested_at: string;
+	winner_signal: string;
+	proposed_bands: ProposedBand[];
+	proposal_metrics: ProposalMetrics;
+	phase_attempts: CascadePhaseAttempt[];
+	coverage: CoverageSummary | null;
+}
+
+export interface JobCreatedResponse {
+	job_id: string;
+	sse_url: string;
+	run_id: string;
+}
+
+export interface ApproveProposalRequest {
+	confirm_cvar_infeasible?: boolean;
+	operator_message?: string | null;
+}
+
+export interface SetOverrideRequest {
+	block_id: string;
+	override_min: number | null;
+	override_max: number | null;
+	rationale: string | null;
+}
+
+export type AllocationProfile = "conservative" | "moderate" | "growth";
+
+export const ALLOCATION_PROFILES: readonly AllocationProfile[] = [
+	"conservative",
+	"moderate",
+	"growth",
+] as const;
+
+export const PROFILE_LABELS: Record<AllocationProfile, string> = {
+	conservative: "Conservative",
+	moderate: "Moderate",
+	growth: "Growth",
+};
+
+/** Block family grouping — drives donut/chart color buckets. */
+export type BlockFamily = "equity" | "fixed_income" | "alternatives" | "cash";
+
+export function blockFamily(block_id: string): BlockFamily {
+	if (block_id === "cash") return "cash";
+	if (block_id.startsWith("fi_")) return "fixed_income";
+	if (block_id.startsWith("alt_")) return "alternatives";
+	return "equity";
+}

--- a/packages/ii-terminal-core/src/lib/types/analytics.ts
+++ b/packages/ii-terminal-core/src/lib/types/analytics.ts
@@ -1,0 +1,282 @@
+/** Analytics domain types — Attribution, Drift, Correlation. */
+
+export interface SectorAttribution {
+	sector: string;
+	block_id: string;
+	allocation_effect: number;
+	selection_effect: number;
+	interaction_effect: number;
+	total_effect: number;
+}
+
+export interface AttributionResult {
+	profile: string;
+	start_date: string;
+	end_date: string;
+	granularity: "monthly" | "quarterly";
+	total_portfolio_return: number;
+	total_benchmark_return: number;
+	total_excess_return: number;
+	allocation_total: number;
+	selection_total: number;
+	interaction_total: number;
+	total_allocation_combined: number;
+	sectors: SectorAttribution[];
+	n_periods: number;
+	benchmark_available: boolean;
+	benchmark_approach: string;
+}
+
+export interface MetricDrift {
+	metric_name: string;
+	recent_mean: number;
+	baseline_mean: number;
+	baseline_std: number;
+	z_score: number;
+	is_anomalous: boolean;
+}
+
+export interface StrategyDriftAlert {
+	alert_type: string;
+	instrument_id: string;
+	instrument_name: string;
+	status: string;
+	anomalous_count: number;
+	total_metrics: number;
+	metrics: MetricDrift[];
+	severity: "none" | "moderate" | "severe";
+	detected_at: string;
+}
+
+export interface StrategyDriftScanResult {
+	scanned_count: number;
+	alerts_found?: number;
+	alerts: StrategyDriftAlert[];
+	stable_count: number;
+	insufficient_data_count: number;
+	scan_timestamp: string;
+}
+
+export interface ParetoResult {
+	profile: string;
+	recommended_weights: Record<string, number>;
+	pareto_sharpe: number[];
+	pareto_cvar: number[];
+	n_solutions: number;
+	seed: number;
+	input_hash: string;
+	status: string;
+	job_id?: string;
+}
+
+export interface ConcentrationAnalysis {
+	absorption_ratio: number;
+	eigenvalues: number[];
+	mp_threshold: number;
+	n_signal_eigenvalues: number;
+}
+
+export interface CorrelationResult {
+	profile: string;
+	matrix: number[][];
+	labels: string[];
+	concentration: ConcentrationAnalysis;
+}
+
+export interface RollingCorrelation {
+	dates: string[];
+	values: number[];
+	instrument_a: string;
+	instrument_b: string;
+}
+
+export interface BacktestFoldResult {
+	fold: number;
+	sharpe: number | null;
+	cvar_95: number | null;
+	max_drawdown: number | null;
+	n_obs: number;
+	period_start?: string;
+	period_end?: string;
+}
+
+export interface BacktestResult {
+	mean_sharpe: number | null;
+	std_sharpe: number | null;
+	positive_folds: number;
+	total_folds: number;
+	folds: BacktestFoldResult[];
+}
+
+// ── Risk Budgeting (eVestment p.43-44) ──────────────────────────────
+
+export interface FundRiskBudget {
+	block_id: string;
+	block_name: string;
+	weight: number;
+	mean_return: number;
+	mctr: number | null;
+	pctr: number | null;
+	mcetl: number | null;
+	pcetl: number | null;
+	implied_return_vol: number | null;
+	implied_return_etl: number | null;
+	difference_vol: number | null;
+	difference_etl: number | null;
+}
+
+export interface RiskBudgetResult {
+	profile: string;
+	portfolio_volatility: number;
+	portfolio_etl: number;
+	portfolio_starr: number | null;
+	funds: FundRiskBudget[];
+	as_of_date: string | null;
+}
+
+// ── Factor Analysis (eVestment p.46) ────────────────────────────────
+
+export interface FactorContribution {
+	factor_label: string;
+	pct_contribution: number;
+}
+
+export interface FactorAnalysisResult {
+	profile: string;
+	systematic_risk_pct: number;
+	specific_risk_pct: number;
+	factor_contributions: FactorContribution[];
+	r_squared: number;
+	portfolio_factor_exposures: Record<string, number>;
+	as_of_date: string | null;
+}
+
+// ── Monte Carlo Simulation ─────────────────────────────────────────
+
+export interface MonteCarloConfidenceBar {
+	horizon: string;
+	horizon_days: number;
+	pct_5: number;
+	pct_10: number;
+	pct_25: number;
+	pct_50: number;
+	pct_75: number;
+	pct_90: number;
+	pct_95: number;
+	mean: number;
+}
+
+export interface MonteCarloResult {
+	entity_id: string;
+	entity_name: string;
+	n_simulations: number;
+	statistic: string;
+	percentiles: Record<string, number>;
+	mean: number;
+	median: number;
+	std: number;
+	historical_value: number;
+	confidence_bars: MonteCarloConfidenceBar[];
+}
+
+// ── Peer Group Rankings (eVestment Section IV) ────────────────────
+
+export interface PeerRanking {
+	metric_name: string;
+	value: number | null;
+	percentile: number;
+	quartile: number;
+	peer_count: number;
+	peer_median: number;
+	peer_p25: number;
+	peer_p75: number;
+}
+
+export interface PeerGroupResult {
+	entity_id: string;
+	entity_name: string;
+	strategy_label: string;
+	peer_count: number;
+	rankings: PeerRanking[];
+	as_of_date: string | null;
+}
+
+// ── Active Share (eVestment p.73) ─────────────────────────────────
+
+export interface ActiveShareResult {
+	entity_id: string;
+	entity_name: string;
+	active_share: number;
+	overlap: number;
+	active_share_efficiency: number | null;
+	n_portfolio_positions: number;
+	n_benchmark_positions: number;
+	n_common_positions: number;
+	as_of_date: string | null;
+}
+
+// ── Correlation Regime (Marchenko-Pastur denoising, contagion) ──────
+
+export interface InstrumentCorrelation {
+	instrument_a_id: string;
+	instrument_a_name: string;
+	instrument_b_id: string;
+	instrument_b_name: string;
+	current_correlation: number;
+	baseline_correlation: number;
+	correlation_change: number;
+	is_contagion: boolean;
+}
+
+export interface RegimeConcentrationAnalysis {
+	eigenvalues: number[];
+	explained_variance_ratios: number[];
+	first_eigenvalue_ratio: number;
+	concentration_status: string;
+	diversification_ratio: number;
+	dr_alert: boolean;
+	absorption_ratio: number;
+	absorption_status: string;
+	mp_threshold: number;
+	n_signal_eigenvalues: number;
+}
+
+export interface CorrelationRegimeResult {
+	profile: string;
+	instrument_count: number;
+	window_days: number;
+	correlation_matrix: number[][];
+	instrument_labels: string[];
+	contagion_pairs: InstrumentCorrelation[];
+	concentration: RegimeConcentrationAnalysis;
+	average_correlation: number;
+	baseline_average_correlation: number;
+	regime_shift_detected: boolean;
+	computed_at: string;
+}
+
+export interface PairCorrelationResult {
+	instrument_a_id: string;
+	instrument_a_name: string;
+	instrument_b_id: string;
+	instrument_b_name: string;
+	dates: string[];
+	correlations: number[];
+	window_days: number;
+}
+
+export type Timeframe = "ytd" | "1y" | "3y" | "custom";
+
+export function effectColor(value: number): string {
+	if (value > 0.001) return "var(--ii-success)";
+	if (value < -0.001) return "var(--ii-danger)";
+	return "var(--ii-text-muted)";
+}
+
+export function severityColor(severity: string): string {
+	switch (severity) {
+		case "severe":   return "var(--ii-danger)";
+		case "moderate": return "var(--ii-warning)";
+		default:         return "var(--ii-success)";
+	}
+}

--- a/packages/ii-terminal-core/src/lib/types/cascade-telemetry.ts
+++ b/packages/ii-terminal-core/src/lib/types/cascade-telemetry.ts
@@ -1,0 +1,156 @@
+/**
+ * Cascade telemetry payload — emitted by the construction_run_executor
+ * (PR-A11) and stored on ``portfolio_construction_runs.cascade_telemetry``
+ * (JSONB). The same shape is mirrored on the ``cascade_telemetry_completed``
+ * SSE event, so the panel can hydrate before the final REST GET arrives.
+ *
+ * PR-A13 consumes ``achievable_return_band`` + ``operator_signal`` to drive
+ * the Builder Risk Budget panel. PR-A13.2 will reuse these types for the
+ * live drag-preview branch (``previewBand``).
+ */
+
+export interface AchievableReturnBand {
+	lower: number;
+	upper: number;
+	lower_at_cvar: number;
+	upper_at_cvar: number;
+}
+
+export type OperatorSignalKind =
+	| "feasible"
+	| "cvar_limit_below_universe_floor"
+	| "upstream_data_missing"
+	| "constraint_polytope_empty"
+	// PR-A14 — surfaces only when coverage < 0.20 (hard-fail).
+	| "universe_coverage_insufficient";
+
+/**
+ * PR-A14 — non-blocking secondary signal flagged by the executor when the
+ * approved universe covers < 85% of the profile's strategic allocation
+ * targets. Primary signal keeps its existing contract; consumers opt in
+ * to the secondary by reading ``operator_signal.secondary``.
+ */
+export interface OperatorSignalSecondary {
+	kind: "universe_coverage_insufficient";
+	binding: string | null;
+	message_key: string;
+	pct_covered: number | null;
+	missing_blocks_count: number | null;
+}
+
+export interface OperatorSignal {
+	kind: OperatorSignalKind;
+	binding: string | null;
+	message_key: string;
+	// PR-A14 — additive, None outside the coverage-warning window.
+	secondary?: OperatorSignalSecondary | null;
+	// PR-A14 — populated only when ``kind === "universe_coverage_insufficient"``.
+	pct_covered?: number | null;
+	missing_blocks_count?: number | null;
+}
+
+/**
+ * PR-A14 — universe coverage payload. Surfaces the structural fit between
+ * the approved universe (instruments_org) and the profile's strategic
+ * allocation blocks. Nullable for legacy runs that predate the surface.
+ */
+export interface CoverageTelemetry {
+	pct_covered: number;
+	n_total_blocks: number;
+	n_covered_blocks: number;
+	covered_blocks: string[];
+	missing_blocks: string[];
+	renormalization_scale: number | null;
+	hard_fail: boolean;
+}
+
+export type CascadeSummary =
+	| "phase_1_succeeded"
+	| "phase_2_robust_succeeded"
+	| "phase_3_min_cvar_within_limit"
+	| "phase_3_min_cvar_above_limit"
+	| "upstream_heuristic";
+
+export interface PhaseAttempt {
+	phase: string;
+	status: "succeeded" | "infeasible" | "skipped" | "error";
+	solver?: string;
+	objective_value?: number | null;
+	wall_ms?: number;
+	infeasibility_reason?: string | null;
+	cvar_at_solution?: number | null;
+}
+
+/**
+ * PR-A19.1 Section C — cascade-aware operator signal. Additive to the
+ * legacy ``operator_signal``; distinguishes Phase 1 optimal from
+ * Phase 3 min-CVaR fallback when the CVaR target is infeasible. The
+ * backend owns the displayable copy (``operator_message``) — smart
+ * backend / dumb frontend.
+ */
+export type WinnerSignal =
+	| "optimal"
+	| "cvar_infeasible_min_var"
+	| "robustness_fallback"
+	| "degraded_other"
+	| "pre_solve_failure"
+	// PR-A22 — block coverage gate aborted the run before the optimizer.
+	| "block_coverage_insufficient";
+
+/**
+ * PR-A22 — per-block gap in the profile's StrategicAllocation. Surfaced
+ * when ``winner_signal === "block_coverage_insufficient"``.
+ */
+export interface BlockCoverageGap {
+	block_id: string;
+	target_weight: number;
+	suggested_strategy_labels: string[];
+	catalog_candidates_available: number;
+	example_tickers: string[];
+}
+
+export interface CoverageReport {
+	organization_id: string;
+	profile: string;
+	is_sufficient: boolean;
+	total_target_weight_at_risk: number;
+	gaps: BlockCoverageGap[];
+}
+
+export type OperatorMessageSeverity = "info" | "warning" | "error";
+
+export interface OperatorMessage {
+	title: string;
+	body: string;
+	severity: OperatorMessageSeverity;
+	action_hint: string;
+}
+
+export interface CascadeTelemetry {
+	phase_attempts: PhaseAttempt[];
+	cascade_summary: CascadeSummary;
+	min_achievable_cvar: number | null;
+	achievable_return_band: AchievableReturnBand | null;
+	operator_signal: OperatorSignal | null;
+	// PR-A14 — universe coverage surface (nullable for legacy runs).
+	coverage?: CoverageTelemetry | null;
+	// PR-A19.1 — cascade-aware signal + backend-owned copy.
+	winner_signal?: WinnerSignal | null;
+	operator_message?: OperatorMessage | null;
+	// PR-A22 — populated only when ``winner_signal === "block_coverage_insufficient"``.
+	coverage_report?: CoverageReport | null;
+}
+
+/**
+ * PR-A13.2 — POST /preview-cvar response. Mirrors
+ * ``backend/app/domains/wealth/schemas/preview.py``. Used by the Builder
+ * RiskBudgetPanel to populate the ``previewBand ?? serverBand`` channel
+ * while the operator drags the slider.
+ */
+export interface PreviewCvarResponse {
+	achievable_return_band: AchievableReturnBand;
+	min_achievable_cvar: number;
+	operator_signal: OperatorSignal;
+	cached: boolean;
+	wall_ms: number;
+}

--- a/packages/ii-terminal-core/src/lib/types/dd-report.ts
+++ b/packages/ii-terminal-core/src/lib/types/dd-report.ts
@@ -1,0 +1,100 @@
+/** DD Report domain types — maps 1:1 to backend schemas. */
+
+export type DDReportStatus =
+	| "draft"
+	| "generating"
+	| "pending_approval"
+	| "approved"
+	| "rejected"
+	| "failed";
+
+export type DecisionAnchor = "APPROVE" | "CONDITIONAL" | "REJECT";
+
+export interface DDChapter {
+	id: string;
+	chapter_tag: string;
+	chapter_order: number;
+	content_md: string | null;
+	evidence_refs: Record<string, unknown> | null;
+	quant_data: Record<string, unknown> | null;
+	critic_iterations: number;
+	critic_status: "pending" | "accepted" | "escalated";
+	generated_at: string | null;
+}
+
+export interface DDReportSummary {
+	id: string;
+	instrument_id: string;
+	report_type: "dd_report" | "bond_brief";
+	version: number;
+	status: DDReportStatus;
+	confidence_score: number | null;
+	decision_anchor: DecisionAnchor | null;
+	is_current: boolean;
+	created_at: string;
+	created_by: string | null;
+	approved_by: string | null;
+	approved_at: string | null;
+	rejection_reason: string | null;
+}
+
+export interface DDReportListItem extends DDReportSummary {
+	instrument_name: string;
+	instrument_ticker: string | null;
+}
+
+export interface DDReportFull extends DDReportSummary {
+	config_snapshot: Record<string, unknown> | null;
+	schema_version: number;
+	chapters: DDChapter[];
+}
+
+export interface AuditEvent {
+	id: string;
+	action: string;
+	actor_id: string | null;
+	before: Record<string, unknown> | null;
+	after: Record<string, unknown> | null;
+	created_at: string | null;
+}
+
+/** Chapter registry — mirrors backend CHAPTER_REGISTRY order */
+export const CHAPTER_TITLES: Record<string, string> = {
+	executive_summary: "Executive Summary",
+	investment_strategy: "Investment Strategy & Process",
+	manager_assessment: "Fund Manager Assessment",
+	performance_analysis: "Performance Analysis",
+	risk_framework: "Risk Management Framework",
+	fee_analysis: "Fee Analysis",
+	operational_dd: "Operational Due Diligence",
+	recommendation: "Recommendation",
+};
+
+export function chapterTitle(tag: string): string {
+	return CHAPTER_TITLES[tag] ?? tag.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function anchorLabel(anchor: DecisionAnchor | null): string {
+	switch (anchor) {
+		case "APPROVE": return "Approve";
+		case "CONDITIONAL": return "Conditional";
+		case "REJECT": return "Reject";
+		default: return "—";
+	}
+}
+
+export function confidenceColor(score: number | null): string {
+	if (score === null) return "var(--ii-text-muted)";
+	if (score >= 80) return "var(--ii-success)";
+	if (score >= 60) return "var(--ii-info)";
+	return "var(--ii-warning)";
+}
+
+export function anchorColor(anchor: DecisionAnchor | null): string {
+	switch (anchor) {
+		case "APPROVE": return "var(--ii-success)";
+		case "CONDITIONAL": return "var(--ii-warning)";
+		case "REJECT": return "var(--ii-danger)";
+		default: return "var(--ii-text-muted)";
+	}
+}

--- a/packages/ii-terminal-core/src/lib/types/model-portfolio.ts
+++ b/packages/ii-terminal-core/src/lib/types/model-portfolio.ts
@@ -1,0 +1,468 @@
+/** Model Portfolio domain types — maps 1:1 to backend schemas. */
+
+/** Universal cash instrument ID — matches backend CASH_INSTRUMENT_ID. */
+export const CASH_INSTRUMENT_ID = "00000000-0000-0000-0000-000000000000";
+
+/**
+ * Canonical lifecycle state set — kept in sync with the CHECK constraint
+ * in migration 0098 and ``state_machine.TRANSITIONS`` (Phase 1 Task 1.1).
+ * Never read this directly in Svelte to decide whether to render a
+ * button — always use ``allowed_actions`` instead (DL3).
+ */
+export type PortfolioState =
+	| "draft"
+	| "constructed"
+	| "validated"
+	| "approved"
+	| "live"
+	| "paused"
+	| "archived"
+	| "rejected";
+
+/**
+ * Action strings the backend state machine returns in ``allowed_actions``.
+ * Phase 5 Task 5.2 maps each value to a button label, variant, icon, and
+ * onclick handler. Adding a new entry here is a coordinated change with
+ * ``backend/vertical_engines/wealth/model_portfolio/state_machine.py``.
+ */
+export type PortfolioAction =
+	| "construct"
+	| "validate"
+	| "approve"
+	| "activate"
+	| "pause"
+	| "resume"
+	| "archive"
+	| "reject"
+	| "rebuild_draft";
+
+export interface ModelPortfolio {
+	id: string;
+	profile: string;
+	display_name: string;
+	description: string | null;
+	benchmark_composite: string | null;
+	inception_date: string | null;
+	backtest_start_date: string | null;
+	inception_nav: number;
+	status: string;
+	// ── State machine (migration 0098, Phase 1 Task 1.4) ──────────
+	state: PortfolioState;
+	state_metadata: Record<string, unknown>;
+	state_changed_at: string | null;
+	state_changed_by: string | null;
+	/**
+	 * Action strings the backend state machine has computed for the
+	 * current state. The Builder action bar renders one button per
+	 * entry — DL3 forbids ``if state === "validated"`` conditionals
+	 * anywhere in the wealth frontend.
+	 */
+	allowed_actions: PortfolioAction[];
+	fund_selection_schema: SelectionSchema | null;
+	created_at: string;
+	created_by: string | null;
+}
+
+export interface OptimizationMeta {
+	expected_return: number | null;
+	portfolio_volatility: number | null;
+	sharpe_ratio: number | null;
+	solver: string | null;
+	status: string;
+	cvar_95: number | null;
+	cvar_limit: number | null;
+	cvar_within_limit: boolean;
+}
+
+export interface SelectionSchema {
+	profile: string;
+	total_weight: number;
+	funds: InstrumentWeight[];
+	optimization?: OptimizationMeta;
+}
+
+export interface InstrumentWeight {
+	instrument_id: string;
+	fund_name: string;
+	instrument_type: "mutual_fund" | "etf" | "bdc" | "money_market" | "closed_end" | "interval_fund" | "ucits" | "private" | null;
+	block_id: string;
+	weight: number;
+	score: number;
+}
+
+/** @deprecated Use SelectionSchema */
+export type FundSelectionSchema = SelectionSchema;
+/** @deprecated Use InstrumentWeight */
+export type FundWeight = InstrumentWeight;
+
+export interface BacktestFold {
+	fold: number;
+	sharpe: number | null;
+	cvar_95: number | null;
+	max_drawdown: number | null;
+	n_obs: number;
+}
+
+export interface BacktestResult {
+	mean_sharpe: number | null;
+	std_sharpe: number | null;
+	positive_folds: number;
+	total_folds: number;
+	youngest_fund_start: string | null;
+	folds: BacktestFold[];
+}
+
+export interface StressScenario {
+	name: string;
+	start_date: string;
+	end_date: string;
+	portfolio_return: number;
+	max_drawdown: number;
+	recovery_days: number | null;
+}
+
+export interface StressResult {
+	scenarios: StressScenario[];
+}
+
+export interface NAVPoint {
+	date: string;
+	nav: number;
+	daily_return: number | null;
+}
+
+export interface TrackRecord {
+	portfolio_id: string;
+	profile: string;
+	status: string;
+	fund_selection: SelectionSchema | null;
+	backtest: BacktestResult | null;
+	nav_series: NAVPoint[] | null;
+	live_nav: unknown;
+	stress: StressResult | null;
+}
+
+export function scenarioLabel(name: string): string {
+	const map: Record<string, string> = {
+		"2008_gfc": "Global Financial Crisis (2008)",
+		"2020_covid": "COVID-19 Crash (2020)",
+		"2022_rate_hike": "Rate Hike Cycle (2022)",
+		"taper_2013": "Taper Tantrum (2013)",
+		"rate_shock_200bps": "Rate Shock +200bps",
+	};
+	return map[name] ?? name.replace(/_/g, " ");
+}
+
+export function optimizerStatusLabel(status: string): { label: string; description: string; severity: "success" | "warning" | "danger" } {
+	const map: Record<string, { label: string; description: string; severity: "success" | "warning" | "danger" }> = {
+		"optimal": {
+			label: "Optimal",
+			description: "Maximum risk-adjusted return found within all constraints",
+			severity: "success",
+		},
+		"optimal:robust": {
+			label: "Robust Optimal",
+			description: "SOCP optimization applied \u2014 portfolio is resilient to estimation error in covariance matrix",
+			severity: "success",
+		},
+		"optimal:cvar_constrained": {
+			label: "CVaR-Constrained",
+			description: "Variance-capped solution \u2014 CVaR constraint was binding, reducing expected return to meet risk limit",
+			severity: "warning",
+		},
+		"optimal:min_variance_fallback": {
+			label: "Min-Variance Fallback",
+			description: "Minimum-variance portfolio \u2014 all higher-return phases exceeded CVaR limit",
+			severity: "warning",
+		},
+		"optimal:cvar_violated": {
+			label: "CVaR Limit Exceeded",
+			description: "Warning: CVaR limit exceeded in all optimization phases. Consider adding diversifying funds or adjusting the profile.",
+			severity: "danger",
+		},
+		"fallback:insufficient_fund_data": {
+			label: "Heuristic Fallback",
+			description: "Insufficient aligned trading data between funds \u2014 weights assigned by block-level heuristic, not optimizer",
+			severity: "danger",
+		},
+	};
+	return map[status] ?? { label: status.replace(/_/g, " "), description: "Optimizer status", severity: "warning" };
+}
+
+export interface PortfolioView {
+	id: string;
+	portfolio_id: string;
+	asset_instrument_id: string | null;
+	peer_instrument_id: string | null;
+	view_type: "absolute" | "relative";
+	expected_return: number;
+	confidence: number;
+	rationale: string | null;
+	created_by: string | null;
+	effective_from: string;
+	effective_to: string | null;
+	created_at: string;
+}
+
+/** Parametric stress test request for POST /model-portfolios/{id}/stress-test */
+export interface ParametricStressRequest {
+	scenario_name: "gfc_2008" | "covid_2020" | "taper_2013" | "rate_shock_200bps" | "custom";
+	shocks?: Record<string, number>;
+}
+
+/** Parametric stress test result from POST /stress-test */
+export interface ParametricStressResult {
+	portfolio_id: string;
+	scenario_name: string;
+	nav_impact_pct: number;
+	cvar_stressed: number | null;
+	block_impacts: Record<string, number>;
+	worst_block: string | null;
+	best_block: string | null;
+}
+
+/** Human-readable labels for allocation block IDs — re-exported from canonical source */
+export { blockLabel } from "$wealth/constants/blocks";
+
+/** Holdings overlap analysis result from GET /model-portfolios/{id}/overlap */
+export interface CusipExposure {
+	cusip: string;
+	issuer_name: string | null;
+	total_exposure_pct: number;
+	funds_holding: string[];
+	is_breach: boolean;
+}
+
+export interface SectorExposure {
+	sector: string;
+	total_exposure_pct: number;
+	cusip_count: number;
+}
+
+export interface OverlapResult {
+	portfolio_id: string;
+	computed_at: string;
+	limit_pct: number;
+	total_holdings: number;
+	funds_analyzed: number;
+	funds_without_data: number;
+	top_cusip_exposures: CusipExposure[];
+	sector_exposures: SectorExposure[];
+	breaches: CusipExposure[];
+	has_sufficient_data: boolean;
+	data_warning: string | null;
+}
+
+export interface GeneratedReport {
+	id: string;
+	job_id: string;
+	display_filename: string;
+	generated_at: string;
+	size_bytes: number | null;
+}
+
+// ── Unified Report Endpoints ──────────────────────────────────────────
+
+export type ReportType = "fact_sheet" | "monthly_report";
+
+export interface ReportHistoryItem {
+	id: string;
+	portfolio_id: string;
+	report_type: ReportType;
+	job_id: string;
+	display_filename: string;
+	generated_at: string;
+	size_bytes: number | null;
+	status: string;
+}
+
+export interface ReportHistoryResponse {
+	portfolio_id: string;
+	reports: ReportHistoryItem[];
+	total: number;
+}
+
+export interface ReportGenerateRequest {
+	report_type: ReportType;
+	as_of_date?: string;
+	language?: "pt" | "en";
+	format?: "executive" | "institutional";
+}
+
+export interface ReportGenerateResponse {
+	job_id: string;
+	portfolio_id: string;
+	report_type: string;
+	status: string;
+}
+
+// ── SSE Progress Events ───────────────────────────────────────────────
+
+export type ReportStage =
+	| "QUEUED"
+	| "FETCHING_MARKET_DATA"
+	| "RUNNING_QUANT_ENGINE"
+	| "SYNTHESIZING_LLM"
+	| "GENERATING_PDF"
+	| "STORING_PDF"
+	| "COMPLETED";
+
+export interface ReportProgressEvent {
+	stage: ReportStage;
+	message: string;
+	pct: number;
+}
+
+export interface ReportDoneEvent {
+	status: string;
+	report_type: string;
+	storage_path?: string;
+	size_bytes?: number;
+	error?: string | null;
+}
+
+export interface ReportErrorEvent {
+	error: string;
+}
+
+export type ReportSSEEvent =
+	| { event: "progress"; data: ReportProgressEvent }
+	| { event: "done"; data: ReportDoneEvent }
+	| { event: "error"; data: ReportErrorEvent };
+
+export const REPORT_TYPE_LABELS: Record<ReportType, string> = {
+	fact_sheet: "Fact Sheet",
+	monthly_report: "Monthly Report",
+};
+
+export const REPORT_STAGE_LABELS: Record<ReportStage, string> = {
+	QUEUED: "Queued",
+	FETCHING_MARKET_DATA: "Fetching Market Data",
+	RUNNING_QUANT_ENGINE: "Running Quant Engine",
+	SYNTHESIZING_LLM: "Synthesizing with AI",
+	GENERATING_PDF: "Generating PDF",
+	STORING_PDF: "Storing PDF",
+	COMPLETED: "Completed",
+};
+
+// ── Rebalance Preview ─────────────────────────────────────────────────
+
+export interface HoldingInput {
+	instrument_id: string;
+	quantity: number;
+	current_price: number;
+}
+
+export interface RebalancePreviewRequest {
+	total_aum?: number;
+	cash_available: number;
+	current_holdings: HoldingInput[];
+}
+
+export interface SuggestedTrade {
+	instrument_id: string;
+	fund_name: string;
+	block_id: string;
+	action: "BUY" | "SELL" | "HOLD";
+	current_weight: number;
+	target_weight: number;
+	delta_weight: number;
+	current_value: number;
+	target_value: number;
+	trade_value: number;
+	estimated_quantity: number;
+}
+
+export interface WeightDelta {
+	block_id: string;
+	current_weight: number;
+	target_weight: number;
+	delta_pp: number;
+}
+
+export interface RebalancePreviewResponse {
+	portfolio_id: string;
+	portfolio_name: string;
+	profile: string;
+	total_aum: number;
+	cash_available: number;
+	total_trades: number;
+	estimated_turnover_pct: number;
+	trades: SuggestedTrade[];
+	weight_comparison: WeightDelta[];
+	cvar_95_projected: number | null;
+	cvar_limit: number | null;
+	cvar_warning: boolean;
+}
+
+export function profileColor(profile: string): string {
+	switch (profile) {
+		case "conservative": return "var(--ii-info)";
+		case "moderate": return "var(--ii-warning)";
+		case "growth": return "var(--ii-success)";
+		default: return "var(--ii-text-secondary)";
+	}
+}
+
+// ── Construction Advisor ────────────────────────────────────────────────
+
+export interface BlockGap {
+	block_id: string;
+	display_name: string;
+	asset_class: string;
+	target_weight: number;
+	current_weight: number;
+	gap_weight: number;
+	priority: number;
+	reason: string;
+}
+
+export interface CoverageAnalysis {
+	total_blocks: number;
+	covered_blocks: number;
+	covered_pct: number;
+	block_gaps: BlockGap[];
+}
+
+export interface CandidateFund {
+	block_id: string;
+	instrument_id: string;
+	name: string;
+	ticker: string | null;
+	strategy_label: string | null;
+	volatility_1y: number | null;
+	correlation_with_portfolio: number;
+	overlap_pct: number;
+	projected_cvar_95: number | null;
+	cvar_improvement: number;
+	in_universe: boolean;
+	external_id: string;
+	has_holdings_data: boolean;
+}
+
+export interface MinimumViableSet {
+	funds: string[];
+	projected_cvar_95: number;
+	projected_within_limit: boolean;
+	blocks_filled: string[];
+	search_method: string;
+}
+
+export interface AlternativeProfile {
+	profile: string;
+	cvar_limit: number;
+	current_cvar_would_pass: boolean;
+}
+
+export interface ConstructionAdvice {
+	portfolio_id: string;
+	profile: string;
+	current_cvar_95: number;
+	cvar_limit: number;
+	cvar_gap: number;
+	coverage: CoverageAnalysis;
+	candidates: CandidateFund[];
+	minimum_viable_set: MinimumViableSet | null;
+	alternative_profiles: AlternativeProfile[];
+	projected_cvar_is_heuristic: boolean;
+}

--- a/packages/ii-terminal-core/src/lib/types/model-portfolio.ts
+++ b/packages/ii-terminal-core/src/lib/types/model-portfolio.ts
@@ -222,7 +222,7 @@ export interface ParametricStressResult {
 }
 
 /** Human-readable labels for allocation block IDs — re-exported from canonical source */
-export { blockLabel } from "$wealth/constants/blocks";
+export { blockLabel } from "../constants/blocks";
 
 /** Holdings overlap analysis result from GET /model-portfolios/{id}/overlap */
 export interface CusipExposure {

--- a/packages/ii-terminal-core/src/lib/types/portfolio-build.ts
+++ b/packages/ii-terminal-core/src/lib/types/portfolio-build.ts
@@ -1,0 +1,33 @@
+// PR-A5 Section A.2 — types for POST /api/v1/portfolios/{id}/build (Job-or-Stream).
+// Kept DISTINCT from ConstructRunEvent (legacy /model-portfolios/{id}/construct path)
+// until the legacy wiring is fully retired in PR-A7.
+
+export interface BuildAccepted {
+	job_id: string;
+	stream_url: string; // "/api/v1/jobs/{job_id}/stream"
+	status: "accepted";
+}
+
+export type BuildPhase =
+	| "STARTED"
+	| "FACTOR_MODELING"
+	| "SHRINKAGE"
+	| "SOCP_OPTIMIZATION"
+	| "BACKTESTING"
+	| "COMPLETED"
+	| "CANCELLED"
+	| "ERROR"
+	| "DEDUPED";
+
+export interface BuildEvent {
+	type: string; // humanised label from backend (already sanitised server-side)
+	raw_type?: string; // original backend event type, e.g. "optimizer_phase_complete"
+	phase?: BuildPhase | string; // pipeline phase OR optimizer cascade sub-phase
+	message?: string;
+	progress?: number; // 0.0 … 1.0
+	metrics?: Record<string, unknown>;
+	run_id?: string; // only populated on COMPLETED
+	status?: string;
+	reason?: string; // only on ERROR / CANCELLED / DEDUPED
+	objective_value?: number | null; // only on optimizer_phase_complete
+}

--- a/packages/ii-terminal-core/src/lib/types/portfolio-calibration.ts
+++ b/packages/ii-terminal-core/src/lib/types/portfolio-calibration.ts
@@ -1,0 +1,103 @@
+/**
+ * Portfolio calibration — shared TS surface for the Builder
+ * CalibrationPanel, the portfolio-workspace store, and the construction
+ * run payload consumers.
+ *
+ * Mirrors the Pydantic ``PortfolioCalibrationRead`` schema in
+ * ``backend/app/domains/wealth/schemas/model_portfolio.py`` (Phase 4
+ * backend route). Numeric columns come back as JSON numbers — the
+ * backend serializes ``Decimal`` through Pydantic's default encoder.
+ *
+ * DL5 — tier structure (Basic 5 / Advanced 10 / Expert 48). DL14 —
+ * every field label surfaces via the jargon translation layer in
+ * Phase 10; labels in this file are placeholders and MUST be replaced
+ * from ``JARGON_TRANSLATION`` when that table lands.
+ */
+
+export type CalibrationMandate = "conservative" | "moderate" | "aggressive" | "balanced";
+
+export type CalibrationRegimeOverride =
+	| "auto"
+	| "NORMAL"
+	| "RISK_ON"
+	| "RISK_OFF"
+	| "CRISIS"
+	| "INFLATION";
+
+/** DL7 canonical stress scenario ids. */
+export type StressScenarioId =
+	| "gfc_2008"
+	| "covid_2020"
+	| "taper_2013"
+	| "rate_shock_200bps";
+
+export interface PortfolioCalibration {
+	id: string;
+	portfolio_id: string;
+	schema_version: number;
+
+	// ── Basic tier (5) ──
+	mandate: CalibrationMandate;
+	cvar_limit: number;
+	max_single_fund_weight: number;
+	turnover_cap: number | null;
+	stress_scenarios_active: StressScenarioId[];
+
+	// ── Advanced tier (10) ──
+	regime_override: CalibrationRegimeOverride | null;
+	bl_enabled: boolean;
+	bl_view_confidence_default: number;
+	garch_enabled: boolean;
+	turnover_lambda: number | null;
+	stress_severity_multiplier: number;
+	advisor_enabled: boolean;
+	cvar_level: number;
+	lambda_risk_aversion: number | null;
+	shrinkage_intensity_override: number | null;
+
+	// ── Expert tier — untyped blob ──
+	expert_overrides: Record<string, unknown>;
+
+	// ── Audit ──
+	created_at: string;
+	updated_at: string;
+	updated_by: string | null;
+}
+
+/**
+ * Partial update body sent to PUT /{portfolio_id}/calibration. The
+ * frontend uses ``exclude_unset`` semantics on the backend — only
+ * touched fields are shipped.
+ */
+export type PortfolioCalibrationUpdate = Partial<
+	Omit<PortfolioCalibration, "id" | "portfolio_id" | "schema_version" | "created_at" | "updated_at" | "updated_by">
+>;
+
+/** Deep-equal helper tailored to the calibration shape (shallow enough for primitives + arrays + flat expert_overrides). */
+export function calibrationsEqual(a: PortfolioCalibration, b: PortfolioCalibration): boolean {
+	if (a.mandate !== b.mandate) return false;
+	if (a.cvar_limit !== b.cvar_limit) return false;
+	if (a.max_single_fund_weight !== b.max_single_fund_weight) return false;
+	if (a.turnover_cap !== b.turnover_cap) return false;
+	if (a.stress_scenarios_active.length !== b.stress_scenarios_active.length) return false;
+	for (let i = 0; i < a.stress_scenarios_active.length; i++) {
+		if (a.stress_scenarios_active[i] !== b.stress_scenarios_active[i]) return false;
+	}
+	if (a.regime_override !== b.regime_override) return false;
+	if (a.bl_enabled !== b.bl_enabled) return false;
+	if (a.bl_view_confidence_default !== b.bl_view_confidence_default) return false;
+	if (a.garch_enabled !== b.garch_enabled) return false;
+	if (a.turnover_lambda !== b.turnover_lambda) return false;
+	if (a.stress_severity_multiplier !== b.stress_severity_multiplier) return false;
+	if (a.advisor_enabled !== b.advisor_enabled) return false;
+	if (a.cvar_level !== b.cvar_level) return false;
+	if (a.lambda_risk_aversion !== b.lambda_risk_aversion) return false;
+	if (a.shrinkage_intensity_override !== b.shrinkage_intensity_override) return false;
+	const aKeys = Object.keys(a.expert_overrides);
+	const bKeys = Object.keys(b.expert_overrides);
+	if (aKeys.length !== bKeys.length) return false;
+	for (const k of aKeys) {
+		if (a.expert_overrides[k] !== b.expert_overrides[k]) return false;
+	}
+	return true;
+}

--- a/packages/ii-terminal-core/src/lib/types/taa.ts
+++ b/packages/ii-terminal-core/src/lib/types/taa.ts
@@ -1,0 +1,96 @@
+/**
+ * TAA (Tactical Asset Allocation) frontend types.
+ * Mirrors backend schemas from `allocation.py` Sprint 3.
+ */
+
+export interface EffectiveBand {
+	min: number;
+	max: number;
+	center: number | null;
+}
+
+export interface RegimeBands {
+	profile: string;
+	as_of_date: string;
+	raw_regime: string;
+	stress_score: number | null;
+	smoothed_centers: Record<string, number>;
+	effective_bands: Record<string, EffectiveBand>;
+	transition_velocity: Record<string, number> | null;
+	ips_clamps_applied: string[];
+	taa_enabled: boolean;
+}
+
+export interface TaaHistoryRow {
+	as_of_date: string;
+	raw_regime: string;
+	stress_score: number | null;
+	smoothed_centers: Record<string, number>;
+	effective_bands: Record<string, Record<string, number>>;
+	transition_velocity: Record<string, number> | null;
+	created_at: string;
+}
+
+export interface TaaHistory {
+	profile: string;
+	rows: TaaHistoryRow[];
+	total: number;
+}
+
+export interface EffectiveAllocationWithRegime {
+	profile: string;
+	block_id: string;
+	strategic_weight: number | null;
+	tactical_overweight: number | null;
+	effective_weight: number | null;
+	min_weight: number | null;
+	max_weight: number | null;
+	regime_min: number | null;
+	regime_max: number | null;
+	regime_center: number | null;
+}
+
+/**
+ * OD-22 translated regime labels for institutional display.
+ * Backend emits RISK_ON/RISK_OFF/CRISIS/INFLATION.
+ * Frontend shows Expansion/Defensive/Stress/Inflation.
+ */
+export const TAA_REGIME_LABELS: Record<string, string> = {
+	RISK_ON: "Expansion",
+	RISK_OFF: "Defensive",
+	CRISIS: "Stress",
+	INFLATION: "Inflation",
+};
+
+export function taaRegimeLabel(raw: string): string {
+	return TAA_REGIME_LABELS[raw] ?? raw;
+}
+
+/**
+ * Regime posture description — one-liner institutional summary.
+ * Shown below the regime badge in the CalibrationPanel.
+ */
+export const TAA_REGIME_POSTURE: Record<string, string> = {
+	RISK_ON: "Growth-oriented allocation bands active",
+	RISK_OFF: "Defensive posture — reduced equity exposure",
+	CRISIS: "Stress posture — maximum capital preservation",
+	INFLATION: "Inflation hedge tilt — real assets favored",
+};
+
+export function taaRegimePosture(raw: string): string {
+	return TAA_REGIME_POSTURE[raw] ?? "Allocation bands adjusted to current conditions";
+}
+
+/**
+ * Regime color tokens — CSS variable references for institutional palette.
+ */
+export const TAA_REGIME_COLORS: Record<string, string> = {
+	RISK_ON: "var(--ii-success)",
+	RISK_OFF: "var(--ii-warning)",
+	CRISIS: "var(--ii-danger)",
+	INFLATION: "var(--ii-brand-highlight)",
+};
+
+export function taaRegimeColor(raw: string): string {
+	return TAA_REGIME_COLORS[raw] ?? "var(--ii-text-muted)";
+}

--- a/packages/ii-terminal-core/src/lib/utils/metric-translators.ts
+++ b/packages/ii-terminal-core/src/lib/utils/metric-translators.ts
@@ -1,0 +1,351 @@
+/**
+ * metric-translators — PR-A5 Section C.
+ *
+ * Sanitisation-aware rendering helpers. The backend
+ * (``construction_run_executor._publish_event_sanitized``) already
+ * humanises the ``type`` and ``message`` fields of every SSE event;
+ * the frontend renders those verbatim. The raw quant numbers survive
+ * inside ``payload.metrics`` so the UI can surface secondary chips
+ * that translate the numbers into PT-BR institutional labels next to
+ * (not replacing) the formatted value.
+ *
+ * Every translator is a pure function ``(value) => TranslatedMetric``.
+ * Translators NEVER format numbers — callers use ``@investintell/ui``
+ * formatters for the raw value and place it alongside the chip.
+ *
+ * Thresholds come directly from the Section C table of the PR-A5
+ * spec (``docs/prompts/2026-04-15-construction-engine-pr-a5-frontend-migration.md``).
+ * Do not tune thresholds locally — surface a spec-change request if a
+ * value looks wrong.
+ */
+
+export type Tone = "success" | "neutral" | "warning" | "danger";
+
+export interface TranslatedMetric {
+	label: string;
+	tone: Tone;
+}
+
+/**
+ * ``kappa`` — condition number of the covariance matrix (Ledoit-Wolf
+ * regularised). Read: higher = less stable. Backend already falls back
+ * to a heuristic when κ explodes; we surface the tone so the PM knows
+ * why the numbers might look different than expected.
+ */
+export function translateKappa(value: number): TranslatedMetric {
+	if (value < 1e4) {
+		return { label: "Boa estabilidade do modelo de risco", tone: "success" };
+	}
+	if (value < 1e6) {
+		return { label: "Estabilidade aceitável", tone: "neutral" };
+	}
+	return {
+		label: "Atenção: modelo instável — considere regime override",
+		tone: "warning",
+	};
+}
+
+/**
+ * ``shrinkage_lambda`` — Ledoit-Wolf shrinkage intensity in [0, 1].
+ * 0 = sample covariance, 1 = pure diagonal target. Institutional
+ * sweet spot is the mid-range; extremes warrant a human note.
+ */
+export function translateShrinkageLambda(value: number): TranslatedMetric {
+	if (value < 0.15) {
+		return { label: "Estimativa direta", tone: "neutral" };
+	}
+	if (value <= 0.7) {
+		return { label: "Estimativa robusta", tone: "success" };
+	}
+	return {
+		label: "Forte shrinkage — covariância quase diagonal",
+		tone: "warning",
+	};
+}
+
+/**
+ * ``regime`` — detected macro regime label from the regime detector.
+ * Unknown regimes pass through as a neutral default; never throw.
+ */
+export function translateRegime(value: string): TranslatedMetric {
+	switch (value) {
+		case "NORMAL":
+			return { label: "Regime normal", tone: "neutral" };
+		case "RISK_ON":
+			return { label: "Regime expansionista", tone: "success" };
+		case "RISK_OFF":
+			return { label: "Regime defensivo ativo", tone: "warning" };
+		case "CRISIS":
+			return { label: "Regime de crise — CVaR reforçado", tone: "danger" };
+		case "INFLATION":
+			return { label: "Regime inflacionário", tone: "warning" };
+		default:
+			return { label: `Regime ${value}`, tone: "neutral" };
+	}
+}
+
+/**
+ * ``regime_multiplier`` — CVaR multiplier applied when the detected
+ * regime tightens the risk budget. ``1.0`` means no adjustment — the
+ * caller should hide the chip in that case (return ``null``).
+ */
+export function translateRegimeMultiplier(
+	value: number,
+): TranslatedMetric | null {
+	if (value === 1.0) return null;
+	const pct = Math.round((1 - value) * 100);
+	if (value < 1.0) {
+		return {
+			label: `Tolerância a risco reduzida em ${pct}%`,
+			tone: "warning",
+		};
+	}
+	const loosePct = Math.round((value - 1) * 100);
+	return {
+		label: `Tolerância a risco ampliada em ${loosePct}%`,
+		tone: "neutral",
+	};
+}
+
+/**
+ * ``k_factors_effective`` vs ``k_factors`` — PCA factor model coverage.
+ * Flag when effective < 75% of total, so the analyst knows the
+ * benchmark set collapsed.
+ */
+export function translateFactorCoverage(
+	effective: number,
+	total: number,
+): TranslatedMetric {
+	if (total <= 0) {
+		return {
+			label: "Cobertura de fatores indisponível",
+			tone: "warning",
+		};
+	}
+	if (effective >= 0.75 * total) {
+		return {
+			label: `${effective} de ${total} fatores ativos`,
+			tone: "success",
+		};
+	}
+	return {
+		label: `Cobertura de fatores limitada (${effective} de ${total})`,
+		tone: "warning",
+	};
+}
+
+/**
+ * ``r_squared_p50`` — median explanatory power of the factor model
+ * across funds. Anchors the "how well does the risk model describe my
+ * universe" question.
+ */
+export function translateRSquaredMedian(value: number): TranslatedMetric {
+	if (value >= 0.7) {
+		return { label: "Aderência média: alta", tone: "success" };
+	}
+	if (value >= 0.4) {
+		return { label: "Aderência média: moderada", tone: "neutral" };
+	}
+	return {
+		label: "Aderência média: baixa — revisar benchmarks",
+		tone: "warning",
+	};
+}
+
+/**
+ * ``phase_used`` — which optimiser cascade phase produced the final
+ * weights. PR-A12 reshaped the cascade into three Rockafellar-Uryasev
+ * phases; legacy keys are aliased for one release so stale runs still
+ * render a sensible label.
+ */
+export function translateOptimizerPhase(value: string): TranslatedMetric {
+	switch (value) {
+		// PR-A12 canonical keys
+		case "phase_1_ru_max_return":
+			return { label: "Máximo retorno (risco limitado)", tone: "success" };
+		case "phase_2_ru_robust":
+			return { label: "Máximo retorno (robusto)", tone: "success" };
+		case "phase_3_min_cvar":
+			return { label: "Mínimo risco de cauda", tone: "neutral" };
+		case "upstream_heuristic":
+			return { label: "Fallback por dados insuficientes", tone: "warning" };
+		// Legacy aliases — drop after one release cycle
+		case "primary":
+			return { label: "Otimizador principal", tone: "success" };
+		case "robust":
+			return { label: "Otimizador robusto", tone: "success" };
+		case "variance_capped":
+			return { label: "Variância limitada", tone: "neutral" };
+		case "min_variance":
+			return { label: "Variância mínima", tone: "neutral" };
+		case "heuristic":
+			return { label: "Fallback heurístico", tone: "warning" };
+		default:
+			return { label: `Otimizador: ${value}`, tone: "neutral" };
+	}
+}
+
+/**
+ * ``cascade_summary`` (PR-A11/A12) — operator-vocabulary headline for the
+ * construction run's cascade outcome. Drives the Builder's cascade chip
+ * colour + top-line message. Allowed vocabulary only; never shows solver
+ * names, phase keys or math jargon.
+ */
+export function translateCascadeSummary(value: string): TranslatedMetric {
+	switch (value) {
+		case "phase_1_succeeded":
+			return {
+				label: "Otimizado para máximo retorno dentro do limite de risco",
+				tone: "success",
+			};
+		case "phase_2_robust_succeeded":
+			return {
+				label: "Otimizado com ajuste robusto conservador",
+				tone: "success",
+			};
+		case "phase_3_min_cvar_within_limit":
+			return {
+				label: "Alocação de mínimo risco de cauda dentro do limite",
+				tone: "success",
+			};
+		case "phase_3_min_cvar_above_limit":
+			return {
+				label:
+					"Limite de perda está abaixo do piso do universo — exibindo alocação de mínimo risco",
+				tone: "warning",
+			};
+		case "upstream_heuristic":
+			return {
+				label: "Dados insuficientes para otimização — alocação provisória",
+				tone: "warning",
+			};
+		case "constraint_polytope_empty":
+			return {
+				label: "Bandas por bloco incompatíveis — revisar estrutura de alocação",
+				tone: "danger",
+			};
+		default:
+			return { label: value, tone: "neutral" };
+	}
+}
+
+/**
+ * ``operator_signal.kind`` (PR-A11/A12) — structured signal driving the
+ * feedback panel next to the CVaR slider. Emits the copy the Builder
+ * surfaces; numeric values travel alongside in the signal payload.
+ */
+export function translateOperatorSignalKind(value: string): TranslatedMetric {
+	switch (value) {
+		case "feasible":
+			return {
+				label: "Alocação viável dentro do limite de perda",
+				tone: "success",
+			};
+		case "cvar_limit_below_universe_floor":
+			return {
+				label:
+					"Seu limite de perda está abaixo do menor risco de cauda que o universo entrega",
+				tone: "warning",
+			};
+		case "upstream_data_missing":
+			return {
+				label: "Estatísticas de retorno indisponíveis para o universo atual",
+				tone: "warning",
+			};
+		case "constraint_polytope_empty":
+			return {
+				label: "Soma das bandas por bloco não fecha em 100% — revisar bandas",
+				tone: "danger",
+			};
+		case "universe_coverage_insufficient":
+			return {
+				label:
+					"Universo aprovado não cobre todos os blocos deste perfil — importe fundos nos blocos ausentes",
+				tone: "warning",
+			};
+		default:
+			return { label: value, tone: "neutral" };
+	}
+}
+
+/**
+ * PR-A14 — copy for the non-blocking secondary signal surfaced when the
+ * approved universe covers < 85% of the profile's strategic allocation
+ * blocks. Renders next to (not replacing) the primary signal.
+ */
+export function translateCoverageSecondary(
+	pctCovered: number | null | undefined,
+	missingBlocksCount: number | null | undefined,
+): TranslatedMetric {
+	const pct =
+		typeof pctCovered === "number"
+			? Math.round(pctCovered * 100)
+			: null;
+	const n = typeof missingBlocksCount === "number" ? missingBlocksCount : null;
+	const pctFragment = pct !== null ? ` (${pct}% coberto)` : "";
+	const nFragment = n !== null && n > 0 ? ` — ${n} blocos ausentes` : "";
+	return {
+		label: `Universo aprovado parcial${pctFragment}${nFragment}`,
+		tone: "warning",
+	};
+}
+
+/**
+ * ``cvar_95`` (portfolio) — the tail loss at 95% confidence. Returns a
+ * tone driven by whether the realised CVaR is within the mandate cap.
+ * The caller renders the raw percentage via ``formatPercent``; this
+ * helper only picks the chip tone. Passing ``mandateLimit = null``
+ * yields a neutral tone (mandate not configured).
+ *
+ * CVaR is intentionally exposed as a term (Andrei's audience knows the
+ * acronym — see Section C "CVaR labelling exception").
+ */
+export function translateCvar(
+	value: number,
+	mandateLimit: number | null,
+): TranslatedMetric {
+	if (mandateLimit == null) {
+		return { label: "CVaR 95%", tone: "neutral" };
+	}
+	const breach = Math.abs(value) > Math.abs(mandateLimit);
+	if (breach) {
+		return { label: "CVaR 95% acima do limite do mandato", tone: "danger" };
+	}
+	const headroom = Math.abs(mandateLimit) - Math.abs(value);
+	const tight = headroom < 0.1 * Math.abs(mandateLimit);
+	return {
+		label: tight
+			? "CVaR 95% próximo ao limite do mandato"
+			: "CVaR 95% dentro do mandato",
+		tone: tight ? "warning" : "success",
+	};
+}
+
+/**
+ * ``max_drawdown_pct`` — worst historical drawdown observed in the
+ * backtest. Same contract as ``translateCvar``: caller formats the raw
+ * number; this helper picks the tone.
+ */
+export function translateMaxDrawdown(
+	value: number,
+	mandateLimit: number | null,
+): TranslatedMetric {
+	if (mandateLimit == null) {
+		return { label: "Drawdown máximo", tone: "neutral" };
+	}
+	const breach = Math.abs(value) > Math.abs(mandateLimit);
+	if (breach) {
+		return {
+			label: "Drawdown máximo acima do limite do mandato",
+			tone: "danger",
+		};
+	}
+	const headroom = Math.abs(mandateLimit) - Math.abs(value);
+	const tight = headroom < 0.1 * Math.abs(mandateLimit);
+	return {
+		label: tight
+			? "Drawdown máximo próximo ao limite"
+			: "Drawdown máximo dentro do mandato",
+		tone: tight ? "warning" : "success",
+	};
+}

--- a/packages/ii-terminal-core/src/lib/utils/profile-defaults.ts
+++ b/packages/ii-terminal-core/src/lib/utils/profile-defaults.ts
@@ -1,0 +1,33 @@
+/**
+ * Profile-differentiated CVaR defaults — mirrors the authoritative backend
+ * helper ``app.domains.wealth.models.model_portfolio.default_cvar_limit_for_profile``
+ * (PR-A18, recalibrated from A12.2). Keep the two in sync; a future PR may
+ * expose these via an admin config endpoint so the frontend stops
+ * duplicating the mapping.
+ *
+ * Unknown / null profile → 0.075 (moderate), matching the backend fallback.
+ */
+export function defaultCvarForProfile(profile: string | null | undefined): number {
+	switch ((profile ?? "").toLowerCase()) {
+		case "conservative":
+			return 0.05; // PR-A18: was 0.025
+		case "moderate":
+			return 0.075; // PR-A18: was 0.05
+		case "growth":
+			return 0.1; // PR-A18: was 0.08
+		case "aggressive":
+			return 0.125; // PR-A18: was 0.1
+		default:
+			return 0.075; // moderate fallback (PR-A18)
+	}
+}
+
+/** Human label for the profile, used in UI copy. */
+export function profileLabel(profile: string | null | undefined): string {
+	const p = (profile ?? "").toLowerCase();
+	if (p === "conservative") return "Conservative";
+	if (p === "moderate") return "Moderate";
+	if (p === "growth") return "Growth";
+	if (p === "aggressive") return "Aggressive";
+	return profile ?? "Moderate";
+}

--- a/packages/ii-terminal-core/src/lib/utils/render-markdown.css
+++ b/packages/ii-terminal-core/src/lib/utils/render-markdown.css
@@ -1,0 +1,87 @@
+/* Rendered markdown — shared styles for semantic HTML produced by `marked`.
+   Import in any component that uses renderMarkdown() + {@html}.
+   Parent container should scope these via :global(). */
+
+h1 {
+	font-size: var(--ii-text-h2, 1.75rem);
+	font-weight: 700;
+	margin: var(--ii-space-stack-lg, 28px) 0 var(--ii-space-stack-sm, 12px);
+	color: var(--ii-text-primary);
+}
+
+h2 {
+	font-size: var(--ii-text-h3, 1.375rem);
+	font-weight: 600;
+	margin: var(--ii-space-stack-md, 20px) 0 var(--ii-space-stack-xs, 8px);
+	color: var(--ii-text-primary);
+}
+
+h3 {
+	font-size: var(--ii-text-h4, 1.125rem);
+	font-weight: 600;
+	margin: var(--ii-space-stack-sm, 16px) 0 var(--ii-space-stack-2xs, 4px);
+	color: var(--ii-text-primary);
+}
+
+p {
+	margin: 0 0 var(--ii-space-stack-sm, 12px);
+}
+
+ul {
+	margin: 0 0 var(--ii-space-stack-sm, 12px);
+	padding-left: var(--ii-space-inline-lg, 24px);
+}
+
+ol {
+	margin: 0 0 var(--ii-space-stack-sm, 12px);
+	padding-left: var(--ii-space-inline-lg, 24px);
+}
+
+li {
+	margin: 0 0 var(--ii-space-stack-2xs, 4px);
+}
+
+code {
+	font-family: var(--ii-font-mono);
+	font-size: var(--ii-text-mono, 0.875rem);
+	padding: 1px 5px;
+	border-radius: 4px;
+	background: var(--ii-surface-alt);
+}
+
+table {
+	width: 100%;
+	border-collapse: collapse;
+	margin: 1rem 0;
+	font-size: 0.875rem;
+}
+
+th,
+td {
+	border: 1px solid var(--ii-border-subtle, var(--border));
+	padding: 0.5rem 0.75rem;
+	text-align: left;
+}
+
+th {
+	background: var(--ii-surface-alt, var(--muted));
+	font-weight: 600;
+}
+
+hr {
+	border: none;
+	border-top: 1px solid var(--ii-border-subtle, var(--border));
+	margin: 1.5rem 0;
+}
+
+blockquote {
+	border-left: 3px solid var(--ii-border-subtle, var(--border));
+	margin: 0 0 var(--ii-space-stack-sm, 12px);
+	padding-left: var(--ii-space-inline-md, 16px);
+	color: var(--ii-text-secondary);
+}
+
+.rw-empty {
+	color: var(--ii-text-muted);
+	font-style: italic;
+}

--- a/packages/ii-terminal-core/src/lib/utils/render-markdown.ts
+++ b/packages/ii-terminal-core/src/lib/utils/render-markdown.ts
@@ -1,0 +1,48 @@
+/**
+ * Safe markdown → HTML renderer using `marked` + DOMPurify defense-in-depth.
+ *
+ * marked handles full CommonMark including tables, horizontal rules,
+ * numbered lists, and nested structures.
+ * DOMPurify sanitizes the output — backend nh3 is the persist-boundary guard.
+ */
+
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+
+const ALLOWED_TAGS = [
+	"h1", "h2", "h3", "h4", "h5", "h6",
+	"p", "strong", "em", "code", "pre",
+	"ul", "ol", "li",
+	"table", "thead", "tbody", "tr", "th", "td",
+	"blockquote", "hr", "br",
+	"a", "sup", "sub",
+];
+const ALLOWED_ATTR = ["href", "title", "class", "colspan", "rowspan", "align"];
+
+// Configure marked: no async, use GFM (GitHub Flavored Markdown) for tables
+marked.setOptions({ gfm: true, breaks: false });
+
+export function renderMarkdown(md: string | null): string {
+	if (!md) return '<p class="rw-empty">Content not yet generated.</p>';
+	const raw = marked.parse(md) as string;
+	return DOMPurify.sanitize(raw, { ALLOWED_TAGS, ALLOWED_ATTR });
+}
+
+/**
+ * Recursively flatten a nested object into dot-notation key-value pairs.
+ */
+export function flattenObject(
+	obj: Record<string, unknown>,
+	prefix = "",
+): Array<{ key: string; value: string }> {
+	const entries: Array<{ key: string; value: string }> = [];
+	for (const [k, v] of Object.entries(obj)) {
+		const label = prefix ? `${prefix} \u203A ${k}` : k;
+		if (v && typeof v === "object" && !Array.isArray(v)) {
+			entries.push(...flattenObject(v as Record<string, unknown>, label));
+		} else {
+			entries.push({ key: label, value: String(v ?? "\u2014") });
+		}
+	}
+	return entries;
+}

--- a/packages/ii-terminal-core/src/lib/utils/sse-reader.ts
+++ b/packages/ii-terminal-core/src/lib/utils/sse-reader.ts
@@ -1,0 +1,78 @@
+// PR-A5 Section A.3 — shared SSE parser.
+//
+// Extracted verbatim from portfolio-workspace.runConstructJob (the canonical
+// fetch()+ReadableStream implementation used since DL15 — EventSource cannot
+// carry Clerk JWT on Authorization header, so fetch is mandatory).
+//
+// Contract:
+//   parseSseStream(res, onEvent, signal)
+//     - Streams ``res.body`` until the server closes the connection OR
+//       ``signal`` is aborted. Callers drive early termination by calling
+//       ``controller.abort()`` from inside ``onEvent`` when a terminal
+//       payload arrives — this keeps the legacy early-exit semantics
+//       without forcing the parser to know about domain terminals.
+//     - Parses ``data:`` lines into JSON objects; malformed payloads are
+//       silently skipped (matches legacy behaviour — the server never
+//       emits anything but JSON on this channel).
+//     - Always cancels the reader on exit so we do not leak pending reads.
+
+export async function parseSseStream(
+	res: Response,
+	onEvent: (event: unknown) => void,
+	signal: AbortSignal,
+): Promise<void> {
+	if (!res.ok || !res.body) {
+		throw new Error(`SSE stream failed: HTTP ${res.status}`);
+	}
+
+	const reader = res.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	let currentData = "";
+
+	try {
+		while (true) {
+			if (signal.aborted) break;
+
+			let chunk: ReadableStreamReadResult<Uint8Array>;
+			try {
+				chunk = await reader.read();
+			} catch (err) {
+				// AbortError is the legitimate terminal path when the caller
+				// calls controller.abort() from onEvent. Propagate anything else.
+				if ((err as { name?: string } | null)?.name === "AbortError") break;
+				throw err;
+			}
+
+			if (chunk.done) break;
+
+			buffer += decoder.decode(chunk.value, { stream: true });
+			buffer = buffer.replace(/\r\n/g, "\n");
+			const lines = buffer.split("\n");
+			buffer = lines.pop() ?? "";
+
+			for (const line of lines) {
+				if (line.startsWith("data:")) {
+					currentData += (currentData ? "\n" : "") + line.slice(5).replace(/^ /, "");
+				} else if (line === "") {
+					if (currentData) {
+						let parsed: unknown = null;
+						try {
+							parsed = JSON.parse(currentData);
+						} catch {
+							parsed = null;
+						}
+						if (parsed !== null) {
+							onEvent(parsed);
+						}
+						currentData = "";
+					}
+				}
+			}
+		}
+	} finally {
+		reader.cancel().catch(() => {
+			/* ignore abort noise */
+		});
+	}
+}

--- a/packages/ii-terminal-core/svelte.config.js
+++ b/packages/ii-terminal-core/svelte.config.js
@@ -1,0 +1,11 @@
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	preprocess: vitePreprocess(),
+	kit: {
+		// Package mode — no adapter needed
+	},
+};
+
+export default config;

--- a/packages/ii-terminal-core/tsconfig.json
+++ b/packages/ii-terminal-core/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["svelte"],
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -98,7 +98,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -335,6 +335,9 @@ importers:
       '@investintell/ui':
         specifier: workspace:*
         version: link:../investintell-ui
+      '@sveltejs/kit':
+        specifier: ^2.0.0
+        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2))
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,28 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.5.0)(happy-dom@20.8.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)
 
+  packages/ii-terminal-core:
+    dependencies:
+      '@investintell/ui':
+        specifier: workspace:*
+        version: link:../investintell-ui
+    devDependencies:
+      '@sveltejs/package':
+        specifier: ^2.0.0
+        version: 2.5.7(svelte@5.53.12)(typescript@5.9.3)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.0
+        version: 5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2))
+      svelte:
+        specifier: ^5.0.0
+        version: 5.53.12
+      svelte-check:
+        specifier: ^4.0.0
+        version: 4.4.5(picomatch@4.0.3)(svelte@5.53.12)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+
   packages/investintell-ui:
     dependencies:
       '@codemirror/commands':


### PR DESCRIPTION
## Summary

X5a of the II Terminal extraction plan (`docs/plans/2026-04-19-ii-terminal-extraction.md`). Creates the `@investintell/ii-terminal-core` workspace package by **copying** (not moving) the terminal/allocation/screener component subtrees plus their transitive deps from `frontends/wealth/`. Rewrites all `$wealth/*` imports inside the package to relative paths so the package is self-contained and builds in isolation without needing a consumer-provided alias.

Zero edit in `frontends/terminal/` or `frontends/wealth/` — that is X5b's job.

## What changed

**New package** `packages/ii-terminal-core/` (0.1.0, private):
- `components/terminal/` — shell, live, builder, allocation, macro, dd, focus-mode, layout, charts, data, runtime
- `components/allocation/` — donut, tables, cascade timeline, proposal review, regime strip, propose button, overrides
- `components/screener-terminal/` — filter chip row, data grid, filters, shell (flat, was `screener/terminal/` in wealth)
- `components/charts/GenericEChart.svelte` — cross-cut dep
- `components/portfolio/` — `AchievableReturnBandChart.svelte` + `live/workbench-state.ts` (TERMINAL_MARKET_DATA_KEY)
- `components/analytics/entity/EntityAnalyticsVitrine.svelte` — cross-cut dep
- `stores/` — `market-data.svelte.ts`, `terminal-tweaks.svelte.ts`
- `state/` — `portfolio-workspace.svelte.ts`, `pinned-regime.svelte.ts`
- `types/` — alerts, allocation-page, analytics, cascade-telemetry, dd-report, model-portfolio, portfolio-build, portfolio-calibration, taa (9 modules)
- `utils/` — `render-markdown.ts` + `.css`, `sse-reader.ts`, `metric-translators.ts`, `profile-defaults.ts` (consolidates wealth's `util/` singular + `utils/` plural)
- `constants/` — `blocks.ts`, `regime.ts` (new subsystem not in original plan skeleton, required transitively)
- `api/client.ts`

## Stats

- **100 source files** migrated (78 components, 9 types, 5 utils, 2 each of constants/state/stores, 1 api, 1 barrel `index.ts`)
- **85 `$wealth/*` imports rewritten** across 46 files via `scripts/rewrite-imports.py` (longest-prefix-first remap, relative paths per source file depth)
- **Zero `$wealth/` leftovers** (one remaining comment reference is JSDoc, not an import)
- **Zero self-reference bootstrap** — relative paths avoid the `@investintell/ii-terminal-core/*` → `dist/` chicken-and-egg at first build

## Build verification

```
pnpm -F @investintell/ii-terminal-core build  → dist/ emitted (all subsystems, .d.ts + .js)
pnpm -F @investintell/ui build                 → baseline unchanged
pnpm -F ii-terminal build                      → baseline unchanged (41.85s)
pnpm -F netz-wealth-os build                   → baseline unchanged (58.69s)
```

Remaining warning (`import.meta.env` usage inside copied components) is inherited from wealth verbatim per copy-not-move and is not a regression introduced by this PR.

## Scope decisions

- **Plan extension — cross-cut components**: the original Phase B listed only 3 component subtrees but transitive closure required 4 additional files (`charts/GenericEChart`, `portfolio/AchievableReturnBandChart`, `portfolio/live/workbench-state`, `analytics/entity/EntityAnalyticsVitrine`). Blast radius measured before committing: zero additional transitive deps. Copied in dedicated commit.
- **Plan extension — constants subsystem**: `$wealth/constants/blocks` and `/regime` referenced by state/types. Added as `constants/` subdir with matching exports entry.
- **Plan extension — util/ → utils/ consolidation**: wealth has both `util/` (singular, metric-translators/sse-reader/profile-defaults) and `utils/` (plural, render-markdown). Unified to plural inside package. Sed rule maps both source prefixes to same target.
- **Self-reference → relative paths**: advisor flagged `@investintell/ii-terminal-core/*` self-reference would fail at first build because svelte-package resolves dts imports against `dist/` which doesn't exist yet. Relative paths via Python rewrite script are idempotent and don't depend on exports map resolution at build time.

## Out of scope

- `frontends/terminal/` — zero edit (X5b: migrate terminal routes to import from package, drop `$wealth` alias)
- `frontends/wealth/` — zero edit (X7: delete duplicates once terminal is green)
- Scanner Invariant H (X5b)
- `TerminalPriceChart.svelte`, `TerminalResearchShell.svelte` — referenced by terminal routes but not by any package-internal file; X5b will copy them

## Test plan

- [x] `pnpm -F @investintell/ii-terminal-core build` green
- [x] `pnpm -F @investintell/ui build` green
- [x] `pnpm -F ii-terminal build` green
- [x] `pnpm -F netz-wealth-os build` green
- [x] `grep -rn '\$wealth/' packages/ii-terminal-core/src/lib/` shows only JSDoc comment ref (zero imports)
- [x] `packages/ii-terminal-core/dist/` emitted with `.svelte` + `.svelte.js` + `.svelte.d.ts` for all subsystems
- [x] Barrel `src/lib/index.ts` exports TerminalShell, FundFocusMode, stores, state, API
- [ ] X5b follow-up: terminal routes migrate from `$wealth/*` to `@investintell/ii-terminal-core/*`

## Commits

14 atomic commits from skeleton through build verification. See `git log main..HEAD --oneline`.