### PR TITLE
feat(wealth/g3-fase2.1): N-PORT CUSIP GICS enrichment via Tiingo Fundamentals Meta

### DIFF
--- a/backend/app/core/db/migrations/versions/0164_cusip_map_tiingo_enrichment.py
+++ b/backend/app/core/db/migrations/versions/0164_cusip_map_tiingo_enrichment.py
@@ -1,0 +1,61 @@
+"""sec_cusip_ticker_map — Tiingo fundamentals enrichment columns.
+
+Extends sec_cusip_ticker_map to store the Tiingo /fundamentals/meta
+payload used by PR-Q4.1 holdings-rail enrichment worker. All columns
+nullable — existing rows remain valid, the worker backfills over time.
+
+New columns:
+    sic_code              INTEGER          — Tiingo sicCode (SEC-native)
+    tiingo_industry       TEXT             — Tiingo industry (GICS-approx granular)
+    tiingo_meta_fetched_at TIMESTAMPTZ     — last Tiingo meta call timestamp
+
+`gics_sector` (already on the table) becomes the write target for Tiingo's
+`sector` field. Layered storage — SIC for compliance/research, GICS-approx
+for display in DD ch.4 + matview.
+
+depends_on: 0163 (mv_nport_sector_attribution).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0164_cusip_map_tiingo_enrichment"
+down_revision = "0163_mv_nport_sector_attribution"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sec_cusip_ticker_map",
+        sa.Column("sic_code", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "sec_cusip_ticker_map",
+        sa.Column("tiingo_industry", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "sec_cusip_ticker_map",
+        sa.Column(
+            "tiingo_meta_fetched_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    # Partial index for the worker's "needs-enrichment" scan: equity rows with
+    # a ticker resolved but no GICS sector yet. Tight — only covers the working
+    # set, not the full 33k-row catalog.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_cusip_map_needs_tiingo_enrichment "
+        "ON sec_cusip_ticker_map (ticker) "
+        "WHERE ticker IS NOT NULL AND gics_sector IS NULL",
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_cusip_map_needs_tiingo_enrichment")
+    op.drop_column("sec_cusip_ticker_map", "tiingo_meta_fetched_at")
+    op.drop_column("sec_cusip_ticker_map", "tiingo_industry")
+    op.drop_column("sec_cusip_ticker_map", "sic_code")

--- a/backend/app/domains/wealth/workers/nport_cusip_enrichment_tiingo.py
+++ b/backend/app/domains/wealth/workers/nport_cusip_enrichment_tiingo.py
@@ -1,0 +1,461 @@
+"""N-PORT CUSIP sector enrichment via Tiingo Fundamentals Meta.
+
+Closes the PR-Q4 enrichment gap: after the holdings matview ships, 15k+
+equity CUSIPs in sec_nport_holdings still carry raw N-PORT issuer codes
+(CORP, EC, EP) instead of GICS sectors. The default enrichment path in
+data_providers/sec/shared.py (SIC heuristic → OpenFIGI marketSector →
+keyword) has poor yield on the long tail.
+
+This worker uses Tiingo's /tiingo/fundamentals/meta endpoint, which
+returns `sector` (GICS-approximate) and `industry` derived from SEC SIC
+filings — 100% coverage for US equities.
+
+Two-phase pipeline:
+
+    A) CUSIP → ticker via OpenFIGI batch (100 CUSIPs/request)
+    B) ticker → Tiingo fundamentals meta (100 tickers/request)
+
+Results upsert `gics_sector`, `tiingo_industry`, `sic_code`, `ticker` into
+sec_cusip_ticker_map; propagates `gics_sector` into sec_nport_holdings
+for all matching equity holdings; refreshes mv_nport_sector_attribution
+CONCURRENTLY at the end.
+
+GLOBAL table, no RLS. Advisory lock 900_110. Fail-open on all API calls
+(individual batch failures logged but don't abort the run). Idempotent —
+safe to re-run; skips rows already enriched in the last 90 days.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections.abc import Iterable
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.engine import async_session_factory as async_session
+
+logger = structlog.get_logger()
+
+NPORT_TIINGO_ENRICHMENT_LOCK_ID = 900_110
+_OPENFIGI_BATCH_SIZE = 100
+_TIINGO_BATCH_SIZE = 100
+# Tiingo free fundamentals tier: ~2400 req/hr. 100 tickers/req → ~4M
+# tickers/hr. The real bottleneck is OpenFIGI (25 req/min free tier).
+# Default cadence adds a small sleep between batches to be polite.
+_OPENFIGI_BATCH_SLEEP_S = 2.5
+_TIINGO_BATCH_SLEEP_S = 0.3
+# Skip tickers whose meta was fetched in the last N days (re-enrich later).
+_TIINGO_STALENESS_DAYS = 90
+
+# N-PORT raw codes that indicate "no GICS classification yet" in
+# sec_nport_holdings.sector. Mirrors the list in nport_ingestion worker.
+_RAW_NPORT_CODES: tuple[str, ...] = (
+    "CORP", "UST", "USGA", "USGSE", "NUSS", "MUN", "RF", "PF", "OTHER", "EC", "OT",
+)
+
+TIINGO_META_URL = "https://api.tiingo.com/tiingo/fundamentals/meta"
+
+# Tiingo free/evaluation tier returns this literal string in every restricted
+# field instead of null. We must scrub before hitting the DB, otherwise the
+# INTEGER sic_code UPDATE aborts with DatatypeMismatch and kills the whole
+# transaction. Seen on tickers outside the DOW-30-ish evaluation whitelist.
+_TIINGO_GATED_SENTINEL = "Field not available for free/evaluation"
+
+
+def _scrub_tiingo_value(value: Any) -> Any:
+    """Convert the Tiingo evaluation-gate sentinel into None."""
+    if isinstance(value, str) and value == _TIINGO_GATED_SENTINEL:
+        return None
+    return value
+
+
+async def run(
+    *,
+    max_openfigi_batches: int | None = None,
+    max_tiingo_batches: int | None = None,
+) -> dict[str, Any]:
+    """Run a full enrichment cycle.
+
+    Parameters cap API calls for safety when running ad-hoc. In production
+    scheduling, both are None (process everything).
+    """
+    async with async_session() as db:
+        got = await db.execute(
+            text(f"SELECT pg_try_advisory_lock({NPORT_TIINGO_ENRICHMENT_LOCK_ID})"),
+        )
+        if not got.scalar():
+            logger.warning("nport_cusip_tiingo_enrichment_lock_held")
+            return {"status": "skipped", "reason": "lock_held"}
+
+        try:
+            phase_a = await _phase_resolve_tickers(
+                db, max_batches=max_openfigi_batches,
+            )
+            phase_b = await _phase_fetch_tiingo_meta(
+                db, max_batches=max_tiingo_batches,
+            )
+            propagated = await _propagate_to_nport_holdings(db)
+            summary = {
+                "status": "completed",
+                "phase_a": phase_a,
+                "phase_b": phase_b,
+                "nport_rows_updated": propagated,
+            }
+            logger.info("nport_cusip_tiingo_enrichment_complete", **summary)
+        finally:
+            await db.execute(
+                text(f"SELECT pg_advisory_unlock({NPORT_TIINGO_ENRICHMENT_LOCK_ID})"),
+            )
+
+    # Matview refresh outside the lock (same pattern as nport_ingestion).
+    refresh = await _refresh_matview()
+    summary["matview_refresh"] = refresh
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Phase A — CUSIP → ticker via OpenFIGI
+# ---------------------------------------------------------------------------
+
+
+async def _phase_resolve_tickers(
+    db: AsyncSession,
+    *,
+    max_batches: int | None,
+) -> dict[str, Any]:
+    """Upsert tickers for distinct equity CUSIPs in N-PORT that lack them.
+
+    Pulls CUSIPs present in sec_nport_holdings as equity (EC/EP) whose
+    sector is still a raw N-PORT code and whose corresponding row in
+    sec_cusip_ticker_map either doesn't exist or has no ticker. Tiny
+    working set — the matview enrichment runs pick them up within days.
+    """
+    api_key = os.getenv("OPENFIGI_API_KEY")
+    cusips_needed = await _distinct_cusips_without_ticker(db)
+    logger.info("nport_cusip_tiingo_phase_a_start", candidates=len(cusips_needed))
+
+    if not cusips_needed:
+        return {"candidates": 0, "resolved": 0, "batches": 0, "skipped": True}
+
+    resolved_total = 0
+    batches_run = 0
+
+    import httpx
+
+    from data_providers.sec.shared import resolve_cusip_to_ticker_batch
+
+    async with httpx.AsyncClient() as http_client:
+        for batch in _chunks(cusips_needed, _OPENFIGI_BATCH_SIZE):
+            if max_batches is not None and batches_run >= max_batches:
+                break
+            try:
+                results = await resolve_cusip_to_ticker_batch(
+                    list(batch),
+                    http_client=http_client,
+                    api_key=api_key,
+                )
+            except Exception as exc:  # pragma: no cover
+                logger.warning(
+                    "nport_cusip_tiingo_openfigi_batch_failed",
+                    error=str(exc),
+                    batch_size=len(batch),
+                )
+                batches_run += 1
+                await asyncio.sleep(_OPENFIGI_BATCH_SLEEP_S)
+                continue
+
+            resolved = await _upsert_ticker_map(db, results)
+            resolved_total += resolved
+            batches_run += 1
+            logger.info(
+                "nport_cusip_tiingo_openfigi_batch_done",
+                batch=batches_run,
+                resolved=resolved,
+                size=len(batch),
+            )
+            await asyncio.sleep(_OPENFIGI_BATCH_SLEEP_S)
+
+    return {
+        "candidates": len(cusips_needed),
+        "resolved": resolved_total,
+        "batches": batches_run,
+    }
+
+
+async def _distinct_cusips_without_ticker(db: AsyncSession) -> list[str]:
+    """Equity CUSIPs in N-PORT with raw sector + no ticker in the map yet."""
+    rows = (await db.execute(text("""
+        SELECT DISTINCT h.cusip
+        FROM sec_nport_holdings h
+        LEFT JOIN sec_cusip_ticker_map m ON m.cusip = h.cusip
+        WHERE h.asset_class IN ('EC', 'EP')
+          AND h.sector = ANY(:raw_codes)
+          AND (m.ticker IS NULL OR m.cusip IS NULL)
+    """), {"raw_codes": list(_RAW_NPORT_CODES)})).all()
+    return [r[0] for r in rows if r[0]]
+
+
+async def _upsert_ticker_map(
+    db: AsyncSession, results: Iterable[Any],
+) -> int:
+    """Upsert CusipTickerResult rows into sec_cusip_ticker_map."""
+    payload = []
+    for r in results:
+        ticker = r.ticker or None
+        payload.append({
+            "cusip": r.cusip,
+            "ticker": ticker,
+            "issuer_name": r.issuer_name,
+            "exchange": r.exchange,
+            "security_type": r.security_type,
+            "figi": r.figi,
+            "composite_figi": r.composite_figi,
+            "resolved_via": "openfigi" if ticker else "openfigi_unresolved",
+            "is_tradeable": bool(ticker),
+        })
+
+    if not payload:
+        return 0
+
+    await db.execute(text("""
+        INSERT INTO sec_cusip_ticker_map
+            (cusip, ticker, issuer_name, exchange, security_type,
+             figi, composite_figi, resolved_via, is_tradeable, last_verified_at)
+        VALUES
+            (:cusip, :ticker, :issuer_name, :exchange, :security_type,
+             :figi, :composite_figi, :resolved_via, :is_tradeable, now())
+        ON CONFLICT (cusip) DO UPDATE SET
+            ticker = COALESCE(EXCLUDED.ticker, sec_cusip_ticker_map.ticker),
+            issuer_name = COALESCE(EXCLUDED.issuer_name, sec_cusip_ticker_map.issuer_name),
+            exchange = COALESCE(EXCLUDED.exchange, sec_cusip_ticker_map.exchange),
+            security_type = COALESCE(EXCLUDED.security_type, sec_cusip_ticker_map.security_type),
+            figi = COALESCE(EXCLUDED.figi, sec_cusip_ticker_map.figi),
+            composite_figi = COALESCE(EXCLUDED.composite_figi, sec_cusip_ticker_map.composite_figi),
+            resolved_via = EXCLUDED.resolved_via,
+            is_tradeable = EXCLUDED.is_tradeable,
+            last_verified_at = now()
+    """), payload)
+    await db.commit()
+    return sum(1 for p in payload if p["ticker"])
+
+
+# ---------------------------------------------------------------------------
+# Phase B — ticker → Tiingo fundamentals meta
+# ---------------------------------------------------------------------------
+
+
+async def _phase_fetch_tiingo_meta(
+    db: AsyncSession,
+    *,
+    max_batches: int | None,
+) -> dict[str, Any]:
+    api_key = os.getenv("TIINGO_API_KEY")
+    if not api_key:
+        logger.warning("nport_cusip_tiingo_phase_b_no_key")
+        return {"candidates": 0, "enriched": 0, "batches": 0, "skipped": True}
+
+    tickers = await _distinct_tickers_needing_meta(db)
+    logger.info("nport_cusip_tiingo_phase_b_start", candidates=len(tickers))
+
+    if not tickers:
+        return {"candidates": 0, "enriched": 0, "batches": 0}
+
+    enriched_total = 0
+    batches_run = 0
+
+    import httpx
+
+    async with httpx.AsyncClient(timeout=30.0) as http_client:
+        for batch in _chunks(tickers, _TIINGO_BATCH_SIZE):
+            if max_batches is not None and batches_run >= max_batches:
+                break
+
+            metas = await _fetch_tiingo_meta_batch(http_client, api_key, list(batch))
+            enriched = await _upsert_tiingo_meta(db, metas)
+            enriched_total += enriched
+            batches_run += 1
+            logger.info(
+                "nport_cusip_tiingo_meta_batch_done",
+                batch=batches_run,
+                enriched=enriched,
+                size=len(batch),
+            )
+            await asyncio.sleep(_TIINGO_BATCH_SLEEP_S)
+
+    return {
+        "candidates": len(tickers),
+        "enriched": enriched_total,
+        "batches": batches_run,
+    }
+
+
+async def _distinct_tickers_needing_meta(db: AsyncSession) -> list[str]:
+    """Tickers with no GICS sector OR stale Tiingo meta."""
+    rows = (await db.execute(text("""
+        SELECT DISTINCT m.ticker
+        FROM sec_cusip_ticker_map m
+        JOIN sec_nport_holdings h ON h.cusip = m.cusip
+        WHERE m.ticker IS NOT NULL
+          AND h.asset_class IN ('EC', 'EP')
+          AND h.sector = ANY(:raw_codes)
+          AND (
+              m.gics_sector IS NULL
+              OR m.tiingo_meta_fetched_at IS NULL
+              OR m.tiingo_meta_fetched_at < now() - make_interval(days => :staleness)
+          )
+    """), {
+        "raw_codes": list(_RAW_NPORT_CODES),
+        "staleness": _TIINGO_STALENESS_DAYS,
+    })).all()
+    return [r[0] for r in rows if r[0]]
+
+
+async def _fetch_tiingo_meta_batch(
+    http_client: Any, api_key: str, tickers: list[str],
+) -> list[dict[str, Any]]:
+    """Call Tiingo /tiingo/fundamentals/meta for up to 100 tickers.
+
+    Returns raw payloads aligned by ticker. Unknown tickers are dropped
+    by Tiingo's response — we don't raise.
+    """
+    try:
+        resp = await http_client.get(
+            TIINGO_META_URL,
+            params={
+                "tickers": ",".join(tickers),
+                "token": api_key,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        logger.warning(
+            "nport_cusip_tiingo_meta_request_failed",
+            error=str(exc),
+            size=len(tickers),
+        )
+        return []
+
+    if not isinstance(data, list):
+        logger.warning(
+            "nport_cusip_tiingo_meta_unexpected_shape",
+            got=type(data).__name__,
+        )
+        return []
+    return data
+
+
+async def _upsert_tiingo_meta(
+    db: AsyncSession, metas: list[dict[str, Any]],
+) -> int:
+    if not metas:
+        return 0
+
+    payload = []
+    gated = 0
+    for meta in metas:
+        ticker = meta.get("ticker")
+        if not ticker:
+            continue
+        sector = _scrub_tiingo_value(meta.get("sector"))
+        industry = _scrub_tiingo_value(meta.get("industry"))
+        sic_raw = _scrub_tiingo_value(meta.get("sicCode"))
+        # sicCode is INTEGER on disk — coerce, ignore non-numeric sentinels.
+        try:
+            sic_code = int(sic_raw) if sic_raw is not None else None
+        except (TypeError, ValueError):
+            sic_code = None
+        if sector is None and industry is None and sic_code is None:
+            # Evaluation-tier gate — count but skip the UPDATE (no-op).
+            gated += 1
+            continue
+        payload.append({
+            "ticker": (ticker or "").upper(),
+            "gics_sector": sector,
+            "tiingo_industry": industry,
+            "sic_code": sic_code,
+        })
+    if gated:
+        logger.info("nport_cusip_tiingo_meta_gated_skipped", count=gated)
+
+    if not payload:
+        return 0
+
+    # Updates every matching ticker row — one Tiingo ticker maps to all
+    # CUSIPs sharing it (e.g. share classes). This is correct: all classes
+    # of the same issuer belong to the same GICS sector.
+    await db.execute(text("""
+        UPDATE sec_cusip_ticker_map
+           SET gics_sector = COALESCE(:gics_sector, gics_sector),
+               tiingo_industry = COALESCE(:tiingo_industry, tiingo_industry),
+               sic_code = COALESCE(:sic_code, sic_code),
+               tiingo_meta_fetched_at = now()
+         WHERE UPPER(ticker) = :ticker
+    """), payload)
+    await db.commit()
+    return sum(1 for p in payload if p["gics_sector"])
+
+
+# ---------------------------------------------------------------------------
+# Propagate to sec_nport_holdings + matview refresh
+# ---------------------------------------------------------------------------
+
+
+async def _propagate_to_nport_holdings(db: AsyncSession) -> int:
+    """Push gics_sector from sec_cusip_ticker_map into sec_nport_holdings.
+
+    Only touches equity rows still carrying a raw N-PORT code. Idempotent.
+    """
+    result = await db.execute(text("""
+        UPDATE sec_nport_holdings h
+           SET sector = m.gics_sector
+          FROM sec_cusip_ticker_map m
+         WHERE m.cusip = h.cusip
+           AND m.gics_sector IS NOT NULL
+           AND h.asset_class IN ('EC', 'EP')
+           AND h.sector = ANY(:raw_codes)
+    """), {"raw_codes": list(_RAW_NPORT_CODES)})
+    await db.commit()
+    count = result.rowcount or 0
+    logger.info("nport_cusip_tiingo_propagated", rows=count)
+    return int(count)
+
+
+async def _refresh_matview() -> dict[str, Any]:
+    start = time.monotonic()
+    try:
+        async with async_session() as s:
+            await s.execute(text(
+                "REFRESH MATERIALIZED VIEW CONCURRENTLY "
+                "mv_nport_sector_attribution",
+            ))
+            await s.commit()
+        return {
+            "status": "refreshed",
+            "duration_s": round(time.monotonic() - start, 3),
+        }
+    except Exception as exc:
+        return {
+            "status": "failed",
+            "error": str(exc),
+            "duration_s": round(time.monotonic() - start, 3),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
+def _chunks(seq: list[str], n: int) -> Iterable[list[str]]:
+    for i in range(0, len(seq), n):
+        yield seq[i:i + n]
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/backend/scripts/backfill_nport_sector_tiingo.py
+++ b/backend/scripts/backfill_nport_sector_tiingo.py
@@ -1,0 +1,55 @@
+"""CLI runner for the N-PORT CUSIP Tiingo enrichment worker.
+
+Usage:
+    python -m scripts.backfill_nport_sector_tiingo \
+        --max-openfigi-batches 10 \
+        --max-tiingo-batches 20
+
+Defaults cap both phases at 10 batches each — safe for dev iteration.
+Remove caps (--max-* 0) to run full backfill.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+
+from app.domains.wealth.workers.nport_cusip_enrichment_tiingo import run
+
+
+def _none_if_zero(v: int) -> int | None:
+    return None if v <= 0 else v
+
+
+async def _main(args: argparse.Namespace) -> int:
+    summary = await run(
+        max_openfigi_batches=_none_if_zero(args.max_openfigi_batches),
+        max_tiingo_batches=_none_if_zero(args.max_tiingo_batches),
+    )
+    print(json.dumps(summary, indent=2, default=str))
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--max-openfigi-batches", type=int, default=10,
+        help="Cap on OpenFIGI batches (0 = uncapped).",
+    )
+    p.add_argument(
+        "--max-tiingo-batches", type=int, default=20,
+        help="Cap on Tiingo fundamentals/meta batches (0 = uncapped).",
+    )
+    args = p.parse_args()
+
+    if not os.getenv("DATABASE_URL"):
+        print("DATABASE_URL not set", file=sys.stderr)
+        return 2
+    return asyncio.run(_main(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_nport_cusip_enrichment_tiingo.py
+++ b/backend/tests/test_nport_cusip_enrichment_tiingo.py
@@ -1,0 +1,309 @@
+"""Unit tests for PR-Q4.1 — N-PORT CUSIP Tiingo enrichment worker.
+
+Exercises the two-phase pipeline (OpenFIGI → Tiingo) against mocked HTTP
+clients and a fake async session. Validates upsert payloads, dedup,
+degradation, and the ticker-case normalisation on the Tiingo UPDATE.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from app.domains.wealth.workers import nport_cusip_enrichment_tiingo as mod
+
+
+class _FakeResult:
+    def __init__(self, scalar=None, rows=None, rowcount=0):
+        self._scalar = scalar
+        self._rows = rows or []
+        self.rowcount = rowcount
+
+    def scalar(self):
+        return self._scalar
+
+    def all(self):
+        return self._rows
+
+
+class _FakeSession:
+    def __init__(self):
+        self.executed: list[tuple[str, object]] = []
+        self.committed = 0
+        self._queue: list[_FakeResult] = []
+
+    def queue(self, *results: _FakeResult) -> None:
+        self._queue.extend(results)
+
+    async def execute(self, stmt, params=None):
+        self.executed.append((str(stmt), params))
+        if self._queue:
+            return self._queue.pop(0)
+        return _FakeResult()
+
+    async def commit(self):
+        self.committed += 1
+
+
+def test_chunks_yields_evenly():
+    out = list(mod._chunks(list(range(250)), 100))
+    assert [len(c) for c in out] == [100, 100, 50]
+
+
+def test_distinct_cusips_without_ticker_returns_cusips():
+    session = _FakeSession()
+    session.queue(_FakeResult(rows=[("000111AAA",), ("000222BBB",)]))
+    out = asyncio.run(mod._distinct_cusips_without_ticker(session))
+    assert out == ["000111AAA", "000222BBB"]
+
+
+def test_distinct_cusips_drops_null_rows():
+    session = _FakeSession()
+    session.queue(_FakeResult(rows=[("000111AAA",), (None,), ("000333CCC",)]))
+    out = asyncio.run(mod._distinct_cusips_without_ticker(session))
+    assert out == ["000111AAA", "000333CCC"]
+
+
+def test_upsert_ticker_map_marks_unresolved():
+    from data_providers.sec.shared import CusipTickerResult
+
+    session = _FakeSession()
+    results = [
+        CusipTickerResult(
+            cusip="000111AAA", ticker="AAPL", issuer_name="Apple Inc",
+            exchange="US", security_type="Common Stock",
+            figi="BBG000B9XRY4", composite_figi="BBG000B9XRY4",
+            resolved_via="openfigi", is_tradeable=True,
+        ),
+        CusipTickerResult(
+            cusip="000222BBB", ticker=None, issuer_name=None,
+            exchange=None, security_type=None, figi=None,
+            composite_figi=None, resolved_via="unresolved", is_tradeable=False,
+        ),
+    ]
+    resolved = asyncio.run(mod._upsert_ticker_map(session, results))
+    assert resolved == 1  # only AAPL counted
+    assert session.committed == 1
+
+
+def test_upsert_ticker_map_empty_input_noop():
+    session = _FakeSession()
+    resolved = asyncio.run(mod._upsert_ticker_map(session, []))
+    assert resolved == 0
+    assert session.committed == 0
+
+
+def test_distinct_tickers_needing_meta():
+    session = _FakeSession()
+    session.queue(_FakeResult(rows=[("AAPL",), ("MSFT",)]))
+    out = asyncio.run(mod._distinct_tickers_needing_meta(session))
+    assert out == ["AAPL", "MSFT"]
+
+
+def test_upsert_tiingo_meta_counts_only_with_sector():
+    session = _FakeSession()
+    metas = [
+        {"ticker": "aapl", "sector": "Technology",
+         "industry": "Consumer Electronics", "sicCode": 3571},
+        {"ticker": "abcd", "sector": None, "industry": None, "sicCode": None},
+        {"ticker": None},  # dropped — no ticker
+    ]
+    enriched = asyncio.run(mod._upsert_tiingo_meta(session, metas))
+    assert enriched == 1
+    assert session.committed == 1
+    # Verify ticker was uppercased in the UPDATE params.
+    _, params = session.executed[0]
+    upper = [p for p in params if p.get("ticker") == "AAPL"]
+    assert upper, "ticker normalisation to uppercase missing"
+
+
+def test_upsert_tiingo_meta_drops_evaluation_sentinel():
+    """Free-tier gate: Tiingo returns 'Field not available for free/evaluation'
+    as a string in every restricted field. Must be scrubbed to None, and
+    rows with nothing usable must be skipped entirely (not UPDATE'd)."""
+    session = _FakeSession()
+    sentinel = "Field not available for free/evaluation"
+    metas = [
+        {"ticker": "amzn", "sector": sentinel, "industry": sentinel,
+         "sicCode": sentinel},
+        {"ticker": "aapl", "sector": "Technology",
+         "industry": "Consumer Electronics", "sicCode": 3571},
+    ]
+    enriched = asyncio.run(mod._upsert_tiingo_meta(session, metas))
+    assert enriched == 1  # AMZN skipped, AAPL counted
+    # Only one UPDATE issued (AAPL); AMZN filtered before SQL.
+    _, params = session.executed[0]
+    assert len(params) == 1
+    assert params[0]["ticker"] == "AAPL"
+
+
+def test_upsert_tiingo_meta_coerces_sic_to_int():
+    session = _FakeSession()
+    metas = [
+        {"ticker": "aapl", "sector": "Technology", "industry": "X",
+         "sicCode": "3571"},  # stringified int
+    ]
+    asyncio.run(mod._upsert_tiingo_meta(session, metas))
+    _, params = session.executed[0]
+    assert params[0]["sic_code"] == 3571
+    assert isinstance(params[0]["sic_code"], int)
+
+
+def test_scrub_tiingo_value_passthrough_non_sentinel():
+    assert mod._scrub_tiingo_value("Technology") == "Technology"
+    assert mod._scrub_tiingo_value(3571) == 3571
+    assert mod._scrub_tiingo_value(None) is None
+
+
+def test_scrub_tiingo_value_strips_sentinel():
+    assert mod._scrub_tiingo_value("Field not available for free/evaluation") is None
+
+
+def test_upsert_tiingo_meta_empty_noop():
+    session = _FakeSession()
+    assert asyncio.run(mod._upsert_tiingo_meta(session, [])) == 0
+    assert session.committed == 0
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration via httpx.MockTransport
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_tiingo_meta_batch_parses_aapl_msft():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.tiingo.com"
+        assert "tickers=AAPL" in str(request.url) and "MSFT" in str(request.url)
+        return httpx.Response(200, json=[
+            {
+                "permaTicker": "US000000000038", "ticker": "aapl",
+                "name": "Apple Inc", "isActive": True, "isADR": False,
+                "sector": "Technology", "industry": "Consumer Electronics",
+                "sicCode": 3571,
+            },
+            {
+                "permaTicker": "US000000000039", "ticker": "msft",
+                "name": "Microsoft Corp", "isActive": True, "isADR": False,
+                "sector": "Technology", "industry": "Software—Infrastructure",
+                "sicCode": 7372,
+            },
+        ])
+
+    async def _run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as c:
+            return await mod._fetch_tiingo_meta_batch(c, "token", ["AAPL", "MSFT"])
+
+    out = asyncio.run(_run())
+    assert len(out) == 2
+    assert out[0]["sector"] == "Technology"
+    assert out[0]["sicCode"] == 3571
+
+
+def test_fetch_tiingo_meta_batch_handles_http_error():
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="server error")
+
+    async def _run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as c:
+            return await mod._fetch_tiingo_meta_batch(c, "token", ["AAPL"])
+
+    # Never raises; returns empty list.
+    assert asyncio.run(_run()) == []
+
+
+def test_fetch_tiingo_meta_batch_handles_unexpected_shape():
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"error": "oops"})
+
+    async def _run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as c:
+            return await mod._fetch_tiingo_meta_batch(c, "token", ["AAPL"])
+
+    assert asyncio.run(_run()) == []
+
+
+# ---------------------------------------------------------------------------
+# Matview refresh + orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_matview_returns_status_dict(monkeypatch):
+    class _FakeAsyncSession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *_a):
+            return None
+        async def execute(self, *_a):
+            return _FakeResult()
+        async def commit(self):
+            return None
+
+    monkeypatch.setattr(mod, "async_session", lambda: _FakeAsyncSession())
+    result = asyncio.run(mod._refresh_matview())
+    assert result["status"] == "refreshed"
+    assert "duration_s" in result
+
+
+def test_run_skips_when_lock_held(monkeypatch):
+    class _LockedSession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *_a):
+            return None
+        async def execute(self, *_a, **_kw):
+            return _FakeResult(scalar=False)
+
+    monkeypatch.setattr(mod, "async_session", lambda: _LockedSession())
+    result = asyncio.run(mod.run())
+    assert result == {"status": "skipped", "reason": "lock_held"}
+
+
+def test_run_happy_path_calls_all_phases(monkeypatch):
+    calls: list[str] = []
+
+    class _OkSession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *_a):
+            return None
+        async def execute(self, stmt, *_a, **_kw):
+            s = str(stmt)
+            if "pg_try_advisory_lock" in s:
+                return _FakeResult(scalar=True)
+            return _FakeResult()
+
+    monkeypatch.setattr(mod, "async_session", lambda: _OkSession())
+
+    async def fake_phase_a(_db, **_kw):
+        calls.append("A")
+        return {"candidates": 0, "resolved": 0, "batches": 0}
+
+    async def fake_phase_b(_db, **_kw):
+        calls.append("B")
+        return {"candidates": 0, "enriched": 0, "batches": 0}
+
+    async def fake_propagate(_db):
+        calls.append("propagate")
+        return 0
+
+    async def fake_refresh():
+        calls.append("refresh")
+        return {"status": "refreshed", "duration_s": 0.0}
+
+    monkeypatch.setattr(mod, "_phase_resolve_tickers", fake_phase_a)
+    monkeypatch.setattr(mod, "_phase_fetch_tiingo_meta", fake_phase_b)
+    monkeypatch.setattr(mod, "_propagate_to_nport_holdings", fake_propagate)
+    monkeypatch.setattr(mod, "_refresh_matview", fake_refresh)
+
+    summary = asyncio.run(mod.run())
+    assert calls == ["A", "B", "propagate", "refresh"]
+    assert summary["status"] == "completed"
+    assert summary["matview_refresh"]["status"] == "refreshed"
+
+
+def test_phase_b_skips_when_no_api_key(monkeypatch):
+    monkeypatch.delenv("TIINGO_API_KEY", raising=False)
+    session = _FakeSession()
+    result = asyncio.run(mod._phase_fetch_tiingo_meta(session, max_batches=None))
+    assert result["skipped"] is True


### PR DESCRIPTION
## Summary

- New worker `nport_cusip_enrichment_tiingo` (lock 900_110) backfills GICS sectors for 15,301 equity CUSIPs in `sec_nport_holdings` via a two-phase OpenFIGI → Tiingo Fundamentals Meta pipeline.
- Closes the PR-Q4 gap: after #254 shipped, `mv_nport_sector_attribution` had 11 GICS sectors available for ~67% of equity AUM; the remaining 15k CUSIPs stayed on raw N-PORT codes (CORP/EC/EP).
- Migration 0164 adds `sic_code`, `tiingo_industry`, `tiingo_meta_fetched_at` to `sec_cusip_ticker_map`. `gics_sector` (existing) becomes the display-level taxonomy; `sic_code` preserved for compliance/research.

## Why Tiingo, not deeper SIC cascade?

Tiingo's `/tiingo/fundamentals/meta` returns `sector` (GICS-approximate — their internal SIC→GICS crosswalk, 11 values), `industry`, and `sicCode` in one call. 100% coverage for US equities with a paid Fundamentals add-on. Avoids maintaining an in-repo SIC→GICS mapping (which would have been Cenário B of PR-Q4 if N-PORT had a `sic_code` column).

## Pipeline

```
Phase A: sec_nport_holdings (raw equity)
          └─ distinct CUSIPs w/o ticker  →  OpenFIGI batch (100/req)
             └─ UPSERT sec_cusip_ticker_map (ticker, issuer_name, figi)

Phase B: sec_cusip_ticker_map (gics_sector IS NULL + has ticker)
          └─ Tiingo /fundamentals/meta (100 tickers/req)
             └─ UPDATE sec_cusip_ticker_map SET gics_sector, tiingo_industry, sic_code

Propagate: UPDATE sec_nport_holdings.sector = m.gics_sector
Refresh:   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_nport_sector_attribution
           (outside advisory lock 900_110)
```

## Free/evaluation tier handling

Tiingo returns the literal string `"Field not available for free/evaluation"` for restricted tickers instead of null. Worker scrubs these before INSERT (`_scrub_tiingo_value`) to avoid `DatatypeMismatch` on the INTEGER `sic_code` column, and skips all-gated rows silently with a `gated_skipped` log metric.

## Dev DB run (2026-04-20)

Evaluation-tier key — sanity check only:
- Phase A: 14,091 CUSIP candidates; 19 resolved in first 100-batch (19% hit rate, typical for long tail)
- Phase B: 1,229 ticker candidates; 0 enriched (all hit sentinel — gate scrubbed silently)
- Matview refresh: 1.6s ✅

## Test plan

- [x] `pytest tests/test_nport_cusip_enrichment_tiingo.py` — 19/19 pass
- [x] Migration 0164 applied to Dev DB
- [x] Worker end-to-end runs clean (no transaction aborts)
- [x] `make lint` green
- [x] `make architecture` green (31 contracts kept)
- [ ] **Operator action:** swap `TIINGO_API_KEY` in `.env` / Railway secrets for the paid Fundamentals add-on key, then run `python -m scripts.backfill_nport_sector_tiingo --max-openfigi-batches 0 --max-tiingo-batches 0` to backfill full universe

## Files

- `backend/app/core/db/migrations/versions/0164_cusip_map_tiingo_enrichment.py`
- `backend/app/domains/wealth/workers/nport_cusip_enrichment_tiingo.py` (worker, 330 LOC)
- `backend/scripts/backfill_nport_sector_tiingo.py` (CLI runner)
- `backend/tests/test_nport_cusip_enrichment_tiingo.py` (19 tests)

## Non-goals

- ❌ Schedule as cron (follow-up — piggyback on `nport_ingestion` cadence once paid Tiingo key is in place)
- ❌ Full Brinson-Fachler allocation/selection/interaction — PR-Q5
- ❌ Benchmark holdings ingestion — PR-Q5

## Related

- PR #254 (PR-Q4, merged) — holdings matview + dispatcher
- Next: PR-Q5 full Brinson-Fachler + benchmark holdings

🤖 Generated with [Claude Code](https://claude.com/claude-code)