### PR TITLE
feat(terminal): visual parity phases 3-5 — Live, Screener, Builder

### DIFF
--- a/backend/app/domains/wealth/routes/macro.py
+++ b/backend/app/domains/wealth/routes/macro.py
@@ -52,6 +52,8 @@ from app.domains.wealth.schemas.macro import (
     OfrTimePoint,
     RegimeTrailPoint,
     RegimeTrailResponse,
+    RegionalRegimeResponse,
+    RegionalRegimeRow,
     RegionalScoreRead,
     TreasuryDataResponse,
     TreasuryTimePoint,
@@ -1202,6 +1204,134 @@ async def get_cb_calendar(
     ]
     upcoming.sort(key=lambda event: event.meeting_date)
     return CbCalendarResponse(events=upcoming[:n], as_of_date=today)
+
+
+# ---------------------------------------------------------------------------
+#  Regional regime — 4-region dense table for Live Workbench
+# ---------------------------------------------------------------------------
+
+_REGIONAL_REGIME_CODES = ["US", "EU", "EM", "BR"]
+_REGIONAL_SNAPSHOT_KEYS: dict[str, tuple[str, ...]] = {
+    "US": ("US", "United States"),
+    "EU": ("EU", "EUROPE", "Europe"),
+    "EM": ("EM", "Emerging Markets"),
+    "BR": ("BR", "Brazil"),
+}
+
+
+def _quadrant_label(growth: float, inflation: float) -> str:
+    if growth >= 50 and inflation < 50:
+        return "GOLDILOCKS"
+    if growth >= 50 and inflation >= 50:
+        return "OVERHEATING"
+    if growth < 50 and inflation >= 50:
+        return "STAGFLATION"
+    return "REFLATION"
+
+
+def _stress_level(growth: float, inflation: float) -> Literal["LOW", "MED", "HIGH"]:
+    distance = ((growth - 50) ** 2 + (inflation - 50) ** 2) ** 0.5
+    if distance >= 30:
+        return "HIGH"
+    if distance >= 15:
+        return "MED"
+    return "LOW"
+
+
+def _region_payload(snapshot_data: dict[str, Any], code: str) -> dict[str, Any]:
+    regions = snapshot_data.get("regions", {})
+    if not isinstance(regions, dict):
+        return {}
+    for key in _REGIONAL_SNAPSHOT_KEYS[code]:
+        payload = regions.get(key)
+        if isinstance(payload, dict):
+            return payload
+    return {}
+
+
+def _dimension_score(region_data: dict[str, Any], dimension: str) -> float | None:
+    dimensions = region_data.get("dimensions", {})
+    if not isinstance(dimensions, dict):
+        return None
+    payload = dimensions.get(dimension, {})
+    if not isinstance(payload, dict):
+        return None
+    score = payload.get("score")
+    return float(score) if score is not None else None
+
+
+@router.get(
+    "/regional-regime",
+    response_model=RegionalRegimeResponse,
+    summary="Current regime quadrant per tracked region",
+    tags=["macro"],
+)
+@route_cache(ttl=900, key_prefix="macro:regional_regime")
+async def get_regional_regime(
+    user: CurrentUser = Depends(get_current_user),
+) -> RegionalRegimeResponse:
+    """Return US/EU/EM/BR regime labels for the Live Workbench panel."""
+    stmt = (
+        select(MacroRegionalSnapshot.as_of_date, MacroRegionalSnapshot.data_json)
+        .order_by(MacroRegionalSnapshot.as_of_date.desc())
+        .limit(2)
+    )
+    async with async_session_factory() as db:
+        result = await db.execute(stmt)
+
+    rows = result.all()
+    if not rows:
+        return RegionalRegimeResponse(
+            as_of_date=None,
+            regions=[
+                RegionalRegimeRow(
+                    region_code=code,
+                    regime_label="GOLDILOCKS",
+                    stress_level="LOW",
+                    trend_up=True,
+                )
+                for code in _REGIONAL_REGIME_CODES
+            ],
+        )
+
+    latest = rows[0]
+    previous = rows[1] if len(rows) > 1 else None
+    latest_data = latest.data_json if isinstance(latest.data_json, dict) else {}
+    previous_data = (
+        previous.data_json
+        if previous is not None and isinstance(previous.data_json, dict)
+        else {}
+    )
+
+    regions: list[RegionalRegimeRow] = []
+    for code in _REGIONAL_REGIME_CODES:
+        current_region = _region_payload(latest_data, code)
+        previous_region = _region_payload(previous_data, code)
+        growth_score = _dimension_score(current_region, "growth")
+        inflation_score = _dimension_score(current_region, "inflation")
+        growth = growth_score if growth_score is not None else 50.0
+        inflation = inflation_score if inflation_score is not None else 50.0
+        previous_growth = _dimension_score(previous_region, "growth")
+        trend_up = (
+            previous_growth <= growth
+            if previous_growth is not None
+            else growth >= 50.0
+        )
+
+        regions.append(
+            RegionalRegimeRow(
+                region_code=code,
+                regime_label=_quadrant_label(growth, inflation),
+                stress_level=_stress_level(growth, inflation),
+                trend_up=trend_up,
+                growth_score=round(growth_score, 1) if growth_score is not None else None,
+                inflation_score=round(inflation_score, 1)
+                if inflation_score is not None
+                else None,
+            ),
+        )
+
+    return RegionalRegimeResponse(as_of_date=latest.as_of_date, regions=regions)
 
 
 @router.get(

--- a/backend/app/domains/wealth/schemas/macro.py
+++ b/backend/app/domains/wealth/schemas/macro.py
@@ -273,3 +273,17 @@ class CbEvent(BaseModel):
 class CbCalendarResponse(BaseModel):
     events: list[CbEvent] = Field(default_factory=list)
     as_of_date: date | None = None
+
+
+class RegionalRegimeRow(BaseModel):
+    region_code: str
+    regime_label: str
+    stress_level: Literal["LOW", "MED", "HIGH"]
+    trend_up: bool
+    growth_score: float | None = None
+    inflation_score: float | None = None
+
+
+class RegionalRegimeResponse(BaseModel):
+    as_of_date: date | None = None
+    regions: list[RegionalRegimeRow] = Field(default_factory=list)

--- a/backend/tests/domains/wealth/services/test_macro_new_endpoints.py
+++ b/backend/tests/domains/wealth/services/test_macro_new_endpoints.py
@@ -14,6 +14,8 @@ from app.domains.wealth.schemas.macro import (
     CrossAssetResponse,
     RegimeTrailPoint,
     RegimeTrailResponse,
+    RegionalRegimeResponse,
+    RegionalRegimeRow,
 )
 
 
@@ -81,3 +83,41 @@ def test_cb_event_schema() -> None:
 def test_cb_calendar_response_empty() -> None:
     r = CbCalendarResponse()
     assert r.events == []
+
+
+def test_regional_regime_row_schema() -> None:
+    row = RegionalRegimeRow(
+        region_code="US",
+        regime_label="GOLDILOCKS",
+        stress_level="LOW",
+        trend_up=True,
+        growth_score=62.5,
+        inflation_score=38.2,
+    )
+    assert row.regime_label == "GOLDILOCKS"
+    assert row.stress_level == "LOW"
+    assert row.trend_up is True
+
+
+def test_regional_regime_response_empty() -> None:
+    resp = RegionalRegimeResponse()
+    assert resp.regions == []
+    assert resp.as_of_date is None
+
+
+def test_quadrant_label_logic() -> None:
+    """Growth/inflation quadrant mapping used by /macro/regional-regime."""
+
+    def _label(growth: float, inflation: float) -> str:
+        if growth >= 50 and inflation < 50:
+            return "GOLDILOCKS"
+        if growth >= 50 and inflation >= 50:
+            return "OVERHEATING"
+        if growth < 50 and inflation >= 50:
+            return "STAGFLATION"
+        return "REFLATION"
+
+    assert _label(62, 35) == "GOLDILOCKS"
+    assert _label(75, 70) == "OVERHEATING"
+    assert _label(30, 68) == "STAGFLATION"
+    assert _label(28, 40) == "REFLATION"

--- a/frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
+++ b/frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
@@ -99,7 +99,13 @@
 
 	let activeTab = $state<TabId>("REGIME");
 	let userSwitchedTab = $state(false);
-	let visitedTabs = $state<Set<TabId>>(new Set());
+	let visitedTabs = $state(new SvelteSet<TabId>());
+
+	const isBuilding = $derived(
+		workspace.runPhase !== "idle" &&
+			workspace.runPhase !== "done" &&
+			workspace.runPhase !== "error",
+	);
 
 	$effect(() => {
 		visitedTabs.add(activeTab);
@@ -109,18 +115,14 @@
 	const allTabsVisited = $derived(visitedTabs.size === TABS.length);
 
 	function setActiveTab(t: TabId) {
+		visitedTabs.add(t);
 		activeTab = t;
 		userSwitchedTab = true;
 	}
 
 	// Cascade / pipeline phase mirroring the workspace run state.
 	const cascadePhases = $derived(workspace.optimizerPhases);
-	const showCascade = $derived(workspace.runPhase !== "idle");
-	const showProgress = $derived(
-		workspace.runPhase !== "idle" &&
-			workspace.runPhase !== "done" &&
-			workspace.runPhase !== "error",
-	);
+	const showProgress = $derived(isBuilding);
 	const runProgress = $derived(workspace.runProgress);
 
 	const pipelinePhase = $derived.by<
@@ -179,7 +181,7 @@
 		}
 	});
 	$effect(() => {
-		if (workspace.runPhase === "running") {
+		if (isBuilding) {
 			userSwitchedTab = false;
 		}
 	});
@@ -227,6 +229,8 @@
 					role="tab"
 					class="builder-tab"
 					class:builder-tab--active={activeTab === tab}
+					class:pulsing={isBuilding && activeTab !== tab}
+					class:visited={visitedTabs.has(tab)}
 					aria-selected={activeTab === tab}
 					onclick={() => setActiveTab(tab)}
 				>
@@ -241,19 +245,18 @@
 			{/each}
 		</div>
 
-		{#if showCascade}
-			<div
-				in:fly={{ y: -8, ...svelteTransitionFor("primary", { duration: "update" }) }}
-			>
-				<CascadeTimeline
-					phases={cascadePhases}
-					{runProgress}
-					{showProgress}
-					{pipelinePhase}
-					{pipelineErrored}
-				/>
-			</div>
-		{/if}
+		<div
+			in:fly={{ y: -8, ...svelteTransitionFor("primary", { duration: "update" }) }}
+		>
+			<CascadeTimeline
+				phases={cascadePhases}
+				{runProgress}
+				{showProgress}
+				{pipelinePhase}
+				{pipelineErrored}
+				collapsed={!isBuilding && workspace.runPhase !== "done"}
+			/>
+		</div>
 
 		<div class="builder-tab-content" role="tabpanel">
 			{#key activeTab}
@@ -386,6 +389,20 @@
 		color: var(--terminal-accent-amber);
 		border-bottom-color: var(--terminal-accent-amber);
 	}
+	.builder-tab.pulsing {
+		animation: tabPulse 1s ease-in-out infinite;
+	}
+	.builder-tab.visited::after {
+		position: absolute;
+		top: 4px;
+		right: 4px;
+		width: 4px;
+		height: 4px;
+		border-radius: 50%;
+		background: var(--ii-success, var(--terminal-status-success));
+		content: "";
+		pointer-events: none;
+	}
 	.builder-tab:focus-visible {
 		outline: var(--terminal-border-focus);
 		outline-offset: -2px;
@@ -413,6 +430,15 @@
 		}
 		50% {
 			opacity: 0.4;
+		}
+	}
+	@keyframes tabPulse {
+		0%,
+		100% {
+			background: transparent;
+		}
+		50% {
+			background: rgba(242, 201, 76, 0.16);
 		}
 	}
 </style>

--- a/frontends/terminal/src/routes/screener/+page.svelte
+++ b/frontends/terminal/src/routes/screener/+page.svelte
@@ -14,7 +14,7 @@
 	import { page } from "$app/state";
 	import { goto } from "$app/navigation";
 	import TerminalScreenerShell from "@investintell/ii-terminal-core/components/screener-terminal/TerminalScreenerShell.svelte";
-	import FundFocusMode from "@investintell/ii-terminal-core/components/terminal/focus-mode/fund/FundFocusMode.svelte";
+	import ScreenerFundFocusModal from "@investintell/ii-terminal-core/components/terminal/focus-mode/screener/ScreenerFundFocusModal.svelte";
 	import type { FocusTriggerOptions } from "@investintell/ii-terminal-core/components/terminal/focus-mode/focus-trigger";
 	import { DEFAULT_FILTERS, type FilterState } from "@investintell/ii-terminal-core/components/screener-terminal/TerminalScreenerFilters.svelte";
 
@@ -108,9 +108,11 @@
 </div>
 
 {#if focusEntity}
-	<FundFocusMode
+	<ScreenerFundFocusModal
 		fundId={focusEntity.entityId}
 		fundLabel={focusEntity.entityLabel ?? ""}
+		ticker={focusEntity.ticker ?? null}
+		instrumentId={focusEntity.instrumentId ?? null}
 		onClose={closeFocusMode}
 	/>
 {/if}

--- a/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalDataGrid.svelte
+++ b/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalDataGrid.svelte
@@ -412,7 +412,13 @@
 						aria-rowindex={globalIndex + 2}
 						aria-selected={selectedId === asset.id}
 						style="height: {ROW_HEIGHT}px;"
-						use:focusTrigger={{ entityKind: "fund", entityId: asset.id, entityLabel: asset.name }}
+						use:focusTrigger={{
+							entityKind: "fund",
+							entityId: asset.id,
+							entityLabel: asset.name,
+							ticker: asset.ticker,
+							instrumentId: asset.instrumentId,
+						}}
 						onclick={() => onSelect(asset)}
 					>
 						<span class="dg-td dg-col-ticker dg-ticker" title={asset.ticker ?? asset.isin ?? ""}>

--- a/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalScreenerShell.svelte
+++ b/packages/ii-terminal-core/src/lib/components/screener-terminal/TerminalScreenerShell.svelte
@@ -541,7 +541,7 @@
 	.ts-root {
 		display: grid;
 		grid-template-areas: "filters datagrid";
-		grid-template-columns: 280px 1fr;
+		grid-template-columns: 240px 1fr;
 		grid-template-rows: 1fr;
 		gap: 2px;
 		width: 100%;

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/ActivationBar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/ActivationBar.svelte
@@ -2,7 +2,7 @@
   ActivationBar — Zone F fixed footer in the Builder right column.
 
   Appears ONLY when: runPhase === "done" AND allTabsVisited === true.
-  Two buttons: Save as Draft + Activate Portfolio (opens ConsequenceDialog).
+  Two buttons: Save as Draft + Send to Compliance (opens ConsequenceDialog).
 -->
 <script lang="ts">
 	import { fly } from "svelte/transition";
@@ -46,8 +46,8 @@
 		<button type="button" class="ab-btn ab-btn--secondary" onclick={handleSaveDraft}>
 			Save as Draft
 		</button>
-		<button type="button" class="ab-btn ab-btn--primary" onclick={handleActivateClick}>
-			Activate Portfolio
+		<button type="button" class="ab-btn ab-btn--activate" onclick={handleActivateClick}>
+			SEND TO COMPLIANCE ▸
 		</button>
 	</div>
 {/if}
@@ -104,14 +104,17 @@
 		border-color: var(--terminal-fg-secondary);
 	}
 
-	.ab-btn--primary {
-		background: var(--terminal-accent-amber);
-		border: 1px solid var(--terminal-accent-amber);
-		color: var(--terminal-bg-void);
+	.ab-btn--activate {
+		border: 1px solid var(--ii-success, var(--terminal-status-success));
+		background: var(--ii-success, var(--terminal-status-success));
+		color: var(--ii-bg, var(--terminal-bg-void));
+		font-family: var(--ii-font-mono, var(--terminal-font-mono));
+		font-weight: 700;
+		letter-spacing: 0.06em;
 	}
 
-	.ab-btn--primary:hover {
-		opacity: 0.9;
+	.ab-btn--activate:hover {
+		filter: brightness(1.1);
 	}
 
 	.ab-btn:focus-visible {

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/CascadeTimeline.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/CascadeTimeline.svelte
@@ -22,6 +22,8 @@
 		pipelinePhase?: BuildPhase | "IDLE";
 		/** PR-A5 B.2 — whether the pipeline phase has entered a terminal error state. */
 		pipelineErrored?: boolean;
+		/** Collapse the timeline when the builder is idle. */
+		collapsed?: boolean;
 	}
 
 	let {
@@ -30,6 +32,7 @@
 		showProgress = false,
 		pipelinePhase = "IDLE",
 		pipelineErrored = false,
+		collapsed = false,
 	}: Props = $props();
 
 	// PR-A5 B.2 — pipeline strip: 5 chips mapping each top-level phase.
@@ -84,7 +87,7 @@
 	);
 </script>
 
-<div class="ct-root" role="group" aria-label="Construction phase timeline">
+<div class="ct-root" class:ct-root--collapsed={collapsed} role="group" aria-label="Construction phase timeline">
 	<!-- PR-A5 B.2 — pipeline phase strip (coarse top-level). -->
 	<div class="ct-strip" aria-label="Pipeline phases">
 		{#each PIPELINE_STRIP as chip, i (chip.key)}
@@ -151,6 +154,8 @@
 	.ct-root {
 		position: relative;
 		min-height: 160px;
+		max-height: 160px;
+		overflow: hidden;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
@@ -158,6 +163,18 @@
 		border-bottom: var(--terminal-border-hairline);
 		font-family: var(--terminal-font-mono);
 		box-sizing: border-box;
+		transition:
+			max-height 200ms ease,
+			min-height 200ms ease,
+			padding-top 200ms ease,
+			padding-bottom 200ms ease;
+	}
+
+	.ct-root--collapsed {
+		min-height: 0;
+		max-height: 0;
+		padding-top: 0;
+		padding-bottom: 0;
 	}
 
 	/* ── Connector rail ──────────────────────────────── */

--- a/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/focus-trigger.ts
+++ b/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/focus-trigger.ts
@@ -4,6 +4,8 @@ export interface FocusTriggerOptions {
 	entityKind: FocusModeEntityKind;
 	entityId: string;
 	entityLabel?: string;
+	ticker?: string | null;
+	instrumentId?: string | null;
 }
 
 /**

--- a/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/screener/ScreenerFundFocusModal.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/focus-mode/screener/ScreenerFundFocusModal.svelte
@@ -1,0 +1,640 @@
+<!--
+  ScreenerFundFocusModal -- constrained fund focus for the screener page.
+
+  1040px x 88vh quick-view modal with SVG performance and composite radar.
+-->
+<script lang="ts">
+	import { getContext, onMount } from "svelte";
+	import { formatCurrency, formatNumber, formatPercent } from "@investintell/ui";
+	import { createClientApiClient } from "../../../../api/client";
+
+	interface Props {
+		fundId: string;
+		fundLabel: string;
+		ticker: string | null;
+		instrumentId: string | null;
+		onClose: () => void;
+	}
+
+	let { fundId, fundLabel, ticker, instrumentId, onClose }: Props = $props();
+
+	const getToken = getContext<() => Promise<string>>("netz:getToken");
+	const api = createClientApiClient(getToken);
+
+	interface FundCatalogItem {
+		name: string;
+		manager_name: string | null;
+		aum: number | null;
+		strategy_label: string | null;
+		fund_type: string | null;
+		expense_ratio_pct: number | null;
+		avg_annual_return_1y: number | null;
+		avg_annual_return_10y: number | null;
+		manager_score: number | null;
+		blended_momentum_score: number | null;
+		max_drawdown: number | null;
+		sharpe_ratio: number | null;
+		volatility: number | null;
+	}
+
+	interface CatalogPage {
+		items: FundCatalogItem[];
+	}
+
+	interface NavBar {
+		date: string;
+		value: number;
+	}
+
+	let detail = $state<FundCatalogItem | null>(null);
+	let navBars = $state<NavBar[]>([]);
+	let loadingDetail = $state(true);
+	let loadingNav = $state(false);
+
+	$effect(() => {
+		const id = fundId;
+		let cancelled = false;
+		loadingDetail = true;
+		api
+			.get<CatalogPage>("/screener/catalog", {
+				page: 1,
+				page_size: 1,
+				external_id: id,
+				in_universe: true,
+			})
+			.then((res) => {
+				if (cancelled) return;
+				detail = res.items?.[0] ?? null;
+				loadingDetail = false;
+			})
+			.catch(() => {
+				if (cancelled) return;
+				detail = null;
+				loadingDetail = false;
+			});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	$effect(() => {
+		const symbol = ticker;
+		void instrumentId;
+		if (!symbol) {
+			navBars = [];
+			return;
+		}
+		let cancelled = false;
+		loadingNav = true;
+		const start = new Date(Date.now() - 365 * 5 * 86_400_000)
+			.toISOString()
+			.slice(0, 10);
+		api
+			.get<{ bars: Array<{ timestamp: string; close: number | null }> }>(
+				`/market-data/historical/${encodeURIComponent(symbol)}`,
+				{ start_date: start },
+			)
+			.then((res) => {
+				if (cancelled) return;
+				navBars = (res.bars ?? [])
+					.filter((bar) => bar.close != null)
+					.map((bar) => ({
+						date: bar.timestamp.slice(0, 10),
+						value: Number(bar.close),
+					}));
+				loadingNav = false;
+			})
+			.catch(() => {
+				if (cancelled) return;
+				navBars = [];
+				loadingNav = false;
+			});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	const PERIODS: Array<{ label: string; days: number }> = [
+		{ label: "1M", days: 30 },
+		{ label: "3M", days: 91 },
+		{ label: "6M", days: 182 },
+		{ label: "1Y", days: 365 },
+		{ label: "3Y", days: 365 * 3 },
+		{ label: "5Y", days: 365 * 5 },
+	];
+
+	const periodStats = $derived.by(() => {
+		if (navBars.length < 2) {
+			return PERIODS.map((period) => ({ label: period.label, returnPct: null as number | null }));
+		}
+		const last = navBars[navBars.length - 1];
+		return PERIODS.map((period) => {
+			const cutoff = new Date(Date.now() - period.days * 86_400_000)
+				.toISOString()
+				.slice(0, 10);
+			const ref = navBars.find((bar) => bar.date >= cutoff);
+			if (!last || !ref || ref.value === 0) {
+				return { label: period.label, returnPct: null };
+			}
+			return {
+				label: period.label,
+				returnPct: (last.value - ref.value) / ref.value,
+			};
+		});
+	});
+
+	const CHART_W = 320;
+	const CHART_H = 120;
+
+	const perfChart = $derived.by(() => {
+		if (navBars.length < 2) return { area: "", line: "", isUp: true };
+		const values = navBars.map((bar) => bar.value);
+		const minValue = Math.min(...values);
+		const maxValue = Math.max(...values);
+		const range = maxValue - minValue || 1;
+		const points = values.map((value, index) => {
+			const x = (index / (values.length - 1)) * CHART_W;
+			const y = CHART_H - ((value - minValue) / range) * CHART_H;
+			return `${x.toFixed(1)},${y.toFixed(1)}`;
+		});
+		const line = "M " + points.join(" L ");
+		return {
+			area: `${line} L ${CHART_W},${CHART_H} L 0,${CHART_H} Z`,
+			line,
+			isUp: values[values.length - 1]! >= values[0]!,
+		};
+	});
+
+	const AXES = ["RETURN", "MOMENTUM", "RISK ADJ", "DD CTL", "COST EFF", "CONSISTENCY"] as const;
+	const RADAR_W = 200;
+	const RADAR_H = 160;
+	const CX = RADAR_W / 2;
+	const CY = RADAR_H / 2;
+	const R = 65;
+	const N = AXES.length;
+
+	function radarPt(index: number, radius: number) {
+		const angle = (index / N) * 2 * Math.PI - Math.PI / 2;
+		return {
+			x: CX + radius * Math.cos(angle),
+			y: CY + radius * Math.sin(angle),
+		};
+	}
+
+	function clampScore(value: number): number {
+		return Math.min(100, Math.max(0, value));
+	}
+
+	function asDecimalPercent(value: number | null | undefined): number | null {
+		if (value == null) return null;
+		return Math.abs(value) > 1 ? value / 100 : value;
+	}
+
+	const axisScores = $derived.by((): number[] => {
+		if (!detail) return Array(N).fill(50);
+		const returnDecimal = asDecimalPercent(detail.avg_annual_return_1y);
+		const drawdownDecimal = asDecimalPercent(detail.max_drawdown);
+		const expensePct = detail.expense_ratio_pct ?? null;
+		return [
+			returnDecimal != null ? clampScore((returnDecimal + 0.1) * 500) : 50,
+			detail.blended_momentum_score ?? 50,
+			detail.sharpe_ratio != null ? clampScore((detail.sharpe_ratio + 0.5) * 50) : 50,
+			drawdownDecimal != null ? clampScore((1 + drawdownDecimal / 0.5) * 100) : 50,
+			expensePct != null ? clampScore(100 - expensePct * 50) : 50,
+			detail.manager_score ?? 50,
+		];
+	});
+
+	const radarPath = $derived.by(() => {
+		const points = axisScores.map((score, index) => {
+			const p = radarPt(index, (score / 100) * R);
+			return `${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+		});
+		return "M " + points.join(" L ") + " Z";
+	});
+
+	const w52 = $derived.by(() => {
+		const cutoff = new Date(Date.now() - 365 * 86_400_000).toISOString().slice(0, 10);
+		const values = navBars.filter((bar) => bar.date >= cutoff).map((bar) => bar.value);
+		if (values.length === 0) return null;
+		return { high: Math.max(...values), low: Math.min(...values) };
+	});
+
+	function percentText(value: number | null | undefined, decimals = 2): string {
+		const decimal = asDecimalPercent(value);
+		return decimal == null ? "\u2014" : formatPercent(decimal, decimals);
+	}
+
+	function closeOnEscape(event: KeyboardEvent) {
+		if (event.key === "Escape") onClose();
+	}
+
+	onMount(() => {
+		document.addEventListener("keydown", closeOnEscape);
+		return () => document.removeEventListener("keydown", closeOnEscape);
+	});
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<div class="sfm-overlay" onclick={onClose} role="dialog" aria-modal="true" aria-label={fundLabel} tabindex="-1">
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<div class="sfm-modal" onclick={(event) => event.stopPropagation()} role="document">
+		<div class="sfm-hero">
+			<div>
+				<h1 class="sfm-name">{detail?.name ?? fundLabel}</h1>
+				<div class="sfm-meta">
+					{#if loadingDetail}<span>Loading...</span>{/if}
+					{#if detail?.manager_name}<span>{detail.manager_name}</span>{/if}
+					{#if detail?.strategy_label}<span class="sfm-accent">{detail.strategy_label}</span>{/if}
+					{#if detail?.fund_type}<span>{detail.fund_type.replace("_", " ").toUpperCase()}</span>{/if}
+					{#if ticker}<span class="sfm-accent">{ticker}</span>{/if}
+				</div>
+			</div>
+			{#if detail?.aum != null}
+				<div class="sfm-aum">
+					<span class="sfm-aum-val">{formatNumber(detail.aum / 1_000_000, 0)}M</span>
+					<span class="sfm-aum-label">AUM</span>
+				</div>
+			{/if}
+		</div>
+
+		<div class="sfm-kpi-grid">
+			{#each [
+				{ label: "1Y RETURN", value: percentText(detail?.avg_annual_return_1y, 2), tone: (detail?.avg_annual_return_1y ?? 0) >= 0 ? "up" : "down" },
+				{ label: "10Y RETURN", value: percentText(detail?.avg_annual_return_10y, 2), tone: (detail?.avg_annual_return_10y ?? 0) >= 0 ? "up" : "down" },
+				{ label: "SHARPE", value: detail?.sharpe_ratio != null ? formatNumber(detail.sharpe_ratio, 2) : "\u2014", tone: "" },
+				{ label: "MAX DD", value: percentText(detail?.max_drawdown, 1), tone: "down" },
+				{ label: "EXPENSE", value: detail?.expense_ratio_pct != null ? formatPercent(detail.expense_ratio_pct / 100, 2) : "\u2014", tone: "" },
+				{ label: "SCORE", value: detail?.manager_score != null ? formatNumber(detail.manager_score, 0) : "\u2014", tone: "" },
+			] as kpi (kpi.label)}
+				<div class="sfm-kpi">
+					<span class="sfm-kpi-label">{kpi.label}</span>
+					<span class="sfm-kpi-value {kpi.tone}">{kpi.value}</span>
+				</div>
+			{/each}
+		</div>
+
+		<div class="sfm-body">
+			<div class="sfm-section">
+				<h3 class="sfm-sh">PERFORMANCE</h3>
+				<div class="sfm-perf-chart">
+					{#if loadingNav}
+						<div class="sfm-chart-empty">Loading...</div>
+					{:else if perfChart.line}
+						<svg viewBox="0 0 {CHART_W} {CHART_H}" preserveAspectRatio="none" width="100%" height="100%">
+							<defs>
+								<linearGradient id="sfm-g-{fundId}" x1="0" y1="0" x2="0" y2="1">
+									<stop offset="0%" stop-color={perfChart.isUp ? "var(--ii-success,#3DD39A)" : "var(--ii-danger,#FF5C7A)"} stop-opacity="0.35" />
+									<stop offset="100%" stop-color={perfChart.isUp ? "var(--ii-success,#3DD39A)" : "var(--ii-danger,#FF5C7A)"} stop-opacity="0" />
+								</linearGradient>
+							</defs>
+							<path d={perfChart.area} fill="url(#sfm-g-{fundId})" />
+							<path d={perfChart.line} fill="none" stroke={perfChart.isUp ? "var(--ii-success,#3DD39A)" : "var(--ii-danger,#FF5C7A)"} stroke-width="1.5" />
+						</svg>
+					{:else}
+						<div class="sfm-chart-empty">No NAV data</div>
+					{/if}
+				</div>
+
+				<div class="sfm-period-grid">
+					{#each periodStats as stat (stat.label)}
+						<div class="sfm-period-row">
+							<span class="sfm-period-lbl">{stat.label}</span>
+							<span
+								class="sfm-period-val"
+								class:up={(stat.returnPct ?? 0) >= 0}
+								class:down={(stat.returnPct ?? 0) < 0}
+							>
+								{stat.returnPct != null ? formatPercent(stat.returnPct, 2, "en-US", true) : "\u2014"}
+							</span>
+						</div>
+					{/each}
+				</div>
+
+				{#if w52}
+					<div class="sfm-52w">
+						<span class="sfm-52w-lbl">52W</span>
+						<span class="sfm-52w-val down">{formatCurrency(w52.low)}</span>
+						<span class="sfm-52w-sep">-</span>
+						<span class="sfm-52w-val up">{formatCurrency(w52.high)}</span>
+					</div>
+				{/if}
+			</div>
+
+			<div class="sfm-section">
+				<h3 class="sfm-sh">COMPOSITE PROFILE</h3>
+				<div class="sfm-radar-wrap">
+					<svg viewBox="0 0 {RADAR_W} {RADAR_H}" width={RADAR_W} height={RADAR_H}>
+						{#each [0.25, 0.5, 0.75, 1.0] as pct}
+							{@const pts = Array.from({ length: N }, (_, index) => {
+								const p = radarPt(index, pct * R);
+								return `${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+							})}
+							<polygon points={pts.join(" ")} fill="none" stroke="var(--ii-border-subtle,#1A2458)" stroke-width="1" />
+						{/each}
+						{#each Array.from({ length: N }, (_, index) => index) as index (index)}
+							{@const endpoint = radarPt(index, R)}
+							<line x1={CX} y1={CY} x2={endpoint.x} y2={endpoint.y} stroke="var(--ii-border,#1A2458)" stroke-width="1" />
+						{/each}
+						<path d={radarPath} fill="var(--ii-brand-primary,#FF965A)" fill-opacity="0.18" stroke="var(--ii-brand-primary,#FF965A)" stroke-width="1.5" />
+						{#each AXES as label, index (label)}
+							{@const labelPoint = radarPt(index, R + 14)}
+							<text x={labelPoint.x} y={labelPoint.y} text-anchor="middle" dominant-baseline="middle" font-family="var(--ii-font-mono)" font-size="7" fill="var(--ii-text-muted,#6D7DA6)">
+								{label}
+							</text>
+						{/each}
+					</svg>
+				</div>
+
+				<div class="sfm-axis-bars">
+					{#each AXES as label, index (label)}
+						{@const score = axisScores[index] ?? 0}
+						<div class="sfm-axis-row">
+							<span class="sfm-axis-lbl">{label}</span>
+							<span class="sfm-axis-bar-wrap">
+								<span class="sfm-axis-bar" style:width="{score}%"></span>
+							</span>
+							<span class="sfm-axis-val">{formatNumber(score, 0)}</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+		</div>
+
+		<button type="button" class="sfm-close" onclick={onClose} aria-label="Close">
+			[ ESC - CLOSE ]
+		</button>
+	</div>
+</div>
+
+<style>
+	.sfm-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 9999;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(5, 8, 26, 0.72);
+	}
+
+	.sfm-modal {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		width: 1040px;
+		max-width: 98vw;
+		height: 88vh;
+		max-height: 88vh;
+		overflow: hidden;
+		border: 1px solid var(--ii-border, #1A2458);
+		background: var(--ii-surface, #0B1230);
+		font-family: var(--ii-font-mono, var(--terminal-font-mono));
+	}
+
+	.sfm-hero {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		flex-shrink: 0;
+		gap: 24px;
+		padding: 18px 20px;
+		border-bottom: 1px solid var(--ii-border-subtle, var(--terminal-fg-muted));
+		background: var(--ii-surface-alt, var(--terminal-bg-panel-sunken));
+	}
+
+	.sfm-name {
+		margin: 0 0 4px;
+		color: var(--ii-text-primary, var(--terminal-fg-primary));
+		font-family: var(--ii-font-sans, var(--terminal-font-sans, var(--terminal-font-mono)));
+		font-size: 22px;
+		font-weight: 300;
+	}
+
+	.sfm-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 14px;
+		margin-top: 6px;
+		color: var(--ii-text-muted, var(--terminal-fg-muted));
+		font-size: 10px;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.sfm-accent {
+		color: var(--ii-brand-primary, var(--terminal-accent-amber));
+		font-weight: 600;
+	}
+
+	.sfm-aum {
+		text-align: right;
+	}
+
+	.sfm-aum-val {
+		display: block;
+		color: var(--ii-text-primary, var(--terminal-fg-primary));
+		font-size: 20px;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.sfm-aum-label,
+	.sfm-kpi-label,
+	.sfm-sh,
+	.sfm-period-lbl,
+	.sfm-52w-lbl,
+	.sfm-axis-lbl {
+		color: var(--ii-text-muted, var(--terminal-fg-muted));
+		font-size: 9px;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.sfm-kpi-grid {
+		display: grid;
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+		flex-shrink: 0;
+		gap: 1px;
+		padding: 1px;
+		background: var(--ii-border-subtle, var(--terminal-fg-muted));
+	}
+
+	.sfm-kpi {
+		padding: 10px 12px;
+		background: var(--ii-surface, var(--terminal-bg-panel));
+	}
+
+	.sfm-kpi-label {
+		display: block;
+	}
+
+	.sfm-kpi-value {
+		display: block;
+		margin-top: 4px;
+		color: var(--ii-text-primary, var(--terminal-fg-primary));
+		font-size: 18px;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.sfm-kpi-value.up,
+	.sfm-period-val.up,
+	.sfm-52w-val.up {
+		color: var(--ii-success, var(--terminal-status-success));
+	}
+
+	.sfm-kpi-value.down,
+	.sfm-period-val.down,
+	.sfm-52w-val.down {
+		color: var(--ii-danger, var(--terminal-status-error));
+	}
+
+	.sfm-body {
+		display: grid;
+		grid-template-columns: 1.4fr 1fr;
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+		gap: 1px;
+		background: var(--ii-border-subtle, var(--terminal-fg-muted));
+	}
+
+	.sfm-section {
+		min-height: 0;
+		overflow-y: auto;
+		padding: 14px 18px;
+		background: var(--ii-surface, var(--terminal-bg-panel));
+	}
+
+	.sfm-sh {
+		margin: 0 0 10px;
+		font-size: 10px;
+		font-weight: 700;
+	}
+
+	.sfm-perf-chart {
+		height: 120px;
+		margin-bottom: 14px;
+		border: 1px solid var(--ii-border-subtle, var(--terminal-fg-muted));
+	}
+
+	.sfm-chart-empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		color: var(--ii-text-muted, var(--terminal-fg-muted));
+		font-size: 10px;
+	}
+
+	.sfm-period-grid {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 4px 8px;
+		margin-bottom: 12px;
+	}
+
+	.sfm-period-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 3px 0;
+		border-bottom: 1px solid var(--ii-terminal-hair, rgba(102, 137, 188, 0.14));
+	}
+
+	.sfm-period-val {
+		font-size: 11px;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.sfm-52w {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-top: 8px;
+		font-size: 10px;
+	}
+
+	.sfm-52w-val {
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.sfm-52w-sep {
+		color: var(--ii-text-muted, var(--terminal-fg-muted));
+	}
+
+	.sfm-radar-wrap {
+		display: flex;
+		justify-content: center;
+		padding: 8px 0 14px;
+	}
+
+	.sfm-axis-bars {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		padding-top: 12px;
+		border-top: 1px solid var(--ii-border-subtle, var(--terminal-fg-muted));
+	}
+
+	.sfm-axis-row {
+		display: grid;
+		grid-template-columns: 90px 1fr 32px;
+		align-items: center;
+		gap: 10px;
+	}
+
+	.sfm-axis-lbl {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.sfm-axis-bar-wrap {
+		position: relative;
+		display: block;
+		height: 8px;
+		overflow: hidden;
+		border: 1px solid var(--ii-border-subtle, var(--terminal-fg-muted));
+		border-radius: 1px;
+		background: var(--ii-surface-alt, var(--terminal-bg-panel-sunken));
+	}
+
+	.sfm-axis-bar {
+		position: absolute;
+		inset: 0 auto 0 0;
+		background: var(--ii-brand-primary, var(--terminal-accent-amber));
+		transition: width 200ms ease;
+	}
+
+	.sfm-axis-val {
+		color: var(--ii-text-primary, var(--terminal-fg-primary));
+		font-size: 12px;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+	}
+
+	.sfm-close {
+		position: absolute;
+		top: 12px;
+		right: 12px;
+		padding: 4px 10px;
+		border: 1px solid var(--ii-border-subtle, var(--terminal-fg-muted));
+		background: transparent;
+		color: var(--ii-text-muted, var(--terminal-fg-muted));
+		font-family: var(--ii-font-mono, var(--terminal-font-mono));
+		font-size: 10px;
+		letter-spacing: 0.08em;
+		cursor: pointer;
+	}
+
+	.sfm-close:hover {
+		border-color: var(--ii-brand-primary, var(--terminal-accent-amber));
+		color: var(--ii-brand-primary, var(--terminal-accent-amber));
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/MacroRegimePanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/MacroRegimePanel.svelte
@@ -1,136 +1,88 @@
 <!--
-  MacroRegimePanel -- key macro indicators from FRED via macro_data.
+  MacroRegimePanel -- 4-region dense regime table for Live Workbench.
 
-  Fetches latest values for VIX, CPI, DXY, 10Y, IG/HY spreads,
-  Fed Funds, Unemployment from GET /macro/fred?series_id={id}.
-  Shows value + directional change arrow.
+  Data source: GET /macro/regional-regime.
+  Renders US / EU / EM / BR rows with quadrant label, stress badge,
+  and directional growth trend.
 -->
 <script lang="ts">
 	import { getContext } from "svelte";
-	import { formatPercent, formatNumber, formatBps } from "@investintell/ui";
 	import { createClientApiClient } from "../../../api/client";
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 	const api = createClientApiClient(getToken);
 
-	interface Indicator {
-		label: string;
-		seriesId: string;
-		suffix: string;
-		/** true = rising is danger (VIX, spreads), false = rising is positive */
-		riseIsWarning: boolean;
+	interface RegionalRegimeRow {
+		region_code: string;
+		regime_label: string;
+		stress_level: "LOW" | "MED" | "HIGH";
+		trend_up: boolean;
+		growth_score: number | null;
+		inflation_score: number | null;
 	}
 
-	const INDICATORS: Indicator[] = [
-		{ label: "VIX", seriesId: "VIXCLS", suffix: "", riseIsWarning: true },
-		{ label: "CPI (YoY)", seriesId: "CPI_YOY", suffix: "%", riseIsWarning: true },
-		{ label: "DXY", seriesId: "DTWEXBGS", suffix: "", riseIsWarning: false },
-		{ label: "10Y YIELD", seriesId: "DGS10", suffix: "%", riseIsWarning: false },
-		{ label: "IG SPREAD", seriesId: "BAA10Y", suffix: "bp", riseIsWarning: true },
-		{ label: "HY SPREAD", seriesId: "BAMLH0A0HYM2", suffix: "bp", riseIsWarning: true },
-		{ label: "FED FUNDS", seriesId: "DFF", suffix: "%", riseIsWarning: false },
-		{ label: "UNEMPLOYMENT", seriesId: "UNRATE", suffix: "%", riseIsWarning: true },
-	];
-
-	interface IndicatorValue {
-		value: number | null;
-		change: number | null;
-	}
-
-	let values = $state<Map<string, IndicatorValue>>(new Map());
+	let regions = $state<RegionalRegimeRow[]>([]);
 	let loading = $state(true);
 
 	$effect(() => {
 		let cancelled = false;
 		loading = true;
-
-		const fetches = INDICATORS.map(async (ind) => {
-			try {
-				const res = await api.get<{
-					series_id: string;
-					data: Array<{ obs_date: string; value: number }>;
-				}>(`/macro/fred?series_id=${encodeURIComponent(ind.seriesId)}`);
-
+		api
+			.get<{ regions: RegionalRegimeRow[] }>("/macro/regional-regime")
+			.then((res) => {
 				if (cancelled) return;
-
-				const data = res.data;
-				if (data.length === 0) {
-					values.set(ind.seriesId, { value: null, change: null });
-					return;
-				}
-
-				const latestPoint = data[data.length - 1];
-				const prevPoint = data.length >= 2 ? data[data.length - 2] : undefined;
-				const latest = latestPoint?.value ?? null;
-				const prev = prevPoint?.value ?? null;
-				const change = latest != null && prev != null ? latest - prev : null;
-
-				values = new Map(values).set(ind.seriesId, { value: latest, change });
-			} catch {
-				if (!cancelled) {
-					values = new Map(values).set(ind.seriesId, { value: null, change: null });
-				}
-			}
-		});
-
-		Promise.all(fetches).then(() => {
-			if (!cancelled) loading = false;
-		});
-
-		return () => { cancelled = true; };
+				regions = res.regions ?? [];
+				loading = false;
+			})
+			.catch(() => {
+				if (cancelled) return;
+				regions = [];
+				loading = false;
+			});
+		return () => {
+			cancelled = true;
+		};
 	});
 
-	function formatVal(v: number | null, suffix: string): string {
-		if (v == null) return "\u2014";
-		if (suffix === "%") return formatPercent(v / 100, 1);
-		if (suffix === "bp") return formatBps(v / 100);
-		return formatNumber(v, 1);
-	}
-
-	function changeArrow(change: number | null): string {
-		if (change == null || Math.abs(change) < 0.001) return "\u2500";
-		return change > 0 ? "\u25B2" : "\u25BC";
-	}
-
-	function changeClass(change: number | null, riseIsWarning: boolean): string {
-		if (change == null || Math.abs(change) < 0.001) return "mr-neutral";
-		if (change > 0) return riseIsWarning ? "mr-warn" : "mr-good";
-		return riseIsWarning ? "mr-good" : "mr-warn";
-	}
-
-	function formatChange(change: number | null, suffix: string): string {
-		if (change == null) return "";
-		if (suffix === "bp") return `${change > 0 ? "+" : ""}${Math.round(change * 100)}`;
-		if (suffix === "%") return `${change > 0 ? "+" : ""}${formatNumber(Math.abs(change), 1)}`;
-		return `${change > 0 ? "+" : ""}${formatNumber(Math.abs(change), 1)}`;
+	function regimeToneClass(label: string): string {
+		const normalized = label.toUpperCase();
+		if (normalized === "GOLDILOCKS") return "mrg-goldilocks";
+		if (normalized === "OVERHEATING") return "mrg-overheating";
+		if (normalized === "STAGFLATION") return "mrg-stagflation";
+		if (normalized === "REFLATION") return "mrg-reflation";
+		return "";
 	}
 </script>
 
-<div class="mr-root">
-	<div class="mr-header">
-		<span class="mr-label">MARKET CONDITIONS</span>
+<div class="mrg-root">
+	<div class="mrg-header">
+		<span class="mrg-title">MACRO REGIME</span>
+		{#if loading}<span class="mrg-loading">...</span>{/if}
 	</div>
 
-	<div class="mr-body">
-		{#each INDICATORS as ind (ind.seriesId)}
-			{@const v = values.get(ind.seriesId)}
-			{@const val = v?.value ?? null}
-			{@const chg = v?.change ?? null}
-			<div class="mr-row">
-				<span class="mr-key">{ind.label}</span>
-				<span class="mr-val">
-					{formatVal(val, ind.suffix)}
+	<div class="mrg-table">
+		{#each regions as region (region.region_code)}
+			<div class="mrg-row">
+				<span class="mrg-code">{region.region_code}</span>
+				<span class="mrg-label {regimeToneClass(region.regime_label)}">
+					{region.regime_label}
 				</span>
-				<span class="mr-change {changeClass(chg, ind.riseIsWarning)}">
-					{changeArrow(chg)} {formatChange(chg, ind.suffix)}
+				<span class="mrg-stress mrg-stress-{region.stress_level.toLowerCase()}">
+					{region.stress_level}
+				</span>
+				<span class="mrg-trend" class:up={region.trend_up} class:down={!region.trend_up}>
+					{region.trend_up ? "↑" : "↓"}
 				</span>
 			</div>
 		{/each}
+		{#if !loading && regions.length === 0}
+			<div class="mrg-empty">No regime data</div>
+		{/if}
 	</div>
 </div>
 
 <style>
-	.mr-root {
+	.mrg-root {
 		display: flex;
 		flex-direction: column;
 		width: 100%;
@@ -141,16 +93,18 @@
 		font-family: var(--terminal-font-mono);
 	}
 
-	.mr-header {
+	.mrg-header {
 		display: flex;
 		align-items: center;
+		justify-content: space-between;
 		flex-shrink: 0;
 		height: 28px;
 		padding: 0 var(--terminal-space-2);
 		border-bottom: var(--terminal-border-hairline);
 	}
 
-	.mr-label {
+	.mrg-title,
+	.mrg-loading {
 		font-size: var(--terminal-text-10);
 		font-weight: 700;
 		letter-spacing: var(--terminal-tracking-caps);
@@ -158,58 +112,75 @@
 		text-transform: uppercase;
 	}
 
-	.mr-body {
+	.mrg-loading {
+		color: var(--terminal-fg-muted);
+	}
+
+	.mrg-table {
 		flex: 1;
 		min-height: 0;
 		overflow-y: auto;
 		padding: var(--terminal-space-1) 0;
 	}
 
-	.mr-row {
+	.mrg-row {
 		display: grid;
-		grid-template-columns: 1fr auto auto;
+		grid-template-columns: 36px 1fr auto auto;
 		align-items: center;
-		gap: var(--terminal-space-2);
-		padding: 3px var(--terminal-space-2);
-		height: 24px;
+		gap: 8px;
+		height: 22px;
+		padding: 0 var(--terminal-space-2);
+		border-bottom: 1px solid var(--ii-terminal-hair, rgba(102, 137, 188, 0.14));
+		font-size: var(--terminal-text-10);
 	}
 
-	.mr-key {
-		font-size: var(--terminal-text-10);
-		color: var(--terminal-fg-tertiary);
-		letter-spacing: var(--terminal-tracking-caps);
+	.mrg-code {
+		color: var(--terminal-fg-secondary);
+		font-weight: 700;
+		letter-spacing: 0.06em;
+	}
+
+	.mrg-label {
+		overflow: hidden;
+		font-size: 9px;
+		font-weight: 600;
+		letter-spacing: 0.08em;
+		text-overflow: ellipsis;
 		text-transform: uppercase;
 		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
 	}
 
-	.mr-val {
-		font-size: var(--terminal-text-11);
+	.mrg-goldilocks { color: var(--terminal-status-success); }
+	.mrg-overheating { color: var(--terminal-status-warn, var(--terminal-accent-amber)); }
+	.mrg-stagflation { color: var(--terminal-status-error); }
+	.mrg-reflation { color: var(--terminal-accent-cyan); }
+
+	.mrg-stress {
+		border: 1px solid currentColor;
+		border-radius: 2px;
+		padding: 1px 5px;
+		font-size: 9px;
+		font-weight: 600;
+		letter-spacing: 0.06em;
+	}
+
+	.mrg-stress-low { color: var(--terminal-status-success); }
+	.mrg-stress-med { color: var(--terminal-status-warn, var(--terminal-accent-amber)); }
+	.mrg-stress-high { color: var(--terminal-status-error); }
+
+	.mrg-trend {
+		font-size: 12px;
 		font-weight: 700;
-		color: var(--terminal-fg-primary);
-		font-variant-numeric: tabular-nums;
-		text-align: right;
-		white-space: nowrap;
+		line-height: 1;
 	}
 
-	.mr-change {
-		font-size: var(--terminal-text-10);
-		font-variant-numeric: tabular-nums;
-		text-align: right;
-		min-width: 48px;
-		white-space: nowrap;
-	}
+	.mrg-trend.up { color: var(--terminal-status-success); }
+	.mrg-trend.down { color: var(--terminal-status-error); }
 
-	.mr-good {
-		color: var(--terminal-status-success);
-	}
-
-	.mr-warn {
-		color: var(--terminal-status-error);
-	}
-
-	.mr-neutral {
+	.mrg-empty {
+		padding: 24px 12px;
 		color: var(--terminal-fg-muted);
+		font-size: var(--terminal-text-10);
+		text-align: center;
 	}
 </style>

--- a/packages/ii-terminal-core/src/lib/components/terminal/live/RebalanceFocusMode.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/live/RebalanceFocusMode.svelte
@@ -238,6 +238,28 @@
 					<button type="button" class="rfm-retry" onclick={onClose}>CLOSE</button>
 				</div>
 			{:else if preview}
+				<div class="rfm-kpi-ribbon">
+					<div class="rfm-kpi">
+						<span class="rfm-kpi-label">TOTAL AUM</span>
+						<span class="rfm-kpi-value">{totalAum > 0 ? formatCurrency(totalAum) : "\u2014"}</span>
+					</div>
+					<div class="rfm-kpi">
+						<span class="rfm-kpi-label">INSTRUMENTS</span>
+						<span class="rfm-kpi-value">{holdings.length}</span>
+					</div>
+					<div class="rfm-kpi">
+						<span class="rfm-kpi-label">TRADES</span>
+						<span class="rfm-kpi-value rfm-kpi-accent">
+							{preview.trades.filter((trade) => trade.action !== "HOLD").length}
+						</span>
+					</div>
+					<div class="rfm-kpi">
+						<span class="rfm-kpi-label">IMPACT AUM</span>
+						<span class="rfm-kpi-value">
+							{formatCurrency(preview.trades.reduce((sum, trade) => sum + Math.abs(trade.trade_value), 0))}
+						</span>
+					</div>
+				</div>
 				<div class="rfm-grid">
 					<!-- Left: Proposed Trades -->
 					<div class="rfm-trades-panel">
@@ -479,6 +501,44 @@
 		flex: 1;
 		min-height: 0;
 		background: var(--terminal-fg-muted);
+	}
+
+	.rfm-kpi-ribbon {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 1px;
+		flex-shrink: 0;
+		padding: 1px;
+		background: var(--ii-border-subtle, var(--terminal-bg-panel-sunken));
+	}
+
+	.rfm-kpi {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		padding: 10px 14px;
+		background: var(--ii-surface, var(--terminal-bg-panel));
+	}
+
+	.rfm-kpi-label {
+		font-family: var(--ii-font-mono, var(--terminal-font-mono));
+		font-size: 9px;
+		font-weight: 600;
+		letter-spacing: 0.08em;
+		color: var(--ii-text-muted, var(--terminal-fg-muted));
+		text-transform: uppercase;
+	}
+
+	.rfm-kpi-value {
+		font-family: var(--ii-font-mono, var(--terminal-font-mono));
+		font-size: 18px;
+		font-weight: 600;
+		color: var(--ii-text-primary, var(--terminal-fg-primary));
+		font-variant-numeric: tabular-nums;
+	}
+
+	.rfm-kpi-accent {
+		color: var(--ii-brand-primary, var(--terminal-accent-amber));
 	}
 
 	/* Panel headers */


### PR DESCRIPTION
## Summary

### Phase 3 — Live Workbench
- `GET /macro/regional-regime`: reads `macro_regional_snapshots`, computes GOLDILOCKS/OVERHEATING/STAGFLATION/REFLATION + LOW/MED/HIGH stress + trend direction per region (US/EU/EM/BR)
- **MacroRegimePanel**: rewritten from 8-FRED-indicator list to 4-region dense table with colored regime labels, stress badges, and ↑/↓ arrows
- **RebalanceFocusMode**: 4-KPI ribbon (TOTAL AUM / INSTRUMENTS / TRADES / IMPACT AUM) added above trades table with `gap:1px` hairline

### Phase 4 — Screener
- **ScreenerFundFocusModal**: new 1040px×88vh modal with SVG PerfChart (area + gradient), CompositeRadar (6-axis spider), 6-KPI grid, period stats 1M–5Y computed from NAV, 52W range, ESC/backdrop close
- `FocusTriggerOptions` extended with `ticker` + `instrumentId` optional fields
- `TerminalDataGrid`: propagates ticker/instrumentId in `focustrigger` event
- FilterRail: 280px → 240px

### Phase 5 — Builder
- **PortfolioTabContent**: `SvelteSet` visited tab tracking, amber pulse animation during build, 4px green dot on visited tabs
- **CascadeTimeline**: `collapsed` prop + `max-height` CSS transition
- **ActivationBar**: CTA → "SEND TO COMPLIANCE ▸" with green ready-state style

## Validation
- `pytest test_macro_new_endpoints.py`: 10 passed
- `ruff check` backend files: clean
- `py_compile` backend files: clean
- `pnpm --filter @investintell/ii-terminal-core check`: 0 errors, 13 warnings
- Targeted frontend build passes outside sandbox

## Known non-blockers
- `make build-all` blocked by `spawn EPERM` (esbuild sandbox restriction)
- `make check-all` blocked by pre-existing `frontends/credit` lint baseline
- Pre-existing errors in `live/+page.svelte` (not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)