### PR TITLE
feat(wealth/g3-fase3): benchmark proxy attribution + canonical ETF map (0165)

### DIFF
--- a/backend/app/core/db/migrations/versions/0165_benchmark_etf_canonical_map.py
+++ b/backend/app/core/db/migrations/versions/0165_benchmark_etf_canonical_map.py
@@ -1,0 +1,272 @@
+"""benchmark_etf_canonical_map + primary_benchmark on sec_registered_funds.
+
+PR-Q5 (G3 Fase 3): canonical lookup table resolving any free-text fund
+benchmark string ("S&P 500", "Bloomberg US Agg") to a single proxy ETF.
+Feeds the Brinson-Fachler proxy rail when holdings-based attribution
+degrades.
+
+Global table (no RLS, no organization_id) — the map is universal. Low
+cardinality (~20 rows at seed; expected <50 long-run), so a regular
+CREATE TABLE (not a hypertable).
+
+Also adds ``sec_registered_funds.primary_benchmark TEXT`` so the resolver
+has a source field to read from. Populated by a later worker (PR-Q7
+Tiingo fundamentals / N-CEN enrichment).
+
+Spec: docs/superpowers/specs/2026-04-19-edhec-gaps-data-layer.md §1.
+
+depends_on: 0164 (CUSIP Tiingo enrichment).
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0165_benchmark_etf_canonical_map"
+down_revision = "0164_cusip_map_tiingo_enrichment"
+branch_labels = None
+depends_on = None
+
+
+# Asset class taxonomy — matches the 20-row seed below. Extend with
+# follow-up audit data rather than stuffing this file.
+_ENUM_DDL = """
+DO $$ BEGIN
+    CREATE TYPE benchmark_asset_class AS ENUM (
+        'equity_us_large', 'equity_us_mid', 'equity_us_small',
+        'equity_intl_dev', 'equity_em',
+        'fi_us_agg', 'fi_us_treasury', 'fi_us_hy', 'fi_us_ig', 'fi_us_muni',
+        'fi_intl', 'commodities', 'reits', 'other'
+    );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+"""
+
+
+_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS benchmark_etf_canonical_map (
+    id                         BIGSERIAL PRIMARY KEY,
+    benchmark_name_canonical   TEXT NOT NULL,
+    benchmark_name_aliases     TEXT[] NOT NULL DEFAULT '{}',
+    proxy_etf_ticker           TEXT NOT NULL,
+    proxy_etf_cik              TEXT,
+    proxy_etf_series_id        TEXT,
+    asset_class                benchmark_asset_class NOT NULL,
+    fit_quality_score          NUMERIC(4,3) NOT NULL DEFAULT 1.0
+        CHECK (fit_quality_score >= 0 AND fit_quality_score <= 1),
+    source                     TEXT NOT NULL DEFAULT 'manual_seed',
+    notes                      TEXT,
+    effective_from             DATE NOT NULL DEFAULT '1900-01-01',
+    effective_to               DATE NOT NULL DEFAULT '9999-12-31',
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_canonical_effective UNIQUE (benchmark_name_canonical, effective_from),
+    CONSTRAINT chk_effective_range CHECK (effective_to > effective_from),
+    CONSTRAINT chk_proxy_identifier CHECK (proxy_etf_cik IS NOT NULL OR proxy_etf_series_id IS NOT NULL OR proxy_etf_ticker IS NOT NULL)
+)
+"""
+
+
+_INDEXES = [
+    "CREATE INDEX IF NOT EXISTS ix_benchmark_map_canonical_trgm "
+    "ON benchmark_etf_canonical_map USING GIN (benchmark_name_canonical gin_trgm_ops)",
+    "CREATE INDEX IF NOT EXISTS ix_benchmark_map_aliases_gin "
+    "ON benchmark_etf_canonical_map USING GIN (benchmark_name_aliases)",
+    "CREATE INDEX IF NOT EXISTS ix_benchmark_map_ticker "
+    "ON benchmark_etf_canonical_map (proxy_etf_ticker)",
+    "CREATE INDEX IF NOT EXISTS ix_benchmark_map_asset_class_active "
+    "ON benchmark_etf_canonical_map (asset_class) "
+    "WHERE effective_to = '9999-12-31'",
+]
+
+
+# 20 rows, (canonical, aliases, ticker, asset_class).
+# chk_proxy_identifier is satisfied by ticker alone; cik/series_id
+# backfilled opportunistically in a later data migration.
+_SEED: list[tuple[str, list[str], str, str]] = [
+    (
+        "S&P 500",
+        ["S&P 500", "S&P 500 Index", "S&P 500® Index",
+         "Standard & Poor's 500", "Standard & Poor's 500 Index",
+         "S&P 500 Total Return"],
+        "SPY", "equity_us_large",
+    ),
+    (
+        "Russell 2000",
+        ["Russell 2000", "Russell 2000 Index",
+         "Russell 2000® Index", "Russell 2000 Total Return"],
+        "IWM", "equity_us_small",
+    ),
+    (
+        "Russell 1000",
+        ["Russell 1000", "Russell 1000 Index", "Russell 1000® Index"],
+        "IWB", "equity_us_large",
+    ),
+    (
+        "Russell Midcap",
+        ["Russell Midcap", "Russell Midcap Index", "Russell Mid Cap"],
+        "IWR", "equity_us_mid",
+    ),
+    (
+        "Russell 3000",
+        ["Russell 3000", "Russell 3000 Index", "Russell 3000® Index"],
+        "IWV", "equity_us_large",
+    ),
+    (
+        "MSCI EAFE",
+        ["MSCI EAFE", "MSCI EAFE Index", "MSCI EAFE (Net)",
+         "MSCI Europe Australasia Far East"],
+        "EFA", "equity_intl_dev",
+    ),
+    (
+        "MSCI ACWI ex-US",
+        ["MSCI ACWI ex-US", "MSCI ACWI ex USA", "MSCI ACWI ex-USA Index",
+         "MSCI All Country World ex-US"],
+        "ACWX", "equity_intl_dev",
+    ),
+    (
+        "MSCI Emerging Markets",
+        ["MSCI Emerging Markets", "MSCI EM", "MSCI Emerging Markets Index",
+         "MSCI EM Index"],
+        "EEM", "equity_em",
+    ),
+    (
+        "MSCI World",
+        ["MSCI World", "MSCI World Index", "MSCI World (Net)"],
+        "URTH", "equity_intl_dev",
+    ),
+    (
+        "NASDAQ 100",
+        ["NASDAQ 100", "Nasdaq 100", "NASDAQ-100 Index", "Nasdaq 100 Index"],
+        "QQQ", "equity_us_large",
+    ),
+    (
+        "Dow Jones Industrial Average",
+        ["Dow Jones Industrial Average", "DJIA", "Dow Jones Industrial",
+         "Dow 30"],
+        "DIA", "equity_us_large",
+    ),
+    (
+        "Bloomberg US Aggregate Bond",
+        ["Bloomberg US Aggregate Bond", "Bloomberg US Agg",
+         "Bloomberg US Aggregate", "Bloomberg Barclays US Aggregate",
+         "Barclays US Aggregate Bond"],
+        "AGG", "fi_us_agg",
+    ),
+    (
+        "Bloomberg US Treasury",
+        ["Bloomberg US Treasury", "Bloomberg US Treasury Index",
+         "Bloomberg Barclays US Treasury"],
+        "GOVT", "fi_us_treasury",
+    ),
+    (
+        "ICE BofA US High Yield",
+        ["ICE BofA US High Yield", "ICE BofA US High Yield Index",
+         "Bloomberg US Corporate High Yield", "BBG US Corp HY"],
+        "HYG", "fi_us_hy",
+    ),
+    (
+        "Bloomberg US Corporate IG",
+        ["Bloomberg US Corporate IG", "Bloomberg US Corporate Investment Grade",
+         "Bloomberg Barclays US Corporate", "BBG US Corp"],
+        "LQD", "fi_us_ig",
+    ),
+    (
+        "Bloomberg Municipal",
+        ["Bloomberg Municipal", "Bloomberg Municipal Bond",
+         "Bloomberg Barclays Municipal", "US Municipal Bond Index"],
+        "MUB", "fi_us_muni",
+    ),
+    (
+        "Bloomberg Global Agg ex-USD",
+        ["Bloomberg Global Agg ex-USD", "Bloomberg Global Aggregate ex-US",
+         "Bloomberg Barclays Global Aggregate ex-US"],
+        "BNDX", "fi_intl",
+    ),
+    (
+        "Bloomberg Commodity",
+        ["Bloomberg Commodity", "Bloomberg Commodity Index",
+         "BCOM", "Bloomberg Commodity Total Return"],
+        "DJP", "commodities",
+    ),
+    (
+        "MSCI US REIT",
+        ["MSCI US REIT", "MSCI US REIT Index", "FTSE NAREIT Equity REITs",
+         "MSCI US Investable Market REIT"],
+        "VNQ", "reits",
+    ),
+    (
+        "S&P Target Date",
+        ["S&P Target Date", "S&P Target Date Index",
+         "Morningstar Lifetime Moderate"],
+        "AOR", "other",
+    ),
+]
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    op.execute(_ENUM_DDL)
+    op.execute(_TABLE_DDL)
+    for ddl in _INDEXES:
+        op.execute(ddl)
+
+    # Add primary_benchmark text column to sec_registered_funds so the
+    # resolver has a source field. Populated by a downstream N-CEN/Tiingo
+    # backfill worker (PR-Q7).
+    op.execute("""
+        ALTER TABLE sec_registered_funds
+        ADD COLUMN IF NOT EXISTS primary_benchmark TEXT
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_sec_registered_funds_benchmark
+            ON sec_registered_funds (primary_benchmark)
+            WHERE primary_benchmark IS NOT NULL
+    """)
+
+    # Seed 20 rows. Re-runnable: ON CONFLICT on the canonical+effective_from uq.
+    bind = op.get_bind()
+    for canonical, aliases, ticker, asset_class in _SEED:
+        bind.execute(
+            _seed_stmt(),
+            {
+                "canonical": canonical,
+                "aliases": aliases,
+                "ticker": ticker,
+                "asset_class": asset_class,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_sec_registered_funds_benchmark")
+    op.execute("""
+        ALTER TABLE sec_registered_funds
+        DROP COLUMN IF EXISTS primary_benchmark
+    """)
+    op.execute("DROP INDEX IF EXISTS ix_benchmark_map_asset_class_active")
+    op.execute("DROP INDEX IF EXISTS ix_benchmark_map_ticker")
+    op.execute("DROP INDEX IF EXISTS ix_benchmark_map_aliases_gin")
+    op.execute("DROP INDEX IF EXISTS ix_benchmark_map_canonical_trgm")
+    op.execute("DROP TABLE IF EXISTS benchmark_etf_canonical_map")
+    op.execute("DROP TYPE IF EXISTS benchmark_asset_class")
+    # pg_trgm left intact — may be used by other features.
+
+
+def _seed_stmt():
+    from sqlalchemy import text
+
+    return text("""
+        INSERT INTO benchmark_etf_canonical_map (
+            benchmark_name_canonical, benchmark_name_aliases,
+            proxy_etf_ticker, asset_class, source
+        ) VALUES (
+            :canonical, :aliases, :ticker, CAST(:asset_class AS benchmark_asset_class),
+            'manual_seed_0165'
+        )
+        ON CONFLICT (benchmark_name_canonical, effective_from) DO UPDATE
+            SET benchmark_name_aliases = EXCLUDED.benchmark_name_aliases,
+                proxy_etf_ticker = EXCLUDED.proxy_etf_ticker,
+                asset_class = EXCLUDED.asset_class,
+                updated_at = now()
+    """)

--- a/backend/tests/test_attribution_benchmark_proxy.py
+++ b/backend/tests/test_attribution_benchmark_proxy.py
@@ -1,0 +1,642 @@
+"""Unit tests for the benchmark proxy rail (PR-Q5, G3 Fase 3).
+
+Covers:
+  - 3-level resolver cascade (exact → fuzzy → class_fallback → unmatched).
+  - Proxy rail orchestrator using scripted fake DB sessions + seams.
+  - Degradation paths (null benchmark, unmatched, proxy has no holdings,
+    sector returns unavailable).
+  - Dispatcher integration — falls through when proxy rail degrades.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from uuid import UUID, uuid4
+
+import pytest
+
+from vertical_engines.wealth.attribution import benchmark_proxy
+from vertical_engines.wealth.attribution.benchmark_proxy import (
+    classify_asset_class_keywords,
+    resolve_benchmark,
+    run_proxy_rail,
+)
+from vertical_engines.wealth.attribution.models import (
+    AttributionRequest,
+    BenchmarkProxyResult,
+    BenchmarkResolution,
+    RailBadge,
+)
+from vertical_engines.wealth.attribution.service import compute_fund_attribution
+
+# ---------------------------------------------------------------------------
+# Fake DB scaffolding
+# ---------------------------------------------------------------------------
+
+
+class _FakeMappings:
+    def __init__(self, rows):
+        self._rows = rows or []
+
+    def first(self):
+        return dict(self._rows[0]) if self._rows else None
+
+    def all(self):
+        return [dict(r) for r in self._rows]
+
+
+class _FakeResult:
+    def __init__(self, rows=None, scalar=None):
+        self._rows = rows or []
+        self._scalar = scalar
+
+    def first(self):
+        if self._scalar is not None:
+            return (self._scalar,)
+        if self._rows:
+            first = self._rows[0]
+            return tuple(first.values()) if isinstance(first, dict) else first
+        return None
+
+    def mappings(self):
+        return _FakeMappings(self._rows)
+
+
+class _FakeSession:
+    """Scripted async session — matches SQL fragments in order.
+
+    Each fragment is matched against the rendered SQL; the first match
+    returns the queued result. Matched entries stay in the list so the
+    same fragment returns the same result on repeated queries (good
+    default for idempotent lookups like the canonical map).
+    """
+
+    def __init__(self, script):
+        self._script = list(script)
+        self.calls: list[tuple[str, dict]] = []
+
+    async def execute(self, stmt, params=None):
+        sql = str(stmt)
+        self.calls.append((sql, dict(params or {})))
+        for frag, result in self._script:
+            if frag in sql:
+                return result
+        return _FakeResult()
+
+
+def _req(fund_id=None):
+    return AttributionRequest(
+        fund_instrument_id=fund_id or uuid4(),
+        asof=date(2026, 3, 31),
+        lookback_months=60,
+        min_months=36,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Asset-class keyword classifier
+# ---------------------------------------------------------------------------
+
+
+def test_classify_asset_class_keywords_large_cap_blend():
+    assert classify_asset_class_keywords("Large Cap Blend Index") == "equity_us_large"
+
+
+def test_classify_asset_class_keywords_emerging_markets():
+    assert classify_asset_class_keywords("Some Emerging Markets Benchmark") == "equity_em"
+
+
+def test_classify_asset_class_keywords_high_yield():
+    assert classify_asset_class_keywords("ICE High Yield Corporate Bond") == "fi_us_hy"
+
+
+def test_classify_asset_class_keywords_empty_returns_none():
+    assert classify_asset_class_keywords("") is None
+    assert classify_asset_class_keywords("   ") is None
+
+
+def test_classify_asset_class_keywords_gibberish_returns_none():
+    assert classify_asset_class_keywords("xyz nonsense flavor") is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_benchmark — 3-level cascade
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_benchmark_exact_alias_match():
+    session = _FakeSession([
+        ("= ANY(benchmark_name_aliases)", _FakeResult(rows=[{
+            "proxy_etf_cik": "0000884394",
+            "proxy_etf_series_id": None,
+            "proxy_etf_ticker": "SPY",
+            "asset_class": "equity_us_large",
+        }])),
+    ])
+    result = asyncio.run(resolve_benchmark("S&P 500", session))
+    assert result.match_type == "exact"
+    assert result.proxy_etf_ticker == "SPY"
+    assert result.asset_class == "equity_us_large"
+
+
+def test_resolve_benchmark_fuzzy_match_above_threshold():
+    session = _FakeSession([
+        # First level: exact — no match.
+        ("= ANY(benchmark_name_aliases)", _FakeResult(rows=[])),
+        # Second level: fuzzy — hit with sim > 0.7.
+        ("similarity(benchmark_name_canonical, :name) AS sim", _FakeResult(rows=[{
+            "proxy_etf_cik": "0000884394",
+            "proxy_etf_series_id": None,
+            "proxy_etf_ticker": "SPY",
+            "asset_class": "equity_us_large",
+            "sim": 0.82,
+        }])),
+    ])
+    result = asyncio.run(resolve_benchmark("Standard & Poor's 500 Index", session))
+    assert result.match_type == "fuzzy"
+    assert result.proxy_etf_ticker == "SPY"
+    assert result.similarity == pytest.approx(0.82)
+
+
+def test_resolve_benchmark_fuzzy_below_threshold_falls_through():
+    session = _FakeSession([
+        ("= ANY(benchmark_name_aliases)", _FakeResult(rows=[])),
+        # Fuzzy returns row but sim <= 0.7 → dismissed.
+        ("similarity(benchmark_name_canonical, :name) AS sim", _FakeResult(rows=[{
+            "proxy_etf_cik": "X",
+            "proxy_etf_series_id": None,
+            "proxy_etf_ticker": "XYZ",
+            "asset_class": "equity_us_large",
+            "sim": 0.50,
+        }])),
+        # Class fallback on "large cap" keyword → hits.
+        ("asset_class = CAST(:ac AS benchmark_asset_class)", _FakeResult(rows=[{
+            "proxy_etf_cik": "0000884394",
+            "proxy_etf_series_id": None,
+            "proxy_etf_ticker": "SPY",
+            "asset_class": "equity_us_large",
+        }])),
+    ])
+    result = asyncio.run(resolve_benchmark("Large Cap Blend Benchmark", session))
+    assert result.match_type == "class_fallback"
+    assert result.proxy_etf_ticker == "SPY"
+
+
+def test_resolve_benchmark_null_input_short_circuits():
+    session = _FakeSession([])
+    result = asyncio.run(resolve_benchmark(None, session))
+    assert result.match_type == "null"
+    assert result.proxy_etf_ticker is None
+    # No DB calls issued for null input.
+    assert session.calls == []
+
+
+def test_resolve_benchmark_empty_string_short_circuits():
+    session = _FakeSession([])
+    result = asyncio.run(resolve_benchmark("   ", session))
+    assert result.match_type == "null"
+    assert session.calls == []
+
+
+def test_resolve_benchmark_no_match_anywhere_returns_unmatched():
+    session = _FakeSession([
+        ("= ANY(benchmark_name_aliases)", _FakeResult(rows=[])),
+        ("similarity(benchmark_name_canonical, :name) AS sim", _FakeResult(rows=[])),
+        # Class fallback also empty.
+        ("asset_class = CAST(:ac AS benchmark_asset_class)", _FakeResult(rows=[])),
+    ])
+    result = asyncio.run(resolve_benchmark("some obscure vendor index blob", session))
+    assert result.match_type == "unmatched"
+    assert result.proxy_etf_ticker is None
+
+
+def test_resolve_benchmark_asset_class_fallback_for_large_cap_blend():
+    """Level 3 fires when levels 1 and 2 both miss but the string
+    matches a keyword bucket."""
+    session = _FakeSession([
+        ("= ANY(benchmark_name_aliases)", _FakeResult(rows=[])),
+        ("similarity(benchmark_name_canonical, :name) AS sim", _FakeResult(rows=[])),
+        ("asset_class = CAST(:ac AS benchmark_asset_class)", _FakeResult(rows=[{
+            "proxy_etf_cik": "0000884394",
+            "proxy_etf_series_id": None,
+            "proxy_etf_ticker": "SPY",
+            "asset_class": "equity_us_large",
+        }])),
+    ])
+    result = asyncio.run(resolve_benchmark("Obscure Large Cap Blend Index", session))
+    assert result.match_type == "class_fallback"
+    assert result.asset_class == "equity_us_large"
+
+
+# ---------------------------------------------------------------------------
+# run_proxy_rail orchestrator
+# ---------------------------------------------------------------------------
+
+
+def test_run_proxy_rail_no_cik_returns_none():
+    async def no_cik(_db, _iid):
+        return None
+
+    session = _FakeSession([])
+    result = asyncio.run(run_proxy_rail(_req(), session, cik_resolver=no_cik))
+    assert result is None
+
+
+def test_run_proxy_rail_benchmark_null_degrades():
+    async def cik(_db, _iid):
+        return "0001234567"
+
+    async def bench(_db, _cik):
+        return None
+
+    session = _FakeSession([])
+    result = asyncio.run(
+        run_proxy_rail(
+            _req(), session, cik_resolver=cik, benchmark_fetcher=bench,
+        ),
+    )
+    assert isinstance(result, BenchmarkProxyResult)
+    assert result.degraded is True
+    assert result.degraded_reason == "benchmark_unresolved"
+    assert result.resolution.match_type == "null"
+
+
+def test_run_proxy_rail_benchmark_unmatched_degrades():
+    async def cik(_db, _iid):
+        return "0001234567"
+
+    async def bench(_db, _cik):
+        return "Proprietary Gibberish Index v7"
+
+    session = _FakeSession([
+        ("= ANY(benchmark_name_aliases)", _FakeResult(rows=[])),
+        ("similarity(benchmark_name_canonical, :name) AS sim", _FakeResult(rows=[])),
+        ("asset_class = CAST(:ac AS benchmark_asset_class)", _FakeResult(rows=[])),
+    ])
+    result = asyncio.run(
+        run_proxy_rail(
+            _req(), session, cik_resolver=cik, benchmark_fetcher=bench,
+        ),
+    )
+    assert result.degraded is True
+    assert result.degraded_reason == "benchmark_unresolved"
+
+
+def test_run_proxy_rail_proxy_no_holdings_degrades():
+    """Proxy resolves to a BDC/MMF without N-PORT data → degrade."""
+    async def cik(_db, _iid):
+        return "0001234567"
+
+    async def bench(_db, _cik):
+        return "S&P 500"
+
+    session = _FakeSession([
+        ("= ANY(benchmark_name_aliases)", _FakeResult(rows=[{
+            "proxy_etf_cik": "0000884394",
+            "proxy_etf_series_id": None,
+            "proxy_etf_ticker": "SPY",
+            "asset_class": "equity_us_large",
+        }])),
+        # Latest period lookup — fund has a filing.
+        ("MAX(period_of_report)", _FakeResult(scalar=date(2026, 2, 28))),
+        # Fund sector fetch returns data; proxy sector fetch returns empty.
+        ("SELECT issuer_category", _FakeResult(rows=[
+            {"issuer_category": "EC", "industry_sector": "Tech",
+             "aum_usd": 1000.0, "weight": 1.0, "holdings_count": 10},
+        ])),
+    ])
+
+    # Simpler: intercept fetch_sector_weights to return fund sectors for
+    # the fund CIK and empty for the proxy CIK.
+    fund_sectors = [
+        _sector_weight("Tech", 1.0, 1000.0, 10),
+    ]
+
+    async def fake_fetch_sw(_db, cik_arg, _period):
+        return (fund_sectors, 1000.0) if cik_arg == "0001234567" else ([], 0.0)
+
+    orig = benchmark_proxy.fetch_sector_weights
+    benchmark_proxy.fetch_sector_weights = fake_fetch_sw  # type: ignore[assignment]
+    try:
+        result = asyncio.run(
+            run_proxy_rail(
+                _req(), session, cik_resolver=cik, benchmark_fetcher=bench,
+            ),
+        )
+    finally:
+        benchmark_proxy.fetch_sector_weights = orig  # type: ignore[assignment]
+    assert result.degraded is True
+    assert result.degraded_reason == "proxy_no_holdings"
+
+
+def test_run_proxy_rail_sector_returns_unavailable_degrades():
+    """All data present but sector returns fetcher yields empty → degrade."""
+    async def cik(_db, _iid):
+        return "0001234567"
+
+    async def bench(_db, _cik):
+        return "S&P 500"
+
+    session = _FakeSession([
+        ("= ANY(benchmark_name_aliases)", _FakeResult(rows=[{
+            "proxy_etf_cik": "0000884394",
+            "proxy_etf_series_id": None,
+            "proxy_etf_ticker": "SPY",
+            "asset_class": "equity_us_large",
+        }])),
+        ("MAX(period_of_report)", _FakeResult(scalar=date(2026, 2, 28))),
+    ])
+    fund_sectors = [_sector_weight("Tech", 0.6, 600.0, 6)]
+    proxy_sectors = [_sector_weight("Tech", 0.5, 500.0, 5)]
+
+    async def fake_fetch_sw(_db, cik_arg, _period):
+        if cik_arg == "0001234567":
+            return (fund_sectors, 600.0)
+        return (proxy_sectors, 500.0)
+
+    orig = benchmark_proxy.fetch_sector_weights
+    benchmark_proxy.fetch_sector_weights = fake_fetch_sw  # type: ignore[assignment]
+    try:
+        result = asyncio.run(
+            run_proxy_rail(
+                _req(), session, cik_resolver=cik, benchmark_fetcher=bench,
+            ),
+        )
+    finally:
+        benchmark_proxy.fetch_sector_weights = orig  # type: ignore[assignment]
+    assert result.degraded is True
+    assert result.degraded_reason == "sector_returns_unavailable"
+    # Brinson was still computed on weights alone (allocation uses R_B=0).
+    assert result.brinson is not None
+    assert len(result.brinson.by_sector) == 1
+
+
+def test_run_proxy_rail_happy_path_full_brinson():
+    """All three data sources present → rail succeeds with full Brinson math."""
+    async def cik(_db, _iid):
+        return "0001234567"
+
+    async def bench(_db, _cik):
+        return "S&P 500"
+
+    async def sector_returns(_db, _cik, _period):
+        return {"Tech": 0.10, "Financials": 0.04}
+
+    session = _FakeSession([
+        ("= ANY(benchmark_name_aliases)", _FakeResult(rows=[{
+            "proxy_etf_cik": "0000884394",
+            "proxy_etf_series_id": None,
+            "proxy_etf_ticker": "SPY",
+            "asset_class": "equity_us_large",
+        }])),
+        ("MAX(period_of_report)", _FakeResult(scalar=date(2026, 2, 28))),
+    ])
+    fund_sectors = [
+        _sector_weight("Tech", 0.6, 600.0, 6),
+        _sector_weight("Financials", 0.4, 400.0, 4),
+    ]
+    proxy_sectors = [
+        _sector_weight("Tech", 0.5, 500.0, 5),
+        _sector_weight("Financials", 0.5, 500.0, 5),
+    ]
+
+    async def fake_fetch_sw(_db, cik_arg, _period):
+        if cik_arg == "0001234567":
+            return (fund_sectors, 1000.0)
+        return (proxy_sectors, 1000.0)
+
+    orig = benchmark_proxy.fetch_sector_weights
+    benchmark_proxy.fetch_sector_weights = fake_fetch_sw  # type: ignore[assignment]
+    try:
+        result = asyncio.run(
+            run_proxy_rail(
+                _req(), session,
+                cik_resolver=cik,
+                benchmark_fetcher=bench,
+                sector_returns_fetcher=sector_returns,
+            ),
+        )
+    finally:
+        benchmark_proxy.fetch_sector_weights = orig  # type: ignore[assignment]
+
+    assert result.degraded is False
+    assert result.confidence == pytest.approx(0.60)  # exact-match tier
+    assert result.resolution.match_type == "exact"
+    assert result.resolution.proxy_etf_ticker == "SPY"
+    # Brinson identity holds.
+    total = (
+        result.brinson.allocation_effect
+        + result.brinson.selection_effect
+        + result.brinson.interaction_effect
+    )
+    assert total == pytest.approx(result.brinson.total_active_return, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher integration
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_uses_proxy_when_holdings_degrade():
+    """Holdings rail degrades → proxy rail wins and returns RAIL_PROXY."""
+    import numpy as np  # noqa: F401 — silence unused; kept for parity
+
+    from vertical_engines.wealth.attribution.brinson_fachler import brinson_fachler
+    from vertical_engines.wealth.attribution.models import HoldingsBasedResult
+
+    async def holdings_fetch(_req, _db):
+        return HoldingsBasedResult(
+            sectors=(), period_of_report=None, coverage_pct=0.0,
+            confidence=0.0, holdings_count=0,
+            degraded=True, degraded_reason="low_aum_coverage",
+        )
+
+    brinson = brinson_fachler(
+        fund_weights={"IT": 0.6, "Fin": 0.4},
+        fund_returns={"IT": 0.10, "Fin": 0.03},
+        bench_weights={"IT": 0.5, "Fin": 0.5},
+        bench_returns={"IT": 0.08, "Fin": 0.05},
+    )
+
+    async def proxy_fetch(_req, _db):
+        return BenchmarkProxyResult(
+            resolution=BenchmarkResolution(
+                match_type="exact",
+                proxy_etf_ticker="SPY",
+                proxy_etf_cik="0000884394",
+                asset_class="equity_us_large",
+            ),
+            brinson=brinson,
+            confidence=0.60,
+            period_of_report=date(2026, 2, 28),
+            degraded=False,
+        )
+
+    async def returns_fetch(_req, _db):
+        pytest.fail("dispatcher should not fall through to returns when proxy wins")
+
+    result = asyncio.run(
+        compute_fund_attribution(
+            _req(),
+            db=None,
+            holdings_fetch=holdings_fetch,
+            proxy_fetch=proxy_fetch,
+            returns_fetch=returns_fetch,
+        ),
+    )
+    assert result.badge == RailBadge.RAIL_PROXY
+    assert result.proxy is not None
+    assert result.metadata["match_type"] == "exact"
+    assert result.metadata["proxy_ticker"] == "SPY"
+
+
+def test_dispatcher_falls_through_when_proxy_degrades():
+    """Holdings degraded AND proxy degraded → returns rail runs."""
+    import numpy as np
+
+    from vertical_engines.wealth.attribution.brinson_fachler import brinson_fachler
+    from vertical_engines.wealth.attribution.models import HoldingsBasedResult
+
+    async def holdings_fetch(_req, _db):
+        return HoldingsBasedResult(
+            sectors=(), period_of_report=None, coverage_pct=0.0,
+            confidence=0.0, holdings_count=0,
+            degraded=True, degraded_reason="no_filing",
+        )
+
+    brinson = brinson_fachler({}, {}, {}, {})
+
+    async def proxy_fetch(_req, _db):
+        return BenchmarkProxyResult(
+            resolution=BenchmarkResolution(match_type="unmatched"),
+            brinson=brinson,
+            confidence=0.0,
+            degraded=True,
+            degraded_reason="benchmark_unresolved",
+        )
+
+    rng = np.random.default_rng(7)
+    r_fund = rng.normal(0.005, 0.02, 48)
+    r_styles = rng.normal(0.004, 0.02, (48, 2))
+
+    async def returns_fetch(_req, _db):
+        return r_fund, r_styles, ("SPY", "AGG")
+
+    result = asyncio.run(
+        compute_fund_attribution(
+            _req(),
+            db=None,
+            holdings_fetch=holdings_fetch,
+            proxy_fetch=proxy_fetch,
+            returns_fetch=returns_fetch,
+        ),
+    )
+    assert result.badge == RailBadge.RAIL_RETURNS
+
+
+def test_dispatcher_proxy_serialization_roundtrip():
+    """Redis cache encode/decode of a RAIL_PROXY result must roundtrip."""
+    from vertical_engines.wealth.attribution.brinson_fachler import brinson_fachler
+    from vertical_engines.wealth.attribution.models import FundAttributionResult
+    from vertical_engines.wealth.attribution.service import (
+        _deserialize_result,
+        _serialize_result,
+    )
+
+    brinson = brinson_fachler(
+        fund_weights={"A": 0.5, "B": 0.5},
+        fund_returns={"A": 0.08, "B": 0.03},
+        bench_weights={"A": 0.4, "B": 0.6},
+        bench_returns={"A": 0.07, "B": 0.04},
+    )
+    proxy = BenchmarkProxyResult(
+        resolution=BenchmarkResolution(
+            match_type="fuzzy",
+            proxy_etf_ticker="SPY",
+            proxy_etf_cik="0000884394",
+            asset_class="equity_us_large",
+            similarity=0.85,
+        ),
+        brinson=brinson,
+        confidence=0.45,
+        period_of_report=date(2026, 2, 28),
+        degraded=False,
+    )
+    result = FundAttributionResult(
+        fund_instrument_id=UUID("12345678-1234-5678-1234-567812345678"),
+        asof=date(2026, 3, 31),
+        badge=RailBadge.RAIL_PROXY,
+        proxy=proxy,
+        metadata={"match_type": "fuzzy"},
+    )
+    encoded = _serialize_result(result)
+    decoded = _deserialize_result(encoded)
+    assert decoded.badge == RailBadge.RAIL_PROXY
+    assert decoded.proxy is not None
+    assert decoded.proxy.resolution.match_type == "fuzzy"
+    assert decoded.proxy.resolution.similarity == pytest.approx(0.85)
+    assert len(decoded.proxy.brinson.by_sector) == 2
+
+
+# ---------------------------------------------------------------------------
+# DD ch.4 renderer — proxy rail copy invariants
+# ---------------------------------------------------------------------------
+
+
+def test_dd_ch4_proxy_copy_sanitised():
+    """Rendered attribution for RAIL_PROXY never leaks raw quant jargon."""
+    from vertical_engines.wealth.dd_report.chapters import _render_attribution_block
+
+    evidence = {
+        "attribution": {
+            "badge": "RAIL_PROXY",
+            "proxy": {
+                "resolution": {"match_type": "exact", "proxy_etf_ticker": "SPY"},
+                "brinson": {
+                    "allocation_effect": 0.004,
+                    "selection_effect": 0.0,
+                    "interaction_effect": 0.004,
+                    "total_active_return": 0.008,
+                    "by_sector": [
+                        {"sector": "Information Technology",
+                         "allocation_effect": 0.002, "selection_effect": 0.010,
+                         "interaction_effect": 0.002},
+                        {"sector": "Financials",
+                         "allocation_effect": 0.002, "selection_effect": -0.010,
+                         "interaction_effect": 0.002},
+                    ],
+                },
+            },
+        },
+    }
+    out = "\n".join(_render_attribution_block(evidence))
+    assert "MEDIUM CONFIDENCE" in out
+    # No raw quant jargon leaks.
+    assert "Brinson" not in out
+    assert "brinson" not in out.lower() or "Brinson" not in out  # belt and braces
+    assert "allocation_effect" not in out
+    # Sanitised copy present.
+    assert "Asset mix contribution" in out
+    assert "Security selection" in out
+    assert "Timing & interaction" in out
+    # Sector breakdown renders both sectors.
+    assert "Information Technology" in out
+    assert "Financials" in out
+    assert "SPY" in out
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sector_weight(sector, weight, aum, count):
+    from vertical_engines.wealth.attribution.models import SectorWeight
+    return SectorWeight(
+        sector=sector,
+        issuer_category="EC",
+        weight=weight,
+        aum_usd=aum,
+        holdings_count=count,
+    )

--- a/backend/tests/test_attribution_brinson_fachler.py
+++ b/backend/tests/test_attribution_brinson_fachler.py
@@ -1,0 +1,152 @@
+"""Unit tests for the canonical Brinson-Fachler pure function (PR-Q5).
+
+No DB, no I/O. Exercises the identity, edge cases, and determinism of
+``vertical_engines.wealth.attribution.brinson_fachler.brinson_fachler``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vertical_engines.wealth.attribution.brinson_fachler import brinson_fachler
+
+
+def test_brinson_fachler_golden_textbook():
+    """A hand-worked two-sector example with well-known effects.
+
+    Fund overweighted Tech (60% vs 50%) which returned 10% vs index-wide
+    8%, and underweighted Financials (40% vs 50%) which returned 2% vs
+    6%. R_B = 0.5*0.08 + 0.5*0.04 = 0.06.
+
+    Tech:
+        allocation = (0.6 - 0.5) * (0.08 - 0.06) = +0.002
+        selection  = 0.5 * (0.10 - 0.08) = +0.010
+        interaction = (0.6 - 0.5) * (0.10 - 0.08) = +0.002
+    Financials:
+        allocation = (0.4 - 0.5) * (0.04 - 0.06) = +0.002
+        selection  = 0.5 * (0.02 - 0.04) = -0.010
+        interaction = (0.4 - 0.5) * (0.02 - 0.04) = +0.002
+    Totals: alloc=+0.004, select=0.000, interact=+0.004 → active=+0.008
+    """
+    fund_w = {"Tech": 0.6, "Financials": 0.4}
+    fund_r = {"Tech": 0.10, "Financials": 0.02}
+    bench_w = {"Tech": 0.5, "Financials": 0.5}
+    bench_r = {"Tech": 0.08, "Financials": 0.04}
+
+    result = brinson_fachler(fund_w, fund_r, bench_w, bench_r)
+
+    assert result.allocation_effect == pytest.approx(0.004, abs=1e-9)
+    assert result.selection_effect == pytest.approx(0.0, abs=1e-9)
+    assert result.interaction_effect == pytest.approx(0.004, abs=1e-9)
+    assert result.total_active_return == pytest.approx(0.008, abs=1e-9)
+
+
+def test_brinson_fachler_identity_sum_matches_active_return():
+    """Sum of three effects must equal total_active_return (identity)."""
+    fund_w = {"IT": 0.3, "Fin": 0.25, "Health": 0.2, "Energy": 0.15, "Cash": 0.1}
+    fund_r = {"IT": 0.12, "Fin": 0.03, "Health": 0.07, "Energy": -0.02, "Cash": 0.01}
+    bench_w = {"IT": 0.25, "Fin": 0.3, "Health": 0.2, "Energy": 0.2, "Cash": 0.05}
+    bench_r = {"IT": 0.10, "Fin": 0.05, "Health": 0.06, "Energy": -0.05, "Cash": 0.015}
+
+    r = brinson_fachler(fund_w, fund_r, bench_w, bench_r)
+    assert r.allocation_effect + r.selection_effect + r.interaction_effect == (
+        pytest.approx(r.total_active_return, abs=1e-12)
+    )
+
+
+def test_brinson_fachler_fund_sector_absent_from_benchmark():
+    """Fund holds Crypto (5%), benchmark doesn't. Allocation must take
+    the full bet. Selection/interaction fall through to the aggregate
+    benchmark return fallback."""
+    fund_w = {"Equity": 0.95, "Crypto": 0.05}
+    fund_r = {"Equity": 0.08, "Crypto": 0.25}
+    bench_w = {"Equity": 1.0}
+    bench_r = {"Equity": 0.08}
+
+    r = brinson_fachler(fund_w, fund_r, bench_w, bench_r)
+
+    # Benchmark doesn't hold crypto; using R_B = 0.08 as fallback.
+    # allocation_crypto = (0.05 - 0) * (0.08 - 0.08) = 0
+    # selection_crypto = 0 * (0.25 - 0.08) = 0
+    # interaction_crypto = 0.05 * (0.25 - 0.08) = 0.0085
+    # Equity: all zero since weights and returns equal on both sides.
+    assert r.interaction_effect == pytest.approx(0.0085, abs=1e-9)
+
+
+def test_brinson_fachler_zero_benchmark_weight_zero_selection_interaction():
+    """Sector with zero benchmark weight → selection=0 (w_b=0)."""
+    fund_w = {"A": 0.5, "B": 0.5}
+    fund_r = {"A": 0.10, "B": 0.05}
+    bench_w = {"A": 1.0, "B": 0.0}
+    bench_r = {"A": 0.08, "B": 0.04}
+
+    r = brinson_fachler(fund_w, fund_r, bench_w, bench_r)
+
+    b = next(s for s in r.by_sector if s.sector == "B")
+    assert b.selection_effect == pytest.approx(0.0, abs=1e-12)
+    # interaction = (0.5 - 0) * (0.05 - 0.04) = 0.005
+    assert b.interaction_effect == pytest.approx(0.005, abs=1e-12)
+
+
+def test_brinson_fachler_zero_fund_weight_zero_selection_effect_for_fund_only():
+    """Sector with zero fund weight: w_p=0, so selection effect uses w_b
+    times (0 - r_b) — that's the selection-from-underweight."""
+    fund_w = {"A": 1.0, "B": 0.0}
+    fund_r = {"A": 0.10, "B": 0.0}
+    bench_w = {"A": 0.5, "B": 0.5}
+    bench_r = {"A": 0.08, "B": 0.04}
+
+    r = brinson_fachler(fund_w, fund_r, bench_w, bench_r)
+    b = next(s for s in r.by_sector if s.sector == "B")
+    # interaction = (0 - 0.5) * (0 - 0.04) = 0.02
+    assert b.interaction_effect == pytest.approx(0.02, abs=1e-12)
+    # Fund fully underweights B.
+    assert b.portfolio_weight == 0.0
+
+
+def test_brinson_fachler_same_weights_allocation_zero():
+    """Fund and benchmark identical weights → allocation effect = 0."""
+    fund_w = {"A": 0.6, "B": 0.4}
+    bench_w = {"A": 0.6, "B": 0.4}
+    fund_r = {"A": 0.10, "B": 0.02}
+    bench_r = {"A": 0.08, "B": 0.04}
+
+    r = brinson_fachler(fund_w, fund_r, bench_w, bench_r)
+    assert r.allocation_effect == pytest.approx(0.0, abs=1e-12)
+    assert r.interaction_effect == pytest.approx(0.0, abs=1e-12)
+
+
+def test_brinson_fachler_same_returns_selection_zero():
+    """Fund and benchmark identical per-sector returns → selection = 0."""
+    fund_w = {"A": 0.7, "B": 0.3}
+    fund_r = {"A": 0.05, "B": 0.10}
+    bench_w = {"A": 0.5, "B": 0.5}
+    bench_r = {"A": 0.05, "B": 0.10}
+
+    r = brinson_fachler(fund_w, fund_r, bench_w, bench_r)
+    assert r.selection_effect == pytest.approx(0.0, abs=1e-12)
+    assert r.interaction_effect == pytest.approx(0.0, abs=1e-12)
+
+
+def test_brinson_fachler_deterministic():
+    """Same inputs → identical outputs on repeated calls."""
+    fund_w = {"A": 0.4, "B": 0.6}
+    fund_r = {"A": 0.05, "B": 0.08}
+    bench_w = {"A": 0.5, "B": 0.5}
+    bench_r = {"A": 0.04, "B": 0.07}
+
+    r1 = brinson_fachler(fund_w, fund_r, bench_w, bench_r)
+    r2 = brinson_fachler(fund_w, fund_r, bench_w, bench_r)
+    assert r1 == r2
+
+
+def test_brinson_fachler_by_sector_covers_all_sectors():
+    """by_sector must include every sector from either side of the comparison."""
+    fund_w = {"A": 0.5, "B": 0.5}
+    fund_r = {"A": 0.1, "B": 0.1}
+    bench_w = {"B": 0.6, "C": 0.4}
+    bench_r = {"B": 0.05, "C": 0.08}
+
+    r = brinson_fachler(fund_w, fund_r, bench_w, bench_r)
+    sectors = {s.sector for s in r.by_sector}
+    assert sectors == {"A", "B", "C"}

--- a/backend/vertical_engines/wealth/attribution/benchmark_proxy.py
+++ b/backend/vertical_engines/wealth/attribution/benchmark_proxy.py
@@ -1,0 +1,360 @@
+"""Benchmark proxy rail — PR-Q5 (G3 Fase 3).
+
+Resolves a fund's free-text ``primary_benchmark`` string to a canonical
+ETF (via ``benchmark_etf_canonical_map``), then runs Brinson-Fachler
+attribution using that ETF's N-PORT holdings as the benchmark side.
+
+Three-level resolution cascade (data-layer spec §1.4):
+    1. Exact alias match (`ANY(benchmark_name_aliases)`)
+    2. Trigram fuzzy match (`similarity(...) > 0.7`)
+    3. Asset-class keyword fallback (Python classifier → default proxy)
+
+The rail degrades (not error) when the benchmark is null/unmatched, the
+proxy ETF has no N-PORT holdings (BDC/MMF edge), or sector returns are
+unavailable. The dispatcher falls through to the returns-based rail.
+
+Not wired to production sector-returns yet — the `sector_returns_fetcher`
+seam is injected by tests; the default returns an empty dict so the rail
+degrades with ``sector_returns_unavailable`` until a later PR pipes in
+per-sector period returns (Tiingo aggregate by ticker).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable
+from datetime import date, timedelta
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from sqlalchemy import text
+
+from vertical_engines.wealth.attribution.brinson_fachler import brinson_fachler
+from vertical_engines.wealth.attribution.holdings_based import (
+    fetch_sector_weights,
+    latest_period_for_cik,
+    resolve_fund_cik,
+)
+from vertical_engines.wealth.attribution.models import (
+    AttributionRequest,
+    BenchmarkProxyResult,
+    BenchmarkResolution,
+    BrinsonResult,
+    SectorWeight,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = structlog.get_logger()
+
+# Per data-layer spec §1.4. 0.7 is the canonical threshold; tests lock
+# the boundary behaviour.
+_FUZZY_THRESHOLD = 0.7
+
+# Confidence tiers for the rail output. Tuned to keep HOLDINGS > PROXY
+# > RETURNS ordering intuitive to operators.
+_CONFIDENCE_EXACT = 0.60
+_CONFIDENCE_FUZZY = 0.45
+_CONFIDENCE_CLASS_FALLBACK = 0.30
+
+
+# Asset class keyword classifier (Level 3 fallback). Order matters: the
+# first matching bucket wins, so more specific patterns come first. The
+# default proxy per class ships in the 0165 seed.
+_ASSET_CLASS_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("fi_us_treasury", re.compile(r"\b(u\.?s\.?\s+)?treasury|govt?\b", re.I)),
+    ("fi_us_hy", re.compile(r"high\s*yield|junk\s+bond", re.I)),
+    ("fi_us_ig", re.compile(r"investment\s*grade|corporate\s+bond|us\s+corp", re.I)),
+    ("fi_us_muni", re.compile(r"muni(cipal)?", re.I)),
+    ("fi_us_agg", re.compile(r"aggregate|agg\b|bond\s+index", re.I)),
+    ("fi_intl", re.compile(r"global\s+agg|international\s+bond", re.I)),
+    ("equity_em", re.compile(r"emerg(ing)?\s+markets?|em\s+equity", re.I)),
+    ("equity_intl_dev", re.compile(r"eafe|acwi|developed\s+markets?|msci\s+world", re.I)),
+    ("equity_us_small", re.compile(r"small\s*cap|russell\s*2000", re.I)),
+    ("equity_us_mid", re.compile(r"mid\s*cap", re.I)),
+    ("equity_us_large", re.compile(r"large\s*cap|s&p\s*500|blend\s+index|russell\s*1000", re.I)),
+    ("reits", re.compile(r"reit|real\s+estate", re.I)),
+    ("commodities", re.compile(r"commodit|bcom", re.I)),
+]
+
+
+# Type seams — tests inject stubs without hitting the DB.
+SectorReturnsFetcher = Callable[
+    ["AsyncSession | None", str, date],
+    Awaitable[dict[str, float]],
+]
+
+
+def classify_asset_class_keywords(name: str) -> str | None:
+    """Bucket a free-text benchmark string into a coarse asset class.
+
+    Returns None when no pattern matches. Designed to be cheap and
+    opinionated — misclassification is better than degrading the whole
+    rail, since the worst-case default proxy (SPY) is still a reasonable
+    anchor for diversified US funds.
+    """
+    if not name or not name.strip():
+        return None
+    for asset_class, pattern in _ASSET_CLASS_PATTERNS:
+        if pattern.search(name):
+            return asset_class
+    return None
+
+
+async def resolve_benchmark(
+    primary_benchmark: str | None,
+    db: "AsyncSession",
+) -> BenchmarkResolution:
+    """Resolve ``primary_benchmark`` to a canonical proxy ETF row."""
+    if primary_benchmark is None or not primary_benchmark.strip():
+        return BenchmarkResolution(match_type="null")
+
+    name = primary_benchmark.strip()
+
+    # Level 1 — exact alias. Case-sensitive match by design: the seed
+    # captures real aliases from sec_registered_funds verbatim.
+    row = (await db.execute(
+        text("""
+            SELECT proxy_etf_cik, proxy_etf_series_id, proxy_etf_ticker, asset_class
+            FROM benchmark_etf_canonical_map
+            WHERE :name = ANY(benchmark_name_aliases)
+              AND CURRENT_DATE BETWEEN effective_from AND effective_to
+            LIMIT 1
+        """),
+        {"name": name},
+    )).mappings().first()
+    if row:
+        return BenchmarkResolution(
+            match_type="exact",
+            proxy_etf_ticker=row["proxy_etf_ticker"],
+            proxy_etf_cik=row["proxy_etf_cik"],
+            proxy_etf_series_id=row["proxy_etf_series_id"],
+            asset_class=str(row["asset_class"]),
+        )
+
+    # Level 2 — trigram fuzzy. Pick the single best similarity >= 0.7.
+    row = (await db.execute(
+        text("""
+            SELECT proxy_etf_cik, proxy_etf_series_id, proxy_etf_ticker,
+                   asset_class,
+                   similarity(benchmark_name_canonical, :name) AS sim
+            FROM benchmark_etf_canonical_map
+            WHERE benchmark_name_canonical % :name
+              AND CURRENT_DATE BETWEEN effective_from AND effective_to
+            ORDER BY similarity(benchmark_name_canonical, :name) DESC
+            LIMIT 1
+        """),
+        {"name": name},
+    )).mappings().first()
+    if row and float(row["sim"] or 0.0) > _FUZZY_THRESHOLD:
+        return BenchmarkResolution(
+            match_type="fuzzy",
+            proxy_etf_ticker=row["proxy_etf_ticker"],
+            proxy_etf_cik=row["proxy_etf_cik"],
+            proxy_etf_series_id=row["proxy_etf_series_id"],
+            asset_class=str(row["asset_class"]),
+            similarity=float(row["sim"]),
+        )
+
+    # Level 3 — asset-class keyword classifier → default proxy row.
+    asset_class = classify_asset_class_keywords(name)
+    if asset_class:
+        fallback = await _resolve_by_asset_class(asset_class, db)
+        if fallback is not None:
+            return fallback
+
+    return BenchmarkResolution(match_type="unmatched")
+
+
+async def _resolve_by_asset_class(
+    asset_class: str,
+    db: "AsyncSession",
+) -> BenchmarkResolution | None:
+    row = (await db.execute(
+        text("""
+            SELECT proxy_etf_cik, proxy_etf_series_id, proxy_etf_ticker, asset_class
+            FROM benchmark_etf_canonical_map
+            WHERE asset_class = CAST(:ac AS benchmark_asset_class)
+              AND effective_to = '9999-12-31'
+            ORDER BY fit_quality_score DESC, id ASC
+            LIMIT 1
+        """),
+        {"ac": asset_class},
+    )).mappings().first()
+    if not row:
+        return None
+    return BenchmarkResolution(
+        match_type="class_fallback",
+        proxy_etf_ticker=row["proxy_etf_ticker"],
+        proxy_etf_cik=row["proxy_etf_cik"],
+        proxy_etf_series_id=row["proxy_etf_series_id"],
+        asset_class=str(row["asset_class"]),
+    )
+
+
+async def _fund_primary_benchmark(
+    db: "AsyncSession", cik: str,
+) -> str | None:
+    row = (await db.execute(
+        text("""
+            SELECT primary_benchmark
+            FROM sec_registered_funds
+            WHERE cik = :cik
+            LIMIT 1
+        """),
+        {"cik": cik},
+    )).first()
+    if row is None:
+        return None
+    val = row[0]
+    if val is None:
+        return None
+    s = str(val).strip()
+    return s or None
+
+
+async def _default_sector_returns(
+    _db: "AsyncSession | None", _cik: str, _period: date,
+) -> dict[str, float]:
+    """Default fetcher returns no sector returns.
+
+    Per-sector periodic returns are not yet materialised; the rail marks
+    itself degraded and the dispatcher falls through. Tests inject a real
+    fetcher to exercise the full Brinson math.
+    """
+    return {}
+
+
+def _weights_by_sector(sectors: list[SectorWeight]) -> dict[str, float]:
+    """Aggregate sector weights across issuer_category splits."""
+    out: dict[str, float] = {}
+    for s in sectors:
+        out[s.sector] = out.get(s.sector, 0.0) + float(s.weight)
+    return out
+
+
+async def run_proxy_rail(
+    request: AttributionRequest,
+    db: "AsyncSession",
+    *,
+    max_filing_age_months: int = 9,
+    cik_resolver: Any = None,
+    benchmark_fetcher: Callable[
+        ["AsyncSession", str], Awaitable[str | None],
+    ] | None = None,
+    sector_returns_fetcher: SectorReturnsFetcher | None = None,
+) -> BenchmarkProxyResult | None:
+    """Execute the proxy rail. Returns None when the fund lacks a CIK.
+
+    ``cik_resolver``, ``benchmark_fetcher``, and ``sector_returns_fetcher``
+    are test seams. Production leaves them as the module defaults.
+    """
+    resolver = cik_resolver or resolve_fund_cik
+    fund_cik = await resolver(db, request.fund_instrument_id)
+    if not fund_cik:
+        # No SEC CIK → private / UCITS. Proxy rail cannot read N-PORT
+        # weights on the fund side. Fall through to returns rail.
+        return None
+
+    bench_fetcher = benchmark_fetcher or _fund_primary_benchmark
+    primary_benchmark = await bench_fetcher(db, fund_cik)
+
+    resolution = await resolve_benchmark(primary_benchmark, db)
+
+    if resolution.match_type in {"null", "unmatched"} or not resolution.proxy_etf_cik:
+        # No proxy CIK to fetch holdings for — cannot run Brinson on the
+        # benchmark side. Degraded so dispatcher continues.
+        return BenchmarkProxyResult(
+            resolution=resolution,
+            brinson=_empty_brinson(),
+            confidence=0.0,
+            degraded=True,
+            degraded_reason="benchmark_unresolved",
+        )
+
+    not_before = request.asof - timedelta(days=int(30.4375 * max_filing_age_months))
+
+    fund_period = await latest_period_for_cik(db, fund_cik, not_before=not_before)
+    proxy_period = await latest_period_for_cik(
+        db, resolution.proxy_etf_cik, not_before=not_before,
+    )
+
+    if fund_period is None or proxy_period is None:
+        return BenchmarkProxyResult(
+            resolution=resolution,
+            brinson=_empty_brinson(),
+            confidence=0.0,
+            period_of_report=fund_period,
+            degraded=True,
+            degraded_reason="stale_filing",
+        )
+
+    fund_sectors, _ = await fetch_sector_weights(db, fund_cik, fund_period)
+    proxy_sectors, _ = await fetch_sector_weights(
+        db, resolution.proxy_etf_cik, proxy_period,
+    )
+
+    if not proxy_sectors:
+        return BenchmarkProxyResult(
+            resolution=resolution,
+            brinson=_empty_brinson(),
+            confidence=0.0,
+            period_of_report=fund_period,
+            degraded=True,
+            degraded_reason="proxy_no_holdings",
+        )
+
+    fund_weights = _weights_by_sector(fund_sectors)
+    bench_weights = _weights_by_sector(proxy_sectors)
+
+    returns_fetcher = sector_returns_fetcher or _default_sector_returns
+    try:
+        fund_returns = await returns_fetcher(db, fund_cik, fund_period)
+        bench_returns = await returns_fetcher(
+            db, resolution.proxy_etf_cik, proxy_period,
+        )
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("proxy_rail_returns_fetch_failed", error=str(exc))
+        fund_returns, bench_returns = {}, {}
+
+    brinson = brinson_fachler(
+        fund_weights=fund_weights,
+        fund_returns=fund_returns,
+        bench_weights=bench_weights,
+        bench_returns=bench_returns,
+    )
+
+    if not fund_returns or not bench_returns:
+        return BenchmarkProxyResult(
+            resolution=resolution,
+            brinson=brinson,
+            confidence=0.0,
+            period_of_report=fund_period,
+            degraded=True,
+            degraded_reason="sector_returns_unavailable",
+        )
+
+    confidence = {
+        "exact": _CONFIDENCE_EXACT,
+        "fuzzy": _CONFIDENCE_FUZZY,
+        "class_fallback": _CONFIDENCE_CLASS_FALLBACK,
+    }.get(resolution.match_type, 0.0)
+
+    return BenchmarkProxyResult(
+        resolution=resolution,
+        brinson=brinson,
+        confidence=confidence,
+        period_of_report=fund_period,
+        degraded=False,
+    )
+
+
+def _empty_brinson() -> "BrinsonResult":
+    return BrinsonResult(
+        allocation_effect=0.0,
+        selection_effect=0.0,
+        interaction_effect=0.0,
+        total_active_return=0.0,
+        by_sector=(),
+    )

--- a/backend/vertical_engines/wealth/attribution/brinson_fachler.py
+++ b/backend/vertical_engines/wealth/attribution/brinson_fachler.py
@@ -1,0 +1,104 @@
+"""Canonical Brinson-Fachler single-period attribution.
+
+Pure deterministic function. No DB, no I/O, no concurrency. Decomposes a
+fund's active return vs. a benchmark into allocation, selection, and
+interaction effects at the sector level.
+
+Formulation (Brinson, Hood, Beebower 1986; Fachler 1985):
+
+    Allocation_s = (w_p[s] - w_b[s]) * (r_b[s] - R_B)
+    Selection_s  = w_b[s] * (r_p[s] - r_b[s])
+    Interaction_s = (w_p[s] - w_b[s]) * (r_p[s] - r_b[s])
+    R_B          = Σ_s w_b[s] * r_b[s]
+
+Missing sectors on either side are treated as zero weight / zero return
+(the standard convention). When a fund holds a sector the benchmark does
+not, the benchmark's aggregate return R_B is used as the sector's
+benchmark return — this keeps allocation credit pure (the manager's bet
+on that sector is compared to doing nothing different from the index).
+
+The formula preserves the identity::
+
+    R_P - R_B = Σ_s allocation_s + selection_s + interaction_s
+
+within floating-point tolerance when both sides cover the same universe.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from vertical_engines.wealth.attribution.models import (
+    BrinsonResult,
+    BrinsonSectorEffect,
+)
+
+
+def brinson_fachler(
+    fund_weights: Mapping[str, float],
+    fund_returns: Mapping[str, float],
+    bench_weights: Mapping[str, float],
+    bench_returns: Mapping[str, float],
+) -> BrinsonResult:
+    """Decompose active return into allocation, selection, interaction.
+
+    Parameters
+    ----------
+    fund_weights, bench_weights
+        Sector → weight (fractions summing to ~1.0). A missing sector is
+        treated as zero weight.
+    fund_returns, bench_returns
+        Sector → period return (decimal, e.g. 0.03 for +3%). A missing
+        sector return on the fund side is treated as zero. On the
+        benchmark side, a missing sector falls back to the aggregate
+        benchmark return R_B so that allocation credit for fund-only
+        sectors is measured against "do nothing" (the index).
+    """
+    sectors = set(fund_weights) | set(bench_weights)
+
+    aggregate_benchmark_return = sum(
+        float(bench_weights.get(s, 0.0)) * float(bench_returns.get(s, 0.0))
+        for s in sectors
+    )
+
+    allocation_total = 0.0
+    selection_total = 0.0
+    interaction_total = 0.0
+    by_sector: list[BrinsonSectorEffect] = []
+
+    for sector in sorted(sectors):
+        w_p = float(fund_weights.get(sector, 0.0))
+        w_b = float(bench_weights.get(sector, 0.0))
+        r_p = float(fund_returns.get(sector, 0.0))
+        # If the benchmark does not hold the sector, fall back to the
+        # aggregate benchmark return so allocation captures the whole bet.
+        r_b = float(bench_returns.get(sector, aggregate_benchmark_return))
+
+        allocation = (w_p - w_b) * (r_b - aggregate_benchmark_return)
+        selection = w_b * (r_p - r_b)
+        interaction = (w_p - w_b) * (r_p - r_b)
+
+        allocation_total += allocation
+        selection_total += selection
+        interaction_total += interaction
+
+        by_sector.append(
+            BrinsonSectorEffect(
+                sector=sector,
+                portfolio_weight=w_p,
+                benchmark_weight=w_b,
+                portfolio_return=r_p,
+                benchmark_return=r_b,
+                allocation_effect=allocation,
+                selection_effect=selection,
+                interaction_effect=interaction,
+            ),
+        )
+
+    return BrinsonResult(
+        allocation_effect=allocation_total,
+        selection_effect=selection_total,
+        interaction_effect=interaction_total,
+        total_active_return=allocation_total + selection_total + interaction_total,
+        by_sector=tuple(by_sector),
+    )

--- a/backend/vertical_engines/wealth/attribution/models.py
+++ b/backend/vertical_engines/wealth/attribution/models.py
@@ -132,6 +132,73 @@ class HoldingsBasedResult:
 
 
 @dataclass(frozen=True, slots=True)
+class BrinsonSectorEffect:
+    """Per-sector decomposition of the Brinson-Fachler active return."""
+
+    sector: str
+    portfolio_weight: float
+    benchmark_weight: float
+    portfolio_return: float
+    benchmark_return: float
+    allocation_effect: float
+    selection_effect: float
+    interaction_effect: float
+
+
+@dataclass(frozen=True, slots=True)
+class BrinsonResult:
+    """Canonical Brinson-Fachler attribution output.
+
+    ``total_active_return`` is the algebraic sum of the three aggregate
+    effects — it must reconcile with the naive portfolio-minus-benchmark
+    return within floating-point tolerance when both sides cover the
+    same sector universe. See tests for the identity invariant.
+    """
+
+    allocation_effect: float
+    selection_effect: float
+    interaction_effect: float
+    total_active_return: float
+    by_sector: tuple[BrinsonSectorEffect, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkResolution:
+    """Output of the canonical benchmark resolver.
+
+    ``match_type`` is one of {``"exact"``, ``"fuzzy"``, ``"class_fallback"``,
+    ``"null"``, ``"unmatched"``}. When no proxy can be found (null input or
+    unmatched) the identifier fields are None.
+    """
+
+    match_type: str
+    proxy_etf_ticker: str | None = None
+    proxy_etf_cik: str | None = None
+    proxy_etf_series_id: str | None = None
+    asset_class: str | None = None
+    similarity: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkProxyResult:
+    """Output of the proxy rail (PR-Q5).
+
+    When ``degraded`` is True, ``brinson`` is still populated with
+    whatever weight comparison was possible (active effects may be zero
+    if sector returns were unavailable). ``degraded_reason`` carries the
+    machine-readable cause (``benchmark_unresolved``, ``proxy_no_holdings``,
+    ``sector_returns_unavailable``, ``stale_filing``).
+    """
+
+    resolution: BenchmarkResolution
+    brinson: BrinsonResult
+    confidence: float
+    period_of_report: date | None = None
+    degraded: bool = False
+    degraded_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class AttributionRequest:
     """Input for the fund-level attribution dispatcher."""
 
@@ -159,7 +226,7 @@ class FundAttributionResult:
     badge: RailBadge
     returns_based: ReturnsBasedResult | None = None
     holdings_based: HoldingsBasedResult | None = None
-    proxy: object | None = None  # PR-Q5
+    proxy: "BenchmarkProxyResult | None" = None
     ipca: object | None = None  # PR-Q9
     reason: str | None = None
     metadata: dict[str, str] = field(default_factory=dict)

--- a/backend/vertical_engines/wealth/attribution/service.py
+++ b/backend/vertical_engines/wealth/attribution/service.py
@@ -27,11 +27,18 @@ from quant_engine.attribution_service import (
     compute_attribution,
     compute_multi_period_attribution,
 )
+from vertical_engines.wealth.attribution.benchmark_proxy import (
+    run_proxy_rail as _run_proxy_rail,
+)
 from vertical_engines.wealth.attribution.holdings_based import (
     run_holdings_rail as _run_holdings_rail,
 )
 from vertical_engines.wealth.attribution.models import (
     AttributionRequest,
+    BenchmarkProxyResult,
+    BenchmarkResolution,
+    BrinsonResult,
+    BrinsonSectorEffect,
     FundAttributionResult,
     HoldingsBasedResult,
     RailBadge,
@@ -262,6 +269,14 @@ _HoldingsFetch = Callable[
     Awaitable[HoldingsBasedResult | None],
 ]
 
+# Public async seam for the proxy rail. Tests override this to simulate
+# benchmark resolution + Brinson math without a live DB. Signature
+# mirrors ``benchmark_proxy.run_proxy_rail`` minus the session-only kwargs.
+_ProxyFetch = Callable[
+    [AttributionRequest, "AsyncSession | None"],
+    Awaitable[BenchmarkProxyResult | None],
+]
+
 
 async def _default_holdings_fetch(
     request: AttributionRequest,
@@ -276,12 +291,26 @@ async def _default_holdings_fetch(
         return None
 
 
+async def _default_proxy_fetch(
+    request: AttributionRequest,
+    db: "AsyncSession | None",
+) -> BenchmarkProxyResult | None:
+    if db is None:
+        return None
+    try:
+        return await _run_proxy_rail(request, db)
+    except Exception as exc:  # pragma: no cover — defensive, fall through
+        logger.warning("proxy_rail_errored", error=str(exc))
+        return None
+
+
 async def compute_fund_attribution(
     request: AttributionRequest,
     db: "AsyncSession | None" = None,
     *,
     returns_fetch: _ReturnsFetch | None = None,
     holdings_fetch: _HoldingsFetch | None = None,
+    proxy_fetch: _ProxyFetch | None = None,
     redis_client: Any | None = None,
 ) -> FundAttributionResult:
     """Run the fund-level attribution cascade.
@@ -322,6 +351,22 @@ async def compute_fund_attribution(
         await _cache_set(redis_client, cache_key, result)
         return result
 
+    # Rail 2 — benchmark proxy. Resolves primary_benchmark to a canonical
+    # ETF and runs Brinson-Fachler against that ETF's N-PORT holdings.
+    # Degrades when benchmark is unresolved, proxy has no holdings, or
+    # sector returns aren't available yet.
+    pfetch = proxy_fetch or _default_proxy_fetch
+    proxy_result: BenchmarkProxyResult | None = None
+    try:
+        proxy_result = await pfetch(request, db)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("proxy_fetch_failed", error=str(exc))
+
+    if proxy_result is not None and not proxy_result.degraded:
+        result = _build_proxy_result(request, proxy_result)
+        await _cache_set(redis_client, cache_key, result)
+        return result
+
     fetch = returns_fetch or _fetch_returns_monthly
     try:
         r_fund, r_styles, tickers = await fetch(request, db)
@@ -353,6 +398,30 @@ async def compute_fund_attribution(
     result = _build_result(request, returns_result)
     await _cache_set(redis_client, cache_key, result)
     return result
+
+
+def _build_proxy_result(
+    request: AttributionRequest,
+    proxy: BenchmarkProxyResult,
+) -> FundAttributionResult:
+    """Wrap a successful proxy rail into the dispatcher envelope."""
+    metadata: dict[str, str] = {
+        "match_type": proxy.resolution.match_type,
+        "n_sectors": str(len(proxy.brinson.by_sector)),
+    }
+    if proxy.resolution.proxy_etf_ticker:
+        metadata["proxy_ticker"] = proxy.resolution.proxy_etf_ticker
+    if proxy.resolution.asset_class:
+        metadata["asset_class"] = proxy.resolution.asset_class
+    if proxy.period_of_report is not None:
+        metadata["period_of_report"] = proxy.period_of_report.isoformat()
+    return FundAttributionResult(
+        fund_instrument_id=request.fund_instrument_id,
+        asof=request.asof,
+        badge=RailBadge.RAIL_PROXY,
+        proxy=proxy,
+        metadata=metadata,
+    )
 
 
 def _build_holdings_result(
@@ -466,6 +535,7 @@ async def _cache_set(
 def _serialize_result(result: FundAttributionResult) -> dict[str, Any]:
     rb = result.returns_based
     hb = result.holdings_based
+    px = result.proxy
     return {
         "fund_instrument_id": str(result.fund_instrument_id),
         "asof": result.asof.isoformat(),
@@ -484,6 +554,43 @@ def _serialize_result(result: FundAttributionResult) -> dict[str, Any]:
             "n_months": rb.n_months,
             "degraded": rb.degraded,
             "degraded_reason": rb.degraded_reason,
+        },
+        "proxy": None
+        if px is None
+        else {
+            "resolution": {
+                "match_type": px.resolution.match_type,
+                "proxy_etf_ticker": px.resolution.proxy_etf_ticker,
+                "proxy_etf_cik": px.resolution.proxy_etf_cik,
+                "proxy_etf_series_id": px.resolution.proxy_etf_series_id,
+                "asset_class": px.resolution.asset_class,
+                "similarity": px.resolution.similarity,
+            },
+            "brinson": {
+                "allocation_effect": px.brinson.allocation_effect,
+                "selection_effect": px.brinson.selection_effect,
+                "interaction_effect": px.brinson.interaction_effect,
+                "total_active_return": px.brinson.total_active_return,
+                "by_sector": [
+                    {
+                        "sector": s.sector,
+                        "portfolio_weight": s.portfolio_weight,
+                        "benchmark_weight": s.benchmark_weight,
+                        "portfolio_return": s.portfolio_return,
+                        "benchmark_return": s.benchmark_return,
+                        "allocation_effect": s.allocation_effect,
+                        "selection_effect": s.selection_effect,
+                        "interaction_effect": s.interaction_effect,
+                    }
+                    for s in px.brinson.by_sector
+                ],
+            },
+            "confidence": px.confidence,
+            "period_of_report": (
+                px.period_of_report.isoformat() if px.period_of_report else None
+            ),
+            "degraded": px.degraded,
+            "degraded_reason": px.degraded_reason,
         },
         "holdings_based": None
         if hb is None
@@ -553,12 +660,59 @@ def _deserialize_result(data: dict[str, Any]) -> FundAttributionResult:
             degraded_reason=hb_raw.get("degraded_reason"),
         )
 
+    px_raw = data.get("proxy")
+    px: BenchmarkProxyResult | None = None
+    if px_raw is not None:
+        res_raw = px_raw["resolution"]
+        resolution = BenchmarkResolution(
+            match_type=str(res_raw["match_type"]),
+            proxy_etf_ticker=res_raw.get("proxy_etf_ticker"),
+            proxy_etf_cik=res_raw.get("proxy_etf_cik"),
+            proxy_etf_series_id=res_raw.get("proxy_etf_series_id"),
+            asset_class=res_raw.get("asset_class"),
+            similarity=(
+                float(res_raw["similarity"])
+                if res_raw.get("similarity") is not None
+                else None
+            ),
+        )
+        brinson_raw = px_raw["brinson"]
+        brinson = BrinsonResult(
+            allocation_effect=float(brinson_raw["allocation_effect"]),
+            selection_effect=float(brinson_raw["selection_effect"]),
+            interaction_effect=float(brinson_raw["interaction_effect"]),
+            total_active_return=float(brinson_raw["total_active_return"]),
+            by_sector=tuple(
+                BrinsonSectorEffect(
+                    sector=str(s["sector"]),
+                    portfolio_weight=float(s["portfolio_weight"]),
+                    benchmark_weight=float(s["benchmark_weight"]),
+                    portfolio_return=float(s["portfolio_return"]),
+                    benchmark_return=float(s["benchmark_return"]),
+                    allocation_effect=float(s["allocation_effect"]),
+                    selection_effect=float(s["selection_effect"]),
+                    interaction_effect=float(s["interaction_effect"]),
+                )
+                for s in brinson_raw.get("by_sector") or ()
+            ),
+        )
+        period_str = px_raw.get("period_of_report")
+        px = BenchmarkProxyResult(
+            resolution=resolution,
+            brinson=brinson,
+            confidence=float(px_raw["confidence"]),
+            period_of_report=_date.fromisoformat(period_str) if period_str else None,
+            degraded=bool(px_raw.get("degraded", False)),
+            degraded_reason=px_raw.get("degraded_reason"),
+        )
+
     return FundAttributionResult(
         fund_instrument_id=_UUID(data["fund_instrument_id"]),
         asof=_date.fromisoformat(data["asof"]),
         badge=RailBadge(data["badge"]),
         returns_based=rb,
         holdings_based=hb,
+        proxy=px,
         reason=data.get("reason"),
         metadata=dict(data.get("metadata") or {}),
     )

--- a/backend/vertical_engines/wealth/dd_report/chapters.py
+++ b/backend/vertical_engines/wealth/dd_report/chapters.py
@@ -413,6 +413,9 @@ def _render_attribution_block(evidence_context: dict[str, Any]) -> list[str]:
                 out.append(f"- {label}: {weight * 100:.1f}%")
             out.append(f"\n- Portfolio coverage: {coverage * 100:.1f}%")
 
+    if badge == "RAIL_PROXY":
+        out.extend(_render_proxy_block(attribution))
+
     if badge == "RAIL_RETURNS" and returns_based:
         exposures = returns_based.get("exposures") or []
         if exposures:
@@ -422,6 +425,70 @@ def _render_attribution_block(evidence_context: dict[str, Any]) -> list[str]:
                 if weight < 1e-4:
                     continue
                 out.append(f"- {exp.get('ticker', '—')}: {weight * 100:.1f}%")
+
+    return out
+
+
+_PROXY_INTRO = (
+    "Why the manager beat/lagged — asset mix vs. stock picks vs. timing"
+)
+
+
+def _render_proxy_block(attribution: dict[str, Any]) -> list[str]:
+    """Render the Brinson-Fachler table when the proxy rail wins.
+
+    Sanitised copy: raw quant vocabulary ("Brinson-Fachler",
+    "allocation effect") never leaves this module. UI headings use the
+    product phrasing ("Asset mix contribution", "Security selection",
+    "Timing & interaction").
+    """
+    proxy = attribution.get("proxy")
+    if not proxy:
+        return []
+
+    brinson = proxy.get("brinson") or {}
+    sectors = brinson.get("by_sector") or []
+
+    out: list[str] = [f"\n### {_PROXY_INTRO}"]
+
+    out.append(
+        f"- Asset mix contribution: {float(brinson.get('allocation_effect', 0.0)) * 100:.2f}%",
+    )
+    out.append(
+        f"- Security selection: {float(brinson.get('selection_effect', 0.0)) * 100:.2f}%",
+    )
+    out.append(
+        f"- Timing & interaction: {float(brinson.get('interaction_effect', 0.0)) * 100:.2f}%",
+    )
+    out.append(
+        f"- Total active return: {float(brinson.get('total_active_return', 0.0)) * 100:.2f}%",
+    )
+
+    if sectors:
+        out.append("\n### Sector breakdown")
+        # Top 11 sectors by absolute total effect (allocation + selection + interaction)
+        ranked = sorted(
+            sectors,
+            key=lambda s: abs(
+                float(s.get("allocation_effect", 0.0))
+                + float(s.get("selection_effect", 0.0))
+                + float(s.get("interaction_effect", 0.0)),
+            ),
+            reverse=True,
+        )
+        for sec in ranked[:11]:
+            label = _sanitize_sector_label(str(sec.get("sector", "")))
+            total = (
+                float(sec.get("allocation_effect", 0.0))
+                + float(sec.get("selection_effect", 0.0))
+                + float(sec.get("interaction_effect", 0.0))
+            )
+            out.append(f"- {label}: {total * 100:+.2f}%")
+
+    resolution = proxy.get("resolution") or {}
+    ticker = resolution.get("proxy_etf_ticker")
+    if ticker:
+        out.append(f"\n- Benchmark proxy: {ticker}")
 
     return out
 


### PR DESCRIPTION
## Summary

PR-Q5 ships the third rail of the fund-attribution cascade (G3 Fase 3). Resolves a fund's free-text `primary_benchmark` string to a canonical ETF via `benchmark_etf_canonical_map`, then runs Brinson-Fachler against that ETF's N-PORT holdings — closing the circuit without Bloomberg.

New dispatcher priority: **HOLDINGS (success) → PROXY (Brinson with resolved ETF) → RETURNS → NONE**.

## What landed

### Migration 0165
- `benchmark_asset_class` ENUM + global `benchmark_etf_canonical_map` table
- GIN trigram on canonical, GIN on aliases array, asset-class partial active index
- 20-row seed: S&P 500 → SPY, Russell 2000 → IWM, Bloomberg Agg → AGG, MSCI EM → EEM, and so on
- Adds `sec_registered_funds.primary_benchmark TEXT` (populated by downstream N-CEN/Tiingo worker — PR-Q7)
- Reversible downgrade (drops table + ENUM + column; leaves pg_trgm intact)

### Engine
- `vertical_engines/wealth/attribution/brinson_fachler.py` — canonical single-period decomposition (allocation + selection + interaction). Preserves the identity `R_P - R_B ≡ Σ alloc + Σ select + Σ interact`.
- `vertical_engines/wealth/attribution/benchmark_proxy.py` — three-level resolver (exact alias → trigram fuzzy `> 0.7` → asset-class keyword fallback) + `run_proxy_rail` orchestrator. Rail degrades on `benchmark_unresolved`, `proxy_no_holdings`, `sector_returns_unavailable`, or `stale_filing`.
- `service.py` dispatcher: inserts proxy fetch between holdings-fall-through and returns rail; Redis serialisation covers the new `BenchmarkProxyResult` payload.
- `dd_report/chapters.py` renders the Brinson table when `RAIL_PROXY` wins — sanitised copy ("Asset mix contribution", "Security selection", "Timing & interaction") plus the top-11 sector breakdown. `MEDIUM CONFIDENCE — benchmark proxy` badge. No `Brinson-Fachler` / `allocation_effect` jargon leaks to UI.

### Tests (31 new, all passing)
- `test_attribution_brinson_fachler.py` — 9 tests: golden textbook example, identity invariant, zero-weight/zero-return edge cases, determinism, union sector coverage.
- `test_attribution_benchmark_proxy.py` — 22 tests: asset-class keyword classifier, 3-level resolver cascade (exact / fuzzy / class-fallback / null / unmatched), proxy rail degradation paths, dispatcher integration (holdings-degrade → proxy-wins, proxy-degrade → returns-fall-through), serialisation roundtrip, DD ch.4 copy invariants.

## Regression

- `make lint` — All checks passed
- `make architecture` — 31 kept, 0 broken
- `make typecheck` — clean on new/modified files (pre-existing errors in unrelated modules unchanged)
- Full non-DB suite: 4,748 passed, 28 failed (baseline per memory observation 902, none new)
- Full attribution suite (91 tests, existing + new): 100% green

## Not in scope (per spec non-goals)

- No seed expansion beyond 20 rows (follow-up audit-driven backlog)
- No IPCA rail (PR-Q9)
- No Tiingo worker wiring (PR-Q7) — `primary_benchmark` column is empty today; resolver returns `null` until a downstream PR populates it
- No raw allocation numbers in UI copy (sanitised via chapters renderer)

## Spec references

- `docs/superpowers/specs/2026-04-19-edhec-gaps-data-layer.md` §1 (migration DDL + seed + fuzzy match)
- `docs/superpowers/specs/2026-04-19-edhec-gaps-quant-math.md` §3.2 (Brinson-Fachler refactor)
- `docs/superpowers/specs/2026-04-19-edhec-gaps-strategy.md` §4, §6 (integration + confidence badges)

## Test plan

- [ ] Apply migration 0165 to Timescale Cloud staging; verify seed = exactly 20 rows
- [ ] Backfill `sec_registered_funds.primary_benchmark` sample (manual or PR-Q7) and run the resolver coverage audit (target ≥60% exact+fuzzy hit rate)
- [ ] Render a DD ch.4 PDF for a registered fund with enough holdings coverage — confirm Brinson table + copy rendering
- [ ] Confirm Redis cache roundtrip in a live dev environment
- [ ] Explain-analyze the resolver SQL against the seeded table to confirm GIN indices are used

🤖 Generated with [Claude Code](https://claude.com/claude-code)