### PR TITLE
feat(ii-terminal): X5a.1 backfill missing components in ii-terminal-core

### DIFF
--- a/packages/ii-terminal-core/package.json
+++ b/packages/ii-terminal-core/package.json
@@ -43,6 +43,19 @@
     "./constants/*": {
       "types": "./dist/constants/*.d.ts",
       "default": "./dist/constants/*.js"
+    },
+    "./i18n/*": {
+      "types": "./dist/i18n/*.d.ts",
+      "default": "./dist/i18n/*.js"
+    },
+    "./services/*": {
+      "types": "./dist/services/*.d.ts",
+      "default": "./dist/services/*.js"
+    },
+    "./workers/*": {
+      "types": "./dist/workers/*.d.ts",
+      "svelte": "./dist/workers/*.js",
+      "default": "./dist/workers/*.js"
     }
   },
   "scripts": {

--- a/packages/ii-terminal-core/scripts/rewrite-imports.py
+++ b/packages/ii-terminal-core/scripts/rewrite-imports.py
@@ -31,6 +31,9 @@ PREFIX_MAP: list[tuple[str, str]] = [
     ("$wealth/util/", "utils/"),
     ("$wealth/api/", "api/"),
     ("$wealth/constants/", "constants/"),
+    ("$wealth/i18n/", "i18n/"),
+    ("$wealth/services/", "services/"),
+    ("$wealth/workers/", "workers/"),
 ]
 
 IMPORT_RE = re.compile(r"""((?:from|import)\s*\(?\s*['"])(\$wealth/[^'"]+)(['"]\)?)""")

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryActionBar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryActionBar.svelte
@@ -1,0 +1,117 @@
+<!--
+  LibraryActionBar — multi-select toolbar above the Library grid.
+
+  Phase 6 of the Library frontend (spec §3.4 Fase 6). Renders only
+  when at least one document is selected via the multi-select state.
+  Surfaces the count, a "Clear" affordance, and the "Create Meeting
+  Pack" action — gated on actor role per spec §2.7. Investors never
+  see the create button.
+-->
+<script lang="ts">
+	import Package from "lucide-svelte/icons/package";
+	import X from "lucide-svelte/icons/x";
+	import type { BundleBuilder } from "$wealth/state/library/bundle-builder.svelte";
+
+	interface Props {
+		bundle: BundleBuilder;
+		canCreateBundle: boolean;
+		onOpenWizard: () => void;
+	}
+
+	let { bundle, canCreateBundle, onOpenWizard }: Props = $props();
+
+	const count = $derived(bundle.state.selected.size);
+</script>
+
+{#if count > 0}
+	<div class="action-bar" role="region" aria-label="Library multi-select">
+		<button
+			type="button"
+			class="action-bar__clear"
+			onclick={() => bundle.clearSelection()}
+			title="Clear selection"
+			aria-label="Clear selection"
+		>
+			<X size={14} />
+		</button>
+		<span class="action-bar__count">
+			{count} document{count === 1 ? "" : "s"} selected
+		</span>
+
+		{#if canCreateBundle}
+			<button
+				type="button"
+				class="action-bar__primary"
+				onclick={onOpenWizard}
+			>
+				<Package size={14} />
+				Create Meeting Pack
+			</button>
+		{:else}
+			<span class="action-bar__locked" title="IC role required">
+				Meeting Pack — IC role required
+			</span>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.action-bar {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 10px 20px;
+		background: color-mix(in srgb, #0177fb 14%, #141519);
+		border-bottom: 1px solid #0177fb;
+		color: #ffffff;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+		font-size: 13px;
+	}
+
+	.action-bar__clear {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		border: none;
+		background: rgba(255, 255, 255, 0.12);
+		color: #ffffff;
+		border-radius: 999px;
+		cursor: pointer;
+	}
+
+	.action-bar__clear:hover {
+		background: rgba(255, 255, 255, 0.24);
+	}
+
+	.action-bar__count {
+		font-weight: 600;
+	}
+
+	.action-bar__primary {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		margin-left: auto;
+		padding: 6px 14px;
+		border: 1px solid #0177fb;
+		background: #0177fb;
+		color: #ffffff;
+		font-family: inherit;
+		font-size: 12px;
+		font-weight: 700;
+		border-radius: 8px;
+		cursor: pointer;
+	}
+
+	.action-bar__primary:hover {
+		background: color-mix(in srgb, #0177fb 80%, #ffffff);
+	}
+
+	.action-bar__locked {
+		margin-left: auto;
+		font-size: 12px;
+		color: #85a0bd;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryActionBar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryActionBar.svelte
@@ -10,7 +10,7 @@
 <script lang="ts">
 	import Package from "lucide-svelte/icons/package";
 	import X from "lucide-svelte/icons/x";
-	import type { BundleBuilder } from "$wealth/state/library/bundle-builder.svelte";
+	import type { BundleBuilder } from "../../state/library/bundle-builder.svelte";
 
 	interface Props {
 		bundle: BundleBuilder;

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryBreadcrumbs.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryBreadcrumbs.svelte
@@ -1,0 +1,118 @@
+<!--
+  LibraryBreadcrumbs — reactive folder hierarchy header.
+
+  Phase 3 of the Library frontend (spec §3.4 Fase 3). The breadcrumbs
+  derive entirely from the encoded `selectedPath` prop — no internal
+  state, no separate fetch — so they stay in lock-step with the URL
+  adapter wherever it lives. Each segment is a button that emits an
+  `onNavigate` callback with the cumulative encoded path so the
+  parent shell can both push the URL and ask the tree-loader to
+  expand the right folder.
+-->
+<script lang="ts">
+	import ChevronRight from "lucide-svelte/icons/chevron-right";
+
+	interface Props {
+		selectedPath: string | null;
+		onNavigate: (path: string | null) => void;
+	}
+
+	let { selectedPath, onNavigate }: Props = $props();
+
+	interface Crumb {
+		label: string;
+		path: string;
+	}
+
+	const crumbs = $derived.by<Crumb[]>(() => {
+		if (!selectedPath) return [];
+		const segments = selectedPath.split("/").filter((s) => s.length > 0);
+		const out: Crumb[] = [];
+		for (let i = 0; i < segments.length; i += 1) {
+			const path = segments.slice(0, i + 1).join("/");
+			let label = segments[i]!;
+			try {
+				label = decodeURIComponent(label);
+			} catch {
+				// Leave the raw segment in place if decoding fails —
+				// better than crashing the breadcrumb bar.
+			}
+			out.push({ label, path });
+		}
+		return out;
+	});
+</script>
+
+<nav class="crumbs" aria-label="Library breadcrumbs">
+	<button
+		type="button"
+		class="crumb crumb--root"
+		onclick={() => onNavigate(null)}
+	>
+		Library
+	</button>
+	{#each crumbs as crumb, idx (crumb.path)}
+		<span class="separator" aria-hidden="true">
+			<ChevronRight size={12} />
+		</span>
+		<button
+			type="button"
+			class="crumb"
+			class:crumb--leaf={idx === crumbs.length - 1}
+			onclick={() => onNavigate(crumb.path)}
+		>
+			{crumb.label}
+		</button>
+	{/each}
+</nav>
+
+<style>
+	.crumbs {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 14px 24px;
+		background: #141519;
+		border-bottom: 1px solid #404249;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+		font-size: 13px;
+		color: #85a0bd;
+		flex-wrap: wrap;
+	}
+
+	.crumb {
+		background: none;
+		border: none;
+		color: #85a0bd;
+		font-family: inherit;
+		font-size: inherit;
+		font-weight: 500;
+		cursor: pointer;
+		padding: 4px 6px;
+		border-radius: 4px;
+		transition: color 120ms ease, background-color 120ms ease;
+	}
+
+	.crumb:hover {
+		color: #ffffff;
+		background: #1d1f25;
+	}
+
+	.crumb:focus-visible {
+		outline: 2px solid #0177fb;
+		outline-offset: 1px;
+	}
+
+	.crumb--root { color: #cbccd1; }
+
+	.crumb--leaf {
+		color: #ffffff;
+		font-weight: 600;
+	}
+
+	.separator {
+		display: inline-flex;
+		align-items: center;
+		color: #404249;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryBundleWizard.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryBundleWizard.svelte
@@ -1,0 +1,343 @@
+<!--
+  LibraryBundleWizard — modal dialog driving the Committee Pack
+  bundle worker.
+
+  Phase 6 of the Library frontend (spec §3.4 Fase 6 + §4.4). The
+  wizard reads `bundle.state` from a `BundleBuilder` instance and
+  surfaces three steps:
+
+    1. Idle      — review the selected document count, confirm
+    2. In flight — generating / uploading progress label
+    3. Completed — Download ZIP button + missing-entries warning
+
+  The dialog is dismissable while idle or after completion; once
+  the worker is dispatched the user can still close the dialog —
+  the SSE stream keeps running in the background until completion
+  or error, since `bundle.dispose()` only fires on shell unmount.
+-->
+<script lang="ts">
+	import Download from "lucide-svelte/icons/download";
+	import Loader2 from "lucide-svelte/icons/loader-2";
+	import Package from "lucide-svelte/icons/package";
+	import X from "lucide-svelte/icons/x";
+	import { formatNumber } from "@investintell/ui";
+	import {
+		bundleDownloadUrl,
+		type BundleBuilder,
+	} from "$wealth/state/library/bundle-builder.svelte";
+
+	interface Props {
+		bundle: BundleBuilder;
+		open: boolean;
+		onClose: () => void;
+	}
+
+	let { bundle, open, onClose }: Props = $props();
+
+	const status = $derived(bundle.state.status);
+	const inFlight = $derived(
+		status === "dispatching" ||
+			status === "generating" ||
+			status === "uploading",
+	);
+	const downloadHref = $derived(
+		bundle.state.bundleId ? bundleDownloadUrl(bundle.state.bundleId) : null,
+	);
+
+	function handleConfirm(): void {
+		void bundle.createBundle();
+	}
+
+	function handleClose(): void {
+		if (status === "completed" || status === "error") {
+			bundle.reset();
+			bundle.clearSelection();
+		}
+		onClose();
+	}
+</script>
+
+{#if open}
+	<div
+		class="overlay"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Create Committee Pack"
+	>
+		<div class="dialog">
+			<header class="dialog__header">
+				<span class="dialog__icon">
+					<Package size={16} />
+				</span>
+				<h2 class="dialog__title">Create Committee Pack</h2>
+				<button
+					type="button"
+					class="dialog__close"
+					onclick={handleClose}
+					aria-label="Close wizard"
+				>
+					<X size={14} />
+				</button>
+			</header>
+
+			<div class="dialog__body">
+				{#if status === "idle"}
+					<p class="dialog__sub">
+						Bundle the selected documents into a ZIP archive that
+						the worker uploads to storage. The pack includes a
+						manifest describing every entry. The build runs in the
+						background — you can keep working while it finishes.
+					</p>
+					<div class="dialog__stat">
+						<span class="dialog__stat-num">
+							{bundle.state.selected.size}
+						</span>
+						<span class="dialog__stat-label">documents selected</span>
+					</div>
+				{:else if inFlight}
+					<div class="dialog__progress">
+						<Loader2 size={18} class="spin" />
+						<span>{bundle.state.progressLabel || "Preparing..."}</span>
+					</div>
+					{#if bundle.state.sizeBytes}
+						<p class="dialog__sub">
+							Bundle size:
+							{formatNumber(bundle.state.sizeBytes / 1024 / 1024, 2)} MB
+						</p>
+					{/if}
+				{:else if status === "completed"}
+					<p class="dialog__sub">Your Committee Pack is ready.</p>
+					{#if bundle.state.fetched != null}
+						<p class="dialog__sub">
+							{bundle.state.fetched} document{bundle.state.fetched === 1 ? "" : "s"} packed.
+							{#if bundle.state.missing}
+								{bundle.state.missing} missing.
+							{/if}
+						</p>
+					{/if}
+				{:else if status === "error"}
+					<p class="dialog__error">{bundle.state.error}</p>
+				{/if}
+			</div>
+
+			<footer class="dialog__footer">
+				{#if status === "idle"}
+					<button
+						type="button"
+						class="dialog__btn dialog__btn--secondary"
+						onclick={handleClose}
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="dialog__btn dialog__btn--primary"
+						disabled={bundle.state.selected.size === 0}
+						onclick={handleConfirm}
+					>
+						Build Pack
+					</button>
+				{:else if inFlight}
+					<button
+						type="button"
+						class="dialog__btn dialog__btn--secondary"
+						onclick={onClose}
+					>
+						Hide
+					</button>
+				{:else if status === "completed" && downloadHref}
+					<button
+						type="button"
+						class="dialog__btn dialog__btn--secondary"
+						onclick={handleClose}
+					>
+						Done
+					</button>
+					<a
+						href={downloadHref}
+						class="dialog__btn dialog__btn--primary"
+						download
+					>
+						<Download size={14} />
+						Download ZIP
+					</a>
+				{:else}
+					<button
+						type="button"
+						class="dialog__btn dialog__btn--secondary"
+						onclick={handleClose}
+					>
+						Close
+					</button>
+				{/if}
+			</footer>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 9000;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+	}
+
+	.dialog {
+		width: min(480px, calc(100vw - 48px));
+		background: #141519;
+		border: 1px solid #404249;
+		border-radius: 12px;
+		box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+		color: #cbccd1;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	.dialog__header {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 16px 20px;
+		border-bottom: 1px solid #404249;
+	}
+
+	.dialog__icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		background: color-mix(in srgb, #0177fb 22%, #141519);
+		border-radius: 8px;
+		color: #ffffff;
+	}
+
+	.dialog__title {
+		flex: 1;
+		font-size: 15px;
+		font-weight: 700;
+		color: #ffffff;
+		margin: 0;
+	}
+
+	.dialog__close {
+		background: transparent;
+		border: none;
+		color: #85a0bd;
+		cursor: pointer;
+		padding: 4px;
+		border-radius: 6px;
+	}
+
+	.dialog__close:hover { color: #ffffff; background: #1d1f25; }
+
+	.dialog__body {
+		padding: 20px;
+		display: flex;
+		flex-direction: column;
+		gap: 14px;
+	}
+
+	.dialog__sub {
+		font-size: 13px;
+		color: #85a0bd;
+		margin: 0;
+		line-height: 1.5;
+	}
+
+	.dialog__stat {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 4px;
+		padding: 18px;
+		background: #1d1f25;
+		border: 1px solid #404249;
+		border-radius: 10px;
+	}
+
+	.dialog__stat-num {
+		font-size: 32px;
+		font-weight: 800;
+		color: #ffffff;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.dialog__stat-label {
+		font-size: 12px;
+		color: #85a0bd;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	.dialog__progress {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		font-size: 13px;
+		color: #ffffff;
+	}
+
+	:global(.spin) {
+		animation: spin 1s linear infinite;
+	}
+
+	@keyframes spin { to { transform: rotate(360deg); } }
+
+	.dialog__error {
+		font-size: 13px;
+		color: #ff6b6b;
+		margin: 0;
+	}
+
+	.dialog__footer {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 8px;
+		padding: 14px 20px;
+		border-top: 1px solid #404249;
+	}
+
+	.dialog__btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 8px 14px;
+		border: 1px solid #404249;
+		background: #1d1f25;
+		color: #cbccd1;
+		font-family: inherit;
+		font-size: 13px;
+		font-weight: 600;
+		border-radius: 8px;
+		cursor: pointer;
+		text-decoration: none;
+	}
+
+	.dialog__btn:hover {
+		color: #ffffff;
+		border-color: #85a0bd;
+	}
+
+	.dialog__btn--primary {
+		background: #0177fb;
+		border-color: #0177fb;
+		color: #ffffff;
+	}
+
+	.dialog__btn--primary:hover {
+		background: color-mix(in srgb, #0177fb 80%, #ffffff);
+	}
+
+	.dialog__btn--primary:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryBundleWizard.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryBundleWizard.svelte
@@ -24,7 +24,7 @@
 	import {
 		bundleDownloadUrl,
 		type BundleBuilder,
-	} from "$wealth/state/library/bundle-builder.svelte";
+	} from "../../state/library/bundle-builder.svelte";
 
 	interface Props {
 		bundle: BundleBuilder;

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryContextMenu.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryContextMenu.svelte
@@ -1,0 +1,221 @@
+<!--
+  LibraryContextMenu — right-click menu for Library tree rows.
+
+  Phase 6 of the Library frontend (spec §3.4 Fase 6). The menu is
+  intentionally simple: it's a positioned popover anchored to the
+  cursor, dismissed on click outside or Escape. Items are
+  context-aware — folders only show "Open"; files show Open +
+  Preview + Pin/Unpin + Star/Unstar.
+-->
+<script lang="ts">
+	import { onDestroy } from "svelte";
+	import Eye from "lucide-svelte/icons/eye";
+	import FolderOpen from "lucide-svelte/icons/folder-open";
+	import Pin from "lucide-svelte/icons/pin";
+	import PinOff from "lucide-svelte/icons/pin-off";
+	import Star from "lucide-svelte/icons/star";
+	import StarOff from "lucide-svelte/icons/star-off";
+	import type { LibraryNode } from "$wealth/types/library";
+
+	interface Props {
+		node: LibraryNode | null;
+		x: number;
+		y: number;
+		open: boolean;
+		isPinned: boolean;
+		isStarred: boolean;
+		onClose: () => void;
+		onOpen: (node: LibraryNode) => void;
+		onPreview: (node: LibraryNode) => void;
+		onTogglePin: (node: LibraryNode) => void;
+		onToggleStar: (node: LibraryNode) => void;
+	}
+
+	let {
+		node,
+		x,
+		y,
+		open,
+		isPinned,
+		isStarred,
+		onClose,
+		onOpen,
+		onPreview,
+		onTogglePin,
+		onToggleStar,
+	}: Props = $props();
+
+	const isFile = $derived(node?.node_type === "file");
+
+	function handleGlobalClick(event: MouseEvent): void {
+		if (!open) return;
+		const target = event.target as Node | null;
+		const menu = document.getElementById("library-context-menu");
+		if (menu && target && !menu.contains(target)) {
+			onClose();
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent): void {
+		if (!open) return;
+		if (event.key === "Escape") {
+			event.preventDefault();
+			onClose();
+		} else if (event.key.toLowerCase() === "s" && node) {
+			event.preventDefault();
+			onToggleStar(node);
+			onClose();
+		} else if (event.key.toLowerCase() === "p" && node) {
+			event.preventDefault();
+			onTogglePin(node);
+			onClose();
+		}
+	}
+
+	$effect(() => {
+		if (open) {
+			document.addEventListener("click", handleGlobalClick);
+			document.addEventListener("keydown", handleKeydown);
+		}
+		return () => {
+			document.removeEventListener("click", handleGlobalClick);
+			document.removeEventListener("keydown", handleKeydown);
+		};
+	});
+
+	onDestroy(() => {
+		document.removeEventListener("click", handleGlobalClick);
+		document.removeEventListener("keydown", handleKeydown);
+	});
+</script>
+
+{#if open && node}
+	<div
+		id="library-context-menu"
+		class="menu"
+		style:left="{x}px"
+		style:top="{y}px"
+		role="menu"
+		aria-label="Library actions"
+	>
+		<button
+			type="button"
+			class="menu__item"
+			role="menuitem"
+			onclick={() => {
+				onOpen(node);
+				onClose();
+			}}
+		>
+			<FolderOpen size={14} />
+			<span>Open</span>
+		</button>
+
+		{#if isFile}
+			<button
+				type="button"
+				class="menu__item"
+				role="menuitem"
+				onclick={() => {
+					onPreview(node);
+					onClose();
+				}}
+			>
+				<Eye size={14} />
+				<span>Preview</span>
+			</button>
+
+			<div class="menu__sep" role="separator"></div>
+
+			<button
+				type="button"
+				class="menu__item"
+				role="menuitem"
+				onclick={() => {
+					onTogglePin(node);
+					onClose();
+				}}
+			>
+				{#if isPinned}
+					<PinOff size={14} />
+					<span>Unpin</span>
+				{:else}
+					<Pin size={14} />
+					<span>Pin</span>
+				{/if}
+				<kbd class="menu__kbd">P</kbd>
+			</button>
+
+			<button
+				type="button"
+				class="menu__item"
+				role="menuitem"
+				onclick={() => {
+					onToggleStar(node);
+					onClose();
+				}}
+			>
+				{#if isStarred}
+					<StarOff size={14} />
+					<span>Unstar</span>
+				{:else}
+					<Star size={14} />
+					<span>Star</span>
+				{/if}
+				<kbd class="menu__kbd">S</kbd>
+			</button>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.menu {
+		position: fixed;
+		z-index: 9999;
+		min-width: 200px;
+		background: #1d1f25;
+		border: 1px solid #404249;
+		border-radius: 8px;
+		padding: 4px;
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+		color: #cbccd1;
+	}
+
+	.menu__item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+		padding: 7px 12px;
+		border: none;
+		background: transparent;
+		color: #cbccd1;
+		font-family: inherit;
+		font-size: 13px;
+		text-align: left;
+		cursor: pointer;
+		border-radius: 6px;
+	}
+
+	.menu__item:hover {
+		background: color-mix(in srgb, #0177fb 22%, #141519);
+		color: #ffffff;
+	}
+
+	.menu__sep {
+		height: 1px;
+		background: #404249;
+		margin: 4px 0;
+	}
+
+	.menu__kbd {
+		margin-left: auto;
+		font-family: var(--ii-font-mono, ui-monospace, monospace);
+		font-size: 10px;
+		color: #85a0bd;
+		padding: 1px 5px;
+		border: 1px solid #404249;
+		border-radius: 4px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryContextMenu.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryContextMenu.svelte
@@ -15,7 +15,7 @@
 	import PinOff from "lucide-svelte/icons/pin-off";
 	import Star from "lucide-svelte/icons/star";
 	import StarOff from "lucide-svelte/icons/star-off";
-	import type { LibraryNode } from "$wealth/types/library";
+	import type { LibraryNode } from "../../types/library";
 
 	interface Props {
 		node: LibraryNode | null;

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryFilterBar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryFilterBar.svelte
@@ -1,0 +1,258 @@
+<!--
+  LibraryFilterBar — chip-style secondary taxonomies for the Library.
+
+  Phase 4 of the Library frontend (spec §3.4 Fase 4 + §2.3). Surfaces
+  the orthogonal filters that don't belong in the navigation tree:
+  status, kind, language, starred, plus a coarse date range. Every
+  chip writes through the URL adapter so the entire filter set is
+  shareable / deep-linkable / back-button-safe.
+-->
+<script lang="ts">
+	import Star from "lucide-svelte/icons/star";
+	import X from "lucide-svelte/icons/x";
+	import type { UrlAdapter } from "$wealth/state/library/url-adapter.svelte";
+
+	interface Props {
+		adapter: UrlAdapter;
+	}
+
+	let { adapter }: Props = $props();
+
+	const STATUS_OPTIONS: Array<{ value: string; label: string }> = [
+		{ value: "approved", label: "Approved" },
+		{ value: "published", label: "Published" },
+		{ value: "pending_approval", label: "Pending" },
+		{ value: "rejected", label: "Rejected" },
+		{ value: "archived", label: "Archived" },
+	];
+
+	const KIND_OPTIONS: Array<{ value: string; label: string }> = [
+		{ value: "dd_report", label: "DD Report" },
+		{ value: "investment_outlook", label: "Outlook" },
+		{ value: "flash_report", label: "Flash" },
+		{ value: "manager_spotlight", label: "Spotlight" },
+		{ value: "macro_review", label: "Macro Review" },
+		{ value: "fact_sheet", label: "Fact Sheet" },
+	];
+
+	const LANG_OPTIONS: Array<{ value: string; label: string }> = [
+		{ value: "pt", label: "PT" },
+		{ value: "en", label: "EN" },
+	];
+
+	const DATE_PRESETS: Array<{ id: string; label: string; days: number }> = [
+		{ id: "today", label: "Today", days: 1 },
+		{ id: "week", label: "This Week", days: 7 },
+		{ id: "month", label: "This Month", days: 30 },
+		{ id: "quarter", label: "Quarter", days: 90 },
+		{ id: "year", label: "Year", days: 365 },
+	];
+
+	function applyDatePreset(days: number): void {
+		const to = new Date();
+		const from = new Date();
+		from.setDate(from.getDate() - days);
+		adapter.setDateRange(
+			from.toISOString().slice(0, 10),
+			to.toISOString().slice(0, 10),
+		);
+	}
+
+	function clearDateRange(): void {
+		adapter.setDateRange(null, null);
+	}
+
+	const hasActiveFilters = $derived(
+		adapter.state.q.length > 0 ||
+			adapter.state.statuses.length > 0 ||
+			adapter.state.kinds.length > 0 ||
+			adapter.state.from !== null ||
+			adapter.state.to !== null ||
+			adapter.state.language !== null ||
+			adapter.state.starred,
+	);
+
+	const activeDatePresetDays = $derived.by(() => {
+		if (!adapter.state.from || !adapter.state.to) return null;
+		const from = new Date(adapter.state.from).getTime();
+		const to = new Date(adapter.state.to).getTime();
+		return Math.round((to - from) / (1000 * 60 * 60 * 24));
+	});
+</script>
+
+<div class="filter-bar" role="toolbar" aria-label="Library filters">
+	<div class="group" role="group" aria-label="Date range">
+		<span class="group__label">When</span>
+		{#each DATE_PRESETS as preset (preset.id)}
+			<button
+				type="button"
+				class="chip"
+				class:chip--active={activeDatePresetDays === preset.days}
+				onclick={() => applyDatePreset(preset.days)}
+			>
+				{preset.label}
+			</button>
+		{/each}
+		{#if adapter.state.from || adapter.state.to}
+			<button
+				type="button"
+				class="chip chip--clear"
+				onclick={clearDateRange}
+				aria-label="Clear date range"
+			>
+				<X size={12} />
+			</button>
+		{/if}
+	</div>
+
+	<div class="group" role="group" aria-label="Status filter">
+		<span class="group__label">Status</span>
+		{#each STATUS_OPTIONS as option (option.value)}
+			<button
+				type="button"
+				class="chip"
+				class:chip--active={adapter.state.statuses.includes(option.value)}
+				aria-pressed={adapter.state.statuses.includes(option.value)}
+				onclick={() => adapter.toggleStatus(option.value)}
+			>
+				{option.label}
+			</button>
+		{/each}
+	</div>
+
+	<div class="group" role="group" aria-label="Kind filter">
+		<span class="group__label">Kind</span>
+		{#each KIND_OPTIONS as option (option.value)}
+			<button
+				type="button"
+				class="chip"
+				class:chip--active={adapter.state.kinds.includes(option.value)}
+				aria-pressed={adapter.state.kinds.includes(option.value)}
+				onclick={() => adapter.toggleKind(option.value)}
+			>
+				{option.label}
+			</button>
+		{/each}
+	</div>
+
+	<div class="group" role="group" aria-label="Language filter">
+		<span class="group__label">Lang</span>
+		{#each LANG_OPTIONS as option (option.value)}
+			<button
+				type="button"
+				class="chip"
+				class:chip--active={adapter.state.language === option.value}
+				aria-pressed={adapter.state.language === option.value}
+				onclick={() =>
+					adapter.setLanguage(
+						adapter.state.language === option.value ? null : option.value,
+					)}
+			>
+				{option.label}
+			</button>
+		{/each}
+	</div>
+
+	<button
+		type="button"
+		class="chip chip--star"
+		class:chip--active={adapter.state.starred}
+		aria-pressed={adapter.state.starred}
+		onclick={() => adapter.setStarred(!adapter.state.starred)}
+		title="Show only starred"
+	>
+		<Star size={12} />
+		Starred
+	</button>
+
+	{#if hasActiveFilters}
+		<button
+			type="button"
+			class="chip chip--reset"
+			onclick={() => adapter.clearAllFilters()}
+		>
+			Clear all
+		</button>
+	{/if}
+</div>
+
+<style>
+	.filter-bar {
+		display: flex;
+		align-items: center;
+		gap: 14px;
+		padding: 10px 20px;
+		background: #141519;
+		border-bottom: 1px solid #404249;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+		flex-wrap: wrap;
+	}
+
+	.group {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding-right: 14px;
+		border-right: 1px solid #404249;
+	}
+
+	.group:last-of-type {
+		border-right: none;
+		padding-right: 0;
+	}
+
+	.group__label {
+		font-size: 11px;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: #85a0bd;
+	}
+
+	.chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 5px 10px;
+		border: 1px solid #404249;
+		background: #1d1f25;
+		color: #cbccd1;
+		font-family: inherit;
+		font-size: 12px;
+		font-weight: 500;
+		border-radius: 999px;
+		cursor: pointer;
+		transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+	}
+
+	.chip:hover {
+		border-color: #85a0bd;
+		color: #ffffff;
+	}
+
+	.chip--active {
+		background: color-mix(in srgb, #0177fb 22%, #141519);
+		border-color: #0177fb;
+		color: #ffffff;
+	}
+
+	.chip--clear {
+		padding: 5px 6px;
+		color: #85a0bd;
+	}
+
+	.chip--star {
+		border-color: #404249;
+	}
+
+	.chip--reset {
+		margin-left: auto;
+		background: transparent;
+		color: #85a0bd;
+	}
+
+	.chip--reset:hover {
+		color: #ffffff;
+		border-color: #ffffff;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryFilterBar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryFilterBar.svelte
@@ -10,7 +10,7 @@
 <script lang="ts">
 	import Star from "lucide-svelte/icons/star";
 	import X from "lucide-svelte/icons/x";
-	import type { UrlAdapter } from "$wealth/state/library/url-adapter.svelte";
+	import type { UrlAdapter } from "../../state/library/url-adapter.svelte";
 
 	interface Props {
 		adapter: UrlAdapter;

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryPinsSection.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryPinsSection.svelte
@@ -14,9 +14,9 @@
 	import Clock from "lucide-svelte/icons/clock";
 	import Star from "lucide-svelte/icons/star";
 	import { formatDateTime } from "@investintell/ui";
-	import type { PinsClient } from "$wealth/state/library/pins-client.svelte";
-	import type { UrlAdapter } from "$wealth/state/library/url-adapter.svelte";
-	import type { LibraryPin } from "$wealth/types/library";
+	import type { PinsClient } from "../../state/library/pins-client.svelte";
+	import type { UrlAdapter } from "../../state/library/url-adapter.svelte";
+	import type { LibraryPin } from "../../types/library";
 
 	interface Props {
 		pins: PinsClient;

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryPinsSection.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryPinsSection.svelte
@@ -1,0 +1,213 @@
+<!--
+  LibraryPinsSection — landing-page carousels for pinned, starred,
+  and recently-viewed Library entries.
+
+  Phase 6 of the Library frontend (spec §3.4 Fase 6). Renders only
+  on the Library root (no folder or file selected) and gives the
+  PM a one-click jump back into the documents they actually use.
+
+  Each card writes through the URL adapter so the click round-trips
+  through the same single-flight preview loader as a tree click.
+-->
+<script lang="ts">
+	import Pin from "lucide-svelte/icons/pin";
+	import Clock from "lucide-svelte/icons/clock";
+	import Star from "lucide-svelte/icons/star";
+	import { formatDateTime } from "@investintell/ui";
+	import type { PinsClient } from "$wealth/state/library/pins-client.svelte";
+	import type { UrlAdapter } from "$wealth/state/library/url-adapter.svelte";
+	import type { LibraryPin } from "$wealth/types/library";
+
+	interface Props {
+		pins: PinsClient;
+		adapter: UrlAdapter;
+	}
+
+	let { pins, adapter }: Props = $props();
+
+	function openPin(pin: LibraryPin): void {
+		adapter.setSelectedId(pin.library_index_id);
+	}
+
+	const sections = $derived([
+		{
+			id: "pinned",
+			title: "Pinned",
+			Icon: Pin,
+			items: pins.state.pinned,
+		},
+		{
+			id: "starred",
+			title: "Starred",
+			Icon: Star,
+			items: pins.state.starred,
+		},
+		{
+			id: "recent",
+			title: "Recently Viewed",
+			Icon: Clock,
+			items: pins.state.recent,
+		},
+	]);
+</script>
+
+<div class="pins">
+	{#if pins.state.loading && pins.state.pinned.length === 0 && pins.state.starred.length === 0 && pins.state.recent.length === 0}
+		<p class="pins__loading">Loading your shortcuts…</p>
+	{/if}
+
+	{#each sections as section (section.id)}
+		{@const Icon = section.Icon}
+		<section class="pins__section" aria-label={section.title}>
+			<header class="pins__header">
+				<span class="pins__icon">
+					<Icon size={14} />
+				</span>
+				<h3 class="pins__title">{section.title}</h3>
+				<span class="pins__count">{section.items.length}</span>
+			</header>
+
+			{#if section.items.length === 0}
+				<p class="pins__empty">
+					{#if section.id === "pinned"}
+						No pinned documents yet.
+					{:else if section.id === "starred"}
+						Star a document to keep it within reach.
+					{:else}
+						Documents you open will appear here.
+					{/if}
+				</p>
+			{:else}
+				<div class="pins__row">
+					{#each section.items as pin (pin.id)}
+						<button
+							type="button"
+							class="pins__card"
+							onclick={() => openPin(pin)}
+						>
+							<span class="pins__card-kind">{pin.kind ?? "document"}</span>
+							<span class="pins__card-label">{pin.label}</span>
+							<span class="pins__card-meta">
+								{formatDateTime(pin.last_accessed_at)}
+							</span>
+						</button>
+					{/each}
+				</div>
+			{/if}
+		</section>
+	{/each}
+</div>
+
+<style>
+	.pins {
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
+		padding: 24px;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+		color: #cbccd1;
+	}
+
+	.pins__loading {
+		font-size: 13px;
+		color: #85a0bd;
+		margin: 0;
+	}
+
+	.pins__section {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.pins__header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.pins__icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
+		height: 22px;
+		background: #1d1f25;
+		border: 1px solid #404249;
+		border-radius: 6px;
+		color: #85a0bd;
+	}
+
+	.pins__title {
+		font-size: 13px;
+		font-weight: 700;
+		color: #ffffff;
+		margin: 0;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+
+	.pins__count {
+		font-size: 11px;
+		font-weight: 600;
+		color: #85a0bd;
+		padding: 1px 8px;
+		border-radius: 999px;
+		background: #1d1f25;
+	}
+
+	.pins__empty {
+		font-size: 12px;
+		color: #85a0bd;
+		margin: 0;
+	}
+
+	.pins__row {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+		gap: 10px;
+	}
+
+	.pins__card {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		padding: 12px 14px;
+		border: 1px solid #404249;
+		background: #1d1f25;
+		color: #cbccd1;
+		border-radius: 10px;
+		font-family: inherit;
+		text-align: left;
+		cursor: pointer;
+		transition: border-color 120ms ease, transform 120ms ease;
+	}
+
+	.pins__card:hover {
+		border-color: #0177fb;
+		transform: translateY(-1px);
+	}
+
+	.pins__card-kind {
+		font-size: 10px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: #85a0bd;
+	}
+
+	.pins__card-label {
+		font-size: 13px;
+		font-weight: 600;
+		color: #ffffff;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.pins__card-meta {
+		font-size: 11px;
+		color: #85a0bd;
+		font-variant-numeric: tabular-nums;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryPreviewPane.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryPreviewPane.svelte
@@ -1,0 +1,280 @@
+<!--
+  LibraryPreviewPane — dynamic reader host for the Wealth Library.
+
+  Phase 5 of the Library frontend (spec §3.4 Fase 5). Picks the
+  right standalone reader (`DDReportBody`, `ContentBody`,
+  `MacroReviewBody`) based on the `source_table` discriminator
+  returned by `GET /library/documents/{id}` and renders it under a
+  small toolbar with the title, kind badge and a fullscreen toggle.
+
+  Dynamic import discipline
+  -------------------------
+  None of the three reader bodies are imported statically — that
+  would defeat the whole point of the per-source code split. Instead
+  we resolve the right module via a `dynamic import()` factory inside
+  a Svelte `{#await}` block. The factories are memoised by source
+  table so a re-render of the same kind does not re-fetch the
+  chunk.
+
+  Race condition discipline
+  -------------------------
+  All fetching lives upstream in `preview-loader.svelte.ts` which
+  carries the AbortController + MountedGuard pair. The pane only
+  reads `loader.state` so it cannot trigger a stale render itself —
+  even if the dynamic import resolves out of order, the underlying
+  `document` reference is the latest because it's a single source
+  of truth in the loader's $state.
+-->
+<script lang="ts">
+	import type { Component } from "svelte";
+	import Maximize2 from "lucide-svelte/icons/maximize-2";
+	import Minimize2 from "lucide-svelte/icons/minimize-2";
+	import { PanelEmptyState, PanelErrorState } from "@investintell/ui/runtime";
+	import type { PreviewLoader } from "$wealth/state/library/preview-loader.svelte";
+	import type { UrlAdapter } from "$wealth/state/library/url-adapter.svelte";
+	import type { LibraryDocumentDetail } from "$wealth/types/library";
+
+	interface Props {
+		loader: PreviewLoader;
+		adapter: UrlAdapter;
+	}
+
+	let { loader, adapter }: Props = $props();
+
+	// Dynamic-import factories per source table. Each loader returns
+	// a Promise<{ default: Component }> that Svelte's {#await} can
+	// consume directly. Vite ships them as separate chunks so the
+	// initial Library route never pays the cost of all three readers.
+	const READER_LOADERS: Record<
+		string,
+		() => Promise<{ default: Component<Record<string, unknown>> }>
+	> = {
+		dd_reports: () =>
+			import("./readers/DDReportBody.svelte") as Promise<{
+				default: Component<Record<string, unknown>>;
+			}>,
+		wealth_content: () =>
+			import("./readers/ContentBody.svelte") as Promise<{
+				default: Component<Record<string, unknown>>;
+			}>,
+		macro_reviews: () =>
+			import("./readers/MacroReviewBody.svelte") as Promise<{
+				default: Component<Record<string, unknown>>;
+			}>,
+	};
+
+	function readerProps(doc: LibraryDocumentDetail): Record<string, unknown> {
+		// The three readers expose different prop names for the id.
+		// We translate the discriminator into the right shape so the
+		// preview pane stays the only place that knows the mapping.
+		switch (doc.source_table) {
+			case "dd_reports":
+				return { reportId: doc.source_id };
+			case "wealth_content":
+				return { id: doc.source_id };
+			case "macro_reviews":
+				return { reviewId: doc.source_id };
+			default:
+				return {};
+		}
+	}
+
+	const isFullscreen = $derived(adapter.state.preview === "fullscreen");
+
+	function toggleFullscreen(): void {
+		adapter.setPreview(isFullscreen ? "inline" : "fullscreen");
+	}
+
+	function clearSelection(): void {
+		adapter.setSelectedId(null);
+		loader.clear();
+	}
+</script>
+
+<section class="preview" aria-label="Library document preview">
+	{#if loader.state.loading && !loader.state.document}
+		<div class="preview__loading">
+			<div class="preview__spinner" aria-hidden="true"></div>
+			<p>Loading document…</p>
+		</div>
+	{:else if loader.state.error}
+		<PanelErrorState
+			title="Unable to load document"
+			message={loader.state.error}
+			onRetry={() =>
+				adapter.state.selectedId
+					? loader.loadDocument(adapter.state.selectedId)
+					: undefined}
+		/>
+	{:else if !loader.state.document}
+		<PanelEmptyState
+			title="Select a document"
+			message="Pick a document on the left to read it inline. The preview opens in place — no full-page navigation needed."
+		/>
+	{:else}
+		{@const doc = loader.state.document}
+		<header class="preview__bar">
+			<div class="preview__title">
+				<span class="preview__kind">{doc.kind}</span>
+				<span class="preview__name">{doc.title}</span>
+			</div>
+			<div class="preview__actions">
+				<button
+					type="button"
+					class="preview__btn"
+					title={isFullscreen ? "Exit fullscreen" : "View fullscreen"}
+					aria-pressed={isFullscreen}
+					onclick={toggleFullscreen}
+				>
+					{#if isFullscreen}
+						<Minimize2 size={14} />
+					{:else}
+						<Maximize2 size={14} />
+					{/if}
+				</button>
+				<button
+					type="button"
+					class="preview__btn"
+					title="Close preview"
+					onclick={clearSelection}
+				>
+					Close
+				</button>
+			</div>
+		</header>
+
+		<div class="preview__body">
+			{#if READER_LOADERS[doc.source_table]}
+				{#await READER_LOADERS[doc.source_table]!()}
+					<div class="preview__loading">
+						<div class="preview__spinner" aria-hidden="true"></div>
+						<p>Loading reader…</p>
+					</div>
+				{:then mod}
+					{@const Reader = mod.default}
+					<Reader {...readerProps(doc)} />
+				{:catch err}
+					<PanelErrorState
+						title="Reader failed to load"
+						message={err instanceof Error ? err.message : String(err)}
+					/>
+				{/await}
+			{:else}
+				<PanelEmptyState
+					title="Unsupported document"
+					message="This Library entry has no preview renderer yet."
+				/>
+			{/if}
+		</div>
+	{/if}
+</section>
+
+<style>
+	.preview {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		min-height: 0;
+		background: #141519;
+		color: #cbccd1;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+	}
+
+	.preview__bar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		padding: 10px 16px;
+		border-bottom: 1px solid #404249;
+		background: #141519;
+	}
+
+	.preview__title {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.preview__kind {
+		font-size: 10px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: #85a0bd;
+	}
+
+	.preview__name {
+		font-size: 14px;
+		font-weight: 700;
+		color: #ffffff;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.preview__actions {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.preview__btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 5px 10px;
+		border: 1px solid #404249;
+		background: #1d1f25;
+		color: #cbccd1;
+		font-family: inherit;
+		font-size: 12px;
+		font-weight: 600;
+		border-radius: 6px;
+		cursor: pointer;
+		transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
+	}
+
+	.preview__btn:hover {
+		color: #ffffff;
+		border-color: #0177fb;
+	}
+
+	.preview__btn[aria-pressed="true"] {
+		background: color-mix(in srgb, #0177fb 22%, #141519);
+		color: #ffffff;
+		border-color: #0177fb;
+	}
+
+	.preview__body {
+		flex: 1;
+		min-height: 0;
+		overflow: auto;
+	}
+
+	.preview__loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 12px;
+		padding: 48px 24px;
+		color: #85a0bd;
+		font-size: 13px;
+	}
+
+	.preview__spinner {
+		width: 24px;
+		height: 24px;
+		border: 2px solid #404249;
+		border-top-color: #0177fb;
+		border-radius: 50%;
+		animation: preview-spin 0.8s linear infinite;
+	}
+
+	@keyframes preview-spin {
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryPreviewPane.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryPreviewPane.svelte
@@ -30,9 +30,9 @@
 	import Maximize2 from "lucide-svelte/icons/maximize-2";
 	import Minimize2 from "lucide-svelte/icons/minimize-2";
 	import { PanelEmptyState, PanelErrorState } from "@investintell/ui/runtime";
-	import type { PreviewLoader } from "$wealth/state/library/preview-loader.svelte";
-	import type { UrlAdapter } from "$wealth/state/library/url-adapter.svelte";
-	import type { LibraryDocumentDetail } from "$wealth/types/library";
+	import type { PreviewLoader } from "../../state/library/preview-loader.svelte";
+	import type { UrlAdapter } from "../../state/library/url-adapter.svelte";
+	import type { LibraryDocumentDetail } from "../../types/library";
 
 	interface Props {
 		loader: PreviewLoader;

--- a/packages/ii-terminal-core/src/lib/components/library/LibrarySearchInput.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibrarySearchInput.svelte
@@ -14,7 +14,7 @@
 <script lang="ts">
 	import Search from "lucide-svelte/icons/search";
 	import X from "lucide-svelte/icons/x";
-	import type { UrlAdapter } from "$wealth/state/library/url-adapter.svelte";
+	import type { UrlAdapter } from "../../state/library/url-adapter.svelte";
 
 	interface Props {
 		adapter: UrlAdapter;

--- a/packages/ii-terminal-core/src/lib/components/library/LibrarySearchInput.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibrarySearchInput.svelte
@@ -1,0 +1,118 @@
+<!--
+  LibrarySearchInput — debounced full-text search field.
+
+  Phase 4 of the Library frontend (spec §3.4 Fase 4). Mirrors the
+  current value of `adapter.state.q` so that browser back/forward
+  or a copy-pasted URL paint the input correctly. Calls
+  `adapter.setQuery(value, { debounce: true })` on input so the URL
+  push waits 300 ms after the last keystroke per spec.
+
+  The component is intentionally just an input — the search results
+  list lives elsewhere (Phase 5 / future). All filter chips push
+  immediately; only the typing path is debounced.
+-->
+<script lang="ts">
+	import Search from "lucide-svelte/icons/search";
+	import X from "lucide-svelte/icons/x";
+	import type { UrlAdapter } from "$wealth/state/library/url-adapter.svelte";
+
+	interface Props {
+		adapter: UrlAdapter;
+	}
+
+	let { adapter }: Props = $props();
+
+	function handleInput(event: Event): void {
+		const value = (event.currentTarget as HTMLInputElement).value;
+		adapter.setQuery(value, { debounce: true });
+	}
+
+	function clear(): void {
+		adapter.setQuery("");
+	}
+</script>
+
+<div class="search">
+	<span class="search__icon" aria-hidden="true">
+		<Search size={14} />
+	</span>
+	<input
+		type="search"
+		class="search__input"
+		placeholder="Search the Library..."
+		aria-label="Search the Library"
+		value={adapter.state.q}
+		oninput={handleInput}
+	/>
+	{#if adapter.state.q}
+		<button
+			type="button"
+			class="search__clear"
+			aria-label="Clear search"
+			onclick={clear}
+		>
+			<X size={12} />
+		</button>
+	{/if}
+</div>
+
+<style>
+	.search {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 6px 10px;
+		background: #1d1f25;
+		border: 1px solid #404249;
+		border-radius: 8px;
+		color: #cbccd1;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+		min-width: 240px;
+		max-width: 380px;
+		flex: 1;
+		transition: border-color 120ms ease;
+	}
+
+	.search:focus-within {
+		border-color: #0177fb;
+	}
+
+	.search__icon {
+		display: inline-flex;
+		align-items: center;
+		color: #85a0bd;
+	}
+
+	.search__input {
+		flex: 1;
+		min-width: 0;
+		background: transparent;
+		border: none;
+		outline: none;
+		color: #ffffff;
+		font: inherit;
+		font-size: 13px;
+	}
+
+	.search__input::placeholder {
+		color: #85a0bd;
+	}
+
+	.search__clear {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 18px;
+		height: 18px;
+		border: none;
+		background: #404249;
+		color: #cbccd1;
+		border-radius: 999px;
+		cursor: pointer;
+	}
+
+	.search__clear:hover {
+		background: #0177fb;
+		color: #ffffff;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryShell.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryShell.svelte
@@ -1,0 +1,454 @@
+<!--
+  LibraryShell — top-level orchestrator for the Wealth Library.
+
+  Phase 3 of the Library frontend (spec §3.4 Fase 1 + §2.5). The
+  shell owns the 3-pane desktop layout (tree | content | preview)
+  and the in-memory state that the URL adapter and the future
+  filter/search bar plug into. It is intentionally framework-only:
+  zero data fetching happens here. The initial `LibraryTree` payload
+  comes from the server loader; expansion / children fetching is
+  delegated to a `TreeLoader` instance created in onMount and
+  disposed in onDestroy so a route remount always starts clean.
+
+  Layout decisions
+  ----------------
+  * Tree pane is fixed at 320px (spec §2.8 — desktop-first 1440px+).
+  * Preview pane is fixed at 520px and renders a placeholder until
+    Phase 5 lands the dynamic readers panel.
+  * Content pane is fluid in between, capped at the standard
+    `max-w-screen-2xl` cage by the wrapping route — no full-bleed.
+  * Total height is `calc(100vh - 88px)` to respect the global
+    layout cage pattern documented in CLAUDE.md /
+    docs/reference/wealth-frontend-shell.md.
+-->
+<script lang="ts">
+	import { getContext, onDestroy, onMount, untrack } from "svelte";
+	import { goto } from "$app/navigation";
+	import {
+		createBundleBuilder,
+		type BundleBuilder,
+	} from "$wealth/state/library/bundle-builder.svelte";
+	import {
+		createPinsClient,
+		type PinsClient,
+	} from "$wealth/state/library/pins-client.svelte";
+	import {
+		createPreviewLoader,
+		type PreviewLoader,
+	} from "$wealth/state/library/preview-loader.svelte";
+	import {
+		createTreeLoader,
+		type TreeLoader,
+	} from "$wealth/state/library/tree-loader.svelte";
+	import {
+		createUrlAdapter,
+		type UrlAdapter,
+	} from "$wealth/state/library/url-adapter.svelte";
+	import type { LibraryNode, LibraryTree } from "$wealth/types/library";
+	import LibraryActionBar from "./LibraryActionBar.svelte";
+	import LibraryBreadcrumbs from "./LibraryBreadcrumbs.svelte";
+	import LibraryBundleWizard from "./LibraryBundleWizard.svelte";
+	import LibraryContextMenu from "./LibraryContextMenu.svelte";
+	import LibraryFilterBar from "./LibraryFilterBar.svelte";
+	import LibraryPinsSection from "./LibraryPinsSection.svelte";
+	import LibraryPreviewPane from "./LibraryPreviewPane.svelte";
+	import LibrarySearchInput from "./LibrarySearchInput.svelte";
+	import LibraryTreeView from "./LibraryTree.svelte";
+	import LibraryViewToggle from "./LibraryViewToggle.svelte";
+
+	interface Props {
+		tree: LibraryTree;
+		initialPath: string | null;
+		actorRole: string | null;
+	}
+
+	let { tree, initialPath, actorRole }: Props = $props();
+
+	const IC_ROLES = ["admin", "super_admin", "investment_team"];
+	const canCreateBundle = $derived(
+		actorRole !== null && IC_ROLES.includes(actorRole),
+	);
+
+	const getToken =
+		getContext<() => Promise<string>>("netz:getToken");
+
+	// URL adapter must be created synchronously during script init so
+	// the $effect inside it registers with the component lifecycle.
+	const adapter: UrlAdapter = createUrlAdapter();
+
+	let loader: TreeLoader | null = $state(null);
+	let previewLoader: PreviewLoader | null = $state(null);
+	let pins: PinsClient | null = $state(null);
+	let bundle: BundleBuilder | null = $state(null);
+	let selectedPath = $state<string | null>(untrack(() => initialPath));
+	let selectedNode = $state<LibraryNode | null>(null);
+
+	// Context menu state — single instance shared by every tree row.
+	let menuOpen = $state(false);
+	let menuX = $state(0);
+	let menuY = $state(0);
+	let menuNode = $state<LibraryNode | null>(null);
+
+	// Bundle wizard dialog open state.
+	let wizardOpen = $state(false);
+
+	onMount(() => {
+		loader = createTreeLoader(getToken);
+		previewLoader = createPreviewLoader(getToken);
+		previewLoader.start();
+		pins = createPinsClient(getToken);
+		void pins.load();
+		bundle = createBundleBuilder(getToken);
+		// Bridge the URL adapter to the preview loader: any change to
+		// the selected document id (URL ↔ click ↔ back/forward) drives
+		// a fresh single-flight fetch. The loader's AbortController
+		// guarantees the previous request is cancelled before the new
+		// one starts, so a fast click between docs cannot leak.
+		const initialId = untrack(() => adapter.state.selectedId);
+		if (initialId) {
+			void previewLoader.loadDocument(initialId);
+		}
+		// If the URL deep-linked into a folder path, expand every
+		// ancestor so the row is visible. We snapshot via `untrack`
+		// because the expansion is a one-shot action on mount; the
+		// URL adapter (Phase 4) will pick up subsequent navigations.
+		const path = untrack(() => initialPath);
+		if (path && loader) {
+			const segments = path.split("/").filter(Boolean);
+			const partials: string[] = [];
+			for (let i = 0; i < segments.length; i += 1) {
+				partials.push(segments.slice(0, i + 1).join("/"));
+			}
+			for (const p of partials) {
+				void loader.expand(p);
+			}
+		}
+	});
+
+	// Bridge selectedId → preview loader. Runs on every change to
+	// `adapter.state.selectedId` — including back/forward and direct
+	// URL paste — so the preview pane stays in lock-step with the URL
+	// without the click handler having to call the loader manually.
+	$effect(() => {
+		const id = adapter.state.selectedId;
+		if (!previewLoader) return;
+		void previewLoader.loadDocument(id);
+	});
+
+	onDestroy(() => {
+		loader?.dispose();
+		loader = null;
+		previewLoader?.dispose();
+		previewLoader = null;
+		pins?.dispose();
+		pins = null;
+		bundle?.dispose();
+		bundle = null;
+		adapter.dispose();
+	});
+
+	function openContextMenu(event: MouseEvent, node: LibraryNode): void {
+		event.preventDefault();
+		menuNode = node;
+		menuX = event.clientX;
+		menuY = event.clientY;
+		menuOpen = true;
+	}
+
+	function closeContextMenu(): void {
+		menuOpen = false;
+	}
+
+	function handleContextOpen(node: LibraryNode): void {
+		handleSelect(node);
+	}
+
+	function handleContextPreview(node: LibraryNode): void {
+		if (node.node_type === "file" && node.id) {
+			adapter.setSelectedId(node.id);
+		}
+	}
+
+	function handleContextTogglePin(node: LibraryNode): void {
+		if (!pins || node.node_type !== "file" || !node.id) return;
+		void pins.togglePin(node.id, node.label, node.kind ?? null);
+	}
+
+	function handleContextToggleStar(node: LibraryNode): void {
+		if (!pins || node.node_type !== "file" || !node.id) return;
+		void pins.toggleStar(node.id, node.label, node.kind ?? null);
+	}
+
+	function handleSelect(node: LibraryNode): void {
+		selectedNode = node;
+		selectedPath = node.path;
+		// File selection flows through the URL adapter so the
+		// preview-loader effect picks it up; folder navigation still
+		// uses goto because it changes the pathname rather than just
+		// the search params.
+		if (node.node_type === "file" && node.id) {
+			adapter.setSelectedId(node.id);
+		} else {
+			adapter.setSelectedId(null);
+			void goto(`/library/${node.path}`, {
+				keepFocus: true,
+				noScroll: true,
+			});
+		}
+	}
+
+	const isFullscreen = $derived(adapter.state.preview === "fullscreen");
+
+	function handleNavigate(path: string | null): void {
+		selectedPath = path;
+		selectedNode = null;
+		void goto(path ? `/library/${path}` : "/library", {
+			keepFocus: true,
+			noScroll: true,
+		});
+	}
+</script>
+
+<div class="library-shell" class:library-shell--fullscreen={isFullscreen}>
+	{#if !isFullscreen}
+		<header class="library-header">
+			<div class="library-header__left">
+				<LibrarySearchInput {adapter} />
+			</div>
+			<div class="library-header__right">
+				<LibraryViewToggle {adapter} />
+			</div>
+		</header>
+
+		<LibraryFilterBar {adapter} />
+		<LibraryBreadcrumbs {selectedPath} onNavigate={handleNavigate} />
+
+		{#if bundle}
+			<LibraryActionBar
+				{bundle}
+				{canCreateBundle}
+				onOpenWizard={() => (wizardOpen = true)}
+			/>
+		{/if}
+	{/if}
+
+	<div
+		class="library-grid"
+		class:library-grid--fullscreen={isFullscreen}
+	>
+		{#if !isFullscreen}
+			<aside class="pane pane--tree" aria-label="Library navigation">
+				{#if adapter.state.view === "tree"}
+					{#if loader}
+						<LibraryTreeView
+							{tree}
+							{loader}
+							{selectedPath}
+							onSelect={handleSelect}
+							onContext={openContextMenu}
+						/>
+					{/if}
+				{:else if adapter.state.view === "list"}
+					<div class="view-placeholder">
+						<p class="view-placeholder__title">List view</p>
+						<p class="view-placeholder__sub">
+							Flat list rendering ships in the next sprint. The
+							URL contract is already wired so deep-links survive.
+						</p>
+					</div>
+				{:else}
+					<div class="view-placeholder">
+						<p class="view-placeholder__title">Grid view</p>
+						<p class="view-placeholder__sub">
+							Card grid ships in the next sprint. The URL contract
+							is already wired so deep-links survive.
+						</p>
+					</div>
+				{/if}
+			</aside>
+
+			<section class="pane pane--content" aria-label="Library content">
+				{#if !selectedPath && !selectedNode && pins}
+					<LibraryPinsSection {pins} {adapter} />
+				{:else}
+					<div class="content-empty">
+						<p class="content-empty__title">
+							{#if selectedNode}
+								{selectedNode.label}
+							{:else if selectedPath}
+								{selectedPath}
+							{:else}
+								Welcome to your Library
+							{/if}
+						</p>
+						<p class="content-empty__sub">
+							Pick a folder on the left to browse documents. The
+							content list ships in the next sprint.
+						</p>
+					</div>
+				{/if}
+			</section>
+		{/if}
+
+		<aside class="pane pane--preview" aria-label="Library preview">
+			{#if previewLoader}
+				<LibraryPreviewPane loader={previewLoader} {adapter} />
+			{/if}
+		</aside>
+	</div>
+</div>
+
+<LibraryContextMenu
+	node={menuNode}
+	x={menuX}
+	y={menuY}
+	open={menuOpen}
+	isPinned={menuNode?.id ? (pins?.isPinned(menuNode.id) ?? false) : false}
+	isStarred={menuNode?.id ? (pins?.isStarred(menuNode.id) ?? false) : false}
+	onClose={closeContextMenu}
+	onOpen={handleContextOpen}
+	onPreview={handleContextPreview}
+	onTogglePin={handleContextTogglePin}
+	onToggleStar={handleContextToggleStar}
+/>
+
+{#if bundle}
+	<LibraryBundleWizard
+		{bundle}
+		open={wizardOpen}
+		onClose={() => (wizardOpen = false)}
+	/>
+{/if}
+
+<style>
+	.library-shell {
+		display: flex;
+		flex-direction: column;
+		height: calc(100vh - 88px);
+		background: #141519;
+		color: #cbccd1;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+		border-radius: 12px;
+		overflow: hidden;
+	}
+
+	.library-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		padding: 12px 20px;
+		background: #141519;
+		border-bottom: 1px solid #404249;
+	}
+
+	.library-header__left {
+		flex: 1;
+		display: flex;
+		min-width: 0;
+	}
+
+	.library-header__right {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.view-placeholder {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		padding: 24px;
+		color: #85a0bd;
+	}
+
+	.view-placeholder__title {
+		font-size: 14px;
+		font-weight: 700;
+		color: #ffffff;
+		margin: 0;
+	}
+
+	.view-placeholder__sub {
+		font-size: 12px;
+		margin: 0;
+		line-height: 1.5;
+	}
+
+	.library-grid {
+		flex: 1;
+		display: grid;
+		grid-template-columns: 320px minmax(0, 1fr) 520px;
+		min-height: 0;
+	}
+
+	.library-grid--fullscreen {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.library-shell--fullscreen .pane--preview {
+		border-left: none;
+	}
+
+	.pane {
+		min-height: 0;
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.pane--tree {
+		border-right: 1px solid #404249;
+		background: #141519;
+	}
+
+	.pane--content {
+		background: #141519;
+		padding: 24px;
+		overflow-y: auto;
+	}
+
+	.pane--preview {
+		border-left: 1px solid #404249;
+		background: #141519;
+		padding: 24px;
+		overflow-y: auto;
+	}
+
+	.content-empty {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		max-width: 480px;
+		color: #85a0bd;
+	}
+
+	.content-empty__title {
+		font-size: 18px;
+		font-weight: 700;
+		color: #ffffff;
+		margin: 0;
+	}
+
+	.content-empty__sub {
+		font-size: 13px;
+		color: #85a0bd;
+		margin: 0;
+		line-height: 1.5;
+	}
+
+	@media (max-width: 1280px) {
+		.library-grid {
+			grid-template-columns: 280px minmax(0, 1fr) 420px;
+		}
+	}
+
+	@media (max-width: 1024px) {
+		.library-grid {
+			grid-template-columns: 240px minmax(0, 1fr);
+		}
+		.pane--preview {
+			display: none;
+		}
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryShell.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryShell.svelte
@@ -27,24 +27,24 @@
 	import {
 		createBundleBuilder,
 		type BundleBuilder,
-	} from "$wealth/state/library/bundle-builder.svelte";
+	} from "../../state/library/bundle-builder.svelte";
 	import {
 		createPinsClient,
 		type PinsClient,
-	} from "$wealth/state/library/pins-client.svelte";
+	} from "../../state/library/pins-client.svelte";
 	import {
 		createPreviewLoader,
 		type PreviewLoader,
-	} from "$wealth/state/library/preview-loader.svelte";
+	} from "../../state/library/preview-loader.svelte";
 	import {
 		createTreeLoader,
 		type TreeLoader,
-	} from "$wealth/state/library/tree-loader.svelte";
+	} from "../../state/library/tree-loader.svelte";
 	import {
 		createUrlAdapter,
 		type UrlAdapter,
-	} from "$wealth/state/library/url-adapter.svelte";
-	import type { LibraryNode, LibraryTree } from "$wealth/types/library";
+	} from "../../state/library/url-adapter.svelte";
+	import type { LibraryNode, LibraryTree } from "../../types/library";
 	import LibraryActionBar from "./LibraryActionBar.svelte";
 	import LibraryBreadcrumbs from "./LibraryBreadcrumbs.svelte";
 	import LibraryBundleWizard from "./LibraryBundleWizard.svelte";

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryTree.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryTree.svelte
@@ -15,8 +15,8 @@
 -->
 <script lang="ts">
 	import { createVirtualizer } from "@tanstack/svelte-virtual";
-	import type { LibraryNode, LibraryTree } from "$wealth/types/library";
-	import type { TreeLoader } from "$wealth/state/library/tree-loader.svelte";
+	import type { LibraryNode, LibraryTree } from "../../types/library";
+	import type { TreeLoader } from "../../state/library/tree-loader.svelte";
 	import LibraryTreeNode from "./LibraryTreeNode.svelte";
 
 	interface Props {

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryTree.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryTree.svelte
@@ -1,0 +1,262 @@
+<!--
+  LibraryTree — virtualised hierarchical tree for the Wealth Library.
+
+  Phase 3 of the Library frontend (spec §3.4 Fase 1). The component
+  flattens the lazy-loaded folder hierarchy into an array of visible
+  rows (depth annotated) and hands it to `@tanstack/svelte-virtual`'s
+  `createVirtualizer` so only the rows inside the scroll viewport
+  render. The institutional target is "5000 nodes at 60fps" which
+  the virtualiser meets trivially with a fixed `estimateSize`.
+
+  All expansion + child fetching is delegated to a `TreeLoader`
+  instance owned by the parent shell — see
+  `lib/state/library/tree-loader.svelte.ts`. The component itself
+  carries no fetching logic, only flattening and selection.
+-->
+<script lang="ts">
+	import { createVirtualizer } from "@tanstack/svelte-virtual";
+	import type { LibraryNode, LibraryTree } from "$wealth/types/library";
+	import type { TreeLoader } from "$wealth/state/library/tree-loader.svelte";
+	import LibraryTreeNode from "./LibraryTreeNode.svelte";
+
+	interface Props {
+		tree: LibraryTree;
+		loader: TreeLoader;
+		selectedPath: string | null;
+		onSelect: (node: LibraryNode) => void;
+		onContext?: (event: MouseEvent, node: LibraryNode) => void;
+	}
+
+	let {
+		tree,
+		loader,
+		selectedPath,
+		onSelect,
+		onContext,
+	}: Props = $props();
+
+	interface FlatRow {
+		key: string;
+		node: LibraryNode;
+		depth: number;
+	}
+
+	// ── Flatten the tree into a visible-row list ────────────────────
+	//
+	// The server hands us L1 + L2 in `tree.roots` already linearised
+	// (each root carries the full encoded path). When the user expands
+	// any folder, the loader caches its `LibraryNodePage.items` under
+	// the same encoded path, and we splice them in below the parent.
+	//
+	// We deliberately compute this in $derived rather than $effect so
+	// the virtualiser sees a brand-new identity every time the
+	// underlying data changes — no manual invalidation needed.
+	const flatRows = $derived.by<FlatRow[]>(() => {
+		const rows: FlatRow[] = [];
+
+		// Group L1 roots vs their L2 children. The server returns
+		// every L1 + L2 entry as a separate `roots` element; the L2
+		// rows live under their parent L1's path string.
+		const byParent = new Map<string, LibraryNode[]>();
+		const l1Nodes: LibraryNode[] = [];
+		for (const node of tree.roots) {
+			const segments = node.path.split("/");
+			if (segments.length === 1) {
+				l1Nodes.push(node);
+			} else {
+				const parent = segments.slice(0, -1).join("/");
+				const bucket = byParent.get(parent);
+				if (bucket) {
+					bucket.push(node);
+				} else {
+					byParent.set(parent, [node]);
+				}
+			}
+		}
+
+		function pushNode(node: LibraryNode, depth: number): void {
+			rows.push({ key: `${node.path}|${node.id ?? "f"}`, node, depth });
+
+			// Folders contribute their seeded L2 children (from the
+			// initial /library/tree response) plus any lazily fetched
+			// deeper children once the loader has cached them.
+			if (node.node_type !== "folder" || !loader.expanded.has(node.path)) {
+				return;
+			}
+
+			const seeded = byParent.get(node.path) ?? [];
+			for (const child of seeded) {
+				pushNode(child, depth + 1);
+			}
+
+			const fetched = loader.folders[node.path];
+			if (fetched) {
+				if (fetched.loading && fetched.children.length === 0) {
+					rows.push({
+						key: `${node.path}|loading`,
+						node: {
+							node_type: "folder",
+							path: `${node.path}/__loading`,
+							label: "Loading...",
+							child_count: null,
+						},
+						depth: depth + 1,
+					});
+				} else if (fetched.error && fetched.children.length === 0) {
+					rows.push({
+						key: `${node.path}|error`,
+						node: {
+							node_type: "folder",
+							path: `${node.path}/__error`,
+							label: fetched.error,
+							child_count: null,
+						},
+						depth: depth + 1,
+					});
+				}
+				for (const child of fetched.children) {
+					pushNode(child, depth + 1);
+				}
+			}
+		}
+
+		for (const root of l1Nodes) {
+			pushNode(root, 0);
+		}
+
+		return rows;
+	});
+
+	// ── Virtualisation ──────────────────────────────────────────────
+	let scrollEl = $state<HTMLDivElement | undefined>(undefined);
+	const ROW_HEIGHT = 32;
+
+	// `createVirtualizer` from @tanstack/svelte-virtual returns a
+	// Svelte readable store. We pass getters so the option object
+	// stays stable while the underlying values stay reactive — the
+	// store re-renders the visible window whenever `count` or the
+	// scroll element flip.
+	const virtualizer = createVirtualizer<HTMLDivElement, HTMLDivElement>({
+		get count() {
+			return flatRows.length;
+		},
+		getScrollElement: () => scrollEl ?? null,
+		estimateSize: () => ROW_HEIGHT,
+		overscan: 12,
+	});
+
+	// ── Keyboard navigation between rows ────────────────────────────
+	let focusedIndex = $state(0);
+
+	function handleListKeydown(event: KeyboardEvent): void {
+		if (flatRows.length === 0) return;
+		if (event.key === "ArrowDown") {
+			event.preventDefault();
+			focusedIndex = Math.min(flatRows.length - 1, focusedIndex + 1);
+			$virtualizer.scrollToIndex(focusedIndex, { align: "auto" });
+		} else if (event.key === "ArrowUp") {
+			event.preventDefault();
+			focusedIndex = Math.max(0, focusedIndex - 1);
+			$virtualizer.scrollToIndex(focusedIndex, { align: "auto" });
+		} else if (event.key === "Home") {
+			event.preventDefault();
+			focusedIndex = 0;
+			$virtualizer.scrollToIndex(0, { align: "start" });
+		} else if (event.key === "End") {
+			event.preventDefault();
+			focusedIndex = flatRows.length - 1;
+			$virtualizer.scrollToIndex(focusedIndex, { align: "end" });
+		}
+	}
+
+	function isLoading(node: LibraryNode): boolean {
+		if (node.node_type !== "folder") return false;
+		return loader.folders[node.path]?.loading ?? false;
+	}
+
+	function isSelected(node: LibraryNode): boolean {
+		if (selectedPath === null) return false;
+		if (node.node_type === "file" && node.id) {
+			return selectedPath === node.id;
+		}
+		return selectedPath === node.path;
+	}
+</script>
+
+<div
+	bind:this={scrollEl}
+	class="tree-scroll"
+	role="tree"
+	aria-label="Wealth Library navigation"
+	tabindex="0"
+	onkeydown={handleListKeydown}
+>
+	<div class="tree-spacer" style:height="{$virtualizer.getTotalSize()}px">
+		{#each $virtualizer.getVirtualItems() as item (flatRows[item.index]?.key ?? item.key)}
+			{@const row = flatRows[item.index]}
+			{#if row}
+				<div
+					class="tree-row-wrap"
+					style:transform="translateY({item.start}px)"
+					style:height="{ROW_HEIGHT}px"
+					oncontextmenu={(e) => onContext?.(e, row.node)}
+					role="presentation"
+				>
+					<LibraryTreeNode
+						node={row.node}
+						depth={row.depth}
+						expanded={loader.expanded.has(row.node.path)}
+						selected={isSelected(row.node)}
+						loading={isLoading(row.node)}
+						onToggle={(p) => {
+							focusedIndex = item.index;
+							void loader.toggle(p);
+						}}
+						onSelect={(n) => {
+							focusedIndex = item.index;
+							onSelect(n);
+						}}
+					/>
+				</div>
+			{/if}
+		{/each}
+	</div>
+</div>
+
+<style>
+	.tree-scroll {
+		height: 100%;
+		overflow-y: auto;
+		overflow-x: hidden;
+		background: #141519;
+		padding: 8px 6px;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+		scrollbar-width: thin;
+		scrollbar-color: #404249 transparent;
+	}
+
+	.tree-scroll:focus-visible {
+		outline: 2px solid #0177fb;
+		outline-offset: -2px;
+		border-radius: 8px;
+	}
+
+	.tree-scroll::-webkit-scrollbar {
+		width: 8px;
+	}
+
+	.tree-scroll::-webkit-scrollbar-thumb {
+		background: #404249;
+		border-radius: 4px;
+	}
+
+	.tree-spacer {
+		width: 100%;
+		position: relative;
+	}
+
+	.tree-row-wrap {
+		position: absolute;
+		inset: 0 0 auto 0;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryTreeNode.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryTreeNode.svelte
@@ -1,0 +1,204 @@
+<!--
+  LibraryTreeNode — single virtualised row inside the LibraryTree.
+
+  Phase 3 of the Wealth Library frontend (spec §3.4 Fase 1). The
+  node is intentionally dumb: it receives a flattened representation
+  with the depth pre-computed by `LibraryTree`, plus a handful of
+  callbacks. All expand/collapse + selection state lives upstream
+  in the `tree-loader.svelte.ts` store and the URL adapter, so this
+  component never owns reactive truth on its own — it just renders.
+
+  Both folders and files use the same row height so the virtualiser
+  can keep `estimateSize` constant and free of layout thrash.
+-->
+<script lang="ts">
+	import ChevronRight from "lucide-svelte/icons/chevron-right";
+	import FileText from "lucide-svelte/icons/file-text";
+	import Folder from "lucide-svelte/icons/folder";
+	import FolderOpen from "lucide-svelte/icons/folder-open";
+	import Loader2 from "lucide-svelte/icons/loader-2";
+	import type { LibraryNode } from "$wealth/types/library";
+
+	interface Props {
+		node: LibraryNode;
+		depth: number;
+		expanded: boolean;
+		selected: boolean;
+		loading: boolean;
+		onToggle: (path: string) => void;
+		onSelect: (node: LibraryNode) => void;
+	}
+
+	let {
+		node,
+		depth,
+		expanded,
+		selected,
+		loading,
+		onToggle,
+		onSelect,
+	}: Props = $props();
+
+	const isFolder = $derived(node.node_type === "folder");
+
+	function handleClick(): void {
+		if (isFolder) {
+			onToggle(node.path);
+		} else {
+			onSelect(node);
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent): void {
+		if (event.key === "Enter" || event.key === " ") {
+			event.preventDefault();
+			handleClick();
+		} else if (event.key === "ArrowRight" && isFolder && !expanded) {
+			event.preventDefault();
+			onToggle(node.path);
+		} else if (event.key === "ArrowLeft" && isFolder && expanded) {
+			event.preventDefault();
+			onToggle(node.path);
+		}
+	}
+
+	const indent = $derived(depth * 14);
+	const hoverTitle = $derived(
+		isFolder && node.child_count != null
+			? `${node.label} — ${node.child_count} item${node.child_count === 1 ? "" : "s"}`
+			: (node.label ?? ""),
+	);
+</script>
+
+<button
+	type="button"
+	class="row"
+	class:row--selected={selected}
+	class:row--folder={isFolder}
+	style:padding-left="{8 + indent}px"
+	role="treeitem"
+	aria-level={depth + 1}
+	aria-expanded={isFolder ? expanded : undefined}
+	aria-selected={selected}
+	title={hoverTitle}
+	onclick={handleClick}
+	onkeydown={handleKeydown}
+>
+	{#if isFolder}
+		<span class="chevron" class:chevron--open={expanded}>
+			<ChevronRight size={12} />
+		</span>
+	{:else}
+		<span class="chevron chevron--placeholder"></span>
+	{/if}
+
+	<span class="icon">
+		{#if loading}
+			<Loader2 size={14} class="spin" />
+		{:else if isFolder && expanded}
+			<FolderOpen size={14} />
+		{:else if isFolder}
+			<Folder size={14} />
+		{:else}
+			<FileText size={14} />
+		{/if}
+	</span>
+
+	<span class="label">{node.label}</span>
+
+	{#if isFolder && node.child_count != null && node.child_count > 0}
+		<span class="count">{node.child_count}</span>
+	{/if}
+</button>
+
+<style>
+	.row {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		width: 100%;
+		height: 32px;
+		border: none;
+		background: transparent;
+		color: #cbccd1;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+		font-size: 13px;
+		font-weight: 500;
+		text-align: left;
+		cursor: pointer;
+		padding: 0 12px 0 8px;
+		border-radius: 6px;
+		transition: background-color 120ms ease, color 120ms ease;
+		white-space: nowrap;
+		overflow: hidden;
+	}
+
+	.row:hover {
+		background: #1d1f25;
+		color: #ffffff;
+	}
+
+	.row:focus-visible {
+		outline: 2px solid #0177fb;
+		outline-offset: -2px;
+	}
+
+	.row--selected {
+		background: color-mix(in srgb, #0177fb 18%, #141519);
+		color: #ffffff;
+	}
+
+	.row--selected .count { color: #ffffff; }
+
+	.chevron {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 14px;
+		height: 14px;
+		color: #85a0bd;
+		transition: transform 120ms ease;
+	}
+
+	.chevron--open { transform: rotate(90deg); }
+	.chevron--placeholder { width: 14px; height: 14px; }
+
+	.icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 16px;
+		color: #85a0bd;
+		flex-shrink: 0;
+	}
+
+	.row--selected .icon,
+	.row:hover .icon { color: #ffffff; }
+
+	.label {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.count {
+		font-size: 11px;
+		font-weight: 600;
+		color: #85a0bd;
+		font-variant-numeric: tabular-nums;
+		padding: 1px 6px;
+		border-radius: 999px;
+		background: #1d1f25;
+		flex-shrink: 0;
+	}
+
+	:global(.spin) {
+		animation: spin 1s linear infinite;
+	}
+
+	@keyframes spin {
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryTreeNode.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryTreeNode.svelte
@@ -17,7 +17,7 @@
 	import Folder from "lucide-svelte/icons/folder";
 	import FolderOpen from "lucide-svelte/icons/folder-open";
 	import Loader2 from "lucide-svelte/icons/loader-2";
-	import type { LibraryNode } from "$wealth/types/library";
+	import type { LibraryNode } from "../../types/library";
 
 	interface Props {
 		node: LibraryNode;

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryViewToggle.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryViewToggle.svelte
@@ -1,0 +1,94 @@
+<!--
+  LibraryViewToggle — Tree / List / Grid switch.
+
+  Phase 4 of the Library frontend (spec §3.4 Fase 4). Writes the
+  selected view mode through the URL adapter so it round-trips with
+  every other piece of Library state. The actual List/Grid rendering
+  arrives in a follow-up sprint — for now the LibraryShell renders
+  structural placeholders for those modes so the URL contract is
+  already correct end-to-end.
+-->
+<script lang="ts">
+	import LayoutGrid from "lucide-svelte/icons/layout-grid";
+	import List from "lucide-svelte/icons/list";
+	import Network from "lucide-svelte/icons/network";
+	import type {
+		LibraryViewMode,
+		UrlAdapter,
+	} from "$wealth/state/library/url-adapter.svelte";
+
+	interface Props {
+		adapter: UrlAdapter;
+	}
+
+	let { adapter }: Props = $props();
+
+	const OPTIONS: Array<{
+		value: LibraryViewMode;
+		label: string;
+		icon: typeof Network;
+	}> = [
+		{ value: "tree", label: "Tree", icon: Network },
+		{ value: "list", label: "List", icon: List },
+		{ value: "grid", label: "Grid", icon: LayoutGrid },
+	];
+</script>
+
+<div class="toggle" role="group" aria-label="Library view">
+	{#each OPTIONS as option (option.value)}
+		{@const Icon = option.icon}
+		<button
+			type="button"
+			class="toggle__btn"
+			class:toggle__btn--active={adapter.state.view === option.value}
+			aria-pressed={adapter.state.view === option.value}
+			title={option.label}
+			onclick={() => adapter.setView(option.value)}
+		>
+			<Icon size={14} />
+			<span class="toggle__label">{option.label}</span>
+		</button>
+	{/each}
+</div>
+
+<style>
+	.toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		padding: 3px;
+		background: #1d1f25;
+		border: 1px solid #404249;
+		border-radius: 8px;
+		font-family: var(--ii-font-sans, "Urbanist", system-ui, sans-serif);
+	}
+
+	.toggle__btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 5px 10px;
+		border: none;
+		background: transparent;
+		color: #85a0bd;
+		font-family: inherit;
+		font-size: 12px;
+		font-weight: 600;
+		border-radius: 6px;
+		cursor: pointer;
+		transition: background-color 120ms ease, color 120ms ease;
+	}
+
+	.toggle__btn:hover {
+		color: #ffffff;
+	}
+
+	.toggle__btn--active {
+		background: color-mix(in srgb, #0177fb 22%, #141519);
+		color: #ffffff;
+	}
+
+	.toggle__label {
+		font-size: 12px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/LibraryViewToggle.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/LibraryViewToggle.svelte
@@ -15,7 +15,7 @@
 	import type {
 		LibraryViewMode,
 		UrlAdapter,
-	} from "$wealth/state/library/url-adapter.svelte";
+	} from "../../state/library/url-adapter.svelte";
 
 	interface Props {
 		adapter: UrlAdapter;

--- a/packages/ii-terminal-core/src/lib/components/library/readers/ContentBody.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/readers/ContentBody.svelte
@@ -1,0 +1,473 @@
+<!--
+  ContentBody — standalone reader for `wealth_content` documents
+  (Investment Outlooks, Flash Reports, Manager Spotlights).
+
+  Phase 0 of the Wealth Library refactor: extracted from
+  routes/(app)/content/[id]/+page.svelte so the same body can be
+  embedded inside the future LibraryPreviewPane (Library shell,
+  Phase 3) and any other host that has token context.
+
+  Contract
+  --------
+  * Strictly props: only `id`. Token comes from "netz:getToken".
+  * Optional `netz:content-actor` context exposes actor info for
+    the approval UI; LibraryPreviewPane (read-only host) leaves it
+    empty so the Approve button never renders.
+  * Self-contained client fetch via `/content/{id}`.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import {
+		Button,
+		ConsequenceDialog,
+		StatusBadge,
+		formatDateTime,
+	} from "@investintell/ui";
+	import type { ConsequenceDialogPayload } from "@investintell/ui";
+	import { PanelEmptyState, PanelErrorState } from "@investintell/ui/runtime";
+	import { ForbiddenError } from "@investintell/ui/utils";
+	import { createClientApiClient } from "$wealth/api/client";
+	import type { ContentFull } from "$wealth/types/content";
+	import { contentTypeColor, contentTypeLabel } from "$wealth/types/content";
+	import { flattenObject, renderMarkdown } from "$wealth/utils/render-markdown";
+
+	let { id }: { id: string } = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+
+	interface ActorContext {
+		actorId: string | null;
+		actorRole: string | null;
+	}
+	const actorCtx = getContext<ActorContext | null>("netz:content-actor") ?? null;
+	const actorId = actorCtx?.actorId ?? null;
+	const actorRole = actorCtx?.actorRole ?? null;
+
+	// ── Self-managed content state ───────────────────────────────────
+	let content = $state<ContentFull | null>(null);
+	let loading = $state(true);
+	let loadError = $state<string | null>(null);
+
+	async function loadContent() {
+		loading = true;
+		loadError = null;
+		try {
+			const api = createClientApiClient(getToken);
+			content = await api.get<ContentFull>(`/content/${id}`);
+		} catch (err: unknown) {
+			loadError =
+				err instanceof Error ? err.message : "Failed to load content.";
+			content = null;
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		void id;
+		void loadContent();
+	});
+
+	// ── Approval logic ───────────────────────────────────────────────
+	const IC_ROLES = ["admin", "super_admin", "investment_team"];
+	let canApprove = $derived(
+		content !== null &&
+			(content.status === "draft" || content.status === "review") &&
+			actorRole !== null &&
+			IC_ROLES.includes(actorRole) &&
+			actorId !== content.created_by,
+	);
+	let isSelfAuthored = $derived(
+		content !== null &&
+			actorId !== null &&
+			content.created_by === actorId,
+	);
+
+	let approveDialogOpen = $state(false);
+	let actionError = $state<string | null>(null);
+
+	async function handleApprove(payload: ConsequenceDialogPayload) {
+		if (!content) return;
+		try {
+			const api = createClientApiClient(getToken);
+			await api.post(`/content/${content.id}/approve`, {
+				rationale: payload.rationale,
+			});
+			approveDialogOpen = false;
+			await loadContent();
+		} catch (e) {
+			if (e instanceof ForbiddenError) {
+				actionError =
+					"Cannot approve your own content. Another team member must approve.";
+			} else {
+				actionError = e instanceof Error ? e.message : "Approval failed";
+			}
+			approveDialogOpen = false;
+		}
+	}
+
+	// ── Download ─────────────────────────────────────────────────────
+	let downloading = $state(false);
+
+	function canDownload(): boolean {
+		return (
+			content !== null &&
+			(content.status === "approved" || content.status === "published")
+		);
+	}
+
+	async function downloadPdf() {
+		if (!content) return;
+		downloading = true;
+		try {
+			const api = createClientApiClient(getToken);
+			const blob = await api.getBlob(`/content/${content.id}/download`);
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${content.content_type}_${content.language}.pdf`;
+			a.click();
+			URL.revokeObjectURL(url);
+		} catch (e) {
+			actionError = e instanceof Error ? e.message : "Download failed";
+		} finally {
+			downloading = false;
+		}
+	}
+
+	let hasContentData = $derived(
+		content !== null &&
+			content.content_data !== null &&
+			content.content_data !== undefined &&
+			Object.keys(content.content_data).length > 0,
+	);
+</script>
+
+{#if loading && content === null}
+	<PanelEmptyState
+		title="Loading content"
+		message="Fetching the document from the server..."
+	/>
+{:else if loadError}
+	<PanelErrorState
+		title="Unable to load content"
+		message={loadError}
+		onRetry={loadContent}
+	/>
+{:else if content === null}
+	<PanelEmptyState
+		title="No content available"
+		message="This content is not available at the moment."
+	/>
+{:else}
+	<!-- ── Action bar (no PageHeader / no breadcrumbs) ─────────── -->
+	<div class="cd-actions-bar">
+		{#if canApprove}
+			<Button
+				size="sm"
+				variant="outline"
+				onclick={() => (approveDialogOpen = true)}
+			>
+				Approve
+			</Button>
+		{:else if (content.status === "draft" || content.status === "review") && isSelfAuthored}
+			<span class="cd-self-hint" title="Cannot approve your own content">
+				<Button size="sm" variant="outline" disabled>Approve</Button>
+			</span>
+		{/if}
+		{#if canDownload()}
+			<Button size="sm" onclick={downloadPdf} disabled={downloading}>
+				{downloading ? "Downloading..." : "Download PDF"}
+			</Button>
+		{/if}
+	</div>
+
+	{#if actionError}
+		<div class="cd-error">
+			<span>{actionError}</span>
+			<button
+				class="cd-error-dismiss"
+				onclick={() => (actionError = null)}
+				type="button"
+				aria-label="Dismiss error"
+			>
+				&times;
+			</button>
+		</div>
+	{/if}
+
+	<!-- Meta bar -->
+	<div class="cd-meta-bar">
+		<span class="cd-type" style:color={contentTypeColor(content.content_type)}>
+			{contentTypeLabel(content.content_type)}
+		</span>
+		<StatusBadge status={content.status} />
+		<span class="cd-lang">{content.language.toUpperCase()}</span>
+		<span class="cd-date">{formatDateTime(content.created_at)}</span>
+		{#if content.created_by}
+			<span class="cd-author">by {content.created_by}</span>
+		{/if}
+		{#if content.approved_at}
+			<span class="cd-approved">
+				Approved {formatDateTime(content.approved_at)}
+				{#if content.approved_by} by {content.approved_by}{/if}
+			</span>
+		{/if}
+	</div>
+
+	<!-- Content body -->
+	<div class="cd-page">
+		{#if content.status === "draft" && !content.content_md}
+			<div class="cd-generating">
+				<span class="cd-spinner"></span>
+				Content is being generated&hellip;
+			</div>
+		{:else}
+			<div class="cd-body">
+				<!-- renderMarkdown applies DOMPurify with strict ALLOWED_TAGS/ATTR allowlist.
+				     Backend also sanitizes via nh3 at the persist boundary. Two-layer defense. -->
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+				{@html renderMarkdown(content.content_md)}
+			</div>
+		{/if}
+
+		{#if hasContentData}
+			<details class="cd-data-section">
+				<summary class="cd-data-toggle">View Content Data</summary>
+				<div class="cd-data-grid">
+					{#each flattenObject(content.content_data!) as entry (entry.key)}
+						<div class="cd-data-row">
+							<span class="cd-data-key">{entry.key}</span>
+							<span class="cd-data-val">{entry.value}</span>
+						</div>
+					{/each}
+				</div>
+			</details>
+		{/if}
+	</div>
+
+	<!-- Approve dialog -->
+	<ConsequenceDialog
+		bind:open={approveDialogOpen}
+		title="Approve Content"
+		impactSummary="This content will be marked as approved and available for distribution."
+		requireRationale={true}
+		rationaleLabel="Approval Rationale"
+		rationalePlaceholder="Confirm this content meets committee standards (min 10 chars)."
+		rationaleMinLength={10}
+		confirmLabel="Approve"
+		metadata={[
+			{ label: "Type", value: contentTypeLabel(content.content_type) },
+			{ label: "Language", value: content.language.toUpperCase() },
+		]}
+		onConfirm={handleApprove}
+	/>
+{/if}
+
+<style>
+	.cd-actions-bar {
+		display: flex;
+		gap: var(--ii-space-inline-xs, 6px);
+		padding: var(--ii-space-stack-xs, 8px) var(--ii-space-inline-lg, 24px);
+		border-bottom: 1px solid var(--ii-border-subtle);
+		background: var(--ii-surface-elevated);
+	}
+
+	.cd-self-hint { cursor: not-allowed; }
+
+	.cd-error {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--ii-space-stack-xs, 8px) var(--ii-space-inline-lg, 24px);
+		background: color-mix(in srgb, var(--ii-danger) 8%, transparent);
+		color: var(--ii-danger);
+		font-size: var(--ii-text-small, 0.8125rem);
+	}
+
+	.cd-error-dismiss {
+		background: none;
+		border: none;
+		color: var(--ii-danger);
+		cursor: pointer;
+		font-size: 1.2em;
+		padding: 0 4px;
+		line-height: 1;
+	}
+
+	.cd-meta-bar {
+		display: flex;
+		align-items: center;
+		gap: var(--ii-space-inline-sm, 10px);
+		padding: var(--ii-space-stack-xs, 8px) var(--ii-space-inline-lg, 24px);
+		border-bottom: 1px solid var(--ii-border-subtle);
+		font-size: var(--ii-text-small, 0.8125rem);
+		color: var(--ii-text-muted);
+		flex-wrap: wrap;
+	}
+
+	.cd-type {
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		font-size: var(--ii-text-label, 0.75rem);
+	}
+
+	.cd-lang {
+		font-weight: 600;
+		color: var(--ii-text-secondary);
+	}
+
+	.cd-date,
+	.cd-author { color: var(--ii-text-muted); }
+
+	.cd-approved { color: var(--ii-success); }
+
+	.cd-page {
+		padding: var(--ii-space-stack-lg, 24px) var(--ii-space-inline-lg, 24px);
+		max-width: 820px;
+	}
+
+	.cd-generating {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: var(--ii-space-stack-xl, 40px) 0;
+		color: var(--ii-info);
+		font-size: var(--ii-text-body, 0.9375rem);
+	}
+
+	.cd-spinner {
+		display: inline-block;
+		width: 16px;
+		height: 16px;
+		border: 2px solid color-mix(in srgb, var(--ii-info) 30%, transparent);
+		border-top-color: var(--ii-info);
+		border-radius: 50%;
+		animation: cd-spin 0.8s linear infinite;
+	}
+
+	@keyframes cd-spin { to { transform: rotate(360deg); } }
+
+	.cd-body {
+		line-height: var(--ii-leading-body, 1.65);
+		color: var(--ii-text-primary);
+		font-size: var(--ii-text-body, 0.9375rem);
+	}
+
+	.cd-body :global(h1) {
+		font-size: var(--ii-text-h2, 1.75rem);
+		font-weight: 700;
+		margin: var(--ii-space-stack-lg, 28px) 0 var(--ii-space-stack-sm, 12px);
+		color: var(--ii-text-primary);
+	}
+
+	.cd-body :global(h2) {
+		font-size: var(--ii-text-h3, 1.375rem);
+		font-weight: 600;
+		margin: var(--ii-space-stack-md, 20px) 0 var(--ii-space-stack-xs, 8px);
+		color: var(--ii-text-primary);
+	}
+
+	.cd-body :global(h3) {
+		font-size: var(--ii-text-h4, 1.125rem);
+		font-weight: 600;
+		margin: var(--ii-space-stack-sm, 16px) 0 var(--ii-space-stack-2xs, 4px);
+		color: var(--ii-text-primary);
+	}
+
+	.cd-body :global(p) { margin: 0 0 var(--ii-space-stack-sm, 12px); }
+
+	.cd-body :global(ul),
+	.cd-body :global(ol) {
+		margin: 0 0 var(--ii-space-stack-sm, 12px);
+		padding-left: var(--ii-space-inline-lg, 24px);
+	}
+
+	.cd-body :global(li) { margin: 0 0 var(--ii-space-stack-2xs, 4px); }
+
+	.cd-body :global(code) {
+		font-family: var(--ii-font-mono);
+		font-size: var(--ii-text-mono, 0.875rem);
+		padding: 1px 5px;
+		border-radius: 4px;
+		background: var(--ii-surface-alt);
+	}
+
+	.cd-body :global(table) {
+		width: 100%;
+		border-collapse: collapse;
+		margin: 1rem 0;
+		font-size: 0.875rem;
+	}
+
+	.cd-body :global(th),
+	.cd-body :global(td) {
+		border: 1px solid var(--ii-border-subtle);
+		padding: 0.5rem 0.75rem;
+		text-align: left;
+	}
+
+	.cd-body :global(th) {
+		background: var(--ii-surface-alt);
+		font-weight: 600;
+	}
+
+	.cd-body :global(hr) {
+		border: none;
+		border-top: 1px solid var(--ii-border-subtle);
+		margin: 1.5rem 0;
+	}
+
+	.cd-body :global(blockquote) {
+		border-left: 3px solid var(--ii-border-subtle);
+		margin: 0 0 var(--ii-space-stack-sm, 12px);
+		padding-left: var(--ii-space-inline-md, 16px);
+		color: var(--ii-text-secondary);
+	}
+
+	.cd-body :global(.rw-empty) {
+		color: var(--ii-text-muted);
+		font-style: italic;
+	}
+
+	.cd-data-section {
+		margin-top: var(--ii-space-stack-lg, 28px);
+		border: 1px solid var(--ii-border-subtle);
+		border-radius: var(--ii-radius-sm, 8px);
+		overflow: hidden;
+	}
+
+	.cd-data-toggle {
+		padding: var(--ii-space-stack-xs, 10px) var(--ii-space-inline-md, 16px);
+		font-size: var(--ii-text-small, 0.8125rem);
+		font-weight: 600;
+		color: var(--ii-text-secondary);
+		cursor: pointer;
+		background: var(--ii-surface-alt);
+		border-bottom: 1px solid var(--ii-border-subtle);
+	}
+
+	.cd-data-grid {
+		display: grid;
+		grid-template-columns: minmax(120px, auto) 1fr;
+		gap: 0;
+	}
+
+	.cd-data-row { display: contents; }
+
+	.cd-data-key,
+	.cd-data-val {
+		padding: var(--ii-space-stack-2xs, 4px) var(--ii-space-inline-md, 16px);
+		font-size: var(--ii-text-label, 0.75rem);
+		border-bottom: 1px solid var(--ii-border-subtle);
+		word-break: break-word;
+	}
+
+	.cd-data-key {
+		font-weight: 600;
+		color: var(--ii-text-secondary);
+	}
+
+	.cd-data-val { color: var(--ii-text-primary); }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/readers/ContentBody.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/readers/ContentBody.svelte
@@ -26,10 +26,10 @@
 	import type { ConsequenceDialogPayload } from "@investintell/ui";
 	import { PanelEmptyState, PanelErrorState } from "@investintell/ui/runtime";
 	import { ForbiddenError } from "@investintell/ui/utils";
-	import { createClientApiClient } from "$wealth/api/client";
-	import type { ContentFull } from "$wealth/types/content";
-	import { contentTypeColor, contentTypeLabel } from "$wealth/types/content";
-	import { flattenObject, renderMarkdown } from "$wealth/utils/render-markdown";
+	import { createClientApiClient } from "../../../api/client";
+	import type { ContentFull } from "../../../types/content";
+	import { contentTypeColor, contentTypeLabel } from "../../../types/content";
+	import { flattenObject, renderMarkdown } from "../../../utils/render-markdown";
 
 	let { id }: { id: string } = $props();
 

--- a/packages/ii-terminal-core/src/lib/components/library/readers/DDReportBody.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/readers/DDReportBody.svelte
@@ -34,19 +34,19 @@
 	import type { ConsequenceDialogPayload } from "@investintell/ui";
 	import { Button } from "@investintell/ui/components/ui/button";
 	import { PanelEmptyState, PanelErrorState } from "@investintell/ui/runtime";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../../api/client";
 	import type {
 		AuditEvent,
 		DDChapter,
 		DDReportFull,
-	} from "$wealth/types/dd-report";
+	} from "../../../types/dd-report";
 	import {
 		anchorColor,
 		anchorLabel,
 		chapterTitle,
 		confidenceColor,
-	} from "$wealth/types/dd-report";
-	import { flattenObject, renderMarkdown } from "$wealth/utils/render-markdown";
+	} from "../../../types/dd-report";
+	import { flattenObject, renderMarkdown } from "../../../utils/render-markdown";
 
 	let { reportId }: { reportId: string } = $props();
 

--- a/packages/ii-terminal-core/src/lib/components/library/readers/DDReportBody.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/readers/DDReportBody.svelte
@@ -1,0 +1,1071 @@
+<!--
+  DDReportBody — standalone DD Report reading workbench.
+
+  Phase 0 of the Wealth Library refactor: extracted from
+  routes/(app)/screener/dd-reports/[fundId]/[reportId]/+page.svelte
+  so the same workbench can be embedded inside the future
+  `LibraryPreviewPane` (Library shell, Phase 3) and any other host
+  surface that needs to render a DD report by id.
+
+  Design contract
+  ---------------
+  * Strictly props: only `reportId`. Token comes from the
+    "netz:getToken" Svelte context (set by the (app) layout).
+  * Optional `netz:dd-actor` context (set by the host route or by
+    LibraryPreviewPane) is read for the approval UI. When the
+    context is missing, approve/reject controls hide gracefully.
+  * Self-contained client fetch via `/dd-reports/{reportId}`
+    so this component is reusable in any host that has token
+    context — no PageData prop, no breadcrumbs, no PageHeader.
+  * SSE generation progress, audit trail, approval dialogs and the
+    PDF download all live inside this file. The host owns only the
+    page title and breadcrumbs.
+-->
+<script lang="ts">
+	import { getContext, onDestroy, onMount } from "svelte";
+	import { invalidateAll } from "$app/navigation";
+	import {
+		ConsequenceDialog,
+		StatusBadge,
+		createSSEStream,
+		formatDateTime,
+		formatPercent,
+	} from "@investintell/ui";
+	import type { ConsequenceDialogPayload } from "@investintell/ui";
+	import { Button } from "@investintell/ui/components/ui/button";
+	import { PanelEmptyState, PanelErrorState } from "@investintell/ui/runtime";
+	import { createClientApiClient } from "$wealth/api/client";
+	import type {
+		AuditEvent,
+		DDChapter,
+		DDReportFull,
+	} from "$wealth/types/dd-report";
+	import {
+		anchorColor,
+		anchorLabel,
+		chapterTitle,
+		confidenceColor,
+	} from "$wealth/types/dd-report";
+	import { flattenObject, renderMarkdown } from "$wealth/utils/render-markdown";
+
+	let { reportId }: { reportId: string } = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+
+	// Optional actor context — set by the host route when approval UI
+	// should be enabled. LibraryPreviewPane (read-only host) leaves
+	// this empty so the dialogs never render.
+	interface ActorContext {
+		actorId: string | null;
+		actorRole: string | null;
+	}
+	const actorCtx = getContext<ActorContext | null>("netz:dd-actor") ?? null;
+	const actorId = actorCtx?.actorId ?? null;
+	const actorRole = actorCtx?.actorRole ?? null;
+
+	const apiBase =
+		import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+	// ── Self-managed report state ────────────────────────────────────
+	let report = $state<DDReportFull | null>(null);
+	let loading = $state(true);
+	let loadError = $state<string | null>(null);
+
+	async function loadReport() {
+		loading = true;
+		loadError = null;
+		try {
+			const api = createClientApiClient(getToken);
+			report = await api.get<DDReportFull>(`/dd-reports/${reportId}`);
+		} catch (err: unknown) {
+			loadError =
+				err instanceof Error
+					? err.message
+					: "Failed to load DD report.";
+			report = null;
+		} finally {
+			loading = false;
+		}
+	}
+
+	// React to reportId changes (e.g. when LibraryPreviewPane swaps the
+	// selected document) — re-fetch when the prop flips.
+	$effect(() => {
+		void reportId;
+		void loadReport();
+	});
+
+	// ── Chapter state ────────────────────────────────────────────────
+	let chapters = $derived(
+		((report?.chapters ?? []) as DDChapter[]).toSorted(
+			(a, b) => a.chapter_order - b.chapter_order,
+		),
+	);
+	let activeChapterTag = $state<string | null>(null);
+	let activeChapter = $derived(
+		chapters.find((c) => c.chapter_tag === activeChapterTag) ??
+			chapters[0] ??
+			null,
+	);
+
+	$effect(() => {
+		if (!activeChapterTag && chapters.length > 0) {
+			activeChapterTag = chapters[0]!.chapter_tag;
+		}
+	});
+
+	// ── Approval logic ───────────────────────────────────────────────
+	const IC_ROLES = ["admin", "super_admin", "investment_team"];
+	let canApprove = $derived(
+		report !== null &&
+			report.status === "pending_approval" &&
+			actorRole !== null &&
+			IC_ROLES.includes(actorRole) &&
+			actorId !== report.created_by,
+	);
+
+	let approveDialogOpen = $state(false);
+	let rejectDialogOpen = $state(false);
+
+	let isApproveOverride = $derived(
+		report?.decision_anchor === "REJECT" ||
+			report?.decision_anchor === "CONDITIONAL",
+	);
+	let isRejectOverride = $derived(report?.decision_anchor === "APPROVE");
+
+	async function handleApprove(payload: ConsequenceDialogPayload) {
+		const api = createClientApiClient(getToken);
+		await api.post(`/dd-reports/${reportId}/approve`, {
+			rationale: payload.rationale,
+		});
+		approveDialogOpen = false;
+		await invalidateAll();
+		await loadReport();
+	}
+
+	async function handleReject(payload: ConsequenceDialogPayload) {
+		const api = createClientApiClient(getToken);
+		await api.post(`/dd-reports/${reportId}/reject`, {
+			reason: payload.rationale,
+		});
+		rejectDialogOpen = false;
+		await invalidateAll();
+		await loadReport();
+	}
+
+	// ── SSE generation progress ──────────────────────────────────────
+	interface GenerationEvent {
+		type: string;
+		chapter_tag?: string;
+		order?: number;
+		status?: string;
+		confidence_score?: number;
+		decision_anchor?: string;
+		error?: string;
+	}
+
+	let generationEvents = $state<GenerationEvent[]>([]);
+	let sseConnection: ReturnType<typeof createSSEStream<GenerationEvent>> | null = null;
+
+	function startSSE() {
+		if (!report || report.status !== "generating") return;
+		sseConnection?.disconnect();
+
+		sseConnection = createSSEStream<GenerationEvent>({
+			url: `${apiBase}/dd-reports/${reportId}/stream`,
+			getToken,
+			onEvent(event) {
+				generationEvents = [...generationEvents, event];
+				if (
+					event.type === "report_completed" ||
+					event.type === "report_failed"
+				) {
+					void loadReport();
+				}
+			},
+		});
+		sseConnection.connect();
+	}
+
+	$effect(() => {
+		if (report?.status === "generating") {
+			startSSE();
+		}
+	});
+
+	onMount(() => {
+		// Initial load is triggered by the reportId effect; nothing
+		// to do here besides letting the SSE effect react.
+	});
+
+	onDestroy(() => {
+		sseConnection?.disconnect();
+	});
+
+	// ── Regenerate / download ────────────────────────────────────────
+	let downloading = $state(false);
+	let regenerating = $state(false);
+
+	let canDownload = $derived(
+		report !== null &&
+			[
+				"completed",
+				"pending_approval",
+				"approved",
+				"published",
+			].includes(report.status),
+	);
+
+	async function downloadFactSheet() {
+		if (!report) return;
+		downloading = true;
+		try {
+			const token = await getToken();
+			const res = await fetch(
+				`${apiBase}/fact-sheets/dd-reports/${reportId}/download?language=pt`,
+				{ headers: { Authorization: `Bearer ${token}` } },
+			);
+			if (!res.ok) throw new Error(`Download failed: ${res.status}`);
+			const blob = await res.blob();
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `dd_report_${reportId}_pt.pdf`;
+			a.click();
+			URL.revokeObjectURL(url);
+		} catch (e) {
+			console.error("Fact sheet download failed:", e);
+		} finally {
+			downloading = false;
+		}
+	}
+
+	async function regenerate() {
+		regenerating = true;
+		try {
+			const api = createClientApiClient(getToken);
+			await api.post(`/dd-reports/${reportId}/regenerate`, {});
+			generationEvents = [];
+			await loadReport();
+			startSSE();
+		} finally {
+			regenerating = false;
+		}
+	}
+
+	// ── Audit trail ──────────────────────────────────────────────────
+	let auditTrailOpen = $state(false);
+	let auditEvents = $state<AuditEvent[]>([]);
+	let auditLoading = $state(false);
+
+	async function loadAuditTrail() {
+		if (auditEvents.length > 0) return;
+		auditLoading = true;
+		try {
+			const api = createClientApiClient(getToken);
+			auditEvents = await api.get<AuditEvent[]>(
+				`/dd-reports/${reportId}/audit-trail`,
+			);
+		} catch {
+			auditEvents = [];
+		} finally {
+			auditLoading = false;
+		}
+	}
+
+	function handleAuditToggle() {
+		auditTrailOpen = !auditTrailOpen;
+		if (auditTrailOpen) loadAuditTrail();
+	}
+
+	function auditActionLabel(action: string): string {
+		switch (action) {
+			case "CREATE":
+				return "Created";
+			case "UPDATE":
+				return "Updated";
+			case "APPROVE":
+				return "Approved";
+			case "REJECT":
+				return "Rejected";
+			case "REGENERATE":
+				return "Regenerated";
+			default:
+				return action;
+		}
+	}
+</script>
+
+{#if loading && report === null}
+	<PanelEmptyState
+		title="Loading DD report"
+		message="Fetching the report from the server..."
+	/>
+{:else if loadError}
+	<PanelErrorState
+		title="Unable to load DD report"
+		message={loadError}
+		onRetry={loadReport}
+	/>
+{:else if report === null}
+	<PanelEmptyState
+		title="Report unavailable"
+		message="This DD report is not available at the moment."
+	/>
+{:else}
+	<!-- ── Action bar (no breadcrumbs / no PageHeader) ───────────── -->
+	<div class="action-bar">
+		<StatusBadge status={report.status} />
+
+		{#if report.confidence_score !== null && report.confidence_score !== undefined}
+			<span
+				class="action-confidence"
+				style:color={confidenceColor(report.confidence_score)}
+			>
+				{formatPercent(Number(report.confidence_score) / 100, 1)}
+			</span>
+		{/if}
+
+		{#if report.decision_anchor}
+			<span
+				class="action-anchor"
+				style:color={anchorColor(report.decision_anchor)}
+			>
+				{anchorLabel(report.decision_anchor)}
+			</span>
+		{/if}
+
+		{#if canApprove}
+			<Button size="sm" onclick={() => (approveDialogOpen = true)}>Approve</Button>
+			<Button
+				size="sm"
+				variant="destructive"
+				onclick={() => (rejectDialogOpen = true)}
+			>
+				Reject
+			</Button>
+		{/if}
+
+		{#if report.status === "draft" || report.status === "rejected" || report.status === "failed"}
+			<Button
+				size="sm"
+				variant="outline"
+				onclick={regenerate}
+				disabled={regenerating}
+			>
+				{regenerating ? "Regenerating..." : "Regenerate"}
+			</Button>
+		{/if}
+
+		{#if canDownload}
+			<Button
+				size="sm"
+				variant="outline"
+				onclick={downloadFactSheet}
+				disabled={downloading}
+			>
+				{downloading ? "Downloading..." : "Download PDF"}
+			</Button>
+		{/if}
+	</div>
+
+	<!-- ── SSE generation progress ──────────────────────────────── -->
+	{#if report.status === "generating" || generationEvents.length > 0}
+		<div class="sse-banner">
+			<span class="sse-dot"></span>
+			<span class="sse-text">
+				{#if generationEvents.length === 0}
+					Generating report...
+				{:else}
+					{@const last = generationEvents[generationEvents.length - 1]!}
+					{#if last.type === "chapter_completed"}
+						Chapter {last.order}: {chapterTitle(last.chapter_tag ?? "")} completed
+					{:else if last.type === "chapter_started"}
+						Generating chapter {last.order}: {chapterTitle(last.chapter_tag ?? "")}...
+					{:else if last.type === "critic_started"}
+						Critic reviewing chapter {last.order}...
+					{:else if last.type === "report_completed"}
+						Report generation complete
+					{:else if last.type === "report_failed"}
+						Generation failed: {last.error ?? "Unknown error"}
+					{:else}
+						{last.type}
+					{/if}
+				{/if}
+			</span>
+		</div>
+	{/if}
+
+	<!-- ── Reading workbench ────────────────────────────────────── -->
+	<div class="workbench">
+		<nav class="chapter-nav" aria-label="Chapters">
+			{#each chapters as chapter (chapter.id)}
+				<button
+					class="chapter-nav-item"
+					class:active={activeChapterTag === chapter.chapter_tag}
+					onclick={() => (activeChapterTag = chapter.chapter_tag)}
+				>
+					<span class="chapter-order">{chapter.chapter_order}</span>
+					<span class="chapter-tag">{chapterTitle(chapter.chapter_tag)}</span>
+					{#if chapter.critic_status === "escalated"}
+						<span
+							class="chapter-critic-dot chapter-critic-dot--escalated"
+							title="Escalated"
+						></span>
+					{:else if chapter.critic_status === "accepted"}
+						<span
+							class="chapter-critic-dot chapter-critic-dot--accepted"
+							title="Accepted"
+						></span>
+					{/if}
+				</button>
+			{/each}
+		</nav>
+
+		<article class="chapter-content">
+			{#if activeChapter}
+				<header class="chapter-header">
+					<h2 class="chapter-title">{chapterTitle(activeChapter.chapter_tag)}</h2>
+					{#if activeChapter.generated_at}
+						<span class="chapter-generated">
+							Generated on {formatDateTime(activeChapter.generated_at)}
+						</span>
+					{/if}
+					{#if activeChapter.critic_status !== "pending"}
+						<span class="chapter-critic">
+							Critic: {activeChapter.critic_status} ({activeChapter.critic_iterations}
+							iteration{activeChapter.critic_iterations !== 1 ? "s" : ""})
+						</span>
+					{/if}
+				</header>
+
+				<div class="chapter-body">
+					<!-- renderMarkdown applies DOMPurify with strict ALLOWED_TAGS/ATTR allowlist.
+					     Backend also sanitizes via nh3 at the persist boundary. Two-layer defense. -->
+					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+					{@html renderMarkdown(activeChapter.content_md)}
+				</div>
+
+				{#if activeChapter.evidence_refs || activeChapter.quant_data}
+					<details class="evidence-section">
+						<summary class="evidence-toggle">View Sources & Evidence</summary>
+						<div class="evidence-content">
+							{#if activeChapter.evidence_refs}
+								<h4 class="evidence-title">Evidence References</h4>
+								<div class="evidence-grid">
+									{#each flattenObject(activeChapter.evidence_refs) as entry (entry.key)}
+										<div class="evidence-row">
+											<span class="evidence-key">{entry.key}</span>
+											<span class="evidence-val">{entry.value}</span>
+										</div>
+									{/each}
+								</div>
+							{/if}
+							{#if activeChapter.quant_data}
+								<h4 class="evidence-title">Quantitative Context</h4>
+								<div class="evidence-grid">
+									{#each flattenObject(activeChapter.quant_data) as entry (entry.key)}
+										<div class="evidence-row">
+											<span class="evidence-key">{entry.key}</span>
+											<span class="evidence-val">{entry.value}</span>
+										</div>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					</details>
+				{/if}
+			{:else}
+				<div class="chapter-empty">
+					<p>No chapters available.</p>
+				</div>
+			{/if}
+		</article>
+	</div>
+
+	<!-- ── Audit trail ──────────────────────────────────────────── -->
+	<div class="audit-section">
+		<button class="audit-toggle" onclick={handleAuditToggle}>
+			<span class="audit-toggle-icon">{auditTrailOpen ? "▾" : "▸"}</span>
+			Audit Trail
+		</button>
+
+		{#if auditTrailOpen}
+			<div class="audit-content">
+				{#if auditLoading}
+					<p class="audit-loading">Loading audit trail...</p>
+				{:else if auditEvents.length === 0}
+					<p class="audit-empty">No audit events recorded yet.</p>
+				{:else}
+					<div class="audit-timeline">
+						{#each auditEvents as event (event.id)}
+							<div class="audit-event">
+								<div class="audit-event-header">
+									<span class="audit-action">{auditActionLabel(event.action)}</span>
+									{#if event.created_at}
+										<span class="audit-date">{formatDateTime(event.created_at)}</span>
+									{/if}
+								</div>
+								{#if event.actor_id}
+									<span class="audit-actor">by {event.actor_id}</span>
+								{/if}
+								{#if event.after}
+									<div class="audit-detail">
+										{#each Object.entries(event.after) as [key, value] (key)}
+											{#if value !== null && value !== undefined}
+												<span class="audit-field">
+													<span class="audit-field-key">{key}:</span>
+													<span class="audit-field-val">
+														{typeof value === "object"
+															? JSON.stringify(value)
+															: String(value)}
+													</span>
+												</span>
+											{/if}
+										{/each}
+									</div>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<!-- ── Approval dialogs ─────────────────────────────────────── -->
+	<ConsequenceDialog
+		bind:open={approveDialogOpen}
+		title="Approve DD Report"
+		impactSummary="This report will be marked as approved and available for distribution."
+		requireRationale={true}
+		rationaleLabel="Approval Rationale"
+		rationalePlaceholder={isApproveOverride
+			? "This overrides the AI recommendation. Record the investment committee basis for this decision."
+			: "Record the investment committee basis for this approval."}
+		rationaleMinLength={10}
+		confirmLabel="Approve Report"
+		metadata={[
+			{
+				label: "AI Recommendation",
+				value: anchorLabel(report.decision_anchor),
+				emphasis: isApproveOverride,
+			},
+			{
+				label: "Confidence Score",
+				value:
+					report.confidence_score != null
+						? formatPercent(Number(report.confidence_score) / 100, 1)
+						: "—",
+			},
+		]}
+		onConfirm={handleApprove}
+	>
+		{#if isApproveOverride}
+			{#snippet consequenceList()}
+				<div class="override-warning">
+					Override detected — AI recommends "{anchorLabel(
+						report!.decision_anchor,
+					)}" but you are approving.
+				</div>
+			{/snippet}
+		{/if}
+	</ConsequenceDialog>
+
+	<ConsequenceDialog
+		bind:open={rejectDialogOpen}
+		title="Reject DD Report"
+		impactSummary="This report will be sent back to draft status for regeneration."
+		destructive={true}
+		requireRationale={true}
+		rationaleLabel="Rejection Reason"
+		rationalePlaceholder={isRejectOverride
+			? "This overrides the AI recommendation. Record the investment committee basis for this rejection."
+			: "Describe why this report does not meet committee standards."}
+		rationaleMinLength={10}
+		confirmLabel="Reject Report"
+		metadata={[
+			{
+				label: "AI Recommendation",
+				value: anchorLabel(report.decision_anchor),
+				emphasis: isRejectOverride,
+			},
+			{
+				label: "Confidence Score",
+				value:
+					report.confidence_score != null
+						? formatPercent(Number(report.confidence_score) / 100, 1)
+						: "—",
+			},
+		]}
+		onConfirm={handleReject}
+	>
+		{#if isRejectOverride}
+			{#snippet consequenceList()}
+				<div class="override-warning">
+					Override detected — AI recommends "{anchorLabel(
+						report!.decision_anchor,
+					)}" but you are rejecting.
+				</div>
+			{/snippet}
+		{/if}
+	</ConsequenceDialog>
+{/if}
+
+<style>
+	/* ── Action bar ──────────────────────────────────────────── */
+	.action-bar {
+		display: flex;
+		align-items: center;
+		gap: var(--ii-space-inline-sm, 10px);
+		padding: var(--ii-space-stack-xs, 8px) var(--ii-space-inline-lg, 24px);
+		border-bottom: 1px solid var(--ii-border-subtle);
+		background: var(--ii-surface-elevated);
+	}
+
+	.action-confidence {
+		font-size: var(--ii-text-body, 0.9375rem);
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.action-anchor {
+		font-size: var(--ii-text-small, 0.8125rem);
+		font-weight: 600;
+		padding: 2px 8px;
+		border-radius: var(--ii-radius-pill, 999px);
+		background: color-mix(in srgb, currentColor 10%, transparent);
+	}
+
+	/* ── SSE banner ──────────────────────────────────────────── */
+	.sse-banner {
+		display: flex;
+		align-items: center;
+		gap: var(--ii-space-inline-sm, 8px);
+		padding: var(--ii-space-stack-2xs, 6px) var(--ii-space-inline-md, 16px);
+		background: color-mix(in srgb, var(--ii-info) 10%, transparent);
+		border-bottom: 1px solid color-mix(in srgb, var(--ii-info) 20%, transparent);
+		font-size: var(--ii-text-small, 0.8125rem);
+		color: var(--ii-text-primary);
+	}
+
+	.sse-dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background: var(--ii-info);
+		animation: pulse-dot 1.5s ease infinite;
+		flex-shrink: 0;
+	}
+
+	@keyframes pulse-dot {
+		0%,
+		100% { opacity: 1; }
+		50% { opacity: 0.3; }
+	}
+
+	.sse-text {
+		flex: 1;
+	}
+
+	/* ── Workbench grid ──────────────────────────────────────── */
+	.workbench {
+		display: grid;
+		grid-template-columns: 220px 1fr;
+		min-height: 480px;
+		overflow: hidden;
+	}
+
+	.chapter-nav {
+		overflow-y: auto;
+		border-right: 1px solid var(--ii-border-subtle);
+		background: var(--ii-surface-elevated);
+		padding: var(--ii-space-stack-xs, 8px);
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.chapter-nav-item {
+		display: flex;
+		align-items: center;
+		gap: var(--ii-space-inline-xs, 8px);
+		padding: var(--ii-space-stack-2xs, 8px) var(--ii-space-inline-sm, 10px);
+		border: none;
+		border-radius: var(--ii-radius-sm, 8px);
+		background: transparent;
+		color: var(--ii-text-secondary);
+		font-size: var(--ii-text-small, 0.8125rem);
+		font-family: var(--ii-font-sans);
+		text-align: left;
+		cursor: pointer;
+		transition: background-color 120ms ease, color 120ms ease;
+	}
+
+	.chapter-nav-item:hover {
+		background: var(--ii-surface-alt);
+		color: var(--ii-text-primary);
+	}
+
+	.chapter-nav-item.active {
+		background: color-mix(in srgb, var(--ii-brand-primary) 12%, transparent);
+		color: var(--ii-brand-primary);
+		font-weight: 600;
+	}
+
+	.chapter-order {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
+		height: 22px;
+		border-radius: 50%;
+		background: var(--ii-surface-alt);
+		font-size: var(--ii-text-label, 0.75rem);
+		font-weight: 600;
+		flex-shrink: 0;
+	}
+
+	.chapter-nav-item.active .chapter-order {
+		background: var(--ii-brand-primary);
+		color: var(--ii-text-on-brand, #ffffff);
+	}
+
+	.chapter-tag {
+		flex: 1;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.chapter-critic-dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+
+	.chapter-critic-dot--accepted { background: var(--ii-success); }
+	.chapter-critic-dot--escalated { background: var(--ii-danger); }
+
+	.chapter-content {
+		overflow-y: auto;
+		padding: var(--ii-space-stack-md, 20px) var(--ii-space-inline-xl, 32px);
+		background: var(--ii-surface);
+	}
+
+	.chapter-header {
+		margin-bottom: var(--ii-space-stack-md, 20px);
+		padding-bottom: var(--ii-space-stack-sm, 12px);
+		border-bottom: 1px solid var(--ii-border-subtle);
+		display: flex;
+		flex-direction: column;
+		gap: var(--ii-space-stack-2xs, 4px);
+	}
+
+	.chapter-title {
+		font-size: var(--ii-text-h3, 1.375rem);
+		font-weight: 700;
+		color: var(--ii-text-primary);
+		line-height: var(--ii-leading-h3, 1.24);
+	}
+
+	.chapter-generated {
+		font-size: var(--ii-text-label, 0.75rem);
+		color: var(--ii-text-muted);
+		font-style: italic;
+	}
+
+	.chapter-critic {
+		font-size: var(--ii-text-label, 0.75rem);
+		color: var(--ii-text-secondary);
+	}
+
+	.chapter-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 200px;
+		color: var(--ii-text-muted);
+	}
+
+	.chapter-body {
+		max-width: 720px;
+		line-height: var(--ii-leading-body, 1.65);
+		color: var(--ii-text-primary);
+		font-size: var(--ii-text-body, 0.9375rem);
+	}
+
+	.chapter-body :global(h1) {
+		font-size: var(--ii-text-h2, 1.75rem);
+		font-weight: 700;
+		margin: var(--ii-space-stack-lg, 28px) 0 var(--ii-space-stack-sm, 12px);
+		color: var(--ii-text-primary);
+	}
+
+	.chapter-body :global(h2) {
+		font-size: var(--ii-text-h3, 1.375rem);
+		font-weight: 600;
+		margin: var(--ii-space-stack-md, 20px) 0 var(--ii-space-stack-xs, 8px);
+		color: var(--ii-text-primary);
+	}
+
+	.chapter-body :global(h3) {
+		font-size: var(--ii-text-h4, 1.125rem);
+		font-weight: 600;
+		margin: var(--ii-space-stack-sm, 16px) 0 var(--ii-space-stack-2xs, 4px);
+		color: var(--ii-text-primary);
+	}
+
+	.chapter-body :global(p) { margin: 0 0 var(--ii-space-stack-sm, 12px); }
+
+	.chapter-body :global(ul),
+	.chapter-body :global(ol) {
+		margin: 0 0 var(--ii-space-stack-sm, 12px);
+		padding-left: var(--ii-space-inline-lg, 24px);
+	}
+
+	.chapter-body :global(li) { margin: 0 0 var(--ii-space-stack-2xs, 4px); }
+
+	.chapter-body :global(code) {
+		font-family: var(--ii-font-mono);
+		font-size: var(--ii-text-mono, 0.875rem);
+		padding: 1px 5px;
+		border-radius: 4px;
+		background: var(--ii-surface-alt);
+	}
+
+	.chapter-body :global(table) {
+		width: 100%;
+		border-collapse: collapse;
+		margin: 1rem 0;
+		font-size: 0.875rem;
+	}
+
+	.chapter-body :global(th),
+	.chapter-body :global(td) {
+		border: 1px solid var(--ii-border-subtle);
+		padding: 0.5rem 0.75rem;
+		text-align: left;
+	}
+
+	.chapter-body :global(th) {
+		background: var(--ii-surface-alt);
+		font-weight: 600;
+	}
+
+	.chapter-body :global(hr) {
+		border: none;
+		border-top: 1px solid var(--ii-border-subtle);
+		margin: 1.5rem 0;
+	}
+
+	.chapter-body :global(blockquote) {
+		border-left: 3px solid var(--ii-border-subtle);
+		margin: 0 0 var(--ii-space-stack-sm, 12px);
+		padding-left: var(--ii-space-inline-md, 16px);
+		color: var(--ii-text-secondary);
+	}
+
+	.chapter-body :global(.rw-empty) {
+		color: var(--ii-text-muted);
+		font-style: italic;
+	}
+
+	/* ── Evidence section ────────────────────────────────────── */
+	.evidence-section {
+		margin-top: var(--ii-space-stack-lg, 28px);
+		border: 1px solid var(--ii-border-subtle);
+		border-radius: var(--ii-radius-sm, 8px);
+		overflow: hidden;
+	}
+
+	.evidence-toggle {
+		padding: var(--ii-space-stack-xs, 10px) var(--ii-space-inline-md, 16px);
+		font-size: var(--ii-text-small, 0.8125rem);
+		font-weight: 600;
+		color: var(--ii-text-secondary);
+		cursor: pointer;
+		background: var(--ii-surface-alt);
+		border-bottom: 1px solid var(--ii-border-subtle);
+	}
+
+	.evidence-toggle:hover { color: var(--ii-text-primary); }
+
+	.evidence-content {
+		padding: var(--ii-space-stack-sm, 12px) var(--ii-space-inline-md, 16px);
+		display: flex;
+		flex-direction: column;
+		gap: var(--ii-space-stack-md, 16px);
+	}
+
+	.evidence-title {
+		font-size: var(--ii-text-small, 0.8125rem);
+		font-weight: 600;
+		color: var(--ii-text-primary);
+		margin-bottom: var(--ii-space-stack-2xs, 4px);
+	}
+
+	.evidence-grid {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.evidence-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: var(--ii-space-inline-md, 16px);
+		padding: 3px 0;
+		font-size: var(--ii-text-label, 0.75rem);
+		border-bottom: 1px solid var(--ii-border-subtle);
+	}
+
+	.evidence-key {
+		color: var(--ii-text-muted);
+		flex-shrink: 0;
+		max-width: 50%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.evidence-val {
+		color: var(--ii-text-primary);
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+		word-break: break-all;
+	}
+
+	/* ── Override warning ────────────────────────────────────── */
+	.override-warning {
+		padding: var(--ii-space-stack-xs, 8px) var(--ii-space-inline-sm, 12px);
+		border-radius: var(--ii-radius-sm, 6px);
+		background: color-mix(in srgb, var(--ii-warning) 12%, transparent);
+		color: var(--ii-warning);
+		font-size: var(--ii-text-small, 0.8125rem);
+		font-weight: 500;
+	}
+
+	/* ── Audit trail ─────────────────────────────────────────── */
+	.audit-section { border-top: 1px solid var(--ii-border-subtle); }
+
+	.audit-toggle {
+		display: flex;
+		align-items: center;
+		gap: var(--ii-space-inline-xs, 6px);
+		width: 100%;
+		padding: var(--ii-space-stack-xs, 10px) var(--ii-space-inline-md, 16px);
+		border: none;
+		background: var(--ii-surface-elevated);
+		color: var(--ii-text-secondary);
+		font-size: var(--ii-text-small, 0.8125rem);
+		font-weight: 600;
+		font-family: var(--ii-font-sans);
+		cursor: pointer;
+		text-align: left;
+	}
+
+	.audit-toggle:hover {
+		color: var(--ii-text-primary);
+		background: var(--ii-surface-alt);
+	}
+
+	.audit-toggle-icon {
+		font-size: 10px;
+		width: 14px;
+		text-align: center;
+	}
+
+	.audit-content {
+		padding: var(--ii-space-stack-sm, 12px) var(--ii-space-inline-md, 16px);
+	}
+
+	.audit-loading,
+	.audit-empty {
+		font-size: var(--ii-text-small, 0.8125rem);
+		color: var(--ii-text-muted);
+	}
+
+	.audit-timeline {
+		display: flex;
+		flex-direction: column;
+		gap: var(--ii-space-stack-xs, 8px);
+	}
+
+	.audit-event {
+		padding: var(--ii-space-stack-xs, 8px) var(--ii-space-inline-sm, 12px);
+		border-left: 3px solid var(--ii-border-accent);
+		background: var(--ii-surface-alt);
+		border-radius: 0 var(--ii-radius-sm, 6px) var(--ii-radius-sm, 6px) 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.audit-event-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.audit-action {
+		font-size: var(--ii-text-small, 0.8125rem);
+		font-weight: 600;
+		color: var(--ii-text-primary);
+	}
+
+	.audit-date {
+		font-size: var(--ii-text-label, 0.75rem);
+		color: var(--ii-text-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.audit-actor {
+		font-size: var(--ii-text-label, 0.75rem);
+		color: var(--ii-text-secondary);
+	}
+
+	.audit-detail {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--ii-space-inline-xs, 6px);
+		margin-top: 4px;
+	}
+
+	.audit-field {
+		font-size: var(--ii-text-label, 0.75rem);
+		display: inline-flex;
+		gap: 3px;
+	}
+
+	.audit-field-key { color: var(--ii-text-muted); }
+
+	.audit-field-val {
+		color: var(--ii-text-secondary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	@media (max-width: 768px) {
+		.workbench {
+			grid-template-columns: 1fr;
+			grid-template-rows: auto 1fr;
+		}
+
+		.chapter-nav {
+			border-right: none;
+			border-bottom: 1px solid var(--ii-border-subtle);
+			flex-direction: row;
+			overflow-x: auto;
+			padding: var(--ii-space-stack-2xs, 4px);
+		}
+
+		.chapter-nav-item { white-space: nowrap; }
+		.chapter-tag { display: none; }
+
+		.chapter-content {
+			padding: var(--ii-space-stack-sm, 12px) var(--ii-space-inline-md, 16px);
+		}
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/readers/MacroReviewBody.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/readers/MacroReviewBody.svelte
@@ -1,0 +1,409 @@
+<!--
+  MacroReviewBody — standalone reader for a single weekly macro
+  committee review.
+
+  Phase 0 of the Wealth Library refactor: extracted from
+  routes/(app)/market/reviews/[reviewId]/+page.svelte so the same
+  body powers both the legacy route and the future LibraryPreviewPane.
+
+  Contract
+  --------
+  * Strictly props: only `reviewId`. Token comes from "netz:getToken".
+  * Self-contained client fetch via `/macro/reviews` (the existing
+    list endpoint — backend route surface is intentionally unchanged
+    in this phase, see Phase 0 spec).
+  * Optional `region` query-param highlighting still works in the
+    legacy route because the host page reads `$page.url` and passes
+    nothing — the body computes the highlight from
+    `globalThis.location.search` only when running in the browser.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatDate, formatNumber } from "@investintell/ui";
+	import { PanelEmptyState, PanelErrorState } from "@investintell/ui/runtime";
+	import { createClientApiClient } from "$wealth/api/client";
+	import { regimeLabel } from "$wealth/i18n/quant-labels";
+	import type { MacroReview } from "$wealth/types/macro";
+
+	let { reviewId }: { reviewId: string } = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+
+	// ── Self-managed review state ────────────────────────────────────
+	let review = $state<MacroReview | null>(null);
+	let loading = $state(true);
+	let loadError = $state<string | null>(null);
+
+	async function loadReview() {
+		loading = true;
+		loadError = null;
+		try {
+			const api = createClientApiClient(getToken);
+			const reviews = await api.get<MacroReview[]>("/macro/reviews", {
+				limit: 50,
+			});
+			review = reviews.find((r) => r.id === reviewId) ?? null;
+			if (review === null) {
+				loadError =
+					"This committee review is not in the latest 50 entries. It may have been archived.";
+			}
+		} catch (err: unknown) {
+			loadError =
+				err instanceof Error ? err.message : "Failed to load review.";
+			review = null;
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		void reviewId;
+		void loadReview();
+	});
+
+	let report = $derived(
+		(review?.report_json ?? {}) as Record<string, unknown>,
+	);
+
+	// Region highlight is read from the URL only on the client. The
+	// body never touches `$page` so it works inside any host shell.
+	let highlightRegion = $state("");
+	$effect(() => {
+		if (typeof globalThis !== "undefined" && globalThis.location) {
+			const params = new URLSearchParams(globalThis.location.search);
+			highlightRegion = (params.get("region") ?? "").toUpperCase();
+		}
+	});
+
+	interface ScoreDelta {
+		region: string;
+		previous_score: number;
+		current_score: number;
+		delta: number;
+		flagged: boolean;
+	}
+
+	let scoreDeltas = $derived(
+		(report.score_deltas ?? []) as ScoreDelta[],
+	);
+	let regime = $derived(
+		report.regime as Record<string, unknown> | null,
+	);
+	let stalenessAlerts = $derived(
+		(report.staleness_alerts ?? []) as string[],
+	);
+	let hasMaterialChanges = $derived(
+		report.has_material_changes as boolean | undefined,
+	);
+
+	function deltaColor(d: number): string {
+		if (d > 5) return "var(--ii-success)";
+		if (d < -5) return "var(--ii-danger)";
+		return "var(--ii-text-secondary)";
+	}
+
+	function regionDisplayName(code: string): string {
+		const names: Record<string, string> = {
+			US: "United States",
+			EUROPE: "Europe",
+			ASIA: "Asia Pacific",
+			EM: "Emerging Markets",
+		};
+		return names[code] ?? code;
+	}
+</script>
+
+{#if loading && review === null}
+	<PanelEmptyState
+		title="Loading committee review"
+		message="Fetching the review from the server..."
+	/>
+{:else if loadError}
+	<PanelErrorState
+		title="Unable to load committee review"
+		message={loadError}
+		onRetry={loadReview}
+	/>
+{:else if review === null}
+	<PanelEmptyState
+		title="Review unavailable"
+		message="This committee review is not available."
+	/>
+{:else}
+	<div class="review-page">
+		<h1 class="review-title">
+			Macro Committee Review
+			<span class="review-date">{formatDate(review.as_of_date)}</span>
+		</h1>
+
+		{#if review.is_emergency}
+			<span class="review-badge review-badge--emergency">Emergency</span>
+		{/if}
+		<span class="review-badge review-badge--{review.status}">
+			{review.status.replace(/_/g, " ")}
+		</span>
+
+		{#if hasMaterialChanges}
+			<p class="review-material">Material changes detected in this period.</p>
+		{/if}
+
+		{#if scoreDeltas.length > 0}
+			<section class="review-section">
+				<h2 class="review-section-title">Regional Score Changes</h2>
+				<div class="delta-grid">
+					{#each scoreDeltas as sd (sd.region)}
+						<div
+							class="delta-card"
+							class:delta-card--highlight={sd.region === highlightRegion}
+						>
+							<span class="delta-region">{regionDisplayName(sd.region)}</span>
+							<div class="delta-scores">
+								<span class="delta-prev">{formatNumber(sd.previous_score, 0)}</span>
+								<span class="delta-arrow">&rarr;</span>
+								<span
+									class="delta-curr"
+									style:color={deltaColor(sd.delta)}
+								>
+									{formatNumber(sd.current_score, 0)}
+								</span>
+							</div>
+							<span class="delta-change" style:color={deltaColor(sd.delta)}>
+								{sd.delta > 0 ? "+" : ""}{formatNumber(sd.delta, 1)}
+							</span>
+							{#if sd.flagged}
+								<span class="delta-flag">Flagged</span>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</section>
+		{/if}
+
+		{#if regime}
+			<section class="review-section">
+				<h2 class="review-section-title">Market Regime</h2>
+				{#if regime.global}
+					<p class="regime-global">
+						Global: <strong>{regimeLabel(String(regime.global))}</strong>
+					</p>
+				{/if}
+				{#if regime.regional}
+					<div class="regime-grid">
+						{#each Object.entries(regime.regional as Record<string, string>) as [region, regimeVal] (region)}
+							<div class="regime-item">
+								<span class="regime-label">{regionDisplayName(region)}</span>
+								<span class="regime-value">{regimeLabel(regimeVal)}</span>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</section>
+		{/if}
+
+		{#if stalenessAlerts.length > 0}
+			<section class="review-section">
+				<h2 class="review-section-title">Staleness Alerts</h2>
+				<ul class="alert-list">
+					{#each stalenessAlerts as alert (alert)}
+						<li>{alert}</li>
+					{/each}
+				</ul>
+			</section>
+		{/if}
+
+		{#if review.decision_rationale}
+			<section class="review-section">
+				<h2 class="review-section-title">Decision</h2>
+				<p class="review-rationale">{review.decision_rationale}</p>
+				{#if review.approved_by}
+					<p class="review-meta">
+						Approved by {review.approved_by} on
+						{review.approved_at ? formatDate(review.approved_at) : "—"}
+					</p>
+				{/if}
+			</section>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.review-page {
+		max-width: 900px;
+		margin: 0 auto;
+		padding: 24px;
+	}
+
+	.review-title {
+		font-size: 24px;
+		font-weight: 800;
+		color: var(--ii-text-primary);
+		margin: 0 0 8px;
+	}
+
+	.review-date {
+		font-size: 14px;
+		font-weight: 500;
+		color: var(--ii-text-muted);
+		margin-left: 12px;
+	}
+
+	.review-badge {
+		display: inline-block;
+		padding: 2px 10px;
+		border-radius: 999px;
+		font-size: 11px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+		margin-right: 8px;
+		margin-bottom: 16px;
+		background: var(--ii-surface-alt);
+		color: var(--ii-text-secondary);
+	}
+
+	.review-badge--published {
+		background: color-mix(in srgb, var(--ii-success) 18%, transparent);
+		color: var(--ii-success);
+	}
+
+	.review-badge--approved {
+		background: color-mix(in srgb, var(--ii-brand-primary) 18%, transparent);
+		color: var(--ii-brand-primary);
+	}
+
+	.review-badge--rejected,
+	.review-badge--emergency {
+		background: color-mix(in srgb, var(--ii-danger) 18%, transparent);
+		color: var(--ii-danger);
+	}
+
+	.review-material {
+		font-size: 13px;
+		color: var(--ii-warning);
+		font-weight: 600;
+		margin-bottom: 16px;
+	}
+
+	.review-section {
+		margin-top: 24px;
+		padding-top: 20px;
+		border-top: 1px solid var(--ii-border-subtle);
+	}
+
+	.review-section-title {
+		font-size: 11px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 1px;
+		color: var(--ii-text-muted);
+		margin: 0 0 12px;
+	}
+
+	.delta-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+		gap: 12px;
+	}
+
+	.delta-card {
+		padding: 14px;
+		border: 1px solid var(--ii-border-subtle);
+		border-radius: 10px;
+		background: var(--ii-surface);
+	}
+
+	.delta-card--highlight {
+		border-color: var(--ii-brand-primary);
+		box-shadow: 0 0 0 2px color-mix(in srgb, var(--ii-brand-primary) 15%, transparent);
+	}
+
+	.delta-region {
+		font-size: 14px;
+		font-weight: 700;
+		color: var(--ii-text-primary);
+		display: block;
+		margin-bottom: 8px;
+	}
+
+	.delta-scores {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-size: 20px;
+		font-weight: 800;
+	}
+
+	.delta-prev { color: var(--ii-text-muted); }
+	.delta-arrow { color: var(--ii-text-muted); font-size: 14px; }
+
+	.delta-change {
+		display: block;
+		font-size: 13px;
+		font-weight: 600;
+		margin-top: 4px;
+	}
+
+	.delta-flag {
+		display: inline-block;
+		margin-top: 6px;
+		padding: 1px 8px;
+		border-radius: 999px;
+		font-size: 10px;
+		font-weight: 700;
+		background: color-mix(in srgb, var(--ii-danger) 18%, transparent);
+		color: var(--ii-danger);
+		text-transform: uppercase;
+	}
+
+	.regime-global {
+		font-size: 14px;
+		color: var(--ii-text-primary);
+		margin-bottom: 12px;
+	}
+
+	.regime-grid {
+		display: flex;
+		gap: 16px;
+		flex-wrap: wrap;
+	}
+
+	.regime-item {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.regime-label {
+		font-size: 11px;
+		color: var(--ii-text-muted);
+		font-weight: 600;
+		text-transform: uppercase;
+	}
+
+	.regime-value {
+		font-size: 13px;
+		font-weight: 700;
+		color: var(--ii-text-primary);
+	}
+
+	.alert-list {
+		margin: 0;
+		padding-left: 18px;
+		font-size: 13px;
+		color: var(--ii-text-secondary);
+	}
+
+	.alert-list li { margin-bottom: 4px; }
+
+	.review-rationale {
+		font-size: 14px;
+		color: var(--ii-text-primary);
+		line-height: 1.6;
+	}
+
+	.review-meta {
+		font-size: 12px;
+		color: var(--ii-text-muted);
+		margin-top: 8px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/library/readers/MacroReviewBody.svelte
+++ b/packages/ii-terminal-core/src/lib/components/library/readers/MacroReviewBody.svelte
@@ -21,9 +21,9 @@
 	import { getContext } from "svelte";
 	import { formatDate, formatNumber } from "@investintell/ui";
 	import { PanelEmptyState, PanelErrorState } from "@investintell/ui/runtime";
-	import { createClientApiClient } from "$wealth/api/client";
-	import { regimeLabel } from "$wealth/i18n/quant-labels";
-	import type { MacroReview } from "$wealth/types/macro";
+	import { createClientApiClient } from "../../../api/client";
+	import { regimeLabel } from "../../../i18n/quant-labels";
+	import type { MacroReview } from "../../../types/macro";
 
 	let { reviewId }: { reviewId: string } = $props();
 

--- a/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationPanel.svelte
@@ -1,0 +1,863 @@
+<!--
+  CalibrationPanel — Builder right-rail surface that exposes the
+  63-input calibration model to the PM (DL5).
+
+  Phase 4 Task 4.1 + 4.2 of the portfolio-enterprise-workbench plan.
+  Replaces the legacy PolicyPanel no-op: every field writes to the
+  typed ``portfolio_calibration`` row via the new GET/PUT backend
+  route. The panel holds a local draft and ONLY persists on Apply
+  (Preview triggers an in-flight preview fetch but never touches the
+  DB). DL5 is explicit about this.
+
+  Tier structure (OD-1 default = Basic, user can expand):
+    - Basic (5)    — mandate, cvar_limit, max_single_fund_weight,
+                     turnover_cap, stress_scenarios_active
+    - Advanced (10) — regime_override + BL + GARCH + turnover lambda
+                     + stress severity + advisor + cvar level + risk
+                     aversion + shrinkage
+    - Expert (48)  — accordion over the ``expert_overrides`` JSONB
+                     with arbitrary key/value rows
+
+  DL15 (no localStorage) — the draft lives in component $state and
+  is lost on unmount if not Applied. DL16 (formatter discipline) —
+  every number renders via @investintell/ui formatters.
+-->
+<script lang="ts">
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import { formatNumber, formatShortDate } from "@investintell/ui";
+	import type {
+		PortfolioCalibration,
+		PortfolioCalibrationUpdate,
+		CalibrationMandate,
+		StressScenarioId,
+	} from "$wealth/types/portfolio-calibration";
+	import { calibrationsEqual } from "$wealth/types/portfolio-calibration";
+	import CalibrationSliderField from "./CalibrationSliderField.svelte";
+	import CalibrationSelectField from "./CalibrationSelectField.svelte";
+	import CalibrationToggleField from "./CalibrationToggleField.svelte";
+	import CalibrationScenarioGroup from "./CalibrationScenarioGroup.svelte";
+	import RiskBudgetPanel from "./RiskBudgetPanel.svelte";
+
+	// ── Tier + preview state ─────────────────────────────────────
+	let tier = $state<"basic" | "advanced" | "expert">("basic");
+	let isPreviewing = $state(false);
+	let previewError = $state<string | null>(null);
+	let previewTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const calibration = $derived(workspace.calibration);
+	const loading = $derived(workspace.isLoadingCalibration);
+	const applying = $derived(workspace.isApplyingCalibration);
+
+	// PR-A5 F.1 — snapshot of the calibration as of the most recent
+	// construction run. Drives the per-field "Anteriormente" overlay
+	// in every CalibrationField. Loose typing is intentional — the
+	// snapshot JSONB schema evolves with calibration; readers cast
+	// per known key with safe fallbacks.
+	const snapshot = $derived(
+		(workspace.constructionRun?.calibration_snapshot ?? null) as
+			| (Partial<PortfolioCalibration> & Record<string, unknown>)
+			| null,
+	);
+
+	// ── TAA regime indicator state (Sprint 4) ────────────────────
+
+	// Local working copy of the calibration — cloned on load + on portfolio switch.
+	let draft = $state<PortfolioCalibration | null>(null);
+
+	// Sync draft when the backend snapshot changes (new portfolio, or Apply reload).
+	$effect(() => {
+		const snap = calibration;
+		if (snap === null) {
+			draft = null;
+			return;
+		}
+		if (!draft || draft.portfolio_id !== snap.portfolio_id) {
+			draft = structuredClone(snap);
+		}
+	});
+
+	const dirty = $derived.by(() => {
+		if (!draft || !calibration) return false;
+		return !calibrationsEqual(draft, calibration);
+	});
+
+	/**
+	 * Partial updater — the field components drive every edit through
+	 * this single function so the ``draft`` is always a fresh object
+	 * (Svelte 5 tracks identity, not deep mutation).
+	 */
+	function update(patch: Partial<PortfolioCalibration>) {
+		if (!draft) return;
+		draft = { ...draft, ...patch };
+	}
+
+	// ── Option catalogs (OD-22 locked for regime labels) ──────────
+	const MANDATE_OPTIONS = [
+		{ value: "conservative", label: "Conservative" },
+		{ value: "moderate", label: "Moderate" },
+		{ value: "balanced", label: "Balanced" },
+		{ value: "aggressive", label: "Aggressive" },
+	] as const;
+
+	const REGIME_OPTIONS = [
+		{ value: "auto", label: "Auto (engine-detected)" },
+		{ value: "NORMAL", label: "Balanced" },
+		{ value: "RISK_ON", label: "Expansion" },
+		{ value: "RISK_OFF", label: "Defensive" },
+		{ value: "CRISIS", label: "Stress" },
+		{ value: "INFLATION", label: "Inflation" },
+	] as const;
+
+	const CVAR_LEVEL_OPTIONS = [
+		{ value: "0.90", label: "90%" },
+		{ value: "0.95", label: "95% (default)" },
+		{ value: "0.99", label: "99%" },
+	] as const;
+
+	const STRESS_OPTIONS: readonly { value: StressScenarioId; label: string }[] = [
+		{ value: "gfc_2008", label: "GFC 2008" },
+		{ value: "covid_2020", label: "COVID 2020" },
+		{ value: "taper_2013", label: "Taper Tantrum 2013" },
+		{ value: "rate_shock_200bps", label: "Rate Shock +200bps" },
+	];
+
+	// ── Nullable-value sentinels ─────────────────────────────────
+	// These convert null to a display sentinel for the slider (which
+	// cannot bind to null) and back at diff time. 1.0 = "no cap" for
+	// turnover, "auto" = null for regime, etc.
+	const TURNOVER_CAP_SENTINEL = 1.0;
+	const TURNOVER_LAMBDA_SENTINEL = 1.0;
+	const LAMBDA_RISK_AVERSION_SENTINEL = 2.0;
+	const SHRINKAGE_SENTINEL = 0.5;
+
+	// ── Preview + Apply ───────────────────────────────────────────
+
+	/**
+	 * Preview — DL5 mandates an explicit user action, NEVER reactive.
+	 * The button kicks off a 1500ms debounce so a PM who presses it
+	 * twice in quick succession only fires one request. Preview does
+	 * not mutate the backend; in v1 it acts as "apply + construct"
+	 * because a dedicated ``/construct/preview`` endpoint is a v1.1
+	 * item. The dirty draft is flushed to the backend, then the
+	 * construction job runs so the PM can see the narrative update.
+	 */
+	function schedulePreview() {
+		if (!draft || !calibration || !dirty) return;
+		if (previewTimer) clearTimeout(previewTimer);
+		isPreviewing = true;
+		previewError = null;
+		previewTimer = setTimeout(async () => {
+			const applied = await workspace.applyCalibration(diffPatch(calibration!, draft!));
+			if (!applied) {
+				isPreviewing = false;
+				previewError = workspace.lastError?.message ?? "Preview failed to persist";
+				return;
+			}
+			await workspace.runBuildJob();
+			isPreviewing = false;
+		}, 1500);
+	}
+
+	async function handleApply() {
+		if (!draft || !calibration) return;
+		const patch = diffPatch(calibration, draft);
+		const next = await workspace.applyCalibration(patch);
+		if (next) draft = structuredClone(next);
+	}
+
+	function handleReset() {
+		if (calibration) draft = structuredClone(calibration);
+	}
+
+	/**
+	 * Compute the partial-update body the backend expects (``exclude_unset``
+	 * semantics). Only includes fields that changed between ``base`` and
+	 * ``next`` so we don't clobber fields the user did not touch.
+	 */
+	function diffPatch(
+		base: PortfolioCalibration,
+		next: PortfolioCalibration,
+	): PortfolioCalibrationUpdate {
+		const patch: PortfolioCalibrationUpdate = {};
+		if (base.mandate !== next.mandate) patch.mandate = next.mandate;
+		if (base.cvar_limit !== next.cvar_limit) patch.cvar_limit = next.cvar_limit;
+		if (base.max_single_fund_weight !== next.max_single_fund_weight)
+			patch.max_single_fund_weight = next.max_single_fund_weight;
+		if (base.turnover_cap !== next.turnover_cap) patch.turnover_cap = next.turnover_cap;
+		const activeChanged =
+			base.stress_scenarios_active.length !== next.stress_scenarios_active.length ||
+			base.stress_scenarios_active.some((v, i) => v !== next.stress_scenarios_active[i]);
+		if (activeChanged) patch.stress_scenarios_active = next.stress_scenarios_active;
+
+		if (base.regime_override !== next.regime_override)
+			patch.regime_override = next.regime_override;
+		if (base.bl_enabled !== next.bl_enabled) patch.bl_enabled = next.bl_enabled;
+		if (base.bl_view_confidence_default !== next.bl_view_confidence_default)
+			patch.bl_view_confidence_default = next.bl_view_confidence_default;
+		if (base.garch_enabled !== next.garch_enabled) patch.garch_enabled = next.garch_enabled;
+		if (base.turnover_lambda !== next.turnover_lambda)
+			patch.turnover_lambda = next.turnover_lambda;
+		if (base.stress_severity_multiplier !== next.stress_severity_multiplier)
+			patch.stress_severity_multiplier = next.stress_severity_multiplier;
+		if (base.advisor_enabled !== next.advisor_enabled)
+			patch.advisor_enabled = next.advisor_enabled;
+		if (base.cvar_level !== next.cvar_level) patch.cvar_level = next.cvar_level;
+		if (base.lambda_risk_aversion !== next.lambda_risk_aversion)
+			patch.lambda_risk_aversion = next.lambda_risk_aversion;
+		if (base.shrinkage_intensity_override !== next.shrinkage_intensity_override)
+			patch.shrinkage_intensity_override = next.shrinkage_intensity_override;
+
+		const baseKeys = Object.keys(base.expert_overrides);
+		const nextKeys = Object.keys(next.expert_overrides);
+		const sameShape =
+			baseKeys.length === nextKeys.length &&
+			baseKeys.every((k) => base.expert_overrides[k] === next.expert_overrides[k]);
+		if (!sameShape) patch.expert_overrides = next.expert_overrides;
+
+		return patch;
+	}
+
+	// ── Expert tier row editor ────────────────────────────────────
+	let newExpertKey = $state("");
+	let newExpertValue = $state("");
+
+	function addExpertKey() {
+		if (!draft || !newExpertKey.trim()) return;
+		draft = {
+			...draft,
+			expert_overrides: {
+				...draft.expert_overrides,
+				[newExpertKey.trim()]: coerceExpertValue(newExpertValue),
+			},
+		};
+		newExpertKey = "";
+		newExpertValue = "";
+	}
+
+	function removeExpertKey(key: string) {
+		if (!draft) return;
+		const next = { ...draft.expert_overrides };
+		delete next[key];
+		draft = { ...draft, expert_overrides: next };
+	}
+
+	function coerceExpertValue(raw: string): unknown {
+		const trimmed = raw.trim();
+		if (trimmed === "") return null;
+		if (trimmed === "true") return true;
+		if (trimmed === "false") return false;
+		const asNumber = Number(trimmed);
+		if (!Number.isNaN(asNumber)) return asNumber;
+		return trimmed;
+	}
+
+	function formatExpertValue(value: unknown): string {
+		if (value === null || value === undefined) return "—";
+		if (typeof value === "number") return formatNumber(value, 4);
+		if (typeof value === "boolean") return value ? "true" : "false";
+		if (typeof value === "string") return value;
+		return JSON.stringify(value);
+	}
+
+	const expertEntries = $derived.by(() => {
+		if (!draft) return [];
+		return Object.entries(draft.expert_overrides).sort(([a], [b]) => a.localeCompare(b));
+	});
+</script>
+
+{#if !workspace.portfolio}
+	<div class="cp-empty">
+		<div class="cp-empty-block">
+			<span class="cp-empty-title">NO PORTFOLIO SELECTED</span>
+			<span class="cp-empty-msg">Select a model portfolio on the left to edit its calibration.</span>
+		</div>
+	</div>
+{:else if loading && !draft}
+	<div class="cp-empty">
+		<div class="cp-empty-block">
+			<span class="cp-empty-title">LOADING CALIBRATION</span>
+			<span class="cp-empty-msg">Fetching the 63-input surface from the backend.</span>
+		</div>
+	</div>
+{:else if !draft}
+	<div class="cp-empty">
+		<div class="cp-empty-block">
+			<span class="cp-empty-title">CALIBRATION UNAVAILABLE</span>
+			<span class="cp-empty-msg">{workspace.lastError?.message ?? "Calibration could not be loaded for this portfolio."}</span>
+		</div>
+	</div>
+{:else}
+	<div class="cp-root">
+		<div class="cp-tabs" role="tablist">
+			<button type="button" role="tab" class="cp-tab" class:cp-tab--active={tier === "basic"}
+				aria-selected={tier === "basic"} onclick={() => (tier = "basic")}>BASIC</button>
+			<button type="button" role="tab" class="cp-tab" class:cp-tab--active={tier === "advanced"}
+				aria-selected={tier === "advanced"} onclick={() => (tier = "advanced")}>ADVANCED</button>
+			<button type="button" role="tab" class="cp-tab" class:cp-tab--active={tier === "expert"}
+				aria-selected={tier === "expert"} onclick={() => (tier = "expert")}>EXPERT</button>
+		</div>
+
+		{#if tier === "basic"}
+			<!-- ── Basic tier (5 fields) ───────────────────────────── -->
+			<section class="cp-section" role="tabpanel">
+					<CalibrationSelectField
+						id="cp-mandate"
+						label="Mandate"
+						description="Risk profile archetype — drives downstream defaults for tail loss budget, diversification, and turnover."
+						value={draft.mandate}
+						onChange={(v) => update({ mandate: v as CalibrationMandate })}
+						options={MANDATE_OPTIONS}
+						originalValue={snapshot?.mandate as string | undefined}
+					/>
+
+					{#if workspace.portfolio}
+						<RiskBudgetPanel
+							portfolio={workspace.portfolio}
+							calibration={draft}
+							snapshot={snapshot}
+							onChange={(patch) => update(patch)}
+						/>
+					{/if}
+
+					<CalibrationSliderField
+						id="cp-max-weight"
+						label="Max single-fund weight"
+						description="Hard cap on concentration in any one instrument."
+						value={draft.max_single_fund_weight}
+						onChange={(v) => update({ max_single_fund_weight: v })}
+						min={0.05}
+						max={0.4}
+						step={0.01}
+						displayFormat="percent"
+						digits={1}
+						originalValue={snapshot?.max_single_fund_weight as number | undefined}
+					/>
+
+					<CalibrationSliderField
+						id="cp-turnover-cap"
+						label="Turnover cap"
+						description="Upper bound on rebalance trading — 100% means no cap."
+						value={draft.turnover_cap ?? TURNOVER_CAP_SENTINEL}
+						onChange={(v) => update({ turnover_cap: v })}
+						min={0.05}
+						max={1.0}
+						step={0.05}
+						displayFormat="percent"
+						digits={0}
+						originalValue={snapshot == null
+							? undefined
+							: ((snapshot.turnover_cap ?? TURNOVER_CAP_SENTINEL) as number)}
+					/>
+
+					<CalibrationScenarioGroup
+						label="Active stress scenarios"
+						description="Scenarios run at every construction — drive the Builder Stress matrix."
+						value={draft.stress_scenarios_active}
+						onChange={(v) => update({ stress_scenarios_active: v })}
+						options={STRESS_OPTIONS}
+						originalValue={snapshot?.stress_scenarios_active as
+							| readonly StressScenarioId[]
+							| undefined}
+					/>
+				</section>
+		{:else if tier === "advanced"}
+			<!-- ── Advanced tier (10 fields) ───────────────────────── -->
+			<section class="cp-section" role="tabpanel">
+					<CalibrationSelectField
+						id="cp-regime-override"
+						label="Regime override"
+						description="Force a regime to pin covariance shrinkage. ``Auto`` leaves it to the engine."
+						value={draft.regime_override ?? "auto"}
+						onChange={(v) =>
+							update({
+								regime_override: v === "auto"
+									? null
+									: (v as PortfolioCalibration["regime_override"]),
+							})}
+						options={REGIME_OPTIONS}
+						originalValue={snapshot == null
+							? undefined
+							: ((snapshot.regime_override as string | null | undefined) ?? "auto")}
+					/>
+
+					<CalibrationToggleField
+						id="cp-bl-enabled"
+						label="Expected return blending"
+						description="Enable the Bayesian blend of the prior with IC views. Off = equilibrium prior only."
+						value={draft.bl_enabled}
+						onChange={(v) => update({ bl_enabled: v })}
+						originalValue={snapshot?.bl_enabled as boolean | undefined}
+					/>
+
+					<CalibrationSliderField
+						id="cp-bl-confidence"
+						label="BL view confidence (default)"
+						description="Default confidence applied to new IC views — higher pulls the posterior closer to the view."
+						value={draft.bl_view_confidence_default}
+						onChange={(v) => update({ bl_view_confidence_default: v })}
+						min={0}
+						max={1}
+						step={0.05}
+						displayFormat="raw"
+						digits={2}
+						disabled={!draft.bl_enabled}
+						originalValue={snapshot?.bl_view_confidence_default as number | undefined}
+					/>
+
+					<CalibrationToggleField
+						id="cp-garch-enabled"
+						label="Forward-looking volatility"
+						description="Use forward-looking conditional volatility instead of realized vol."
+						value={draft.garch_enabled}
+						onChange={(v) => update({ garch_enabled: v })}
+						originalValue={snapshot?.garch_enabled as boolean | undefined}
+					/>
+
+					<CalibrationSliderField
+						id="cp-turnover-lambda"
+						label="Turnover penalty"
+						description="L1 penalty weight on turnover inside the optimizer objective."
+						value={draft.turnover_lambda ?? TURNOVER_LAMBDA_SENTINEL}
+						onChange={(v) => update({ turnover_lambda: v })}
+						min={0.1}
+						max={10}
+						step={0.1}
+						displayFormat="raw"
+						digits={1}
+						originalValue={snapshot == null
+							? undefined
+							: ((snapshot.turnover_lambda ?? TURNOVER_LAMBDA_SENTINEL) as number)}
+					/>
+
+					<CalibrationSliderField
+						id="cp-stress-multiplier"
+						label="Stress severity multiplier"
+						description="Scales the preset stress shocks — 1.0 = canonical severity."
+						value={draft.stress_severity_multiplier}
+						onChange={(v) => update({ stress_severity_multiplier: v })}
+						min={0.5}
+						max={2.0}
+						step={0.05}
+						displayFormat="x"
+						digits={2}
+						originalValue={snapshot?.stress_severity_multiplier as number | undefined}
+					/>
+
+					<CalibrationToggleField
+						id="cp-advisor-enabled"
+						label="Construction advisor"
+						description="Enable the credit-side advisor that recommends fund additions to close risk budget gaps."
+						value={draft.advisor_enabled}
+						onChange={(v) => update({ advisor_enabled: v })}
+						originalValue={snapshot?.advisor_enabled as boolean | undefined}
+					/>
+
+					<CalibrationSelectField
+						id="cp-cvar-level"
+						label="Tail loss confidence level"
+						description="Confidence level used for the tail loss budget."
+						value={draft.cvar_level.toString()}
+						onChange={(v) => update({ cvar_level: Number.parseFloat(v) })}
+						options={CVAR_LEVEL_OPTIONS}
+						originalValue={snapshot?.cvar_level == null
+							? undefined
+							: (snapshot.cvar_level as number).toString()}
+					/>
+
+					<CalibrationSliderField
+						id="cp-risk-aversion"
+						label="Risk aversion"
+						description="Coefficient on variance in the utility — higher = more conservative."
+						value={draft.lambda_risk_aversion ?? LAMBDA_RISK_AVERSION_SENTINEL}
+						onChange={(v) => update({ lambda_risk_aversion: v })}
+						min={0.5}
+						max={5}
+						step={0.1}
+						displayFormat="raw"
+						digits={1}
+						originalValue={snapshot == null
+							? undefined
+							: ((snapshot.lambda_risk_aversion ?? LAMBDA_RISK_AVERSION_SENTINEL) as number)}
+					/>
+
+					<CalibrationSliderField
+						id="cp-shrinkage"
+						label="Shrinkage intensity override"
+						description="Covariance shrinkage override (0..1). Leave at default for auto-selection."
+						value={draft.shrinkage_intensity_override ?? SHRINKAGE_SENTINEL}
+						onChange={(v) => update({ shrinkage_intensity_override: v })}
+						min={0}
+						max={1}
+						step={0.05}
+						displayFormat="raw"
+						digits={2}
+						originalValue={snapshot == null
+							? undefined
+							: ((snapshot.shrinkage_intensity_override ?? SHRINKAGE_SENTINEL) as number)}
+					/>
+				</section>
+		{:else if tier === "expert"}
+			<!-- ── Expert tier (arbitrary JSONB overrides) ─────────── -->
+			<section class="cp-section" role="tabpanel">
+					<p class="cp-expert-hint">
+						Expert overrides are free-form key/value pairs stored in
+						<code>expert_overrides</code> JSONB. Use only for optimizer knobs
+						that have not graduated to typed columns.
+					</p>
+
+					{#if expertEntries.length === 0}
+						<p class="cp-expert-empty">No expert overrides set.</p>
+					{:else}
+						<ul class="cp-expert-list">
+							{#each expertEntries as [k, v] (k)}
+								<li class="cp-expert-row">
+									<span class="cp-expert-key">{k}</span>
+									<span class="cp-expert-value">{formatExpertValue(v)}</span>
+									<button
+										type="button"
+										class="cp-expert-remove"
+										onclick={() => removeExpertKey(k)}
+										aria-label={`Remove ${k}`}
+									>
+										×
+									</button>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+
+					<div class="cp-expert-add">
+						<input
+							type="text"
+							class="cp-expert-input"
+							placeholder="knob_name"
+							bind:value={newExpertKey}
+						/>
+						<input
+							type="text"
+							class="cp-expert-input"
+							placeholder="value (number / true / false / text)"
+							bind:value={newExpertValue}
+						/>
+						<button
+							type="button"
+							class="cp-expert-add-btn"
+							onclick={addExpertKey}
+							disabled={!newExpertKey.trim()}
+						>
+							ADD
+						</button>
+					</div>
+			</section>
+		{/if}
+
+		<!-- ── Preview + Apply row (DL5) ───────────────────────── -->
+		<footer class="cp-footer">
+			<div class="cp-footer-status">
+				{#if applying}
+					<span class="cp-status cp-status--pending">Applying…</span>
+				{:else if isPreviewing}
+					<span class="cp-status cp-status--pending">Previewing…</span>
+				{:else if dirty}
+					<span class="cp-status cp-status--dirty">Unsaved edits</span>
+				{:else if calibration}
+					<span class="cp-status cp-status--clean">
+						Saved · last updated {formatShortDate(calibration.updated_at)}
+					</span>
+				{/if}
+				{#if previewError}
+					<span class="cp-status cp-status--error">{previewError}</span>
+				{/if}
+			</div>
+			<div class="cp-footer-actions">
+				<button type="button" class="cp-action cp-action--ghost"
+					disabled={!dirty || applying || isPreviewing}
+					onclick={handleReset}>RESET</button>
+				<button type="button" class="cp-action cp-action--outline"
+					disabled={!dirty || applying || isPreviewing}
+					onclick={schedulePreview}>PREVIEW</button>
+				<button type="button" class="cp-action cp-action--primary"
+					disabled={!dirty || applying || isPreviewing}
+					onclick={handleApply}>APPLY</button>
+			</div>
+		</footer>
+	</div>
+{/if}
+
+<style>
+	.cp-root {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		min-height: 0;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.cp-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: var(--terminal-space-6);
+		height: 100%;
+		font-family: var(--terminal-font-mono);
+		background: var(--terminal-bg-panel);
+	}
+	.cp-empty-block {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+	.cp-empty-title {
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+	}
+	.cp-empty-msg {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		text-align: center;
+		max-width: 280px;
+		line-height: var(--terminal-leading-normal);
+	}
+
+	.cp-tabs {
+		display: flex;
+		align-items: stretch;
+		height: 32px;
+		padding: 0;
+		flex-shrink: 0;
+		border-bottom: var(--terminal-border-hairline);
+	}
+	.cp-tab {
+		display: inline-flex;
+		align-items: center;
+		padding: 0 var(--terminal-space-3);
+		background: transparent;
+		border: none;
+		border-bottom: 2px solid transparent;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+		cursor: pointer;
+		transition:
+			color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			border-color var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.cp-tab:hover {
+		color: var(--terminal-accent-amber);
+	}
+	.cp-tab--active {
+		color: var(--terminal-accent-amber);
+		border-bottom-color: var(--terminal-accent-amber);
+	}
+	.cp-tab:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -2px;
+	}
+
+	.cp-section {
+		display: flex;
+		flex-direction: column;
+		gap: 20px;
+		padding: 20px 16px;
+		overflow-y: auto;
+		min-height: 0;
+	}
+
+	/* Expert tier styling ── */
+	.cp-expert-hint {
+		margin: 0;
+		font-size: 11px;
+		line-height: 1.5;
+		color: var(--terminal-fg-muted);
+	}
+	.cp-expert-hint code {
+		background: var(--terminal-bg-panel-raised);
+		padding: 1px 5px;
+		font-size: 10px;
+	}
+	.cp-expert-empty {
+		font-size: 12px;
+		color: var(--terminal-fg-muted);
+		font-style: italic;
+		margin: 0;
+	}
+	.cp-expert-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	.cp-expert-row {
+		display: grid;
+		grid-template-columns: 1fr 1fr 24px;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 8px;
+		background: var(--terminal-bg-panel-sunken);
+	}
+	.cp-expert-key {
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.cp-expert-value {
+		font-size: 12px;
+		color: var(--terminal-fg-muted);
+		font-variant-numeric: tabular-nums;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.cp-expert-remove {
+		width: 20px;
+		height: 20px;
+		border: none;
+		background: transparent;
+		color: var(--terminal-fg-muted);
+		cursor: pointer;
+		font-size: 14px;
+		line-height: 1;
+	}
+	.cp-expert-remove:hover {
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-status-error);
+	}
+	.cp-expert-add {
+		display: grid;
+		grid-template-columns: 1fr 1fr auto;
+		gap: 8px;
+		padding-top: 8px;
+		border-top: var(--terminal-border-hairline);
+	}
+	.cp-expert-input {
+		height: 30px;
+		padding: 0 8px;
+		font-size: 12px;
+		border: var(--terminal-border-hairline);
+		background: transparent;
+		color: var(--terminal-fg-primary);
+		font-family: inherit;
+	}
+	.cp-expert-input:focus {
+		outline: none;
+		border-color: var(--terminal-accent-amber);
+	}
+	.cp-expert-add-btn {
+		height: 28px;
+		padding: 0 var(--terminal-space-3);
+		background: transparent;
+		color: var(--terminal-fg-secondary);
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+	.cp-expert-add-btn:hover:not(:disabled) {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+	.cp-expert-add-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	/* Footer ── */
+	.cp-footer {
+		flex-shrink: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		padding: 12px 16px;
+		border-top: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+	}
+	.cp-footer-status {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		min-width: 0;
+	}
+	.cp-status {
+		font-size: 11px;
+		font-weight: 600;
+	}
+	.cp-status--clean {
+		color: var(--terminal-fg-muted);
+	}
+	.cp-status--dirty {
+		color: var(--terminal-status-warn);
+	}
+	.cp-status--pending {
+		color: var(--terminal-accent-cyan);
+	}
+	.cp-status--error {
+		color: var(--terminal-status-error);
+	}
+	.cp-footer-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+	}
+	.cp-action {
+		height: 28px;
+		padding: 0 var(--terminal-space-3);
+		border: none;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		transition:
+			background var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			color var(--terminal-motion-tick) var(--terminal-motion-easing-out),
+			opacity var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.cp-action:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+	.cp-action:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+	.cp-action--ghost {
+		background: transparent;
+		color: var(--terminal-fg-tertiary);
+	}
+	.cp-action--ghost:hover:not(:disabled) {
+		color: var(--terminal-fg-primary);
+	}
+	.cp-action--outline {
+		background: transparent;
+		color: var(--terminal-fg-secondary);
+		border: var(--terminal-border-hairline);
+	}
+	.cp-action--outline:hover:not(:disabled) {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+	.cp-action--primary {
+		background: var(--terminal-accent-amber);
+		color: var(--terminal-fg-inverted);
+	}
+	.cp-action--primary:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationPanel.svelte
@@ -23,15 +23,15 @@
   every number renders via @investintell/ui formatters.
 -->
 <script lang="ts">
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import { workspace } from "../../state/portfolio-workspace.svelte";
 	import { formatNumber, formatShortDate } from "@investintell/ui";
 	import type {
 		PortfolioCalibration,
 		PortfolioCalibrationUpdate,
 		CalibrationMandate,
 		StressScenarioId,
-	} from "$wealth/types/portfolio-calibration";
-	import { calibrationsEqual } from "$wealth/types/portfolio-calibration";
+	} from "../../types/portfolio-calibration";
+	import { calibrationsEqual } from "../../types/portfolio-calibration";
 	import CalibrationSliderField from "./CalibrationSliderField.svelte";
 	import CalibrationSelectField from "./CalibrationSelectField.svelte";
 	import CalibrationToggleField from "./CalibrationToggleField.svelte";

--- a/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationScenarioGroup.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationScenarioGroup.svelte
@@ -6,7 +6,7 @@
   draft as the single source of truth.
 -->
 <script lang="ts">
-	import type { StressScenarioId } from "$wealth/types/portfolio-calibration";
+	import type { StressScenarioId } from "../../types/portfolio-calibration";
 
 	interface Option {
 		value: StressScenarioId;

--- a/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationScenarioGroup.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationScenarioGroup.svelte
@@ -1,0 +1,217 @@
+<!--
+  CalibrationScenarioGroup — 4 stress-scenario checkboxes for the
+  Basic tier ``stress_scenarios_active`` field (DL7 canonical set).
+
+  Explicit ``value`` + ``onChange`` props so the parent keeps the
+  draft as the single source of truth.
+-->
+<script lang="ts">
+	import type { StressScenarioId } from "$wealth/types/portfolio-calibration";
+
+	interface Option {
+		value: StressScenarioId;
+		label: string;
+	}
+
+	interface Props {
+		label: string;
+		description?: string;
+		value: readonly StressScenarioId[];
+		onChange: (value: StressScenarioId[]) => void;
+		options: readonly Option[];
+		disabled?: boolean;
+		originalValue?: readonly StressScenarioId[];
+	}
+
+	let {
+		label,
+		description,
+		value,
+		onChange,
+		options,
+		disabled = false,
+		originalValue,
+	}: Props = $props();
+
+	const originalSet = $derived(
+		originalValue ? new Set(originalValue) : null,
+	);
+	const draftSet = $derived(new Set(value));
+
+	const added = $derived.by(() =>
+		originalSet ? value.filter((v) => !originalSet.has(v)) : [],
+	);
+	const removed = $derived.by(() =>
+		originalSet ? [...originalSet].filter((v) => !draftSet.has(v)) : [],
+	);
+	const showOriginal = $derived(
+		originalValue !== undefined && (added.length > 0 || removed.length > 0),
+	);
+
+	function toggle(id: StressScenarioId) {
+		if (value.includes(id)) {
+			onChange(value.filter((v) => v !== id));
+		} else {
+			onChange([...value, id]);
+		}
+	}
+</script>
+
+<div class="csg-root" class:csg-root--disabled={disabled}>
+	<div class="csg-header">
+		<span class="csg-label">{label}</span>
+		<span class="csg-count">{value.length}/{options.length}</span>
+		{#if showOriginal}
+			{#if added.length > 0}
+				<span
+					class="csg-original-chip csg-original-chip--added"
+					title="Cenários adicionados desde a última construção"
+				>
+					+{added.length} {added.length === 1 ? "cenário" : "cenários"}
+				</span>
+			{/if}
+			{#if removed.length > 0}
+				<span
+					class="csg-original-chip csg-original-chip--removed"
+					title="Cenários removidos desde a última construção"
+				>
+					−{removed.length} {removed.length === 1 ? "cenário" : "cenários"}
+				</span>
+			{/if}
+		{/if}
+	</div>
+	{#if description}
+		<p class="csg-description">{description}</p>
+	{/if}
+	<div class="csg-grid">
+		{#each options as opt (opt.value)}
+			{@const checked = value.includes(opt.value)}
+			<button
+				type="button"
+				class="csg-chip"
+				class:csg-chip--on={checked}
+				{disabled}
+				onclick={() => toggle(opt.value)}
+				aria-pressed={checked}
+			>
+				<span class="csg-chip-box">
+					{#if checked}
+						<span class="csg-chip-tick">✓</span>
+					{/if}
+				</span>
+				<span class="csg-chip-label">{opt.label}</span>
+			</button>
+		{/each}
+	</div>
+</div>
+
+<style>
+	.csg-root {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		font-family: var(--terminal-font-mono);
+	}
+	.csg-root--disabled {
+		opacity: 0.55;
+	}
+
+	.csg-header {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 12px;
+	}
+	.csg-label {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+	.csg-count {
+		font-size: 11px;
+		font-weight: 700;
+		color: var(--terminal-fg-muted);
+		font-variant-numeric: tabular-nums;
+	}
+	.csg-description {
+		margin: 0;
+		font-size: 11px;
+		color: var(--terminal-fg-muted);
+		line-height: 1.4;
+	}
+
+	.csg-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 8px;
+	}
+	.csg-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 10px;
+		border: var(--terminal-border-hairline);
+		background: transparent;
+		cursor: pointer;
+		color: var(--terminal-fg-muted);
+		font-family: inherit;
+		font-size: 12px;
+		font-weight: 500;
+		text-align: left;
+		transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+	}
+	.csg-chip:hover:not(:disabled) {
+		background: var(--terminal-bg-panel-raised);
+		color: var(--terminal-fg-primary);
+	}
+	.csg-chip--on {
+		background: color-mix(in srgb, var(--terminal-accent-amber) 10%, transparent);
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-fg-primary);
+	}
+	.csg-chip-box {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 16px;
+		height: 16px;
+		border: 1px solid var(--terminal-fg-tertiary);
+		flex-shrink: 0;
+	}
+	.csg-chip--on .csg-chip-box {
+		background: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+	}
+	.csg-chip-tick {
+		font-size: 11px;
+		font-weight: 700;
+		color: var(--terminal-fg-inverted);
+		line-height: 1;
+	}
+	.csg-chip-label {
+		flex: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.csg-original-chip {
+		margin-left: 8px;
+		padding: 2px 6px;
+		font-size: 10px;
+		font-weight: 500;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		border: 1px solid var(--terminal-fg-muted);
+		border-radius: 2px;
+		font-family: var(--terminal-font-mono);
+		white-space: nowrap;
+	}
+	.csg-original-chip--added {
+		color: var(--terminal-status-success);
+		background: var(--terminal-bg-panel-raised);
+	}
+	.csg-original-chip--removed {
+		color: var(--terminal-status-warn);
+		background: var(--terminal-bg-panel-raised);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationSelectField.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationSelectField.svelte
@@ -1,0 +1,141 @@
+<!--
+  CalibrationSelectField — dropdown version of CalibrationSliderField,
+  used for enum-valued knobs (mandate, regime_override, cvar_level
+  segmented, etc.).
+
+  Uses explicit ``value`` + ``onChange`` props (no bindable) so the
+  parent can transform — e.g. ``"auto"`` sentinel → ``null`` — without
+  touching internal state.
+-->
+<script lang="ts">
+	interface Option {
+		value: string;
+		label: string;
+	}
+
+	interface Props {
+		id: string;
+		label: string;
+		description?: string;
+		value: string;
+		onChange: (value: string) => void;
+		options: readonly Option[];
+		placeholder?: string;
+		disabled?: boolean;
+		originalValue?: string;
+	}
+
+	let {
+		id,
+		label,
+		description,
+		value,
+		onChange,
+		options,
+		placeholder = "Select...",
+		disabled = false,
+		originalValue,
+	}: Props = $props();
+
+	const showOriginal = $derived(
+		originalValue !== undefined && originalValue !== value,
+	);
+	const originalLabel = $derived(
+		showOriginal && originalValue !== undefined
+			? (options.find((o) => o.value === originalValue)?.label ?? originalValue)
+			: null,
+	);
+</script>
+
+<div class="csf-root" class:csf-root--disabled={disabled}>
+	<div class="csf-header">
+		<label class="csf-label" for={id}>{label}</label>
+		{#if showOriginal && originalLabel !== null}
+			<span class="csf-original-chip" title="Valor da última construção">
+				Anteriormente: {originalLabel}
+			</span>
+		{/if}
+	</div>
+	{#if description}
+		<p class="csf-description">{description}</p>
+	{/if}
+	<div class="csf-control">
+		<select
+			{id}
+			class="csf-select"
+			{disabled}
+			value={value}
+			onchange={(e) => onChange((e.currentTarget as HTMLSelectElement).value)}
+		>
+			{#each options as opt (opt.value)}
+				<option value={opt.value}>{opt.label}</option>
+			{/each}
+		</select>
+	</div>
+</div>
+
+<style>
+	.csf-root {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		font-family: var(--terminal-font-mono);
+	}
+	.csf-root--disabled {
+		opacity: 0.55;
+	}
+	.csf-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+	}
+	.csf-label {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+	.csf-description {
+		margin: 0;
+		font-size: 11px;
+		color: var(--terminal-fg-muted);
+		line-height: 1.4;
+	}
+	.csf-control {
+		width: 100%;
+	}
+	.csf-select {
+		width: 100%;
+		height: 28px;
+		background: var(--terminal-bg-panel-sunken);
+		color: var(--terminal-fg-primary);
+		border: var(--terminal-border-hairline);
+		border-radius: 0;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		padding: 0 var(--terminal-space-2);
+		cursor: pointer;
+	}
+	.csf-select:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+	.csf-select:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+	.csf-original-chip {
+		margin-left: 8px;
+		padding: 2px 6px;
+		font-size: 10px;
+		font-weight: 500;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel-raised);
+		border: 1px solid var(--terminal-fg-muted);
+		border-radius: 2px;
+		font-family: var(--terminal-font-mono);
+		white-space: nowrap;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationSliderField.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationSliderField.svelte
@@ -1,0 +1,297 @@
+<!--
+  CalibrationSliderField — paired slider + numeric input used inside the
+  Builder CalibrationPanel.
+
+  Phase 4 Task 4.1 (OD-2 locked → paired slider + bound numeric input).
+  The slider drives the number, the number drives the slider, and the
+  keyboard arrows nudge by ``step``. ``displayFormat`` renders the
+  inline value chip next to the label so the PM always sees the
+  institutional representation (percent, bps, x, raw).
+
+  API uses ``value`` + ``onChange`` (no bindable) so the parent can
+  drive transforms — e.g. sentinel-for-null, percent-for-ratio — at
+  the call site without touching the internal $state here.
+
+  Formatting is routed through @investintell/ui formatters — never
+  ``.toFixed`` or ``new Intl.NumberFormat`` (DL16).
+-->
+<script lang="ts">
+	import { formatPercent, formatNumber, formatBps } from "@investintell/ui";
+
+	type DisplayFormat = "percent" | "bps" | "raw" | "x";
+
+	interface Props {
+		id: string;
+		label: string;
+		description?: string;
+		value: number;
+		onChange: (value: number) => void;
+		min: number;
+		max: number;
+		step: number;
+		displayFormat?: DisplayFormat;
+		digits?: number;
+		edgeLabels?: [string, string];
+		disabled?: boolean;
+		accent?: "primary" | "danger" | "success";
+		originalValue?: number;
+	}
+
+	let {
+		id,
+		label,
+		description,
+		value,
+		onChange,
+		min,
+		max,
+		step,
+		displayFormat = "raw",
+		digits,
+		edgeLabels,
+		disabled = false,
+		accent = "primary",
+		originalValue,
+	}: Props = $props();
+
+	const showOriginal = $derived(
+		originalValue !== undefined && originalValue !== value,
+	);
+	const originalDisplay = $derived.by(() => {
+		if (!showOriginal || originalValue === undefined) return null;
+		switch (displayFormat) {
+			case "percent":
+				return formatPercent(originalValue, digits ?? 2);
+			case "bps":
+				return formatBps(originalValue);
+			case "x":
+				return `${formatNumber(originalValue, digits ?? 2)}x`;
+			case "raw":
+			default:
+				return formatNumber(originalValue, digits ?? 2);
+		}
+	});
+
+	const display = $derived.by(() => {
+		switch (displayFormat) {
+			case "percent":
+				return formatPercent(value, digits ?? 2);
+			case "bps":
+				return formatBps(value);
+			case "x":
+				return `${formatNumber(value, digits ?? 2)}x`;
+			case "raw":
+			default:
+				return formatNumber(value, digits ?? 2);
+		}
+	});
+
+	function handleSliderInput(e: Event) {
+		const next = Number.parseFloat((e.target as HTMLInputElement).value);
+		if (!Number.isNaN(next)) onChange(clamp(next));
+	}
+
+	function handleNumberInput(e: Event) {
+		const next = Number.parseFloat((e.target as HTMLInputElement).value);
+		if (!Number.isNaN(next)) onChange(clamp(next));
+	}
+
+	function clamp(v: number): number {
+		if (v < min) return min;
+		if (v > max) return max;
+		return v;
+	}
+</script>
+
+<div class="csf-root" class:csf-root--disabled={disabled}>
+	<div class="csf-header">
+		<label class="csf-label" for={id}>{label}</label>
+		<span class="csf-value" data-accent={accent}>{display}</span>
+		{#if showOriginal && originalDisplay !== null}
+			<span class="csf-original-chip" title="Valor da última construção">
+				Anteriormente: {originalDisplay}
+			</span>
+		{/if}
+	</div>
+	{#if description}
+		<p class="csf-description">{description}</p>
+	{/if}
+
+	<div class="csf-controls">
+		<input
+			{id}
+			type="range"
+			class="csf-slider"
+			{min}
+			{max}
+			{step}
+			{value}
+			{disabled}
+			oninput={handleSliderInput}
+		/>
+		<input
+			type="number"
+			class="csf-number"
+			aria-label={`${label} (numeric input)`}
+			{min}
+			{max}
+			{step}
+			{value}
+			{disabled}
+			oninput={handleNumberInput}
+		/>
+	</div>
+
+	{#if edgeLabels}
+		<div class="csf-edges">
+			<span>{edgeLabels[0]}</span>
+			<span>{edgeLabels[1]}</span>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.csf-root {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		font-family: var(--terminal-font-mono);
+	}
+	.csf-root--disabled {
+		opacity: 0.55;
+	}
+
+	.csf-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+	}
+	.csf-label {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+	.csf-value {
+		font-size: 13px;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		color: var(--terminal-accent-amber);
+	}
+	.csf-value[data-accent="danger"] {
+		color: var(--terminal-status-error);
+	}
+	.csf-value[data-accent="success"] {
+		color: var(--terminal-status-success);
+	}
+
+	.csf-description {
+		margin: 0;
+		font-size: 11px;
+		color: var(--terminal-fg-muted);
+		line-height: 1.4;
+	}
+
+	.csf-controls {
+		display: grid;
+		grid-template-columns: 1fr 84px;
+		gap: 12px;
+		align-items: center;
+	}
+
+	.csf-slider {
+		width: 100%;
+		-webkit-appearance: none;
+		appearance: none;
+		background: transparent;
+	}
+	.csf-slider::-webkit-slider-runnable-track {
+		width: 100%;
+		height: 4px;
+		background: var(--terminal-fg-muted);
+	}
+	.csf-slider::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		appearance: none;
+		height: 16px;
+		width: 16px;
+		border-radius: 50%;
+		background: var(--terminal-bg-panel);
+		border: 2px solid var(--terminal-accent-amber);
+		margin-top: -6px;
+		cursor: pointer;
+		transition: transform 120ms ease, box-shadow 120ms ease;
+	}
+	.csf-slider::-webkit-slider-thumb:hover {
+		transform: scale(1.08);
+	}
+	.csf-slider:focus {
+		outline: none;
+	}
+	.csf-slider:focus::-webkit-slider-thumb {
+		box-shadow: 0 0 0 4px color-mix(in srgb, var(--terminal-accent-amber) 25%, transparent);
+	}
+	.csf-slider::-moz-range-track {
+		width: 100%;
+		height: 4px;
+		background: var(--terminal-fg-muted);
+	}
+	.csf-slider::-moz-range-thumb {
+		height: 16px;
+		width: 16px;
+		border-radius: 50%;
+		background: var(--terminal-bg-panel);
+		border: 2px solid var(--terminal-accent-amber);
+		cursor: pointer;
+	}
+
+	.csf-number {
+		height: 28px;
+		padding: 0 8px;
+		font-size: 12px;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		border: var(--terminal-border-hairline);
+		border-radius: 0;
+		background: transparent;
+		color: var(--terminal-fg-primary);
+		text-align: right;
+		font-family: inherit;
+	}
+	.csf-number:focus {
+		outline: none;
+		border-color: var(--terminal-accent-amber);
+	}
+	.csf-number::-webkit-outer-spin-button,
+	.csf-number::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+	.csf-number[type="number"] {
+		-moz-appearance: textfield;
+		appearance: textfield;
+	}
+
+	.csf-edges {
+		display: flex;
+		justify-content: space-between;
+		font-size: 10px;
+		font-weight: 500;
+		color: var(--terminal-fg-muted);
+	}
+
+	.csf-original-chip {
+		margin-left: 8px;
+		padding: 2px 6px;
+		font-size: 10px;
+		font-weight: 500;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel-raised);
+		border: 1px solid var(--terminal-fg-muted);
+		border-radius: 2px;
+		font-family: var(--terminal-font-mono);
+		white-space: nowrap;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationToggleField.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationToggleField.svelte
@@ -1,0 +1,148 @@
+<!--
+  CalibrationToggleField — boolean toggle for the Advanced tier knobs
+  (bl_enabled, garch_enabled, advisor_enabled).
+
+  Explicit ``value`` + ``onChange`` props so the parent keeps the draft
+  as the single source of truth.
+-->
+<script lang="ts">
+	interface Props {
+		id: string;
+		label: string;
+		description?: string;
+		value: boolean;
+		onChange: (value: boolean) => void;
+		disabled?: boolean;
+		originalValue?: boolean;
+	}
+
+	let {
+		id,
+		label,
+		description,
+		value,
+		onChange,
+		disabled = false,
+		originalValue,
+	}: Props = $props();
+
+	const showOriginal = $derived(
+		originalValue !== undefined && originalValue !== value,
+	);
+	const originalLabel = $derived(
+		showOriginal ? (originalValue ? "Ativado" : "Desativado") : null,
+	);
+
+	function handleChange(e: Event) {
+		onChange((e.target as HTMLInputElement).checked);
+	}
+</script>
+
+<div class="ctf-root" class:ctf-root--disabled={disabled}>
+	<div class="ctf-header">
+		<label class="ctf-label" for={id}>{label}</label>
+		{#if showOriginal && originalLabel !== null}
+			<span class="ctf-original-chip" title="Valor da última construção">
+				Anteriormente: {originalLabel}
+			</span>
+		{/if}
+		<label class="ctf-switch">
+			<input
+				{id}
+				type="checkbox"
+				checked={value}
+				{disabled}
+				onchange={handleChange}
+			/>
+			<span class="ctf-slider" aria-hidden="true"></span>
+		</label>
+	</div>
+	{#if description}
+		<p class="ctf-description">{description}</p>
+	{/if}
+</div>
+
+<style>
+	.ctf-root {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		font-family: var(--terminal-font-mono);
+	}
+	.ctf-root--disabled {
+		opacity: 0.55;
+	}
+
+	.ctf-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+	}
+	.ctf-label {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+	.ctf-description {
+		margin: 0;
+		font-size: 11px;
+		color: var(--terminal-fg-muted);
+		line-height: 1.4;
+	}
+
+	.ctf-switch {
+		position: relative;
+		display: inline-block;
+		width: 36px;
+		height: 20px;
+		cursor: pointer;
+	}
+	.ctf-switch input {
+		opacity: 0;
+		width: 0;
+		height: 0;
+		position: absolute;
+	}
+	.ctf-slider {
+		position: absolute;
+		inset: 0;
+		background: var(--terminal-fg-muted);
+		border-radius: 999px;
+		transition: background 140ms ease;
+	}
+	.ctf-slider::before {
+		content: "";
+		position: absolute;
+		left: 2px;
+		top: 2px;
+		width: 16px;
+		height: 16px;
+		background: var(--terminal-fg-primary);
+		border-radius: 999px;
+		transition: transform 140ms ease;
+	}
+	.ctf-switch input:checked + .ctf-slider {
+		background: var(--terminal-accent-amber);
+	}
+	.ctf-switch input:checked + .ctf-slider::before {
+		transform: translateX(16px);
+	}
+	.ctf-switch input:focus-visible + .ctf-slider {
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--terminal-accent-amber) 25%, transparent);
+	}
+	.ctf-original-chip {
+		margin-left: 8px;
+		padding: 2px 6px;
+		font-size: 10px;
+		font-weight: 500;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel-raised);
+		border: 1px solid var(--terminal-fg-muted);
+		border-radius: 2px;
+		font-family: var(--terminal-font-mono);
+		white-space: nowrap;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/RiskBudgetPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/RiskBudgetPanel.svelte
@@ -1,0 +1,317 @@
+<!--
+  RiskBudgetPanel — Builder risk budget surface. Composes:
+    1. RiskBudgetSlider (operator edits the tail loss limit)
+    2. AchievableReturnBandChart (derived from live preview ?? latest
+       cascade_telemetry)
+    3. Signal banner (operator_signal → copy + tone)
+
+  PR-A13 shipped the static form; PR-A13.2 wires the live drag preview
+  via POST /preview-cvar. ``previewBand ?? serverBand`` precedence lets
+  the drag-derived band override the last completed run's band, while
+  clearing ``previewBand`` on ``runPhase === "done"`` re-grants authority
+  to the fresh server band (closes the two-channel state gap from
+  PR-A13 Section B.2).
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
+	import type { ModelPortfolio } from "$wealth/types/model-portfolio";
+	import type { PortfolioCalibration } from "$wealth/types/portfolio-calibration";
+	import type {
+		AchievableReturnBand,
+		OperatorMessage,
+		OperatorSignal,
+		WinnerSignal,
+	} from "$wealth/types/cascade-telemetry";
+	import { defaultCvarForProfile } from "$wealth/util/profile-defaults";
+	import RiskBudgetSlider from "./RiskBudgetSlider.svelte";
+	import AchievableReturnBandChart from "./AchievableReturnBandChart.svelte";
+
+	interface Props {
+		portfolio: ModelPortfolio;
+		calibration: PortfolioCalibration;
+		snapshot?: Partial<PortfolioCalibration> | null;
+		onChange: (patch: Partial<PortfolioCalibration>) => void;
+	}
+
+	let { portfolio, calibration, snapshot, onChange }: Props = $props();
+
+	const profileDefault = $derived(defaultCvarForProfile(portfolio.profile));
+	const cvarLimit = $derived(calibration.cvar_limit);
+
+	// ── Server-channel state (authoritative when no live preview) ──
+	const serverBand = $derived(
+		workspace.constructionRun?.cascade_telemetry?.achievable_return_band ?? null,
+	);
+	const serverSignal = $derived(
+		workspace.constructionRun?.cascade_telemetry?.operator_signal ?? null,
+	);
+	const serverMinCvar = $derived(
+		workspace.constructionRun?.cascade_telemetry?.min_achievable_cvar ?? null,
+	);
+	// PR-A19.1 Section C — cascade-aware signal + backend-owned copy.
+	const winnerSignal = $derived<WinnerSignal | null>(
+		workspace.constructionRun?.cascade_telemetry?.winner_signal ?? null,
+	);
+	const operatorMessage = $derived<OperatorMessage | null>(
+		workspace.constructionRun?.cascade_telemetry?.operator_message ?? null,
+	);
+
+	// ── Preview-channel state (PR-A13.2 live drag) ─────────────────
+	let previewBand = $state<AchievableReturnBand | null>(null);
+	let previewSignal = $state<OperatorSignal | null>(null);
+	let previewMinCvar = $state<number | null>(null);
+	let previewing = $state(false);
+	let previewError = $state<string | null>(null);
+
+	const band = $derived(previewBand ?? serverBand);
+	const signal = $derived(previewSignal ?? serverSignal);
+	const minAchievableCvar = $derived(previewMinCvar ?? serverMinCvar);
+
+	const belowFloor = $derived(signal?.kind === "cvar_limit_below_universe_floor");
+	const dataMissing = $derived(signal?.kind === "upstream_data_missing");
+	const polytopeEmpty = $derived(signal?.kind === "constraint_polytope_empty");
+
+	// ── Debounced preview fetch ────────────────────────────────────
+	// 250ms debounce on slider mutations. AbortController cancels stale
+	// in-flight requests so rapid drags don't produce a late response that
+	// overwrites a newer one.
+	let previewTimer: ReturnType<typeof setTimeout> | null = null;
+	let previewAbort: AbortController | null = null;
+	let lastPreviewedCvar: number | null = null;
+
+	$effect(() => {
+		const cv = cvarLimit;
+		// Skip when the operator hasn't moved from the current calibration
+		// value — server band is already authoritative in that case.
+		if (cv === null || cv === undefined) return;
+		if (cv === lastPreviewedCvar) return;
+		if (previewTimer) clearTimeout(previewTimer);
+		previewTimer = setTimeout(() => {
+			void runPreview(cv);
+		}, 250);
+		return () => {
+			if (previewTimer) {
+				clearTimeout(previewTimer);
+				previewTimer = null;
+			}
+		};
+	});
+
+	// Clear the preview channel once a new construction completes so the
+	// freshly-authoritative server band wins. Without this, a stale drag
+	// preview would continue masking the real completed-run band.
+	$effect(() => {
+		if (workspace.runPhase === "done") {
+			previewBand = null;
+			previewSignal = null;
+			previewMinCvar = null;
+			previewError = null;
+			lastPreviewedCvar = null;
+		}
+	});
+
+	async function runPreview(cv: number): Promise<void> {
+		previewAbort?.abort();
+		const ac = new AbortController();
+		previewAbort = ac;
+		previewing = true;
+		previewError = null;
+		try {
+			const res = await workspace.previewCvar(cv, ac.signal);
+			if (ac.signal.aborted) return;
+			if (res === null) return;
+			previewBand = res.achievable_return_band;
+			previewSignal = res.operator_signal;
+			previewMinCvar = res.min_achievable_cvar;
+			lastPreviewedCvar = cv;
+		} catch (err) {
+			if (ac.signal.aborted) return;
+			if (err instanceof DOMException && err.name === "AbortError") return;
+			// Preserve last good preview; surface a non-blocking chip.
+			previewError =
+				err instanceof Error ? err.message : "Live preview unavailable";
+		} finally {
+			if (previewAbort === ac) previewAbort = null;
+			previewing = false;
+		}
+	}
+</script>
+
+<div class="rbp-root">
+	<RiskBudgetSlider
+		value={cvarLimit}
+		{profileDefault}
+		profile={portfolio.profile}
+		onChange={(v) => onChange({ cvar_limit: v })}
+		originalValue={snapshot?.cvar_limit as number | undefined}
+	/>
+
+	{#if dataMissing}
+		<div class="rbp-banner rbp-banner--empty" role="status">
+			<p class="rbp-banner__msg">
+				We don't have enough return history for this universe to model an achievable
+				range. Add instruments with at least 36 months of NAV, or check the Universe
+				column.
+			</p>
+		</div>
+	{:else if polytopeEmpty}
+		<div class="rbp-banner rbp-banner--blocking" role="alert">
+			<p class="rbp-banner__msg">
+				The current strategic allocation has no feasible portfolio. Adjust block
+				min/max bounds.
+			</p>
+		</div>
+	{:else}
+		<div class="rbp-chart-frame" class:rbp-chart-frame--previewing={previewing}>
+			<AchievableReturnBandChart
+				{band}
+				{cvarLimit}
+				{minAchievableCvar}
+				height={220}
+			/>
+			{#if previewing}
+				<div class="rbp-preview-pulse" aria-label="Updating preview" data-testid="rbp-preview-spinner"></div>
+			{/if}
+		</div>
+		{#if previewError}
+			<div class="rbp-banner rbp-banner--preview-error" role="status" data-testid="rbp-preview-error">
+				<p class="rbp-banner__msg">
+					Live preview unavailable — showing the last completed run's band. Adjust
+					the slider or trigger a full build.
+				</p>
+			</div>
+		{/if}
+		<div class="rbp-stats" data-testid="rbp-stats">
+			{#if band}
+				<div class="rbp-stats__primary">
+					At your tail loss limit: <strong>{formatPercent(band.upper, 2)}</strong> expected
+				</div>
+				<div class="rbp-stats__range">
+					Achievable range across this universe:
+					{formatPercent(band.lower, 2)} – {formatPercent(band.upper, 2)}
+				</div>
+			{:else}
+				<div class="rbp-stats__empty">
+					Run a construction to see the achievable return band.
+				</div>
+			{/if}
+		</div>
+		{#if belowFloor && minAchievableCvar !== null}
+			<div class="rbp-banner rbp-banner--warning" role="status">
+				<p class="rbp-banner__msg">
+					Your tail loss limit ({formatPercent(cvarLimit, 2)}) sits below the lowest
+					tail risk this universe can deliver ({formatPercent(minAchievableCvar, 2)}).
+					We're showing the lowest-tail-risk portfolio achievable. Loosen the limit or
+					expand the universe.
+				</p>
+			</div>
+		{/if}
+		<!--
+		  PR-A19.1 Section C — cascade-aware operator message.
+
+		  Backend owns the displayable copy; frontend renders verbatim
+		  (smart backend / dumb frontend). Shown only when the cascade
+		  winner signal is non-optimal and the backend returned a
+		  formatted message.
+		-->
+		{#if winnerSignal && winnerSignal !== "optimal" && operatorMessage}
+			<div
+				class="rbp-banner rbp-banner--{operatorMessage.severity}"
+				role={operatorMessage.severity === "error" ? "alert" : "status"}
+				data-testid="rbp-operator-message"
+				data-winner-signal={winnerSignal}
+			>
+				<p class="rbp-banner__title">{operatorMessage.title}</p>
+				<p class="rbp-banner__msg">{operatorMessage.body}</p>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.rbp-root {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+	.rbp-stats {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		font-family: var(--terminal-font-mono);
+	}
+	.rbp-stats__primary {
+		font-size: 12px;
+		color: var(--terminal-fg-primary);
+	}
+	.rbp-stats__range {
+		font-size: 11px;
+		color: var(--terminal-fg-muted);
+	}
+	.rbp-stats__empty {
+		font-size: 11px;
+		color: var(--terminal-fg-muted);
+		font-style: italic;
+	}
+	.rbp-banner {
+		padding: 10px 12px;
+		border-left: 3px solid var(--terminal-fg-muted);
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+	}
+	.rbp-banner--warning {
+		border-left-color: var(--terminal-status-warning);
+	}
+	.rbp-banner--blocking {
+		border-left-color: var(--terminal-status-error);
+	}
+	.rbp-banner--empty {
+		border-left-color: var(--terminal-fg-muted);
+	}
+	.rbp-banner__msg {
+		margin: 0;
+		font-size: 11px;
+		line-height: 1.45;
+		color: var(--terminal-fg-secondary);
+	}
+	.rbp-banner--preview-error {
+		border-left-color: var(--terminal-status-warning);
+	}
+	/* PR-A19.1 — operator_message severity variants */
+	.rbp-banner--info {
+		border-left-color: var(--terminal-status-info, var(--terminal-fg-muted));
+	}
+	.rbp-banner--error {
+		border-left-color: var(--terminal-status-error);
+	}
+	.rbp-banner__title {
+		margin: 0 0 4px 0;
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		text-transform: uppercase;
+		letter-spacing: 0.4px;
+	}
+	.rbp-chart-frame {
+		position: relative;
+	}
+	.rbp-chart-frame--previewing {
+		opacity: 0.85;
+	}
+	.rbp-preview-pulse {
+		position: absolute;
+		top: 8px;
+		right: 8px;
+		width: 10px;
+		height: 10px;
+		border-radius: 50%;
+		background: var(--terminal-status-info, var(--terminal-fg-muted));
+		animation: rbp-preview-pulse 1.2s ease-in-out infinite;
+		pointer-events: none;
+	}
+	@keyframes rbp-preview-pulse {
+		0%, 100% { opacity: 0.3; transform: scale(0.85); }
+		50%      { opacity: 1;   transform: scale(1);    }
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/RiskBudgetPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/RiskBudgetPanel.svelte
@@ -14,16 +14,16 @@
 -->
 <script lang="ts">
 	import { formatPercent } from "@investintell/ui";
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
-	import type { ModelPortfolio } from "$wealth/types/model-portfolio";
-	import type { PortfolioCalibration } from "$wealth/types/portfolio-calibration";
+	import { workspace } from "../../state/portfolio-workspace.svelte";
+	import type { ModelPortfolio } from "../../types/model-portfolio";
+	import type { PortfolioCalibration } from "../../types/portfolio-calibration";
 	import type {
 		AchievableReturnBand,
 		OperatorMessage,
 		OperatorSignal,
 		WinnerSignal,
-	} from "$wealth/types/cascade-telemetry";
-	import { defaultCvarForProfile } from "$wealth/util/profile-defaults";
+	} from "../../types/cascade-telemetry";
+	import { defaultCvarForProfile } from "../../utils/profile-defaults";
 	import RiskBudgetSlider from "./RiskBudgetSlider.svelte";
 	import AchievableReturnBandChart from "./AchievableReturnBandChart.svelte";
 

--- a/packages/ii-terminal-core/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/live/charts/TerminalPriceChart.svelte
@@ -1,0 +1,518 @@
+<!--
+  TerminalPriceChart — lightweight-charts v5 with NAV overlay.
+
+  Two series on one chart in Percentage mode:
+    1. Baseline (blue) — selected instrument price
+    2. Line (gold) — composite portfolio NAV
+
+  PriceScaleMode.Percentage normalises both to the same Y-axis
+  so instruments with different base prices are visually comparable.
+
+  Anti-SSR: dynamic import() inside onMount.
+  Dual-effect: historical setData vs live update() (no fitContent).
+  Toggle: "vs Portfolio NAV" button shows/hides the gold line.
+-->
+<script lang="ts">
+	import { onMount } from "svelte";
+	import {
+		createTerminalLightweightChartOptions,
+		terminalLWSeriesColors,
+	} from "@investintell/ui";
+
+	// ── Types ─────────────────────────────────────────────────
+	export interface BarData {
+		time: number; // UTC seconds
+		value: number;
+	}
+
+	export interface LiveTick {
+		time: number; // UTC seconds
+		value: number;
+	}
+
+	type Timeframe = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
+	export type DataStatus = "live" | "delayed" | "offline";
+	export type ChartMode = "candle" | "line";
+
+	export interface CandleBar {
+		time: number;
+		open: number;
+		high: number;
+		low: number;
+		close: number;
+	}
+
+	interface Props {
+		ticker: string;
+		historicalBars: BarData[];
+		candleBars?: CandleBar[];
+		lastTick: LiveTick | null;
+		portfolioNavBars: BarData[];
+		timeframe: Timeframe;
+		onTimeframeChange: (tf: Timeframe) => void;
+		dataStatus?: DataStatus;
+		mode?: ChartMode;
+	}
+
+	let {
+		ticker,
+		historicalBars,
+		candleBars = [],
+		lastTick,
+		portfolioNavBars,
+		timeframe,
+		onTimeframeChange,
+		dataStatus = "live",
+		mode = "line",
+	}: Props = $props();
+
+	const TIMEFRAMES: { id: Timeframe; label: string }[] = [
+		{ id: "1D", label: "1D" },
+		{ id: "1W", label: "1W" },
+		{ id: "1M", label: "1M" },
+		{ id: "3M", label: "3M" },
+		{ id: "6M", label: "6M" },
+		{ id: "1Y", label: "1Y" },
+	];
+
+	// ── Chart state ($state for reactivity tracking) ──────────
+	let containerEl: HTMLDivElement | undefined = $state();
+	let chart = $state<any>(null);
+	let series = $state<any>(null);
+	let navSeries = $state<any>(null);
+	let showNav = $state(true);
+	let lcModule = $state<typeof import("lightweight-charts") | null>(null);
+	let currentSeriesMode = $state<ChartMode | null>(null);
+	/** Last rolled candle — used to aggregate live ticks in candle mode. */
+	let currentCandle: CandleBar | null = null;
+
+	// ── Async chart initialization (SSR-safe) ─────────────────
+	onMount(() => {
+		let disposed = false;
+
+		(async () => {
+			const lc = await import("lightweight-charts");
+			if (disposed || !containerEl) return;
+
+			const opts = createTerminalLightweightChartOptions({
+				timeVisible: true,
+				priceScaleMode: lc.PriceScaleMode.Percentage,
+			});
+			const c = lc.createChart(containerEl, { autoSize: true, ...opts });
+
+			// Series 2: Portfolio NAV (amber line) — stable across mode swaps.
+			const sc = terminalLWSeriesColors();
+			const nav = c.addSeries(lc.LineSeries, {
+				...sc.navOverlay,
+				lineWidth: 2,
+				title: "NAV",
+				crosshairMarkerVisible: true,
+				crosshairMarkerRadius: 3,
+				priceLineVisible: false,
+				lastValueVisible: true,
+			});
+
+			lcModule = lc;
+			chart = c;
+			navSeries = nav;
+		})();
+
+		return () => {
+			disposed = true;
+			if (chart) {
+				chart.remove();
+				chart = null;
+				series = null;
+				navSeries = null;
+			}
+		};
+	});
+
+	/**
+	 * Build the instrument series for the current `mode`. Creates the
+	 * baseline/candlestick series on the owning chart, seeds it with
+	 * the appropriate data source, and returns the handle. Keeps the
+	 * <div> container + IChartApi instance stable (plan §A.9 contract).
+	 */
+	function mountInstrumentSeries(lc: typeof import("lightweight-charts"), c: any, m: ChartMode) {
+		const sc = terminalLWSeriesColors();
+		if (m === "candle") {
+			const s = c.addSeries(lc.CandlestickSeries, {
+				upColor: "#22c55e",
+				downColor: "#ef4444",
+				borderUpColor: "#22c55e",
+				borderDownColor: "#ef4444",
+				wickUpColor: "#22c55e",
+				wickDownColor: "#ef4444",
+				priceLineVisible: true,
+				lastValueVisible: true,
+			});
+			return s;
+		}
+		const s = c.addSeries(lc.BaselineSeries, {
+			baseValue: { type: "price", price: 0 },
+			...sc.baseline,
+			lineWidth: 2,
+			priceLineVisible: true,
+			lastValueVisible: true,
+			title: "",
+		});
+		return s;
+	}
+
+	// ── Effect: mode swap (preserve visible range) ───────────
+	// Replaces the instrument series in place when mode changes.
+	// Captures the visible range BEFORE removing the old series and
+	// restores it after the new series is seeded, so the viewport
+	// does not reset on toggle (plan §A.9).
+	$effect(() => {
+		const lc = lcModule;
+		const c = chart;
+		const m = mode;
+		if (!lc || !c) return;
+		if (currentSeriesMode === m && series !== null) return;
+
+		const priorRange = (() => {
+			try {
+				return c.timeScale().getVisibleRange();
+			} catch {
+				return null;
+			}
+		})();
+
+		if (series !== null) {
+			try {
+				c.removeSeries(series);
+			} catch {
+				// If removal fails (e.g. disposed chart), bail — the
+				// next onMount cycle will rebuild from scratch.
+				return;
+			}
+		}
+
+		const next = mountInstrumentSeries(lc, c, m);
+
+		// Swap price-scale mode per series type: percentage for the
+		// baseline line (% change vs first bar), normal for candles
+		// (absolute OHLC values).
+		c.applyOptions({
+			rightPriceScale: {
+				mode: m === "candle" ? lc.PriceScaleMode.Normal : lc.PriceScaleMode.Percentage,
+			},
+		});
+
+		// Seed with data appropriate for the mode.
+		if (m === "candle" && candleBars.length) {
+			next.setData(candleBars);
+			currentCandle = candleBars[candleBars.length - 1] ?? null;
+		} else if (m === "line" && historicalBars.length) {
+			next.applyOptions({
+				baseValue: { type: "price", price: historicalBars[0]!.value },
+			});
+			next.setData(historicalBars);
+			currentCandle = null;
+		}
+
+		// Restore the user's viewport if one existed.
+		if (priorRange) {
+			try {
+				c.timeScale().setVisibleRange(priorRange);
+			} catch {
+				// Ranges can mismatch if the two datasets have
+				// different domains; fall back to fit.
+				c.timeScale().fitContent();
+			}
+		} else {
+			c.timeScale().fitContent();
+		}
+
+		series = next;
+		currentSeriesMode = m;
+	});
+
+	// ── Effect 1: Historical instrument bars ─────────────────
+	// Reseed when the underlying bars array changes AND the current
+	// series matches mode=line. The mode-swap effect above handles
+	// the cross-mode reseed path.
+	$effect(() => {
+		const s = series;
+		const c = chart;
+		const bars = historicalBars;
+		if (!s || !c || mode !== "line" || !bars.length) return;
+		if (currentSeriesMode !== "line") return;
+
+		s.applyOptions({
+			baseValue: { type: "price", price: bars[0]!.value },
+		});
+		s.setData(bars);
+	});
+
+	// ── Effect 1b: Historical candle bars ────────────────────
+	$effect(() => {
+		const s = series;
+		const c = chart;
+		const bars = candleBars;
+		if (!s || !c || mode !== "candle" || !bars.length) return;
+		if (currentSeriesMode !== "candle") return;
+
+		s.setData(bars);
+		currentCandle = bars[bars.length - 1] ?? null;
+	});
+
+	// ── Effect 2: Portfolio NAV bars ─────────────────────────
+	$effect(() => {
+		const ns = navSeries;
+		const bars = portfolioNavBars;
+		if (!ns) return;
+
+		if (bars.length > 0) {
+			ns.setData(bars);
+		}
+	});
+
+	// ── Effect 3: NAV visibility toggle ──────────────────────
+	// NAV is hidden in candle mode because the price axis switches to
+	// absolute values — a percent-baselined NAV line on an absolute
+	// OHLC axis is visually misleading.
+	$effect(() => {
+		const ns = navSeries;
+		const visible = showNav && mode === "line";
+		if (!ns) return;
+		ns.applyOptions({ visible });
+	});
+
+	// ── Effect 4: Live tick (incremental update) ─────────────
+	$effect(() => {
+		const s = series;
+		const tick = lastTick;
+		if (!s || !tick) return;
+
+		if (mode === "line") {
+			s.update({ time: tick.time, value: tick.value });
+			return;
+		}
+
+		// Candle mode: aggregate tick into the current bar. If the
+		// tick timestamp advances past the current bar, roll a new
+		// candle seeded from the prior close. This mirrors plan §A.9
+		// "local tick aggregation" until a dedicated 1m-bars stream
+		// exists on the backend.
+		const price = tick.value;
+		const t = tick.time;
+		if (!currentCandle || t > currentCandle.time) {
+			const open = currentCandle?.close ?? price;
+			currentCandle = { time: t, open, high: price, low: price, close: price };
+		} else {
+			currentCandle = {
+				...currentCandle,
+				high: Math.max(currentCandle.high, price),
+				low: Math.min(currentCandle.low, price),
+				close: price,
+			};
+		}
+		s.update(currentCandle);
+	});
+
+	function toggleNav() {
+		showNav = !showNav;
+	}
+</script>
+
+<div class="tpc-root">
+	<!-- Controls bar -->
+	<div class="tpc-controls">
+		<div class="tpc-ticker-row">
+			<span class="tpc-ticker">{ticker || "---"}</span>
+			{#if dataStatus !== "live"}
+				<span
+					class="tpc-status-badge"
+					class:tpc-status-delayed={dataStatus === "delayed"}
+					class:tpc-status-offline={dataStatus === "offline"}
+					aria-label="Data status: {dataStatus}"
+				>{dataStatus.toUpperCase()}</span>
+			{/if}
+		</div>
+
+		<div class="tpc-right-controls">
+			<!-- NAV overlay toggle -->
+			<button
+				type="button"
+				class="tpc-nav-toggle"
+				class:tpc-nav-toggle--active={showNav}
+				onclick={toggleNav}
+				aria-pressed={showNav}
+				title="Toggle portfolio NAV overlay"
+			>
+				<span class="tpc-nav-check" aria-hidden="true">{showNav ? "\u2713" : ""}</span>
+				vs NAV
+			</button>
+
+			<!-- Timeframe pills -->
+			<div class="tpc-timeframes" role="group" aria-label="Timeframe">
+				{#each TIMEFRAMES as tf}
+					<button
+						type="button"
+						class="tpc-tf-btn"
+						class:tpc-tf-active={timeframe === tf.id}
+						onclick={() => onTimeframeChange(tf.id)}
+						aria-pressed={timeframe === tf.id}
+					>
+						{tf.label}
+					</button>
+				{/each}
+			</div>
+		</div>
+	</div>
+
+	<!-- Chart canvas -->
+	<div class="tpc-chart" bind:this={containerEl}></div>
+</div>
+
+<style>
+	.tpc-root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	/* ── Controls bar ────────────────────────────────────────── */
+	.tpc-controls {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-shrink: 0;
+		height: 32px;
+		padding: 0 10px;
+		border-bottom: var(--terminal-border-hairline);
+		position: relative;
+		z-index: 10;
+	}
+
+	.tpc-ticker-row {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.tpc-ticker {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.tpc-status-badge {
+		font-family: var(--terminal-font-mono);
+		font-size: 8px;
+		font-weight: 800;
+		letter-spacing: 0.08em;
+		padding: 1px 5px;
+	}
+	.tpc-status-delayed {
+		color: var(--terminal-status-warn);
+		background: color-mix(in srgb, var(--terminal-status-warn) 12%, transparent);
+		border: 1px solid color-mix(in srgb, var(--terminal-status-warn) 25%, transparent);
+	}
+	.tpc-status-offline {
+		color: var(--terminal-status-error);
+		background: color-mix(in srgb, var(--terminal-status-error) 12%, transparent);
+		border: 1px solid color-mix(in srgb, var(--terminal-status-error) 25%, transparent);
+	}
+
+	/* ── Right controls (toggle + timeframes) ────────────────── */
+	.tpc-right-controls {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	/* ── NAV toggle button ───────────────────────────────────── */
+	.tpc-nav-toggle {
+		appearance: none;
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 3px 8px;
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		color: var(--terminal-fg-tertiary);
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		cursor: pointer;
+		transition: color 80ms, background 80ms, border-color 80ms;
+	}
+	.tpc-nav-toggle:hover {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber-dim);
+	}
+	.tpc-nav-toggle--active {
+		color: var(--terminal-accent-amber);
+		background: color-mix(in srgb, var(--terminal-accent-amber) 8%, transparent);
+		border-color: var(--terminal-accent-amber-dim);
+	}
+	.tpc-nav-toggle:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 1px;
+	}
+	.tpc-nav-check {
+		font-size: 9px;
+		width: 9px;
+		text-align: center;
+	}
+
+	/* ── Separator between toggle and timeframes ─────────────── */
+	.tpc-right-controls .tpc-timeframes {
+		padding-left: 8px;
+		border-left: var(--terminal-border-hairline);
+	}
+
+	.tpc-timeframes {
+		display: flex;
+		gap: 2px;
+	}
+
+	.tpc-tf-btn {
+		appearance: none;
+		padding: 3px 8px;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		color: var(--terminal-fg-tertiary);
+		background: transparent;
+		border: 1px solid transparent;
+		cursor: pointer;
+		transition: color 80ms, background 80ms, border-color 80ms;
+	}
+	.tpc-tf-btn:hover {
+		color: var(--terminal-fg-secondary);
+		background: var(--terminal-bg-panel-raised);
+	}
+	.tpc-tf-active {
+		color: var(--terminal-accent-cyan);
+		border-color: var(--terminal-accent-cyan-dim);
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 8%, transparent);
+	}
+	.tpc-tf-btn:focus-visible {
+		outline: 2px solid var(--terminal-accent-cyan);
+		outline-offset: 1px;
+	}
+
+	/* ── Chart container ─────────────────────────────────────── */
+	.tpc-chart {
+		position: relative;
+		z-index: 0;
+		flex: 1;
+		min-height: 0;
+		min-width: 0;
+		width: 100%;
+		overflow: hidden;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/live/charts/WorkbenchCoreChart.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/live/charts/WorkbenchCoreChart.svelte
@@ -1,0 +1,252 @@
+<!--
+  WorkbenchCoreChart — Phase 9 Block C central chart of the Live
+  Workbench. Terminal-dark styled ECharts line chart that slides
+  smoothly as ticks arrive from the LivePricePoller.
+
+  Design rules (per original plan DL9 + the re-scoped Block C
+  mandate):
+    - ONE ECharts instance, initialised once in onMount. Never
+      destroyed on tick updates. Never re-mounted via {#if}.
+    - Updates via ``setOption(patch, { notMerge: false,
+      lazyUpdate: true, replaceMerge: ['series'] })`` — the
+      "slide-in" pattern. Avoids the notMerge churn that
+      ChartContainer does for static option swaps.
+    - Base theme is "Terminal Dark": transparent background,
+      hairline dashed split lines on the y axis only, no x split
+      lines, monochrome numeric axis labels, 1.5px brand-accent
+      line with a soft gradient fill beneath. No animation.
+    - Reads the brand accent from the live CSS custom property
+      on mount + on theme changes (same pattern as
+      MainPortfolioChart) so a future light-mode toggle recolours
+      the line without a rebuild.
+
+  Contract:
+    ticks  — the full sliding buffer from LivePricePoller. The
+             chart renders the entire series on every tick — the
+             replaceMerge pattern means ECharts only diffs the
+             series data, not the axes / grid / legend.
+    height — pixel height of the chart canvas (default 260).
+
+  Cleanup:
+    The onMount return disposes the chart instance and disconnects
+    the ResizeObserver. The parent shell's $effect manages the
+    poller lifecycle; this component only cares about the ticks
+    prop and never touches the poller directly.
+-->
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { echarts } from "@investintell/ui/charts/echarts-setup";
+	import { formatNumber } from "@investintell/ui";
+	import type { PriceTick } from "$wealth/workers/live_price_poll.svelte";
+
+	interface Props {
+		ticks: readonly PriceTick[];
+		height?: number;
+		ariaLabel?: string;
+	}
+
+	let {
+		ticks,
+		height = 260,
+		ariaLabel = "Live price chart",
+	}: Props = $props();
+
+	let containerEl: HTMLDivElement | undefined = $state();
+	let chart: ReturnType<typeof echarts.init> | null = null;
+
+	// Resolve brand accent from the live computed style so the chart
+	// recolours cleanly on theme changes. Matches MainPortfolioChart.
+	let brandAccent = $state("#2d7ef7");
+
+	function readBrandAccent(): string {
+		if (typeof document === "undefined") return "#2d7ef7";
+		const style = getComputedStyle(document.documentElement);
+		return (
+			style.getPropertyValue("--ii-brand-accent").trim() ||
+			style.getPropertyValue("--ii-brand-primary").trim() ||
+			"#2d7ef7"
+		);
+	}
+
+	const seriesData = $derived(
+		ticks.map((t) => [t.ts, Math.round(t.price * 10000) / 10000] as [number, number]),
+	);
+
+	function buildBaseOption(accent: string) {
+		return {
+			backgroundColor: "transparent",
+			animation: false,
+			textStyle: {
+				fontFamily: "Urbanist, system-ui, sans-serif",
+				color: "#85a0bd",
+			},
+			grid: {
+				left: 56,
+				right: 20,
+				top: 18,
+				bottom: 28,
+				containLabel: false,
+			},
+			tooltip: {
+				trigger: "axis" as const,
+				backgroundColor: "rgba(20, 21, 25, 0.96)",
+				borderColor: "rgba(64, 66, 73, 0.6)",
+				borderWidth: 1,
+				padding: [6, 10],
+				textStyle: {
+					color: "#ffffff",
+					fontSize: 11,
+					fontFamily: "Urbanist, system-ui, sans-serif",
+				},
+				axisPointer: {
+					type: "line" as const,
+					lineStyle: {
+						color: "rgba(133, 160, 189, 0.4)",
+						type: "dashed" as const,
+					},
+				},
+				formatter(params: unknown) {
+					const p = Array.isArray(params) ? params[0] : params;
+					const v = (p as { value?: unknown }).value;
+					if (!Array.isArray(v) || v.length < 2) return "";
+					const ts = Number(v[0]);
+					const price = Number(v[1]);
+					const d = new Date(ts);
+					const hh = d.getHours().toString().padStart(2, "0");
+					const mm = d.getMinutes().toString().padStart(2, "0");
+					const ss = d.getSeconds().toString().padStart(2, "0");
+					return `<strong>${hh}:${mm}:${ss}</strong><br/>${formatNumber(price, 4)}`;
+				},
+			},
+			xAxis: {
+				type: "time" as const,
+				boundaryGap: false,
+				axisLine: { lineStyle: { color: "rgba(64, 66, 73, 0.6)" } },
+				axisTick: { show: false },
+				axisLabel: {
+					color: "#85a0bd",
+					fontSize: 9,
+					fontFamily: "Urbanist, system-ui, sans-serif",
+					hideOverlap: true,
+				},
+				splitLine: { show: false },
+			},
+			yAxis: {
+				type: "value" as const,
+				scale: true,
+				axisLine: { show: false },
+				axisTick: { show: false },
+				axisLabel: {
+					color: "#85a0bd",
+					fontSize: 9,
+					fontFamily: "Urbanist, system-ui, sans-serif",
+					formatter: (value: number) => formatNumber(value, 3),
+				},
+				splitLine: {
+					show: true,
+					lineStyle: {
+						color: "rgba(64, 66, 73, 0.4)",
+						type: "dashed" as const,
+					},
+				},
+			},
+			series: [
+				{
+					id: "price",
+					name: "Price",
+					type: "line" as const,
+					showSymbol: false,
+					smooth: 0.2,
+					lineStyle: { width: 1.5, color: accent },
+					itemStyle: { color: accent },
+					areaStyle: {
+						color: {
+							type: "linear" as const,
+							x: 0,
+							y: 0,
+							x2: 0,
+							y2: 1,
+							colorStops: [
+								{ offset: 0, color: "rgba(45, 126, 247, 0.28)" },
+								{ offset: 1, color: "rgba(45, 126, 247, 0.02)" },
+							],
+						},
+					},
+					data: [] as Array<[number, number]>,
+				},
+			],
+		};
+	}
+
+	onMount(() => {
+		if (!containerEl) return;
+		brandAccent = readBrandAccent();
+		chart = echarts.init(containerEl, null, { renderer: "canvas" });
+		chart.setOption(buildBaseOption(brandAccent), { notMerge: true });
+
+		const ro = new ResizeObserver(() => chart?.resize());
+		ro.observe(containerEl);
+
+		// Recolour on theme change. Rebuilds the base option once per
+		// flip — negligible cost compared to per-tick patches.
+		const themeObserver = new MutationObserver(() => {
+			brandAccent = readBrandAccent();
+			if (chart) {
+				chart.setOption(buildBaseOption(brandAccent), { notMerge: true });
+			}
+		});
+		themeObserver.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ["data-theme"],
+		});
+
+		return () => {
+			ro.disconnect();
+			themeObserver.disconnect();
+			chart?.dispose();
+			chart = null;
+		};
+	});
+
+	// Slide-in update path. Running through replaceMerge:['series']
+	// means ECharts only diffs the series data array, leaving axes,
+	// grid, tooltip, and markLines untouched between ticks.
+	$effect(() => {
+		if (!chart) return;
+		const data = seriesData; // reactivity dependency pickup
+		chart.setOption(
+			{ series: [{ id: "price", data }] },
+			{ notMerge: false, lazyUpdate: true, replaceMerge: ["series"] },
+		);
+	});
+</script>
+
+<div class="wcc-root" style:height="{height}px">
+	<div
+		bind:this={containerEl}
+		class="wcc-canvas"
+		role="img"
+		aria-label={ariaLabel}
+	></div>
+</div>
+
+<style>
+	.wcc-root {
+		position: relative;
+		width: 100%;
+		background: linear-gradient(
+			180deg,
+			rgba(20, 21, 25, 0.5) 0%,
+			rgba(14, 15, 19, 0) 100%
+		);
+		border: 1px solid var(--ii-border-subtle, rgba(64, 66, 73, 0.4));
+		border-radius: 8px;
+		padding: 12px;
+		flex-shrink: 0;
+		min-width: 0;
+	}
+	.wcc-canvas {
+		width: 100%;
+		height: 100%;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/live/charts/WorkbenchCoreChart.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/live/charts/WorkbenchCoreChart.svelte
@@ -37,7 +37,7 @@
 	import { onMount } from "svelte";
 	import { echarts } from "@investintell/ui/charts/echarts-setup";
 	import { formatNumber } from "@investintell/ui";
-	import type { PriceTick } from "$wealth/workers/live_price_poll.svelte";
+	import type { PriceTick } from "../../../../workers/live_price_poll.svelte";
 
 	interface Props {
 		ticks: readonly PriceTick[];

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/LibraryWrapper.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/LibraryWrapper.svelte
@@ -1,0 +1,159 @@
+<!--
+  LibraryWrapper — embeds the existing LibraryShell in the terminal
+  Research surface with CSS variable remapping so library components
+  render with terminal tokens without rewriting them.
+
+  Data fetching is client-side (no +page.server.ts) — the tree
+  payload is fetched on mount via the auth'd API client.
+-->
+<script lang="ts">
+	import { getContext, onMount } from "svelte";
+	import LibraryShell from "$wealth/components/library/LibraryShell.svelte";
+	import { createClientApiClient } from "$wealth/api/client";
+	import type { LibraryTree } from "$wealth/types/library";
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	let tree = $state<LibraryTree | null>(null);
+	let loading = $state(true);
+	let errorMsg = $state<string | null>(null);
+
+	onMount(async () => {
+		try {
+			tree = await api.get<LibraryTree>("/library/tree");
+		} catch (err: unknown) {
+			errorMsg = err instanceof Error ? err.message : "Failed to load library tree";
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<div class="library-terminal-wrapper">
+	{#if loading}
+		<div class="lw-empty">
+			<span class="lw-empty-text">Loading library...</span>
+		</div>
+	{:else if errorMsg}
+		<div class="lw-empty">
+			<span class="lw-empty-text lw-err">{errorMsg}</span>
+		</div>
+	{:else if tree}
+		<LibraryShell {tree} initialPath={null} actorRole={null} />
+	{:else}
+		<div class="lw-empty">
+			<span class="lw-empty-text">Library is empty</span>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.library-terminal-wrapper {
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+
+		/* ── CSS variable remapping: --ii-* → --terminal-* ── */
+
+		/* Surfaces */
+		--ii-surface: var(--terminal-bg-surface);
+		--ii-surface-alt: var(--terminal-bg-panel);
+		--ii-surface-elevated: var(--terminal-bg-panel-raised);
+
+		/* Text */
+		--ii-text-primary: var(--terminal-fg-primary);
+		--ii-text-secondary: var(--terminal-fg-secondary);
+		--ii-text-muted: var(--terminal-fg-muted);
+		--ii-text-on-brand: var(--terminal-fg-primary);
+
+		/* Borders */
+		--ii-border-subtle: var(--terminal-border-hairline);
+		--ii-border-accent: var(--terminal-accent-cyan);
+		--ii-border: var(--terminal-border-hairline);
+
+		/* Brand / status */
+		--ii-brand-primary: var(--terminal-accent-cyan);
+		--ii-success: var(--terminal-status-success);
+		--ii-danger: var(--terminal-status-error);
+		--ii-warning: var(--terminal-status-warn);
+		--ii-info: var(--terminal-accent-cyan);
+
+		/* Font */
+		--ii-font-sans: var(--terminal-font-mono);
+		--ii-font-mono: var(--terminal-font-mono);
+
+		/* Radius — terminal uses 0 */
+		--ii-radius-sm: 0px;
+		--ii-radius-pill: 0px;
+
+		font-family: var(--terminal-font-mono);
+		border-radius: 0;
+	}
+
+	/* Override hex colors that library components use directly */
+	.library-terminal-wrapper :global(.library-shell) {
+		background: var(--terminal-bg-surface);
+		color: var(--terminal-fg-secondary);
+		border-radius: 0;
+		height: 100%;
+	}
+
+	.library-terminal-wrapper :global(.library-header) {
+		background: var(--terminal-bg-surface);
+		border-bottom-color: var(--terminal-border-hairline-color, rgba(255, 255, 255, 0.06));
+	}
+
+	.library-terminal-wrapper :global(.pane--tree) {
+		background: var(--terminal-bg-surface);
+		border-right-color: var(--terminal-border-hairline-color, rgba(255, 255, 255, 0.06));
+	}
+
+	.library-terminal-wrapper :global(.pane--content) {
+		background: var(--terminal-bg-surface);
+	}
+
+	.library-terminal-wrapper :global(.pane--preview) {
+		background: var(--terminal-bg-surface);
+		border-left-color: var(--terminal-border-hairline-color, rgba(255, 255, 255, 0.06));
+	}
+
+	.library-terminal-wrapper :global(.view-placeholder) {
+		color: var(--terminal-fg-muted);
+	}
+
+	.library-terminal-wrapper :global(.view-placeholder__title) {
+		color: var(--terminal-fg-primary);
+	}
+
+	.library-terminal-wrapper :global(.content-empty) {
+		color: var(--terminal-fg-muted);
+	}
+
+	.library-terminal-wrapper :global(.content-empty__title) {
+		color: var(--terminal-fg-primary);
+	}
+
+	.library-terminal-wrapper :global(.content-empty__sub) {
+		color: var(--terminal-fg-muted);
+	}
+
+	/* ── Empty / loading states ── */
+	.lw-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		color: var(--terminal-fg-muted);
+	}
+
+	.lw-empty-text {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		letter-spacing: 0.04em;
+	}
+
+	.lw-err {
+		color: var(--terminal-status-error);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/LibraryWrapper.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/LibraryWrapper.svelte
@@ -8,9 +8,9 @@
 -->
 <script lang="ts">
 	import { getContext, onMount } from "svelte";
-	import LibraryShell from "$wealth/components/library/LibraryShell.svelte";
-	import { createClientApiClient } from "$wealth/api/client";
-	import type { LibraryTree } from "$wealth/types/library";
+	import LibraryShell from "../../../components/library/LibraryShell.svelte";
+	import { createClientApiClient } from "../../../api/client";
+	import type { LibraryTree } from "../../../types/library";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 	const api = createClientApiClient(getToken);

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/ReportsPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/ReportsPanel.svelte
@@ -8,11 +8,11 @@
 <script lang="ts">
 	import { getContext, onDestroy, onMount } from "svelte";
 	import { formatDateTime } from "@investintell/ui";
-	import { createClientApiClient } from "$wealth/api/client";
-	import { createTerminalStream, type TerminalStreamHandle } from "$wealth/components/terminal/runtime/stream";
-	import LiveDot from "$wealth/components/terminal/data/LiveDot.svelte";
-	import type { ContentSummary } from "$wealth/types/content";
-	import { contentTypeLabel } from "$wealth/types/content";
+	import { createClientApiClient } from "../../../api/client";
+	import { createTerminalStream, type TerminalStreamHandle } from "../../../components/terminal/runtime/stream";
+	import LiveDot from "../../../components/terminal/data/LiveDot.svelte";
+	import type { ContentSummary } from "../../../types/content";
+	import { contentTypeLabel } from "../../../types/content";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 	const api = createClientApiClient(getToken);

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/ReportsPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/ReportsPanel.svelte
@@ -1,0 +1,694 @@
+<!--
+  ReportsPanel — terminal-native content generation surface.
+
+  Renders existing reports (outlooks, flash reports, spotlights)
+  with generate buttons, SSE streaming progress, and PDF download.
+  Uses createTerminalStream for SSE, createClientApiClient for auth.
+-->
+<script lang="ts">
+	import { getContext, onDestroy, onMount } from "svelte";
+	import { formatDateTime } from "@investintell/ui";
+	import { createClientApiClient } from "$wealth/api/client";
+	import { createTerminalStream, type TerminalStreamHandle } from "$wealth/components/terminal/runtime/stream";
+	import LiveDot from "$wealth/components/terminal/data/LiveDot.svelte";
+	import type { ContentSummary } from "$wealth/types/content";
+	import { contentTypeLabel } from "$wealth/types/content";
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	// ── State ─────────────────────────────────────────────────────
+	let reports = $state<ContentSummary[]>([]);
+	let loading = $state(true);
+	let errorMsg = $state<string | null>(null);
+	let generating = $state(false);
+	let downloadingId = $state<string | null>(null);
+
+	// Fund picker for spotlight
+	let spotlightOpen = $state(false);
+	let spotlightSearch = $state("");
+	let fundResults = $state<{ fund_id: string; name: string; manager_name?: string | null }[]>([]);
+	let fundLoading = $state(false);
+
+	// SSE handles
+	let activeStreamHandle = $state<TerminalStreamHandle | null>(null);
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+	// ── Lifecycle ─────────────────────────────────────────────────
+
+	onMount(async () => {
+		await fetchReports();
+	});
+
+	onDestroy(() => {
+		if (pollTimer) clearInterval(pollTimer);
+		activeStreamHandle?.close();
+	});
+
+	// Poll while any item is generating
+	let hasGenerating = $derived(reports.some((r) => r.status === "draft" || r.status === "generating"));
+
+	$effect(() => {
+		if (hasGenerating && !pollTimer) {
+			pollTimer = setInterval(() => { void fetchReports(); }, 5000);
+		} else if (!hasGenerating && pollTimer) {
+			clearInterval(pollTimer);
+			pollTimer = null;
+		}
+	});
+
+	// ── Data fetching ─────────────────────────────────────────────
+
+	async function fetchReports() {
+		try {
+			reports = await api.get<ContentSummary[]>("/content");
+			errorMsg = null;
+		} catch (err: unknown) {
+			if (loading) {
+				errorMsg = err instanceof Error ? err.message : "Failed to load reports";
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	// ── Generation ────────────────────────────────────────────────
+
+	async function generateContent(endpoint: string, params?: Record<string, string>) {
+		generating = true;
+		errorMsg = null;
+		try {
+			const qs = params ? "?" + new URLSearchParams(params).toString() : "";
+			const res = await api.post<ContentSummary & { job_id?: string }>(`/content/${endpoint}${qs}`, {});
+			await fetchReports();
+			if (res.job_id && res.id) {
+				startSSE(String(res.id), res.job_id);
+			}
+		} catch (err: unknown) {
+			if (err instanceof Error && err.message.includes("409")) {
+				errorMsg = "A flash report was already generated recently. Please wait before generating another.";
+			} else {
+				errorMsg = err instanceof Error ? err.message : "Generation failed";
+			}
+		} finally {
+			generating = false;
+		}
+	}
+
+	function startSSE(contentId: string, jobId: string) {
+		const apiBase = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+		const abortController = new AbortController();
+
+		// Get token async and start stream
+		(async () => {
+			const token = await getToken();
+			activeStreamHandle = createTerminalStream<Record<string, unknown>>({
+				url: `${apiBase}/content/${contentId}/stream/${jobId}`,
+				headers: { Authorization: `Bearer ${token}` },
+				signal: abortController.signal,
+				reconnect: false,
+				onMessage: (data) => {
+					if (data.type === "done" || data.type === "error") {
+						void fetchReports();
+						activeStreamHandle?.close();
+					}
+				},
+				onError: () => {
+					void fetchReports();
+				},
+				onClose: () => {
+					activeStreamHandle = null;
+				},
+			});
+		})();
+	}
+
+	// ── Spotlight fund picker ────────────────────────────────────
+
+	function openSpotlightPicker() {
+		spotlightOpen = true;
+		spotlightSearch = "";
+		fundResults = [];
+	}
+
+	async function searchFunds() {
+		if (!spotlightSearch.trim()) {
+			fundResults = [];
+			return;
+		}
+		fundLoading = true;
+		try {
+			fundResults = await api.get<typeof fundResults>(`/funds?q=${encodeURIComponent(spotlightSearch.trim())}&limit=10`);
+		} catch {
+			fundResults = [];
+		} finally {
+			fundLoading = false;
+		}
+	}
+
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function handleSearchInput() {
+		if (searchDebounce) clearTimeout(searchDebounce);
+		searchDebounce = setTimeout(searchFunds, 300);
+	}
+
+	async function selectSpotlightFund(fundId: string) {
+		spotlightOpen = false;
+		await generateContent("spotlights", { instrument_id: fundId });
+	}
+
+	// ── Download ──────────────────────────────────────────────────
+
+	async function downloadPdf(item: ContentSummary) {
+		downloadingId = item.id;
+		try {
+			const blob = await api.getBlob(`/content/${item.id}/download`);
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${item.content_type}_${item.language}.pdf`;
+			a.click();
+			URL.revokeObjectURL(url);
+		} catch (err: unknown) {
+			errorMsg = err instanceof Error ? err.message : "Download failed";
+		} finally {
+			downloadingId = null;
+		}
+	}
+
+	// ── Retry ─────────────────────────────────────────────────────
+
+	function retryContent(item: ContentSummary) {
+		if (item.content_type === "manager_spotlight") {
+			openSpotlightPicker();
+			return;
+		}
+		const endpointMap: Record<string, string> = {
+			investment_outlook: "outlooks",
+			flash_report: "flash-reports",
+		};
+		const endpoint = endpointMap[item.content_type];
+		if (endpoint) void generateContent(endpoint);
+	}
+
+	// ── Status helpers ────────────────────────────────────────────
+
+	function statusLabel(s: string): string {
+		switch (s) {
+			case "draft":
+			case "generating": return "GENERATING";
+			case "ready":
+			case "published": return "PUBLISHED";
+			case "failed": return "FAILED";
+			default: return s.toUpperCase();
+		}
+	}
+
+	type DotStatus = "success" | "warn" | "error" | "muted";
+
+	function statusDot(s: string): DotStatus {
+		switch (s) {
+			case "draft":
+			case "generating": return "warn";
+			case "ready":
+			case "published": return "success";
+			case "failed": return "error";
+			default: return "muted";
+		}
+	}
+</script>
+
+<div class="rp-root">
+	<!-- Generate bar -->
+	<div class="rp-generate-bar">
+		<span class="rp-generate-label">GENERATE:</span>
+		<button
+			class="rp-gen-btn"
+			onclick={() => generateContent("outlooks")}
+			disabled={generating}
+		>
+			[ OUTLOOK ]
+		</button>
+		<button
+			class="rp-gen-btn"
+			onclick={() => generateContent("flash-reports")}
+			disabled={generating}
+		>
+			[ FLASH ]
+		</button>
+		<button
+			class="rp-gen-btn"
+			onclick={openSpotlightPicker}
+			disabled={generating}
+		>
+			[ SPOTLIGHT ]
+		</button>
+	</div>
+
+	{#if errorMsg}
+		<div class="rp-error">
+			<span>{errorMsg}</span>
+			<button class="rp-error-dismiss" onclick={() => errorMsg = null} type="button">x</button>
+		</div>
+	{/if}
+
+	<!-- Report list -->
+	<div class="rp-list">
+		{#if loading}
+			<div class="rp-empty">
+				<span class="rp-empty-text">Loading reports...</span>
+			</div>
+		{:else if reports.length === 0}
+			<div class="rp-empty">
+				<span class="rp-empty-text">No reports yet. Generate an outlook or flash report to start.</span>
+			</div>
+		{:else}
+			{#each reports as item (item.id)}
+				<div class="rp-card">
+					<div class="rp-card-top">
+						<div class="rp-card-info">
+							<span class="rp-card-type">{contentTypeLabel(item.content_type)}</span>
+							<span class="rp-card-title">{item.title ?? contentTypeLabel(item.content_type)}</span>
+						</div>
+						<div class="rp-card-meta">
+							<span class="rp-card-lang">{item.language.toUpperCase()}</span>
+							<span class="rp-card-date">{formatDateTime(item.created_at)}</span>
+						</div>
+					</div>
+					<div class="rp-card-bottom">
+						<div class="rp-card-status">
+							<LiveDot
+								status={statusDot(item.status)}
+								pulse={item.status === "draft" || item.status === "generating"}
+							/>
+							<span class="rp-status-text">{statusLabel(item.status)}</span>
+						</div>
+						<div class="rp-card-actions">
+							{#if item.status === "draft" || item.status === "generating"}
+								<span class="rp-btn rp-btn-generating">[ GENERATING... ]</span>
+							{:else if item.status === "published" || item.status === "ready"}
+								<button
+									class="rp-btn rp-btn-download"
+									onclick={() => downloadPdf(item)}
+									disabled={downloadingId === item.id}
+								>
+									{downloadingId === item.id ? "[ DOWNLOADING... ]" : "[ DOWNLOAD PDF ]"}
+								</button>
+							{:else if item.status === "failed"}
+								<button class="rp-btn rp-btn-retry" onclick={() => retryContent(item)}>
+									[ REGENERATE ]
+								</button>
+							{/if}
+						</div>
+					</div>
+				</div>
+			{/each}
+		{/if}
+	</div>
+</div>
+
+<!-- Spotlight fund picker dialog -->
+{#if spotlightOpen}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="rp-overlay" onclick={() => spotlightOpen = false}>
+		<div class="rp-dialog" onclick={(e) => e.stopPropagation()}>
+			<div class="rp-dialog-header">
+				<span class="rp-dialog-title">SELECT FUND FOR SPOTLIGHT</span>
+				<button class="rp-dialog-close" onclick={() => spotlightOpen = false}>x</button>
+			</div>
+			<div class="rp-dialog-body">
+				<input
+					type="text"
+					class="rp-dialog-search"
+					placeholder="Search funds..."
+					bind:value={spotlightSearch}
+					oninput={handleSearchInput}
+				/>
+				{#if fundLoading}
+					<div class="rp-dialog-msg">Searching...</div>
+				{:else if spotlightSearch && fundResults.length === 0}
+					<div class="rp-dialog-msg">No funds found</div>
+				{:else}
+					<div class="rp-dialog-results">
+						{#each fundResults as fund (fund.fund_id)}
+							<button
+								class="rp-dialog-fund"
+								onclick={() => selectSpotlightFund(fund.fund_id)}
+							>
+								<span class="rp-fund-name">{fund.name}</span>
+								{#if fund.manager_name}
+									<span class="rp-fund-manager">{fund.manager_name}</span>
+								{/if}
+							</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.rp-root {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--terminal-bg-panel);
+		font-family: var(--terminal-font-mono);
+		overflow: hidden;
+	}
+
+	/* ── Generate bar ── */
+	.rp-generate-bar {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 12px 16px;
+		border-bottom: var(--terminal-border-hairline);
+		flex-shrink: 0;
+	}
+
+	.rp-generate-label {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		color: var(--terminal-fg-muted);
+		text-transform: uppercase;
+	}
+
+	.rp-gen-btn {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-accent-cyan);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		padding: 4px 10px;
+		cursor: pointer;
+		transition: all 150ms ease;
+		outline: none;
+	}
+
+	.rp-gen-btn:hover:not(:disabled) {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 10%, transparent);
+		border-color: var(--terminal-accent-cyan);
+	}
+
+	.rp-gen-btn:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	/* ── Error banner ── */
+	.rp-error {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 6px 16px;
+		background: color-mix(in srgb, var(--terminal-status-error) 10%, transparent);
+		color: var(--terminal-status-error);
+		font-size: var(--terminal-text-11);
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.rp-error-dismiss {
+		background: none;
+		border: none;
+		color: var(--terminal-status-error);
+		cursor: pointer;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		padding: 0 4px;
+	}
+
+	/* ── Report list ── */
+	.rp-list {
+		flex: 1;
+		overflow-y: auto;
+		padding: 8px 0;
+	}
+
+	.rp-card {
+		border-bottom: var(--terminal-border-hairline);
+		padding: 10px 16px;
+	}
+
+	.rp-card-top {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 12px;
+		margin-bottom: 6px;
+	}
+
+	.rp-card-info {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
+	}
+
+	.rp-card-type {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		color: var(--terminal-accent-cyan);
+		text-transform: uppercase;
+	}
+
+	.rp-card-title {
+		font-size: var(--terminal-text-12);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.rp-card-meta {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-shrink: 0;
+	}
+
+	.rp-card-lang {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rp-card-date {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.rp-card-bottom {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+	}
+
+	.rp-card-status {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.rp-status-text {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		color: var(--terminal-fg-secondary);
+	}
+
+	.rp-card-actions {
+		display: flex;
+		gap: 8px;
+	}
+
+	/* ── Action buttons ── */
+	.rp-btn {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		padding: 3px 8px;
+		cursor: pointer;
+		transition: all 150ms ease;
+		outline: none;
+	}
+
+	.rp-btn-generating {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+		cursor: default;
+		animation: rp-pulse 1.5s infinite alternate;
+	}
+
+	@keyframes rp-pulse {
+		0% { opacity: 0.5; }
+		100% { opacity: 1; }
+	}
+
+	.rp-btn-download {
+		color: var(--terminal-accent-cyan);
+		border-color: var(--terminal-accent-cyan);
+	}
+
+	.rp-btn-download:hover:not(:disabled) {
+		background: color-mix(in srgb, var(--terminal-accent-cyan) 10%, transparent);
+	}
+
+	.rp-btn-download:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.rp-btn-retry {
+		color: var(--terminal-status-error);
+		border-color: var(--terminal-status-error);
+	}
+
+	.rp-btn-retry:hover {
+		background: color-mix(in srgb, var(--terminal-status-error) 10%, transparent);
+	}
+
+	/* ── Empty state ── */
+	.rp-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		padding: 24px;
+	}
+
+	.rp-empty-text {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		letter-spacing: 0.04em;
+	}
+
+	/* ── Spotlight dialog ── */
+	.rp-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: var(--terminal-z-modal, 1000);
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.rp-dialog {
+		width: 420px;
+		max-height: 480px;
+		display: flex;
+		flex-direction: column;
+		background: var(--terminal-bg-surface);
+		border: var(--terminal-border-hairline);
+		overflow: hidden;
+	}
+
+	.rp-dialog-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 10px 14px;
+		border-bottom: var(--terminal-border-hairline);
+	}
+
+	.rp-dialog-title {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		color: var(--terminal-fg-secondary);
+	}
+
+	.rp-dialog-close {
+		background: none;
+		border: none;
+		color: var(--terminal-fg-muted);
+		cursor: pointer;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-12);
+		padding: 2px 4px;
+	}
+
+	.rp-dialog-body {
+		display: flex;
+		flex-direction: column;
+		padding: 10px 14px;
+		gap: 8px;
+		overflow: hidden;
+	}
+
+	.rp-dialog-search {
+		width: 100%;
+		padding: 6px 10px;
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		outline: none;
+	}
+
+	.rp-dialog-search::placeholder {
+		color: var(--terminal-fg-muted);
+	}
+
+	.rp-dialog-search:focus {
+		border-color: var(--terminal-accent-cyan);
+	}
+
+	.rp-dialog-msg {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		padding: 8px 0;
+	}
+
+	.rp-dialog-results {
+		display: flex;
+		flex-direction: column;
+		overflow-y: auto;
+		max-height: 320px;
+	}
+
+	.rp-dialog-fund {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		padding: 6px 8px;
+		background: transparent;
+		border: none;
+		border-bottom: var(--terminal-border-hairline);
+		cursor: pointer;
+		text-align: left;
+		font-family: var(--terminal-font-mono);
+		transition: background 100ms ease;
+	}
+
+	.rp-dialog-fund:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.rp-fund-name {
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+
+	.rp-fund-manager {
+		font-size: 9px;
+		color: var(--terminal-fg-muted);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/ScoreBreakdownPopover.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/ScoreBreakdownPopover.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+    import { formatNumber } from "@investintell/ui";
+
+    const COMPONENT_LABELS: Record<string, string> = {
+        return_consistency: "Return Consistency",
+        risk_adjusted_return: "Risk-Adjusted Return",
+        drawdown_control: "Drawdown Control",
+        information_ratio: "Information Ratio",
+        flows_momentum: "Flows Momentum",
+        fee_efficiency: "Fee Efficiency",
+    };
+
+    function humanLabel(key: string): string {
+        return COMPONENT_LABELS[key] ?? key.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+    }
+
+    interface Props {
+        scoreComponents: Record<string, number> | null;
+        managerScore: number | null;
+    }
+
+    let { scoreComponents, managerScore }: Props = $props();
+
+    const entries = $derived(
+        scoreComponents
+            ? Object.entries(scoreComponents).map(([key, value]) => ({
+                label: humanLabel(key),
+                value,
+            }))
+            : []
+    );
+</script>
+
+<div class="popover-root">
+    <div class="popover-header">QUANTITATIVE ENGINE</div>
+
+    {#if entries.length > 0}
+        <table class="popover-table">
+            <thead>
+                <tr>
+                    <th class="text-left">COMPONENT</th>
+                    <th class="text-right">SCORE</th>
+                </tr>
+            </thead>
+            <tbody>
+                {#each entries as comp}
+                    <tr>
+                        <td class="text-left comp-name">{comp.label}</td>
+                        <td class="text-right comp-score">{formatNumber(comp.value, 1)}</td>
+                    </tr>
+                {/each}
+            </tbody>
+        </table>
+
+        {#if managerScore != null}
+            <div class="popover-footer">
+                COMPOSITE: {formatNumber(managerScore, 0)}/100
+            </div>
+        {/if}
+    {:else}
+        <div class="popover-empty">No score components available</div>
+    {/if}
+</div>
+
+<style>
+    .popover-root {
+        background: var(--terminal-bg-panel-raised);
+        border: var(--terminal-border-hairline);
+        width: 280px;
+        display: flex;
+        flex-direction: column;
+        font-family: var(--terminal-font-mono);
+    }
+
+    .popover-header {
+        font-size: var(--terminal-text-10);
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        color: var(--terminal-fg-secondary);
+        padding: 8px 12px;
+        border-bottom: var(--terminal-border-hairline);
+        background: var(--terminal-bg-panel);
+    }
+
+    .popover-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: var(--terminal-text-11);
+    }
+
+    .popover-table th {
+        font-size: 9px;
+        color: var(--terminal-fg-tertiary);
+        font-weight: 600;
+        padding: 6px 12px;
+        border-bottom: var(--terminal-border-hairline);
+        background: var(--terminal-bg-panel);
+    }
+
+    .popover-table td {
+        padding: 6px 12px;
+        border-bottom: 1px solid var(--terminal-fg-disabled);
+    }
+
+    .text-left { text-align: left; }
+    .text-right { text-align: right; }
+
+    .comp-name {
+        color: var(--terminal-fg-secondary);
+    }
+
+    .comp-score {
+        color: var(--terminal-fg-primary);
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .popover-footer {
+        padding: 10px 12px;
+        font-size: var(--terminal-text-10);
+        font-weight: 700;
+        color: var(--terminal-accent-cyan);
+        border-top: var(--terminal-border-hairline);
+    }
+
+    .popover-empty {
+        padding: 16px 12px;
+        font-size: var(--terminal-text-11);
+        color: var(--terminal-fg-muted);
+        text-align: center;
+    }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalAssetTree.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalAssetTree.svelte
@@ -1,0 +1,291 @@
+<!--
+  TerminalAssetTree — searchable real-data fund browser.
+
+  Flat list view over `/screener/catalog` with a debounced search box.
+  Replaces the previous 3-level hardcoded tree (Portfolio → Class → Fund)
+  with the actual universe of ~9k funds that have NAV history.
+
+  Each row exposes `instrumentId` (global instruments_universe UUID),
+  which the parent Research shell threads through to the chart so
+  the `/risk/timeseries/{instrument_id}` endpoint can resolve it.
+-->
+<script module lang="ts">
+	export interface TreeNode {
+		id: string;                 // external_id from catalog (stable row key)
+		instrumentId: string | null; // global instruments_universe UUID (null if not imported)
+		label: string;               // fund name
+		ticker: string | null;
+		fundType: string;
+		aum: number | null;
+	}
+</script>
+
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatNumber } from "@investintell/ui";
+	import { createClientApiClient } from "$wealth/api/client";
+
+	interface Props {
+		selectedId: string | null;
+		onSelect: (node: TreeNode) => void;
+	}
+
+	let { selectedId, onSelect }: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	interface UnifiedFundItem {
+		external_id: string;
+		instrument_id: string | null;
+		name: string;
+		ticker: string | null;
+		fund_type: string;
+		aum: number | null;
+	}
+	interface UnifiedCatalogPage {
+		items: UnifiedFundItem[];
+		total: number;
+	}
+
+	let searchQuery = $state("");
+	let nodes = $state<TreeNode[]>([]);
+	let total = $state(0);
+	let loading = $state(false);
+	let errorMessage = $state<string | null>(null);
+
+	function toNode(raw: UnifiedFundItem): TreeNode {
+		return {
+			id: raw.external_id,
+			instrumentId: raw.instrument_id,
+			label: raw.name,
+			ticker: raw.ticker,
+			fundType: raw.fund_type,
+			aum: raw.aum,
+		};
+	}
+
+	let debounceHandle: ReturnType<typeof setTimeout> | null = null;
+	let fetchSeq = 0;
+
+	$effect(() => {
+		const q = searchQuery.trim();
+
+		if (debounceHandle) clearTimeout(debounceHandle);
+		debounceHandle = setTimeout(async () => {
+			const fetchId = ++fetchSeq;
+			loading = true;
+			errorMessage = null;
+
+			const params: Record<string, string> = {
+				in_universe: "true",
+				page: "1",
+				page_size: "150",
+				sort: "aum_desc",
+			};
+			if (q.length > 0) params.q = q;
+
+			try {
+				const page = await api.get<UnifiedCatalogPage>("/screener/catalog", params);
+				if (fetchId !== fetchSeq) return; // stale
+				nodes = page.items.map(toNode);
+				total = page.total;
+			} catch (err) {
+				if (fetchId !== fetchSeq) return;
+				nodes = [];
+				total = 0;
+				errorMessage = err instanceof Error ? err.message : "Failed to load fund catalog";
+			} finally {
+				if (fetchId === fetchSeq) loading = false;
+			}
+		}, 250);
+
+		return () => {
+			if (debounceHandle) clearTimeout(debounceHandle);
+		};
+	});
+
+	function fmtAum(n: number | null): string {
+		if (n == null || n <= 0) return "";
+		if (n >= 1e12) return formatNumber(n / 1e12, 1) + "T";
+		if (n >= 1e9) return formatNumber(n / 1e9, 1) + "B";
+		if (n >= 1e6) return formatNumber(n / 1e6, 0) + "M";
+		return formatNumber(n, 0);
+	}
+</script>
+
+<div class="at-root">
+	<div class="at-header">
+		<span class="at-title">ASSET BROWSER</span>
+		<span class="at-count">{nodes.length} / {formatNumber(total, 0)}</span>
+	</div>
+
+	<div class="at-search">
+		<input
+			type="text"
+			placeholder="Search ticker / name / manager"
+			bind:value={searchQuery}
+			class="at-search-input"
+		/>
+	</div>
+
+	<div class="at-scroll">
+		{#if errorMessage}
+			<div class="at-empty at-err">{errorMessage}</div>
+		{:else if loading && nodes.length === 0}
+			<div class="at-empty">Loading catalog&hellip;</div>
+		{:else if nodes.length === 0}
+			<div class="at-empty">No funds match that search.</div>
+		{:else}
+			{#each nodes as node (node.id)}
+				<button
+					class="at-row"
+					class:selected={selectedId === node.id}
+					class:dim={!node.instrumentId}
+					onclick={() => onSelect(node)}
+					title={node.instrumentId ? node.label : `${node.label} (no NAV data)`}
+				>
+					<span class="at-ticker">{node.ticker ?? "—"}</span>
+					<span class="at-name">{node.label}</span>
+					<span class="at-aum">{fmtAum(node.aum)}</span>
+				</button>
+			{/each}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.at-root {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--terminal-bg-panel);
+		border-right: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-secondary);
+		min-width: 0;
+	}
+
+	.at-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 10px 12px 8px;
+		border-bottom: var(--terminal-border-hairline);
+		flex-shrink: 0;
+	}
+
+	.at-title {
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+	}
+
+	.at-count {
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		color: var(--terminal-fg-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.at-search {
+		padding: 8px 10px;
+		border-bottom: 1px solid var(--terminal-fg-disabled);
+		flex-shrink: 0;
+	}
+
+	.at-search-input {
+		width: 100%;
+		background: var(--terminal-bg-panel-sunken);
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		padding: 5px 8px;
+		outline: none;
+		border-radius: var(--terminal-radius-none);
+	}
+	.at-search-input:focus {
+		border-color: var(--terminal-accent-cyan-dim);
+	}
+	.at-search-input::placeholder {
+		color: var(--terminal-fg-muted);
+	}
+
+	.at-scroll {
+		flex: 1;
+		overflow-y: auto;
+		overflow-x: hidden;
+		min-height: 0;
+	}
+
+	.at-row {
+		display: grid;
+		grid-template-columns: 56px 1fr auto;
+		align-items: center;
+		gap: 6px;
+		width: 100%;
+		padding: 5px 10px;
+		background: transparent;
+		border: none;
+		border-bottom: 1px solid var(--terminal-fg-disabled);
+		color: inherit;
+		font-family: inherit;
+		font-size: inherit;
+		cursor: pointer;
+		text-align: left;
+		min-width: 0;
+	}
+	.at-row:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+	.at-row.selected {
+		background: var(--terminal-bg-overlay);
+	}
+	.at-row.dim {
+		opacity: 0.55;
+	}
+
+	.at-ticker {
+		font-family: var(--terminal-font-mono);
+		font-weight: 700;
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-primary);
+		letter-spacing: 0.04em;
+	}
+	.at-row.selected .at-ticker {
+		color: var(--terminal-accent-cyan);
+	}
+
+	.at-name {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-tertiary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		min-width: 0;
+	}
+
+	.at-aum {
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		color: var(--terminal-fg-tertiary);
+		font-variant-numeric: tabular-nums;
+		flex-shrink: 0;
+	}
+
+	.at-empty {
+		padding: 24px 14px;
+		text-align: center;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		font-style: italic;
+	}
+	.at-err {
+		color: var(--terminal-status-error);
+		font-style: normal;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalAssetTree.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalAssetTree.svelte
@@ -23,7 +23,7 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { formatNumber } from "@investintell/ui";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../../api/client";
 
 	interface Props {
 		selectedId: string | null;

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalHoldingsGrid.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalHoldingsGrid.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+	import { formatNumber, formatPercent } from "@investintell/ui";
+
+	interface Props {
+		ticker: string;
+	}
+
+	let { ticker }: Props = $props();
+
+	type Holding = {
+		issuer_name: string;
+		sector: string;
+		weight: number;
+		market_value: number;
+	};
+
+	type SectorInfo = {
+		name: string;
+		weight: number;
+		holdings_count: number;
+	};
+
+	type HoldingsData = {
+		top_holdings: Holding[];
+		sector_breakdown: SectorInfo[];
+	};
+
+	let data = $state<HoldingsData | null>(null);
+	let loading = $state(false);
+	let error = $state<string | null>(null);
+
+	$effect(() => {
+		if (!ticker || ticker === "PORTFOLIO") {
+			data = null;
+			return;
+		}
+
+		let controller = new AbortController();
+
+		async function fetchHoldings() {
+			loading = true;
+			error = null;
+			try {
+				const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+				const res = await fetch(`${API_BASE}/wealth/discovery/funds/${ticker}/analysis/holdings/top`, {
+					signal: controller.signal,
+				});
+				if (!res.ok) {
+					throw new Error(`Failed to fetch holdings: ${res.statusText}`);
+				}
+				data = await res.json();
+			} catch (err: any) {
+				if (err.name !== "AbortError") {
+					error = err.message;
+				}
+			} finally {
+				loading = false;
+			}
+		}
+
+		fetchHoldings();
+
+		return () => {
+			controller.abort();
+		};
+	});
+</script>
+
+<div class="h-root">
+	{#if loading}
+		<div class="h-message">Loading holdings...</div>
+	{:else if error}
+		<div class="h-message h-error">{error}</div>
+	{:else if !data}
+		<div class="h-message">No holdings data available.</div>
+	{:else}
+		<div class="h-grid">
+			<!-- Top Holdings Section -->
+			<div class="h-section">
+				<div class="h-section-header">TOP HOLDINGS</div>
+				<div class="h-scroll-area">
+					<table class="h-table">
+						<thead>
+							<tr>
+								<th class="text-left">ISSUER</th>
+								<th class="text-left">SECTOR</th>
+								<th class="text-right">WEIGHT</th>
+								<th class="text-right">MARKET VALUE</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each data.top_holdings as holding}
+								<tr>
+									<td class="text-left td-primary">{holding.issuer_name}</td>
+									<td class="text-left td-secondary">{holding.sector}</td>
+									<td class="text-right">{formatPercent(holding.weight * 100)}</td>
+									<td class="text-right">${formatNumber(holding.market_value)}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</div>
+
+			<!-- Sector Breakdown Section -->
+			<div class="h-section">
+				<div class="h-section-header">SECTOR BREAKDOWN</div>
+				<div class="h-scroll-area">
+					<table class="h-table">
+						<thead>
+							<tr>
+								<th class="text-left">SECTOR</th>
+								<th class="text-right">COUNT</th>
+								<th class="text-right">WEIGHT</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each data.sector_breakdown as sector}
+								<tr class="sector-row">
+									<td class="text-left sector-cell">
+										<div
+											class="sector-bar"
+											style="width: {sector.weight * 100}%;"
+										></div>
+										<span class="sector-name">{sector.name}</span>
+									</td>
+									<td class="text-right">{sector.holdings_count}</td>
+									<td class="text-right">{formatPercent(sector.weight * 100)}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.h-root {
+		width: 100%;
+		height: 100%;
+		background: var(--terminal-bg-panel);
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+		font-family: var(--terminal-font-mono);
+	}
+
+	.h-message {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		color: var(--terminal-fg-secondary);
+		font-size: var(--terminal-text-11);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.h-error {
+		color: var(--terminal-status-error);
+	}
+
+	.h-grid {
+		display: grid;
+		grid-template-rows: 1fr 1fr;
+		gap: 2px;
+		width: 100%;
+		height: 100%;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	@media (min-width: 1024px) {
+		.h-grid {
+			grid-template-rows: 100%;
+			grid-template-columns: 2fr 1fr;
+		}
+	}
+
+	.h-section {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+		border: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.h-section-header {
+		height: 24px;
+		line-height: 24px;
+		padding: 0 8px;
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		color: var(--terminal-fg-secondary);
+		background: var(--terminal-bg-panel);
+		border-bottom: var(--terminal-border-hairline);
+		flex-shrink: 0;
+	}
+
+	.h-scroll-area {
+		flex: 1;
+		min-width: 0;
+		min-height: 0;
+		overflow-y: auto;
+	}
+
+	.h-scroll-area::-webkit-scrollbar {
+		width: 4px;
+		height: 4px;
+	}
+	.h-scroll-area::-webkit-scrollbar-track {
+		background: transparent;
+	}
+	.h-scroll-area::-webkit-scrollbar-thumb {
+		background: var(--terminal-fg-disabled);
+	}
+	.h-scroll-area::-webkit-scrollbar-thumb:hover {
+		background: var(--terminal-fg-muted);
+	}
+
+	.h-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: var(--terminal-text-11);
+		font-variant-numeric: tabular-nums;
+		color: var(--terminal-fg-secondary);
+	}
+
+	.h-table th {
+		position: sticky;
+		top: 0;
+		z-index: 20;
+		background: var(--terminal-bg-panel);
+		color: var(--terminal-fg-tertiary);
+		font-weight: 600;
+		padding: 4px 8px;
+		border-bottom: var(--terminal-border-hairline);
+		white-space: nowrap;
+	}
+
+	.h-table td {
+		padding: 4px 8px;
+		border-bottom: 1px solid var(--terminal-fg-disabled);
+		white-space: nowrap;
+	}
+
+	.h-table tr:hover td {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.text-left { text-align: left; }
+	.text-right { text-align: right; }
+
+	.td-primary {
+		font-weight: 600;
+		color: var(--terminal-fg-primary);
+	}
+
+	.td-secondary {
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.sector-row {
+		position: relative;
+	}
+
+	.sector-cell {
+		position: relative;
+	}
+
+	.sector-bar {
+		position: absolute;
+		left: 0;
+		top: 0;
+		height: 100%;
+		background: var(--terminal-fg-disabled);
+		z-index: 0;
+	}
+
+	.sector-name {
+		position: relative;
+		z-index: 1;
+		padding-left: 4px;
+		color: var(--terminal-fg-primary);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalResearchChart.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalResearchChart.svelte
@@ -1,0 +1,411 @@
+<!--
+  TerminalResearchChart — lightweight-charts v5 risk analytics workspace.
+
+  Three stacked panes sharing a synced time axis:
+    1. Drawdown (baseline, red)    — peak-to-trough from NAV running max
+    2. GARCH volatility (line)     — conditional vol from fund_risk_metrics
+    3. Regime probability (area)   — p_high_vol from macro_regime_history
+
+  All three series are pre-computed server-side in TimescaleDB. The
+  frontend only renders them via lightweight-charts — zero math here.
+  Fetch is skipped when `instrumentId` is null (mock / unselected).
+
+  Data source: GET /api/v1/risk/timeseries/{instrument_id}
+  Chart library: lightweight-charts ^5 (already in use by TerminalPriceChart).
+-->
+<script lang="ts">
+	import { formatNumber } from "@investintell/ui";
+	import {
+		createTerminalLightweightChartOptions,
+		terminalLWSeriesColors,
+	} from "@investintell/ui";
+	import { getContext, onMount } from "svelte";
+	import type { UTCTimestamp } from "lightweight-charts";
+	import {
+		fetchRiskTimeseries,
+		type RiskTimeseries,
+	} from "$wealth/services/risk-engine-client";
+
+	interface Props {
+		ticker: string;
+		tickerLabel: string;
+		instrumentId?: string | null;
+	}
+
+	let { ticker, tickerLabel, instrumentId = null }: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+
+	let drawdownEl: HTMLDivElement | undefined = $state();
+	let volEl: HTMLDivElement | undefined = $state();
+	let regimeEl: HTMLDivElement | undefined = $state();
+
+	let charts: unknown[] = [];
+	let loading = $state(false);
+	let errorMessage = $state<string | null>(null);
+	let riskData = $state<RiskTimeseries | null>(null);
+
+	onMount(() => {
+		let disposed = false;
+
+		return () => {
+			disposed = true;
+			destroyCharts();
+		};
+
+		function destroyCharts() {
+			for (const c of charts) {
+				if (c && typeof (c as Record<string, unknown>).remove === "function") {
+					(c as { remove: () => void }).remove();
+				}
+			}
+			charts = [];
+		}
+	});
+
+	// Re-fetch and re-render whenever the selected instrument changes.
+	$effect(() => {
+		const iid = instrumentId;
+		if (!iid) {
+			riskData = null;
+			errorMessage = null;
+			return;
+		}
+
+		let cancelled = false;
+		loading = true;
+		errorMessage = null;
+
+		(async () => {
+			try {
+				const data = await fetchRiskTimeseries(iid, getToken);
+				if (!cancelled) {
+					riskData = data;
+				}
+			} catch (err) {
+				if (!cancelled) {
+					riskData = null;
+					errorMessage = err instanceof Error ? err.message : "Failed to fetch risk timeseries";
+				}
+			} finally {
+				if (!cancelled) loading = false;
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	// Render panes whenever riskData or container elements change.
+	$effect(() => {
+		const data = riskData;
+		const dd = drawdownEl;
+		const vl = volEl;
+		const rg = regimeEl;
+		if (!data || !dd || !vl || !rg) return;
+
+		let disposed = false;
+
+		(async () => {
+			const lc = await import("lightweight-charts");
+			if (disposed) return;
+
+			// Tear down previous charts before rebuilding
+			for (const c of charts) {
+				if (c && typeof (c as Record<string, unknown>).remove === "function") {
+					(c as { remove: () => void }).remove();
+				}
+			}
+			charts = [];
+
+			const sc = terminalLWSeriesColors();
+
+			// ── Pane 1: Drawdown (baseline red) ─────────────
+			const ddOpts = createTerminalLightweightChartOptions({
+				fontSize: 9,
+				crosshairColor: sc.drawdown.bottomLineColor,
+			});
+			const ddChart = lc.createChart(dd, { autoSize: true, ...ddOpts });
+			const ddSeries = ddChart.addSeries(lc.BaselineSeries, {
+				baseValue: { type: "price", price: 0 },
+				...sc.drawdown,
+				lineWidth: 2,
+				priceLineVisible: false,
+				lastValueVisible: true,
+				priceFormat: { type: "price", precision: 2, minMove: 0.01 },
+			});
+			ddSeries.setData(data.drawdown.map((p) => ({ time: p.time as unknown as UTCTimestamp, value: p.value })));
+			ddChart.timeScale().fitContent();
+
+			// ── Pane 2: GARCH Volatility (violet line) ──────
+			const vlOpts = createTerminalLightweightChartOptions({
+				fontSize: 9,
+				scaleMargins: { top: 0.15, bottom: 0.1 },
+				crosshairColor: sc.volatility.color,
+			});
+			const vlChart = lc.createChart(vl, { autoSize: true, ...vlOpts });
+			const vlSeries = vlChart.addSeries(lc.LineSeries, {
+				...sc.volatility,
+				lineWidth: 2,
+				priceLineVisible: false,
+				lastValueVisible: true,
+				priceFormat: { type: "price", precision: 2, minMove: 0.01 },
+			});
+			vlSeries.setData(
+				data.volatilityGarch.map((p) => ({ time: p.time as unknown as UTCTimestamp, value: p.value })),
+			);
+			vlChart.timeScale().fitContent();
+
+			// ── Pane 3: Regime Probability (amber area) ──────
+			const rgOpts = createTerminalLightweightChartOptions({
+				fontSize: 9,
+				timeVisible: true,
+			});
+			const rgChart = lc.createChart(rg, { autoSize: true, ...rgOpts });
+			const rgSeries = rgChart.addSeries(lc.AreaSeries, {
+				...sc.regime,
+				lineWidth: 1,
+				priceLineVisible: false,
+				lastValueVisible: true,
+				priceFormat: { type: "price", precision: 2, minMove: 0.01 },
+			});
+			rgSeries.setData(
+				data.regimeProb.map((p) => ({ time: p.time as unknown as UTCTimestamp, value: p.value })),
+			);
+			rgChart.timeScale().fitContent();
+
+			// ── Time-axis sync ──────────────────────────────
+			// When user scrolls/zooms one pane, mirror the visible range
+			// on the other two. Guard against feedback loops with a flag.
+			let syncing = false;
+			const all = [ddChart, vlChart, rgChart];
+			for (const source of all) {
+				source.timeScale().subscribeVisibleLogicalRangeChange((range: unknown) => {
+					if (!range || syncing) return;
+					syncing = true;
+					for (const target of all) {
+						if (target === source) continue;
+						target.timeScale().setVisibleLogicalRange(range as { from: number; to: number });
+					}
+					syncing = false;
+				});
+			}
+
+			charts = [ddChart, vlChart, rgChart];
+		})();
+
+		return () => {
+			disposed = true;
+		};
+	});
+
+	// ── Header summary numbers ───────────────────────────
+	const summary = $derived.by(() => {
+		if (!riskData) return null;
+		const maxDd = riskData.drawdown.length
+			? Math.min(...riskData.drawdown.map((p) => p.value))
+			: null;
+		const lastVol = riskData.volatilityGarch.length
+			? riskData.volatilityGarch[riskData.volatilityGarch.length - 1]!.value
+			: null;
+		const lastRegime = riskData.regimeProb.length
+			? riskData.regimeProb[riskData.regimeProb.length - 1]
+			: null;
+		return { maxDd, lastVol, lastRegime };
+	});
+</script>
+
+<div class="rc-root">
+	<div class="rc-header">
+		<div class="rc-header-left">
+			<span class="rc-ticker">{ticker || "---"}</span>
+			<span class="rc-label">{tickerLabel}</span>
+		</div>
+		<div class="rc-header-right">
+			{#if loading}
+				<span class="rc-tag">Loading risk series&hellip;</span>
+			{:else if summary}
+				<span class="rc-summary">
+					MAX DD
+					<strong class="neg">{summary.maxDd != null ? formatNumber(summary.maxDd, 2) + "%" : "—"}</strong>
+				</span>
+				<span class="rc-summary">
+					FORWARD VOL
+					<strong class="purple">{summary.lastVol != null ? formatNumber(summary.lastVol, 2) + "%" : "—"}</strong>
+				</span>
+				<span class="rc-summary">
+					REGIME
+					<strong class="amber">{summary.lastRegime?.regime ?? "—"}</strong>
+				</span>
+			{/if}
+		</div>
+	</div>
+
+	{#if !instrumentId}
+		<div class="rc-placeholder">
+			<div class="rc-placeholder-title">SELECT AN INSTRUMENT</div>
+			<div class="rc-placeholder-sub">
+				Pick a fund from the asset browser to render<br />
+				drawdown, conditional volatility and regime overlays.
+			</div>
+		</div>
+	{:else if errorMessage}
+		<div class="rc-placeholder">
+			<div class="rc-placeholder-title neg">RISK DATA UNAVAILABLE</div>
+			<div class="rc-placeholder-sub">{errorMessage}</div>
+		</div>
+	{:else}
+		<div class="rc-pane">
+			<div class="rc-pane-label">DRAWDOWN</div>
+			<div class="rc-pane-chart" bind:this={drawdownEl}></div>
+		</div>
+		<div class="rc-pane">
+			<div class="rc-pane-label">CONDITIONAL VOLATILITY</div>
+			<div class="rc-pane-chart" bind:this={volEl}></div>
+		</div>
+		<div class="rc-pane">
+			<div class="rc-pane-label">MACRO REGIME P(HIGH VOL)</div>
+			<div class="rc-pane-chart" bind:this={regimeEl}></div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.rc-root {
+		width: 100%;
+		height: 100%;
+		background: var(--terminal-bg-panel);
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	.rc-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 8px 12px;
+		border-bottom: var(--terminal-border-hairline);
+		flex-shrink: 0;
+		height: 36px;
+	}
+
+	.rc-header-left {
+		display: flex;
+		align-items: baseline;
+		gap: 10px;
+		min-width: 0;
+	}
+
+	.rc-ticker {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-14);
+		font-weight: 800;
+		color: var(--terminal-fg-primary);
+		letter-spacing: 0.04em;
+	}
+
+	.rc-label {
+		font-family: var(--terminal-font-sans);
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-tertiary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.rc-header-right {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		flex-shrink: 0;
+	}
+
+	.rc-summary {
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		color: var(--terminal-fg-tertiary);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		display: inline-flex;
+		gap: 4px;
+		align-items: baseline;
+	}
+
+	.rc-summary strong {
+		font-size: 11px;
+		font-weight: 700;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.rc-tag {
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		color: var(--terminal-fg-muted);
+		letter-spacing: 0.06em;
+	}
+
+	/* ── Panes ───────────────────────────────────────────── */
+	.rc-pane {
+		flex: 1;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		border-bottom: var(--terminal-border-hairline);
+	}
+	.rc-pane:last-child {
+		border-bottom: none;
+	}
+
+	.rc-pane-label {
+		flex-shrink: 0;
+		padding: 4px 10px 2px;
+		font-family: var(--terminal-font-mono);
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		color: var(--terminal-fg-muted);
+		text-transform: uppercase;
+	}
+
+	.rc-pane-chart {
+		flex: 1;
+		min-height: 0;
+		min-width: 0;
+		width: 100%;
+		position: relative;
+	}
+
+	/* ── Placeholder ─────────────────────────────────────── */
+	.rc-placeholder {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		padding: 32px;
+		text-align: center;
+	}
+
+	.rc-placeholder-title {
+		font-family: var(--terminal-font-mono);
+		font-size: 11px;
+		font-weight: 700;
+		letter-spacing: 0.12em;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rc-placeholder-sub {
+		font-family: var(--terminal-font-sans);
+		font-size: 11px;
+		color: var(--terminal-fg-muted);
+		line-height: 1.5;
+	}
+
+	.neg { color: var(--terminal-status-error); }
+	.purple { color: var(--terminal-accent-violet); }
+	.amber { color: var(--terminal-accent-amber); }
+</style>

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalResearchChart.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalResearchChart.svelte
@@ -24,7 +24,7 @@
 	import {
 		fetchRiskTimeseries,
 		type RiskTimeseries,
-	} from "$wealth/services/risk-engine-client";
+	} from "../../../services/risk-engine-client";
 
 	interface Props {
 		ticker: string;

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalResearchShell.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalResearchShell.svelte
@@ -1,0 +1,228 @@
+<!--
+  TerminalResearchShell — 3-column research & risk desk.
+
+  Grid topology:
+    ┌──────────┬──────────────────────┬─────────────┐
+    │          │                      │             │
+    │  ASSET   │   CHART WORKSPACE    │  RISK KPIs  │
+    │ BROWSER  │   (lightweight-      │             │
+    │ (280px)  │     charts)          │   (320px)   │
+    │          │       (1fr)          │             │
+    └──────────┴──────────────────────┴─────────────┘
+
+  The asset browser hits `/screener/catalog?in_universe=true` for
+  real fund data (~9k funds with NAV history). Selection produces a
+  `TreeNode` whose `instrumentId` is the global instruments_universe
+  UUID — the Research chart uses it to fetch the risk timeseries
+  (drawdown, GARCH vol, macro regime) straight from TimescaleDB.
+-->
+<script lang="ts">
+	import TerminalAssetTree, { type TreeNode } from "./TerminalAssetTree.svelte";
+	import TerminalResearchChart from "./TerminalResearchChart.svelte";
+	import TerminalHoldingsGrid from "./TerminalHoldingsGrid.svelte";
+	import TerminalRiskKpis from "./TerminalRiskKpis.svelte";
+	import LibraryWrapper from "./LibraryWrapper.svelte";
+	import ReportsPanel from "./ReportsPanel.svelte";
+
+	// ── Top-level view tab ────────────────────────────
+	type ViewTab = "ANALYTICS" | "LIBRARY" | "REPORTS";
+	let activeView = $state<ViewTab>("ANALYTICS");
+
+	// ── Analytics selection state ─────────────────────
+	let selectedNode = $state<TreeNode | null>(null);
+	let activeTab = $state<"CHART" | "HOLDINGS">("CHART");
+
+	const selectedId = $derived(selectedNode?.id ?? null);
+
+	const chartTicker = $derived(selectedNode?.ticker ?? "—");
+	const chartLabel = $derived(selectedNode?.label ?? "Select a fund from the browser");
+	const chartInstrumentId = $derived(selectedNode?.instrumentId ?? null);
+
+	function handleSelect(node: TreeNode) {
+		selectedNode = node;
+	}
+</script>
+
+<div class="tr-shell">
+	<!-- Top-level view tab bar -->
+	<div class="tr-view-bar">
+		{#each (["ANALYTICS", "LIBRARY", "REPORTS"] as ViewTab[]) as tab (tab)}
+			<button
+				class="tr-view-tab {activeView === tab ? 'tr-view-tab-active' : ''}"
+				onclick={() => activeView = tab}
+			>
+				{tab}
+			</button>
+		{/each}
+	</div>
+
+	<!-- View content -->
+	<div class="tr-view-content">
+		{#if activeView === "ANALYTICS"}
+			<div class="tr-root">
+				<div class="tr-zone tr-tree" aria-label="Asset browser">
+					<TerminalAssetTree {selectedId} onSelect={handleSelect} />
+				</div>
+				<div class="tr-zone tr-chart" aria-label="Chart workspace">
+					<div class="tr-panel-header">
+						<button
+							class="tr-tab {activeTab === 'CHART' ? 'tr-tab-active' : ''}"
+							onclick={() => activeTab = 'CHART'}
+						>
+							CHART
+						</button>
+						<button
+							class="tr-tab {activeTab === 'HOLDINGS' ? 'tr-tab-active' : ''}"
+							onclick={() => activeTab = 'HOLDINGS'}
+						>
+							HOLDINGS
+						</button>
+					</div>
+					<div class="tr-panel-content">
+						{#if activeTab === 'CHART'}
+							<TerminalResearchChart
+								ticker={chartTicker}
+								tickerLabel={chartLabel}
+								instrumentId={chartInstrumentId}
+							/>
+						{:else}
+							<TerminalHoldingsGrid ticker={chartTicker} />
+						{/if}
+					</div>
+				</div>
+				<div class="tr-zone tr-kpis" aria-label="Risk KPIs">
+					<TerminalRiskKpis {selectedNode} />
+				</div>
+			</div>
+		{:else if activeView === "LIBRARY"}
+			<LibraryWrapper />
+		{:else}
+			<ReportsPanel />
+		{/if}
+	</div>
+</div>
+
+<style>
+	.tr-shell {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+		background: var(--terminal-bg-void);
+		font-family: var(--terminal-font-mono);
+	}
+
+	/* ── View tab bar ── */
+	.tr-view-bar {
+		display: flex;
+		align-items: flex-end;
+		gap: 20px;
+		padding: 0 16px;
+		height: 30px;
+		flex-shrink: 0;
+		border-bottom: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+	}
+
+	.tr-view-tab {
+		height: 100%;
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		color: var(--terminal-fg-tertiary);
+		background: transparent;
+		border: none;
+		border-bottom: 2px solid transparent;
+		padding: 0 2px;
+		cursor: pointer;
+		outline: none;
+		font-family: var(--terminal-font-mono);
+		transition: color 120ms ease;
+	}
+
+	.tr-view-tab:hover {
+		color: var(--terminal-fg-secondary);
+	}
+
+	.tr-view-tab-active {
+		color: var(--terminal-fg-primary);
+		border-bottom-color: var(--terminal-accent-cyan);
+	}
+
+	.tr-view-content {
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	/* ── Analytics grid ── */
+	.tr-root {
+		display: grid;
+		grid-template-areas: "tree chart kpis";
+		grid-template-columns: 280px 1fr 320px;
+		grid-template-rows: 100%;
+		gap: 2px;
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+		background: var(--terminal-bg-void);
+		font-family: var(--terminal-font-mono);
+	}
+
+	.tr-zone {
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.tr-tree { grid-area: tree; }
+	.tr-chart {
+		grid-area: chart;
+		display: flex;
+		flex-direction: column;
+	}
+	.tr-kpis { grid-area: kpis; }
+
+	.tr-panel-header {
+		height: 32px;
+		flex-shrink: 0;
+		display: flex;
+		align-items: flex-end;
+		border-bottom: var(--terminal-border-hairline);
+		background: var(--terminal-bg-panel);
+		padding: 0 8px;
+		gap: 16px;
+	}
+
+	.tr-tab {
+		height: 100%;
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: 0.05em;
+		color: var(--terminal-fg-tertiary);
+		background: transparent;
+		border: none;
+		border-bottom: 2px solid transparent;
+		padding: 0 4px;
+		cursor: pointer;
+		outline: none;
+		font-family: var(--terminal-font-mono);
+	}
+
+	.tr-tab:hover {
+		color: var(--terminal-fg-secondary);
+	}
+
+	.tr-tab-active {
+		color: var(--terminal-fg-primary);
+		border-bottom-color: var(--terminal-accent-cyan);
+	}
+
+	.tr-panel-content {
+		flex: 1;
+		min-width: 0;
+		min-height: 0;
+		overflow: hidden;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalRiskKpis.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalRiskKpis.svelte
@@ -1,0 +1,561 @@
+<!--
+  TerminalRiskKpis — right panel showing real risk metrics for selected node.
+  Fetches from GET /instruments/{instrumentId}/risk-metrics.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatNumber, formatPercent } from "@investintell/ui";
+	import type { TreeNode } from "./TerminalAssetTree.svelte";
+	import ScoreBreakdownPopover from "./ScoreBreakdownPopover.svelte";
+	import { createClientApiClient } from "$wealth/api/client";
+
+	interface RiskMetrics {
+		instrument_id: string;
+		score_components: Record<string, number> | null;
+		manager_score: number | null;
+		sharpe_1y: number | null;
+		volatility_1y: number | null;
+		max_drawdown_1y: number | null;
+		cvar_95_1m: number | null;
+		return_1y: number | null;
+		return_3y_ann: number | null;
+		sortino_1y: number | null;
+		max_drawdown_3y: number | null;
+		alpha_1y: number | null;
+		beta_1y: number | null;
+		information_ratio_1y: number | null;
+		tracking_error_1y: number | null;
+		blended_momentum_score: number | null;
+		volatility_garch: number | null;
+	}
+
+	interface Props {
+		selectedNode: TreeNode | null;
+	}
+
+	let { selectedNode }: Props = $props();
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	let risk = $state<RiskMetrics | null>(null);
+	let loading = $state(false);
+	let errorMessage = $state<string | null>(null);
+
+	// Fetch real risk metrics when selected node changes
+	$effect(() => {
+		const iid = selectedNode?.instrumentId;
+		if (!iid) {
+			risk = null;
+			errorMessage = null;
+			loading = false;
+			return;
+		}
+
+		let cancelled = false;
+		loading = true;
+		errorMessage = null;
+
+		(async () => {
+			try {
+				const data = await api.get<RiskMetrics>(`/instruments/${iid}/risk-metrics`);
+				if (!cancelled) {
+					risk = data;
+					errorMessage = null;
+				}
+			} catch (err: unknown) {
+				if (!cancelled) {
+					risk = null;
+					if (err instanceof Error && err.message.includes("404")) {
+						errorMessage = null; // 404 = no data, not an error
+					} else {
+						errorMessage = err instanceof Error ? err.message : "Failed to fetch risk metrics";
+					}
+				}
+			} finally {
+				if (!cancelled) loading = false;
+			}
+		})();
+
+		return () => { cancelled = true; };
+	});
+
+	function pctClass(v: number | null): string {
+		if (v == null) return "";
+		if (v > 0) return "pos";
+		if (v < 0) return "neg";
+		return "";
+	}
+
+	let showPopover = $state(false);
+	let scoreButtonRef = $state<HTMLElement>(undefined!);
+	let popoverTop = $state(0);
+	let popoverLeft = $state(0);
+
+	function togglePopover(e: MouseEvent) {
+		if (!showPopover) {
+			const rect = scoreButtonRef.getBoundingClientRect();
+			popoverTop = rect.bottom + 8;
+			popoverLeft = rect.right - 280;
+			showPopover = true;
+		} else {
+			showPopover = false;
+		}
+	}
+
+	function closePopover() {
+		if (showPopover) showPopover = false;
+	}
+
+	$effect(() => {
+		if (showPopover) {
+			window.addEventListener("click", closePopover);
+			return () => window.removeEventListener("click", closePopover);
+		}
+	});
+
+	function stopPropagation(e: MouseEvent) {
+		e.stopPropagation();
+	}
+
+	// Hide popover if node changes
+	$effect(() => {
+		if (selectedNode) {
+			showPopover = false;
+		}
+	});
+
+	// Tear Sheet Export Logic
+	let isGeneratingPdf = $state(false);
+
+	async function exportTearSheet() {
+		if (!selectedNode || isGeneratingPdf) return;
+
+		const externalId = selectedNode.ticker ?? selectedNode.id;
+		isGeneratingPdf = true;
+
+		try {
+			const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+			const token = await getToken();
+			const response = await fetch(`${API_BASE}/wealth/funds/${externalId}/reports/tear-sheet`, {
+				method: "POST",
+				headers: {
+					"Authorization": `Bearer ${token}`
+				}
+			});
+
+			if (!response.ok) {
+				throw new Error("Failed to generate Tear Sheet");
+			}
+
+			const blob = await response.blob();
+			const url = URL.createObjectURL(blob);
+
+			const a = document.createElement("a");
+			a.style.display = "none";
+			a.href = url;
+			a.download = `${externalId}-tear-sheet.pdf`;
+
+			document.body.appendChild(a);
+			a.click();
+
+			setTimeout(() => {
+				document.body.removeChild(a);
+				URL.revokeObjectURL(url);
+			}, 100);
+		} catch (error) {
+			console.error("Export failed:", error);
+		} finally {
+			isGeneratingPdf = false;
+		}
+	}
+
+	const hasData = $derived(risk != null);
+	const noData = $derived(!loading && !risk && !errorMessage && selectedNode?.instrumentId != null);
+</script>
+
+<div class="rk-root">
+	{#if loading}
+		<div class="rk-empty">
+			<span class="rk-empty-text">Loading risk metrics...</span>
+		</div>
+	{:else if errorMessage}
+		<div class="rk-empty">
+			<span class="rk-empty-text rk-err">{errorMessage}</span>
+		</div>
+	{:else if noData || (!selectedNode?.instrumentId && selectedNode)}
+		<div class="rk-empty">
+			<span class="rk-empty-icon">&#9670;</span>
+			<span class="rk-empty-text">No risk data available</span>
+		</div>
+	{:else if hasData && selectedNode}
+		<div class="rk-header">
+			<div class="rk-header-left">
+				<span class="rk-node-label">
+					{selectedNode.ticker ?? selectedNode.label}
+				</span>
+				<span class="rk-node-type">{selectedNode.fundType}</span>
+			</div>
+			<div class="rk-header-right">
+				<div
+					class="rk-score-btn"
+					bind:this={scoreButtonRef}
+					onclick={(e) => { stopPropagation(e); togglePopover(e); }}
+					onkeydown={(e) => { if (e.key === "Enter") togglePopover(e as any); }}
+					role="button"
+					tabindex="0"
+					aria-haspopup="dialog"
+					aria-expanded={showPopover}
+				>
+					<div class="rk-score-label">SCORE</div>
+					<div class="rk-score-val">
+						{#if risk!.manager_score == null}
+							<span class="rk-na">--</span>
+						{:else if risk!.manager_score >= 75}
+							<span class="elite">[ ELITE ]</span>
+						{:else if risk!.manager_score < 40}
+							<span class="eviction">[ EVICTION ]</span>
+						{:else}
+							{formatNumber(risk!.manager_score, 0)}
+						{/if}
+					</div>
+				</div>
+
+				<button
+					class="rk-export-btn {isGeneratingPdf ? 'exporting' : ''}"
+					onclick={exportTearSheet}
+					disabled={isGeneratingPdf}
+				>
+					{isGeneratingPdf ? "[ GENERATING PDF... ]" : "[ EXPORT TEAR SHEET ]"}
+				</button>
+			</div>
+		</div>
+
+		<!-- Return & Risk -->
+		<div class="rk-section">
+			<div class="rk-section-title">RETURN & RISK</div>
+			<div class="rk-block">
+				<div class="rk-kpi">
+					<span class="rk-label">Annual Return</span>
+					<span class="rk-value {pctClass(risk!.return_1y)}">
+						{risk!.return_1y != null ? formatPercent(risk!.return_1y) : "--"}
+					</span>
+				</div>
+				<div class="rk-kpi">
+					<span class="rk-label">Annual Volatility</span>
+					<span class="rk-value">
+						{risk!.volatility_1y != null ? formatPercent(risk!.volatility_1y) : "--"}
+					</span>
+				</div>
+				<div class="rk-kpi">
+					<span class="rk-label">Sharpe Ratio</span>
+					<span class="rk-value">
+						{risk!.sharpe_1y != null ? formatNumber(risk!.sharpe_1y, 2) : "--"}
+					</span>
+				</div>
+				<div class="rk-kpi">
+					<span class="rk-label">Sortino Ratio</span>
+					<span class="rk-value">
+						{risk!.sortino_1y != null ? formatNumber(risk!.sortino_1y, 2) : "--"}
+					</span>
+				</div>
+			</div>
+		</div>
+
+		<!-- Drawdown Analysis -->
+		<div class="rk-section">
+			<div class="rk-section-title">DRAWDOWN ANALYSIS</div>
+			<div class="rk-block">
+				<div class="rk-kpi">
+					<span class="rk-label">Max Drawdown (1Y)</span>
+					<span class="rk-value neg">
+						{risk!.max_drawdown_1y != null ? formatPercent(risk!.max_drawdown_1y) : "--"}
+					</span>
+				</div>
+				<div class="rk-kpi">
+					<span class="rk-label">Max Drawdown (3Y)</span>
+					<span class="rk-value neg">
+						{risk!.max_drawdown_3y != null ? formatPercent(risk!.max_drawdown_3y) : "--"}
+					</span>
+				</div>
+				<div class="rk-kpi">
+					<span class="rk-label">Risk Budget (1M)</span>
+					<span class="rk-value neg">
+						{risk!.cvar_95_1m != null ? formatPercent(risk!.cvar_95_1m) : "--"}
+					</span>
+				</div>
+			</div>
+		</div>
+
+		<!-- Factor Exposure -->
+		<div class="rk-section">
+			<div class="rk-section-title">FACTOR EXPOSURE</div>
+			<div class="rk-block">
+				<div class="rk-kpi">
+					<span class="rk-label">Beta</span>
+					<span class="rk-value">
+						{risk!.beta_1y != null ? formatNumber(risk!.beta_1y, 2) : "--"}
+					</span>
+				</div>
+				<div class="rk-kpi">
+					<span class="rk-label">Tracking Error</span>
+					<span class="rk-value">
+						{risk!.tracking_error_1y != null ? formatPercent(risk!.tracking_error_1y) : "--"}
+					</span>
+				</div>
+				<div class="rk-kpi">
+					<span class="rk-label">Information Ratio</span>
+					<span class="rk-value {pctClass(risk!.information_ratio_1y)}">
+						{risk!.information_ratio_1y != null ? formatNumber(risk!.information_ratio_1y, 2) : "--"}
+					</span>
+				</div>
+				<div class="rk-kpi">
+					<span class="rk-label">Alpha</span>
+					<span class="rk-value {pctClass(risk!.alpha_1y)}">
+						{risk!.alpha_1y != null ? formatPercent(risk!.alpha_1y) : "--"}
+					</span>
+				</div>
+			</div>
+		</div>
+
+		<!-- Momentum -->
+		<div class="rk-section">
+			<div class="rk-section-title">MOMENTUM</div>
+			<div class="rk-block">
+				<div class="rk-kpi">
+					<span class="rk-label">Momentum</span>
+					<span class="rk-value">
+						{risk!.blended_momentum_score != null ? formatNumber(risk!.blended_momentum_score, 0) + "/100" : "--"}
+					</span>
+				</div>
+				<div class="rk-kpi">
+					<span class="rk-label">Score</span>
+					<span class="rk-value">
+						{risk!.manager_score != null ? formatNumber(risk!.manager_score, 0) + "/100" : "--"}
+					</span>
+				</div>
+			</div>
+		</div>
+	{:else}
+		<div class="rk-empty">
+			<span class="rk-empty-icon">&#9670;</span>
+			<span class="rk-empty-text">Select a node to view risk analysis</span>
+		</div>
+	{/if}
+</div>
+
+{#if showPopover && risk}
+	<div
+		class="rk-popover-portal"
+		style="top: {popoverTop}px; left: {popoverLeft}px;"
+		onclick={stopPropagation}
+		onkeydown={(e) => e.stopPropagation()}
+		role="presentation"
+	>
+		<ScoreBreakdownPopover
+			scoreComponents={risk.score_components}
+			managerScore={risk.manager_score}
+		/>
+	</div>
+{/if}
+
+<style>
+	.rk-root {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--terminal-bg-panel);
+		border-left: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		overflow-y: auto;
+		overflow-x: hidden;
+	}
+
+	/* -- Header ----------------------------------------- */
+	.rk-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 12px 14px 8px;
+		border-bottom: var(--terminal-border-hairline);
+		flex-shrink: 0;
+	}
+
+	.rk-header-left {
+		display: flex;
+		align-items: baseline;
+		gap: 8px;
+	}
+
+	.rk-header-right {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+	}
+
+	.rk-node-label {
+		font-size: var(--terminal-text-14);
+		font-weight: 800;
+		color: var(--terminal-fg-primary);
+		letter-spacing: 0.04em;
+	}
+
+	.rk-node-type {
+		font-size: 9px;
+		font-weight: 600;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rk-score-btn {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 4px 8px;
+		border-radius: var(--terminal-radius-none);
+		cursor: pointer;
+		transition: background 150ms ease;
+		user-select: none;
+		background: transparent;
+	}
+
+	.rk-score-btn:hover {
+		background: var(--terminal-bg-panel-raised);
+	}
+
+	.rk-score-label {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		color: var(--terminal-fg-tertiary);
+	}
+
+	.rk-score-val {
+		font-size: var(--terminal-text-14);
+		font-weight: 800;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.rk-na { color: var(--terminal-fg-muted); }
+	.elite { color: var(--terminal-accent-cyan); font-size: var(--terminal-text-11); letter-spacing: 0.05em; }
+	.eviction { color: var(--terminal-accent-amber); font-size: var(--terminal-text-11); letter-spacing: 0.05em; }
+
+	.rk-export-btn {
+		background: transparent;
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-secondary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		padding: 4px 8px;
+		cursor: pointer;
+		transition: all 150ms ease;
+		outline: none;
+	}
+
+	.rk-export-btn:hover:not(:disabled) {
+		border-color: var(--terminal-accent-cyan);
+		color: var(--terminal-accent-cyan);
+	}
+
+	.rk-export-btn:disabled {
+		cursor: not-allowed;
+	}
+
+	.rk-export-btn.exporting {
+		color: var(--terminal-accent-amber);
+		border-color: var(--terminal-accent-amber);
+		animation: pulseBorder 1.5s infinite alternate;
+	}
+
+	@keyframes pulseBorder {
+		0% { border-color: var(--terminal-accent-amber-dim); color: var(--terminal-accent-amber-dim); }
+		100% { border-color: var(--terminal-accent-amber); color: var(--terminal-accent-amber); }
+	}
+
+	/* -- Section ---------------------------------------- */
+	.rk-section {
+		padding: 0 10px;
+		margin-bottom: 2px;
+	}
+
+	.rk-section-title {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		color: var(--terminal-fg-muted);
+		text-transform: uppercase;
+		padding: 10px 4px 4px;
+	}
+
+	.rk-block {
+		background: var(--terminal-bg-panel-raised);
+		border-radius: var(--terminal-radius-none);
+		padding: 8px 10px;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	/* -- KPI row ---------------------------------------- */
+	.rk-kpi {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 8px;
+	}
+
+	.rk-label {
+		font-size: 9px;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		color: var(--terminal-fg-tertiary);
+		text-transform: uppercase;
+		flex-shrink: 0;
+	}
+
+	.rk-value {
+		font-size: var(--terminal-text-16);
+		font-weight: 800;
+		color: var(--terminal-fg-primary);
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+	}
+
+	.pos { color: var(--terminal-status-success); }
+	.neg { color: var(--terminal-status-error); }
+
+	/* -- Empty ------------------------------------------ */
+	.rk-empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		height: 100%;
+		color: var(--terminal-fg-muted);
+	}
+
+	.rk-empty-icon {
+		font-size: 20px;
+		opacity: 0.3;
+	}
+
+	.rk-empty-text {
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		letter-spacing: 0.04em;
+	}
+
+	.rk-err {
+		color: var(--terminal-status-error);
+	}
+
+	/* -- Popover Portal --------------------------------- */
+	.rk-popover-portal {
+		position: fixed;
+		z-index: var(--terminal-z-dropdown);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalRiskKpis.svelte
+++ b/packages/ii-terminal-core/src/lib/components/research/terminal/TerminalRiskKpis.svelte
@@ -7,7 +7,7 @@
 	import { formatNumber, formatPercent } from "@investintell/ui";
 	import type { TreeNode } from "./TerminalAssetTree.svelte";
 	import ScoreBreakdownPopover from "./ScoreBreakdownPopover.svelte";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "../../../api/client";
 
 	interface RiskMetrics {
 		instrument_id: string;

--- a/packages/ii-terminal-core/src/lib/i18n/quant-labels.ts
+++ b/packages/ii-terminal-core/src/lib/i18n/quant-labels.ts
@@ -1,0 +1,154 @@
+/**
+ * Institutional label dictionary — Risk Methodology v3.
+ *
+ * Surface-facing replacement for the raw quant jargon that flows out
+ * of the backend risk engines (CVaR, Expected Shortfall, GARCH,
+ * EWMA, CFNAI, regime labels, drawdown). The wealth frontend is
+ * "dumb" by design — it never renders a bare model identifier to an
+ * institutional allocator. Every metric shown to a user passes
+ * through this dictionary first.
+ *
+ * Scope of v3
+ * -----------
+ * The mapping mirrors the Risk Methodology v3 reference and the
+ * §3 UX charter:
+ *
+ *   Quant key                           →  Institutional label
+ *   ------------------------------------ -----------------------------
+ *   CVaR / Expected Shortfall           →  Conditional Tail Risk (CVaR 95%)
+ *   Regime                              →  Market Regime: Expansion / Cautious / Stress
+ *   GARCH / EWMA Volatility             →  Conditional Volatility
+ *   CFNAI / Macro Score                 →  Real Economy Activity Index
+ *   Drawdown                            →  Maximum Drawdown
+ *
+ * Backend regime labels (RISK_ON / RISK_OFF / CRISIS) are translated
+ * by `regimeLabel()` to the three-state institutional phrasing
+ * (Expansion / Cautious / Stress).
+ *
+ * Consumers
+ * ---------
+ *   import { humanizeMetric, regimeLabel } from "$wealth/i18n/quant-labels";
+ *   <MetricCard label={humanizeMetric("cvar_95")} value={formatPercent(x)} />
+ *   <span>{regimeLabel(store.regime.label)}</span>
+ *
+ * Adding a new label
+ * ------------------
+ * 1. Add the canonical quant key to `QuantMetricKey`.
+ * 2. Add the institutional phrasing to `METRIC_LABELS`.
+ * 3. If the key has alternate spellings (e.g. "cvar_95", "cvar95",
+ *    "expected_shortfall"), route them through `humanizeMetric`'s
+ *    normalisation branch — never add alternate keys as top-level
+ *    entries, that splinters the dictionary.
+ */
+
+export type QuantMetricKey =
+	| "cvar_95"
+	| "expected_shortfall"
+	| "regime"
+	| "garch_volatility"
+	| "ewma_volatility"
+	| "cfnai"
+	| "macro_score"
+	| "drawdown"
+	| "max_drawdown";
+
+const METRIC_LABELS: Readonly<Record<QuantMetricKey, string>> = {
+	cvar_95: "Conditional Tail Risk (CVaR 95%)",
+	expected_shortfall: "Conditional Tail Risk (CVaR 95%)",
+	regime: "Market Regime",
+	garch_volatility: "Conditional Volatility",
+	ewma_volatility: "Conditional Volatility",
+	cfnai: "Real Economy Activity Index",
+	macro_score: "Real Economy Activity Index",
+	drawdown: "Maximum Drawdown",
+	max_drawdown: "Maximum Drawdown",
+};
+
+/**
+ * Normalise an incoming metric key to the canonical QuantMetricKey.
+ * Accepts snake_case, camelCase, SCREAMING, hyphenated, and a few
+ * well-known aliases. Returns `null` for unknown keys so callers
+ * can fall back to the raw string if they prefer.
+ */
+function normalise(raw: string): QuantMetricKey | null {
+	const k = raw.trim().toLowerCase().replace(/[-\s]+/g, "_");
+	switch (k) {
+		case "cvar":
+		case "cvar95":
+		case "cvar_95":
+		case "c_var_95":
+		case "conditional_value_at_risk":
+		case "expected_shortfall":
+		case "es":
+			return "cvar_95";
+		case "regime":
+		case "market_regime":
+			return "regime";
+		case "garch":
+		case "garch_vol":
+		case "garch_volatility":
+			return "garch_volatility";
+		case "ewma":
+		case "ewma_vol":
+		case "ewma_volatility":
+			return "ewma_volatility";
+		case "cfnai":
+		case "macro_score":
+		case "macroscore":
+			return "macro_score";
+		case "drawdown":
+		case "max_drawdown":
+		case "maxdrawdown":
+		case "maximum_drawdown":
+			return "max_drawdown";
+		default:
+			return null;
+	}
+}
+
+/**
+ * Translate a raw quant metric key into its institutional label.
+ * Unknown keys fall through to the input string so ad-hoc metrics
+ * keep rendering — never silently hide a field from the user.
+ */
+export function humanizeMetric(raw: string): string {
+	const key = normalise(raw);
+	if (key && METRIC_LABELS[key]) return METRIC_LABELS[key];
+	return raw;
+}
+
+/**
+ * Regime label translation — Risk Methodology v3 tri-state phrasing.
+ *
+ * Backend emits uppercase enum (`RISK_ON` / `RISK_OFF` / `CRISIS`).
+ * The institutional reading is Expansion (benign growth), Cautious
+ * (late-cycle / mixed signals), and Stress (drawdown / crisis).
+ * `NEUTRAL` is an intermediate state that maps to Cautious.
+ *
+ * Unknown labels pass through unchanged so a new backend regime
+ * (e.g. `STAGFLATION`) is visible rather than silently relabelled.
+ */
+export function regimeLabel(raw: string | null | undefined): string {
+	if (!raw) return "—";
+	const k = raw.trim().toUpperCase();
+	switch (k) {
+		case "RISK_ON":
+		case "EXPANSION":
+			return "Expansion";
+		case "NEUTRAL":
+		case "RISK_OFF":
+		case "CAUTIOUS":
+			return "Cautious";
+		case "CRISIS":
+		case "STRESS":
+			return "Stress";
+		default:
+			return raw;
+	}
+}
+
+/**
+ * Fully-qualified header string for the market regime tri-state —
+ * used in chart titles and section headings.
+ */
+export const MARKET_REGIME_HEADER = "Market Regime: Expansion / Cautious / Stress";

--- a/packages/ii-terminal-core/src/lib/i18n/quant-labels.ts
+++ b/packages/ii-terminal-core/src/lib/i18n/quant-labels.ts
@@ -27,7 +27,7 @@
  *
  * Consumers
  * ---------
- *   import { humanizeMetric, regimeLabel } from "$wealth/i18n/quant-labels";
+ *   import { humanizeMetric, regimeLabel } from "../i18n/quant-labels";
  *   <MetricCard label={humanizeMetric("cvar_95")} value={formatPercent(x)} />
  *   <span>{regimeLabel(store.regime.label)}</span>
  *

--- a/packages/ii-terminal-core/src/lib/services/risk-engine-client.ts
+++ b/packages/ii-terminal-core/src/lib/services/risk-engine-client.ts
@@ -1,0 +1,110 @@
+/**
+ * Risk Engine Client — fetches pre-computed risk timeseries from backend.
+ *
+ * Consumes GET /api/v1/risk/timeseries/{instrument_id} and formats data
+ * into TradingView-compatible { time, value } arrays.
+ *
+ * All computation (drawdown, GARCH, regime) is done server-side
+ * in TimescaleDB — zero math in the frontend.
+ *
+ * Primary key is instrument_id (UUID), consistent with the rest of the
+ * wealth domain. Ticker is only used for display labels, never for
+ * routing or lookups.
+ */
+
+import { createClientApiClient } from "$wealth/api/client";
+
+export interface TVPoint {
+	time: number; // UNIX seconds
+	value: number;
+}
+
+export interface RegimeTVPoint extends TVPoint {
+	regime: string;
+}
+
+export interface RiskTimeseries {
+	instrumentId: string;
+	ticker: string | null;
+	drawdown: TVPoint[];
+	/** Institutional label for GARCH-filtered volatility. Client key
+	 * kept stable for chart callers; wire key is `conditional_volatility`. */
+	volatilityGarch: TVPoint[];
+	regimeProb: RegimeTVPoint[];
+}
+
+interface RawPoint {
+	time: string; // ISO-8601 date
+	value: number;
+}
+
+interface RawRegimePoint extends RawPoint {
+	regime: string; // sanitised label: Expansion / Cautious / Stress
+}
+
+interface RawResponse {
+	instrument_id: string;
+	ticker: string | null;
+	from_date: string;
+	to_date: string;
+	drawdown: RawPoint[];
+	// Backend emits `conditional_volatility` as of Phase 2 Session C
+	// commit 2 — the previous `volatility_garch` key is gone.
+	conditional_volatility: RawPoint[];
+	regime_prob: RawRegimePoint[];
+}
+
+/** Convert ISO-8601 date string to UNIX seconds (midnight UTC). */
+function isoToUnix(iso: string): number {
+	return Math.floor(new Date(iso + "T00:00:00Z").getTime() / 1000);
+}
+
+function mapPoints(raw: RawPoint[]): TVPoint[] {
+	return raw.map((p) => ({ time: isoToUnix(p.time), value: p.value }));
+}
+
+function mapRegimePoints(raw: RawRegimePoint[]): RegimeTVPoint[] {
+	return raw.map((p) => ({
+		time: isoToUnix(p.time),
+		value: p.value,
+		regime: p.regime,
+	}));
+}
+
+/**
+ * Fetch risk timeseries for an instrument from the backend.
+ *
+ * Uses the shared authenticated client so the request hits the real
+ * API base URL (VITE_API_BASE_URL) with the Clerk token attached.
+ *
+ * @param instrumentId - UUID of the instrument in instruments_universe
+ * @param getToken     - Clerk token provider from the page context
+ * @param opts         - Optional ISO date range
+ * @returns Formatted series ready for TradingView injection
+ */
+export async function fetchRiskTimeseries(
+	instrumentId: string,
+	getToken: () => Promise<string>,
+	opts?: {
+		from?: string; // ISO date
+		to?: string;
+	},
+): Promise<RiskTimeseries> {
+	const api = createClientApiClient(getToken);
+
+	const params = new URLSearchParams();
+	if (opts?.from) params.set("from", opts.from);
+	if (opts?.to) params.set("to", opts.to);
+	const qs = params.toString();
+
+	const path = `/risk/timeseries/${encodeURIComponent(instrumentId)}${qs ? `?${qs}` : ""}`;
+	const data = await api.get<RawResponse>(path);
+
+	return {
+		instrumentId: data.instrument_id,
+		ticker: data.ticker,
+		drawdown: mapPoints(data.drawdown),
+		volatilityGarch: mapPoints(data.conditional_volatility),
+		regimeProb: mapRegimePoints(data.regime_prob),
+	};
+}

--- a/packages/ii-terminal-core/src/lib/services/risk-engine-client.ts
+++ b/packages/ii-terminal-core/src/lib/services/risk-engine-client.ts
@@ -12,7 +12,7 @@
  * routing or lookups.
  */
 
-import { createClientApiClient } from "$wealth/api/client";
+import { createClientApiClient } from "../api/client";
 
 export interface TVPoint {
 	time: number; // UNIX seconds

--- a/packages/ii-terminal-core/src/lib/state/library/bundle-builder.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/library/bundle-builder.svelte.ts
@@ -14,7 +14,7 @@
  */
 
 import { createSSEStream, type SSEConnection } from "@investintell/ui";
-import { createClientApiClient } from "$wealth/api/client";
+import { createClientApiClient } from "../../api/client";
 
 export type BundleStatus =
 	| "idle"

--- a/packages/ii-terminal-core/src/lib/state/library/bundle-builder.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/library/bundle-builder.svelte.ts
@@ -1,0 +1,217 @@
+/**
+ * Wealth Library — multi-select + Committee Pack bundle builder.
+ *
+ * Phase 6 of the Library frontend (spec §3.4 Fase 6 + §4.4). Owns
+ * the multi-select state for the LibraryTree, the bundle dispatch
+ * to `POST /library/bundle`, and the SSE progress stream that
+ * surfaces the worker's `generating → uploading → completed` events.
+ *
+ * The state is exposed through getters so the shell can plug it
+ * straight into the LibraryActionBar and LibraryBundleWizard
+ * without prop drilling. SSE consumption uses
+ * `@investintell/ui`'s `createSSEStream` (fetch + ReadableStream
+ * with auth headers — never EventSource per CLAUDE.md).
+ */
+
+import { createSSEStream, type SSEConnection } from "@investintell/ui";
+import { createClientApiClient } from "$wealth/api/client";
+
+export type BundleStatus =
+	| "idle"
+	| "dispatching"
+	| "generating"
+	| "uploading"
+	| "completed"
+	| "error";
+
+export interface BundleAcceptedResponse {
+	bundle_id: string;
+	job_id: string;
+	sse_channel: string;
+	item_count: number;
+}
+
+interface BundleProgressEvent {
+	event?: string;
+	bundle_id?: string;
+	step?: string;
+	resolved?: number;
+	fetched?: number;
+	missing?: number;
+	size_bytes?: number;
+	zip_path?: string;
+	manifest_path?: string;
+	error?: string;
+}
+
+export interface BundleState {
+	selected: Set<string>;
+	status: BundleStatus;
+	bundleId: string | null;
+	jobId: string | null;
+	step: string | null;
+	progressLabel: string;
+	error: string | null;
+	sizeBytes: number | null;
+	fetched: number | null;
+	missing: number | null;
+}
+
+export interface BundleBuilder {
+	readonly state: BundleState;
+	readonly canBuild: boolean;
+	toggleSelected(libraryIndexId: string): void;
+	clearSelection(): void;
+	createBundle(): Promise<void>;
+	reset(): void;
+	dispose(): void;
+}
+
+const apiBase =
+	import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+export function createBundleBuilder(
+	getToken: () => Promise<string>,
+): BundleBuilder {
+	const state = $state<BundleState>({
+		selected: new Set<string>(),
+		status: "idle",
+		bundleId: null,
+		jobId: null,
+		step: null,
+		progressLabel: "",
+		error: null,
+		sizeBytes: null,
+		fetched: null,
+		missing: null,
+	});
+
+	const api = createClientApiClient(getToken);
+	let sse: SSEConnection<BundleProgressEvent> | null = null;
+
+	function toggleSelected(libraryIndexId: string): void {
+		const next = new Set(state.selected);
+		if (next.has(libraryIndexId)) {
+			next.delete(libraryIndexId);
+		} else {
+			next.add(libraryIndexId);
+		}
+		state.selected = next;
+	}
+
+	function clearSelection(): void {
+		state.selected = new Set<string>();
+	}
+
+	function reset(): void {
+		sse?.disconnect();
+		sse = null;
+		state.status = "idle";
+		state.bundleId = null;
+		state.jobId = null;
+		state.step = null;
+		state.progressLabel = "";
+		state.error = null;
+		state.sizeBytes = null;
+		state.fetched = null;
+		state.missing = null;
+	}
+
+	function applyEvent(event: BundleProgressEvent): void {
+		const type = event.event;
+		if (type === "generating") {
+			state.status = "generating";
+			state.step = event.step ?? null;
+			state.progressLabel =
+				event.step === "download"
+					? `Downloading ${event.resolved ?? 0} entries...`
+					: event.step === "zip"
+						? `Packing ${event.fetched ?? 0} entries...`
+						: "Generating bundle...";
+		} else if (type === "uploading") {
+			state.status = "uploading";
+			state.progressLabel = "Uploading bundle to storage...";
+			state.sizeBytes = event.size_bytes ?? null;
+		} else if (type === "completed") {
+			state.status = "completed";
+			state.progressLabel = "Bundle ready.";
+			state.sizeBytes = event.size_bytes ?? state.sizeBytes;
+			state.fetched = event.fetched ?? null;
+			state.missing = event.missing ?? null;
+			sse?.disconnect();
+			sse = null;
+		} else if (type === "error") {
+			state.status = "error";
+			state.error = event.error ?? "Bundle generation failed.";
+			sse?.disconnect();
+			sse = null;
+		}
+	}
+
+	async function createBundle(): Promise<void> {
+		if (state.selected.size === 0 || state.status === "dispatching") return;
+		reset();
+		state.status = "dispatching";
+
+		try {
+			const response = await api.post<BundleAcceptedResponse>(
+				"/workers/run-library-bundle-builder",
+				{
+					library_index_ids: Array.from(state.selected),
+				},
+			);
+			// The HTTP trigger returns { status, worker } today; the
+			// fully wired endpoint will return bundle_id + job_id.
+			// We tolerate both shapes so the wiring lands now and
+			// the worker response evolves independently.
+			const bundleId =
+				(response as unknown as BundleAcceptedResponse).bundle_id ?? null;
+			const jobId =
+				(response as unknown as BundleAcceptedResponse).job_id ?? null;
+			state.bundleId = bundleId;
+			state.jobId = jobId;
+			state.status = "generating";
+			state.progressLabel = "Generation scheduled...";
+
+			if (jobId) {
+				sse = createSSEStream<BundleProgressEvent>({
+					url: `${apiBase}/jobs/${jobId}/stream`,
+					getToken,
+					onEvent: applyEvent,
+					onError: (err) => {
+						state.status = "error";
+						state.error = err.message;
+					},
+				});
+				sse.connect();
+			}
+		} catch (err: unknown) {
+			state.status = "error";
+			state.error =
+				err instanceof Error ? err.message : "Failed to dispatch bundle.";
+		}
+	}
+
+	function dispose(): void {
+		sse?.disconnect();
+		sse = null;
+	}
+
+	return {
+		get state() {
+			return state;
+		},
+		get canBuild() {
+			return state.selected.size > 0 && state.status === "idle";
+		},
+		toggleSelected,
+		clearSelection,
+		createBundle,
+		reset,
+		dispose,
+	};
+}
+
+export function bundleDownloadUrl(bundleId: string): string {
+	return `${apiBase}/library/bundle/${bundleId}/download`;
+}

--- a/packages/ii-terminal-core/src/lib/state/library/pins-client.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/library/pins-client.svelte.ts
@@ -21,12 +21,12 @@
  * `createPinsClient(getToken)` and disposed in onDestroy.
  */
 
-import { createClientApiClient } from "$wealth/api/client";
+import { createClientApiClient } from "../../api/client";
 import type {
 	LibraryPin,
 	LibraryPinType,
 	LibraryPinsResponse,
-} from "$wealth/types/library";
+} from "../../types/library";
 
 export interface PinsState {
 	loading: boolean;

--- a/packages/ii-terminal-core/src/lib/state/library/pins-client.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/library/pins-client.svelte.ts
@@ -1,0 +1,241 @@
+/**
+ * Wealth Library — pins client with optimistic mutations.
+ *
+ * Phase 6 of the Library frontend (spec §3.4 Fase 6 + §4.4). Owns
+ * the pinned / starred / recent lists displayed by
+ * `LibraryPinsSection` and the per-row pin/star toggles emitted by
+ * the context menu.
+ *
+ * Optimistic discipline
+ * ---------------------
+ * Every toggle mutates the local $state synchronously so the row
+ * re-renders before the network call returns. The network call
+ * runs in the background; if it fails, the change is rolled back
+ * and an error string is exposed via `state.lastError` so the
+ * shell can surface a toast. Concurrent toggles on the same row
+ * are guarded by a tiny pending Set keyed off
+ * `(pin_type, library_index_id)` so the user can't double-click
+ * the same star into a busy loop.
+ *
+ * The client is created once per LibraryShell mount via
+ * `createPinsClient(getToken)` and disposed in onDestroy.
+ */
+
+import { createClientApiClient } from "$wealth/api/client";
+import type {
+	LibraryPin,
+	LibraryPinType,
+	LibraryPinsResponse,
+} from "$wealth/types/library";
+
+export interface PinsState {
+	loading: boolean;
+	error: string | null;
+	lastError: string | null;
+	pinned: LibraryPin[];
+	starred: LibraryPin[];
+	recent: LibraryPin[];
+}
+
+export interface PinsClient {
+	readonly state: PinsState;
+	load(): Promise<void>;
+	togglePin(libraryIndexId: string, label: string, kind?: string | null): Promise<void>;
+	toggleStar(libraryIndexId: string, label: string, kind?: string | null): Promise<void>;
+	isPinned(libraryIndexId: string): boolean;
+	isStarred(libraryIndexId: string): boolean;
+	dispose(): void;
+}
+
+function makeOptimisticPin(
+	libraryIndexId: string,
+	pinType: LibraryPinType,
+	label: string,
+	kind: string | null,
+): LibraryPin {
+	const now = new Date().toISOString();
+	return {
+		id: `optimistic:${pinType}:${libraryIndexId}`,
+		pin_type: pinType,
+		library_index_id: libraryIndexId,
+		library_path: "",
+		label,
+		kind: kind ?? null,
+		created_at: now,
+		last_accessed_at: now,
+		position: null,
+	};
+}
+
+export function createPinsClient(
+	getToken: () => Promise<string>,
+): PinsClient {
+	const state = $state<PinsState>({
+		loading: false,
+		error: null,
+		lastError: null,
+		pinned: [],
+		starred: [],
+		recent: [],
+	});
+
+	const api = createClientApiClient(getToken);
+	const pending = new Set<string>();
+	let disposed = false;
+
+	function pendingKey(pinType: LibraryPinType, libraryIndexId: string): string {
+		return `${pinType}:${libraryIndexId}`;
+	}
+
+	async function load(): Promise<void> {
+		state.loading = true;
+		state.error = null;
+		try {
+			const data = await api.get<LibraryPinsResponse>("/library/pins");
+			if (disposed) return;
+			state.pinned = data.pinned;
+			state.starred = data.starred;
+			state.recent = data.recent;
+		} catch (err: unknown) {
+			if (disposed) return;
+			state.error =
+				err instanceof Error ? err.message : "Failed to load pins.";
+		} finally {
+			if (!disposed) state.loading = false;
+		}
+	}
+
+	function listFor(pinType: LibraryPinType): LibraryPin[] {
+		switch (pinType) {
+			case "pinned":
+				return state.pinned;
+			case "starred":
+				return state.starred;
+			case "recent":
+				return state.recent;
+		}
+	}
+
+	function setListFor(pinType: LibraryPinType, list: LibraryPin[]): void {
+		switch (pinType) {
+			case "pinned":
+				state.pinned = list;
+				return;
+			case "starred":
+				state.starred = list;
+				return;
+			case "recent":
+				state.recent = list;
+				return;
+		}
+	}
+
+	async function toggle(
+		pinType: LibraryPinType,
+		libraryIndexId: string,
+		label: string,
+		kind: string | null,
+	): Promise<void> {
+		const key = pendingKey(pinType, libraryIndexId);
+		if (pending.has(key)) return;
+		pending.add(key);
+
+		const before = listFor(pinType);
+		const existing = before.find(
+			(p) => p.library_index_id === libraryIndexId,
+		);
+
+		try {
+			if (existing) {
+				// Optimistic remove
+				setListFor(
+					pinType,
+					before.filter(
+						(p) => p.library_index_id !== libraryIndexId,
+					),
+				);
+				try {
+					await api.delete(`/library/pins/${existing.id}`);
+				} catch (err) {
+					// Roll back
+					setListFor(pinType, before);
+					state.lastError =
+						err instanceof Error
+							? err.message
+							: "Failed to remove pin.";
+				}
+			} else {
+				// Optimistic add
+				const placeholder = makeOptimisticPin(
+					libraryIndexId,
+					pinType,
+					label,
+					kind,
+				);
+				setListFor(pinType, [placeholder, ...before]);
+				try {
+					const created = await api.post<LibraryPin>("/library/pins", {
+						library_index_id: libraryIndexId,
+						pin_type: pinType,
+					});
+					// Replace placeholder with the server's authoritative row
+					setListFor(
+						pinType,
+						listFor(pinType).map((p) =>
+							p.id === placeholder.id ? created : p,
+						),
+					);
+				} catch (err) {
+					setListFor(pinType, before);
+					state.lastError =
+						err instanceof Error
+							? err.message
+							: "Failed to create pin.";
+				}
+			}
+		} finally {
+			pending.delete(key);
+		}
+	}
+
+	function togglePin(
+		libraryIndexId: string,
+		label: string,
+		kind: string | null = null,
+	): Promise<void> {
+		return toggle("pinned", libraryIndexId, label, kind);
+	}
+
+	function toggleStar(
+		libraryIndexId: string,
+		label: string,
+		kind: string | null = null,
+	): Promise<void> {
+		return toggle("starred", libraryIndexId, label, kind);
+	}
+
+	function isPinned(libraryIndexId: string): boolean {
+		return state.pinned.some((p) => p.library_index_id === libraryIndexId);
+	}
+
+	function isStarred(libraryIndexId: string): boolean {
+		return state.starred.some((p) => p.library_index_id === libraryIndexId);
+	}
+
+	function dispose(): void {
+		disposed = true;
+		pending.clear();
+	}
+
+	return {
+		get state() {
+			return state;
+		},
+		load,
+		togglePin,
+		toggleStar,
+		isPinned,
+		isStarred,
+		dispose,
+	};
+}

--- a/packages/ii-terminal-core/src/lib/state/library/preview-loader.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/library/preview-loader.svelte.ts
@@ -31,8 +31,8 @@ import {
 	createMountedGuard,
 	type MountedGuard,
 } from "@investintell/ui/runtime";
-import { createClientApiClient } from "$wealth/api/client";
-import type { LibraryDocumentDetail } from "$wealth/types/library";
+import { createClientApiClient } from "../../api/client";
+import type { LibraryDocumentDetail } from "../../types/library";
 
 export interface PreviewState {
 	loading: boolean;

--- a/packages/ii-terminal-core/src/lib/state/library/preview-loader.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/library/preview-loader.svelte.ts
@@ -1,0 +1,163 @@
+/**
+ * Wealth Library — preview pane document loader.
+ *
+ * Phase 5 of the Library frontend (spec §3.4 Fase 5 + §3.6). The
+ * loader sits between the URL adapter (selected document id) and
+ * the LibraryPreviewPane (renders the appropriate reader). It is
+ * single-flight: every new selection aborts the previous fetch
+ * before issuing the next, so a fast click between document A and
+ * document B can never paint A's contents inside B's pane.
+ *
+ * Lifecycle hardening
+ * -------------------
+ * The loader uses two complementary safety nets:
+ *
+ *  1. `AbortController` per request — last-click-wins on the
+ *     network layer. The controller is stored in `current` so any
+ *     new `loadDocument(id)` first aborts the previous one.
+ *  2. `createMountedGuard()` from @investintell/ui/runtime — even
+ *     if a request slips past the abort because the response was
+ *     already in flight, the post-await mutation is wrapped in
+ *     `guard.guard(...)` so a torn-down loader never writes back
+ *     into reactive state. Together they prevent both cross-render
+ *     bleed and "setState on unmounted component" warnings.
+ *
+ * The loader is constructed once per LibraryShell mount via
+ * `createPreviewLoader(getToken)`, started inside an $effect.pre,
+ * and disposed (`stop` + abort current) in onDestroy.
+ */
+
+import {
+	createMountedGuard,
+	type MountedGuard,
+} from "@investintell/ui/runtime";
+import { createClientApiClient } from "$wealth/api/client";
+import type { LibraryDocumentDetail } from "$wealth/types/library";
+
+export interface PreviewState {
+	loading: boolean;
+	error: string | null;
+	document: LibraryDocumentDetail | null;
+	requestedId: string | null;
+}
+
+export interface PreviewLoader {
+	readonly state: PreviewState;
+	loadDocument(id: string | null): Promise<void>;
+	clear(): void;
+	start(): void;
+	dispose(): void;
+}
+
+export function createPreviewLoader(
+	getToken: () => Promise<string>,
+): PreviewLoader {
+	const state = $state<PreviewState>({
+		loading: false,
+		error: null,
+		document: null,
+		requestedId: null,
+	});
+
+	const guard: MountedGuard = createMountedGuard();
+	const api = createClientApiClient(getToken);
+
+	let current: AbortController | null = null;
+
+	async function loadDocument(id: string | null): Promise<void> {
+		// Cancel any in-flight fetch immediately so the network layer
+		// stops chasing the previous document.
+		if (current) {
+			current.abort();
+			current = null;
+		}
+
+		if (id === null) {
+			// Selection cleared — drop the cached document.
+			state.requestedId = null;
+			state.document = null;
+			state.error = null;
+			state.loading = false;
+			return;
+		}
+
+		const controller = new AbortController();
+		current = controller;
+		state.requestedId = id;
+		state.loading = true;
+		state.error = null;
+
+		try {
+			const detail = await api.get<LibraryDocumentDetail>(
+				`/library/documents/${id}`,
+				undefined,
+				{ signal: controller.signal },
+			);
+
+			// Two layers of safety before we publish:
+			//   1. The component must still be mounted (guard).
+			//   2. The latest selection must still be this id —
+			//      otherwise a slower request finished AFTER a
+			//      newer one. Drop the result on the floor.
+			guard.guard(() => {
+				if (current !== controller) return;
+				if (state.requestedId !== id) return;
+				state.document = detail;
+				state.loading = false;
+			});
+		} catch (err: unknown) {
+			if (err instanceof DOMException && err.name === "AbortError") {
+				// Aborted by a newer click — leave state alone, the
+				// new request will populate it.
+				return;
+			}
+			guard.guard(() => {
+				if (current !== controller) return;
+				if (state.requestedId !== id) return;
+				state.error =
+					err instanceof Error
+						? err.message
+						: "Failed to load document.";
+				state.loading = false;
+				state.document = null;
+			});
+		} finally {
+			if (current === controller) {
+				current = null;
+			}
+		}
+	}
+
+	function clear(): void {
+		if (current) {
+			current.abort();
+			current = null;
+		}
+		state.requestedId = null;
+		state.document = null;
+		state.error = null;
+		state.loading = false;
+	}
+
+	function start(): void {
+		guard.start();
+	}
+
+	function dispose(): void {
+		guard.stop();
+		if (current) {
+			current.abort();
+			current = null;
+		}
+	}
+
+	return {
+		get state() {
+			return state;
+		},
+		loadDocument,
+		clear,
+		start,
+		dispose,
+	};
+}

--- a/packages/ii-terminal-core/src/lib/state/library/tree-loader.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/library/tree-loader.svelte.ts
@@ -1,0 +1,202 @@
+/**
+ * Wealth Library — tree state and lazy children loader.
+ *
+ * Phase 3 of the Library frontend (spec §3.4 / §3.6). This module
+ * is the single source of truth for *expansion* + *children fetching*
+ * inside the LibraryTree. It deliberately stays small and dumb:
+ *
+ *   * The L1 + L2 roots come pre-loaded from `GET /library/tree`
+ *     (server loader → page data) so the very first render is
+ *     instant. The state module never re-fetches the tree itself.
+ *   * When the user expands an L2 (or deeper) folder we hit
+ *     `GET /library/folders/{path}/children` and store the result
+ *     under the encoded path key.
+ *   * Concurrent expand→collapse→expand cycles can race the
+ *     network. We track an `AbortController` per path so the
+ *     stale request is cancelled the moment the user collapses
+ *     the folder again. The result of an aborted fetch never
+ *     reaches the cache.
+ *
+ * The store is intentionally not exported as a singleton: the
+ * Library shell creates one instance per mount via
+ * `createTreeLoader(getToken)` and passes it down via prop. That
+ * keeps the lifetime tied to the route — leaving `/library` and
+ * coming back creates a fresh, abort-clean cache without any
+ * teardown gymnastics.
+ */
+
+import { createClientApiClient } from "$wealth/api/client";
+import type { LibraryNode, LibraryNodePage } from "$wealth/types/library";
+
+/**
+ * State for a single folder path inside the cache.
+ *
+ * - `loading`  the fetch is in flight; the row should render a
+ *              spinner placeholder under the parent.
+ * - `error`    the fetch failed (network, 5xx, abort handled
+ *              separately); shown inline with a retry affordance.
+ * - `children` the resolved list of child nodes.
+ * - `cursor`   pagination cursor for the next page (null when the
+ *              folder has no more rows). The current sprint stops
+ *              at the first page; pagination ships in a follow-up.
+ */
+export interface FolderEntry {
+	loading: boolean;
+	error: string | null;
+	children: LibraryNode[];
+	cursor: string | null;
+}
+
+export interface TreeLoader {
+	/** Reactive map keyed by encoded folder path. */
+	readonly folders: Record<string, FolderEntry>;
+	/** Reactive set of expanded folder paths. */
+	readonly expanded: ReadonlySet<string>;
+
+	/** Toggle a folder's expanded state — fetches children on first open. */
+	toggle(path: string): Promise<void>;
+	/** Force-expand a folder (used by URL adapter on initial render). */
+	expand(path: string): Promise<void>;
+	/** Collapse a folder and abort any in-flight fetch for it. */
+	collapse(path: string): void;
+	/** Retry a failed fetch — clears error then re-issues the request. */
+	retry(path: string): Promise<void>;
+	/** Aborts every in-flight fetch — call from $effect cleanup. */
+	dispose(): void;
+}
+
+export function createTreeLoader(
+	getToken: () => Promise<string>,
+): TreeLoader {
+	// Reactive containers — both are $state-backed so consumers can
+	// `$derived` over them. We use plain object/Set rather than Map
+	// so Svelte 5 deep proxies the structure cleanly.
+	const folders = $state<Record<string, FolderEntry>>({});
+	const expanded = $state(new Set<string>());
+
+	// AbortController per folder path. Not reactive — the lifecycle
+	// is purely network-side, no UI needs to observe it.
+	const inflight = new Map<string, AbortController>();
+
+	const api = createClientApiClient(getToken);
+
+	function ensureEntry(path: string): FolderEntry {
+		if (!folders[path]) {
+			folders[path] = {
+				loading: false,
+				error: null,
+				children: [],
+				cursor: null,
+			};
+		}
+		return folders[path]!;
+	}
+
+	async function fetchChildren(path: string): Promise<void> {
+		const entry = ensureEntry(path);
+
+		// Cancel any previous in-flight fetch for the same folder
+		// before issuing the new one. Last-write-wins.
+		const previous = inflight.get(path);
+		if (previous) previous.abort();
+
+		const controller = new AbortController();
+		inflight.set(path, controller);
+
+		entry.loading = true;
+		entry.error = null;
+
+		try {
+			// The path comes URL-encoded already (segment-by-segment)
+			// from the LibraryTreeNode click handler — we forward it
+			// verbatim so the router-level `path:path` capture matches
+			// the same encoding the backend expects.
+			const page = await api.get<LibraryNodePage>(
+				`/library/folders/${path}/children`,
+				undefined,
+				{ signal: controller.signal },
+			);
+
+			// If a newer fetch superseded us, drop the result on the
+			// floor — the cache is owned by whoever holds the live
+			// controller for this path.
+			if (inflight.get(path) !== controller) return;
+
+			entry.children = page.items;
+			entry.cursor = page.next_cursor;
+			entry.loading = false;
+		} catch (err: unknown) {
+			if (err instanceof DOMException && err.name === "AbortError") {
+				// Aborted because the user collapsed the folder or a
+				// newer fetch superseded us — leave the entry quiet.
+				return;
+			}
+			if (inflight.get(path) !== controller) return;
+			entry.loading = false;
+			entry.error =
+				err instanceof Error
+					? err.message
+					: "Failed to load folder.";
+		} finally {
+			if (inflight.get(path) === controller) {
+				inflight.delete(path);
+			}
+		}
+	}
+
+	async function expand(path: string): Promise<void> {
+		expanded.add(path);
+		const entry = ensureEntry(path);
+		// Only fetch if we have not loaded this folder yet (or a
+		// previous attempt failed). Re-expanding a successfully
+		// loaded folder is free.
+		if (entry.children.length === 0 && !entry.loading) {
+			await fetchChildren(path);
+		}
+	}
+
+	function collapse(path: string): void {
+		expanded.delete(path);
+		const controller = inflight.get(path);
+		if (controller) {
+			controller.abort();
+			inflight.delete(path);
+		}
+	}
+
+	async function toggle(path: string): Promise<void> {
+		if (expanded.has(path)) {
+			collapse(path);
+		} else {
+			await expand(path);
+		}
+	}
+
+	async function retry(path: string): Promise<void> {
+		const entry = folders[path];
+		if (!entry) return;
+		entry.error = null;
+		await fetchChildren(path);
+	}
+
+	function dispose(): void {
+		for (const controller of inflight.values()) {
+			controller.abort();
+		}
+		inflight.clear();
+	}
+
+	return {
+		get folders() {
+			return folders;
+		},
+		get expanded() {
+			return expanded;
+		},
+		toggle,
+		expand,
+		collapse,
+		retry,
+		dispose,
+	};
+}

--- a/packages/ii-terminal-core/src/lib/state/library/tree-loader.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/library/tree-loader.svelte.ts
@@ -25,8 +25,8 @@
  * teardown gymnastics.
  */
 
-import { createClientApiClient } from "$wealth/api/client";
-import type { LibraryNode, LibraryNodePage } from "$wealth/types/library";
+import { createClientApiClient } from "../../api/client";
+import type { LibraryNode, LibraryNodePage } from "../../types/library";
 
 /**
  * State for a single folder path inside the cache.

--- a/packages/ii-terminal-core/src/lib/state/library/url-adapter.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/library/url-adapter.svelte.ts
@@ -1,0 +1,296 @@
+/**
+ * Wealth Library — bidirectional URL ↔ state adapter.
+ *
+ * Phase 4 of the Library frontend (spec §3.4 Fase 4 + §2.5). The
+ * adapter is the *only* place that touches the URL on the Library
+ * surface. It owns:
+ *
+ *   * filter chips:    status[], kind[], starred, language
+ *   * date range:      from, to
+ *   * search:          q  (debounced 300 ms before pushing to URL)
+ *   * view mode:       view = tree | list | grid
+ *   * preview mode:    preview = inline | fullscreen
+ *   * selected file:   id
+ *
+ * The adapter is constructed once per LibraryShell mount via
+ * `createUrlAdapter()` and disposed in onDestroy. It exposes a
+ * reactive `state` object plus a small set of mutators; consumers
+ * mutate via the mutators and read via `state.*`. The adapter takes
+ * care of:
+ *
+ *   1. Pushing every state change into `$page.url` via `goto`
+ *      with `keepFocus: true, noScroll: true, replaceState: true`
+ *      so the back/forward stack is not flooded with intermediate
+ *      typing states.
+ *   2. Re-syncing internal state whenever the user navigates back
+ *      or forward — handled by an `$effect` that watches
+ *      `$page.url.searchParams` and copies the new values in.
+ *   3. Anti-loop guard: a transient `applyingFromUrl` flag is set
+ *      while we copy URL → state, so the URL → state effect does
+ *      not re-trigger the state → URL effect on the same tick.
+ *
+ * The debounced search input is the only consumer that calls
+ * `setQuery(value, { debounce: true })`. Filters and view toggles
+ * push immediately because user perception is instantaneous.
+ */
+
+import { goto } from "$app/navigation";
+import { page } from "$app/state";
+
+export type LibraryViewMode = "tree" | "list" | "grid";
+export type LibraryPreviewMode = "inline" | "fullscreen";
+
+export interface LibraryUrlState {
+	q: string;
+	statuses: string[];
+	kinds: string[];
+	from: string | null;
+	to: string | null;
+	language: string | null;
+	starred: boolean;
+	view: LibraryViewMode;
+	preview: LibraryPreviewMode;
+	selectedId: string | null;
+}
+
+const DEFAULT_STATE: LibraryUrlState = {
+	q: "",
+	statuses: [],
+	kinds: [],
+	from: null,
+	to: null,
+	language: null,
+	starred: false,
+	view: "tree",
+	preview: "inline",
+	selectedId: null,
+};
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export interface UrlAdapter {
+	readonly state: LibraryUrlState;
+	setQuery(value: string, opts?: { debounce?: boolean }): void;
+	toggleStatus(value: string): void;
+	toggleKind(value: string): void;
+	setDateRange(from: string | null, to: string | null): void;
+	setLanguage(value: string | null): void;
+	setStarred(value: boolean): void;
+	setView(value: LibraryViewMode): void;
+	setPreview(value: LibraryPreviewMode): void;
+	setSelectedId(value: string | null): void;
+	clearAllFilters(): void;
+	dispose(): void;
+}
+
+function readFromUrl(params: URLSearchParams): LibraryUrlState {
+	const view = params.get("view");
+	const preview = params.get("preview");
+	return {
+		q: params.get("q") ?? "",
+		statuses: params.getAll("status"),
+		kinds: params.getAll("kind"),
+		from: params.get("from"),
+		to: params.get("to"),
+		language: params.get("language"),
+		starred: params.get("starred") === "1",
+		view:
+			view === "list" || view === "grid" || view === "tree"
+				? view
+				: "tree",
+		preview: preview === "fullscreen" ? "fullscreen" : "inline",
+		selectedId: params.get("id"),
+	};
+}
+
+function buildSearch(state: LibraryUrlState): URLSearchParams {
+	const params = new URLSearchParams();
+	if (state.q) params.set("q", state.q);
+	for (const s of state.statuses) params.append("status", s);
+	for (const k of state.kinds) params.append("kind", k);
+	if (state.from) params.set("from", state.from);
+	if (state.to) params.set("to", state.to);
+	if (state.language) params.set("language", state.language);
+	if (state.starred) params.set("starred", "1");
+	if (state.view !== "tree") params.set("view", state.view);
+	if (state.preview !== "inline") params.set("preview", state.preview);
+	if (state.selectedId) params.set("id", state.selectedId);
+	return params;
+}
+
+export function createUrlAdapter(): UrlAdapter {
+	// Reactive state mirror — `$state` so consumers can read via
+	// `adapter.state.q` etc and Svelte tracks the dependency.
+	const state = $state<LibraryUrlState>({ ...DEFAULT_STATE });
+
+	// Anti-loop guard. When the URL → state copy runs, it sets this
+	// flag so the state → URL effect skips the next tick. Without it,
+	// every browser back/forward would re-push to the URL, which
+	// would either no-op (still wasteful) or, worse, fight the user.
+	let applyingFromUrl = false;
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	// ── URL → state ──────────────────────────────────────────────
+	// Watches `page.url.search` (the only piece that matters here).
+	// Whenever SvelteKit reports a navigation (popstate, link click,
+	// our own goto), we re-read the params into the reactive mirror.
+	$effect(() => {
+		// Touch the reactive accessor so this effect re-runs.
+		const search = page.url.search;
+		const next = readFromUrl(new URLSearchParams(search));
+		applyingFromUrl = true;
+		state.q = next.q;
+		state.statuses = next.statuses;
+		state.kinds = next.kinds;
+		state.from = next.from;
+		state.to = next.to;
+		state.language = next.language;
+		state.starred = next.starred;
+		state.view = next.view;
+		state.preview = next.preview;
+		state.selectedId = next.selectedId;
+		// Release the guard on the next microtask so the state → URL
+		// effect that may run on the same tick sees `applyingFromUrl`
+		// as true and bails. queueMicrotask is enough — Svelte's
+		// effect scheduler runs synchronously inside the same task.
+		queueMicrotask(() => {
+			applyingFromUrl = false;
+		});
+	});
+
+	// ── state → URL ──────────────────────────────────────────────
+	// Pushes a new URL whenever the reactive mirror changes. Uses
+	// `replaceState: true` so the back/forward stack is not polluted
+	// with every keystroke or chip click. The pathname stays the
+	// same — the adapter never moves between /library and
+	// /library/[...path]; that decision belongs to the shell.
+	$effect(() => {
+		// Read every field so Svelte tracks them as dependencies.
+		const search = buildSearch(state).toString();
+		void state.q;
+		void state.statuses.length;
+		void state.kinds.length;
+		void state.from;
+		void state.to;
+		void state.language;
+		void state.starred;
+		void state.view;
+		void state.preview;
+		void state.selectedId;
+
+		if (applyingFromUrl) return;
+
+		const target = `${page.url.pathname}${search ? "?" + search : ""}`;
+		const current = `${page.url.pathname}${page.url.search}`;
+		if (target === current) return;
+
+		void goto(target, {
+			keepFocus: true,
+			noScroll: true,
+			replaceState: true,
+		});
+	});
+
+	function setQuery(value: string, opts?: { debounce?: boolean }): void {
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+			debounceTimer = null;
+		}
+		if (opts?.debounce) {
+			// Local typing feedback is instant — we mutate the
+			// `q` state synchronously so the input shows the
+			// character immediately. Only the URL push waits.
+			state.q = value;
+			// Re-fire the URL push after the debounce window. The
+			// state → URL effect already ran with the local mutation
+			// above; we trigger it again by writing the same value
+			// after the timeout so any pending fetch/cache that
+			// keys on URL state stays in sync.
+			debounceTimer = setTimeout(() => {
+				// Same value written → still triggers the effect
+				// because Svelte 5 $state mutations notify on write.
+				state.q = value;
+				debounceTimer = null;
+			}, SEARCH_DEBOUNCE_MS);
+		} else {
+			state.q = value;
+		}
+	}
+
+	function toggleStatus(value: string): void {
+		const idx = state.statuses.indexOf(value);
+		if (idx === -1) {
+			state.statuses = [...state.statuses, value];
+		} else {
+			state.statuses = state.statuses.filter((s) => s !== value);
+		}
+	}
+
+	function toggleKind(value: string): void {
+		const idx = state.kinds.indexOf(value);
+		if (idx === -1) {
+			state.kinds = [...state.kinds, value];
+		} else {
+			state.kinds = state.kinds.filter((k) => k !== value);
+		}
+	}
+
+	function setDateRange(from: string | null, to: string | null): void {
+		state.from = from;
+		state.to = to;
+	}
+
+	function setLanguage(value: string | null): void {
+		state.language = value;
+	}
+
+	function setStarred(value: boolean): void {
+		state.starred = value;
+	}
+
+	function setView(value: LibraryViewMode): void {
+		state.view = value;
+	}
+
+	function setPreview(value: LibraryPreviewMode): void {
+		state.preview = value;
+	}
+
+	function setSelectedId(value: string | null): void {
+		state.selectedId = value;
+	}
+
+	function clearAllFilters(): void {
+		state.q = "";
+		state.statuses = [];
+		state.kinds = [];
+		state.from = null;
+		state.to = null;
+		state.language = null;
+		state.starred = false;
+	}
+
+	function dispose(): void {
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+			debounceTimer = null;
+		}
+	}
+
+	return {
+		get state() {
+			return state;
+		},
+		setQuery,
+		toggleStatus,
+		toggleKind,
+		setDateRange,
+		setLanguage,
+		setStarred,
+		setView,
+		setPreview,
+		setSelectedId,
+		clearAllFilters,
+		dispose,
+	};
+}

--- a/packages/ii-terminal-core/src/lib/types/content.ts
+++ b/packages/ii-terminal-core/src/lib/types/content.ts
@@ -1,0 +1,40 @@
+/** Content domain types — Flash Reports, Outlooks, Spotlights. */
+
+export interface ContentSummary {
+	id: string;
+	content_type: string;
+	title: string | null;
+	language: string;
+	status: string;
+	storage_path: string | null;
+	created_by: string | null;
+	approved_by: string | null;
+	approved_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface ContentFull extends ContentSummary {
+	content_md: string | null;
+	content_data: Record<string, unknown> | null;
+}
+
+export type ContentType = "investment_outlook" | "flash_report" | "manager_spotlight";
+
+export function contentTypeLabel(type: string): string {
+	switch (type) {
+		case "investment_outlook": return "Investment Outlook";
+		case "flash_report":      return "Flash Report";
+		case "manager_spotlight": return "Manager Spotlight";
+		default:                  return type.replace(/_/g, " ");
+	}
+}
+
+export function contentTypeColor(type: string): string {
+	switch (type) {
+		case "investment_outlook": return "var(--ii-info)";
+		case "flash_report":      return "var(--ii-warning)";
+		case "manager_spotlight": return "var(--ii-success)";
+		default:                  return "var(--ii-text-muted)";
+	}
+}

--- a/packages/ii-terminal-core/src/lib/types/library.ts
+++ b/packages/ii-terminal-core/src/lib/types/library.ts
@@ -1,0 +1,102 @@
+/**
+ * Wealth Library — frontend types mirroring the backend Pydantic
+ * shapes from `backend/app/domains/wealth/schemas/sanitized.py`.
+ *
+ * The types intentionally mirror the API surface defined in spec
+ * §4.8 of docs/superpowers/specs/2026-04-08-wealth-library.md and
+ * are kept narrow on purpose: storage_path is *only* present on the
+ * detail model, never on listings; quant jargon never reaches this
+ * file because the backend sanitises before serialising.
+ */
+
+export type LibraryNodeKind = "folder" | "file";
+export type LibraryPinType = "pinned" | "starred" | "recent";
+
+export interface LibraryNode {
+	node_type: LibraryNodeKind;
+	path: string;
+	label: string;
+
+	// Folder-only
+	child_count?: number | null;
+	last_updated_at?: string | null;
+
+	// File-only
+	id?: string | null;
+	kind?: string | null;
+	title?: string | null;
+	subtitle?: string | null;
+	status?: string | null;
+	language?: string | null;
+	version?: number | null;
+	is_current?: boolean | null;
+	entity_kind?: string | null;
+	entity_label?: string | null;
+	entity_slug?: string | null;
+	confidence?: number | null;
+	created_at?: string | null;
+	updated_at?: string | null;
+}
+
+export interface LibraryTree {
+	roots: LibraryNode[];
+	generated_at: string;
+}
+
+export interface LibraryNodePage {
+	items: LibraryNode[];
+	next_cursor: string | null;
+	total_estimate?: number | null;
+}
+
+export interface LibrarySearchResult {
+	items: LibraryNode[];
+	next_cursor: string | null;
+	total_estimate?: number | null;
+	query?: string | null;
+}
+
+export interface LibraryPin {
+	id: string;
+	pin_type: LibraryPinType;
+	library_index_id: string;
+	library_path: string;
+	label: string;
+	kind?: string | null;
+	created_at: string;
+	last_accessed_at: string;
+	position?: number | null;
+}
+
+export interface LibraryPinsResponse {
+	pinned: LibraryPin[];
+	starred: LibraryPin[];
+	recent: LibraryPin[];
+}
+
+export interface LibraryDocumentDetail {
+	id: string;
+	source_table: string;
+	source_id: string;
+	kind: string;
+	title: string;
+	subtitle?: string | null;
+	status: string;
+	language?: string | null;
+	version?: number | null;
+	is_current: boolean;
+	entity_kind?: string | null;
+	entity_id?: string | null;
+	entity_slug?: string | null;
+	entity_label?: string | null;
+	folder_path: string[];
+	author_id?: string | null;
+	approver_id?: string | null;
+	approved_at?: string | null;
+	created_at: string;
+	updated_at: string;
+	confidence?: number | null;
+	decision_anchor?: string | null;
+	storage_path?: string | null;
+	metadata?: Record<string, unknown> | null;
+}

--- a/packages/ii-terminal-core/src/lib/types/macro.ts
+++ b/packages/ii-terminal-core/src/lib/types/macro.ts
@@ -1,0 +1,120 @@
+/** Macro domain types — FRED, Treasury, OFR, BIS, IMF. */
+
+export interface MacroIndicators {
+	vix: number | null;
+	vix_date: string | null;
+	yield_curve_10y2y: number | null;
+	yield_curve_date: string | null;
+	cpi_yoy: number | null;
+	cpi_date: string | null;
+	fed_funds_rate: number | null;
+	fed_funds_date: string | null;
+}
+
+export interface DimensionScore {
+	score: number;
+	n_indicators: number;
+	indicators: Record<string, number>;
+}
+
+export interface DataFreshness {
+	last_date: string | null;
+	days_stale: number | null;
+	weight: number;
+	status: "fresh" | "decaying" | "stale";
+}
+
+export interface RegionalScore {
+	composite_score: number;
+	coverage: number;
+	dimensions: Record<string, DimensionScore>;
+	data_freshness: Record<string, DataFreshness>;
+	analysis_text: string | null;
+}
+
+export interface GlobalIndicators {
+	geopolitical_risk_score: number;
+	energy_stress: number;
+	commodity_stress: number;
+	usd_strength: number;
+}
+
+export interface MacroScores {
+	as_of_date: string;
+	regions: Record<string, RegionalScore>;
+	global_indicators: GlobalIndicators;
+}
+
+export interface RegimeHierarchy {
+	global_regime?: string;
+	raw_regime: string;
+	stress_score: number | null;
+	signal_details: Record<string, string>;
+	as_of_date: string;
+}
+
+export interface TreasuryPoint {
+	obs_date: string;
+	value: number;
+}
+
+export interface OfrPoint {
+	obs_date: string;
+	value: number;
+}
+
+export interface BisPoint {
+	period: string;
+	value: number;
+}
+
+export interface ImfPoint {
+	year: number;
+	value: number;
+}
+
+export interface FredPoint {
+	obs_date: string;
+	value: number;
+}
+
+export function regimeColor(regime: string | null | undefined): string {
+	switch (regime) {
+		case "crisis":      return "var(--ii-danger)";
+		case "stress":      return "var(--ii-warning)";
+		case "recovery":    return "var(--ii-info)";
+		case "expansion":   return "var(--ii-success)";
+		case "normal":      return "var(--ii-success)";
+		default:            return "var(--ii-text-muted)";
+	}
+}
+
+export function freshnessColor(status: string): string {
+	switch (status) {
+		case "fresh":    return "var(--ii-success)";
+		case "decaying": return "var(--ii-warning)";
+		case "stale":    return "var(--ii-danger)";
+		default:         return "var(--ii-text-muted)";
+	}
+}
+
+export interface MacroSnapshot {
+	id: string;
+	as_of_date: string;
+	data_json: Record<string, unknown>;
+}
+
+export interface MacroReview {
+	id: string;
+	organization_id: string;
+	status: string;
+	is_emergency: boolean;
+	as_of_date: string;
+	snapshot_id: string | null;
+	report_json: Record<string, unknown>;
+	approved_by: string | null;
+	approved_at: string | null;
+	decision_rationale: string | null;
+	created_at: string;
+	created_by: string | null;
+}

--- a/packages/ii-terminal-core/src/lib/workers/live_price_poll.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/workers/live_price_poll.svelte.ts
@@ -1,0 +1,141 @@
+/**
+ * live_price_poll — Phase 9 Block C mock live price feed.
+ *
+ * A lightweight in-process polling manager that emits a synthetic
+ * price tick every ~1.5s via ``setInterval``. It is NOT a real Web
+ * Worker — Web Workers would complicate the Svelte 5 reactivity
+ * bridge (postMessage → store → effect) for a mock feed that costs
+ * microseconds per tick. A future blocker (Phase 9 Block D or the
+ * original plan's Phase 9 Task 9.1 ``live_price_poll`` backend
+ * worker) will replace this module with an SSE bridge to the real
+ * Yahoo batch quote poller. The consumer-side contract stays the
+ * same: a reactive ``ticks`` buffer + ``start`` / ``stop`` lifecycle.
+ *
+ * Random walk:
+ *   Gaussian-ish (Box-Muller) shocks scaled to ±0.05% std dev on
+ *   each tick, around an anchored base price. Produces a visually
+ *   plausible curve at 1.5s cadence without catastrophic drift.
+ *
+ * Sliding window:
+ *   Last ``BUFFER_SIZE`` ticks (60 by default). New arrays are
+ *   assigned on every tick so Svelte 5 ``$state`` tracks the
+ *   mutation. Down-stream consumers (WorkbenchCoreChart,
+ *   SparklineSVG inside LivePortfolioKpiStrip) slice or consume
+ *   the full buffer as needed.
+ *
+ * Lifecycle rules (LiveWorkbenchShell enforces these via ``$effect``):
+ *   - start() only when the overview tool is active AND a live
+ *     portfolio is selected
+ *   - stop() when the tool changes, the portfolio deselects, or
+ *     the shell unmounts
+ *   - reset() when switching portfolios (wipes buffer, seeds fresh
+ *     base price)
+ */
+
+export interface PriceTick {
+	/** Epoch milliseconds when the tick was generated. */
+	ts: number;
+	/** Synthetic price (no currency — relative to the base). */
+	price: number;
+}
+
+export const LIVE_PRICE_BUFFER_SIZE = 60;
+export const LIVE_PRICE_SPARKLINE_SLICE = 20;
+const DEFAULT_INTERVAL_MS = 1500;
+const DEFAULT_BASE_PRICE = 100;
+const RANDOM_WALK_STD = 0.0005; // 0.05% per-tick std
+
+export interface LivePricePollerOptions {
+	basePrice?: number;
+	intervalMs?: number;
+}
+
+/**
+ * Random-walk price poller with a Svelte-reactive sliding buffer.
+ *
+ * The ``ticks`` field is declared with ``$state`` so Svelte tracks
+ * mutations automatically — consumers can read ``poller.ticks``
+ * inside ``$derived`` / ``$effect`` / templates and reactivity
+ * works through the field access.
+ */
+export class LivePricePoller {
+	/** Sliding window of the last ``LIVE_PRICE_BUFFER_SIZE`` ticks. */
+	ticks = $state<PriceTick[]>([]);
+
+	private intervalId: ReturnType<typeof setInterval> | null = null;
+	private basePrice: number;
+	private lastPrice: number;
+	private readonly intervalMs: number;
+
+	constructor(opts: LivePricePollerOptions = {}) {
+		this.basePrice = opts.basePrice ?? DEFAULT_BASE_PRICE;
+		this.lastPrice = this.basePrice;
+		this.intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+	}
+
+	get isRunning(): boolean {
+		return this.intervalId !== null;
+	}
+
+	/**
+	 * Start emitting ticks. Idempotent — a second call while running
+	 * is a no-op so the shell's ``$effect`` can safely re-invoke on
+	 * dependency changes without tearing down the interval.
+	 */
+	start(): void {
+		if (this.intervalId !== null) return;
+		// Seed the buffer with the opening price so charts never
+		// start with an empty polyline and the sparkline has at
+		// least one point to render immediately.
+		const now = Date.now();
+		this.ticks = [{ ts: now, price: this.lastPrice }];
+		this.intervalId = setInterval(() => this.tick(), this.intervalMs);
+	}
+
+	/** Stop the interval and clear the buffer. Safe to call twice. */
+	stop(): void {
+		if (this.intervalId !== null) {
+			clearInterval(this.intervalId);
+			this.intervalId = null;
+		}
+		this.ticks = [];
+		this.lastPrice = this.basePrice;
+	}
+
+	/**
+	 * Re-anchor the random walk to a new base price. Used when the
+	 * shell switches between live portfolios — each portfolio gets
+	 * its own visual opening price so the chart does not carry over
+	 * the previous series.
+	 */
+	reset(newBasePrice?: number): void {
+		const wasRunning = this.isRunning;
+		this.stop();
+		if (newBasePrice !== undefined) {
+			this.basePrice = newBasePrice;
+		}
+		this.lastPrice = this.basePrice;
+		if (wasRunning) this.start();
+	}
+
+	private tick(): void {
+		// Box-Muller transform for a smoother Gaussian shock than
+		// ``Math.random() - 0.5`` uniform noise. Clamp u1 away from
+		// 0 to avoid ``log(0)`` = -Infinity.
+		const u1 = Math.max(Math.random(), 1e-9);
+		const u2 = Math.random();
+		const gauss = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+		const shock = this.lastPrice * RANDOM_WALK_STD * gauss;
+		this.lastPrice = Math.max(0.01, this.lastPrice + shock);
+
+		const entry: PriceTick = { ts: Date.now(), price: this.lastPrice };
+		// Slide the window: create a new array reference so ``$state``
+		// tracks the mutation. ``slice(1)`` drops the oldest entry once
+		// the buffer is full.
+		const next =
+			this.ticks.length >= LIVE_PRICE_BUFFER_SIZE
+				? [...this.ticks.slice(1), entry]
+				: [...this.ticks, entry];
+		this.ticks = next;
+	}
+}


### PR DESCRIPTION
## Summary

X5a.1 patches 3 gaps discovered during X5b diagnostics where terminal routes reference wealth components that weren't promoted by X5a. Pure copy + rewrite + rebuild — zero contract change.

## Gaps closed

| Gap | Files added | Transitive closure |
|---|---|---|
| G1 `portfolio/CalibrationPanel.svelte` | 6 (panel + 5 sibling fields) | all types/state already in core |
| G2 `portfolio/live/charts/*` | 2 (TerminalPriceChart, WorkbenchCoreChart) | +1 `workers/live_price_poll.svelte.ts` |
| G3 `research/terminal/*` | 8 (shell + 7 siblings) | +12 `components/library/*`, +3 `library/readers/*`, +5 `state/library/*`, +3 types, +1 i18n, +1 services |

**Total files added:** 44 (6 portfolio, 10 portfolio/live, 8 research/terminal, 15 library + readers, 5 state/library, 3 types, 1 i18n, 1 services, 1 workers).

## What changed

**New subsystems** (new package.json exports entries):
- `./i18n/*` — `quant-labels` (regimeLabel, humanizeMetric)
- `./services/*` — `risk-engine-client`
- `./workers/*` — `live_price_poll.svelte` (PriceTick type for WorkbenchCoreChart)

**Rewrite script extended** (`scripts/rewrite-imports.py`): added `i18n/`, `services/`, `workers/` prefix rules. Re-run: **62 imports across 29 files** rewritten to relative paths.

## Verification

```
grep -rn '$wealth/' packages/ii-terminal-core/src/lib/ 
  → 1 hit, harmless JSDoc comment in macro-simulation-store (inherited from X5a)

pnpm -F @investintell/ii-terminal-core build    → dist/ regenerated, all subsystems emitted
pnpm -F @investintell/ui build                  → green
pnpm -F ii-terminal build                       → green (1m 3s, $wealth alias still active)
pnpm -F netz-wealth-os build                    → green (58.67s)
```

## Commits

5 atomic commits:
1. `feat: copy CalibrationPanel from wealth` (panel + 5 sibling fields)
2. `feat: copy portfolio/live/charts from wealth` (bundled with workers/ transitive)
3. `feat: copy research/terminal + transitive closure` (library subtree, state/library, types, i18n, services)
4. `refactor: rewrite \$wealth/* in backfilled files + extend exports` (62 imports, new subsystem exports)

(Sequential numbering in plan — commits 2+3 bundled because the worker transitive was discovered during charts copy; commits 4+5 bundled because no extra research transitives required a separate pass.)

## Scope decisions

- **Phase E (barrel top-level exports) skipped**: terminal routes use direct subpath imports (`$wealth/components/portfolio/CalibrationPanel.svelte`, `$wealth/components/research/terminal/TerminalResearchShell.svelte`, `$wealth/components/portfolio/live/charts/TerminalPriceChart.svelte`), not top-level named exports. X5b sed rule `$wealth/components/` → `@investintell/ii-terminal-core/components/` resolves all 3 without any barrel edit.
- **Research transitive closure expanded scope beyond plan**: LibraryWrapper + ReportsPanel inside `research/terminal/` pull the full `components/library/` subtree (15 files) plus its `state/library/` backend (5 files) plus types/content + types/macro + i18n/quant-labels + services/risk-engine-client. All copied in the single commit to preserve atomicity.

## X5b unblocked

Terminal routes can now mechanically swap `$wealth/*` → `@investintell/ii-terminal-core/*` via sed without any manual file-by-file touch. No prompt changes needed to the X5b plan.

## Test plan

- [x] `pnpm -F @investintell/ii-terminal-core build` green
- [x] Other 3 builds (ui, terminal, wealth) green, baseline preserved
- [x] `grep -rn '$wealth/' packages/ii-terminal-core/src/lib/` shows only JSDoc comment ref
- [x] 3 gap components (CalibrationPanel, TerminalPriceChart, TerminalResearchShell) + full transitive closure present in `dist/`
- [ ] X5b: terminal route migration + `$wealth` alias removal