### PR TITLE
feat(wealth/q5.1.3): canonical_map expansion + RR-1 slice backfill

### DIFF
--- a/backend/app/core/db/migrations/versions/0168_expand_canonical_map_fsds_q1_2025.py
+++ b/backend/app/core/db/migrations/versions/0168_expand_canonical_map_fsds_q1_2025.py
@@ -1,0 +1,877 @@
+"""Expand benchmark_etf_canonical_map from SEC FSDS Q1 2025 RR-1 slice.
+
+Phase A of PR-Q5.1.3: the Q1 2025 lab.tsv slice of SEC Financial
+Statement Data Sets surfaced 135 benchmark label variants spanning 81
+unique (proxy ETF, asset class) buckets. This migration embeds the
+audited mappings so the subsequent backfill script can resolve every
+Q1 2025 filing's benchmark Member label to a canonical proxy ETF.
+
+Source of truth for every row here:
+    docs/diagnostics/2026-04-20-canonical-map-expansion-proposal.csv
+
+Grouping rule (applied at migration-build time, not runtime):
+- Collapse 135 CSV rows by (proposed_etf_ticker, asset_class enum).
+- Merge all variants (canonical_name + top_raw_aliases) into a single
+  alias array per bucket.
+- Pick the cleanest canonical name via a deterministic scorer that
+  penalizes boilerplate ("reflects no deduction"), trailing punctuation,
+  unspaced "U.S.Index" artifacts, and all-uppercase variants.
+
+Application rule (applied at upgrade time):
+- If a row with the same (proxy_etf_ticker, asset_class) already exists
+  (e.g. from 0165 seed or 0166 expansion), MERGE the new aliases into
+  the existing row. Never duplicate the canonical identity.
+- Otherwise INSERT a new row tagged source='fsds_q1_2025_slice_0168'
+  with fit_quality_score = 0.92 (data-validated from FSDS, half-step
+  above 0166's manual 0.90).
+
+Asset-class ENUM is intentionally unchanged: finer-grained CSV labels
+(equity_us_large_value, fi_us_cash, alt_commodities, etc.) are mapped
+into the existing 14-value enum at build time. Canonical and aliases
+preserve the institutional granularity.
+
+No schema change; data only. Idempotent:
+- Inserted rows: ON CONFLICT (canonical, effective_from) DO UPDATE
+  merges aliases on re-run.
+- Updated rows: re-run recomputes the merged alias set and writes it
+  back, reaching the same fixed point.
+
+depends_on: 0167.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0168_expand_canonical_map_fsds_q1_2025"
+down_revision = "0167_primary_benchmark_backfill_log"
+branch_labels = None
+depends_on = None
+
+
+_FIT_QUALITY = 0.92
+_SOURCE_TAG = "fsds_q1_2025_slice_0168"
+
+
+# Auto-generated from 2026-04-20-canonical-map-expansion-proposal.csv
+# Total groups: 81
+_GROUPS: list[tuple[str, list[str], str, str]] = [
+    (
+        'MSCI ACWI Index',
+        [
+            'MSCI ACWI',
+            'MSCI ACWI IMI Index',
+            'MSCI ACWI Index',
+            'MSCI ACWI Total Return Index',
+            'MSCI All Country World Index',
+            'MSCI All Country World Index NR',
+        ],
+        'ACWI', 'equity_intl_dev',
+    ),
+    (
+        'MSCI ACWI Ex U.S. Index',
+        [
+            'MSCI ACWI EX-U.S. Index',
+            'MSCI ACWI Ex U.S. Index',
+            'MSCI ACWI ex U.S. Index',
+            'MSCI ACWI ex U.S. Index reflects no deduction for fees, expenses, or taxes',
+            'MSCI ACWI ex-U.S. Index',
+        ],
+        'ACWX', 'equity_intl_dev',
+    ),
+    (
+        'Bloomberg Aggregate Bond Index',
+        [
+            'BLOOMBERG U.S. AGGREGATE BOND Index',
+            'BLOOMBERG U.S. AGGREGATE Index',
+            'Bloomberg Aggregate Bond Index',
+            'Bloomberg U.S. Aggregate BOND Index',
+            'Bloomberg U.S. Aggregate Bond Index',
+            'Bloomberg U.S. Aggregate Bond Index reflects no deduction for fees, expenses, or taxes',
+            'Bloomberg U.S. Aggregate Bond Index reflects no deductions for fees, expenses or taxes',
+            'Bloomberg U.S. Aggregate Bond Total Return Index',
+            'Bloomberg U.S. Aggregate Index',
+            'Bloomberg U.S. AggregateBond Index',
+            'Bloomberg U.S. Aggregatebond Index',
+            'ICE BofA U.S. Broad Market Index',
+        ],
+        'AGG', 'fi_us_agg',
+    ),
+    (
+        'Lipper Balanced Funds Index',
+        [
+            'Lipper Balanced Funds Index',
+        ],
+        'AOR', 'other',
+    ),
+    (
+        'ICE BofA U.S. Treasury Bill Index',
+        [
+            'Bloomberg 1-3 Month U.S. Treasury Bill Index',
+            'ICE BOFA 3-MONTH U.S. TREASURY BILL Index',
+            'ICE BOFA 3-month U.S. Treasury BILL Index',
+            'ICE BofA 3 Month U.S. Treasury Bill Index',
+            'ICE BofA 3-Month U.S. Treasury Bill Index',
+            'ICE BofA 3-month U.S. Treasury Bill Index',
+            'ICE BofA U.S. Treasury Bill Index',
+            'ICE BofA U.S.3 Month Treasury Bill Index',
+            'ICE BofA U.S.3-Month Treasury Bill Index',
+            'ICE BofA U.S.3-Month Treasury Bill Total Return Index',
+            'ICE BofA U.S.3-month Treasury Bill Index',
+        ],
+        'BIL', 'fi_us_treasury',
+    ),
+    (
+        'Bloomberg U.S.1-5 Year Government/credit Index',
+        [
+            'Bloomberg U.S. Government/Credit 1-3 Year Index',
+            'Bloomberg U.S. Government/credit 1-3 Year Index',
+            'Bloomberg U.S.1-3 Year Government/Credit Bond Index',
+            'Bloomberg U.S.1-3 Year Government/credit Bond Index',
+            'Bloomberg U.S.1-5 Year Government/Credit Index',
+            'Bloomberg U.S.1-5 Year Government/credit Index',
+        ],
+        'BIV', 'fi_us_treasury',
+    ),
+    (
+        'S&P UBS Leveraged Loan Index',
+        [
+            'Morningstar LSTA U.S. Leveraged Loan 100 Index',
+            'Morningstar LSTA U.S. Leveraged Loan Index',
+            'S&P UBS Leveraged Loan Index',
+            'S&P UBS Leveraged Loan Index reflects no deductions for fees, expenses or taxes',
+        ],
+        'BKLN', 'fi_us_hy',
+    ),
+    (
+        'Bloomberg Global Aggregate Index',
+        [
+            'Bloomberg Global Aggregate Bond Index',
+            'Bloomberg Global Aggregate Bond Index Reflects No Deduction For Fees Expenses Or Taxes',
+            'Bloomberg Global Aggregate Index',
+        ],
+        'BNDX', 'fi_intl',
+    ),
+    (
+        'FTSE World Government Bond Index',
+        [
+            'FTSE World Government Bond Index',
+        ],
+        'BWX', 'fi_intl',
+    ),
+    (
+        'Bloomberg Commodity Index',
+        [
+            'Bloomberg Commodity Index',
+        ],
+        'DJP', 'commodities',
+    ),
+    (
+        'Dow Jones U.S. Select Dividend Index',
+        [
+            'Dow Jones U.S. Select Dividend Index',
+        ],
+        'DVY', 'equity_us_large',
+    ),
+    (
+        'MSCI Emerging Markets Index',
+        [
+            'MSCI Emerging Markets Index',
+            'MSCI Emerging Markets Index reflects no deductions for fees, expenses or taxes',
+            'MSCI Emerging Markets Index)',
+            'MSCI Emerging Markets Index?',
+            'MSCI Emerging Markets Total Return Index',
+        ],
+        'EEM', 'equity_em',
+    ),
+    (
+        'MSCI EAFE Index',
+        [
+            'MSCI EAFE Index',
+            'MSCI EAFE Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes',
+            'MSCI EAFE Index reflects no deductions for fees, expenses or taxes',
+            'MSCI EAFE NR Index',
+        ],
+        'EFA', 'equity_intl_dev',
+    ),
+    (
+        'MSCI EAFE Value Index',
+        [
+            'MSCI EAFE Value Index',
+        ],
+        'EFV', 'equity_intl_dev',
+    ),
+    (
+        'JP Morgan EMBI Global Diversified Index',
+        [
+            'JP Morgan EMBI Global Diversified Index',
+        ],
+        'EMB', 'fi_intl',
+    ),
+    (
+        'Russell 1000 Equal Weight Index',
+        [
+            'Russell 1000 Equal Weight Index',
+        ],
+        'EQAL', 'equity_us_large',
+    ),
+    (
+        'MSCI Japan Index',
+        [
+            'MSCI Japan Index',
+        ],
+        'EWJ', 'equity_intl_dev',
+    ),
+    (
+        'Bloomberg U.S. Treasury Index',
+        [
+            'Bloomberg U.S. Treasury Index',
+        ],
+        'GOVT', 'fi_us_treasury',
+    ),
+    (
+        'Bloomberg Municipal High Yield Bond Index',
+        [
+            'Bloomberg Municipal High Yield Bond Index',
+        ],
+        'HYD', 'fi_us_muni',
+    ),
+    (
+        'ICE BofA U.S. High Yield Index',
+        [
+            'Bloomberg U.S. Corporate High Yield Index',
+            'ICE BofA U.S. Cash Pay High Yield Constrained Index',
+            'ICE BofA U.S. High Yield Constrained Index',
+            'ICE BofA U.S. High Yield Index',
+            'ICE BofA U.S. High Yield Index reflects no deduction for fees, expenses, or taxes',
+        ],
+        'HYG', 'fi_us_hy',
+    ),
+    (
+        'Bloomberg Intermediate U.S. Aggregate Bond Index',
+        [
+            'Bloomberg Intermediate U.S. Aggregate Bond Index',
+        ],
+        'IAGG', 'fi_us_agg',
+    ),
+    (
+        'Bloomberg U.S. Intermediate Corporate Bond Index',
+        [
+            'Bloomberg U.S. Intermediate Corporate Bond Index',
+        ],
+        'IGIB', 'fi_us_ig',
+    ),
+    (
+        'S&P MidCap 400 Value Index',
+        [
+            'S&P MidCap 400 Value Index',
+        ],
+        'IJJ', 'equity_us_mid',
+    ),
+    (
+        'S&P MidCap 400 Growth Index',
+        [
+            'S&P MidCap 400 Growth Index',
+        ],
+        'IJK', 'equity_us_mid',
+    ),
+    (
+        'S&P SmallCap 600 Index',
+        [
+            'S&P Small Cap 600 Index',
+            'S&P SmallCap 600 Index',
+            'S&P SmallCap 600 TR Index',
+        ],
+        'IJR', 'equity_us_small',
+    ),
+    (
+        'S&P SmallCap 600 Value Index',
+        [
+            'S&P SmallCap 600 Value Index',
+        ],
+        'IJS', 'equity_us_small',
+    ),
+    (
+        'S&P SmallCap 600 Growth Index',
+        [
+            'S&P SmallCap 600 Growth Index',
+        ],
+        'IJT', 'equity_us_small',
+    ),
+    (
+        'S&P 1500 Index',
+        [
+            'S&P 1500 Index',
+            'S&P 1500 Index -',
+            'S&P 1500 Index-',
+            'S&P COMPOSITE 1500 Index',
+            'S&P Composite 1500 Index',
+            'S&P Composite 1500 Total Return Index',
+        ],
+        'ITOT', 'equity_us_large',
+    ),
+    (
+        'S&P 500 Value Index',
+        [
+            'S&P 500 Value Index',
+        ],
+        'IVE', 'equity_us_large',
+    ),
+    (
+        'S&P 500 Growth Index',
+        [
+            'S&P 500 Growth Index',
+        ],
+        'IVW', 'equity_us_large',
+    ),
+    (
+        'Russell 1000 Index',
+        [
+            'RUSSELL 1000 Index',
+            'Russell 1000 Index',
+            'Russell 1000 Index reflects no deduction for fees, expenses, or taxes',
+            'Russell 1000 Index reflects no deductions for fees, expenses or taxes',
+        ],
+        'IWB', 'equity_us_large',
+    ),
+    (
+        'Russell 1000 Value Index',
+        [
+            'RUSSELL 1000 VALUE Index',
+            'Russell 1000 Value Index',
+            'Russell 1000 Value Index reflects no deduction for fees, expenses or taxes',
+            'Russell 1000 Value Index reflects no deduction for fees, expenses, or taxes',
+            'Russell 1000 Value Index reflects no deductions for fees, expenses or taxes',
+        ],
+        'IWD', 'equity_us_large',
+    ),
+    (
+        'Russell 1000 Growth Index',
+        [
+            'RUSSELL 1000 GROWTH Index',
+            'Russell 1000 Growth Index',
+            'Russell 1000 Growth Index reflects no deduction for fees, expenses, or taxes',
+            'Russell 1000 Growth Total Return Index',
+        ],
+        'IWF', 'equity_us_large',
+    ),
+    (
+        'S&P 1000 Index',
+        [
+            'Bloomberg U.S.2000 Index',
+            'RUSSELL 2000 Index',
+            'RUSSELL 2500 Index',
+            'Russell 2000 Index',
+            'Russell 2000 Index reflects no deductions for fees, expenses or taxes',
+            'Russell 2000 Total Return Index',
+            'Russell 2500 Index',
+            'Russell 2500 Total Return Index',
+            'S&P 1000 Index',
+        ],
+        'IWM', 'equity_us_small',
+    ),
+    (
+        'Russell 2000 Value Index',
+        [
+            'RUSSELL 2000 VALUE Index',
+            'Russell 2000 Value Index',
+            'Russell 2000 Value Index reflects no deduction for fees, expenses or taxes',
+            'Russell 2000 Value Index reflects no deductions for fees, expenses or taxes',
+        ],
+        'IWN', 'equity_us_small',
+    ),
+    (
+        'Russell 2000 Growth Index',
+        [
+            'RUSSELL 2000 GROWTH Index',
+            'Russell 2000 Growth Index',
+            'Russell 2000 Growth Total Return Index',
+        ],
+        'IWO', 'equity_us_small',
+    ),
+    (
+        'Russell MidCap Growth Index',
+        [
+            'RUSSELL MIDCAP GROWTH Index',
+            'Russell MidCap Growth Index',
+            'Russell Midcap Growth Index',
+            'Russell Midcap Growth Index reflects no deduction for fees, expenses, or taxes',
+            'Russell Midcap Growth Total Return Index',
+        ],
+        'IWP', 'equity_us_mid',
+    ),
+    (
+        'Russell MidCap Index',
+        [
+            'RUSSELL MIDCAP Index',
+            'Russell Mid Cap Index',
+            'Russell Mid Cap Total Return Index',
+            'Russell MidCap Index',
+            'Russell Midcap Index',
+            'Russell Midcap Index reflects no deduction for fees, expenses or taxes',
+            'Russell Midcap Index reflects no deductions for fees, expenses or taxes',
+        ],
+        'IWR', 'equity_us_mid',
+    ),
+    (
+        'Russell MidCap Value Index',
+        [
+            'RUSSELL MIDCAP VALUE Index',
+            'Russell MidCap Value Index',
+            'Russell Midcap Value Index',
+            'Russell Midcap Value Index reflects no deduction for fees, expenses or taxes',
+            'Russell Midcap Value Index reflects no deductions for fees, expenses or taxes',
+        ],
+        'IWS', 'equity_us_mid',
+    ),
+    (
+        'Russell 3000 Index',
+        [
+            'RUSSELL 3000 Index',
+            'Russell 3000 Index',
+            'Russell 3000 Index reflects no deduction for fees, expenses, or taxes',
+            'Russell 3000 Index reflects no deductions for fees, expenses or taxes',
+            'Russell 3000 Index?',
+        ],
+        'IWV', 'equity_us_large',
+    ),
+    (
+        'Russell 3000 Value Index',
+        [
+            'RUSSELL 3000 VALUE Index',
+            'Russell 3000 Value Index',
+            'Russell 3000 Value Total Return Index',
+        ],
+        'IWW', 'equity_us_large',
+    ),
+    (
+        'Russell 3000 Growth Index',
+        [
+            'RUSSELL 3000 GROWTH Index',
+            'Russell 3000 Growth Index',
+            'Russell 3000 Growth Total Return Index',
+        ],
+        'IWZ', 'equity_us_large',
+    ),
+    (
+        'JP Morgan CLOIE AAA Index',
+        [
+            'JP Morgan CLOIE AAA Index',
+            'JP Morgan CLOIE AAA Total Return Index',
+        ],
+        'JAAA', 'fi_us_ig',
+    ),
+    (
+        'S&P Banks Select Industry Index',
+        [
+            'S&P Banks Select Industry Index',
+        ],
+        'KBE', 'other',
+    ),
+    (
+        'Bloomberg U.S. Credit Index',
+        [
+            'Bloomberg U.S. Corporate Bond Index',
+            'Bloomberg U.S. Corporate Bond Index reflects no deduction for fees, expenses, or taxes',
+            'Bloomberg U.S. Corporate Index',
+            'Bloomberg U.S. Credit Index',
+        ],
+        'LQD', 'fi_us_ig',
+    ),
+    (
+        'Bloomberg U.S. MBS Index',
+        [
+            'Bloomberg U.S. MBS Index',
+        ],
+        'MBB', 'fi_us_agg',
+    ),
+    (
+        'S&P MidCap 400 Index',
+        [
+            'S&P MidCap 400 Index',
+        ],
+        'MDY', 'equity_us_mid',
+    ),
+    (
+        'S&P Municipal Bond Index',
+        [
+            'Bloomberg 3 15 Year Blend Municipal Bond Index',
+            'Bloomberg 3-15 Year Blend Municipal Bond Index',
+            'Bloomberg Minnesota Municipal Bond Index',
+            'Bloomberg Municipal Bond Index',
+            'Bloomberg Municipal Bond Index reflects no deduction for fees, expenses, or taxes',
+            'Bloomberg Pennsylvania Municipal Bond Index',
+            'Bloomberg U.S. Municipal Bond Index',
+            'Bloomberg U.S. Municipal Bond Index*',
+            'S&P Municipal Bond Index',
+            'S&P Municipal Bond Index reflects no deductions for fees, expenses or taxes',
+            'S&P Municipal Bond Index*',
+            'S&P Municipal Bond Index* reflects no deductions for fees, expenses or taxes',
+            'S&P National AMT-Free Municipal Bond Index',
+            'S&P National Amt-free Municipal Bond Index',
+        ],
+        'MUB', 'fi_us_muni',
+    ),
+    (
+        'Nasdaq Composite Index',
+        [
+            'NASDAQ Composite Index',
+            'NASDAQ Composite Total Return Index',
+            'Nasdaq Composite Index',
+        ],
+        'ONEQ', 'equity_us_large',
+    ),
+    (
+        'ICE BOFA U.S. ALL Capital Securities Index',
+        [
+            'ICE BOFA U.S. ALL CAPITAL SECURITIES Index',
+            'ICE BOFA U.S. ALL Capital Securities Index',
+            'ICE BofA U.S. All Capital Securities Index',
+        ],
+        'PFF', 'fi_us_ig',
+    ),
+    (
+        'Nasdaq-100 Index',
+        [
+            'NASDAQ - 100 Total Return Index',
+            'NASDAQ 100 Total Return Index',
+            'NASDAQ-100 Index',
+            'NASDAQ-100 Total Return Index',
+            'Nasdaq 100 Index',
+            'Nasdaq 100 Total Return Index',
+            'Nasdaq-100 Index',
+        ],
+        'QQQ', 'equity_us_large',
+    ),
+    (
+        'S&P 500 Equal Weight Index',
+        [
+            'S&P 500 Equal Weight Index',
+            'S&P 500 Equal Weight Total Return Index',
+        ],
+        'RSP', 'equity_us_large',
+    ),
+    (
+        'Dow Jones U.S. Total Stock Market Float Adjusted Index',
+        [
+            'Dow Jones U.S. Total Stock Market Float Adjusted Index',
+        ],
+        'SCHB', 'equity_us_large',
+    ),
+    (
+        'ICE BofA 1 3 Year U.S. Treasury Index',
+        [
+            'ICE BofA 1 3 Year U.S. Treasury Index',
+            'ICE BofA 1-3 Year U.S. Treasury Index',
+        ],
+        'SHY', 'fi_us_treasury',
+    ),
+    (
+        'Russell 2500 Growth Index',
+        [
+            'Russell 2500 Growth Index',
+        ],
+        'SMLG', 'equity_us_small',
+    ),
+    (
+        'Russell 2500 Value Index',
+        [
+            'Russell 2500 Value Index',
+            'Russell 2500 Value Total Return Index',
+        ],
+        'SMLV', 'equity_us_small',
+    ),
+    (
+        'S&P Total Market Index',
+        [
+            'S&P Total Market Index',
+        ],
+        'SPTM', 'equity_us_large',
+    ),
+    (
+        'S&P 500 index',
+        [
+            'S&P 500 Index',
+            'S&P 500 Index reflects no deduction for fees, expenses or taxes',
+            'S&P 500 Index reflects no deduction for fees, expenses, or taxes',
+            'S&P 500 Index reflects no deductions for fees, expenses or taxes',
+            'S&P 500 Index)',
+            'S&P 500 index',
+        ],
+        'SPY', 'equity_us_large',
+    ),
+    (
+        'Bloomberg 1 Year Municipal Bond Index',
+        [
+            'Bloomberg 1 Year Municipal Bond Index',
+            'Bloomberg 1-Year Municipal Bond Index',
+            'Bloomberg 1-year Municipal Bond Index',
+        ],
+        'SUB', 'fi_us_muni',
+    ),
+    (
+        'Bloomberg U.S. Government Inflation-linked Bond Index',
+        [
+            'Bloomberg U.S. Government Inflation-Linked Bond Index',
+            'Bloomberg U.S. Government Inflation-linked Bond Index',
+        ],
+        'TIP', 'fi_us_treasury',
+    ),
+    (
+        'Bloomberg U.S. Universal Index',
+        [
+            'Bloomberg U.S. Universal Bond Index',
+            'Bloomberg U.S. Universal Index',
+            'Bloomberg U.S. Universal Index reflects no deductions for fees, expenses or taxes',
+            'Bloomberg U.S. Universal Total Return Index',
+        ],
+        'UBND', 'fi_us_agg',
+    ),
+    (
+        'MSCI World Index',
+        [
+            'MSCI WORLD Index',
+            'MSCI World Index',
+            'MSCI World Index -',
+            'MSCI World Index)',
+            'MSCI World Index-',
+            'MSCI World NR Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes',
+        ],
+        'URTH', 'equity_intl_dev',
+    ),
+    (
+        'Bloomberg High Yield Very Liquid Index',
+        [
+            'Bloomberg High Yield Very Liquid Index',
+        ],
+        'USHY', 'fi_us_hy',
+    ),
+    (
+        'MSCI U.S. Minimum Volatility Index',
+        [
+            'MSCI U.S. Minimum Volatility Index',
+        ],
+        'USMV', 'equity_us_large',
+    ),
+    (
+        'MSCI World Ex U.S. Index',
+        [
+            'MSCI World Ex U.S. Index',
+            'MSCI World ex U.S. Index',
+            'MSCI World ex-U.S. Index',
+        ],
+        'VEA', 'equity_intl_dev',
+    ),
+    (
+        'S&P Target Date To 2055 Index',
+        [
+            'S&P Target Date To 2055 Index',
+        ],
+        'VFFVX', 'other',
+    ),
+    (
+        'S&P Target Date To 2050 Index',
+        [
+            'S&P Target Date To 2050 Index',
+        ],
+        'VFIFX', 'other',
+    ),
+    (
+        'S&P Target Date To 2040 Index',
+        [
+            'S&P Target Date To 2040 Index',
+        ],
+        'VFORX', 'other',
+    ),
+    (
+        'MSCI Europe Index',
+        [
+            'MSCI Europe Index',
+        ],
+        'VGK', 'equity_intl_dev',
+    ),
+    (
+        'S&P Target Date To 2030 Index',
+        [
+            'S&P Target Date To 2030 Index',
+        ],
+        'VTHRX', 'other',
+    ),
+    (
+        'MSCI U.S. Index',
+        [
+            'CRSP U.S. Total Market Index',
+            'MSCI U.S. Index',
+        ],
+        'VTI', 'equity_us_large',
+    ),
+    (
+        'S&P Target Date To 2045 Index',
+        [
+            'S&P Target Date To 2045 Index',
+        ],
+        'VTIVX', 'other',
+    ),
+    (
+        'S&P Target Date To 2035 Index',
+        [
+            'S&P Target Date To 2035 Index',
+        ],
+        'VTTHX', 'other',
+    ),
+    (
+        'S&P Target Date To 2060 Index',
+        [
+            'S&P Target Date To 2060 Index',
+        ],
+        'VTTSX', 'other',
+    ),
+    (
+        'MSCI ACWI Ex U.S. Investable Market Index',
+        [
+            'MSCI ACWI Ex U.S. Investable Market Index',
+            'MSCI ACWI ex U.S. Investable Market Index',
+        ],
+        'VXUS', 'equity_intl_dev',
+    ),
+    (
+        'S&P Biotechnology Select Industry Index',
+        [
+            'S&P Biotechnology Select Industry Index',
+        ],
+        'XBI', 'other',
+    ),
+    (
+        'S&P Oil & Gas Equipment & Services Select Industry Index',
+        [
+            'S&P Oil & Gas Equipment & Services Select Industry Index',
+        ],
+        'XES', 'other',
+    ),
+    (
+        'S&P 500 Financials Index',
+        [
+            'S&P 500 Financials Index',
+        ],
+        'XLF', 'other',
+    ),
+    (
+        'S&P 500 Information Technology Index',
+        [
+            'S&P 500 Information Technology Index',
+        ],
+        'XLK', 'other',
+    ),
+    (
+        'S&P 500 Utilities Index',
+        [
+            'S&P 500 Utilities Index',
+        ],
+        'XLU', 'other',
+    ),
+    (
+        'S&P Pharmaceuticals Select Industry Index',
+        [
+            'S&P Pharmaceuticals Select Industry Index',
+        ],
+        'XPH', 'other',
+    ),
+]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    lookup_sql = text("""
+        SELECT id, benchmark_name_aliases
+          FROM benchmark_etf_canonical_map
+         WHERE proxy_etf_ticker = :ticker
+           AND asset_class = CAST(:asset_class AS benchmark_asset_class)
+           AND effective_to = '9999-12-31'
+         LIMIT 1
+    """)
+
+    update_sql = text("""
+        UPDATE benchmark_etf_canonical_map
+           SET benchmark_name_aliases = :aliases,
+               updated_at             = now()
+         WHERE id = :id
+    """)
+
+    insert_sql = text("""
+        INSERT INTO benchmark_etf_canonical_map (
+            benchmark_name_canonical, benchmark_name_aliases,
+            proxy_etf_ticker, asset_class, source, fit_quality_score
+        ) VALUES (
+            :canonical, :aliases, :ticker,
+            CAST(:asset_class AS benchmark_asset_class),
+            :source, :fit
+        )
+        ON CONFLICT (benchmark_name_canonical, effective_from) DO UPDATE
+            SET benchmark_name_aliases = (
+                    SELECT ARRAY(
+                        SELECT DISTINCT unnest(
+                            benchmark_etf_canonical_map.benchmark_name_aliases
+                            || EXCLUDED.benchmark_name_aliases
+                        )
+                        ORDER BY 1
+                    )
+                ),
+                proxy_etf_ticker = EXCLUDED.proxy_etf_ticker,
+                asset_class     = EXCLUDED.asset_class,
+                updated_at      = now()
+    """)
+
+    inserted = 0
+    merged = 0
+    for canonical, aliases, ticker, asset_class in _GROUPS:
+        existing = bind.execute(
+            lookup_sql, {"ticker": ticker, "asset_class": asset_class}
+        ).mappings().first()
+        if existing is not None:
+            current = list(existing["benchmark_name_aliases"] or [])
+            combined = sorted({*current, *aliases, canonical})
+            bind.execute(
+                update_sql, {"aliases": combined, "id": existing["id"]}
+            )
+            merged += 1
+        else:
+            bind.execute(
+                insert_sql,
+                {
+                    "canonical": canonical,
+                    "aliases": sorted(set(aliases) | {canonical}),
+                    "ticker": ticker,
+                    "asset_class": asset_class,
+                    "source": _SOURCE_TAG,
+                    "fit": _FIT_QUALITY,
+                },
+            )
+            inserted += 1
+
+    # Best-effort visibility in alembic logs.
+    print(
+        f"[0168] benchmark_etf_canonical_map: "
+        f"merged_into_existing={merged} inserted_new={inserted} "
+        f"total_groups={len(_GROUPS)}"
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    # Delete rows created by this migration. Merges into pre-existing
+    # rows cannot be reversed deterministically; callers that need a
+    # true revert should restore from a dump. Log the caveat.
+    r = bind.execute(
+        text(
+            "DELETE FROM benchmark_etf_canonical_map "
+            "WHERE source = :source RETURNING id"
+        ),
+        {"source": _SOURCE_TAG},
+    )
+    deleted = len(r.fetchall())
+    print(
+        f"[0168] downgrade removed {deleted} inserted rows; alias merges "
+        f"on pre-existing rows were not reverted."
+    )

--- a/backend/scripts/backfill_primary_benchmark_from_rr1.py
+++ b/backend/scripts/backfill_primary_benchmark_from_rr1.py
@@ -1,0 +1,431 @@
+"""Backfill ``sec_registered_funds.primary_benchmark`` from SEC Financial
+Statement Data Sets (FSDS) RR-1 Q1 2025 slice.
+
+Reads two local TSVs from the operator's EDGAR mirror:
+
+    E:\\EDGAR FILES\\Tickers\\sub.tsv   (adsh -> cik mapping)
+    E:\\EDGAR FILES\\Tickers\\lab.tsv   (XBRL Member labels per filing)
+
+Benchmark Member rows (dimensional labels referencing a benchmark
+provider) are parsed, normalized, and resolved against
+``benchmark_etf_canonical_map`` (expanded by migration 0168 to 92 rows /
+700+ aliases). Matched CIKs whose ``primary_benchmark`` is NULL get
+populated; every row processed lands in
+``primary_benchmark_backfill_log`` with source tag
+``fsds_q1_2025_rr1_v1``.
+
+Zero external API calls. Single-pass streaming read of lab.tsv
+(~1.5M lines) with bounded memory via dict-of-set aggregation keyed on
+normalized CIK.
+
+Usage::
+
+    python -m scripts.backfill_primary_benchmark_from_rr1 [--dry-run]
+        [--force] [--labels-dir PATH]
+
+Flags:
+    --dry-run     Compute the plan and print counts without persisting.
+    --force       Overwrite rows that already have primary_benchmark set.
+                  Default is idempotent (skipped_existing).
+    --labels-dir  Override the default RR-1 TSV directory.
+
+PR-Q5.1.3 Phase B.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy import text
+
+from app.core.db.engine import async_session_factory
+
+_SOURCE_TAG = "fsds_q1_2025_rr1_v1"
+_DEFAULT_LABELS_DIR = Path(r"E:\EDGAR FILES\Tickers")
+_BATCH_SIZE = 500
+
+# Matches any benchmark provider token. Restricted to institutional
+# providers to keep false-positive rate low — informal or fund-family
+# indices are deliberately excluded.
+_PROVIDER_RE = re.compile(
+    r"\b(S&P|Russell|MSCI|Bloomberg|FTSE|Nasdaq|Dow Jones|Wilshire|CRSP|"
+    r"ICE|BofA|Barclays|Citigroup|JPMorgan|JP Morgan|NASDAQ|NYSE|LBMA|"
+    r"BBG|STOXX|NIKKEI|TOPIX|Lipper|Morningstar|Refinitiv|Reuters)\b",
+    re.IGNORECASE,
+)
+_FUND_RE = re.compile(r"\bFund\b", re.IGNORECASE)
+_INDEX_RE = re.compile(r"\bindex\b", re.IGNORECASE)
+
+
+def _clean_label(label: str) -> str:
+    """Strip XBRL decorators like ``[Member]`` and collapse whitespace."""
+    label = re.sub(r"\[[^\]]+\]", "", label).strip()
+    label = re.sub(r"\s+", " ", label)
+    return label
+
+
+def _is_benchmark_label(tag: str, label: str) -> bool:
+    if not label or len(label) < 10 or len(label) > 250:
+        return False
+    if "Member" not in tag:
+        return False
+    if not _PROVIDER_RE.search(label):
+        return False
+    if not _INDEX_RE.search(label):
+        return False
+    if _FUND_RE.search(label):
+        return False
+    return True
+
+
+def _norm_lookup(value: str) -> str:
+    """Canonical-map lookup key: strip symbols, collapse whitespace, lower."""
+    value = (
+        value
+        .replace("\u00ae", "")
+        .replace("\u2122", "")
+        .replace("\u00a0", " ")
+    )
+    # Collapse SEC disclosure boilerplate that varies across prospectuses.
+    value = re.sub(
+        r"\s*\(reflects\s+no\s+deduct(?:ions?|s)\s+for[^)]*\)",
+        "",
+        value,
+        flags=re.IGNORECASE,
+    )
+    value = re.sub(r"\s*\(net of[^)]+\)", "", value, flags=re.IGNORECASE)
+    value = re.sub(r"\s+", " ", value).strip().lower()
+    return value
+
+
+def _normalize_cik(cik: str | None) -> str | None:
+    if cik is None:
+        return None
+    stripped = str(cik).lstrip("0")
+    return stripped or "0"
+
+
+@dataclass(frozen=True)
+class _Resolution:
+    cik: str
+    db_cik: str
+    raw_label: str
+    resolved_canonical: str | None
+    has_existing_benchmark: bool
+
+
+async def _load_alias_lookup(session) -> dict[str, str]:
+    """Build ``normalized_alias -> canonical_name`` from the full map."""
+    r = await session.execute(
+        text("""
+            SELECT benchmark_name_canonical, benchmark_name_aliases
+              FROM benchmark_etf_canonical_map
+             WHERE effective_to = '9999-12-31'
+        """)
+    )
+    lookup: dict[str, str] = {}
+    for canonical, aliases in r.fetchall():
+        lookup[_norm_lookup(canonical)] = canonical
+        for alias in aliases or []:
+            lookup[_norm_lookup(alias)] = canonical
+    return lookup
+
+
+async def _load_registered_ciks(session) -> dict[str, tuple[str, bool]]:
+    """Return ``normalized_cik -> (db_raw_cik, has_primary_benchmark)``."""
+    r = await session.execute(
+        text("""
+            SELECT cik, (primary_benchmark IS NOT NULL) AS has_benchmark
+              FROM sec_registered_funds
+        """)
+    )
+    out: dict[str, tuple[str, bool]] = {}
+    for cik, has in r.fetchall():
+        key = _normalize_cik(cik) or ""
+        prev = out.get(key)
+        if prev is None or (not prev[1] and has):
+            out[key] = (str(cik), bool(has))
+    return out
+
+
+def _parse_sub_tsv(path: Path) -> dict[str, str]:
+    """Parse ``sub.tsv`` -> ``adsh -> normalized_cik`` mapping."""
+    mapping: dict[str, str] = {}
+    with path.open(encoding="utf-8") as f:
+        header = f.readline().rstrip("\n").split("\t")
+        adsh_idx = header.index("adsh")
+        cik_idx = header.index("cik")
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) <= max(adsh_idx, cik_idx):
+                continue
+            adsh = parts[adsh_idx]
+            cik = parts[cik_idx]
+            if adsh and cik:
+                mapping[adsh] = _normalize_cik(cik) or ""
+    return mapping
+
+
+def _scan_lab_tsv(
+    path: Path, adsh_to_cik: dict[str, str]
+) -> tuple[dict[str, set[str]], int, int]:
+    """Stream-scan ``lab.tsv`` -> ``cik -> {raw_benchmark_label}``.
+
+    Returns ``(cik_to_benchmarks, total_members_scanned, benchmark_hits)``.
+    """
+    cik_to_benchmarks: dict[str, set[str]] = defaultdict(set)
+    total_members = 0
+    benchmark_hits = 0
+    with path.open(encoding="utf-8", errors="replace") as f:
+        _header = f.readline()
+        # Fixed column order (SEC FSDS schema):
+        #   adsh tag version std terse verbose total negated negatedTerse
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 6:
+                continue
+            adsh = parts[0]
+            tag = parts[1]
+            if "Member" not in tag:
+                continue
+            total_members += 1
+            cik = adsh_to_cik.get(adsh)
+            if not cik:
+                continue
+            # Try std -> terse -> verbose, take first matching label.
+            for idx in (3, 4, 5):
+                if idx >= len(parts):
+                    continue
+                label = parts[idx]
+                if _is_benchmark_label(tag, label):
+                    cleaned = _clean_label(label)
+                    cik_to_benchmarks[cik].add(cleaned)
+                    benchmark_hits += 1
+                    break
+    return cik_to_benchmarks, total_members, benchmark_hits
+
+
+def _resolve(
+    cik_to_benchmarks: dict[str, set[str]],
+    alias_lookup: dict[str, str],
+    registered: dict[str, tuple[str, bool]],
+) -> list[_Resolution]:
+    """For each CIK, pick the best resolvable benchmark (first wins by
+    sort order for determinism). Non-registered CIKs are dropped — this
+    script writes only to ``sec_registered_funds``.
+    """
+    resolutions: list[_Resolution] = []
+    for cik, labels in cik_to_benchmarks.items():
+        reg = registered.get(cik)
+        if reg is None:
+            continue
+        db_cik, has_existing = reg
+        # Deterministic order: shortest-first inside sorted, so the
+        # cleanest label wins when multiple resolve to the same canonical.
+        best_canonical: str | None = None
+        best_raw: str | None = None
+        for label in sorted(labels, key=lambda s: (len(s), s)):
+            canonical = alias_lookup.get(_norm_lookup(label))
+            if canonical is not None:
+                best_canonical = canonical
+                best_raw = label
+                break
+        resolutions.append(_Resolution(
+            cik=cik,
+            db_cik=db_cik,
+            raw_label=best_raw or (sorted(labels)[0] if labels else ""),
+            resolved_canonical=best_canonical,
+            has_existing_benchmark=has_existing,
+        ))
+    return resolutions
+
+
+def _classify(resolution: _Resolution, force: bool) -> str:
+    if resolution.resolved_canonical is None:
+        return "unresolvable"
+    if resolution.has_existing_benchmark and not force:
+        return "skipped_existing"
+    return "inserted"
+
+
+async def _apply_batch(
+    session,
+    action: str,
+    rows: list[_Resolution],
+    *,
+    force: bool,
+) -> None:
+    if not rows:
+        return
+    if action == "inserted":
+        update_sql = text("""
+            UPDATE sec_registered_funds
+               SET primary_benchmark = :canonical
+             WHERE cik = :cik
+               AND (:force OR primary_benchmark IS NULL)
+        """)
+        for r in rows:
+            await session.execute(
+                update_sql,
+                {
+                    "canonical": r.resolved_canonical,
+                    "cik": r.db_cik,
+                    "force": force,
+                },
+            )
+
+    log_sql = text("""
+        INSERT INTO primary_benchmark_backfill_log (
+            cik, ticker, description_snippet, extracted_raw,
+            resolved_canonical, pattern_id, source, action
+        ) VALUES (
+            :cik, NULL, NULL, :extracted,
+            :canonical, 'fsds_rr1_member', :source, :action
+        )
+        ON CONFLICT (cik, source) DO UPDATE
+            SET extracted_raw      = EXCLUDED.extracted_raw,
+                resolved_canonical = EXCLUDED.resolved_canonical,
+                pattern_id         = EXCLUDED.pattern_id,
+                action             = EXCLUDED.action,
+                created_at         = now()
+    """)
+    for r in rows:
+        await session.execute(
+            log_sql,
+            {
+                "cik": r.db_cik,
+                "extracted": (r.raw_label or "")[:400],
+                "canonical": r.resolved_canonical,
+                "source": _SOURCE_TAG,
+                "action": action,
+            },
+        )
+
+
+async def run(
+    *,
+    dry_run: bool,
+    force: bool,
+    labels_dir: Path,
+) -> int:
+    sub_path = labels_dir / "sub.tsv"
+    lab_path = labels_dir / "lab.tsv"
+    if not sub_path.exists():
+        print(f"missing input file: {sub_path}", file=sys.stderr)
+        return 2
+    if not lab_path.exists():
+        print(f"missing input file: {lab_path}", file=sys.stderr)
+        return 2
+
+    print(f"[rr1] reading {sub_path} ...")
+    adsh_to_cik = _parse_sub_tsv(sub_path)
+    print(f"  filings (adsh -> cik) : {len(adsh_to_cik):,}")
+
+    print(f"[rr1] streaming {lab_path} ...")
+    cik_to_benchmarks, total_members, hits = _scan_lab_tsv(lab_path, adsh_to_cik)
+    print(f"  *Member rows scanned  : {total_members:,}")
+    print(f"  benchmark label hits  : {hits:,}")
+    print(f"  unique CIKs with bench: {len(cik_to_benchmarks):,}")
+
+    async with async_session_factory() as session:
+        alias_lookup = await _load_alias_lookup(session)
+        registered = await _load_registered_ciks(session)
+
+    mf_total = len(registered)
+    mf_with_bench_pre = sum(1 for _cik, has in registered.values() if has)
+    print(f"  registered funds      : {mf_total:,}")
+    print(f"  with benchmark (pre)  : {mf_with_bench_pre:,} "
+          f"({100 * mf_with_bench_pre / mf_total:.1f}%)")
+    print(f"  alias lookup entries  : {len(alias_lookup):,}")
+
+    resolutions = _resolve(cik_to_benchmarks, alias_lookup, registered)
+    print(f"  resolvable against DB : {len(resolutions):,}")
+
+    planned: dict[str, list[_Resolution]] = {
+        "inserted": [], "skipped_existing": [], "unresolvable": [],
+    }
+    for r in resolutions:
+        planned[_classify(r, force)].append(r)
+
+    counts = Counter({k: len(v) for k, v in planned.items()})
+    print("\nplanned actions:")
+    for k in ("inserted", "skipped_existing", "unresolvable"):
+        print(f"  {k:<18} {counts[k]:>6}")
+
+    top_canonicals = Counter(
+        r.resolved_canonical for r in planned["inserted"] if r.resolved_canonical
+    )
+    if top_canonicals:
+        print("\ntop canonicals (inserted):")
+        for name, cnt in top_canonicals.most_common(15):
+            print(f"  {cnt:>4}  {name}")
+
+    projected = mf_with_bench_pre + counts["inserted"]
+    print(
+        f"\nprojected post-backfill MF coverage: {projected:,}/{mf_total:,} "
+        f"= {100 * projected / mf_total:.2f}%"
+    )
+
+    if dry_run:
+        print("\n[dry-run] no writes performed.")
+        return 0
+
+    async with async_session_factory() as session:
+        for action, rows in planned.items():
+            for start in range(0, len(rows), _BATCH_SIZE):
+                chunk = rows[start:start + _BATCH_SIZE]
+                try:
+                    await _apply_batch(session, action, chunk, force=force)
+                    await session.commit()
+                except Exception:
+                    await session.rollback()
+                    raise
+                print(f"  persisted {action:<18} "
+                      f"{min(start + len(chunk), len(rows)):>6} / {len(rows)}")
+
+    # Post-apply coverage verification.
+    async with async_session_factory() as session:
+        r = await session.execute(text("""
+            SELECT
+                COUNT(*) FILTER (WHERE primary_benchmark IS NOT NULL),
+                COUNT(*)
+              FROM sec_registered_funds
+        """))
+        with_bench, total = r.fetchone()
+    print(
+        f"\npost-apply DB coverage: {with_bench:,}/{total:,} "
+        f"= {100 * with_bench / total:.2f}%"
+    )
+
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print plan without persisting.")
+    p.add_argument("--force", action="store_true",
+                   help="Overwrite existing primary_benchmark values.")
+    p.add_argument("--labels-dir", type=Path, default=_DEFAULT_LABELS_DIR,
+                   help="Directory containing sub.tsv and lab.tsv.")
+    args = p.parse_args()
+
+    if not os.getenv("DATABASE_URL"):
+        print("DATABASE_URL not set", file=sys.stderr)
+        return 2
+    return asyncio.run(run(
+        dry_run=args.dry_run,
+        force=args.force,
+        labels_dir=args.labels_dir,
+    ))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/backfill_primary_benchmark_from_rr1.py
+++ b/backend/scripts/backfill_primary_benchmark_from_rr1.py
@@ -392,13 +392,15 @@ async def run(
 
     # Post-apply coverage verification.
     async with async_session_factory() as session:
-        r = await session.execute(text("""
+        coverage_result = await session.execute(text("""
             SELECT
                 COUNT(*) FILTER (WHERE primary_benchmark IS NOT NULL),
                 COUNT(*)
               FROM sec_registered_funds
         """))
-        with_bench, total = r.fetchone()
+        row = coverage_result.fetchone()
+        assert row is not None
+        with_bench, total = row
     print(
         f"\npost-apply DB coverage: {with_bench:,}/{total:,} "
         f"= {100 * with_bench / total:.2f}%"

--- a/docs/diagnostics/2026-04-20-benchmark-gap-analysis.csv
+++ b/docs/diagnostics/2026-04-20-benchmark-gap-analysis.csv
@@ -1,0 +1,1689 @@
+rank,canonicalized_benchmark,unique_ciks_declaring
+1,S&P 500 Index,117
+2,Bloomberg U.S.Aggregate Bond Index,94
+3,Russell 3000 Index,52
+4,Russell 1000 Growth Index,33
+5,Bloomberg Municipal Bond Index,31
+6,Russell 1000 Value Index,30
+7,Russell 1000 Index,29
+8,MSCI EAFE Index,26
+9,Russell 2000 Growth Index,23
+10,MSCI Emerging Markets Index,23
+11,Russell 2000 Index,21
+12,S&P 500 Total Return Index,21
+13,Russell Midcap Growth Index,17
+14,MSCI World Index,15
+15,MSCI All Country World Index,14
+16,MSCI ACWI Index,13
+17,Russell 2000 Value Index,12
+18,Bloomberg Global Aggregate Index,12
+19,S&P MidCap 400 Index,11
+20,MSCI ACWI ex U.S.Index,10
+21,Bloomberg U.S.Aggregate Index,9
+22,Russell Midcap Index,9
+23,Nasdaq-100 Index,8
+24,Bloomberg Global Aggregate Bond Index,7
+25,Russell 2500 Value Index,7
+26,Russell Midcap Value Index,7
+27,ICE BofA 3-Month U.S.Treasury Bill Index,7
+28,ICE BofA U.S.3-Month Treasury Bill Index,7
+29,Russell 2500 Index,7
+30,S&P 500 Growth Index,7
+31,S&P 500 Value Index,7
+32,Russell 1000 Index&#160;,6
+33,Russell 3000 Value Index,6
+34,S&P 500 TR Index,6
+35,MSCI U.S.Index,6
+36,S&P UBS Leveraged Loan Index,6
+37,Bloomberg U.S.Universal Index,6
+38,RUSSELL 3000 Index,6
+39,MSCI World ex U.S.Index,6
+40,S&P Municipal Bond Index,5
+41,S&P 500 Index&#160;,5
+42,Russell 2500 Growth Index,5
+43,Bloomberg U.S.Municipal Bond Index,5
+44,S&P SmallCap 600 Index,5
+45,Bloomberg Commodity Index,5
+46,MSCI All Country World ex-U.S.Index-NR,5
+47,Bloomberg Municipal Bond Index&#160;,4
+48,Russell 1000 Growth Index&#160;,4
+49,NASDAQ Composite Index,4
+50,Russell 3000 Growth Index,4
+51,Bloomberg U.S.Treasury Index,4
+52,Morningstar LSTA U.S.Leveraged Loan Index,4
+53,S&P Composite 1500 Index,4
+54,S&P 500 Equal Weight Index,4
+55,Bloomberg U.S.Corporate Bond Index,4
+56,ICE BofA U.S.High Yield Index,4
+57,MSCI EAFE Value Index,4
+58,Russell 1000 Value Index&#160;,4
+59,Russell 2000 Index&#160;,4
+60,S&P Biotechnology Select Industry Index,4
+61,S&P MidCap 400 Growth Index,4
+62,S&P MidCap 400 Value Index,4
+63,S&P SmallCap 600 Growth Index,4
+64,S&P SmallCap 600 Value Index,4
+65,Bloomberg U.S.Aggregate Bond Index&#160;,4
+66,Dow Jones U.S.Total Stock Market Float Adjusted Index,4
+67,ICE BofA U.S.Broad Market Index,4
+68,"S&P 500 Index reflects no deduction for fees, expenses, or taxes",3
+69,MSCI EAFE Index&#160;,3
+70,S&P 500 Utilities Index,3
+71,S&P 1500 Index,3
+72,Russell 3000 Total Return Index,3
+73,Bloomberg Intermediate U.S.Aggregate Bond Index,3
+74,MSCI Europe Index,3
+75,Bloomberg U.S.1-3 Year Government/Credit Bond Index,3
+76,Bloomberg Minnesota Municipal Bond Index,3
+77,ICE BofA U.S.High Yield Constrained Index,3
+78,Bloomberg U.S.Corporate Index,3
+79,ICE BofA U.S.Treasury Bill Index,3
+80,Bloomberg Municipal High Yield Bond Index,3
+81,BLOOMBERG U.S.AGGREGATE Index,3
+82,RUSSELL 1000 GROWTH Index,3
+83,RUSSELL 1000 Index,3
+84,RUSSELL 1000 VALUE Index,3
+85,RUSSELL 2000 VALUE Index,3
+86,ICE BOFA 3-MONTH U.S.TREASURY BILL Index,3
+87,"Bloomberg U.S.Aggregate Bond Index reflects no deduction for fees, expenses, or taxes",3
+88,Bloomberg High Yield Very Liquid Index,3
+89,Bloomberg U.S.MBS Index,3
+90,MSCI ACWI IMI Index,3
+91,MSCI All Country World Ex U.S.Index NR,3
+92,Russell 3000 Index&#160;,3
+93,Bloomberg Aggregate Bond Index,3
+94,"S&P Total Market Index (Returns do not reflect deductions for fees, expenses or taxes)",3
+95,MSCI Japan Index,3
+96,Bloomberg U.S.Universal Total Return Index,3
+97,S&P 500 Information Technology Index,3
+98,Bloomberg U.S.1-5 Year Government/Credit Index,3
+99,MSCI All Country World Index-NR,3
+100,"Russell 2000 Index reflects no deductions for fees, expenses or taxes",2
+101,"Russell 3000 Index reflects no deductions for fees, expenses or taxes",2
+102,"S&P 500 Index reflects no deductions for fees, expenses or taxes",2
+103,Bloomberg Global Aggregate Index&#160;,2
+104,MSCI EAFE Value Index&#160;,2
+105,MSCI Emerging Markets Index&#160;,2
+106,S&P National AMT-Free Municipal Bond Index,2
+107,NASDAQ Composite Total Return Index,2
+108,Lipper Balanced Funds Index,2
+109,Russell 2000 Total Return Index,2
+110,Bloomberg U.S.2000 Index,2
+111,ICE BofA U.S.All Capital Securities Index,2
+112,MSCI U.S.Minimum Volatility Index,2
+113,Nasdaq Composite Index,2
+114,Bloomberg Pennsylvania Municipal Bond Index,2
+115,Bloomberg 1 Year Municipal Bond Index,2
+116,Bloomberg U.S.Universal Bond Index,2
+117,FTSE World Government Bond Index,2
+118,Bloomberg U.S.Corporate High Yield Index,2
+119,Morningstar LSTA U.S.Leveraged Loan 100 Index,2
+120,Russell 1000 Equal Weight Index,2
+121,S&P 500 Financials Index,2
+122,ICE BofA U.S.Cash Pay High Yield Constrained Index,2
+123,Bloomberg 3-15 Year Blend Municipal Bond Index,2
+124,"S&P 500 Index (Index returns do not reflect deductions for fees, expenses or taxes)",2
+125,Bloomberg U.S.Credit Index,2
+126,ICE BofA 1 3 Year U.S.Treasury Index,2
+127,S&P 1000 Index,2
+128,Bloomberg U.S.Aggregate Index&#160;,2
+129,Russell 2000 Value Index&#160;,2
+130,"MSCI All-Country World Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",2
+131,"Russell 2000 Value Index reflects no deduction for fees, expenses or taxes",2
+132,"Russell 3000 Index reflects no deduction for fees, expenses, or taxes",2
+133,Bloomberg 1-3 Month U.S.Treasury Bill Index,2
+134,Bloomberg U.S.Government Inflation-Linked Bond Index,2
+135,Bloomberg U.S.Intermediate Corporate Bond Index,2
+136,S&P Banks Select Industry Index,2
+137,S&P Oil & Gas Equipment & Services Select Industry Index,2
+138,S&P Pharmaceuticals Select Industry Index,2
+139,Bloomberg U.S.Government/Credit 1-3 Year Index,2
+140,JP Morgan CLOIE AAA Index,2
+141,MSCI ACWI ex U.S.Investable Market Index,2
+142,Dow Jones U.S.Select Dividend Index,2
+143,JP Morgan EMBI Global Diversified Index,2
+144,S&P Target Date To 2055 Index,2
+145,S&P Target Date To 2030 Index,2
+146,S&P Target Date To 2035 Index,2
+147,S&P Target Date To 2040 Index,2
+148,S&P Target Date To 2045 Index,2
+149,S&P Target Date To 2050 Index,2
+150,S&P Target Date To 2060 Index,2
+151,Morningstar LSTA Leveraged Loan Index,2
+152,ICE BofA 3 Month U.S.Treasury Bill Index,2
+153,Morningstar U.S.Moderate Target Allocation Index,2
+154,FTSE 3-Month U.S.Treasury Bill Index,2
+155,Bloomberg U.S.Aggregate Float Adjusted Index,2
+156,MSCI India Index,2
+157,MSCI All Country World Index NR,2
+158,Bloomberg U.S.Corporate High Yield Bond Index,2
+159,"MSCI All Country World Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or taxes)",2
+160,CBOE S&P 500 BuyWrite Monthly Index,2
+161,Bloomberg U.S.Short Aggregate Enhanced Yield Index,2
+162,Bloomberg U.S.Short Aggregate Composite Index,2
+163,MSCI AC World Index,2
+164,S&P 500 Health Care Index,2
+165,Bloomberg 1-5 Year U.S.Government/Credit Index,2
+166,Morningstar Aggressive Target Risk Index,2
+167,MSCI ACWI Investable Market Index,2
+168,S&P Global Broad Market Index,2
+169,Bloomberg 1-5 Year Government/Credit Index,2
+170,Bloomberg U.S.Corporate High Yield 2% Issuer Capped Index,2
+171,Russell 2000 Value Total Return Index,2
+172,S&P Composite 1500 Total Return Index,2
+173,Bloomberg 500 Index,2
+174,CBOE S&P 500 BuyWrite Index,2
+175,Bloomberg U.S.Government/Credit Bond Index,1
+176,Bloomberg U.S.Intermediate Credit Index,1
+177,Bloomberg U.S.Intermediate Government/Credit Index,1
+178,S&P Municipal Bond Investment Grade Intermediate Index,1
+179,S&P Municipal Bond Investment Grade Short Index,1
+180,ICE BofA Merrill Lynch 3-Month U.S.Treasury Bill Index,1
+181,"Russell 2000 Value Index reflects no deductions for fees, expenses or taxes",1
+182,"ICE BofA 1-5 Year U.S.Corporate/Government Index reflects no deductions for fees, expenses or taxes",1
+183,Dow Jones Index,1
+184,Bloomberg Municipal 1-3 Years Index1,1
+185,Bloomberg Municipal 3-15 Years Blend Index1,1
+186,Bloomberg U.S.Municipal Bond Index1,1
+187,"Bloomberg Municipal High Yield Index*reflects no deductions for fees, expenses or taxes",1
+188,"NYSE Technology Index reflects no deductions for fees, expenses or taxes",1
+189,"Russell 1000 Index reflects no deductions for fees, expenses or taxes",1
+190,"Russell 1000 Value Index reflects no deductions for fees, expenses or taxes",1
+191,"Russell Midcap Value Index reflects no deductions for fees, expenses or taxes",1
+192,"Bloomberg U.S.Universal Index reflects no deductions for fees, expenses or taxes",1
+193,"S&P UBS Leveraged Loan Index reflects no deductions for fees, expenses or taxes",1
+194,Bloomberg Municipal 1-3 Years Index*,1
+195,"Bloomberg U.S.Aggregate Bond Index reflects no deductions for fees, expenses or taxes",1
+196,"Bloomberg U.S.Government/Credit Bond Index reflects no deductions for fees, expenses or taxes",1
+197,"Bloomberg U.S.Intermediate Credit Index reflects no deductions for fees, expenses or taxes",1
+198,"Bloomberg U.S.Intermediate Government/Credit Index reflects no deductions for fees, expenses or taxes",1
+199,Bloomberg U.S.Municipal Bond Index*,1
+200,"Morningstar Moderate Target Risk Index reflects no deductions for fees, expenses or taxes",1
+201,"MSCI EAFE Index reflects no deductions for fees, expenses or taxes",1
+202,"MSCI Emerging Markets Index reflects no deductions for fees, expenses or taxes",1
+203,"Russell Midcap Index reflects no deductions for fees, expenses or taxes",1
+204,"S&P Municipal Bond Index reflects no deductions for fees, expenses or taxes",1
+205,"S&P Municipal Bond Index* reflects no deductions for fees, expenses or taxes",1
+206,"S&P Municipal Bond Investment Grade Intermediate Index reflects no deductions for fees, expenses or taxes",1
+207,"S&P Municipal Bond Investment Grade Short Index reflects no deductions for fees, expenses or taxes",1
+208,Bloomberg California Exempt Municipal Bond Index&#160;,1
+209,Bloomberg New York Exempt Municipal Bond Index&#160;,1
+210,MSCI ACWI All Cap Index&#160;,1
+211,S&P Target Risk Conservative Index&#160;,1
+212,S&P Target Risk Moderate Index&#160;,1
+213,Morgan Stanley Capital International All Country World ex U.S.Index&#160;,1
+214,Bloomberg U.S.Universal Bond Index&#160;,1
+215,FTSE Developed ex U.S.Comprehensive Factor Index&#160;,1
+216,FTSE Developed ex U.S.Net Tax Index&#160;,1
+217,ICE BofA BB-B Non-FNCL Non-Distressed U.S.HY Constrained Index&#160;,1
+218,MSCI EAFE Selection Index&#160;,1
+219,MSCI Global Climate 500 EM Selection Index&#160;,1
+220,MSCI Kokusai Index&#160;,1
+221,MSCI U.S.Climate Action Index&#160;,1
+222,MSCI U.S.Index&#160;,1
+223,MSCI U.S.Selection Index&#160;,1
+224,MSCI World Index&#160;,1
+225,Russell 1000 2Qual/Val 5% Capped Factor Index&#160;,1
+226,Russell 1000 Comprehensive Factor Index&#160;,1
+227,S&P 100 Ex-Top 20 Select Index&#160;,1
+228,S&P Composite 1500 Index&#160;,1
+229,S&P 500 Growth Scored & Screened Index&#160;,1
+230,S&P 500 Scored & Screened Index&#160;,1
+231,S&P 500 Value Scored & Screened Index&#160;,1
+232,S&P High Yield Dividend Aristocrats Screened Index&#160;,1
+233,S&P MidCap 400 Index&#160;,1
+234,S&P MidCap 400 Scored & Screened Index&#160;,1
+235,S&P Intermediate Term California AMT-Free Municipal Bond Index,1
+236,S&P Municipal Bond California 50% Investment Grade/50% High Yield Index,1
+237,NYSE Arca Gold Miners Index,1
+238,S&P 500 Equal Weight Total Return Index,1
+239,"MSCI ACWI Net Total Return Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses, or taxes)",1
+240,"S&P Global REIT Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses, or taxes)",1
+241,MSCI AC World Index ex U.S.Net Index,1
+242,MSCI All Country World ex-U.S.Small Cap Index,1
+243,Russell 3000 Growth Total Return Index,1
+244,Russell 3000 Total Return Index?,1
+245,Russell 2500TM Index,1
+246,Russell 2500TM Value Index,1
+247,Bloomberg Mortgage Backed Securities Index,1
+248,Bloomberg Municipal 1-15 Year Index,1
+249,21Shares FTSE Crypto 10 ex-BTC Index ETF Class,1
+250,21Shares FTSE Crypto 10 ex-BTC Index ETF,1
+251,21Shares FTSE Crypto 10 Index ETF,1
+252,Russell 1000 Total Return Index,1
+253,MSCI All Country World Index ex U.S.,1
+254,Russell 1000 Growth Total Return Index,1
+255,Russell 3000 Index?,1
+256,S&P Real Assets Equity Index,1
+257,Bloomberg Short Treasury Total Return Index,1
+258,"FTSE NAREIT All Equity REITS Total Return Index, Since 5/15/18",1
+259,JP Morgan CLO High Quality Mezzanine Index,1
+260,JP Morgan CLOIE AAA Total Return Index,1
+261,Bloomberg Intermediate Government/Credit Bond Index,1
+262,Lipper Mid-Cap Growth Funds Index,1
+263,S&P 500 Index/Bloomberg Intermediate Government/Credit Bond Index,1
+264,Russell Mid Cap Index,1
+265,Bloomberg Municipal Bond: Muni Inter-Short Index,1
+266,CRSP U.S.Total Market Index,1
+267,S&P Classic ADR Composite Index,1
+268,FTSE U.S.Broad Investment Grade Bond Index,1
+269,Morningstar Global Markets ex-U.S.Index,1
+270,Morningstar Global Markets ex-U.S.Large-Mid Index,1
+271,Morningstar U.S.Market Total Return Index,1
+272,Bloomberg 1-15 Year Municipal Bond Index,1
+273,Bloomberg U.S.Corporate 1-5 Years Index,1
+274,MSCI AC World Index ex U.S.Index,1
+275,S&P SmallCap 600 TR Index,1
+276,Bloomberg Microcap Total Return Index,1
+277,Bloomberg U.S.2000 Growth Index,1
+278,NASDAQ Internet Index,1
+279,Bloomberg Commodity Index TR,1
+280,Bloomberg U.S.Treasury TIPS Index,1
+281,"FTSE EPRA/NAREIT Developed Markets Index NTR (reflects withholding taxes on foreign dividends, but no deduction for fees, expenses, or other taxes)",1
+282,"FTSE EPRA Nareit Developed Net Tax Index (reflects withholding taxes on foreign dividends, but no deduction for fees, expenses, or other taxes)",1
+283,"FTSE Global Core Infrastructure 50/50 Net Tax Index (reflects withholding taxes on foreign dividends, but no deduction for fees, expenses, or other taxes)",1
+284,"MSCI ACWI Index NTR (reflects withholding taxes on foreign dividends, but no deduction for fees, expenses, or other taxes)",1
+285,"MSCI ACWI NR USD Index (reflects withholding taxes on foreign dividends, but no deduction for fees, expenses, or other taxes)",1
+286,"MSCI EAFE Index NTR (reflects withholding taxes on foreign dividends, but no deduction for fees, expenses, or other taxes)",1
+287,"MSCI World ex U.S.Small Cap Index NTR (reflects withholding taxes on foreign dividends, but no deduction for fees, expenses, or other taxes)",1
+288,"S&P Global Infrastructure Index NTR (reflects withholding taxes on foreign dividends, but no deduction for fees, expenses, or other taxes) 1",1
+289,"S&P Global Natural Resources Index NTR (reflects withholding taxes on foreign dividends, but no deduction for fees, expenses, or other taxes)",1
+290,JPMorgan Emerging Markets Bond Index Global Diversified,1
+291,MSCI All Country World Small Mid Cap Index,1
+292,FTSE EPRA Nareit Developed Real Estate Index,1
+293,MSCI All Country World Minimum Volatility Index,1
+294,Bloomberg 1 10 Year Municipal Bond Blend Index,1
+295,Bloomberg U.S.1 10 Year Municipal Bond Blend Index,1
+296,S000093944 Bloomberg Municipal Bond Index,1
+297,S000093946 Bloomberg Municipal Bond Index,1
+298,S000047073 MSCI ACWI Index,1
+299,S000011057 Bloomberg U.S.Aggregate Bond Index,1
+300,Bloomberg Global Aggregate Bond USD Hedged Index,1
+301,MSCI ACWI net Index,1
+302,S000010512 MSCI ACWI Index,1
+303,S000010515 MSCI ACWI net Index,1
+304,sixty S And P 500 Index 40 Bloomberg U.S.Government Credit Index,1
+305,FT Wilshire 5000 Index,1
+306,MSCI ACWI Small Cap Index,1
+307,MSCI All Country World ex U.S.Index,1
+308,Russell 3000 Health Care Index,1
+309,S&P North American Technology Index,1
+310,ICE BofA High Yield U.S.Corporate Cash Pay BB-B USD Index,1
+311,MSCI EAFE Index with Net Dividends,1
+312,Fidelity MSCI Consumer Discretionary Index ETF Fidelity MSCI Consumer Discretionary Index ETF,1
+313,Fidelity MSCI Utilities Index ETF Fidelity MSCI Utilities Index ETF,1
+314,Fidelity MSCI Consumer Staples Index ETF Fidelity MSCI Consumer Staples Index ETF,1
+315,Fidelity MSCI Energy Index ETF Fidelity MSCI Energy Index ETF,1
+316,Fidelity MSCI Financials Index ETF Fidelity MSCI Financials Index ETF,1
+317,Fidelity MSCI Health Care Index ETF Fidelity MSCI Health Care Index ETF,1
+318,Fidelity MSCI Industrials Index ETF Fidelity MSCI Industrials Index ETF,1
+319,Fidelity MSCI Information Technology Index ETF Fidelity MSCI Information Technology Index ETF,1
+320,Fidelity MSCI Materials Index ETF Fidelity MSCI Materials Index ETF,1
+321,Fidelity MSCI Communication Services Index ETF Fidelity MSCI Communication Services Index ETF,1
+322,Fidelity MSCI Real Estate Index ETF Fidelity MSCI Real Estate Index ETF,1
+323,Fidelity MSCI Consumer Discretionary Index ETF,1
+324,Fidelity MSCI Utilities Index ETF,1
+325,Fidelity MSCI Consumer Staples Index ETF,1
+326,Fidelity MSCI Energy Index ETF,1
+327,Fidelity MSCI Financials Index ETF,1
+328,Fidelity MSCI Health Care Index ETF,1
+329,Fidelity MSCI Industrials Index ETF,1
+330,Fidelity MSCI Information Technology Index ETF,1
+331,Fidelity MSCI Materials Index ETF,1
+332,Fidelity MSCI Communication Services Index ETF,1
+333,Fidelity MSCI Real Estate Index ETF,1
+334,Bloomberg U.S.Treasury Inflation Protected Securities TIPS Index,1
+335,FTSE 3 Month U.S.Treasury Bill Index,1
+336,S000008437 Bloomberg U.S.Aggregate Bond Index,1
+337,S000008438 Bloomberg U.S.Corporate High Yield Bond Index,1
+338,S000008438 Bloomberg U.S.Universal Bond Index,1
+339,S000008439 FTSE Non U.S.Dollar World Government Bond Index USD Hedged,1
+340,S000008439 FTSE Non U.S.Dollar World Government Bond Index USD Unhedged,1
+341,S000052236 Bloomberg U.S.Aggregate Bond Index,1
+342,S000052237 Bloomberg U.S.Aggregate Bond Index,1
+343,S000060155 Bloomberg U.S.Universal Bond Index,1
+344,HFRX Global Hedge Index,1
+345,S000088120 Russell 2500 Index,1
+346,S000088120 Russell 3000 Index,1
+347,Bloomberg Municipal Bond 1-5 Year Blend Index,1
+348,Bloomberg Wisconsin Municipal Bond Index,1
+349,Bloomberg 1-3 Year Composite Municipal Bond Index,1
+350,Bloomberg California Municipal 1-5 Year Blend Index,1
+351,Bloomberg California Municipal Bond Index,1
+352,Bloomberg Municipal Bond 1-15 Year Blend Index,1
+353,Bloomberg Short-Intermediate Municipal Bond Index,1
+354,Bloomberg U.S.Aggregate ex Credit Index,1
+355,Bloomberg U.S.1-3 Year Government Bond Index,1
+356,ICE BofA 1-3 Year BB U.S.Cash Pay High Yield Index,1
+357,Bloomberg U.S.Government Bond Index,1
+358,Bloomberg Short-Term Government/Corporate Bond Index,1
+359,MSCI All Country World Ex-U.S.Net Index Return,1
+360,60% MSCI All Country World Index/40% FTSE World Government Bond Index,1
+361,MSCI World ex-U.S.Index,1
+362,Bloomberg 1-3 Year Municipal Bond Index,1
+363,Bloomberg 3-10 Year Blend Total Return Index Unhedged*,1
+364,Bloomberg U.S.Government Index,1
+365,Bloomberg U.S.High Yield Ba/B 2% Issuer Capped Index,1
+366,Bloomberg U.S.Securitized Index,1
+367,S&P Global Infrastructure Index,1
+368,"S&P 500 Index (returns reflect no deduction for fees, expenses, or taxes)",1
+369,Blended 35% Russell 3000 Index/65% Bloomberg Intermediate U.S.Aggregate Bond Index,1
+370,Blended 60% Russell 3000 Index/40% Bloomberg Intermediate U.S.Aggregate Bond Index,1
+371,Russell 3000 Index Return,1
+372,ICE BofA All U.S.Convertibles Index,1
+373,"Bloomberg Global Aggregate ex USD 50% Hedged Index (Indices reflect no deduction for fees, expenses or taxes.)",1
+374,"Bloomberg Global Aggregate Index (Index reflects no deduction for fees, expenses or taxes.)",1
+375,"Bloomberg Municipal Bond Index (Index reflects no deduction for fees, expenses or taxes.)",1
+376,"Bloomberg U.S.Aggregate Bond Index (Index reflects no deduction for fees, expenses or taxes.)",1
+377,"Bloomberg U.S.Government/ Credit Index (Index reflects no deduction for fees, expenses or taxes.)",1
+378,"Bloomberg U.S.Government/Credit Index (Index reflects no deduction for fees, expenses or taxes.)",1
+379,"Bloomberg U.S.Mortgage-Backed Securities Index (Index reflects no deduction for fees, expenses or taxes.)",1
+380,"Bloomberg U.S.Municipal 3-15 Year Blend Index (Index reflects no deduction for fees, expenses or taxes.)",1
+381,"FTSE EPRA/NAREIT Developed Index (Index reflects no deduction for fees, expenses or taxes.)",1
+382,"FTSE Three-Month U.S.Treasury Bill Index (Index reflects no deduction for fees, expenses or taxes.)",1
+383,"ICE BofA Global High Yield Index (Index reflects no deduction for fees, expenses or taxes.)",1
+384,MSCI EAFE Index (Index reflects no deduction for fees and expenses.),1
+385,MSCI Emerging Markets Index (Index reflects no deduction for fees and expenses),1
+386,MSCI World Index (Index reflects no deduction for fees and expenses.),1
+387,"MSCI World Index (Index reflects no deduction for fees, expenses or taxes.)",1
+388,"Russell 1000 Growth Index (Index reflects no deduction for fees, expenses or taxes.)",1
+389,"Russell 1000 Index (Index reflects no deduction for fees, expenses or taxes.)",1
+390,"Russell 1000 Value Index (Index reflects no deduction for fees, expenses or taxes.)",1
+391,"Russell 2500 Growth Index (Index reflects no deduction for fees, expenses or taxes.)",1
+392,"Russell 2500 Value Index (Index reflects no deduction for fees, expenses or taxes.)",1
+393,"Russell 3000 Index (Index reflects no deduction for fees, expenses or taxes.)",1
+394,Blended - ICE U.S.Municipal AMT-Free VRDO Constrained Index,1
+395,Blended - ICE Variable Rate Preferred & Hybrid Securities Index,1
+396,BlendedICE BofA U.S.Taxable Municipal Securities Plus Index,1
+397,Bloomberg Municipal 1-Year Bond Index,1
+398,Bloomberg Municipal Bond 20 Year Index,1
+399,Dow Jones U.S.Real Estate Index,1
+400,ICE 1-30 Year Laddered Maturity U.S.Treasury Index,1
+401,ICE BofA California Long-Term Core Plus Municipal Securities Index,1
+402,ICE BofA Core Plus Fixed Rate Preferred Securities Index,1
+403,ICE BofA National Long-Term Core Plus Municipal Securities Index,1
+404,ICE BofA New York Long-Term Core Plus Municipal Securities Index,1
+405,ICE BofA U.S.Corporate Master Index,1
+406,ICE BofA U.S.Taxable Municipal Securities Plus Index,1
+407,ICE U.S.Municipal AMT-Free VRDO Constrained Index,1
+408,ICE U.S.Treasury Short Bond Index,1
+409,ICE Variable Rate Preferred & Hybrid Securities Index,1
+410,KBW Nasdaq Bank Index,1
+411,KBW Nasdaq Financial Sector Dividend Yield Index,1
+412,KBW Nasdaq Premium Yield Equity REIT Index,1
+413,KBW Nasdaq Property & Casualty Index,1
+414,KBW Nasdaq Regional Banking Index,1
+415,"MSCI ACWI Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or other taxes)",1
+416,"MSCI World Growth Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or other taxes)",1
+417,Nasdaq Biotechnology Index,1
+418,Nasdaq Innovators Completion Cap Index,1
+419,Nasdaq Next Generation 100 ESG Index,1
+420,Nasdaq Next Generation 100 Index,1
+421,Nasdaq U.S.Free Cash Flow Achievers Index,1
+422,Nasdaq-100 ESG Index,1
+423,S&P 500 Enhanced Value Index,1
+424,S&P 500 Equal Weight Scored & Screened Leaders Select Index,1
+425,S&P 500 High Beta Index,1
+426,S&P 500 High Dividend Growth Index,1
+427,S&P 500 Low Volatility High Dividend Index,1
+428,S&P 500 Low Volatility Index,1
+429,S&P 500 Low Volatility Rate Response Index,1
+430,S&P 500 Minimum Volatility Index,1
+431,S&P 500 Momentum Index,1
+432,S&P 500 Property & Casualty Index,1
+433,"S&P 500 Quality, Value & Momentum Top 90% Multi-factor Index",1
+434,S&P 500 Revenue-Weighted Index,1
+435,S&P 900 Dividend Revenue-Weighted Index,1
+436,S&P 900 Index,1
+437,S&P Composite 1500 Biotechnology Index,1
+438,S&P Composite 1500 Commercial Banks Index,1
+439,S&P Composite 1500 Semiconductor Index,1
+440,S&P MidCap 400 Low Volatility Index,1
+441,"S&P MidCap 400 Quality, Value & Momentum Top 90% Multi-factor Index-TR",1
+442,S&P MidCap 400 Revenue-Weighted Index,1
+443,S&P SmallCap 600 Capped Consumer Discretionary Index,1
+444,S&P SmallCap 600 Capped Consumer Staples Index,1
+445,S&P SmallCap 600 Capped Energy Index,1
+446,S&P SmallCap 600 Capped Financials & Real Estate Index,1
+447,S&P SmallCap 600 Capped Health Care Index,1
+448,S&P SmallCap 600 Capped Industrials Index,1
+449,S&P SmallCap 600 Capped Information Technology Index,1
+450,S&P SmallCap 600 Capped Materials Index,1
+451,S&P SmallCap 600 Capped Utilities & Communication Services Index,1
+452,S&P SmallCap 600 Low Volatility Index,1
+453,S&P SmallCap 600 Quality Index,1
+454,"S&P SmallCap 600 Quality, Value & Momentum Top 90% Multi-factor Index",1
+455,S&P SmallCap 600 Revenue-Weighted Index,1
+456,S&P U.S.Preferred Stock Index,1
+457,Bloomberg Pricing Power Index,1
+458,"FTSE Developed ex U.S.Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or other taxes)",1
+459,"FTSE Developed ex U.S.Invesco Dynamic Multifactor Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or other taxes)",1
+460,"MSCI EAFE Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or other taxes)",1
+461,Russell 1000 Invesco Dynamic Multifactor Index,1
+462,Russell 2000 Invesco Dynamic Multifactor Index,1
+463,Bloomberg U.S.Government/Credit Index,1
+464,"FTSE EPRA/NAREIT Developed Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or other taxes)",1
+465,JP Morgan Leveraged Loan Index,1
+466,S&P Municipal Bond High Yield Index,1
+467,S&P Municipal Bond Short Index,1
+468,Schwab 1000 Index ETF,1
+469,Dow Jones International Dividend 100 Index?,1
+470,Dow Jones U.S.Broad Stock Market Index,1
+471,Dow Jones U.S.Dividend 100 Index,1
+472,Dow Jones U.S.Large-Cap Growth Total Stock Market Index,1
+473,Dow Jones U.S.Large-Cap Total Stock Market Index,1
+474,Dow Jones U.S.Large-Cap Value Total Stock Market Index,1
+475,Dow Jones U.S.Mid-Cap Total Stock Market Index,1
+476,Dow Jones U.S.Small-Cap Total Stock Market Index,1
+477,FTSE Developed ex U.S.Index,1
+478,FTSE Developed Small Cap ex U.S.Liquid Index?,1
+479,FTSE Emerging Index,1
+480,MSCI Emerging Markets Index?,1
+481,Schwab 1000 Index,1
+482,Bloomberg California Municipal 3-15 Year Blend Index?,1
+483,Bloomberg Municipal 3-15 Year Blend Index,1
+484,Bloomberg U.S.Government/Credit 1-5 Year Index,1
+485,S&P California AMT-Free Municipal Bond Index,1
+486,Bloomberg 1-Year Municipal Bond Index Return,1
+487,Bloomberg 3-10 Year Municipal Blend Index Return,1
+488,Bloomberg 3-15 Year Municipal Blend Index Return,1
+489,Bloomberg California Intermediate Municipal Index Return,1
+490,Bloomberg Massachusetts Intermediate Municipal Index Return,1
+491,Bloomberg New York Intermediate Municipal Index Return,1
+492,Bloomberg Pennsylvania Intermediate Municipal Index Return,1
+493,S&P 500 Price Index,1
+494,"MSCI Emerging Markets Index (reflects net dividends, which reflect the deduction of withholding taxes)",1
+495,ICE BofA U.S.Dollar 3-Month Deposit Offered Rate Constant Maturity Index,1
+496,"ICE BofA 1-3 Year U.S.Corporate Index Reflects no deduction for fees, expenses, or taxes",1
+497,Bloomberg Global-Aggregate Total Return Index Value Hedged USD,1
+498,S&P 500 Index TR,1
+499,Bloomberg Arizona Municipal Bond Index,1
+500,Bloomberg Connecticut Municipal Bond Index,1
+501,Bloomberg New Jersey Municipal Bond Index,1
+502,Bloomberg Long U.S.Corporate Index,1
+503,"MSCI China Index (reflects net dividends, which reflect the deduction of withholding taxes)",1
+504,"MSCI World Index (reflects net dividends, which reflect the deduction of withholding taxes)",1
+505,"MSCI World Health Care Index (reflects net dividends, which reflect the deduction of withholding taxes)",1
+506,"MSCI ACWI Index (reflects net dividends, which reflect the deduction of withholding taxes)",1
+507,Blended Index (60% MSCI ACWI Index and 40% Bloomberg U.S.Aggregate Bond Index,1
+508,Blended Index (60% Bloomberg U.S.Aggregate Bond Index and 40% MSCI ACWI Index),1
+509,Bloomberg Georgia Municipal Bond Index,1
+510,Bloomberg Maryland Municipal Bond Index,1
+511,Bloomberg Missouri Municipal Bond Index,1
+512,Bloomberg North Carolina Municipal Bond Index,1
+513,Bloomberg Oregon Municipal Bond Index,1
+514,Bloomberg South Carolina Municipal Bond Index,1
+515,Bloomberg Virginia Municipal Bond Index,1
+516,MSCI ACWI ex-U.S.Index,1
+517,MSCI ACWI Index(From Inception Date of R5 Class and R6 Class Shares),1
+518,NYSE Arca Steel Index,1
+519,MSCI ACWI Net TR Index,1
+520,NYSE Arca Environmental Services Index,1
+521,HFRX Event Driven Index,1
+522,Russell MidCap Value Index,1
+523,ICE BofA ML Corp Govt 1 to 3 Yr Index,1
+524,Russell Microcap Growth Index,1
+525,S&P 500 Index No Load,1
+526,S&P 400 Midcap Index,1
+527,S&P 500 Index Inst,1
+528,S&P 500 Index Inv,1
+529,S&P 500 Index Select,1
+530,S&P 500 Index Texas,1
+531,Bloomberg 3 year Municipal Bond Index,1
+532,S000094550 Bloomberg Municipal Bond Index,1
+533,S000094551 Bloomberg Municipal Bond Index,1
+534,S000094552 Bloomberg Municipal Bond Index,1
+535,S000094553 Bloomberg Municipal Bond Index,1
+536,S000094554 Bloomberg Municipal Bond Index,1
+537,S000094555 Bloomberg Municipal Bond Index,1
+538,S000094556 Bloomberg Municipal Bond Index,1
+539,S000094557 Bloomberg Municipal Bond Index,1
+540,S000094558 Bloomberg Municipal Bond Index,1
+541,Bloomberg MBS Index,1
+542,Bloomberg U.S.Bellwether 10 Year Swap Index,1
+543,Bloomberg U.S.Treasury 7 10 Year Bond Index,1
+544,S000001470 Bloomberg U.S.Aggregate Bond Index,1
+545,S000011985 Bloomberg U.S.Aggregate Bond Index,1
+546,S000071703 Bloomberg Municipal Bond Index,1
+547,Bloomberg Global Aggregate ex-USD Index&#160;,1
+548,"50% JPMorgan Global Bond Index Emerging Markets-Global Diversified, 25% JPMorgan Emerging Markets Bond Index Global and 25% JPMorgan Corporate Emerging Market Bond Index Diversified&#160;",1
+549,"Russell 2500TM Index,",1
+550,S&P MidCap 400 ESG Index,1
+551,S&P TARGET DATE 2025 Index,1
+552,S&P TARGET DATE 2030 Index,1
+553,S&P TARGET DATE 2035 Index,1
+554,S&P TARGET DATE 2040 Index,1
+555,S&P TARGET DATE 2045 Index,1
+556,S&P TARGET DATE 2050 Index,1
+557,S&P TARGET DATE 2055 Index,1
+558,S&P TARGET DATE 2060 Index,1
+559,S&P TARGET DATE RETIREMENT INCOME Index,1
+560,BLOOMBERG U.S.INTERMEDIATE AGGREGATE Index,1
+561,LIPPER MIXED-ASSET TARGET ALLOCATION AGGRESSIVE GROWTH FUNDS Index,1
+562,LIPPER MIXED-ASSET TARGET ALLOCATION CONSERVATIVE FUNDS Index,1
+563,LIPPER MIXED-ASSET TARGET ALLOCATION GROWTH FUNDS Index,1
+564,LIPPER MIXED-ASSET TARGET ALLOCATION MODERATE FUNDS Index,1
+565,RUSSELL 2000 GROWTH Index,1
+566,RUSSELL 2500 Index,1
+567,RUSSELL MIDCAP GROWTH Index,1
+568,RUSSELL MIDCAP VALUE Index,1
+569,RUSSELL 3000 GROWTH Index,1
+570,NASDAQ-100 Index,1
+571,RUSSELL 1000 EQUAL WEIGHT TECHNOLOGY Index,1
+572,S&P COMPOSITE 1500 Index,1
+573,ICE BOFA U.S.ALL CAPITAL SECURITIES Index,1
+574,75%ICE BOFA U.S.ALL CAPITAL SECURITIES INDEX/25%BLOOMBERG DEVELOPED MKT. USD CONTINGENT CAPITAL Index,1
+575,S&P TARGET DATE 2065+ Index,1
+576,MSCI WORLD Index,1
+577,RUSSELL 2000 Index,1
+578,RUSSELL 3000 VALUE Index,1
+579,RUSSELL MIDCAP Index,1
+580,60% MSCI WORLD INDEX / 40% BLOOMBERG U.S.AGGREGATE Index,1
+581,S000002334 Bloomberg Municipal Bond Index,1
+582,S000002335 Bloomberg Municipal 1 5 Year Index,1
+583,S000002335 Bloomberg Municipal Bond Index,1
+584,S000002177 MSCI EAFE Index,1
+585,S000002177 MSCI EMU Index,1
+586,S000002724 MSCI All Country World Index,1
+587,S000004034 Bloomberg Municipal Bond Index,1
+588,50% MSCI ACWI High Dividend Yield Index / 50% Bloomberg U.S.Aggregate Index&#160;,1
+589,MSCI All Country World ex U.S.Index&#160;,1
+590,MSCI All Country World ex U.S.Value Index&#160;,1
+591,MSCI All Country World Index&#160;,1
+592,MSCI Emerging Markets Value Index&#160;,1
+593,S&P Target Date 2030 Index&#160;,1
+594,S&P Target Date 2035 Index&#160;,1
+595,S&P Target Date 2040 Index&#160;,1
+596,S&P Target Date 2045 Index&#160;,1
+597,S&P Target Date 2050 Index&#160;,1
+598,S&P Target Date 2055 Index&#160;,1
+599,S&P Target Date 2060 Index&#160;,1
+600,S&P Target Date 2065+ Index&#160;,1
+601,S&P Target Date Retirement Income Index&#160;,1
+602,Bloomberg 1-15 Year Municipal Bond Index&#160;,1
+603,Bloomberg 1-Year Municipal Bond Index&#160;,1
+604,Bloomberg Commodity Index Total Return&#160;,1
+605,Bloomberg U.S.MBS Fixed-Rate Index&#160;,1
+606,FTSE 3-Month Treasury Bill Index&#160;,1
+607,ICE BofA 0-5 Year U.S.High Yield Constrained Index&#160;,1
+608,ICE BofA 1-3 Year U.S.Treasury Index&#160;,1
+609,ICE BofA 15+ Year U.S.Inflation-Linked Treasury Index&#160;,1
+610,ICE BofA 1-5 Year U.S.Inflation-Linked Treasury Index&#160;,1
+611,ICE BofA Long U.S.Treasury Principal STRIPS Index&#160;,1
+612,ICE BofA U.S.All Capital Securities Index&#160;,1
+613,ICE BofA U.S.Corporate Index&#160;,1
+614,ICE BofA U.S.Inflation-Linked Treasury Index&#160;,1
+615,S000004419 Russell 2000 Index,1
+616,S000004423 Russell 3000 Index,1
+617,S000004423 Russell Microcap Index,1
+618,S000004424 Russell 3000 Index,1
+619,S000004424 Russell Microcap Index,1
+620,S000004427 Russell 2000 Value Index,1
+621,S000004427 Russell 3000 Index,1
+622,S000033567 Russell 2000 Value Index,1
+623,S000033567 Russell 3000 Index,1
+624,"Bloomberg U.S.Corporate Bond Index reflects no deduction for fees, expenses, or taxes",1
+625,"Bloomberg 1-3 Year Credit Index reflects no deduction for fees, expenses, or taxes",1
+626,"Bloomberg U.S.Treasury Bellwethers 3 Month Index reflects no deduction for fees, expenses, or taxes",1
+627,"MSCI EAFE Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+628,"Blended-Nasdaq Victory International Value Momentum Index/MSCI World ex U.S.Select Value Momentum Blend Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+629,"Nasdaq DM Ex United States Large Mid Cap Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+630,"Nasdaq Emerging Market Large Mid Cap Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+631,"Nasdaq U.S.1300 Small Mid Cap Index reflects no deduction for fees, expenses, or taxes",1
+632,"Nasdaq U.S.500 Large Cap Index reflects no deduction for fees, expenses, or taxes",1
+633,"Nasdaq Victory Dividend Accelerator Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+634,"Nasdaq Victory Emerging Market Value Momentum Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+635,"Blended-Nasdaq Victory Emerging Market Value Momentum Index/MSCI Emerging Markets Select Value Momentum Blend Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+636,"Nasdaq Victory International 500 Volatility Weighted Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+637,"Nasdaq Victory International Value Momentum Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+638,"Nasdaq Victory U.S.Large Cap High Dividend 100 Volatility Weighted Index reflects no deduction for fees, expenses, or taxes",1
+639,"Nasdaq Victory U.S.Multi-Factor Minimum Volatility Index reflects no deduction for fees, expenses, or taxes",1
+640,"Nasdaq Victory U.S.Small Cap High Dividend 100 Volatility Weighted Index reflects no deduction for fees, expenses, or taxes",1
+641,"Nasdaq Victory U.S.Small Mid Cap Value Momentum Index reflects no deduction for fees, expenses, or taxes",1
+642,"Blended-Nasdaq Victory U.S.Small Mid Cap Value Momentum Index/MSCI U.S.Small Cap Select Value Momentum Blend Index reflects no deduction for fees, expenses, or taxes",1
+643,"Nasdaq Victory U.S.Value Momentum Index reflects no deduction for fees, expenses, or taxes",1
+644,"Blended-Nasdaq Victory U.S.Value Momentum Index/MSCI U.S.Select Value Momentum Blend Index reflects no deduction for fees, expenses, or taxes",1
+645,"Russell 1000 Index reflects no deduction for fees, expenses, or taxes",1
+646,"Russell 1000 Value Index reflects no deduction for fees, expenses or taxes",1
+647,"S&P 500 Index reflects no deduction for fees, expenses or taxes",1
+648,"Bloomberg 1-5 Year U.S.Government Bond Index reflects no deduction for fees, expenses or taxes",1
+649,"ICE BofAML Investment Grade U.S.Convertible 5% Constrained Index reflects no deduction for fees, expenses, or taxes",1
+650,"ICE BofAML Investment Grade U.S.Convertible Index reflects no deduction for fees, expenses, or taxes",1
+651,"MSCI ACWI ex U.S.Index reflects no deduction for fees, expenses, or taxes",1
+652,"Russell 2500&#8482; Value Index reflects no deduction for fees, expenses or taxes",1
+653,"Russell Microcap Value Index reflects no deduction for fees, expenses, or taxes",1
+654,"Russell Midcap Growth Index reflects no deduction for fees, expenses, or taxes",1
+655,"Russell Midcap Index reflects no deduction for fees, expenses or taxes",1
+656,"Russell Midcap Value Index reflects no deduction for fees, expenses or taxes",1
+657,"S&P Developed ex-U.S.SmallCap Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+658,Bloomberg Emerging Market USD Sovereign and Sovereign Owned Index/Bloomberg Emerging USD Bond Core Index,1
+659,Bloomberg Long U.S.Treasury Index,1
+660,Bloomberg Managed Money Municipal Short Term Index,1
+661,Bloomberg Municipal Managed Money 1-25 Years Index/Bloomberg Municipal Managed Money Index,1
+662,Bloomberg Municipal Yield Index/S&P Municipal Yield Index,1
+663,Bloomberg 1-10 Year U.S.Government Inflation-Linked Bond Index,1
+664,Bloomberg 1-3 Year U.S.Treasury Index/Bloomberg 1-5 Year U.S.Treasury Index,1
+665,Bloomberg 3-10 Year U.S.Treasury Index/Bloomberg Intermediate U.S.Treasury Index,1
+666,Bloomberg 3-12 Month U.S.Treasury Bill Index,1
+667,Bloomberg U.S.1-3 Year Corporate Bond Index,1
+668,Bloomberg U.S.Convertible Liquid Bond Index,1
+669,Bloomberg U.S.Corporate Bond Index/Bloomberg Issuer Scored Corporate Index,1
+670,"""Bloomberg U.S.Dollar Floating Rate Note """"Less Than"""" 5 Years Index""",1
+671,Bloomberg U.S.High Yield 350mn Cash Pay 0-5 Yr 2% Capped Index,1
+672,Bloomberg U.S.Long Term Corporate Bond Index,1
+673,Dow Jones U.S.Select REIT Capped Index / Dow Jones U.S.Select REIT Index,1
+674,ICE BofA U.S.High Yield Index/ICE BofAML U.S.Diversified Crossover Corporate Index,1
+675,ICE Exchange-Listed Fixed & Adjustable Rate Preferred Securities Index/Wells Fargo Hybrid and Preferred Securities Aggregate Index,1
+676,MSCI U.S.Climate Paris Aligned Index,1
+677,MSCI U.S.Gender Diversity Select Index/SSGA Gender Diversity Index,1
+678,NYSE Technology Index,1
+679,Russell 1000 Low Volatility Focused Factor Index,1
+680,Russell 1000 Momentum Focused Factor Index,1
+681,Russell 1000 Yield Focused Factor Index,1
+682,S&P 1500 Low Valuation Tilt Index,1
+683,S&P 1500 Positive Momentum Tilt Index,1
+684,S&P 500 Fossil Fuel Reserves Free Index,1
+685,S&P 500 High Dividend Index,1
+686,S&P 500 Index/SSGA Large Cap Index/Russell 1000 Index,1
+687,S&P 500 Scored & Screened Index,1
+688,S&P Aerospace & Defense Select Industry Index,1
+689,S&P Capital Markets Select Industry Index,1
+690,S&P Composite 1500 Index/SSGA Total Stock Market Index/Russell 3000 Index,1
+691,S&P Health Care Equipment Select Industry Index,1
+692,S&P Health Care Services Select Industry Index,1
+693,S&P High Yield Dividend Aristocrats Index,1
+694,S&P Homebuilders Select Industry Index,1
+695,S&P Insurance Select Industry Index,1
+696,S&P Kensho Clean Power Index,1
+697,S&P Kensho Final Frontiers Index,1
+698,S&P Kensho Future Security Index,1
+699,S&P Kensho Intelligent Infrastructure Index,1
+700,S&P Kensho New Economies Composite Index,1
+701,S&P Kensho Smart Transportation Index,1
+702,S&P Metals & Mining Select Industry Index,1
+703,S&P MidCap 400 Index/S&P 1000 Index/Russell Small Cap Completeness Index,1
+704,S&P Oil & Gas Exploration & Production Select Industry Index,1
+705,S&P Regional Banks Select Industry Index,1
+706,S&P Retail Select Industry Index,1
+707,S&P Sector-Neutral High Yield Dividend Aristocrats Index,1
+708,S&P Semiconductor Select Industry Index,1
+709,S&P SmallCap 600 Index/SSGA Small Cap Index/Russell 2000 Index,1
+710,S&P SmallCap 600 Scored & Screened Index,1
+711,S&P Software & Services Select Industry Index,1
+712,S&P Telecom Select Industry Index,1
+713,S&P Transportation Select Industry Index,1
+714,State Street U.S.Large Cap Low Volatility Index/Russell 1000 Low Volatility Index,1
+715,State Street U.S.Small Cap Low Volatility Index/Russell 2000 Low Volatility Index,1
+716,Bloomberg U.S.Aggregate 1-3 Year Index,1
+717,Bloomberg U.S.Long Government/Credit Bond Index,1
+718,Bloomberg U.S.Treasury Bellwether 3 Month Index,1
+719,JP Morgan Corporate Emerging Market Bond Index Broad Diversified,1
+720,Cboe S&P 500 BuyWrite Index,1
+721,S000001463 Russell 3000 Index,1
+722,S000042770 Russell 3000 Index,1
+723,MSCI EAFE Index NR,1
+724,MSCI EAFE Value Index NR,1
+725,Bloomberg Municipal 1 15 Year Index,1
+726,Bloomberg Municipal 65 High Grade 35 High Yield Index,1
+727,S000040853 Bloomberg U.S.Aggregate Bond Index,1
+728,S000048334 Russell 3000 Index,1
+729,S000048335 Russell 3000 Index,1
+730,S000048336 Russell 3000 Index,1
+731,S000048337 Russell 3000 Index,1
+732,S000049700 MSCI EAFE Index,1
+733,S000049701 Bloomberg U.S.Aggregate Bond Index,1
+734,S000050632 Bloomberg Municipal Bond Index,1
+735,S000076295 Russell 3000 Index,1
+736,S000079794 Bloomberg Municipal Bond Index,1
+737,Blend comprised of 60% Russell 1000 Index and 40% Bloomberg U.S.Aggregate Bond Index&#160;,1
+738,MSCI All Country World Ex U.S.Index&#160;,1
+739,Bloomberg U.S.Long Government Credit Index,1
+740,ICE BofA SOFR Overnight Rate Index,1
+741,MSCI Europe Net Total Return USD Index,1
+742,S000028163 Bloomberg U.S.Aggregate Bond Index,1
+743,S000028163 Bloomberg U.S.Mortgage Backed Securities MBS Index,1
+744,S000028164 Bloomberg U.S.Aggregate Bond Index,1
+745,S000028165 Bloomberg Global Aggregate Bond Index,1
+746,S000028165 JP Morgan Emerging Markets Bond Global Diversified Index,1
+747,S000034129 Bloomberg U.S.Aggregate 1 3 Years Index,1
+748,S000034129 Bloomberg U.S.Aggregate Bond Index,1
+749,S000034129 I C E Bofa 1 3 Year U.S.Treasury Index,1
+750,S000039682 Bloomberg U.S.Aggregate Bond Index,1
+751,S000039682 Morningstar L S T A U.S.Leveraged Loan T R U.S.D Index,1
+752,S000044832 Bloomberg U.S.Aggregate Bond Index,1
+753,S000044833 Bloomberg Global Aggregate Bond Index,1
+754,S000044833 Bloomberg U.S.Aggregate 1 3 Years Index,1
+755,S000047461 Bloomberg U.S.Aggregate Bond Index,1
+756,S000051748 Bloomberg Global Aggregate Bond Index,1
+757,S000053014 Bloomberg U.S.Aggregate Bond Index,1
+758,S000065632 Bloomberg Global Aggregate Bond Index,1
+759,S000066303 Bloomberg U.S.Aggregate Bond Index,1
+760,Bloomberg 1-3 Year U.S.Government/Credit Index&#160;,1
+761,Bloomberg Global Aggregate Bond Index&#160;,1
+762,Bloomberg Global Aggregate Credit Index&#160;,1
+763,Bloomberg U.S.Corporate High-Yield Bond Index&#160;,1
+764,ICE BofA U.S.3-Month Treasury Bill Total Return Index&#160;,1
+765,Russell 2500TM Value Index&#160;,1
+766,Russell Midcap Value Index&#160;,1
+767,S000000605 Russell 3000 Index,1
+768,S000000605 Russell 3000 Value Index,1
+769,S000000606 Russell 2000 Value Index,1
+770,S000000606 Russell 3000 Index,1
+771,S000014608 Russell 1000 Index,1
+772,S000014608 Russell 1000 Value Index,1
+773,S000014609 Russell 2500 Value Index,1
+774,S000014609 Russell 3000 Index,1
+775,S000026520 MSCI World Index,1
+776,S000026520 MSCI World Value Index,1
+777,Bloomberg Municipal Taxable Bond Index,1
+778,Bloomberg U.S.Intermediate Government Bond Index,1
+779,S000011998 Bloomberg Municipal Bond Index,1
+780,S000011999 Bloomberg Municipal Bond Index,1
+781,S000012001 Bloomberg Municipal Bond Index,1
+782,S000012002 Bloomberg Municipal Bond Index,1
+783,S000012004 Bloomberg Municipal Bond Index,1
+784,ICE BofA U.S.3 Month Treasury Bill Index,1
+785,S000003464 Russell 3000 Index,1
+786,S000054182 MSCI World Index,1
+787,Bloomberg Municipal Bond Index/Bloomberg Municipal High Yield Bond Index,1
+788,Bloomberg 1-15 Year Municipal Index,1
+789,Bloomberg U.S.Corporate High Yield 1% Issuer Capped Index,1
+790,Bloomberg U.S.High Yield Ba/B 1-5 Year 1% Capped Index,1
+791,Bloomberg California 1-15 Year Municipal Intermediate Index,1
+792,Bloomberg 1-3 Year High Yield Corporate 1% Capped Index,1
+793,Bloomberg U.S.High Yield Very Liquid Index,1
+794,Bloomberg U.S.Aggregate 1 3 Years Index,1
+795,Bloomberg U.S.Mortgage Backed Securities MBS Index,1
+796,S000044833 Bloomberg U.S.Aggregate Index,1
+797,S000047461 Bloomberg U.S.Long Government Credit Index,1
+798,S000051748 FTSE World Government Bond Index,1
+799,S000055534 MSCI Europe Net Total Return USD Index,1
+800,Bloomberg Pan European High Yield Euro TR Index Hedged USD Spliced,1
+801,S000036906 ICE BofA Global Fixed Income Markets Index,1
+802,S000036907 ICE BofA Global Fixed Income Markets Index,1
+803,FTSE Global Core Infrastructure 50 50 Net Index,1
+804,FTSE U.S.Core Infrastructure Capped Index,1
+805,Fifty MSCI World High Dividend Index Net 50 Bloomberg U.S.High Yield 2 Issuer Capped Index,1
+806,S000062370 Bloomberg Global Aggregate Bond Index,1
+807,S000062370 ICE BofA 3 Month U.S.Treasury Bill Index,1
+808,Fifty Percent MSCI World Index Net 50 Bloomberg U.S.Aggregate Bond Index,1
+809,Thirty Three Point Three Four Percent MSCI World High Dividend Yield Index Net 33 33 Bloomberg U.S.Corporate High Yield 2 Issuer Capped Index 33 33 Bloomberg U.S.Aggregate Bond Index,1
+810,MSCI EAFE NR Index,1
+811,MSCI World Equal Weighted NR Index,1
+812,STOXX Global Breakthrough Healthcare Index,1
+813,Russell 2500 Total Return Index,1
+814,I C E Bofa 6 Month U.S.Treasury Bill Index,1
+815,ICE BofA 0-3 Month U.S.Treasury Bill Index,1
+816,30% MSCI All Country World Index/70% Bloomberg Global Aggregate Bond Index,1
+817,ICE U.S.3000 Index,1
+818,Morningstar Exponential Technologies Index,1
+819,Morningstar Global Emerging Green Technologies Select Index,1
+820,Morningstar Multi Asset High Income Index,1
+821,MSCI AC Asia ex Japan Index,1
+822,"MSCI ACWI ex U.S.100% Hedged to USD Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+823,MSCI ACWI Low Carbon Target Index,1
+824,MSCI China A Inclusion Index,1
+825,MSCI EAFE 100 Hedged to USD Index,1
+826,MSCI EAFE Investable Market Index,1
+827,MSCI EAFE Small Cap 100 Hedged to USD Index,1
+828,MSCI Europe Financials Index,1
+829,MSCI Europe Investable Market Index,1
+830,MSCI Kokusai Index,1
+831,MSCI Pacific Investable Market Index,1
+832,MSCI U.S.Enhanced Value Index,1
+833,MSCI U.S.Low Size Index Spliced,1
+834,MSCI U.S.Minimum Volatility Extended ESG Reduced Carbon Target Index,1
+835,MSCI U.S.Momentum SR Variant Index Spliced,1
+836,MSCI U.S.Sector Neutral Quality Index Spliced,1
+837,MSCI U.S.Small Cap Minimum Volatility Index,1
+838,MSCI World ex U.S.Enhanced Value Index,1
+839,MSCI World ex U.S.Investable Market Index,1
+840,MSCI World ex U.S.Momentum Index,1
+841,MSCI World ex U.S.Sector Neutral Quality Index,1
+842,NYSE FactSet Global Autonomous Driving and Electric Vehicle Index,1
+843,NYSE FactSet Global Cyber Security Index,1
+844,NYSE FactSet Global Genomics and Immuno Biopharma Index,1
+845,NYSE FactSet Global Neuro Biopharma and MedTech Index,1
+846,NYSE FactSet U.S.Tech Breakthrough Index,1
+847,S000004351 MSCI ACWI ex U.S.Index,1
+848,"FTSE China 50 Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+849,"FTSE Emerging All Cap Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+850,"MSCI ACWI ex U.S.Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+851,"MSCI EAFE Growth Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+852,S000004438 MSCI ACWI ex U.S.Index,1
+853,S000004438 MSCI EAFE Value Index,1
+854,S000018145 MSCI ACWI ex U.S.Index,1
+855,S000018145 MSCI Europe Small Cap Index,1
+856,"MSCI EAFE Small Cap Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+857,S000019898 MSCI All Country World Index,1
+858,S000021460 MSCI ACWI ex U.S.Index,1
+859,S000021461 MSCI All Country World Index,1
+860,S000023585 Bloomberg U.S.Universal Index,1
+861,S000023585 MSCI All Country World Index,1
+862,S000023586 Bloomberg U.S.Universal Index,1
+863,S000023586 MSCI All Country World Index,1
+864,S000023587 Bloomberg U.S.Universal Index,1
+865,S000023587 MSCI All Country World Index,1
+866,S000023588 Bloomberg U.S.Universal Index,1
+867,S000023588 MSCI All Country World Index,1
+868,S000027327 MSCI ACWI ex U.S.Index,1
+869,"MSCI EAFE Minimum Volatility Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+870,S000031838 MSCI U.S.Index,1
+871,S000036830 Bloomberg U.S.Universal Index,1
+872,S000036830 MSCI All Country World Index,1
+873,S000038930 MSCI ACWI ex U.S.Index,1
+874,S000038931 MSCI ACWI ex U.S.Index,1
+875,S000040204 MSCI U.S.Index,1
+876,S000040205 MSCI U.S.Index,1
+877,S000040316 MSCI U.S.Index,1
+878,S000041444 MSCI U.S.Index,1
+879,S000043040 MSCI ACWI ex U.S.Index,1
+880,S000045102 MSCI ACWI ex U.S.Index,1
+881,S000045103 MSCI ACWI ex U.S.Index,1
+882,S000047435 MSCI Emerging Markets Index,1
+883,S000047503 MSCI ACWI ex U.S.Index,1
+884,S000047504 MSCI ACWI ex U.S.Index,1
+885,S000047644 MSCI All Country World Index,1
+886,S000048311 MSCI All Country World Index,1
+887,"S&P Global Broad Market Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+888,"STOXX Global Equity Factor Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+889,"S&P Developed ex U.S.Broad Market Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+890,"STOXX International Equity Factor Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+891,"STOXX International Small-Cap Equity Factor Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+892,S000049573 MSCI ACWI ex U.S.Index,1
+893,S000049792 MSCI ACWI ex U.S.Index,1
+894,S000049795 MSCI ACWI ex U.S.Index,1
+895,S000054723 MSCI U.S.Index,1
+896,S000056604 MSCI ACWI ex U.S.Index,1
+897,S000063520 MSCI All Country World Index,1
+898,S000065015 MSCI All Country World Index,1
+899,S000065599 MSCI All Country World Index,1
+900,S000068729 Bloomberg U.S.Universal Index,1
+901,S000068729 MSCI All Country World Index,1
+902,S000068730 Bloomberg U.S.Universal Index,1
+903,S000068730 MSCI All Country World Index,1
+904,S000068731 Bloomberg U.S.Universal Index,1
+905,S000068731 MSCI All Country World Index,1
+906,S000068732 Bloomberg U.S.Universal Index,1
+907,S000068732 MSCI All Country World Index,1
+908,S000073837 MSCI U.S.Index,1
+909,S000076483 MSCI All Country World Index,1
+910,S000079480 MSCI All Country World Index,1
+911,S000082197 Bloomberg U.S.Aggregate Bond Index,1
+912,S000082197 Russell 1000 Index,1
+913,S000082198 Bloomberg U.S.Aggregate Bond Index,1
+914,S000082198 Russell 1000 Index,1
+915,S000082200 Bloomberg U.S.Aggregate Bond Index,1
+916,S000082200 Russell 1000 Index,1
+917,S000082201 Bloomberg U.S.Aggregate Bond Index,1
+918,S000082201 Russell 1000 Index,1
+919,S000082202 Bloomberg U.S.Aggregate Bond Index,1
+920,S000082202 Russell 1000 Index,1
+921,S000082203 Bloomberg U.S.Aggregate Bond Index,1
+922,S000082203 Russell 1000 Index,1
+923,S000082204 Bloomberg U.S.Aggregate Bond Index,1
+924,S000082204 Russell 1000 Index,1
+925,S000082205 Bloomberg U.S.Aggregate Bond Index,1
+926,S000082205 Russell 1000 Index,1
+927,S000082206 Bloomberg U.S.Aggregate Bond Index,1
+928,S000082206 Russell 1000 Index,1
+929,"S&P Target Risk Aggressive Index (Returns do not reflect deductions for fees, expenses or taxes)",1
+930,"S&P Target Risk Balanced Index (Returns do not reflect deductions for fees, expenses or taxes)",1
+931,"S&P Target Risk Conservative Index (Returns do not reflect deductions for fees, expenses or taxes)",1
+932,"S&P Target Risk Moderate Index (Returns do not reflect deductions for fees, expenses or taxes)",1
+933,STOXX U.S.Equity Factor Index Spliced,1
+934,STOXX U.S.Small Cap Equity Factor Index Spliced,1
+935,Bloomberg 3 15 Year Blend Municipal Bond Index,1
+936,Bloomberg U.S.Short Term Government Corporate Index,1
+937,S000010620 Bloomberg Municipal Bond Index,1
+938,S000012071 Bloomberg Municipal Bond Index,1
+939,S000027194 Bloomberg U.S.Aggregate Bond Index,1
+940,Blended Benchmark consisting of 50 MSCI ACWI All Cap Index Net and 50 Bloomberg Global Aggregate Index,1
+941,Bloomberg High Yield Municipal Bond Index,1
+942,Bloomberg U.S.1 5 Year Corporate Index,1
+943,ICE BofA BB B U.S.Cash Pay High Yield Constrained Index,1
+944,MSCI ACWI All Cap Index,1
+945,S000031341 Bloomberg U.S.Aggregate Bond Index,1
+946,S000031351 Russell 1000 Index,1
+947,S000031352 Bloomberg U.S.Aggregate Bond Index,1
+948,S000031353 Russell 1000 Index,1
+949,S000031366 Bloomberg Municipal Bond Index,1
+950,S000031369 Bloomberg Municipal Bond Index,1
+951,S000031374 Bloomberg U.S.Aggregate Bond Index,1
+952,S&P 500Index,1
+953,MSCI All Country World Ex-U.S.Index-NR,1
+954,ICE BofAML U.S.High Yield Master II Index,1
+955,JP Morgan EMB Hard Currency / Local Currency 50/50 Index,1
+956,MSCI All Country World ex U.S.Small Cap Index,1
+957,MSCI ACWI ex U.S.SMID Index,1
+958,MSCI ACWI Small Mid Cap Index,1
+959,MSCI EAFE Small Cap Growth Index,1
+960,S&P UBS Leverage Loan Index,1
+961,Bloomberg 3 To 15 Year Blend Municipal Bond Index,1
+962,S000034192 Bloomberg U.S.Aggregate Index,1
+963,S000034192 ICE BofA U.S.Treasury Bill Index,1
+964,S000080127 Bloomberg U.S.Aggregate Index,1
+965,S000080127 ICE BofA U.S.Treasury Bill Index,1
+966,S000003995 Bloomberg U.S.Aggregate Index,1
+967,S000003995 Russell 3000 Index,1
+968,S000003996 Bloomberg U.S.Aggregate Index,1
+969,S000003996 Russell 3000 Index,1
+970,S000003997 Bloomberg U.S.Aggregate Index,1
+971,S000003997 Russell 3000 Index,1
+972,S000003998 Bloomberg U.S.Aggregate Index,1
+973,S000003998 Russell 3000 Index,1
+974,S000003999 Bloomberg U.S.Aggregate Index,1
+975,S000003999 Russell 3000 Index,1
+976,S000004000 Bloomberg U.S.Aggregate Index,1
+977,S000004000 Russell 3000 Index,1
+978,S000030470 Bloomberg U.S.Aggregate Index,1
+979,S000030470 Russell 3000 Index,1
+980,S000051718 Bloomberg U.S.Aggregate Index,1
+981,S000051718 Russell 3000 Index,1
+982,S000070577 Bloomberg U.S.Aggregate Index,1
+983,S000070577 Russell 3000 Index,1
+984,S&P Target Date To 2065+ Index,1
+985,S&P Target Date To Retirement Income Index,1
+986,S000003853 Russell 3000 Index,1
+987,Bloomberg U.S.High Yield 1 5 Yr Cash Pay 2 Constrained Index,1
+988,S000008975 Bloomberg U.S.Aggregate Index,1
+989,Transamerica MSCI EAFE Index VP,1
+990,Transamerica S&P 500 Index VP,1
+991,"Bloomberg Custom Blend Benchmark (Index returns do not reflect deductions for fees, expenses or taxes)",1
+992,Bloomberg Municipal 3 10 Year Index,1
+993,"Former Bloomberg Custom Blend Benchmark (Index returns do not reflect deductions for fees, expenses or taxes)",1
+994,S000070976 Bloomberg Municipal Bond Index,1
+995,MSCI World Ex U.S.Index,1
+996,Bloomberg California Municipal 0 2 Year Index,1
+997,"Blended Benchmark (35% MSCI All Country World NR Index/ 65% Bloomberg U.S.Aggregate Bond Index) reflects no deduction for fees, expenses, or taxes",1
+998,"Blended Benchmark (60% MSCI World NR Index/ 40% Bloomberg U.S.Aggregate Bond Index) reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+999,"Blended Benchmark (60% S&P 500 Index/40% Bloomberg U.S.Aggregate Bond Index) reflects no deduction for fees, expenses, or taxes",1
+1000,"Bloomberg U.S.Securitized MBS/ABS/CMBS Index reflects no deduction for fees, expenses, or taxes",1
+1001,"MSCI All-Country World NR Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+1002,"MSCI World NR Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes",1
+1003,S000055017 ICE BofA Enhanced Yield U.S.Broad Bond Index,1
+1004,S000055017 ICE BofA U.S.Broad Market Index,1
+1005,S000056738 Bloomberg 1 5 Year U.S.Aggregate Bond Index,1
+1006,S000056738 Bloomberg U.S.Aggregate Bond Index,1
+1007,S000059077 Bloomberg MSCI U.S.Aggregate ESG Select Index,1
+1008,S000059077 Bloomberg U.S.Aggregate Bond Index,1
+1009,S000064846 Bloomberg MSCI U.S.High Yield Very Liquid ESG Select Index,1
+1010,S000064846 Bloomberg U.S.Aggregate Bond Index,1
+1011,S000064846 Bloomberg U.S.High Yield Very Liquid Index,1
+1012,Bloomberg Bitcoin Index,1
+1013,Dow Jones Internet Composite Index,1
+1014,Dow Jones Precious MetalsSM Index,1
+1015,Dow Jones U.S.SemiconductorsSM Index,1
+1016,ICE U.S.Dollar Index,1
+1017,S&P China Select ADR Index,1
+1018,S&P Communication Services Select Sector Index,1
+1019,S&P Consumer Discretionary Select Sector Index,1
+1020,S&P Consumer Staples Select Sector Index,1
+1021,S&P Emerging 50 ADR Index,1
+1022,S&P Energy Select Sector Index,1
+1023,S&P Financial Select Sector Index,1
+1024,S&P Global 1200 Index,1
+1025,S&P Health Care Select Sector Index,1
+1026,S&P Industrials Select Sector Index,1
+1027,S&P Latin America 35 ADR Index,1
+1028,S&P Materials Select Sector Index,1
+1029,S&P Real Estate Select Sector Index,1
+1030,S&P Technology Select Sector Index,1
+1031,S&P Total Market Index,1
+1032,S&P U.S.Treasury Bond Current 10-Year Total Return Index,1
+1033,S&P U.S.Treasury Bond Current 30-Year Total Return Index,1
+1034,S&P Utilities Select Sector Index,1
+1035,STOXX Europe 50 Index,1
+1036,Bloomberg Municipal Bond 1-15 Year Blend Index&#160;,1
+1037,JP Morgan CLOIE AAA Index&#160;,1
+1038,"MSCI Emerging Markets Index&#160; (reflects reinvested dividends net of withholding taxes but reflects no deduction for fees, expenses or other taxes)",1
+1039,"MSCI World ex U.S.Index&#160; (reflects reinvested dividends net of withholding taxes but reflects no deduction for fees, expenses or other taxes)",1
+1040,S000017347 Bloomberg 7 Year Municipal Bond Index,1
+1041,S000017347 Bloomberg Municipal Bond Index,1
+1042,S000068798 Bloomberg U.S.Aggregate Bond Index,1
+1043,S000077852 JP Morgan EMBI Global Diversified Index,1
+1044,S000077853 Bloomberg U.S.Aggregate Bond Index,1
+1045,S000077853 ICE BofA BB B U.S.Cash Pay High Yield Constrained Index,1
+1046,S000077854 Bloomberg U.S.Aggregate Bond Index,1
+1047,S000077854 ICE U.S.Institutional Capital Securities Index,1
+1048,S000077855 Bloomberg U.S.Aggregate Bond Index,1
+1049,S000077855 Bloomberg U.S.Securitized Index,1
+1050,S000007714 Bloomberg U.S.Intermediate Credit 1 10 Year Index,1
+1051,S000007714 BofA Merrill Lynch 1 10 Year U.S.Corp Government Index,1
+1052,S&P 1500 Index -,1
+1053,S000055094 MSCI World Ex U.S.Index,1
+1054,S000047012 Bloomberg U.S.Aggregate Bond Index,1
+1055,S000047012 Fifty MSCI World High Dividend Index Net 50 Bloomberg U.S.High Yield 2 Issuer Capped Index,1
+1056,S000047012 MSCI World Index,1
+1057,MSCI ACWI Information Technology Index,1
+1058,MSCI U.S.Financials Index,1
+1059,S000096485 MSCI ACWI Index,1
+1060,Morningstar U.S.Conservative Target Allocation Index,1
+1061,Morningstar U.S.Moderately Aggressive Target Allocation Index,1
+1062,Morningstar U.S.Moderately Conservative Target Allocation Index,1
+1063,MSCI EAFE Net Dividend Index,1
+1064,Bloomberg Global Aggregate Float Adjusted Composite Index,1
+1065,Bloomberg Global Aggregate Float Adjusted Index in USD,1
+1066,Bloomberg U.S.10+ Year Corporate Bond Index,1
+1067,Bloomberg U.S.1-5 Year Corporate Bond Index,1
+1068,Bloomberg U.S.5-10 Year Corporate Bond Index,1
+1069,Bloomberg U.S.Long Treasury Bond Index,1
+1070,Bloomberg U.S.MBS Float Adjusted Index,1
+1071,Bloomberg U.S.Treasury 1-3 Year Index,1
+1072,Bloomberg U.S.Treasury 3-10 Year Index,1
+1073,Spliced Bloomberg U.S.Long Treasury Index in USD,1
+1074,Spliced Bloomberg U.S.Treasury 1-3 Year Index in USD,1
+1075,Spliced Bloomberg U.S.Treasury 3-10 Year Index in USD,1
+1076,Bloomberg MSCI U.S.Corporate SRI Select Index,1
+1077,Bloomberg U.S.Treasury STRIPS 20-30 Year Equal Par Bond Index,1
+1078,CRSP U.S.Mega Cap Index,1
+1079,CRSP U.S.Mega Cap Value Index,1
+1080,FTSE Developed Net Tax Index,1
+1081,FTSE Global All Cap ex U.S.Choice Index,1
+1082,FTSE Global All Cap ex U.S.Index,1
+1083,FTSE U.S.Index,1
+1084,FTSE U.S.All Cap Choice Index,1
+1085,FTSE U.S.Choice Index,1
+1086,MSCI U.S.Investable Market 2500 Index,1
+1087,MSCI ACWI Select Metals Mining Producers ex Gold and Silver Investable Market Index,1
+1088,MSCI All Country World Minimum Volatility USD Index,1
+1089,MSCI Australia Index,1
+1090,MSCI Austria IMI 25 50 Index,1
+1091,MSCI Belgium IMI 25 50 Index,1
+1092,MSCI Canada Custom Capped Index,1
+1093,MSCI EM Asia Custom Capped Index Spliced,1
+1094,MSCI Emerging Markets 100 USD Hedged Index,1
+1095,MSCI Emerging Markets Extended ESG Focus Index Spliced,1
+1096,MSCI Emerging Markets Investable Market Index,1
+1097,MSCI EMU Index,1
+1098,MSCI France Index,1
+1099,MSCI Germany Index,1
+1100,MSCI Hong Kong 25 50 Index Spliced,1
+1101,MSCI Israel Capped Investable Market Index,1
+1102,MSCI Italy 25 50 Index,1
+1103,MSCI Japan Small Cap Index,1
+1104,MSCI Malaysia Index,1
+1105,MSCI Netherlands IMI 25 50 Index,1
+1106,MSCI Spain 25 50 Index,1
+1107,MSCI Sweden 25 50 Index Spliced,1
+1108,MSCI Switzerland 25 50 Index,1
+1109,MSCI Taiwan 25 50 Index Spliced,1
+1110,MSCI Thailand IMI 25 50 Index,1
+1111,MSCI U.S.Equal Weighted Index,1
+1112,S000004246 MSCI ACWI ex U.S.Index,1
+1113,S000004247 MSCI ACWI ex U.S.Index,1
+1114,S000004248 MSCI ACWI ex U.S.Index,1
+1115,S000004249 MSCI ACWI ex U.S.Index,1
+1116,S000004250 MSCI Emerging Markets Index,1
+1117,S000004251 MSCI Emerging Markets Index,1
+1118,S000004251 MSCI Mexico IMI 25 50 Index,1
+1119,S000004252 MSCI ACWI ex U.S.Index,1
+1120,S000004253 MSCI ACWI ex U.S.Index,1
+1121,S000004253 MSCI Pacific ex Japan Index,1
+1122,S000004254 MSCI ACWI ex U.S.Index,1
+1123,S000004254 MSCI Singapore 25 50 Index Spliced,1
+1124,S000004255 MSCI Emerging Markets Index,1
+1125,S000004255 MSCI South Africa 25 50 Index,1
+1126,S000004256 MSCI ACWI ex U.S.Index,1
+1127,S000004258 MSCI Emerging Markets Index,1
+1128,S000004258 MSCI Korea 25 50 Index,1
+1129,S000004259 MSCI ACWI ex U.S.Index,1
+1130,S000004260 MSCI ACWI ex U.S.Index,1
+1131,S000004261 MSCI Emerging Markets Index,1
+1132,S000004263 MSCI ACWI ex U.S.Index,1
+1133,S000004264 MSCI Brazil 25 50 Index,1
+1134,S000004264 MSCI Emerging Markets Index,1
+1135,S000004265 MSCI ACWI ex U.S.Index,1
+1136,S000004266 MSCI Emerging Markets Index,1
+1137,S000004267 MSCI ACWI ex U.S.Index,1
+1138,S000004268 MSCI ACWI ex U.S.Index,1
+1139,S000004269 MSCI ACWI ex U.S.Index,1
+1140,S000018069 MSCI BIC Index,1
+1141,S000018069 MSCI Emerging Markets Index,1
+1142,S000018070 MSCI Chile IMI 25 50 Index,1
+1143,S000018070 MSCI Emerging Markets Index,1
+1144,S000018072 MSCI Emerging Markets Index,1
+1145,S000018073 MSCI Emerging Markets Index,1
+1146,S000018073 MSCI Turkey IMI 25 50 Index,1
+1147,S000019125 MSCI Emerging Markets Index,1
+1148,S000019125 MSCI Emerging Markets Small Cap Index,1
+1149,S000019126 MSCI ACWI ex U.S.Index,1
+1150,S000021462 MSCI ACWI ex U.S.Index,1
+1151,S000032497 MSCI Emerging Markets Index,1
+1152,S000032497 MSCI Emerging Markets Minimum Volatility USD Index,1
+1153,S000032498 MSCI All Country World Index,1
+1154,S000035395 MSCI All Country World Index,1
+1155,S000035395 MSCI World Index,1
+1156,S000035880 MSCI ACWI Select Silver Miners Investable Market Index,1
+1157,S000035880 MSCI All Country World Index,1
+1158,"MSCI ACWI Select Gold Miners Investable Market Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1159,"MSCI ACWI Select Agriculture Producers Investable Market Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1160,S000035884 MSCI All Country World Index,1
+1161,"S&P U.S.Power Infrastructure Select Index (Returns do not reflect deductions for fees, expenses or taxes except as noted)",1
+1162,S000035885 MSCI All Country World Index,1
+1163,S000038923 MSCI Emerging Markets Index,1
+1164,S000045639 MSCI Emerging Markets Index,1
+1165,S000054183 MSCI Emerging Markets Index,1
+1166,S000057835 MSCI Emerging Markets ex China Index,1
+1167,S000057835 MSCI Emerging Markets Index,1
+1168,"S&P Emerging Broad Market Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1169,STOXX Emerging Markets Equity Factor Index Spliced,1
+1170,MSCI ACWI Sustainable Development Index,1
+1171,MSCI All Ireland Capped Index,1
+1172,MSCI All Kuwait Select Size Liquidity Capped Index,1
+1173,MSCI All UAE Capped Index,1
+1174,MSCI EAFE Choice ESG Screened Index,1
+1175,MSCI EAFE Extended ESG Focus Index,1
+1176,"MSCI Emerging Markets Choice ESG Screened 5% Issuer Capped Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1177,MSCI EM Extended ESG Leaders 5 Issuer Capped Index,1
+1178,MSCI EMU 100 Hedged to USD Index,1
+1179,MSCI Finland IMI 2550 Index,1
+1180,MSCI India Small Cap Index,1
+1181,MSCI Indonesia IMI 25 50 Index Spliced,1
+1182,MSCI Japan 100 Hedged to USD Index,1
+1183,MSCI Japan Value Index,1
+1184,MSCI New Zealand All Cap Top 25 Capped Index,1
+1185,MSCI Norway IMI 2550 Index,1
+1186,MSCI Poland IMI 2550 Index,1
+1187,MSCI U.S.Choice ESG Screened Index,1
+1188,MSCI U.S.Climate Paris Aligned Benchmark Extended Select Index,1
+1189,MSCI U.S.Extended Climate Action Index,1
+1190,MSCI U.S.Extended ESG Focus Index,1
+1191,MSCI U.S.Extended ESG Leaders Index,1
+1192,MSCI U.S.Growth Extended ESG Focus Index,1
+1193,MSCI U.S.Value Extended ESG Focus Index,1
+1194,S000024426 MSCI All Peru Capped Index,1
+1195,S000024426 MSCI Emerging Markets Index,1
+1196,"MSCI China Small Cap Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1197,S000028553 MSCI Emerging Markets Index,1
+1198,S000028554 MSCI ACWI Ex U.S.Index,1
+1199,S000028556 MSCI Emerging Markets Index,1
+1200,"MSCI Brazil Small Cap Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1201,S000028681 MSCI ACWI Ex U.S.Index,1
+1202,S000028735 MSCI Emerging Markets Index,1
+1203,S000028735 MSCI Philippines IMI 25 50 Index Spliced,1
+1204,"MSCI China Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1205,S000034700 MSCI Emerging Markets Index,1
+1206,S000034702 MSCI Emerging Markets Index,1
+1207,S000035383 MSCI ACWI ex U.S.Index,1
+1208,S000035383 MSCI Denmark IMI 25 50 Index,1
+1209,S000035386 MSCI ACWI Ex U.S.Index,1
+1210,S000035389 MSCI ACWI Ex U.S.Index,1
+1211,"MSCI United Kingdom Small Cap Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1212,S000043043 MSCI ACWI ex U.S.Index,1
+1213,S000045074 MSCI All Qatar Capped Index,1
+1214,S000045075 MSCI Emerging Markets Index,1
+1215,S000045646 MSCI ACWI ex U.S.Index,1
+1216,"MSCI United Kingdom Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1217,S000047939 MSCI Emerging Markets Index,1
+1218,S000047939 MSCI Saudi Arabia IMI 25 50 Index,1
+1219,S000053601 MSCI All Country World Index,1
+1220,S000054185 MSCI ACWI ex U.S.Index,1
+1221,S000054185 MSCI All Country World Index,1
+1222,S000055381 MSCI U.S.Index,1
+1223,S000061604 MSCI U.S.Index,1
+1224,S000061604 MSCI U.S.Small Cap Extended ESG Focus Index,1
+1225,S000064903 MSCI ACWI Ex U.S.Index,1
+1226,S000065418 MSCI U.S.Index,1
+1227,S000068137 MSCI Emerging Markets Index,1
+1228,S000068771 MSCI ACWI ex U.S.Index,1
+1229,S000068773 MSCI Emerging Markets Index,1
+1230,S000068775 MSCI U.S.Index,1
+1231,"MSCI China Technology Sub-Industries Select Capped Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1232,S000074757 MSCI U.S.Index,1
+1233,S000079196 MSCI U.S.Index,1
+1234,JPMorgan Emerging Markets Bond Index - Global,1
+1235,S000074121 Russell 1000 Index,1
+1236,FTSE Non U.S.World Government Bond All Maturities Index Unhedged,1
+1237,FTSE Three Month U.S.Treasury Bill Index,1
+1238,JPMorgan Emerging Markets Bond Index Global,1
+1239,S000010617 Bloomberg U.S.Aggregate Bond Index,1
+1240,S000012068 Blended Benchmark Consisting Of60 S P500 Index And40 Bloomberg U.S.Aggregate Bond Index,1
+1241,S000012068 Bloomberg U.S.Aggregate Bond Index,1
+1242,S000012069 MSCI China Index,1
+1243,S000012070 Russell 3000 Index,1
+1244,S000012073 Russell 3000 Index,1
+1245,S000012074 MSCI ACWI Ex U.S.Index,1
+1246,S000012074 MSCI ACWI Ex U.S.Value Index,1
+1247,S000012075 MSCI ACWI Index,1
+1248,"S&P Global 1200 Information Technology Index (reflects reinvested dividends net of withholding taxes but reflects no deductions for fees, expenses or other taxes)",1
+1249,S000012077 Russell 1000 Index,1
+1250,"MSCI EAFE Index (reflects reinvested dividends net of withholding taxes but reflects no deductions for fees, expenses or other taxes)",1
+1251,"MSCI Emerging Markets Index (reflects reinvested dividends net of withholding taxes but reflects no deductions for fees, expenses or other taxes)",1
+1252,S000036205 Bloomberg U.S.Aggregate Bond Index,1
+1253,S000036206 Russell 2000 Index,1
+1254,S000036206 Russell 3000 Index,1
+1255,S000061733 MSCI EAFE Index,1
+1256,"MSCI EAFE Value Index (reflects reinvested dividends net of withholding taxes but reflects no deductions for fees, expenses or other taxes)",1
+1257,S000066845 Bloomberg U.S.Aggregate Bond Index,1
+1258,"Bloomberg Municipal Bond Index reflects no deduction for fees, expenses, or taxes",1
+1259,"Bloomberg U.S.Government/Credit 1-3 Year Bond Index reflects no deduction for fees, expenses, or taxes",1
+1260,"Bloomberg U.S.Municipal High Yield Bond Index reflects no deduction for fees, expenses, or taxes",1
+1261,"ICE BofA U.S.High Yield Index reflects no deduction for fees, expenses, or taxes",1
+1262,"Russell 1000 Growth Index reflects no deduction for fees, expenses, or taxes",1
+1263,"Russell 1000 Value Index reflects no deduction for fees, expenses, or taxes",1
+1264,Lipper Global Natural Resources Index,1
+1265,S000067465 Bloomberg U.S.Aggregate Index,1
+1266,S000067465 Russell 3000 Index,1
+1267,S000067466 Russell 3000 Index,1
+1268,S000067467 Bloomberg U.S.Aggregate Index,1
+1269,S000067467 Russell 3000 Index,1
+1270,S000067468 Bloomberg U.S.Aggregate Index,1
+1271,S000067468 Russell 3000 Index,1
+1272,S000067469 Bloomberg U.S.Aggregate Index,1
+1273,S000067469 Russell 3000 Index,1
+1274,S000067470 Bloomberg U.S.Aggregate Index,1
+1275,S000067470 Russell 3000 Index,1
+1276,S000067471 Bloomberg U.S.Aggregate Index,1
+1277,S000067471 Russell 3000 Index,1
+1278,S000067472 Bloomberg U.S.Aggregate Index,1
+1279,S000067472 Russell 3000 Index,1
+1280,S000070572 Bloomberg U.S.Aggregate Index,1
+1281,S000070572 Russell 3000 Index,1
+1282,MSCI ACWI Information Technology Index NR,1
+1283,MSCI Emerging Markets Index NR,1
+1284,FTSE EPRA/NAREIT Developed Index,1
+1285,S000071710 Russell 3000 Index,1
+1286,S000071711 Russell 3000 Index,1
+1287,S000071712 Russell 3000 Index,1
+1288,MSCI World Health Care Index NR,1
+1289,S&P Developed ex-U.S.SmallCap Index,1
+1290,Bloomberg Intermediate U.S.Government/Credit Bond Index&#160;,1
+1291,ICE U.S.Treasury 7-10 Year Bond Index&#160;,1
+1292,NASDAQ-100 Index&#160;,1
+1293,Nasdaq Composite Index&#160;,1
+1294,Bloomberg U.S.Corporate High Yield 2 Issuer Capped Bond Index,1
+1295,S000005573 Bloomberg U.S.Aggregate Bond Index,1
+1296,S000028810 Bloomberg U.S.Aggregate Bond Index,1
+1297,S000015514 Bloomberg U.S.Aggregate Bond Index,1
+1298,Bloomberg U.S.Intermediate Treasury Index,1
+1299,Bloomberg 1-5 Year U.S.Treasury Index,1
+1300,Strategic Factor Allocation Composite Index,1
+1301,Bloomberg Goldman Sachs Community Municipal Index,1
+1302,Bloomberg Municipal 1-17 Year ex AMT Index,1
+1303,Bloomberg U.S.Corporate Investment Grade Index,1
+1304,FTSE Goldman Sachs Emerging Markets USD Bond Index,1
+1305,FTSE Goldman Sachs High Yield Corporate Bond Index,1
+1306,FTSE Goldman Sachs Investment Grade Corporate Bond Index,1
+1307,FTSE Goldman Sachs Treasury Inflation Protected USD Bond Index,1
+1308,FTSE Goldman Sachs U.S.Broad Bond Market Index,1
+1309,FTSE Goldman Sachs U.S.Investment-Grade Corporate Bond 1-5 Years Index,1
+1310,FTSE U.S.Treasury 0-1 Year Composite Select Index,1
+1311,FTSE Three-Month U.S.Treasury Bill Index,1
+1312,Russell 1000 Growth 40 Act Daily Capped Index,1
+1313,Russell 1000 Value 40 Act Daily Capped Index,1
+1314,MSCI ACWI Health Care Index,1
+1315,MSCI ACWI Select Information Technology + Communication Services Index,1
+1316,S000094965 Russell 1000 Index,1
+1317,S000094966 Russell 1000 Index,1
+1318,S000094967 Russell 1000 Index,1
+1319,MSCI Canada Custom Capped Index Spliced,1
+1320,MSCI Netherlands IMI 25 50 Index Spliced,1
+1321,"MSCI Switzerland 25/50 Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1322,"MSCI U.S.Index (Returns do not reflect deductions for fees, expenses or taxes)",1
+1323,S000004248 MSCI ACWI Ex U.S.Index,1
+1324,S000004252 MSCI ACWI Ex U.S.Index,1
+1325,"MSCI Spain 25/50 Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1326,S000004257 MSCI ACWI ex U.S.Index,1
+1327,"MSCI Sweden 25/50 Index (Returns do not reflect deductions for fees, expenses or taxes except for withholding taxes on reinvested dividends)",1
+1328,S000021462 MSCI ACWI Ex U.S.Index,1
+1329,"MSCI U.S.Equal Weighted Index (Returns do not reflect deductions for fees, expenses or taxes)",1
+1330,Morningstar Developed Markets ex-U.S.All Cap Target Market Exposure Index,1
+1331,Morningstar Developed Markets ex-U.S.Small-Cap Target Market Exposure Index,1
+1332,Morningstar Developed Markets ex-U.S.Value Target Market Exposure Index,1
+1333,Morningstar Emerging Markets All Cap Target Market Exposure Index,1
+1334,Morningstar Emerging Markets Value Target Market Exposure Index,1
+1335,Morningstar Global 1-5 Yr Treasury Bond Hedged Index,1
+1336,Morningstar Global Core Bond Hedged Index,1
+1337,Morningstar Global Index,1
+1338,Morningstar U.S.1-3 Yr Composite Government and Corporate Bond Index,1
+1339,Morningstar U.S.Core Bond Index,1
+1340,Morningstar U.S.Large-Mid Cap Broad Value Index,1
+1341,Morningstar U.S.Market Extended Index,1
+1342,Morningstar U.S.REIT Index,1
+1343,Morningstar U.S.Small Cap Extended Index,1
+1344,MSCI ACWI EX-U.S.Index,1
+1345,S&P 500Total Return Index,1
+1346,MSCI Emerging Markets Price Return Index,1
+1347,MSCI Emerging Markets Total Return Index,1
+1348,NASDAQ-100 Price Return Index,1
+1349,NASDAQ-100 Total Return Index,1
+1350,S&P 500 Price Return Index,1
+1351,ICE U.S.Treasury 20+ Year Index Excluding Transaction Costs,1
+1352,S&P U.S.Aggregate Bond Index,1
+1353,Russell 2000 Price Return Index,1
+1354,MSCI EAFE Price Return Index,1
+1355,MSCI EAFE Total Return Index,1
+1356,Russell Mid Cap Total Return Index,1
+1357,Bloomberg 1-3 Year U.S.Government/Credit Index,1
+1358,Bloomberg Credit Bond Index,1
+1359,S&P 500 VIX Mid-Term Futures Inverse Daily Index,1
+1360,Bloomberg Barclays Aggregate Bond Index,1
+1361,Bloomberg U.S.Corporate 1-3 Year Index,1
+1362,ICE BofA 1-3 Year U.S.Treasury Index,1
+1363,S&P Composite 1500 Energy Index,1
+1364,S&P High Yield Dividend Aristocrats Index*,1
+1365,MSCI Israeli Index,1
+1366,NASDAQ Healthcare Index,1
+1367,Dow Jones Global Index,1
+1368,50% Cboe S&P 500 One-Week PutWrite Index / 50% Cboe S&P 500 PutWrite Index,1
+1369,"MSCI China A Onshore Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or taxes)",1
+1370,"MSCI China All Shares Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or taxes)",1
+1371,FTSE Nareit All Equity REITs Index,1
+1372,"MSCI EAFE Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or taxes)",1
+1373,"MSCI Emerging Markets Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or taxes)",1
+1374,Bloomberg 1-Year Municipal Bond Index,1
+1375,ICE BofA Merrill Lynch 1-5 Year U.S.Corporate/Government Index,1
+1376,MSCI World Energy Index,1
+1377,MSCI Emerging Markets Index2,1
+1378,MSCI Frontier Markets Index,1
+1379,MSCI AC World ex-U.S.Growth Index,1
+1380,MSCI AC World ex-U.S.Index,1
+1381,MSCI ACWI Value Index,1
+1382,60% MSCI ACWI Value Index/40% Bloomberg U.S.Aggregate Bond Index Composite,1
+1383,75% MSCI ACWI Value Index/25% Bloomberg U.S.Aggregate Bond Index Composite,1
+1384,ICE U.S.1-Month Treasury Bill Index,1
+1385,ICE BofA Merrill Lynch U.S.Corporate Index,1
+1386,CE BofA Merrill Lynch U.S.High Yield Index,1
+1387,Bloomberg U.S.Universal Total Return Index Value Unhedged USD,1
+1388,ICE BofA Merrill Lynch 1-5 Year U.S.Corporate Index,1
+1389,60% S&P 500 Index / 40% Bloomberg U.S.Aggregate Index Composite,1
+1390,BVP Nasdaq Emerging Cloud Index,1
+1391,MSCI Emerging Markets ex-China Index,1
+1392,MSCI EAFE Local Currency Index,1
+1393,MSCI EAFE Small Cap Index,1
+1394,MSCI EAFE Small Cap Value Index,1
+1395,MSCI EAFE Small Cap Local Currency Index,1
+1396,MSCI U.S.Investible Market Index,1
+1397,"ICE BofA Merrill Lynch 0-5 Year U.S.High Yield Constrained, Zero Duration Index/ WisdomTree U.S.High Yield Corporate Bond, Zero Duration Spliced Index",1
+1398,ICE BofA Merrill Lynch U.S.High Yield Index,1
+1399,"Bloomberg Rate Hedged U.S.Aggregate Bond Index, Zero Duration",1
+1400,Bloomberg U.S.Securitized MBS/ABS/CMBS Index,1
+1401,Bloomberg U.S.Aggregate Enhanced Yield Index,1
+1402,Bloomberg Dollar Spot Index,1
+1403,Bloomberg U.S.Universal Enhanced Yield Index,1
+1404,Cboe S&P 500 PutWrite Index/Volos U.S.Large Cap Target 2.5% PutWrite Spliced Index,1
+1405,Bloomberg Dollar Total Return Index,1
+1406,S&P GSCI Index,1
+1407,60% S&P 500 Index/40% Bloomberg U.S.Aggregate Index Composite,1
+1408,NYSE ARCA Gold Miners Index,1
+1409,JP Morgan Emerging Local Markets Index Plus,1
+1410,JP Morgan CEMBI Diversified Index,1
+1411,JP Morgan GBI-EM Global Diversified Index Unhedged USD,1
+1412,Bloomberg U.S.Treasury Floating Rate Bond Index,1
+1413,Bloomberg U.S.AggregateBond Index,1
+1414,MSCI AC World IMI Index,1
+1415,S&P Target Date Retirement Income Index,1
+1416,S&P Target Date To 2025 Index,1
+1417,S&P Target Date to 2065+ Index,1
+1418,S&P 1000 Value Index,1
+1419,Russell Microcap Index,1
+1420,Bloomberg U.S.Equity:Fixed Income 60:40 Index,1
+1421,BLOOMBERG U.S.AGGREGATE BOND Index,1
+1422,"Bloomberg U.S.Aggregate Bond Index (The index returns do not reflect deductions for fees, expenses, or taxes.) | CCM Affordable Housing MBS ETF",1
+1423,"Bloomberg U.S.MBS Index (The index returns do not reflect deductions for fees, expenses, or taxes.) | CCM Affordable Housing MBS ETF",1
+1424,"S&P 500 Index, Democratic Large Cap Core ETF",1
+1425,MSCI AC World Index NR,1
+1426,FTSE 3-Month U.S.T-Bill Index,1
+1427,55% S&P 500 Index/ 45% ICE BofA U.S.Broad Market Index,1
+1428,Morningstar Moderately Conservative Target Risk Index,1
+1429,ICE BofA U.S.Corporate Index,1
+1430,Morningstar Moderate Target Risk Index,1
+1431,Morningstar Moderately Aggressive Target Risk Index,1
+1432,70% S&P 500 Index/30% ICE BofA U.S.Corporate Index,1
+1433,FTSE Global Infrastructure Opportunities Index,1
+1434,CBOE S&P 500 BUYWRITE INDEX - BXM,1
+1435,S&P 500 Index),1
+1436,MSCI World Index),1
+1437,FT Wilshire U.S.Large NxtGen Index,1
+1438,MSCI Emerging Markets Index),1
+1439,MSCI Emerging Markets ex-China Index),1
+1440,FT Wilshire Emerging Large NxtGen Index),1
+1441,ICE BofA 1-3 Year BB U.S.Cash Pay High Yield Index*,1
+1442,S&P Short-Term National AMT-Free Municipal Bond Index,1
+1443,Bloomberg Global Aggregate Hedged USD Index,1
+1444,MSCI ACWI Total Return Index,1
+1445,MSCI AC World Index ex U.S.Gross Index,1
+1446,MSCI World Index - Gross Return,1
+1447,MSCI World Index -,1
+1448,Bloomberg U.S.Treasury Bellwether 30Y Total Return USD Unhedged Index,1
+1449,ICE BofA Current 30-Year U.S.Treasury Index,1
+1450,ICE U.S.Treasury Code Bond Index,1
+1451,Bloomberg U.S.Treasury Bellwether 20Y Total Return USD Unhedged Index,1
+1452,ICE BofA Current 20-Year U.S.Treasury Index,1
+1453,Bloomberg U.S.Treasury Bellwether 10Y Total Return USD Unhedged Index,1
+1454,ICE BofA Current 10-Year U.S.Treasury Total Return Index,1
+1455,Bloomberg U.S.Treasury Bellwether 7Y Total Return USD Unhedged Index.,1
+1456,ICE BofA Current 7-Year U.S.Treasury Index,1
+1457,Bloomberg U.S.Treasury Bellwether 5Y Total Return USD Unhedged Index.,1
+1458,ICE BofA Current 5-Year U.S.Treasury Index,1
+1459,Bloomberg U.S.Treasury Bellwether 3Y Total Return USD Unhedged Index,1
+1460,ICE BofA Current 3-Year U.S.Treasury Index,1
+1461,Bloomberg U.S.Treasury Bellwether 2Y Total Return USD Unhedged Index,1
+1462,ICE BofA Current 2-Year U.S.Treasury Total Return Index,1
+1463,Bloomberg U.S.Treasury Bellwether 1Y Total Return USD Unhedged Index,1
+1464,ICE BofA U.S.1-Year Treasury Bill Total Return Index,1
+1465,Bloomberg U.S.Treasury Bellwether 6M Total Return USD Unhedged Index,1
+1466,ICE BofA 6-Month U.S.Treasury Bill Index,1
+1467,Bloomberg U.S.Treasury Bellwether 3M Total Return USD Unhedged Index,1
+1468,ICE BofA 3 Month Treasury Bill Index,1
+1469,Dow Jones Industrial AverageTM Index,1
+1470,"S&P 500 Total Return Index (reflects reinvestment of dividends and no deductions for fees, expenses or taxes)",1
+1471,Russell Midcap Growth Total Return Index,1
+1472,FTSE Global All Cap Net Tax Index,1
+1473,Russell 2000 Growth Total Return Index,1
+1474,"Bloomberg Global-Aggregate Total Return Index (does not reflect deductions for fees, expenses or taxes)",1
+1475,"S&P Target Risk Conservative Index (does not reflect deductions for fees, expenses or taxes)",1
+1476,"S&P 500 Index (does not reflect deductions for fees, expenses or taxes)",1
+1477,"S&P Target Risk Moderate Index (does not reflect deductions for fees, expenses or taxes)",1
+1478,"S&P Target Risk Growth Index (does not reflect deductions for fees, expenses or taxes)",1
+1479,"S&P Target Risk Aggressive Index (does not reflect deductions for fees, expenses or taxes)",1
+1480,"S&P Balanced Equity & Bond Index ? Moderate(does not reflect deductions for fees, expenses or taxes)",1
+1481,Bloomberg 10 Year California Exempt Index,1
+1482,Bloomberg Municipal New York 12-17 Years Index,1
+1483,Bloomberg Municipal Short Year Index,1
+1484,Bloomberg Municipal Short-Term Index,1
+1485,S&P Merger Arbitrage Total Return Index,1
+1486,Nasdaq AlphaDEX Large Cap Core Index,1
+1487,Nasdaq AlphaDEX Large Cap Growth Index,1
+1488,Nasdaq AlphaDEX Large Cap Value Index,1
+1489,Nasdaq AlphaDEX Mid Cap Core Index,1
+1490,Nasdaq AlphaDEX Mid Cap Growth Index,1
+1491,Nasdaq AlphaDEX Mid Cap Value Index,1
+1492,Nasdaq AlphaDEX Multi Cap Growth Index,1
+1493,Nasdaq AlphaDEX Multi Cap Value Index,1
+1494,Nasdaq AlphaDEX Small Cap Core Index,1
+1495,Nasdaq AlphaDEX Small Cap Growth Index,1
+1496,Nasdaq AlphaDEX Small Cap Value Index,1
+1497,Nasdaq U.S.500 Large Cap Growth Index,1
+1498,Nasdaq U.S.500 Large Cap Index,1
+1499,Nasdaq U.S.500 Large Cap Value Index,1
+1500,Nasdaq U.S.600 Mid Cap Growth Index,1
+1501,Nasdaq U.S.600 Mid Cap Index,1
+1502,Nasdaq U.S.600 Mid Cap Value Index,1
+1503,Nasdaq U.S.700 Small Cap Growth Index,1
+1504,Nasdaq U.S.700 Small Cap Index,1
+1505,Nasdaq U.S.700 Small Cap Value Index,1
+1506,Nasdaq U.S.Multi Cap Growth Index,1
+1507,Nasdaq U.S.Multi Cap Value Index,1
+1508,Russell 1000 Consumer Discretionary Index,1
+1509,Russell 1000 Consumer Staples Index,1
+1510,Russell 1000 Energy Index,1
+1511,Russell 1000 Financials Index,1
+1512,Russell 1000 Health Care Index,1
+1513,Russell 1000 Industrials Index,1
+1514,Russell 1000 Basic Materials Index,1
+1515,Russell 1000 Technology Index,1
+1516,Russell 1000 Utilities Index,1
+1517,S&P 500 Consumer Discretionary Index,1
+1518,S&P 500 Consumer Staples Index,1
+1519,S&P 500 Energy Index,1
+1520,S&P 500 Industrials Index,1
+1521,S&P 500 Materials Index,1
+1522,S&P Composite 1500 Growth Index,1
+1523,S&P Composite 1500 Value Index,1
+1524,Nasdaq-100 Equal Weighted Index,1
+1525,Nasdaq-100 Select Equal Weight Index,1
+1526,Bloomberg Municipal Long Bond Index,1
+1527,Bloomberg U.S.Mortgage-Backed Securities Index,1
+1528,Bloomberg U.S.Aggregate Bond Total Return Index,1
+1529,Bloomberg U.S.Corporate Investment Grade Bond Index,1
+1530,FTSE NAREIT All Equity REITs Index,1
+1531,ICE BofA 7% Constrained DRD Eligible Preferred Securities Index,1
+1532,ICE BofA U.S.Investment Grade Institutional Capital Securities Index,1
+1533,Dow Jones Global Select REIT Total Return Net Index,1
+1534,Dow Jones U.S.Real Estate Total Return Index,1
+1535,S&P Merger Arbitrage Total Return Local Currency Index,1
+1536,Bloomberg Global Aggregate USD Hedged Index,1
+1537,Bloomberg U.S.1-3 Year Government/Credit Index,1
+1538,S&P 500 Stock Index,1
+1539,Russell 2500 Value Total Return Index,1
+1540,Russell 3000 Value Total Return Index,1
+1541,Russell Midcap Value Total Return Index,1
+1542,Barclays U.S.Gov?t/Credit Bond Index,1
+1543,Bloomberg Global Aggregate Bond Index Reflects No Deduction For Fees Expenses Or Taxes,1
+1544,Dow Jones Moderately Conservative Index,1
+1545,HFRX Equity Hedge Index,1
+1546,Nasdaq 100 Total Return Index,1
+1547,Standard & Poor?s 500 Index,1
+1548,Standard & Poor?s 500 Value Index,1
+1549,50/50 S&P 500/Bloomberg Aggregate Bond Index,1
+1550,NASDAQ 100 Total Return Index,1
+1551,"Blended Benchmark Index (50% Bloomberg U.S.Aggregate Bond Index/ 50% S&P 500 Total Return Index) (Index returns do not reflect deduction for fees, expenses, or taxes)",1
+1552,"Bloomberg U.S.Aggregate Bond Index (Index returns do not reflect deductions for fees, expenses, or taxes)",1
+1553,"S&P 500 Total Return Index (Index returns do not reflect deductions for fees, expenses, or taxes)",1
+1554,"Blended Index (25% VettaFi U.S.Equity Large/Mid-Cap 1000 TR Index, 25% VettaFi U.S.Equity Small-Cap 2000 TR Index, 50% Bloomberg Intermediate U.S.Government/Credit Bond Index",1
+1555,"65% VettaFi U.S.Equity 3000 TR Index, 35% Bloomberg U.S.Aggregate Government/Credit Bond Index",1
+1556,Bloomberg Mid Cap/Intermediate U.S.Aggregate 50/50 TR Index,1
+1557,Bloomberg U.S.2500 Technology Total Return Index,1
+1558,Bloomberg U.S.3000 Equal Weight Total Return Index,1
+1559,Bloomberg U.S.Govt/Credit 1-3 YR TR Index,1
+1560,Bloomberg U.S.Mid Cap Growth Total Return Index,1
+1561,Bloomberg U.S.Mid Cap Total Return Index,1
+1562,BofA Merrill Lynch 3-Month U.S.Treasury Bill Index,1
+1563,ICE BofA High Yield U.S.Corporates Cash Pay Index,1
+1564,ICE BofA U.S.Cash Pay High Yield Index,1
+1565,MSCI ACWI Gross Index,1
+1566,MSCI ACWI Value Gross Index,1
+1567,MSCI ACWI Value Index Gross,1
+1568,NASDAQ - 100 Total Return Index,1
+1569,S&P 500/40% Bloomberg U.S.Aggregate Bond Index,1
+1570,ICE BofA 1-10 Year Corporate Index,1
+1571,ICE BofA U.S.Corporate & Government 1-10 Year Index,1
+1572,ICE BofA Yield Alternatives U.S.Convertible Index,1
+1573,Morningstar Global Flexible Allocation EW Index,1
+1574,FT Wilshire Small Cap Total Return Index,1
+1575,S&P Small Cap 600 Index,1
+1576,Bloomberg U.S.Aggregate 1-3 Years Index,1
+1577,MSCI World High Dividend Yield Index,1
+1578,Standard & Poor?s 500 Index (S&P 500 Index,1
+1579,Bloomberg 3 Year Municipal Bond Index,1
+1580,"Bloomberg Municipal Bond Index (reflects no deduction for fees, expenses or taxes",1
+1581,"Bloomberg REIT & Real Estate DM Large, Mid & Small Cap Net Return Index",1
+1582,Bloomberg U.S.2000 Value Index,1
+1583,Bloomberg U.S.3000 Index,1
+1584,Bloomberg U.S.3000 Value Index,1
+1585,FTSE EPRA/NAREIT Developed Net Index,1
+1586,70% Bloomberg U.S.3000 Value Index/30% ICE BofA 3 Month U.S.Treasury Bill Blend Index,1
+1587,70% Russell 3000 Value Total Return/30% ICE BofA 3 Month U.S.Treasury Bill Blend Index,1
+1588,Bloomberg 500 Index/Solactive GBS United States 500 Index,1
+1589,Bloomberg Emerging Markets Ex-China Large & Mid-Cap Index,1
+1590,Bloomberg Natural Resources and Security Index,1
+1591,Bloomberg U.S.1000 Dividend Growth Index,1
+1592,Bloomberg U.S.1000 Growth Index,1
+1593,Bloomberg U.S.1000 Index,1
+1594,Bloomberg U.S.1000 Value Index,1
+1595,Bloomberg U.S.600 Index/ Bloomberg U.S.2000 Index,1
+1596,Bloomberg U.S.Energy Select Index/ Solactive United States Energy Regulated Capped Index,1
+1597,Bloomberg U.S.Listed Semiconductors Select Index/ Solactive United States Semiconductors 30 Capped Index1,1
+1598,Bloomberg U.S.Treasury Bill Index,1
+1599,ICE BofA 1-Year U.S.Treasury Note Index,1
+1600,Bloomberg BVAL Municipal Yield Curve 3-Month Index,1
+1601,ICE BofA Global High Yield Constrained USD Hedged Index,1
+1602,"S&P 10% AAA&AA/15% A/25% BBB/50% High Yield, All 3-Year Plus Sub-Index",1
+1603,S&P Municipal Bond Ohio Index,1
+1604,S&P Municipal Bond Pennsylvania Index,1
+1605,Bloomberg 1-Year U.S.Municipal Bond Index,1
+1606,Bloomberg U.S.Treasury Inflation Protected Securities Index,1
+1607,Bloomberg U.S.Short-Term Government/Corporate Index,1
+1608,S&P 500 Inverse Daily Index,1
+1609,MSCI World ex U.S.High Dividend Yield Index,1
+1610,MSCI All Country World SMID Cap Index,1
+1611,Bloomberg Municipal M.F. CA Intermediate Index,1
+1612,FTSE Gold Mines Index,1
+1613,ICE BofA Emerging Market Corporate Plus Index,1
+1614,JP Morgan EMBI Global Diversified ex-GCC Index,1
+1615,JP Morgan GBI-EM Broad Diversified Index,1
+1616,MSCI EAFE Index-NR,1
+1617,MSCI Emerging Markets Index-NR,1
+1618,MSCI Emerging Markets Small Cap Index-NR,1
+1619,Bloomberg Municipal Bond California Exempt Index,1
+1620,50% Bloomberg High Yield Very Liquid Index and 50% Bloomberg U.S.Corporate Index,1
+1621,MSCI U.S.High Dividend Yield Index,1
+1622,MSCI All Country World Small Cap Index-NR,1
+1623,65% MSCI ACWI IMI Index / 35% Bloomberg U.S.1-5 Year Government / Credit Bond Index,1
+1624,Bloomberg U.S.1-3 Month Treasury Bill Index,1
+1625,Bloomberg U.S.1-5 Year Government/Credit Bond Index,1
+1626,MSCI ACWI ex U.S.IMI Index,1
+1627,MSCI ACWI IMI Value Index,1
+1628,MSCI Emerging Markets IMI Index,1
+1629,MSCI Emerging Markets IMI Value Index,1
+1630,MSCI Emerging Market Small Cap Index,1
+1631,MSCI World ex U.S.IMI Index,1
+1632,MSCI World ex U.S.Small Cap Index,1
+1633,MSCI World ex U.S.Value Index,1
+1634,MSCI World IMI Index,1
+1635,S&P Global REIT Index,1
+1636,Msci All Country World Index Net Reflects No Deduction For Fees Expenses Or Taxes,1
+1637,Bloomberg U.S.EQ:FI 60:40 Index,1
+1638,"Bloomberg U.S.Mortgage Backed Securities Index (reflects no deduction for fees, expenses or taxes",1
+1639,ICE U.S.Treasury 20+ Year Bond Index,1
+1640,ICE U.S.Treasury 7-10 Year Bond Index,1
+1641,MSCI U.S.IMI Health Care Net Total Return USD Index,1
+1642,MSCI U.S.IMI/Health Care Net Index,1
+1643,Nasdaq Bitcoin Reference Price Index 09.29.22,1
+1644,KraneShares InspereX Nasdaq Dynamic Buffered High Income Index ETF,1
+1645,Nasdaq Sprott Critical Materials Index,1
+1646,Nasdaq Sprott Junior Copper MinersTM Index,1
+1647,Nasdaq Sprott Junior Uranium MinersTM Index,1
+1648,Nasdaq Sprott Lithium MinersTM Index,1
+1649,Nasdaq Sprott Nickel MinersTM Index,1
+1650,Morningstar Minority Empowerment Index,1
+1651,Morningstar U.S.Large-Mid Cap Index,1
+1652,Morningstar Women's Empowerment Index,1
+1653,Dow Jones U.S.Thematic Market Neutral Low Beta Index,1
+1654,Lipper Equity Income Funds Index,1
+1655,Russell 1000 Value Total Return Index,1
+1656,MSCI Emerging Markets Stock Index,1
+1657,The Nasdaq 100 Index Risks,1
+1658,Russell 2000 Index Risks,1
+1659,S&P 500 Index Risks,1
+1660,MSCI World SMID Cap Index,1
+1661,S&P Target Risk Moderate Index,1
+1662,ICE U.S.Treasury 7-10 Year Bond 1X Inverse Index,1
+1663,Bloomberg Emerging Markets USD Aggregate Bond Index,1
+1664,ICE BofA 1-3 BB U.S.Cash Pay High Yield Index,1
+1665,ICE BofA 1-3 Year A-BBB U.S.Corporate Index,1
+1666,ICE BofA 1-5 Year Corporate & Government Bond Index,1
+1667,S&P Global Clean Energy Transition Index,1
+1668,Russell 1000 Value Secondary Index,1
+1669,S&P 500 Total Return PRIMARY Index,1
+1670,S&P Composite 1500 Equal Weight Total Return Index,1
+1671,BofA Merrill Lynch 1-3 Year U.S.Corporate/Government Index,1
+1672,Dow Jones Global Index TR,1
+1673,MSCI All Country Asia ex Japan Index,1
+1674,MSCI All Country World Index ex U.S.Growth,1
+1675,MSCI All Country World Index ex U.S.Net,1
+1676,MSCI Arabian Markets & Africa 10/40 Investable Market Index,1
+1677,MSCI Emerging Markets Latin America Index,1
+1678,S&P Global ex-U.S.Small Cap Index,1
+1679,TOPIX Index,1
+1680,Bloomberg Municipal 1-15 Year Blend Bond Index,1
+1681,Morningstar Global Allocation Index,1
+1682,MSCI All Country World Index Growth,1
+1683,MSCI Emerging Markets Europe Index,1
+1684,MSCI World Value Index,1
+1685,MSCI China All Shares Index,1
+1686,Wilshire Liquid Alternative Equity Hedge Total Return Index,1
+1687,Bloomberg U.S.Municipal Index,1
+1688,Bloomberg Commodity Index Total ReturnSM,1

--- a/docs/diagnostics/2026-04-20-canonical-map-expansion-proposal.csv
+++ b/docs/diagnostics/2026-04-20-canonical-map-expansion-proposal.csv
@@ -1,0 +1,179 @@
+canonical_name,ciks_impact,proposed_etf_ticker,asset_class,top_raw_aliases
+S&P 500 Index,155,SPY,equity_us_large_cap,"S&P 500 Index | S&P 500 Index reflects no deduction for fees, expenses or taxes | S&P 500 Index reflects no deduction for fees, expenses, or taxes | S&P 500 Index reflects no deductions for fees, expenses or taxes | S&P 500 Index&#160;"
+Bloomberg U.s.. Aggregate Bond Index,103,AGG,fi_us_aggregate,"Bloomberg U.S.Aggregate Bond Index | Bloomberg U.S.Aggregate Bond Index reflects no deduction for fees, expenses, or taxes | Bloomberg U.S.Aggregate Bond Index reflects no deductions for fees, expenses or taxes | Bloomberg U.S.Aggregate Bond Index&#160; | Bloomberg U.S.Aggregate Bond Total Return Index"
+Russell 3000 Index,68,IWV,equity_us_total,"RUSSELL 3000 Index | Russell 3000 Index | Russell 3000 Index reflects no deduction for fees, expenses, or taxes | Russell 3000 Index reflects no deductions for fees, expenses or taxes | Russell 3000 Index&#160;"
+Russell 1000 Growth Index,42,IWF,equity_us_large_growth,"RUSSELL 1000 GROWTH Index | Russell 1000 Growth Index | Russell 1000 Growth Index reflects no deduction for fees, expenses, or taxes | Russell 1000 Growth Index&#160; | Russell 1000 Growth Total Return Index"
+Russell 1000 Value Index,41,IWD,equity_us_large_value,"RUSSELL 1000 VALUE Index | Russell 1000 Value Index | Russell 1000 Value Index reflects no deduction for fees, expenses or taxes | Russell 1000 Value Index reflects no deduction for fees, expenses, or taxes | Russell 1000 Value Index reflects no deductions for fees, expenses or taxes"
+Russell 1000 Index,41,IWB,equity_us_large_cap,"RUSSELL 1000 Index | Russell 1000 Index | Russell 1000 Index reflects no deduction for fees, expenses, or taxes | Russell 1000 Index reflects no deductions for fees, expenses or taxes | Russell 1000 Index&#160;"
+Bloomberg Municipal Bond Index,36,MUB,fi_us_muni,"Bloomberg Municipal Bond Index | Bloomberg Municipal Bond Index reflects no deduction for fees, expenses, or taxes | Bloomberg Municipal Bond Index&#160;"
+MSCI EAFE Index,33,EFA,equity_developed_ex_us,"MSCI EAFE Index | MSCI EAFE Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes | MSCI EAFE Index reflects no deductions for fees, expenses or taxes | MSCI EAFE Index&#160; | MSCI EAFE NR Index"
+Russell 2000 Index,30,IWM,equity_us_small,"RUSSELL 2000 Index | Russell 2000 Index | Russell 2000 Index reflects no deductions for fees, expenses or taxes | Russell 2000 Index&#160; | Russell 2000 Total Return Index"
+MSCI Emerging Markets Index,27,EEM,equity_emerging,"MSCI Emerging Markets Index | MSCI Emerging Markets Index reflects no deductions for fees, expenses or taxes | MSCI Emerging Markets Index&#160; | MSCI Emerging Markets Total Return Index"
+Russell 2000 Growth Index,25,IWO,equity_us_small_growth,RUSSELL 2000 GROWTH Index | Russell 2000 Growth Index | Russell 2000 Growth Total Return Index
+Russell 2000 Value Index,22,IWN,equity_us_small_value,"RUSSELL 2000 VALUE Index | Russell 2000 Value Index | Russell 2000 Value Index reflects no deduction for fees, expenses or taxes | Russell 2000 Value Index reflects no deductions for fees, expenses or taxes | Russell 2000 Value Index&#160;"
+Russell MidCap Growth Index,20,IWP,equity_us_mid_growth,"RUSSELL MIDCAP GROWTH Index | Russell Midcap Growth Index | Russell Midcap Growth Index reflects no deduction for fees, expenses, or taxes | Russell Midcap Growth Total Return Index"
+MSCI World Index,18,URTH,equity_developed_world,"MSCI WORLD Index | MSCI World Index | MSCI World Index&#160; | MSCI World NR Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes"
+MSCI ACWI Index,16,ACWI,equity_global,MSCI ACWI Index | MSCI ACWI Total Return Index | MSCI All Country World Index NR
+MSCI ACWI,15,ACWI,equity_global,MSCI All Country World Index | MSCI All Country World Index&#160;
+Bloomberg Global Aggregate Index,14,BNDX,fi_global_aggregate,Bloomberg Global Aggregate Index | Bloomberg Global Aggregate Index&#160;
+Bloomberg U.s.. Aggregate Index,14,AGG,fi_us_aggregate,BLOOMBERG U.S.AGGREGATE Index | Bloomberg U.S.Aggregate Index | Bloomberg U.S.Aggregate Index&#160;
+Russell MidCap Value Index,13,IWS,equity_us_mid_value,"RUSSELL MIDCAP VALUE Index | Russell MidCap Value Index | Russell Midcap Value Index | Russell Midcap Value Index reflects no deduction for fees, expenses or taxes | Russell Midcap Value Index reflects no deductions for fees, expenses or taxes"
+S&P MidCap 400 Index,12,MDY,equity_us_mid,S&P MidCap 400 Index | S&P MidCap 400 Index&#160;
+Russell MidCap Index,12,IWR,equity_us_mid,"RUSSELL MIDCAP Index | Russell Midcap Index | Russell Midcap Index reflects no deduction for fees, expenses or taxes | Russell Midcap Index reflects no deductions for fees, expenses or taxes"
+Nasdaq-100 Index,12,QQQ,equity_us_large_growth,NASDAQ - 100 Total Return Index | NASDAQ-100 Index | NASDAQ-100 Index&#160; | NASDAQ-100 Total Return Index | Nasdaq-100 Index
+MSCI ACWI Ex U.s.. Index,11,ACWX,equity_developed_emerging_ex_us,"MSCI ACWI ex U.S.Index | MSCI ACWI ex U.S.Index reflects no deduction for fees, expenses, or taxes"
+Bloomberg U.s.. Universal Index,10,UBND,fi_us_universal,"Bloomberg U.S.Universal Index | Bloomberg U.S.Universal Index reflects no deductions for fees, expenses or taxes | Bloomberg U.S.Universal Total Return Index"
+Bloomberg Global Aggregate Bond Index,9,BNDX,fi_global_aggregate,Bloomberg Global Aggregate Bond Index | Bloomberg Global Aggregate Bond Index Reflects No Deduction For Fees Expenses Or Taxes | Bloomberg Global Aggregate Bond Index&#160;
+Russell 2500 Index,9,IWM,equity_us_small,RUSSELL 2500 Index | Russell 2500 Index | Russell 2500 Total Return Index
+Nasdaq Composite Index,9,ONEQ,equity_us_large_growth,NASDAQ Composite Index | NASDAQ Composite Total Return Index | Nasdaq Composite Index | Nasdaq Composite Index&#160;
+Russell 2500 Value Index,8,SMLV,equity_us_small_value,Russell 2500 Value Index | Russell 2500 Value Total Return Index
+ICE BofA U.S.3-month Treasury Bill Index,8,BIL,fi_us_cash,ICE BofA U.S.3-Month Treasury Bill Index | ICE BofA U.S.3-Month Treasury Bill Total Return Index&#160;
+Russell 3000 Value Index,8,IWW,equity_us_value,RUSSELL 3000 VALUE Index | Russell 3000 Value Index | Russell 3000 Value Total Return Index
+S&P Composite 1500 Index,8,ITOT,equity_us_total,S&P COMPOSITE 1500 Index | S&P Composite 1500 Index | S&P Composite 1500 Index&#160; | S&P Composite 1500 Total Return Index
+ICE BofA 3-month U.s.. Treasury Bill Index,7,BIL,fi_us_cash,ICE BofA 3-Month U.S.Treasury Bill Index
+S&P 500 Growth Index,7,IVW,equity_us_large_growth,S&P 500 Growth Index
+S&P 500 Value Index,7,IVE,equity_us_large_value,S&P 500 Value Index
+MSCI U.s.. Index,7,VTI,equity_us_total,MSCI U.S.Index | MSCI U.S.Index&#160;
+S&P UBS Leveraged Loan Index,7,BKLN,fi_us_bankloan,"S&P UBS Leveraged Loan Index | S&P UBS Leveraged Loan Index reflects no deductions for fees, expenses or taxes"
+MSCI World Ex U.s.. Index,7,VEA,equity_developed_ex_us,MSCI World Ex U.S.Index | MSCI World ex U.S.Index
+S&P Municipal Bond Index,6,MUB,fi_us_muni,"S&P Municipal Bond Index | S&P Municipal Bond Index reflects no deductions for fees, expenses or taxes"
+S&P SmallCap 600 Index,6,IJR,equity_us_small,S&P SmallCap 600 Index | S&P SmallCap 600 TR Index
+Russell 3000 Growth Index,6,IWZ,equity_us_growth,RUSSELL 3000 GROWTH Index | Russell 3000 Growth Index | Russell 3000 Growth Total Return Index
+MSCI EAFE Value Index,6,EFV,equity_developed_value,MSCI EAFE Value Index | MSCI EAFE Value Index&#160;
+Russell 2500 Growth Index,5,SMLG,equity_us_small_growth,Russell 2500 Growth Index
+Bloomberg U.s.. Municipal Bond Index,5,MUB,fi_us_muni,Bloomberg U.S.Municipal Bond Index
+Bloomberg Commodity Index,5,DJP,alt_commodities,Bloomberg Commodity Index
+S&P 500 Equal Weight Index,5,RSP,equity_us_large_cap,S&P 500 Equal Weight Index | S&P 500 Equal Weight Total Return Index
+Bloomberg U.s.. Corporate Bond Index,5,LQD,fi_us_corporate,"Bloomberg U.S.Corporate Bond Index | Bloomberg U.S.Corporate Bond Index reflects no deduction for fees, expenses, or taxes"
+ICE BofA U.s.. High Yield Index,5,HYG,fi_us_hy,"ICE BofA U.S.High Yield Index | ICE BofA U.S.High Yield Index reflects no deduction for fees, expenses, or taxes"
+Bloomberg U.s.. Treasury Index,4,GOVT,fi_us_treasury,Bloomberg U.S.Treasury Index
+Morningstar LSTA U.s.. Leveraged Loan Index,4,BKLN,fi_us_bankloan,Morningstar LSTA U.S.Leveraged Loan Index
+S&P Biotechnology Select Industry Index,4,XBI,equity_us_biotech,S&P Biotechnology Select Industry Index
+S&P MidCap 400 Growth Index,4,IJK,equity_us_mid_growth,S&P MidCap 400 Growth Index
+S&P MidCap 400 Value Index,4,IJJ,equity_us_mid_value,S&P MidCap 400 Value Index
+S&P SmallCap 600 Growth Index,4,IJT,equity_us_small_growth,S&P SmallCap 600 Growth Index
+S&P SmallCap 600 Value Index,4,IJS,equity_us_small_value,S&P SmallCap 600 Value Index
+Dow Jones U.s.. Total Stock Market Float Adjusted Index,4,SCHB,equity_us_total,Dow Jones U.S.Total Stock Market Float Adjusted Index
+ICE BofA U.s.. Broad Market Index,4,AGG,fi_us_aggregate,ICE BofA U.S.Broad Market Index
+JP Morgan CLOIE AAA Index,4,JAAA,fi_us_clo_aaa,JP Morgan CLOIE AAA Index | JP Morgan CLOIE AAA Index&#160; | JP Morgan CLOIE AAA Total Return Index
+S&P 500 Utilities Index,3,XLU,equity_us_utilities,S&P 500 Utilities Index
+S&P 1500 Index,3,ITOT,equity_us_total,S&P 1500 Index
+Bloomberg Intermediate U.s.. Aggregate Bond Index,3,IAGG,fi_us_intermediate,Bloomberg Intermediate U.S.Aggregate Bond Index
+MSCI Europe Index,3,VGK,equity_europe,MSCI Europe Index
+Bloomberg U.S.1-3 Year Government/credit Bond Index,3,BIV,fi_us_short,Bloomberg U.S.1-3 Year Government/Credit Bond Index
+Bloomberg Minnesota Municipal Bond Index,3,MUB,fi_us_muni,Bloomberg Minnesota Municipal Bond Index
+ICE BofA U.s.. High Yield Constrained Index,3,HYG,fi_us_hy,ICE BofA U.S.High Yield Constrained Index
+Bloomberg U.s.. Corporate Index,3,LQD,fi_us_corporate,Bloomberg U.S.Corporate Index
+ICE BofA U.s.. Treasury Bill Index,3,BIL,fi_us_cash,ICE BofA U.S.Treasury Bill Index
+Bloomberg Municipal High Yield Bond Index,3,HYD,fi_us_muni_hy,Bloomberg Municipal High Yield Bond Index
+ICE BOFA 3-month U.s.. Treasury BILL Index,3,BIL,fi_us_cash,ICE BOFA 3-MONTH U.S.TREASURY BILL Index
+Bloomberg High Yield Very Liquid Index,3,USHY,fi_us_hy,Bloomberg High Yield Very Liquid Index
+Bloomberg U.s.. MBS Index,3,MBB,fi_us_mbs,Bloomberg U.S.MBS Index
+MSCI ACWI IMI Index,3,ACWI,equity_global,MSCI ACWI IMI Index
+Bloomberg Aggregate Bond Index,3,AGG,fi_us_aggregate,Bloomberg Aggregate Bond Index
+MSCI Japan Index,3,EWJ,equity_japan,MSCI Japan Index
+S&P 500 Information Technology Index,3,XLK,equity_us_technology,S&P 500 Information Technology Index
+Bloomberg U.S.1-5 Year Government/credit Index,3,BIV,fi_us_short,Bloomberg U.S.1-5 Year Government/Credit Index
+ICE BofA U.s.. All Capital Securities Index,3,PFF,fi_us_preferred,ICE BofA U.S.All Capital Securities Index | ICE BofA U.S.All Capital Securities Index&#160;
+Bloomberg U.s.. Universal Bond Index,3,UBND,fi_us_universal,Bloomberg U.S.Universal Bond Index | Bloomberg U.S.Universal Bond Index&#160;
+S&P National Amt-free Municipal Bond Index,2,MUB,fi_us_muni,S&P National AMT-Free Municipal Bond Index
+Lipper Balanced Funds Index,2,AOR,allocation_balanced,Lipper Balanced Funds Index
+Bloomberg U.S.2000 Index,2,IWM,equity_us_small,Bloomberg U.S.2000 Index
+MSCI U.s.. Minimum Volatility Index,2,USMV,equity_us_minvol,MSCI U.S.Minimum Volatility Index
+Bloomberg Pennsylvania Municipal Bond Index,2,MUB,fi_us_muni,Bloomberg Pennsylvania Municipal Bond Index
+Bloomberg 1 Year Municipal Bond Index,2,SUB,fi_us_muni_short,Bloomberg 1 Year Municipal Bond Index
+FTSE World Government Bond Index,2,BWX,fi_global_treasury,FTSE World Government Bond Index
+Bloomberg U.s.. Corporate High Yield Index,2,HYG,fi_us_hy,Bloomberg U.S.Corporate High Yield Index
+Morningstar LSTA U.s.. Leveraged Loan 100 Index,2,BKLN,fi_us_bankloan,Morningstar LSTA U.S.Leveraged Loan 100 Index
+Russell 1000 Equal Weight Index,2,EQAL,equity_us_large_cap,Russell 1000 Equal Weight Index
+S&P 500 Financials Index,2,XLF,equity_us_financials,S&P 500 Financials Index
+ICE BofA U.s.. Cash Pay High Yield Constrained Index,2,HYG,fi_us_hy,ICE BofA U.S.Cash Pay High Yield Constrained Index
+Bloomberg 3-15 Year Blend Municipal Bond Index,2,MUB,fi_us_muni,Bloomberg 3-15 Year Blend Municipal Bond Index
+Bloomberg U.s.. Credit Index,2,LQD,fi_us_corporate,Bloomberg U.S.Credit Index
+ICE BofA 1 3 Year U.s.. Treasury Index,2,SHY,fi_us_short,ICE BofA 1 3 Year U.S.Treasury Index
+S&P 1000 Index,2,IWM,equity_us_small,S&P 1000 Index
+Bloomberg 1-3 Month U.s.. Treasury Bill Index,2,BIL,fi_us_cash,Bloomberg 1-3 Month U.S.Treasury Bill Index
+Bloomberg U.s.. Government Inflation-linked Bond Index,2,TIP,fi_us_tips,Bloomberg U.S.Government Inflation-Linked Bond Index
+Bloomberg U.s.. Intermediate Corporate Bond Index,2,IGIB,fi_us_corporate,Bloomberg U.S.Intermediate Corporate Bond Index
+S&P Banks Select Industry Index,2,KBE,equity_us_banks,S&P Banks Select Industry Index
+S&P Oil & Gas Equipment & Services Select Industry Index,2,XES,equity_us_energy,S&P Oil & Gas Equipment & Services Select Industry Index
+S&P Pharmaceuticals Select Industry Index,2,XPH,equity_us_pharma,S&P Pharmaceuticals Select Industry Index
+Bloomberg U.s.. Government/credit 1-3 Year Index,2,BIV,fi_us_short,Bloomberg U.S.Government/Credit 1-3 Year Index
+MSCI ACWI Ex U.s.. Investable Market Index,2,VXUS,equity_developed_emerging_ex_us,MSCI ACWI ex U.S.Investable Market Index
+Dow Jones U.s.. Select Dividend Index,2,DVY,equity_us_dividend,Dow Jones U.S.Select Dividend Index
+JP Morgan EMBI Global Diversified Index,2,EMB,fi_em_sovereign,JP Morgan EMBI Global Diversified Index
+S&P Target Date To 2055 Index,2,VFFVX,allocation_target_date_2055,S&P Target Date To 2055 Index
+S&P Target Date To 2030 Index,2,VTHRX,allocation_target_date_2030,S&P Target Date To 2030 Index
+S&P Target Date To 2035 Index,2,VTTHX,allocation_target_date_2035,S&P Target Date To 2035 Index
+S&P Target Date To 2040 Index,2,VFORX,allocation_target_date_2040,S&P Target Date To 2040 Index
+S&P Target Date To 2045 Index,2,VTIVX,allocation_target_date_2045,S&P Target Date To 2045 Index
+S&P Target Date To 2050 Index,2,VFIFX,allocation_target_date_2050,S&P Target Date To 2050 Index
+S&P Target Date To 2060 Index,2,VTTSX,allocation_target_date_2060,S&P Target Date To 2060 Index
+ICE BofA 3 Month U.s.. Treasury Bill Index,2,BIL,fi_us_cash,ICE BofA 3 Month U.S.Treasury Bill Index
+Russell Mid Cap Index,2,IWR,equity_us_mid,Russell Mid Cap Index | Russell Mid Cap Total Return Index
+MSCI ACWI Ex U.S.. Index,2,ACWX,equity_developed_emerging_ex_us,MSCI ACWI EX-U.S.Index | MSCI ACWI ex-U.S.Index
+Bloomberg 1-year Municipal Bond Index,2,SUB,fi_us_muni_short,Bloomberg 1-Year Municipal Bond Index | Bloomberg 1-Year Municipal Bond Index&#160;
+ICE BofA 1-3 Year U.s.. Treasury Index,2,SHY,fi_us_short,ICE BofA 1-3 Year U.S.Treasury Index | ICE BofA 1-3 Year U.S.Treasury Index&#160;
+Nasdaq 100 Index,2,QQQ,equity_us_large_growth,NASDAQ 100 Total Return Index | Nasdaq 100 Total Return Index
+Bloomberg U.s.. Municipal Bond Index*,1,MUB,fi_us_muni,Bloomberg U.S.Municipal Bond Index*
+S&P Municipal Bond Index*,1,MUB,fi_us_muni,"S&P Municipal Bond Index* reflects no deductions for fees, expenses or taxes"
+Russell 3000 Index?,1,IWV,equity_us_total,Russell 3000 Index?
+CRSP U.s.. Total Market Index,1,VTI,equity_us_total,CRSP U.S.Total Market Index
+MSCI World Ex U.S.. Index,1,VEA,equity_developed_ex_us,MSCI World ex-U.S.Index
+MSCI Emerging Markets Index?,1,EEM,equity_emerging,MSCI Emerging Markets Index?
+ICE BOFA U.s.. ALL Capital Securities Index,1,PFF,fi_us_preferred,ICE BOFA U.S.ALL CAPITAL SECURITIES Index
+ICE BofA U.S.3 Month Treasury Bill Index,1,BIL,fi_us_cash,ICE BofA U.S.3 Month Treasury Bill Index
+Bloomberg 3 15 Year Blend Municipal Bond Index,1,MUB,fi_us_muni,Bloomberg 3 15 Year Blend Municipal Bond Index
+S&P 500index,1,SPY,equity_us_large_cap,S&P 500Index
+S&P Total Market Index,1,SPTM,equity_us_total,S&P Total Market Index
+S&P 1500 Index-,1,ITOT,equity_us_total,S&P 1500 Index -
+Bloomberg U.s.. Aggregatebond Index,1,AGG,fi_us_aggregate,Bloomberg U.S.AggregateBond Index
+Bloomberg U.s.. Aggregate BOND Index,1,AGG,fi_us_aggregate,BLOOMBERG U.S.AGGREGATE BOND Index
+S&P 500 Index),1,SPY,equity_us_large_cap,S&P 500 Index)
+MSCI World Index),1,URTH,equity_developed_world,MSCI World Index)
+MSCI Emerging Markets Index),1,EEM,equity_emerging,MSCI Emerging Markets Index)
+MSCI World Index-,1,URTH,equity_developed_world,MSCI World Index -
+S&P Small Cap 600 Index,1,IJR,equity_us_small,S&P Small Cap 600 Index
+
+UNMAPPED BELOW (need human decision or skip)
+canonical_name,ciks_impact,,,top_raw_aliases
+MSCI All Country World Ex U.S.. Index-nr,6,,,MSCI All Country World Ex-U.S.Index-NR | MSCI All Country World ex-U.S.Index-NR
+MSCI All Country World Ex U.s.. Index Index,3,,,MSCI All Country World Ex U.S.Index NR
+"S&P Total Market Index (returns Do Not Reflect Deductions For Fees, Expenses Or Taxes)",3,,,"S&P Total Market Index (Returns do not reflect deductions for fees, expenses or taxes)"
+MSCI ACWI-nr,3,,,MSCI All Country World Index-NR
+MSCI All-country World Index,3,,,"MSCI All-Country World Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes | MSCI All-Country World NR Index reflects no deduction for fees, expenses, or taxes, except foreign withholding taxes"
+MSCI All Country World Ex U.s.. Index,3,,,MSCI All Country World Ex U.S.Index&#160; | MSCI All Country World ex U.S.Index | MSCI All Country World ex U.S.Index&#160;
+S&P 500 Index ( Index,2,,,"S&P 500 Index (Index returns do not reflect deductions for fees, expenses or taxes)"
+Morningstar LSTA Leveraged Loan Index,2,,,Morningstar LSTA Leveraged Loan Index
+Morningstar U.s.. Moderate Target Allocation Index,2,,,Morningstar U.S.Moderate Target Allocation Index
+FTSE 3-month U.s.. Treasury Bill Index,2,,,FTSE 3-Month U.S.Treasury Bill Index
+Bloomberg U.s.. Aggregate Float Adjusted Index,2,,,Bloomberg U.S.Aggregate Float Adjusted Index
+MSCI India Index,2,,,MSCI India Index
+Bloomberg U.s.. Corporate High Yield Bond Index,2,,,Bloomberg U.S.Corporate High Yield Bond Index
+"MSCI ACWI (reflects Reinvested Dividends Net Of Withholding Taxes, But",2,,,"MSCI All Country World Index (reflects reinvested dividends net of withholding taxes, but reflects no deduction for fees, expenses or taxes)"
+CBOE S&P 500 Buywrite Monthly Index,2,,,CBOE S&P 500 BuyWrite Monthly Index
+Bloomberg U.s.. Short Aggregate Enhanced Yield Index,2,,,Bloomberg U.S.Short Aggregate Enhanced Yield Index
+Bloomberg U.s.. Short Aggregate Composite Index,2,,,Bloomberg U.S.Short Aggregate Composite Index
+MSCI AC World Index,2,,,MSCI AC World Index
+S&P 500 Health Care Index,2,,,S&P 500 Health Care Index
+Bloomberg 1-5 Year U.s.. Government/credit Index,2,,,Bloomberg 1-5 Year U.S.Government/Credit Index
+Morningstar Aggressive Target Risk Index,2,,,Morningstar Aggressive Target Risk Index
+MSCI ACWI Investable Market Index,2,,,MSCI ACWI Investable Market Index
+S&P Global Broad Market Index,2,,,S&P Global Broad Market Index
+Bloomberg 1-5 Year Government/credit Index,2,,,Bloomberg 1-5 Year Government/Credit Index
+Bloomberg U.s.. Corporate High Yield 2% Issuer Capped Index,2,,,Bloomberg U.S.Corporate High Yield 2% Issuer Capped Index
+Bloomberg 500 Index,2,,,Bloomberg 500 Index
+CBOE S&P 500 Buywrite Index,2,,,CBOE S&P 500 BuyWrite Index
+Bloomberg U.s.. Government/credit Bond Index,2,,,"Bloomberg U.S.Government/Credit Bond Index | Bloomberg U.S.Government/Credit Bond Index reflects no deductions for fees, expenses or taxes"
+Bloomberg U.s.. Intermediate Credit Index,2,,,"Bloomberg U.S.Intermediate Credit Index | Bloomberg U.S.Intermediate Credit Index reflects no deductions for fees, expenses or taxes"
+Bloomberg U.s.. Intermediate Government/credit Index,2,,,"Bloomberg U.S.Intermediate Government/Credit Index | Bloomberg U.S.Intermediate Government/Credit Index reflects no deductions for fees, expenses or taxes"
+S&P Municipal Bond Investment Grade Intermediate Index,2,,,"S&P Municipal Bond Investment Grade Intermediate Index | S&P Municipal Bond Investment Grade Intermediate Index reflects no deductions for fees, expenses or taxes"
+S&P Municipal Bond Investment Grade Short Index,2,,,"S&P Municipal Bond Investment Grade Short Index | S&P Municipal Bond Investment Grade Short Index reflects no deductions for fees, expenses or taxes"
+NYSE Technology Index,2,,,"NYSE Technology Index | NYSE Technology Index reflects no deductions for fees, expenses or taxes"
+Morningstar Moderate Target Risk Index,2,,,"Morningstar Moderate Target Risk Index | Morningstar Moderate Target Risk Index reflects no deductions for fees, expenses or taxes"
+MSCI ACWI All Cap Index,2,,,MSCI ACWI All Cap Index | MSCI ACWI All Cap Index&#160;
+S&P Target Risk Moderate Index,2,,,S&P Target Risk Moderate Index | S&P Target Risk Moderate Index&#160;
+MSCI Kokusai Index,2,,,MSCI Kokusai Index | MSCI Kokusai Index&#160;
+S&P 500 Scored & Screened Index,2,,,S&P 500 Scored & Screened Index | S&P 500 Scored & Screened Index&#160;
+Russell 2500tm Value Index,2,,,Russell 2500TM Value Index | Russell 2500TM Value Index&#160;
+Bloomberg 1-15 Year Municipal Bond Index,2,,,Bloomberg 1-15 Year Municipal Bond Index | Bloomberg 1-15 Year Municipal Bond Index&#160;

--- a/docs/diagnostics/2026-04-20-q5-1-3-rr1-validation.md
+++ b/docs/diagnostics/2026-04-20-q5-1-3-rr1-validation.md
@@ -1,0 +1,89 @@
+# PR-Q5.1.3 — Canonical Map Expansion + RR-1 Slice Backfill Validation
+
+Date: 2026-04-20
+Branch: `feat/q5.1.3-canonical-map-rr1-backfill`
+Target gate: MF coverage ≥12% (baseline 8.0%, projection 13-15%)
+
+## Phase A — Migration 0168 (canonical map expansion)
+
+Source: [`docs/diagnostics/2026-04-20-canonical-map-expansion-proposal.csv`](./2026-04-20-canonical-map-expansion-proposal.csv) (135 mapped rows over 81 unique `(proxy_etf_ticker, asset_class)` buckets).
+
+Pre-apply: 44 rows (20 from 0165 + 24 from 0166).
+Post-apply: 92 rows (+48 inserted, 33 merged into existing by ticker+asset_class lookup).
+
+Apply log:
+
+```
+INFO  [alembic] Running upgrade 0167_primary_benchmark_backfill_log -> 0168_expand_canonical_map_fsds_q1_2025
+[0168] benchmark_etf_canonical_map: merged_into_existing=33 inserted_new=48 total_groups=81
+```
+
+Source distribution after migration:
+
+| source | rows |
+|---|---|
+| `manual_seed_0165` | 20 |
+| `manual_seed_0166` | 24 |
+| `fsds_q1_2025_slice_0168` | 48 |
+| **total** | **92** |
+
+Top aliases-merged buckets (new):
+
+| ticker | canonical | #aliases |
+|---|---|---|
+| BIL | ICE BofA U.S. Treasury Bill Index | 11 |
+| BIV | Bloomberg U.S.1-5 Year Government/Credit Index | 6 |
+| UBND | Bloomberg U.S. Universal Index | 4 |
+| BKLN | S&P UBS Leveraged Loan Index | 4 |
+
+## Phase B — RR-1 slice backfill
+
+Inputs:
+- `E:\EDGAR FILES\Tickers\sub.tsv` — 1,506 Q1 2025 filings (`adsh → cik`)
+- `E:\EDGAR FILES\Tickers\lab.tsv` — 50,738 XBRL Member rows; 3,245 benchmark-label hits; 348 unique CIKs
+
+Resolver: benchmark_etf_canonical_map (322 alias lookup entries post-0168).
+
+Planned actions:
+
+| action | count |
+|---|---|
+| inserted | 177 |
+| skipped_existing | 83 |
+| unresolvable | 82 |
+
+Top canonicals inserted (by CIK count):
+
+| count | canonical |
+|---|---|
+| 73 | S&P 500 |
+| 29 | Bloomberg US Aggregate Bond |
+| 21 | Bloomberg Municipal |
+| 9 | Russell 3000 |
+| 5 | Russell 1000 |
+| 5 | MSCI ACWI |
+| 5 | MSCI EAFE |
+
+## Coverage gate
+
+| cut | total | with `primary_benchmark` | pct |
+|---|---|---|---|
+| MF baseline (post-Q5.1) | 3,652 | 293 | 8.00% |
+| MF post-Q5.1.3 | 3,652 | 470 | **12.87%** |
+| delta | — | +177 | **+4.87pp** |
+| closed_end | 965 | 0 | 0.00% |
+
+**Gate ≥12% MF: PASSED** (+0.87pp margin).
+
+Audit trail: every processed CIK landed in `primary_benchmark_backfill_log`
+with `source='fsds_q1_2025_rr1_v1'` and one of `inserted / skipped_existing / unresolvable`.
+Combined with the Q5.1 audit rows (`source='tiingo_description_regex_v1'`),
+operators can answer "why is fund X still missing?" with a single query.
+
+## Unresolvable tail (Q5.2 input)
+
+82 CIKs had a benchmark label parsed but no canonical match. The label set
+is Q5.2 fodder — expected patterns include: `MSCI Kokusai Index`, `FTSE
+World Government Bond Index` variants, `CBOE S&P 500 BuyWrite`, `Lipper
+Growth Index`, Morningstar target-risk variants. Full historical FSDS
+ingest worker (Q5.2) will expand the canonical map another 30-50 rows.


### PR DESCRIPTION
## Summary

Interim win for the benchmark PROXY rail. Expands `benchmark_etf_canonical_map` and populates `sec_registered_funds.primary_benchmark` from the SEC FSDS Q1 2025 RR-1 slice, moving MF coverage from 8.0% to **12.87%** (+4.87pp, gate >=12% cleared).

Q5.2 (full historical FSDS ingest worker) remains the path to the institutional 30% gate — explicitly out of scope here.

## Phases

**A. Migration 0168** (`backend/app/core/db/migrations/versions/0168_expand_canonical_map_fsds_q1_2025.py`)
- Source CSV: `docs/diagnostics/2026-04-20-canonical-map-expansion-proposal.csv` (135 mapped rows)
- Grouped at build time into 81 unique `(proxy_etf_ticker, asset_class)` buckets via deterministic canonical scorer
- UPDATE-if-exists / INSERT-else logic preserves 0165 + 0166 canonical identities
- `benchmark_etf_canonical_map`: 44 -> 92 rows (33 merged, 48 new), alias lookup 180 -> 322

**B. RR-1 backfill script** (`backend/scripts/backfill_primary_benchmark_from_rr1.py`)
- Zero external API calls — streams local `sub.tsv` + `lab.tsv` (1,506 filings / 50,738 Member rows)
- Filters XBRL Member labels mentioning institutional benchmark providers + "Index"
- Resolves to canonical via expanded map, writes to `sec_registered_funds.primary_benchmark` + `primary_benchmark_backfill_log` (source tag `fsds_q1_2025_rr1_v1`)
- Batched commits (500 rows/chunk), idempotent via ON CONFLICT

**C. Validation evidence** (`docs/diagnostics/2026-04-20-q5-1-3-rr1-validation.md`)

## Gate

| cut | total | with primary_benchmark | pct |
|---|---|---|---|
| MF baseline (post-Q5.1) | 3,652 | 293 | 8.00% |
| MF post-Q5.1.3 | 3,652 | 470 | **12.87%** |
| delta | — | +177 | **+4.87pp** |

Gate >=12% MF: **PASSED** (+0.87pp margin).

## Top canonicals populated

| count | canonical |
|---|---|
| 73 | S&P 500 |
| 29 | Bloomberg US Aggregate Bond |
| 21 | Bloomberg Municipal |
| 9 | Russell 3000 |
| 5 each | Russell 1000, MSCI ACWI, MSCI EAFE |

## Unresolvable tail -> Q5.2 input

82 CIKs had a benchmark label but no canonical match (MSCI Kokusai, CBOE BuyWrite, Lipper Growth, Morningstar target-risk variants). Captured in `primary_benchmark_backfill_log` with `action='unresolvable'` — expected to feed the Q5.2 full-historical FSDS worker.

## Test plan

- [x] `alembic upgrade head` clean (0167 -> 0168)
- [x] migration apply log: `merged_into_existing=33 inserted_new=48 total_groups=81`
- [x] canonical_map row count: 44 -> 92 confirmed via DB query
- [x] RR-1 dry-run: 177 inserted / 83 skipped_existing / 82 unresolvable
- [x] RR-1 apply: post-coverage query confirms 470/3652 MF
- [x] ruff check on new files: clean
- [x] mypy on new files: clean (only pre-existing `engine.py:26` outside our blast radius)
- [x] Zero frontend edits (mandate)
- [x] Zero external API calls (mandate)
- [ ] Operator re-run on prod DB once PR merges (single command: `PYTHONPATH=. python -m scripts.backfill_primary_benchmark_from_rr1`)

## Rollback

- Migration 0168 down-revision drops rows tagged `fsds_q1_2025_slice_0168`; alias merges on pre-existing rows are not reverted (documented in migration docstring).
- Backfill rows reversible via `UPDATE sec_registered_funds SET primary_benchmark = NULL WHERE cik IN (SELECT cik FROM primary_benchmark_backfill_log WHERE source='fsds_q1_2025_rr1_v1' AND action='inserted')`.

Pre-existing frontend lint errors in `frontends/credit/` are present on `main` and unrelated to this PR (zero frontend edits).