### PR TITLE
fix(terminal): build ii-terminal-core before ii-terminal in Dockerfile

### DIFF
--- a/frontends/terminal/Dockerfile
+++ b/frontends/terminal/Dockerfile
@@ -24,7 +24,10 @@ ENV PUBLIC_CLERK_PUBLISHABLE_KEY=$PUBLIC_CLERK_PUBLISHABLE_KEY
 ENV PUBLIC_API_BASE_URL=$PUBLIC_API_BASE_URL
 
 # Build UI packages then terminal frontend
-RUN pnpm --filter @netz/ui build && pnpm --filter @investintell/ui build && pnpm --filter ii-terminal build
+RUN pnpm --filter @netz/ui build \
+  && pnpm --filter @investintell/ui build \
+  && pnpm --filter @investintell/ii-terminal-core build \
+  && pnpm --filter ii-terminal build
 
 WORKDIR /app/frontends/terminal
 EXPOSE 3000


### PR DESCRIPTION
## Summary

One-line Dockerfile fix to unblock the X6 Railway deploy. X5b moved shared components to `@investintell/ii-terminal-core`, which `ii-terminal` now depends on. The previous build step skipped the core package, so Railway prod builds fail with unresolved module imports.

## Change

Added `pnpm --filter @investintell/ii-terminal-core build` before the `ii-terminal` build step in `frontends/terminal/Dockerfile`.

## Test plan

- [ ] Merge and let Railway trigger a build of the `ii-terminal` service
- [ ] Confirm build completes without module resolution errors
- [ ] Verify `terminal.investintell.com` responds once DNS propagates

🤖 Generated with [Claude Code](https://claude.com/claude-code)