### PR TITLE
feat(quant/g2): effective number of bets (Meucci 2009 + Minimum Torsion 2013)

### DIFF
--- a/backend/quant_engine/diversification_service.py
+++ b/backend/quant_engine/diversification_service.py
@@ -1,0 +1,274 @@
+"""Diversification analytics — Effective Number of Bets (Meucci 2009, 2013).
+
+Pure sync computation — no I/O, no DB access, no async, no module-level state.
+Deterministic for fixed inputs (closed-form, no randomness).
+
+Consumable by DD ch.5 and construction dashboards. Does not modify
+``factor_model_service.py``; factor covariance is passed in by the caller
+(typically derived from ``decompose_portfolio()`` output via
+``np.cov(factor_returns.T)``).
+
+References
+----------
+- Meucci, A. (2009). "Managing Diversification". Risk, 22(5), 74-79.
+- Meucci, A., Santangelo, A., Deguest, R. (2013). "Measuring Portfolio
+  Diversification Based on Optimized Uncorrelated Factors".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+_EPS = 1e-12
+_PSD_TOL = -1e-8
+
+
+@dataclass(frozen=True, slots=True)
+class ENBResult:
+    """Effective Number of Bets decomposition.
+
+    ``enb_entropy`` (Meucci 2009) and ``enb_minimum_torsion`` (Meucci 2013)
+    are both bounded by ``n_factors``. Values close to ``n_factors`` indicate
+    balanced diversification across factors; values close to 1 indicate
+    concentration.
+    """
+
+    enb_entropy: float
+    enb_minimum_torsion: float | None
+    risk_contributions: NDArray[np.float64]
+    factor_exposures: NDArray[np.float64]
+    method: Literal["entropy", "minimum_torsion", "both"]
+    n_factors: int
+    degraded: bool
+    degraded_reason: str | None = None
+
+
+def effective_number_of_bets(
+    weights: NDArray[np.float64],
+    factor_loadings: NDArray[np.float64],
+    factor_cov: NDArray[np.float64],
+    method: Literal["entropy", "minimum_torsion", "both"] = "both",
+) -> ENBResult:
+    """Compute Effective Number of Bets for a portfolio.
+
+    Parameters
+    ----------
+    weights : (N,) array
+        Portfolio weights. Need not sum to 1 (scale-invariant for RC).
+    factor_loadings : (N, K) array
+        Asset-on-factor loadings matrix ``B``.
+    factor_cov : (K, K) array
+        Factor covariance matrix ``Sigma_f``. Must be symmetric PSD.
+    method : {"entropy", "minimum_torsion", "both"}
+        Which ENB metric(s) to compute.
+
+    Returns
+    -------
+    ENBResult
+        Degraded flag set if ``factor_cov`` is non-PSD, ``var_p <= 0``,
+        ``B'ΣB`` singular, or any NaN encountered.
+    """
+
+    w = np.asarray(weights, dtype=np.float64).ravel()
+    B = np.asarray(factor_loadings, dtype=np.float64)
+    Sigma_f = np.asarray(factor_cov, dtype=np.float64)
+
+    if B.ndim == 1:
+        B = B.reshape(-1, 1)
+
+    K = B.shape[1]
+
+    if Sigma_f.shape != (K, K):
+        return _degraded(K, "factor_cov_shape_mismatch")
+    if B.shape[0] != w.shape[0]:
+        return _degraded(K, "loadings_weights_shape_mismatch")
+    if not (np.all(np.isfinite(w)) and np.all(np.isfinite(B)) and np.all(np.isfinite(Sigma_f))):
+        return _degraded(K, "nan_in_inputs")
+
+    # Symmetrise and PSD check
+    Sigma_f_sym = 0.5 * (Sigma_f + Sigma_f.T)
+    eigvals = np.linalg.eigvalsh(Sigma_f_sym)
+    if eigvals.min() < _PSD_TOL:
+        return _degraded(K, "factor_cov_not_psd")
+
+    p_f = B.T @ w  # (K,)
+    var_p = float(p_f @ Sigma_f_sym @ p_f)
+    if not np.isfinite(var_p) or var_p <= _EPS:
+        return _degraded(K, "non_positive_portfolio_variance", exposures=p_f)
+
+    # Entropy ENB (Meucci 2009)
+    rc = _risk_contributions(p_f, Sigma_f_sym, var_p)
+    if not np.all(np.isfinite(rc)):
+        return _degraded(K, "nan_risk_contributions", exposures=p_f)
+
+    enb_ent = _entropy_enb(rc)
+
+    if K == 1:
+        # Edge: single factor, exactly one bet
+        single_mt = 1.0 if method in ("minimum_torsion", "both") else None
+        return ENBResult(
+            enb_entropy=1.0,
+            enb_minimum_torsion=single_mt,
+            risk_contributions=rc,
+            factor_exposures=p_f,
+            method=method,
+            n_factors=1,
+            degraded=False,
+            degraded_reason=None,
+        )
+
+    enb_mt: float | None = None
+    if method in ("minimum_torsion", "both"):
+        try:
+            t = _minimum_torsion(Sigma_f_sym)
+            # q = t^{-T} p_f : bet exposures under uncorrelated basis
+            # Portfolio variance = q' I q = ||q||^2
+            t_inv_T = np.linalg.inv(t).T
+            q = t_inv_T @ p_f
+            var_mt = float(q @ q)
+            if not np.isfinite(var_mt) or var_mt <= _EPS:
+                return ENBResult(
+                    enb_entropy=enb_ent,
+                    enb_minimum_torsion=None,
+                    risk_contributions=rc,
+                    factor_exposures=p_f,
+                    method=method,
+                    n_factors=K,
+                    degraded=True,
+                    degraded_reason="minimum_torsion_degenerate_variance",
+                )
+            rc_mt = (q * q) / var_mt
+            rc_mt = np.clip(rc_mt, 0.0, 1.0)
+            enb_mt = _entropy_enb(rc_mt)
+            if not np.isfinite(enb_mt):
+                return ENBResult(
+                    enb_entropy=enb_ent,
+                    enb_minimum_torsion=None,
+                    risk_contributions=rc,
+                    factor_exposures=p_f,
+                    method=method,
+                    n_factors=K,
+                    degraded=True,
+                    degraded_reason="minimum_torsion_nan",
+                )
+        except (np.linalg.LinAlgError, ValueError):
+            return ENBResult(
+                enb_entropy=enb_ent,
+                enb_minimum_torsion=None,
+                risk_contributions=rc,
+                factor_exposures=p_f,
+                method=method,
+                n_factors=K,
+                degraded=True,
+                degraded_reason="minimum_torsion_singular",
+            )
+
+    if method == "entropy":
+        enb_mt = None
+
+    return ENBResult(
+        enb_entropy=enb_ent,
+        enb_minimum_torsion=enb_mt,
+        risk_contributions=rc,
+        factor_exposures=p_f,
+        method=method,
+        n_factors=K,
+        degraded=False,
+        degraded_reason=None,
+    )
+
+
+def _risk_contributions(
+    p_f: NDArray[np.float64],
+    Sigma_f: NDArray[np.float64],
+    var_p: float,
+) -> NDArray[np.float64]:
+    """Euler RC decomposition: sum_k RC_k = 1."""
+    contrib = p_f * (Sigma_f @ p_f)
+    rc = contrib / var_p
+    # Clip tiny negatives from floating-point to 0 (can occur near-zero exposure).
+    rc = np.where(np.abs(rc) < _EPS, 0.0, rc)
+    return rc
+
+
+def _entropy_enb(rc: NDArray[np.float64]) -> float:
+    """Shannon-entropy ENB: exp(-Σ RC_k log RC_k). Guards log(0) with EPS."""
+    # RC can be slightly negative from numerical noise; take positive part
+    # for entropy since H(negative) is undefined. Tiny magnitudes were already
+    # zeroed in ``_risk_contributions``.
+    rc_pos = np.where(rc > 0.0, rc, 0.0)
+    total = rc_pos.sum()
+    if total <= _EPS:
+        return float("nan")
+    rc_norm = rc_pos / total
+    entropy = -float(np.sum(rc_norm * np.log(rc_norm + _EPS)))
+    return float(np.exp(entropy))
+
+
+def _minimum_torsion(Sigma_f: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Meucci 2013 minimum-torsion matrix t with t·Σ_f·tᵀ = I.
+
+    Closed form (Meucci et al. 2013, eq. 18)::
+
+        t = σ⁻¹ · C^{1/2} · (C^{1/2} · σ⁻² · C^{1/2})^{-1/2} · C^{1/2}
+
+    where σ = diag(√diag(Σ_f)), C = σ⁻¹ Σ_f σ⁻¹.
+
+    Among all invertible matrices that decorrelate factors, MT minimises the
+    tracking error of the rotated bets vs original factors, making the bets
+    the "closest uncorrelated basis" — more stable than PCA when factors are
+    correlated.
+    """
+    diag_var = np.diag(Sigma_f).copy()
+    diag_var = np.where(diag_var > _EPS, diag_var, _EPS)
+    sigma = np.sqrt(diag_var)
+    sigma_inv = np.diag(1.0 / sigma)
+    C = sigma_inv @ Sigma_f @ sigma_inv
+    C = 0.5 * (C + C.T)
+
+    C_half = _sym_sqrt(C)
+    sigma_inv_sq = np.diag(1.0 / (sigma * sigma))
+    inner = C_half @ sigma_inv_sq @ C_half
+    inner = 0.5 * (inner + inner.T)
+    inner_inv_half = _sym_sqrt(inner, inverse=True)
+
+    t = sigma_inv @ C_half @ inner_inv_half @ C_half
+    return t
+
+
+def _sym_sqrt(M: NDArray[np.float64], inverse: bool = False) -> NDArray[np.float64]:
+    """Symmetric matrix square root (or inverse square root) via eigendecomp.
+
+    Eigenvalues are clamped at ``_EPS`` to stay real and strictly positive.
+    """
+    eigvals, eigvecs = np.linalg.eigh(M)
+    eigvals = np.clip(eigvals, _EPS, None)
+    if inverse:
+        d = 1.0 / np.sqrt(eigvals)
+    else:
+        d = np.sqrt(eigvals)
+    out: NDArray[np.float64] = (eigvecs * d) @ eigvecs.T
+    return out
+
+
+def _degraded(
+    K: int,
+    reason: str,
+    exposures: NDArray[np.float64] | None = None,
+) -> ENBResult:
+    nan_rc = np.full(K, np.nan, dtype=np.float64)
+    exp = exposures if exposures is not None else np.full(K, np.nan, dtype=np.float64)
+    return ENBResult(
+        enb_entropy=float("nan"),
+        enb_minimum_torsion=float("nan"),
+        risk_contributions=nan_rc,
+        factor_exposures=exp,
+        method="both",
+        n_factors=K,
+        degraded=True,
+        degraded_reason=reason,
+    )

--- a/backend/tests/quant_engine/test_diversification.py
+++ b/backend/tests/quant_engine/test_diversification.py
@@ -1,0 +1,236 @@
+"""Tests for ``quant_engine.diversification_service``.
+
+Covers §2 validation list from
+``docs/superpowers/specs/2026-04-19-edhec-gaps-quant-math.md`` and the
+acceptance gates in the PR-Q2 prompt.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quant_engine.diversification_service import (
+    ENBResult,
+    effective_number_of_bets,
+)
+
+
+def _rng(seed: int = 0) -> np.random.Generator:
+    return np.random.default_rng(seed)
+
+
+def test_uniform_rc_recovers_k():
+    """Σ_f = I_K and p_f = 1_K / √K → every RC_k = 1/K → N_ent = K."""
+    K = 5
+    Sigma_f = np.eye(K)
+    # Pick w, B such that p_f = B^T w = ones(K) / sqrt(K)
+    N = K
+    B = np.eye(N)  # loadings = identity
+    w = np.ones(K) / np.sqrt(K)
+
+    result = effective_number_of_bets(w, B, Sigma_f, method="both")
+
+    assert result.degraded is False
+    assert result.n_factors == K
+    np.testing.assert_allclose(result.risk_contributions, np.full(K, 1.0 / K), atol=1e-10)
+    assert abs(result.enb_entropy - float(K)) < 1e-6
+    # With Σ_f = I, torsion = I → MT ENB = entropy ENB
+    assert result.enb_minimum_torsion is not None
+    assert abs(result.enb_minimum_torsion - float(K)) < 1e-6
+
+
+def test_degenerate_single_factor_concentration():
+    """All mass loaded onto one factor → N_ent → 1."""
+    K = 4
+    Sigma_f = np.eye(K)
+    B = np.zeros((3, K))
+    B[0, 0] = 1.0  # asset 0 exposed only to factor 0
+    w = np.array([1.0, 0.0, 0.0])
+
+    result = effective_number_of_bets(w, B, Sigma_f, method="entropy")
+
+    assert result.degraded is False
+    # Exactly one RC = 1, others = 0 → entropy 0 → exp(0) = 1
+    assert abs(result.enb_entropy - 1.0) < 1e-10
+    assert result.enb_minimum_torsion is None  # method="entropy"
+
+
+def test_mt_greater_or_equal_entropy_correlated_factors():
+    """For correlated factors, MT ENB ≥ entropy ENB (Meucci property)."""
+    rng = _rng(42)
+    K = 4
+    # Build a correlated factor covariance
+    A = rng.standard_normal((K, K))
+    Sigma_f = A @ A.T + 0.1 * np.eye(K)
+
+    N = 6
+    B = rng.standard_normal((N, K))
+    w = rng.dirichlet(np.ones(N))
+
+    result = effective_number_of_bets(w, B, Sigma_f, method="both")
+
+    assert result.degraded is False
+    assert result.enb_minimum_torsion is not None
+    # Allow tiny numerical slack
+    assert result.enb_minimum_torsion >= result.enb_entropy - 1e-6
+
+
+@pytest.mark.parametrize("N,K", [(100, 5), (10, 5), (5, 20)])
+def test_shape_coverage(N: int, K: int):
+    """Runs cleanly across fat, square, and wide loading matrices."""
+    rng = _rng(7)
+    A = rng.standard_normal((K, K))
+    Sigma_f = A @ A.T + 0.05 * np.eye(K)
+    B = rng.standard_normal((N, K))
+    w = rng.standard_normal(N)
+
+    result = effective_number_of_bets(w, B, Sigma_f, method="both")
+
+    if result.degraded:
+        # Only acceptable when zero portfolio variance slipped through
+        assert result.degraded_reason is not None
+        return
+    assert isinstance(result, ENBResult)
+    assert result.n_factors == K
+    assert result.risk_contributions.shape == (K,)
+    assert result.factor_exposures.shape == (K,)
+    # Entropy ENB bounded by K
+    assert 1.0 - 1e-6 <= result.enb_entropy <= K + 1e-6
+
+
+def test_non_psd_sigma_f_degrades():
+    """Non-PSD factor covariance → degraded=True, reason factor_cov_not_psd."""
+    K = 3
+    Sigma_f = np.eye(K)
+    Sigma_f[0, 0] = -1.0  # forces a negative eigenvalue
+    B = np.eye(K)
+    w = np.ones(K)
+
+    result = effective_number_of_bets(w, B, Sigma_f)
+
+    assert result.degraded is True
+    assert result.degraded_reason == "factor_cov_not_psd"
+    assert np.isnan(result.enb_entropy)
+
+
+def test_nan_weights_degrades():
+    K = 3
+    Sigma_f = np.eye(K)
+    B = np.eye(K)
+    w = np.array([1.0, np.nan, 0.5])
+
+    result = effective_number_of_bets(w, B, Sigma_f)
+
+    assert result.degraded is True
+    assert result.degraded_reason == "nan_in_inputs"
+
+
+def test_k_equals_one_edge():
+    """Single factor → ENB identically 1.0 for both methods."""
+    N = 4
+    B = np.ones((N, 1))
+    Sigma_f = np.array([[0.04]])
+    w = np.array([0.25, 0.25, 0.25, 0.25])
+
+    result = effective_number_of_bets(w, B, Sigma_f, method="both")
+
+    assert result.degraded is False
+    assert result.n_factors == 1
+    assert result.enb_entropy == pytest.approx(1.0)
+    assert result.enb_minimum_torsion == pytest.approx(1.0)
+
+
+def test_method_parameter_output_presence():
+    """method controls which fields are populated:
+
+    - "entropy" → enb_minimum_torsion is None
+    - "minimum_torsion" → enb_minimum_torsion is a float (entropy always computed too)
+    - "both" → both are floats
+    """
+    rng = _rng(11)
+    K = 3
+    A = rng.standard_normal((K, K))
+    Sigma_f = A @ A.T + 0.1 * np.eye(K)
+    B = rng.standard_normal((5, K))
+    w = rng.dirichlet(np.ones(5))
+
+    r_ent = effective_number_of_bets(w, B, Sigma_f, method="entropy")
+    r_mt = effective_number_of_bets(w, B, Sigma_f, method="minimum_torsion")
+    r_both = effective_number_of_bets(w, B, Sigma_f, method="both")
+
+    assert r_ent.enb_minimum_torsion is None
+    assert isinstance(r_ent.enb_entropy, float)
+
+    assert r_mt.enb_minimum_torsion is not None
+    assert isinstance(r_mt.enb_minimum_torsion, float)
+
+    assert r_both.enb_entropy == pytest.approx(r_ent.enb_entropy)
+    assert r_both.enb_minimum_torsion is not None
+    assert r_both.enb_minimum_torsion == pytest.approx(r_mt.enb_minimum_torsion)
+
+
+def test_risk_contributions_sum_to_one():
+    """Euler decomposition invariant: Σ RC_k = 1 for any valid input."""
+    rng = _rng(99)
+    K = 6
+    A = rng.standard_normal((K, K))
+    Sigma_f = A @ A.T + 0.2 * np.eye(K)
+    B = rng.standard_normal((10, K))
+    w = rng.standard_normal(10)
+
+    result = effective_number_of_bets(w, B, Sigma_f, method="both")
+
+    assert result.degraded is False
+    assert abs(result.risk_contributions.sum() - 1.0) < 1e-10
+
+
+def test_scale_invariance_of_weights():
+    """Scaling weights by λ ≠ 0 leaves RC (and ENB) unchanged."""
+    rng = _rng(3)
+    K = 4
+    A = rng.standard_normal((K, K))
+    Sigma_f = A @ A.T + 0.1 * np.eye(K)
+    B = rng.standard_normal((8, K))
+    w = rng.standard_normal(8)
+
+    base = effective_number_of_bets(w, B, Sigma_f, method="both")
+    scaled = effective_number_of_bets(2.5 * w, B, Sigma_f, method="both")
+
+    assert not base.degraded and not scaled.degraded
+    np.testing.assert_allclose(
+        base.risk_contributions, scaled.risk_contributions, atol=1e-10
+    )
+    assert base.enb_entropy == pytest.approx(scaled.enb_entropy)
+    assert scaled.enb_minimum_torsion is not None
+    assert base.enb_minimum_torsion == pytest.approx(scaled.enb_minimum_torsion)
+
+
+def test_shape_mismatch_degrades():
+    """Inconsistent loadings/weights shape → degraded with explicit reason."""
+    Sigma_f = np.eye(3)
+    B = np.zeros((4, 3))
+    w = np.ones(5)  # mismatched N
+
+    result = effective_number_of_bets(w, B, Sigma_f)
+
+    assert result.degraded is True
+    assert result.degraded_reason == "loadings_weights_shape_mismatch"
+
+
+def test_pure_function_no_input_mutation():
+    """Service must not mutate caller-provided arrays."""
+    K = 3
+    Sigma_f = np.eye(K) * 0.04
+    B = np.eye(K)
+    w = np.array([0.3, 0.4, 0.3])
+
+    w_before = w.copy()
+    B_before = B.copy()
+    S_before = Sigma_f.copy()
+
+    effective_number_of_bets(w, B, Sigma_f, method="both")
+
+    np.testing.assert_array_equal(w, w_before)
+    np.testing.assert_array_equal(B, B_before)
+    np.testing.assert_array_equal(Sigma_f, S_before)


### PR DESCRIPTION
## Summary

- New pure-function service `quant_engine/diversification_service.py` shipping Meucci 2009 entropy ENB + Meucci 2013 Minimum Torsion ENB for DD ch.5 and construction dashboards.
- Zero modifications to `factor_model_service.py` — factor covariance is passed in by caller (typically `np.cov(factor_returns.T)` from `decompose_portfolio()` output), per spec §2.4.
- Leaf service: no DB, no async, no I/O, no module-level state; deterministic closed-form.

## Design notes

- `_minimum_torsion` implements Meucci 2013 eq. 18 closed form: `t = σ⁻¹ · C^{1/2} · (C^{1/2} σ⁻² C^{1/2})^{-1/2} · C^{1/2}` via symmetric eigendecomp square roots (eigenvalues clamped at EPS for numerical safety).
- MT bet exposures derived as `q = t^{-T} p_f` under uncorrelated basis; RC sums to 1 by construction.
- Degraded flag set on: non-PSD `Σ_f` (eig min < -1e-8), singular torsion matrix, `var_p ≤ 0`, NaN inputs, shape mismatches, K=1 edge preserved (ENB=1.0 both methods).

## Tests (14, all passing)

1. Uniform RC recovers K (Σ_f=I, symmetric loadings)
2. Degenerate single-factor → ENB=1
3. MT ≥ entropy for correlated factors (Meucci property)
4. Shape coverage (100,5), (10,5), (5,20)
5. Non-PSD Σ_f → degraded
6. NaN weights → degraded
7. K=1 edge → ENB=1.0 both methods
8. `method` param contract (entropy/minimum_torsion/both)
9. RC sum = 1 invariant
10. Scale invariance of weights (λw gives identical ENB)
11. Shape mismatch → degraded with explicit reason
12. Pure function — no input array mutation

## Acceptance gates

- [x] `make lint` — ruff clean
- [x] `make architecture` — import-linter 31 contracts kept
- [x] `python -m mypy` on new files — no issues
- [x] `pytest tests/quant_engine/test_diversification.py` — 14 passed
- [x] Zero modifications to `factor_model_service.py`
- [x] Pure function (no DB/async/I/O/module-state)

## Non-goals (deferred)

- Wire into scoring / optimizer — follow-up PR after Q9 integration
- Sanitized UI copy in DD ch.5 — follow-up frontend PR
- CLI / admin tool

Spec: `docs/superpowers/specs/2026-04-19-edhec-gaps-quant-math.md` §2

🤖 Generated with [Claude Code](https://claude.com/claude-code)