### PR TITLE
feat(ii-terminal): X5b migrate terminal to @investintell/ii-terminal-core + remove $wealth alias

### DIFF
--- a/frontends/terminal/package.json
+++ b/frontends/terminal/package.json
@@ -21,6 +21,7 @@
 		"@fontsource/ibm-plex-sans": "^5.0.0",
 		"@fontsource/ibm-plex-mono": "^5.0.0",
 		"@fontsource/montserrat": "^5.0.0",
+		"@investintell/ii-terminal-core": "workspace:*",
 		"@investintell/ui": "workspace:*",
 		"@tanstack/svelte-table": "9.0.0-alpha.10",
 		"@tanstack/svelte-virtual": "^3.0.0",

--- a/frontends/terminal/src/lib/components/builder/BuilderBreadcrumb.svelte
+++ b/frontends/terminal/src/lib/components/builder/BuilderBreadcrumb.svelte
@@ -14,7 +14,7 @@
 	import {
 		PROFILE_LABELS,
 		type AllocationProfile,
-	} from "$wealth/types/allocation-page";
+	} from "@investintell/ii-terminal-core/types/allocation-page";
 
 	interface Props {
 		profile: AllocationProfile;

--- a/frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
+++ b/frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
@@ -29,20 +29,20 @@
 	import { page } from "$app/state";
 	import { fly, fade } from "svelte/transition";
 	import { svelteTransitionFor } from "@investintell/ui";
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
-	import type { ModelPortfolio } from "$wealth/types/model-portfolio";
+	import { workspace } from "@investintell/ii-terminal-core/state/portfolio-workspace.svelte";
+	import type { ModelPortfolio } from "@investintell/ii-terminal-core/types/model-portfolio";
 
-	import RunControls from "$wealth/components/terminal/builder/RunControls.svelte";
-	import WeightsTab from "$wealth/components/terminal/builder/WeightsTab.svelte";
-	import CascadeTimeline from "$wealth/components/terminal/builder/CascadeTimeline.svelte";
-	import StressTab from "$wealth/components/terminal/builder/StressTab.svelte";
-	import RiskTab from "$wealth/components/terminal/builder/RiskTab.svelte";
-	import AdvisorTab from "$wealth/components/terminal/builder/AdvisorTab.svelte";
-	import BacktestTab from "$wealth/components/terminal/builder/BacktestTab.svelte";
-	import MonteCarloTab from "$wealth/components/terminal/builder/MonteCarloTab.svelte";
-	import RegimeTab from "$wealth/components/terminal/builder/RegimeTab.svelte";
-	import ActivationBar from "$wealth/components/terminal/builder/ActivationBar.svelte";
-	import CalibrationPanel from "$wealth/components/portfolio/CalibrationPanel.svelte";
+	import RunControls from "@investintell/ii-terminal-core/components/terminal/builder/RunControls.svelte";
+	import WeightsTab from "@investintell/ii-terminal-core/components/terminal/builder/WeightsTab.svelte";
+	import CascadeTimeline from "@investintell/ii-terminal-core/components/terminal/builder/CascadeTimeline.svelte";
+	import StressTab from "@investintell/ii-terminal-core/components/terminal/builder/StressTab.svelte";
+	import RiskTab from "@investintell/ii-terminal-core/components/terminal/builder/RiskTab.svelte";
+	import AdvisorTab from "@investintell/ii-terminal-core/components/terminal/builder/AdvisorTab.svelte";
+	import BacktestTab from "@investintell/ii-terminal-core/components/terminal/builder/BacktestTab.svelte";
+	import MonteCarloTab from "@investintell/ii-terminal-core/components/terminal/builder/MonteCarloTab.svelte";
+	import RegimeTab from "@investintell/ii-terminal-core/components/terminal/builder/RegimeTab.svelte";
+	import ActivationBar from "@investintell/ii-terminal-core/components/terminal/builder/ActivationBar.svelte";
+	import CalibrationPanel from "@investintell/ii-terminal-core/components/portfolio/CalibrationPanel.svelte";
 
 	interface Props {
 		portfolios: ModelPortfolio[];

--- a/frontends/terminal/src/lib/components/builder/ProfileStrip.svelte
+++ b/frontends/terminal/src/lib/components/builder/ProfileStrip.svelte
@@ -16,7 +16,7 @@
 		ALLOCATION_PROFILES,
 		PROFILE_LABELS,
 		type AllocationProfile,
-	} from "$wealth/types/allocation-page";
+	} from "@investintell/ii-terminal-core/types/allocation-page";
 
 	interface Props {
 		current: AllocationProfile;

--- a/frontends/terminal/src/lib/components/builder/StrategicTabContent.svelte
+++ b/frontends/terminal/src/lib/components/builder/StrategicTabContent.svelte
@@ -19,13 +19,13 @@
 -->
 <script lang="ts">
 	import { formatDateTime, formatPercent } from "@investintell/ui";
-	import IpsSummaryStrip from "$wealth/components/allocation/IpsSummaryStrip.svelte";
-	import StrategicAllocationTable from "$wealth/components/allocation/StrategicAllocationTable.svelte";
-	import AllocationDonut from "$wealth/components/allocation/AllocationDonut.svelte";
-	import ProposalReviewPanel from "$wealth/components/allocation/ProposalReviewPanel.svelte";
-	import ProposeButton from "$wealth/components/allocation/ProposeButton.svelte";
-	import OverrideBandsEditor from "$wealth/components/allocation/OverrideBandsEditor.svelte";
-	import ApprovalHistoryTable from "$wealth/components/allocation/ApprovalHistoryTable.svelte";
+	import IpsSummaryStrip from "@investintell/ii-terminal-core/components/allocation/IpsSummaryStrip.svelte";
+	import StrategicAllocationTable from "@investintell/ii-terminal-core/components/allocation/StrategicAllocationTable.svelte";
+	import AllocationDonut from "@investintell/ii-terminal-core/components/allocation/AllocationDonut.svelte";
+	import ProposalReviewPanel from "@investintell/ii-terminal-core/components/allocation/ProposalReviewPanel.svelte";
+	import ProposeButton from "@investintell/ii-terminal-core/components/allocation/ProposeButton.svelte";
+	import OverrideBandsEditor from "@investintell/ii-terminal-core/components/allocation/OverrideBandsEditor.svelte";
+	import ApprovalHistoryTable from "@investintell/ii-terminal-core/components/allocation/ApprovalHistoryTable.svelte";
 	import {
 		PROFILE_LABELS,
 		type AllocationProfile,
@@ -33,7 +33,7 @@
 		type LatestProposalResponse,
 		type StrategicAllocationBlock,
 		type StrategicAllocationResponse,
-	} from "$wealth/types/allocation-page";
+	} from "@investintell/ii-terminal-core/types/allocation-page";
 
 	interface Props {
 		profile: AllocationProfile;

--- a/frontends/terminal/src/lib/components/builder/StressTabContent.svelte
+++ b/frontends/terminal/src/lib/components/builder/StressTabContent.svelte
@@ -11,9 +11,9 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { page } from "$app/state";
-	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
-	import type { ModelPortfolio } from "$wealth/types/model-portfolio";
-	import StressTab from "$wealth/components/terminal/builder/StressTab.svelte";
+	import { workspace } from "@investintell/ii-terminal-core/state/portfolio-workspace.svelte";
+	import type { ModelPortfolio } from "@investintell/ii-terminal-core/types/model-portfolio";
+	import StressTab from "@investintell/ii-terminal-core/components/terminal/builder/StressTab.svelte";
 
 	interface Props {
 		portfolios: ModelPortfolio[];

--- a/frontends/terminal/src/routes/+layout.svelte
+++ b/frontends/terminal/src/routes/+layout.svelte
@@ -24,10 +24,8 @@
   but only reserved for component-level UI (e.g. UserButton) in
   later sprints.
 
-  Component imports during X2 resolve through the transitional
-  `$wealth/*` alias (see tsconfig.json, vite.config.ts, svelte.config.js).
-  X5 promotes these to `@investintell/ii-terminal-core` and drops the
-  alias entirely.
+  Component imports resolve through `@investintell/ii-terminal-core`
+  (promoted in X5a, alias dropped in X5b).
 -->
 <script lang="ts">
 	import "../app.css";
@@ -36,14 +34,14 @@
 	import {
 		createMarketDataStore,
 		type MarketDataStore,
-	} from "$wealth/stores/market-data.svelte";
-	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
-	import TerminalShell from "$wealth/components/terminal/shell/TerminalShell.svelte";
+	} from "@investintell/ii-terminal-core/stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "@investintell/ii-terminal-core/components/portfolio/live/workbench-state";
+	import TerminalShell from "@investintell/ii-terminal-core/components/terminal/shell/TerminalShell.svelte";
 	import {
 		createTerminalTweaks,
 		TERMINAL_TWEAKS_KEY,
 		type TerminalTweaks,
-	} from "$wealth/stores/terminal-tweaks.svelte";
+	} from "@investintell/ii-terminal-core/stores/terminal-tweaks.svelte";
 	import type { LayoutData } from "./$types";
 
 	let { data, children }: { data: LayoutData; children: import("svelte").Snippet } = $props();

--- a/frontends/terminal/src/routes/alerts/+page.svelte
+++ b/frontends/terminal/src/routes/alerts/+page.svelte
@@ -8,7 +8,7 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { PanelErrorState } from "@investintell/ui/runtime";
-	import { createClientApiClient } from "$wealth/api/client";
+	import { createClientApiClient } from "@investintell/ii-terminal-core/api/client";
 	import { formatTime } from "@investintell/ui";
 
 	type Severity = "info" | "warning" | "critical";

--- a/frontends/terminal/src/routes/allocation/[profile]/+page.server.ts
+++ b/frontends/terminal/src/routes/allocation/[profile]/+page.server.ts
@@ -15,15 +15,15 @@
  */
 import type { PageServerLoad } from "./$types";
 import { okData, errData, type RouteData } from "@investintell/ui/runtime";
-import { createServerApiClient } from "$wealth/api/client";
+import { createServerApiClient } from "@investintell/ii-terminal-core/api/client";
 import {
 	ALLOCATION_PROFILES,
 	type AllocationProfile,
 	type ApprovalHistoryResponse,
 	type LatestProposalResponse,
 	type StrategicAllocationResponse,
-} from "$wealth/types/allocation-page";
-import type { ModelPortfolio } from "$wealth/types/model-portfolio";
+} from "@investintell/ii-terminal-core/types/allocation-page";
+import type { ModelPortfolio } from "@investintell/ii-terminal-core/types/model-portfolio";
 
 const FETCH_TIMEOUT_MS = 8000;
 

--- a/frontends/terminal/src/routes/allocation/[profile]/+page.svelte
+++ b/frontends/terminal/src/routes/allocation/[profile]/+page.svelte
@@ -36,8 +36,8 @@
 	import { goto, invalidateAll } from "$app/navigation";
 	import { page } from "$app/state";
 	import { resolve } from "$app/paths";
-	import { createClientApiClient } from "$wealth/api/client";
-	import type { AllocationProfile } from "$wealth/types/allocation-page";
+	import { createClientApiClient } from "@investintell/ii-terminal-core/api/client";
+	import type { AllocationProfile } from "@investintell/ii-terminal-core/types/allocation-page";
 
 	import BuilderBreadcrumb from "../../../lib/components/builder/BuilderBreadcrumb.svelte";
 	import ProfileStrip from "../../../lib/components/builder/ProfileStrip.svelte";
@@ -47,7 +47,7 @@
 	import StrategicTabContent from "../../../lib/components/builder/StrategicTabContent.svelte";
 	import PortfolioTabContent from "../../../lib/components/builder/PortfolioTabContent.svelte";
 	import StressTabContent from "../../../lib/components/builder/StressTabContent.svelte";
-	import RegimeContextStrip from "$wealth/components/allocation/RegimeContextStrip.svelte";
+	import RegimeContextStrip from "@investintell/ii-terminal-core/components/allocation/RegimeContextStrip.svelte";
 
 	import type { PageData } from "./$types";
 

--- a/frontends/terminal/src/routes/dd/+page.svelte
+++ b/frontends/terminal/src/routes/dd/+page.svelte
@@ -9,10 +9,10 @@
 	import { getContext } from "svelte";
 	import { goto } from "$app/navigation";
 	import { resolve } from "$app/paths";
-	import { createClientApiClient } from "$wealth/api/client";
-	import Panel from "$wealth/components/terminal/layout/Panel.svelte";
-	import PanelHeader from "$wealth/components/terminal/layout/PanelHeader.svelte";
-	import DDQueueCard from "$wealth/components/terminal/dd/DDQueueCard.svelte";
+	import { createClientApiClient } from "@investintell/ii-terminal-core/api/client";
+	import Panel from "@investintell/ii-terminal-core/components/terminal/layout/Panel.svelte";
+	import PanelHeader from "@investintell/ii-terminal-core/components/terminal/layout/PanelHeader.svelte";
+	import DDQueueCard from "@investintell/ii-terminal-core/components/terminal/dd/DDQueueCard.svelte";
 
 	interface DDReportQueueItem {
 		id: string;

--- a/frontends/terminal/src/routes/dd/[reportId]/+page.svelte
+++ b/frontends/terminal/src/routes/dd/[reportId]/+page.svelte
@@ -11,15 +11,15 @@
 	import { goto } from "$app/navigation";
 	import { resolve } from "$app/paths";
 	import { formatDateTime, formatPercent } from "@investintell/ui";
-	import { createClientApiClient } from "$wealth/api/client";
-	import { createTerminalStream } from "$wealth/components/terminal/runtime/stream";
-	import Panel from "$wealth/components/terminal/layout/Panel.svelte";
-	import PanelHeader from "$wealth/components/terminal/layout/PanelHeader.svelte";
-	import LiveDot from "$wealth/components/terminal/data/LiveDot.svelte";
-	import DDChapterSection from "$wealth/components/terminal/dd/DDChapterSection.svelte";
-	import DDApprovalDialog from "$wealth/components/terminal/dd/DDApprovalDialog.svelte";
-	import type { DDReportFull, DDChapter, AuditEvent } from "$wealth/types/dd-report";
-	import { chapterTitle } from "$wealth/types/dd-report";
+	import { createClientApiClient } from "@investintell/ii-terminal-core/api/client";
+	import { createTerminalStream } from "@investintell/ii-terminal-core/components/terminal/runtime/stream";
+	import Panel from "@investintell/ii-terminal-core/components/terminal/layout/Panel.svelte";
+	import PanelHeader from "@investintell/ii-terminal-core/components/terminal/layout/PanelHeader.svelte";
+	import LiveDot from "@investintell/ii-terminal-core/components/terminal/data/LiveDot.svelte";
+	import DDChapterSection from "@investintell/ii-terminal-core/components/terminal/dd/DDChapterSection.svelte";
+	import DDApprovalDialog from "@investintell/ii-terminal-core/components/terminal/dd/DDApprovalDialog.svelte";
+	import type { DDReportFull, DDChapter, AuditEvent } from "@investintell/ii-terminal-core/types/dd-report";
+	import { chapterTitle } from "@investintell/ii-terminal-core/types/dd-report";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 	const api = createClientApiClient(getToken);

--- a/frontends/terminal/src/routes/live/+page.server.ts
+++ b/frontends/terminal/src/routes/live/+page.server.ts
@@ -9,8 +9,8 @@
  */
 
 import type { PageServerLoad } from "./$types";
-import { createServerApiClient } from "$wealth/api/client";
-import type { ModelPortfolio } from "$wealth/types/model-portfolio";
+import { createServerApiClient } from "@investintell/ii-terminal-core/api/client";
+import type { ModelPortfolio } from "@investintell/ii-terminal-core/types/model-portfolio";
 
 export const load: PageServerLoad = async ({ parent, url }) => {
 	const { token } = await parent();

--- a/frontends/terminal/src/routes/live/+page.svelte
+++ b/frontends/terminal/src/routes/live/+page.svelte
@@ -18,31 +18,31 @@
 	import { getContext } from "svelte";
 	import { PanelErrorState } from "@investintell/ui/runtime";
 	import { formatPpDrift } from "@investintell/ui";
-	import { createClientApiClient } from "$wealth/api/client";
-	import type { MarketDataStore } from "$wealth/stores/market-data.svelte";
-	import { TERMINAL_MARKET_DATA_KEY } from "$wealth/components/portfolio/live/workbench-state";
+	import { createClientApiClient } from "@investintell/ii-terminal-core/api/client";
+	import type { MarketDataStore } from "@investintell/ii-terminal-core/stores/market-data.svelte";
+	import { TERMINAL_MARKET_DATA_KEY } from "@investintell/ii-terminal-core/components/portfolio/live/workbench-state";
 	import type { PageData } from "./$types";
 	import type {
 		ModelPortfolio,
 		InstrumentWeight,
-	} from "$wealth/types/model-portfolio";
+	} from "@investintell/ii-terminal-core/types/model-portfolio";
 
 	// Components
 	import Watchlist, {
 		type WatchlistItem,
-	} from "$wealth/components/terminal/live/Watchlist.svelte";
-	import ChartToolbar from "$wealth/components/terminal/live/ChartToolbar.svelte";
-	import PortfolioSummary from "$wealth/components/terminal/live/PortfolioSummary.svelte";
+	} from "@investintell/ii-terminal-core/components/terminal/live/Watchlist.svelte";
+	import ChartToolbar from "@investintell/ii-terminal-core/components/terminal/live/ChartToolbar.svelte";
+	import PortfolioSummary from "@investintell/ii-terminal-core/components/terminal/live/PortfolioSummary.svelte";
 	import HoldingsTable, {
 		type HoldingRow,
-	} from "$wealth/components/terminal/live/HoldingsTable.svelte";
-	import NewsFeed from "$wealth/components/terminal/live/NewsFeed.svelte";
-	import MacroRegimePanel from "$wealth/components/terminal/live/MacroRegimePanel.svelte";
-	import TradeLog from "$wealth/components/terminal/live/TradeLog.svelte";
-	import AlertStreamPanel from "$wealth/components/terminal/live/AlertStreamPanel.svelte";
-	import RebalanceFocusMode from "$wealth/components/terminal/live/RebalanceFocusMode.svelte";
-	import TerminalPriceChart from "$wealth/components/portfolio/live/charts/TerminalPriceChart.svelte";
-	import type { BarData, LiveTick } from "$wealth/components/portfolio/live/charts/TerminalPriceChart.svelte";
+	} from "@investintell/ii-terminal-core/components/terminal/live/HoldingsTable.svelte";
+	import NewsFeed from "@investintell/ii-terminal-core/components/terminal/live/NewsFeed.svelte";
+	import MacroRegimePanel from "@investintell/ii-terminal-core/components/terminal/live/MacroRegimePanel.svelte";
+	import TradeLog from "@investintell/ii-terminal-core/components/terminal/live/TradeLog.svelte";
+	import AlertStreamPanel from "@investintell/ii-terminal-core/components/terminal/live/AlertStreamPanel.svelte";
+	import RebalanceFocusMode from "@investintell/ii-terminal-core/components/terminal/live/RebalanceFocusMode.svelte";
+	import TerminalPriceChart from "@investintell/ii-terminal-core/components/portfolio/live/charts/TerminalPriceChart.svelte";
+	import type { BarData, LiveTick } from "@investintell/ii-terminal-core/components/portfolio/live/charts/TerminalPriceChart.svelte";
 
 	let { data }: { data: PageData } = $props();
 

--- a/frontends/terminal/src/routes/macro/+page.svelte
+++ b/frontends/terminal/src/routes/macro/+page.svelte
@@ -18,23 +18,23 @@
   import { goto } from "$app/navigation";
   import { resolve } from "$app/paths";
   import { getContext } from "svelte";
-  import { createClientApiClient } from "$wealth/api/client";
-  import { pinnedRegime } from "$wealth/state/pinned-regime.svelte";
+  import { createClientApiClient } from "@investintell/ii-terminal-core/api/client";
+  import { pinnedRegime } from "@investintell/ii-terminal-core/state/pinned-regime.svelte";
   import { TerminalDrawer, TerminalKbd } from "@investintell/ui";
-  import Panel from "$wealth/components/terminal/layout/Panel.svelte";
-  import PanelHeader from "$wealth/components/terminal/layout/PanelHeader.svelte";
-  import StressHero from "$wealth/components/terminal/macro/StressHero.svelte";
-  import SignalBreakdown from "$wealth/components/terminal/macro/SignalBreakdown.svelte";
-  import RegionalHealthTile from "$wealth/components/terminal/macro/RegionalHealthTile.svelte";
+  import Panel from "@investintell/ii-terminal-core/components/terminal/layout/Panel.svelte";
+  import PanelHeader from "@investintell/ii-terminal-core/components/terminal/layout/PanelHeader.svelte";
+  import StressHero from "@investintell/ii-terminal-core/components/terminal/macro/StressHero.svelte";
+  import SignalBreakdown from "@investintell/ii-terminal-core/components/terminal/macro/SignalBreakdown.svelte";
+  import RegionalHealthTile from "@investintell/ii-terminal-core/components/terminal/macro/RegionalHealthTile.svelte";
   import SparklineWall, {
     type MacroIndicator,
-  } from "$wealth/components/terminal/macro/SparklineWall.svelte";
-  import CommitteeReviewFeed from "$wealth/components/terminal/macro/CommitteeReviewFeed.svelte";
-  import RegimeMatrix from "$wealth/components/terminal/macro/RegimeMatrix.svelte";
+  } from "@investintell/ii-terminal-core/components/terminal/macro/SparklineWall.svelte";
+  import CommitteeReviewFeed from "@investintell/ii-terminal-core/components/terminal/macro/CommitteeReviewFeed.svelte";
+  import RegimeMatrix from "@investintell/ii-terminal-core/components/terminal/macro/RegimeMatrix.svelte";
   import {
     createMacroSimulationStore,
     type RegimeCell,
-  } from "$wealth/components/terminal/macro/macro-simulation-store.svelte";
+  } from "@investintell/ii-terminal-core/components/terminal/macro/macro-simulation-store.svelte";
 
   // -- Types -----------------------------------------------------------
 

--- a/frontends/terminal/src/routes/screener/+page.svelte
+++ b/frontends/terminal/src/routes/screener/+page.svelte
@@ -13,10 +13,10 @@
 	import "@investintell/ui/styles/surfaces/screener";
 	import { page } from "$app/state";
 	import { goto } from "$app/navigation";
-	import TerminalScreenerShell from "$wealth/components/screener/terminal/TerminalScreenerShell.svelte";
-	import FundFocusMode from "$wealth/components/terminal/focus-mode/fund/FundFocusMode.svelte";
-	import type { FocusTriggerOptions } from "$wealth/components/terminal/focus-mode/focus-trigger";
-	import { DEFAULT_FILTERS, type FilterState } from "$wealth/components/screener/terminal/TerminalScreenerFilters.svelte";
+	import TerminalScreenerShell from "@investintell/ii-terminal-core/components/screener-terminal/TerminalScreenerShell.svelte";
+	import FundFocusMode from "@investintell/ii-terminal-core/components/terminal/focus-mode/fund/FundFocusMode.svelte";
+	import type { FocusTriggerOptions } from "@investintell/ii-terminal-core/components/terminal/focus-mode/focus-trigger";
+	import { DEFAULT_FILTERS, type FilterState } from "@investintell/ii-terminal-core/components/screener-terminal/TerminalScreenerFilters.svelte";
 
 	// ── URL → FilterState ─────���─────────────────────────
 	function parseFiltersFromURL(params: URLSearchParams): FilterState {

--- a/frontends/terminal/src/routes/screener/research/+page.svelte
+++ b/frontends/terminal/src/routes/screener/research/+page.svelte
@@ -3,7 +3,7 @@
 -->
 <script lang="ts">
 	import "@investintell/ui/styles/surfaces/screener";
-	import TerminalResearchShell from "$wealth/components/research/terminal/TerminalResearchShell.svelte";
+	import TerminalResearchShell from "@investintell/ii-terminal-core/components/research/terminal/TerminalResearchShell.svelte";
 </script>
 
 <div data-surface="screener" class="research-page-root">

--- a/frontends/terminal/svelte.config.js
+++ b/frontends/terminal/svelte.config.js
@@ -7,14 +7,13 @@ const config = {
 	kit: {
 		adapter: adapter(),
 		alias: {
-			// X2 transitional: terminal has no src/lib of its own yet — all
-			// components live under wealth/src/lib and are imported via
-			// $wealth/* from copied routes. Pointing $lib at wealth's
-			// src/lib lets those wealth files resolve their own $lib/*
-			// internal imports unchanged. X5 promotes the components to
-			// @investintell/ii-terminal-core and drops this redirection.
+			// X2 transitional holdover: $lib still redirects to wealth's
+			// src/lib for any remaining wealth-internal $lib/* imports
+			// surfaced through copied routes. X5b dropped the $wealth
+			// alias after the terminal migrated to
+			// @investintell/ii-terminal-core. Remove this once terminal
+			// stops piggybacking on wealth's $lib entirely.
 			$lib: "../wealth/src/lib",
-			$wealth: "../wealth/src/lib",
 		},
 	},
 };

--- a/frontends/terminal/vite.config.ts
+++ b/frontends/terminal/vite.config.ts
@@ -19,25 +19,14 @@ export default defineConfig({
 		"import.meta.env.VITE_ENV": JSON.stringify(BUILD_ENV),
 	},
 	resolve: {
-		// X2 transitional — terminal has no src/lib of its own. Both
-		// $lib (so shared wealth components can resolve their own
-		// internal $lib/* imports) and $wealth (explicit transitional
-		// marker in copied terminal route files) point at the wealth
-		// component tree. Using the array form with explicit regex
-		// patterns is required because the object form is merged with
-		// SvelteKit's own alias injection and the plugin's default
-		// `$lib → src/lib` wins in that merge. Array aliases are
-		// evaluated in order — ours run first. X5 promotes these
-		// components to @investintell/ii-terminal-core and removes both.
+		// X2 transitional holdover: $lib still redirects to wealth's
+		// src/lib because copied wealth components may resolve internal
+		// $lib/* imports through this terminal config. $wealth alias
+		// was removed in X5b after migration to
+		// @investintell/ii-terminal-core. Array form required because
+		// the object form merges with SvelteKit's alias injection and
+		// plugin defaults win; array aliases run first in declared order.
 		alias: [
-			{
-				find: /^\$wealth\/(.*)$/,
-				replacement: path.resolve(__dirname, "../wealth/src/lib/$1"),
-			},
-			{
-				find: /^\$wealth$/,
-				replacement: path.resolve(__dirname, "../wealth/src/lib"),
-			},
 			{
 				find: /^\$lib\/(.*)$/,
 				replacement: path.resolve(__dirname, "../wealth/src/lib/$1"),

--- a/packages/ii-terminal-core/package.json
+++ b/packages/ii-terminal-core/package.json
@@ -65,7 +65,14 @@
   },
   "peerDependencies": {
     "@sveltejs/kit": "^2.0.0",
+    "@tanstack/svelte-virtual": "^3.0.0",
+    "dompurify": "^3.3.3",
+    "echarts": "^5.6.0",
+    "lightweight-charts": "^5.0.0",
+    "lucide-svelte": "^0.469.0",
+    "marked": "^17.0.5",
     "svelte": "^5.0.0",
+    "uuid": "^10.0.0",
     "@investintell/ui": "workspace:*"
   },
   "dependencies": {

--- a/packages/ii-terminal-core/src/lib/components/analytics/entity/ScoreCompositionPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/analytics/entity/ScoreCompositionPanel.svelte
@@ -1,0 +1,363 @@
+<!--
+  ScoreCompositionPanel — horizontal bar breakdown of composite score.
+  Shows the 6 scoring components with weighted contributions.
+  Fetches score_components from the fact-sheet detail endpoint.
+-->
+<script lang="ts">
+	import { getContext } from "svelte";
+	import { formatNumber } from "@investintell/ui";
+	import { createClientApiClient } from "../../../api/client";
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	interface Props {
+		id: string;
+	}
+
+	let { id }: Props = $props();
+
+	interface ScoreComponent {
+		name: string;
+		key: string;
+		weight: number;
+		value: number;
+		weighted: number;
+	}
+
+	const EQUITY_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		risk_adjusted_return: { label: "Risk-Adj Return", weight: 0.30 },
+		return_consistency: { label: "Return Consistency", weight: 0.20 },
+		drawdown_control: { label: "Drawdown Control", weight: 0.20 },
+		information_ratio: { label: "Information Ratio", weight: 0.15 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+		flows_momentum: { label: "Flows Momentum", weight: 0.05 },
+	};
+
+	const FI_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		duration_management: { label: "Duration Mgmt", weight: 0.25 },
+		duration_adjusted_drawdown: { label: "Dur-Adj Drawdown", weight: 0.25 },
+		yield_consistency: { label: "Yield Consistency", weight: 0.20 },
+		spread_capture: { label: "Spread Capture", weight: 0.20 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const CASH_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		yield_vs_risk_free: { label: "Yield vs Risk-Free", weight: 0.30 },
+		nav_stability: { label: "NAV Stability", weight: 0.25 },
+		liquidity_quality: { label: "Liquidity Quality", weight: 0.20 },
+		maturity_discipline: { label: "Maturity Discipline", weight: 0.15 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_REIT_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		income_generation: { label: "Income Generation", weight: 0.25 },
+		diversification_value: { label: "Diversification", weight: 0.25 },
+		downside_protection: { label: "Downside Protection", weight: 0.20 },
+		inflation_hedge: { label: "Inflation Hedge", weight: 0.20 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_COMMODITY_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		inflation_hedge: { label: "Inflation Hedge", weight: 0.30 },
+		diversification_value: { label: "Diversification", weight: 0.25 },
+		crisis_alpha: { label: "Crisis Alpha", weight: 0.20 },
+		drawdown_control: { label: "Drawdown Control", weight: 0.15 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_GOLD_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		crisis_alpha: { label: "Crisis Alpha", weight: 0.30 },
+		diversification_value: { label: "Diversification", weight: 0.30 },
+		inflation_hedge: { label: "Inflation Hedge", weight: 0.20 },
+		tracking_efficiency: { label: "Tracking Efficiency", weight: 0.10 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_HEDGE_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		alpha_generation: { label: "Alpha Generation", weight: 0.30 },
+		downside_protection: { label: "Downside Protection", weight: 0.25 },
+		diversification_value: { label: "Diversification", weight: 0.20 },
+		crisis_alpha: { label: "Crisis Alpha", weight: 0.15 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_CTA_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		crisis_alpha: { label: "Crisis Alpha", weight: 0.40 },
+		diversification_value: { label: "Diversification", weight: 0.25 },
+		risk_adjusted_return: { label: "Risk-Adj Return", weight: 0.25 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_GENERIC_WEIGHTS: Record<string, { label: string; weight: number }> = {
+		diversification_value: { label: "Diversification", weight: 0.30 },
+		downside_protection: { label: "Downside Protection", weight: 0.25 },
+		risk_adjusted_return: { label: "Risk-Adj Return", weight: 0.20 },
+		crisis_alpha: { label: "Crisis Alpha", weight: 0.15 },
+		fee_efficiency: { label: "Fee Efficiency", weight: 0.10 },
+	};
+
+	const ALT_PROFILE_MAPS: Record<string, Record<string, { label: string; weight: number }>> = {
+		reit: ALT_REIT_WEIGHTS,
+		commodity: ALT_COMMODITY_WEIGHTS,
+		gold: ALT_GOLD_WEIGHTS,
+		hedge: ALT_HEDGE_WEIGHTS,
+		cta: ALT_CTA_WEIGHTS,
+		generic_alt: ALT_GENERIC_WEIGHTS,
+	};
+
+	const WEIGHT_MAPS: Record<string, Record<string, { label: string; weight: number }>> = {
+		fixed_income: FI_WEIGHTS,
+		cash: CASH_WEIGHTS,
+	};
+
+	let compositeScore = $state<number | null>(null);
+	let components = $state<ScoreComponent[]>([]);
+	let scoringModel = $state<string>("equity");
+	let loading = $state(true);
+	let hasData = $state(false);
+
+	$effect(() => {
+		if (!id) return;
+		loading = true;
+		hasData = false;
+
+		api.get<any>(`/screener/catalog/detail/${id}`)
+			.then((detail) => {
+				const sm = detail?.scoring_metrics;
+				if (sm?.manager_score != null) {
+					compositeScore = sm.manager_score;
+				}
+				scoringModel = sm?.scoring_model || "equity";
+				const sc = sm?.score_components;
+				let weightMap: Record<string, { label: string; weight: number }>;
+				if (scoringModel === "alternatives") {
+					const altProfile = sc?._alt_profile || "generic_alt";
+					weightMap = ALT_PROFILE_MAPS[altProfile] ?? ALT_GENERIC_WEIGHTS;
+				} else {
+					weightMap = WEIGHT_MAPS[scoringModel] ?? EQUITY_WEIGHTS;
+				}
+				if (sc && typeof sc === "object") {
+					const parsed: ScoreComponent[] = [];
+					for (const [key, meta] of Object.entries(weightMap)) {
+						const value = sc[key];
+						if (value != null) {
+							parsed.push({
+								name: meta.label,
+								key,
+								weight: meta.weight,
+								value: Number(value),
+								weighted: Number(value) * meta.weight,
+							});
+						}
+					}
+					// Sort by weight descending (most important first)
+					parsed.sort((a, b) => b.weight - a.weight);
+					components = parsed;
+					hasData = parsed.length > 0;
+				}
+				loading = false;
+			})
+			.catch(() => {
+				loading = false;
+			});
+	});
+
+	function scoreColor(v: number): string {
+		if (v >= 70) return "var(--terminal-status-success, #22c55e)";
+		if (v >= 40) return "var(--terminal-accent-amber, #f59e0b)";
+		return "var(--terminal-status-error, #ef4444)";
+	}
+</script>
+
+<section class="scp-root">
+	<div class="scp-header">
+		<span class="scp-title">SCORE COMPOSITION</span>
+		{#if compositeScore != null}
+			<span class="scp-composite" style="color: {scoreColor(compositeScore)}">
+				{formatNumber(compositeScore, 1)}
+			</span>
+		{/if}
+	</div>
+
+	{#if loading}
+		<div class="scp-loading">LOADING...</div>
+	{:else if hasData}
+		<div class="scp-bars">
+			{#each components as comp (comp.key)}
+				<div class="scp-bar-row">
+					<span class="scp-bar-label">{comp.name}</span>
+					<div class="scp-bar-track">
+						<div
+							class="scp-bar-fill"
+							style="width: {Math.min(comp.value, 100)}%; background: {scoreColor(comp.value)};"
+						></div>
+					</div>
+					<span class="scp-bar-value">{formatNumber(comp.value, 0)}</span>
+					<span class="scp-bar-weighted">({formatNumber(comp.weighted, 1)})</span>
+				</div>
+			{/each}
+		</div>
+		{@const weightedSum = components.reduce((s, c) => s + c.weighted, 0)}
+		<div class="scp-sum">
+			<span>SUM</span>
+			<span class="scp-sum-value">{formatNumber(weightedSum, 1)}</span>
+		</div>
+	{:else}
+		<div class="scp-degraded">
+			{#if compositeScore != null}
+				<div class="scp-degraded-score">COMPOSITE: {formatNumber(compositeScore, 1)}</div>
+			{/if}
+			<div class="scp-degraded-weights">
+				<div class="scp-degraded-title">Component weights ({scoringModel} model):</div>
+				{#each Object.entries(WEIGHT_MAPS[scoringModel] ?? EQUITY_WEIGHTS) as [, meta]}
+					<div class="scp-degraded-row">
+						<span>{meta.label}</span>
+						<span>{Math.round(meta.weight * 100)}%</span>
+					</div>
+				{/each}
+			</div>
+			<div class="scp-degraded-note">
+				Individual component scores not available.
+			</div>
+		</div>
+	{/if}
+</section>
+
+<style>
+	.scp-root {
+		background-color: #000;
+		padding: 16px;
+		display: flex;
+		flex-direction: column;
+		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+		font-size: 0.75rem;
+	}
+
+	.scp-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 12px;
+		border-bottom: 1px solid #222;
+		padding-bottom: 4px;
+	}
+
+	.scp-title {
+		font-size: 0.7rem;
+		font-weight: 700;
+		color: #9ca3af;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.scp-composite {
+		font-size: 1rem;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.scp-loading {
+		text-align: center;
+		color: #6b7280;
+		padding: 12px;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
+
+	.scp-bars {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.scp-bar-row {
+		display: grid;
+		grid-template-columns: 110px 1fr 28px 40px;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.scp-bar-label {
+		font-size: 0.65rem;
+		color: #9ca3af;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.scp-bar-track {
+		height: 8px;
+		background: #1a1a2e;
+		border: 1px solid rgba(255, 255, 255, 0.04);
+		position: relative;
+	}
+
+	.scp-bar-fill {
+		height: 100%;
+		transition: width 400ms ease;
+	}
+
+	.scp-bar-value {
+		text-align: right;
+		font-weight: 600;
+		color: #d1d5db;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.scp-bar-weighted {
+		text-align: right;
+		color: #6b7280;
+		font-variant-numeric: tabular-nums;
+		font-size: 0.65rem;
+	}
+
+	.scp-sum {
+		display: flex;
+		justify-content: flex-end;
+		gap: 12px;
+		margin-top: 8px;
+		padding-top: 6px;
+		border-top: 1px solid #222;
+		color: #6b7280;
+		font-size: 0.65rem;
+	}
+
+	.scp-sum-value {
+		font-weight: 700;
+		color: #d1d5db;
+		font-variant-numeric: tabular-nums;
+	}
+
+	/* Degraded view when component scores are not available */
+	.scp-degraded {
+		color: #6b7280;
+	}
+
+	.scp-degraded-score {
+		font-size: 0.875rem;
+		font-weight: 700;
+		color: #d1d5db;
+		margin-bottom: 12px;
+	}
+
+	.scp-degraded-title {
+		font-size: 0.65rem;
+		color: #9ca3af;
+		margin-bottom: 6px;
+	}
+
+	.scp-degraded-row {
+		display: flex;
+		justify-content: space-between;
+		padding: 2px 0;
+		font-size: 0.7rem;
+	}
+
+	.scp-degraded-note {
+		margin-top: 12px;
+		font-size: 0.65rem;
+		font-style: italic;
+		color: #4b5563;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/RiskBudgetSlider.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/RiskBudgetSlider.svelte
@@ -1,0 +1,107 @@
+<!--
+  RiskBudgetSlider — PR-A13 wrapper around CalibrationSliderField that
+  adds profile-default affordances: a "Default for {profile}: X.XX%" hint
+  and a conditional "Reset to {profile} default" link when the current
+  value drifts from the profile default.
+
+  Vocabulary discipline (metric-translators.ts convention): the operator
+  surface uses "Tail loss budget", never raw "CVaR 95%". "CVaR" remains
+  reserved for the advanced / result chips.
+
+  No $bindable: callback contract matches CalibrationSliderField so the
+  parent owns the draft.
+-->
+<script lang="ts">
+	import { formatPercent } from "@investintell/ui";
+	import CalibrationSliderField from "./CalibrationSliderField.svelte";
+	import { profileLabel } from "../../utils/profile-defaults";
+
+	interface Props {
+		value: number;
+		profileDefault: number;
+		profile: string | null | undefined;
+		onChange: (v: number) => void;
+		originalValue?: number;
+	}
+
+	let {
+		value,
+		profileDefault,
+		profile,
+		onChange,
+		originalValue,
+	}: Props = $props();
+
+	const label = $derived(profileLabel(profile));
+	const isDrifted = $derived(Math.abs(value - profileDefault) > 1e-6);
+</script>
+
+<div class="rbs-root">
+	<CalibrationSliderField
+		id="cp-cvar-limit"
+		label="Tail loss budget"
+		description="Maximum tail loss (95% confidence) the portfolio may carry."
+		{value}
+		{onChange}
+		min={0.005}
+		max={0.25}
+		step={0.0025}
+		displayFormat="percent"
+		digits={2}
+		edgeLabels={["Tighter", "Looser"]}
+		accent="danger"
+		{originalValue}
+	/>
+
+	<div class="rbs-footer">
+		<span class="rbs-hint" title={`Institutional starting default for the ${label} profile`}>
+			Default for {label}: {formatPercent(profileDefault, 2)}
+		</span>
+		{#if isDrifted}
+			<button type="button" class="rbs-reset" onclick={() => onChange(profileDefault)}>
+				Reset to {label} default
+			</button>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.rbs-root {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	.rbs-footer {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		padding-top: 2px;
+	}
+	.rbs-hint {
+		font-size: 10px;
+		color: var(--terminal-fg-muted);
+		font-family: var(--terminal-font-mono);
+		letter-spacing: 0.02em;
+	}
+	.rbs-reset {
+		font-size: 10px;
+		font-weight: 600;
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-accent-amber);
+		background: transparent;
+		border: none;
+		border-bottom: 1px solid var(--terminal-accent-amber);
+		padding: 0 0 1px 0;
+		cursor: pointer;
+		letter-spacing: 0.02em;
+	}
+	.rbs-reset:hover {
+		color: var(--terminal-fg-primary);
+		border-bottom-color: var(--terminal-fg-primary);
+	}
+	.rbs-reset:focus-visible {
+		outline: 2px solid var(--terminal-accent-amber);
+		outline-offset: 2px;
+	}
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -126,6 +126,9 @@ importers:
       '@fontsource/montserrat':
         specifier: ^5.0.0
         version: 5.2.8
+      '@investintell/ii-terminal-core':
+        specifier: workspace:*
+        version: link:../../packages/ii-terminal-core
       '@investintell/ui':
         specifier: workspace:*
         version: link:../../packages/investintell-ui
@@ -216,7 +219,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -219,7 +219,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^6.3.2
-        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@6.0.6)(zod@4.3.6)
+        version: 6.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3))(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(zod@4.3.6)
       '@codemirror/commands':
         specifier: ^6.10.0
         version: 6.10.3
@@ -341,6 +341,27 @@ importers:
       '@sveltejs/kit':
         specifier: ^2.0.0
         version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2))
+      '@tanstack/svelte-virtual':
+        specifier: ^3.0.0
+        version: 3.13.23(svelte@5.53.12)
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.3.3
+      echarts:
+        specifier: ^5.6.0
+        version: 5.6.0
+      lightweight-charts:
+        specifier: ^5.0.0
+        version: 5.1.0
+      lucide-svelte:
+        specifier: ^0.469.0
+        version: 0.469.0(svelte@5.53.12)
+      marked:
+        specifier: ^17.0.5
+        version: 17.0.5
+      uuid:
+        specifier: ^10.0.0
+        version: 10.0.0
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.0.0

--- a/scripts/check-terminal-tokens-sync.mjs
+++ b/scripts/check-terminal-tokens-sync.mjs
@@ -47,6 +47,14 @@
  *      glyphs (see `feedback_no_emojis.md`). Scoped to the 4
  *      terminal route dirs + shared component dir.
  *
+ *   H. The standalone terminal frontend at frontends/terminal/src/
+ *      MUST NOT import from the transitional `$wealth/*` alias.
+ *      After X5b the terminal consumes all shared components,
+ *      stores, state, types, utils, api, and constants via the
+ *      promoted `@investintell/ii-terminal-core` package. Any
+ *      `from "$wealth/..."` or `import("$wealth/...")` statement
+ *      in the terminal source tree FAILS this invariant.
+ *
  *   G. User-visible strings in terminal chrome (top nav brand,
  *      status bar brand, aria-labels, alt, placeholder, title
  *      attributes, and visible text nodes) MUST NOT contain the
@@ -261,6 +269,10 @@ function main() {
 	const terminalShadcnErrors = scanTerminalRoutesForShadcn();
 	errors.push(...terminalShadcnErrors);
 
+	// ── Invariant H — terminal must not import $wealth/* ──────
+	const wealthAliasErrors = scanTerminalForWealthAlias();
+	errors.push(...wealthAliasErrors);
+
 	// ── Invariant G — no hardcoded Netz in user-visible chrome ──
 	const brandErrors = scanChromeBrandLeaks();
 	errors.push(...brandErrors);
@@ -269,7 +281,7 @@ function main() {
 		console.error("[token-sync] terminal drift detected:\n");
 		for (const e of errors) console.error(`  - ${e}`);
 		console.error(
-			`\n[token-sync] FAIL — fix terminal.css, terminal-options.ts, surfaces/*.css, or the offending terminal route/component files.`,
+			`\n[token-sync] FAIL — fix terminal.css, terminal-options.ts, surfaces/*.css, frontends/terminal/src/, or the offending terminal route/component files.`,
 		);
 		process.exit(1);
 	}
@@ -780,6 +792,65 @@ function scanChromeBrandLeaks() {
 				const line = offsetToLine(scanText, m.index);
 				errors.push(
 					`G. ${rel}:${line} hardcoded Netz brand in ${rule.label}: "${m[0].trim()}" — product chrome defaults to "II"; tenant name injected via orgName prop`,
+				);
+			}
+		}
+	}
+	return errors;
+}
+
+// ── Invariant H — terminal must not import from $wealth/* ──
+//
+// frontends/terminal/ is the standalone II Terminal app. X2 copied
+// routes in via a transitional `$wealth/*` alias; X5a promoted the
+// shared surface to `@investintell/ii-terminal-core`; X5b removed
+// the alias from tsconfig/vite/svelte.config and rewrote every
+// import. This invariant prevents regressions: any new terminal
+// file that reaches back into wealth via `$wealth/...` FAILS the
+// scanner.
+//
+// Comments that mention `$wealth` in prose are allowed (documenting
+// history is fine) — only `from "$wealth/..."`, `from '$wealth/...'`,
+// and `import("$wealth/...")` statements are treated as offenses.
+
+const TERMINAL_SRC_DIR = resolve(REPO_ROOT, "frontends/terminal/src");
+
+const WEALTH_ALIAS_PATTERNS = [
+	{ label: "from '$wealth/...'", re: /\bfrom\s+(["'`])\$wealth\/[^"'`]*\1/g },
+	{ label: "import('$wealth/...')", re: /\bimport\s*\(\s*(["'`])\$wealth\/[^"'`]*\1\s*\)/g },
+];
+
+function scanTerminalForWealthAlias() {
+	const errors = [];
+	if (!existsSync(TERMINAL_SRC_DIR)) return errors;
+
+	for (const absFile of walkFiles(TERMINAL_SRC_DIR)) {
+		const ext = extname(absFile);
+		if (!SCAN_EXTENSIONS.has(ext) && ext !== ".js") continue;
+		const rel = relative(REPO_ROOT, absFile).replaceAll("\\", "/");
+		let text;
+		try {
+			text = readFileSync(absFile, "utf8");
+		} catch {
+			continue;
+		}
+		// Strip comments + <style> blocks: legacy prose that mentions
+		// $wealth/* is allowed, only live import statements fail.
+		const decommented = stripCommentary(text, ext);
+		const scanText =
+			ext === ".svelte" ? stripStyleBlocks(decommented) : decommented;
+
+		for (const rule of WEALTH_ALIAS_PATTERNS) {
+			rule.re.lastIndex = 0;
+			let m;
+			while ((m = rule.re.exec(scanText)) !== null) {
+				if (m[0] === "") {
+					rule.re.lastIndex++;
+					continue;
+				}
+				const line = offsetToLine(scanText, m.index);
+				errors.push(
+					`H. ${rel}:${line} forbidden ${rule.label}: ${m[0].trim()} — import from @investintell/ii-terminal-core/* instead`,
 				);
 			}
 		}


### PR DESCRIPTION
## Summary

X5b of the II Terminal extraction sprint. Wires the terminal app at
`frontends/terminal/` to consume `@investintell/ii-terminal-core`
(promoted in X5a) and removes the transitional `\$wealth/*` alias
entirely.

- Added `@investintell/ii-terminal-core` as terminal dependency
- Rewrote 84 imports across 16 terminal source files
  (`\$wealth/* -> @investintell/ii-terminal-core/*`)
- Removed `\$wealth` alias from `svelte.config.js` + `vite.config.ts`
  (tsconfig.json has no explicit paths block — SvelteKit auto-
  generates from kit.alias)
- Added scanner Invariant H: fails CI if any terminal file imports
  from `\$wealth/*`

## Scope extension (mid-flight)

Build verification at Phase E surfaced two secondary gaps in
`@investintell/ii-terminal-core` that X5a.1 missed:

1. **Missing peerDeps** — 7 external packages used by core's dist
   (`lightweight-charts`, `echarts`, `lucide-svelte`, `marked`,
   `dompurify`, `uuid`, `@tanstack/svelte-virtual`) were not
   declared in core's `package.json`. Under pnpm's isolated
   node_modules, they were unresolvable during terminal build.
2. **Missing sibling files** — `EntityAnalyticsVitrine` and
   `RiskBudgetPanel` were copied to core by X5a.1 but their
   sibling dependencies (`ScoreCompositionPanel`,
   `RiskBudgetSlider`) were not. Both surface transitively in
   terminal routes (/screener, /portfolio/builder).

Backfilled in this PR via 2 atomic commits
(`chore(ii-terminal-core): declare peerDeps...`,
`feat(ii-terminal-core): backfill ScoreCompositionPanel +
RiskBudgetSlider sibling deps`) to avoid a third round-trip.

Root cause: X5a.1 audit only checked terminal->core top-level
imports, not core->core intra-dir sibling imports. Future copy
sprints should run
``grep -rn "from [\"']\.\./" packages/ii-terminal-core/dist/``
to surface transitive gaps before merging.

## Stats

- Terminal imports rewritten: **84** across **16** files
- `grep -rn '\\$wealth/' frontends/terminal/src/` -> **0 hits**
- Scanner (Invariant A-H) -> **green**
- Zero edits in `frontends/wealth/**` (verified against baseline)
- Commits: **7** atomic (in order: dep add, rewrite,
  svelte.config, vite.config, peerDeps, sibling backfill, scanner)

## Builds

- ``pnpm -F @investintell/ui build`` -> green
- ``pnpm -F @investintell/ii-terminal-core build`` -> green
- ``pnpm -F ii-terminal build`` -> green (49s, 2623 modules)
- ``pnpm -F netz-wealth-os build`` -> green (baseline-identical)
- ``pnpm -F netz-credit-intelligence build`` -> green

## Lint

- ``pnpm -F ii-terminal lint`` -> green
- ``pnpm -F netz-wealth-os lint`` -> pre-existing errors on main
  (unchanged by X5b, zero wealth edits)
- ``pnpm -F netz-credit-intelligence lint`` -> pre-existing errors
  on main (unchanged by X5b, zero credit edits)

Per ``feedback_dev_first_ci_later.md``: merging to keep dev
productive; pre-existing credit/wealth lint debt tracked
separately.

## Acceptance criteria

- [x] 5 pnpm builds green
- [x] Scanner green incl. Invariant H
- [x] Zero ``\$wealth/`` imports in ``frontends/terminal/src/``
- [x] ``\$wealth`` alias removed from ``svelte.config.js`` +
      ``vite.config.ts`` (tsconfig.json N/A — auto-generated)
- [x] Wealth build identical to baseline
- [x] Atomic commit sequence preserved

## Test plan

- [ ] DNS + Railway deploy (X6)
- [ ] Wealth cleanup: drop ``components/terminal/**``,
      ``components/allocation/**``, and ``\$wealth`` alias from
      wealth's own config (X7)