### PR TITLE
feat(builder): workspace bootstrapping + portfolio picker (S2 D1+D5)

### DIFF
--- a/frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
+++ b/frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
@@ -43,46 +43,43 @@
 	import RegimeTab from "@investintell/ii-terminal-core/components/terminal/builder/RegimeTab.svelte";
 	import ActivationBar from "@investintell/ii-terminal-core/components/terminal/builder/ActivationBar.svelte";
 	import CalibrationPanel from "@investintell/ii-terminal-core/components/portfolio/CalibrationPanel.svelte";
+	import PortfolioPicker from "@investintell/ii-terminal-core/components/portfolio/PortfolioPicker.svelte";
 
 	interface Props {
 		portfolios: ModelPortfolio[];
+		onCreatePortfolio?: () => void;
 	}
 
-	let { portfolios }: Props = $props();
+	let { portfolios, onCreatePortfolio }: Props = $props();
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 
 	// ── Portfolio selection ──────────────────────────────────────
-	let selectedPortfolio = $state<ModelPortfolio | null>(null);
-
-	/** URL wins over auto-select so /portfolio/builder?id=X redirect preserves intent. */
 	const urlPortfolioId = $derived(
 		page.url.searchParams.get("portfolio_id"),
 	);
 
+	const selectedPortfolio = $derived.by<ModelPortfolio | null>(() => {
+		const targetId = urlPortfolioId;
+		if (targetId) {
+			return portfolios.find((p) => p.id === targetId) ?? portfolios[0] ?? null;
+		}
+		return portfolios[0] ?? null;
+	});
+
 	$effect(() => {
 		workspace.setGetToken(getToken);
+	});
 
-		// Prefer the portfolio the URL named — otherwise take the first.
-		const targetId = urlPortfolioId;
-		const target = targetId
-			? (portfolios.find((p) => p.id === targetId) ?? portfolios[0] ?? null)
-			: (portfolios[0] ?? null);
-
-		if (target && target.id !== selectedPortfolio?.id) {
-			selectPortfolio(target);
+	// Side-effect only: sync workspace when selected portfolio changes.
+	$effect(() => {
+		if (selectedPortfolio) {
+			workspace.selectPortfolio(selectedPortfolio);
 		}
 	});
 
 	function selectPortfolio(p: ModelPortfolio) {
-		selectedPortfolio = p;
 		workspace.selectPortfolio(p);
-	}
-
-	function handlePortfolioChange(e: Event) {
-		const select = e.currentTarget as HTMLSelectElement;
-		const p = portfolios.find((x) => x.id === select.value);
-		if (p) selectPortfolio(p);
 	}
 
 	// ── Right-column 7-tab state ─────────────────────────────────
@@ -172,17 +169,14 @@
 	});
 
 	$effect(() => {
-		if (
+		if (isBuilding) {
+			userSwitchedTab = false;
+		} else if (
 			workspace.runPhase === "done" &&
 			!userSwitchedTab &&
 			activeTab === "REGIME"
 		) {
 			activeTab = "WEIGHTS";
-		}
-	});
-	$effect(() => {
-		if (isBuilding) {
-			userSwitchedTab = false;
 		}
 	});
 </script>
@@ -191,20 +185,15 @@
 	<!-- LEFT COLUMN (40%) — Command Panel -->
 	<div class="builder-left">
 		<div class="builder-portfolio-select">
-			<select
-				class="builder-select"
-				value={selectedPortfolio?.id ?? ""}
-				onchange={handlePortfolioChange}
-				aria-label="Select portfolio"
-			>
-				{#if portfolios.length === 0}
-					<option value="" disabled>No portfolios available</option>
-				{:else}
-					{#each portfolios as p (p.id)}
-						<option value={p.id}>{p.display_name}</option>
-					{/each}
-				{/if}
-			</select>
+			<PortfolioPicker
+				{portfolios}
+				selectedId={selectedPortfolio?.id ?? null}
+				onSelect={(id) => {
+					const p = portfolios.find((x) => x.id === id);
+					if (p) selectPortfolio(p);
+				}}
+				onCreate={() => onCreatePortfolio?.()}
+			/>
 		</div>
 
 		<div class="builder-calibration">
@@ -311,23 +300,6 @@
 	.builder-portfolio-select {
 		padding: var(--terminal-space-2);
 		border-bottom: var(--terminal-border-hairline);
-	}
-
-	.builder-select {
-		width: 100%;
-		height: 28px;
-		background: var(--terminal-bg-panel-sunken);
-		color: var(--terminal-fg-primary);
-		border: var(--terminal-border-hairline);
-		border-radius: var(--terminal-radius-none);
-		font-family: var(--terminal-font-mono);
-		font-size: var(--terminal-text-11);
-		padding: 0 var(--terminal-space-2);
-		cursor: pointer;
-	}
-	.builder-select:focus-visible {
-		outline: var(--terminal-border-focus);
-		outline-offset: 2px;
 	}
 
 	.builder-calibration {

--- a/frontends/terminal/src/routes/allocation/[profile]/+page.svelte
+++ b/frontends/terminal/src/routes/allocation/[profile]/+page.svelte
@@ -48,6 +48,8 @@
 	import PortfolioTabContent from "../../../lib/components/builder/PortfolioTabContent.svelte";
 	import StressTabContent from "../../../lib/components/builder/StressTabContent.svelte";
 	import RegimeContextStrip from "@investintell/ii-terminal-core/components/allocation/RegimeContextStrip.svelte";
+	import StrategicApprovalBanner from "@investintell/ii-terminal-core/components/allocation/StrategicApprovalBanner.svelte";
+	import { approval } from "@investintell/ii-terminal-core/state/workspace-approval.svelte";
 
 	import type { PageData } from "./$types";
 
@@ -117,6 +119,14 @@
 			: {},
 	);
 
+	// Wire approval state refresh when profile changes.
+	$effect(() => {
+		if (profile) {
+			approval.setGetToken(getToken);
+			approval.refresh(profile);
+		}
+	});
+
 	// Resolve the selected portfolio's display name for the breadcrumb
 	// badge — only relevant on PORTFOLIO / STRESS tabs where a portfolio
 	// is actually in play.
@@ -162,6 +172,9 @@
 						{apiPost}
 						{getToken}
 						{apiBase}
+					/>
+					<StrategicApprovalBanner
+						onNavigate={(to) => { if (to === "portfolio") setTab("portfolio"); }}
 					/>
 				</div>
 			{:else if activeTab === "portfolio"}

--- a/packages/ii-terminal-core/src/lib/components/allocation/StrategicApprovalBanner.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/StrategicApprovalBanner.svelte
@@ -1,0 +1,161 @@
+<!--
+  StrategicApprovalBanner — CTA between STRATEGIC and PORTFOLIO tabs.
+
+  Surfaces the approval state for the current profile's strategic
+  allocation. When approved, shows a green "Approved" badge with
+  a "Continue to Portfolio" action. When not approved, shows the
+  required action (propose or approve).
+
+  Emits ``onNavigate`` event — parent handles tab switching.
+-->
+<script lang="ts">
+	import { formatDateTime } from "@investintell/ui";
+	import { approval } from "../../state/workspace-approval.svelte";
+	import type { ApprovalStatus } from "../../state/workspace-approval.svelte";
+
+	interface Props {
+		onNavigate?: (to: "portfolio") => void;
+	}
+
+	let { onNavigate }: Props = $props();
+
+	const status = $derived<ApprovalStatus>(approval.state.status);
+	const lastApprovedAt = $derived(approval.state.last_approved_at);
+</script>
+
+{#if status !== "loading"}
+	<div
+		class="sab-root"
+		class:sab-root--approved={status === "approved"}
+		class:sab-root--warn={status === "pending_approval" || status === "never_proposed"}
+		class:sab-root--error={status === "error"}
+	>
+		<div class="sab-body">
+			{#if status === "approved"}
+				<span class="sab-badge sab-badge--success">APPROVED</span>
+				<span class="sab-text">
+					Strategic allocation approved
+					{#if lastApprovedAt}
+						on {formatDateTime(lastApprovedAt)}
+					{/if}
+				</span>
+				{#if onNavigate}
+					<button
+						type="button"
+						class="sab-action"
+						onclick={() => onNavigate?.("portfolio")}
+					>
+						Continue to Portfolio ▸
+					</button>
+				{/if}
+			{:else if status === "pending_approval"}
+				<span class="sab-badge sab-badge--warn">PENDING</span>
+				<span class="sab-text">
+					Strategic allocation proposed but not yet approved.
+					Approve before building a portfolio.
+				</span>
+			{:else if status === "never_proposed"}
+				<span class="sab-badge sab-badge--warn">NOT PROPOSED</span>
+				<span class="sab-text">
+					Start by proposing a strategic allocation for this profile.
+				</span>
+			{:else if status === "error"}
+				<span class="sab-badge sab-badge--error">ERROR</span>
+				<span class="sab-text">
+					Could not load approval status
+					{#if approval.state.error}
+						— {approval.state.error}
+					{/if}
+				</span>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.sab-root {
+		display: flex;
+		align-items: center;
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		border: 1px solid var(--terminal-fg-muted);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+	}
+
+	.sab-root--approved {
+		border-color: var(--terminal-status-success);
+		background: color-mix(in srgb, var(--terminal-status-success) 8%, transparent);
+	}
+
+	.sab-root--warn {
+		border-color: var(--terminal-accent-amber);
+		background: color-mix(in srgb, var(--terminal-accent-amber) 8%, transparent);
+	}
+
+	.sab-root--error {
+		border-color: var(--terminal-status-error);
+		background: color-mix(in srgb, var(--terminal-status-error) 8%, transparent);
+	}
+
+	.sab-body {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		flex-wrap: wrap;
+	}
+
+	.sab-badge {
+		display: inline-flex;
+		align-items: center;
+		height: 20px;
+		padding: 0 var(--terminal-space-2);
+		font-size: var(--terminal-text-10);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		border: 1px solid;
+	}
+
+	.sab-badge--success {
+		border-color: var(--terminal-status-success);
+		color: var(--terminal-status-success);
+	}
+
+	.sab-badge--warn {
+		border-color: var(--terminal-accent-amber);
+		color: var(--terminal-accent-amber);
+	}
+
+	.sab-badge--error {
+		border-color: var(--terminal-status-error);
+		color: var(--terminal-status-error);
+	}
+
+	.sab-text {
+		color: var(--terminal-fg-secondary);
+	}
+
+	.sab-action {
+		margin-left: auto;
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		background: transparent;
+		border: 1px solid var(--terminal-status-success);
+		color: var(--terminal-status-success);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+		transition: background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+
+	.sab-action:hover {
+		background: color-mix(in srgb, var(--terminal-status-success) 12%, transparent);
+	}
+
+	.sab-action:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/PortfolioPicker.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/PortfolioPicker.svelte
@@ -1,0 +1,344 @@
+<!--
+  PortfolioPicker — replaces the raw <select> in PortfolioTabContent.
+
+  Populated state: list with preview (display_name, state badge,
+  holdings count, last build timestamp). Empty state: "Create your
+  first model portfolio" with single-click flow.
+
+  Keyboard: arrow keys navigate, enter selects.
+-->
+<script lang="ts">
+	import { formatDateTime, formatNumber } from "@investintell/ui";
+	import type { ModelPortfolio } from "../../types/model-portfolio";
+
+	interface Props {
+		portfolios: ModelPortfolio[];
+		selectedId: string | null;
+		onSelect: (id: string) => void;
+		onCreate: () => void;
+	}
+
+	let { portfolios, selectedId, onSelect, onCreate }: Props = $props();
+
+	let isOpen = $state(false);
+	let focusIndex = $state(-1);
+
+	const selected = $derived(
+		portfolios.find((p) => p.id === selectedId) ?? null,
+	);
+
+	function toggle() {
+		isOpen = !isOpen;
+		if (isOpen) {
+			focusIndex = portfolios.findIndex((p) => p.id === selectedId);
+		}
+	}
+
+	function select(p: ModelPortfolio) {
+		onSelect(p.id);
+		isOpen = false;
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (!isOpen) {
+			if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") {
+				e.preventDefault();
+				isOpen = true;
+				focusIndex = Math.max(0, portfolios.findIndex((p) => p.id === selectedId));
+			}
+			return;
+		}
+
+		switch (e.key) {
+			case "ArrowDown":
+				e.preventDefault();
+				focusIndex = Math.min(focusIndex + 1, portfolios.length - 1);
+				break;
+			case "ArrowUp":
+				e.preventDefault();
+				focusIndex = Math.max(focusIndex - 1, 0);
+				break;
+			case "Enter": {
+				e.preventDefault();
+				const target = portfolios[focusIndex];
+				if (target) select(target);
+				break;
+			}
+			case "Escape":
+				e.preventDefault();
+				isOpen = false;
+				break;
+		}
+	}
+
+	function stateLabel(state: string): string {
+		switch (state) {
+			case "draft": return "DRAFT";
+			case "constructed": return "CONSTRUCTED";
+			case "validated": return "VALIDATED";
+			case "approved": return "APPROVED";
+			case "live": return "LIVE";
+			case "paused": return "PAUSED";
+			case "archived": return "ARCHIVED";
+			case "rejected": return "REJECTED";
+			default: return state.toUpperCase();
+		}
+	}
+
+	function stateTone(state: string): string {
+		switch (state) {
+			case "live": return "success";
+			case "approved":
+			case "validated": return "info";
+			case "paused": return "warn";
+			case "rejected":
+			case "archived": return "muted";
+			default: return "neutral";
+		}
+	}
+
+	function holdingsCount(p: ModelPortfolio): number | null {
+		return p.fund_selection_schema?.funds?.length ?? null;
+	}
+</script>
+
+<div class="pp-root" role="combobox" aria-expanded={isOpen} aria-haspopup="listbox">
+	{#if portfolios.length === 0}
+		<!-- Empty state -->
+		<div class="pp-empty">
+			<span class="pp-empty-text">No model portfolios yet</span>
+			<button type="button" class="pp-create-btn" onclick={onCreate}>
+				+ Create Portfolio
+			</button>
+		</div>
+	{:else}
+		<!-- Selected display -->
+		<button
+			type="button"
+			class="pp-trigger"
+			onclick={toggle}
+			onkeydown={handleKeydown}
+			aria-label="Select portfolio"
+		>
+			<span class="pp-trigger-name">
+				{selected?.display_name ?? "Select portfolio"}
+			</span>
+			{#if selected}
+				<span class="pp-trigger-state pp-trigger-state--{stateTone(selected.state)}">
+					{stateLabel(selected.state)}
+				</span>
+			{/if}
+			<span class="pp-trigger-chevron" aria-hidden="true">
+				{isOpen ? "▴" : "▾"}
+			</span>
+		</button>
+
+		<!-- Dropdown list -->
+		{#if isOpen}
+			<div class="pp-dropdown" role="listbox">
+				{#each portfolios as p, i (p.id)}
+					<button
+						type="button"
+						class="pp-option"
+						class:pp-option--selected={p.id === selectedId}
+						class:pp-option--focused={i === focusIndex}
+						role="option"
+						aria-selected={p.id === selectedId}
+						onclick={() => select(p)}
+					>
+						<div class="pp-option-header">
+							<span class="pp-option-name">{p.display_name}</span>
+							<span class="pp-option-state pp-option-state--{stateTone(p.state)}">
+								{stateLabel(p.state)}
+							</span>
+						</div>
+						<div class="pp-option-meta">
+							{#if holdingsCount(p) != null}
+								<span>{formatNumber(holdingsCount(p)!, 0)} holdings</span>
+							{/if}
+							{#if p.created_at}
+								<span>Created {formatDateTime(p.created_at)}</span>
+							{/if}
+						</div>
+					</button>
+				{/each}
+
+				<button type="button" class="pp-option pp-option--create" onclick={onCreate}>
+					+ Create new portfolio
+				</button>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.pp-root {
+		position: relative;
+		font-family: var(--terminal-font-mono);
+	}
+
+	/* ── Empty state ───────────────────────────── */
+
+	.pp-empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-4);
+	}
+
+	.pp-empty-text {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-muted);
+		text-transform: uppercase;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.pp-create-btn {
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		background: transparent;
+		border: 1px solid var(--terminal-status-success);
+		color: var(--terminal-status-success);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+	.pp-create-btn:hover {
+		background: color-mix(in srgb, var(--terminal-status-success) 10%, transparent);
+	}
+	.pp-create-btn:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	/* ── Trigger ────────────────────────────────── */
+
+	.pp-trigger {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		width: 100%;
+		height: 32px;
+		padding: 0 var(--terminal-space-2);
+		background: var(--terminal-bg-panel-sunken);
+		border: var(--terminal-border-hairline);
+		color: var(--terminal-fg-primary);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		cursor: pointer;
+	}
+	.pp-trigger:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+
+	.pp-trigger-name {
+		flex: 1;
+		text-align: left;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.pp-trigger-state {
+		font-size: var(--terminal-text-9);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.pp-trigger-state--success { color: var(--terminal-status-success); }
+	.pp-trigger-state--info { color: var(--terminal-accent, var(--terminal-accent-amber)); }
+	.pp-trigger-state--warn { color: var(--terminal-accent-amber); }
+	.pp-trigger-state--muted { color: var(--terminal-fg-muted); }
+	.pp-trigger-state--neutral { color: var(--terminal-fg-secondary); }
+
+	.pp-trigger-chevron {
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-muted);
+	}
+
+	/* ── Dropdown ───────────────────────────────── */
+
+	.pp-dropdown {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		z-index: 100;
+		max-height: 240px;
+		overflow-y: auto;
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		border-top: none;
+	}
+
+	.pp-option {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		width: 100%;
+		padding: var(--terminal-space-2);
+		background: transparent;
+		border: none;
+		border-bottom: 1px solid color-mix(in srgb, var(--terminal-fg-muted) 20%, transparent);
+		font-family: var(--terminal-font-mono);
+		text-align: left;
+		cursor: pointer;
+		transition: background var(--terminal-motion-tick) var(--terminal-motion-easing-out);
+	}
+	.pp-option:hover,
+	.pp-option--focused {
+		background: color-mix(in srgb, var(--terminal-accent-amber) 8%, transparent);
+	}
+	.pp-option--selected {
+		border-left: 2px solid var(--terminal-accent-amber);
+	}
+	.pp-option:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: -2px;
+	}
+
+	.pp-option-header {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+	}
+
+	.pp-option-name {
+		flex: 1;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-primary);
+		font-weight: 600;
+	}
+
+	.pp-option-state {
+		font-size: var(--terminal-text-9);
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+	}
+	.pp-option-state--success { color: var(--terminal-status-success); }
+	.pp-option-state--info { color: var(--terminal-accent, var(--terminal-accent-amber)); }
+	.pp-option-state--warn { color: var(--terminal-accent-amber); }
+	.pp-option-state--muted { color: var(--terminal-fg-muted); }
+	.pp-option-state--neutral { color: var(--terminal-fg-secondary); }
+
+	.pp-option-meta {
+		display: flex;
+		gap: var(--terminal-space-3);
+		font-size: var(--terminal-text-9);
+		color: var(--terminal-fg-muted);
+	}
+
+	.pp-option--create {
+		color: var(--terminal-status-success);
+		font-size: var(--terminal-text-10);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		border-bottom: none;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts
@@ -1832,6 +1832,14 @@ export class PortfolioWorkspaceState {
 	async runBuildJob(): Promise<ConstructionRunPayload | null> {
 		if (!this._getToken || !this.portfolioId) return null;
 
+		// Gate: strategic allocation must be approved before building.
+		const { approval } = await import("./workspace-approval.svelte");
+		if (!approval.canBuild) {
+			this.runError = "Strategic allocation not approved. Approve the IPS before building.";
+			this.runPhase = "error";
+			return null;
+		}
+
 		// Cancel any in-flight BUILD stream if the user re-presses.
 		this._activeBuildAbort?.abort();
 		const abort = new AbortController();

--- a/packages/ii-terminal-core/src/lib/state/workspace-approval.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/workspace-approval.svelte.ts
@@ -1,0 +1,126 @@
+/**
+ * workspace-approval — extracted approval gate state for the Builder.
+ *
+ * Reads the strategic allocation endpoint to determine whether the
+ * current profile has an active approval. The Builder's RunControls
+ * gate on this before allowing ``runBuildJob``.
+ *
+ * Plain class with ``$state`` fields — not a store.
+ */
+
+import type { AllocationProfile } from "../types/allocation-page";
+
+export type ApprovalStatus =
+	| "loading"
+	| "approved"
+	| "pending_approval"
+	| "never_proposed"
+	| "error";
+
+export interface ApprovalState {
+	status: ApprovalStatus;
+	profile: AllocationProfile | null;
+	last_approved_at: string | null;
+	last_approved_by: string | null;
+	error: string | null;
+}
+
+const INITIAL_STATE: ApprovalState = {
+	status: "loading",
+	profile: null,
+	last_approved_at: null,
+	last_approved_by: null,
+	error: null,
+};
+
+class WorkspaceApproval {
+	state = $state<ApprovalState>({ ...INITIAL_STATE });
+
+	private _fetchId = 0;
+	private _abort: AbortController | null = null;
+	private _getToken: (() => Promise<string>) | null = null;
+
+	setGetToken(fn: () => Promise<string>) {
+		this._getToken = fn;
+	}
+
+	async refresh(profile: AllocationProfile): Promise<void> {
+		this._abort?.abort();
+		const abort = new AbortController();
+		this._abort = abort;
+
+		const fetchId = ++this._fetchId;
+
+		this.state = { ...INITIAL_STATE, profile, status: "loading" };
+
+		try {
+			const token = await this._getToken?.();
+			const base =
+				(import.meta.env.VITE_API_BASE_URL as string | undefined) ??
+				"http://localhost:8000/api/v1";
+
+			const res = await fetch(
+				`${base}/portfolio/profiles/${profile}/strategic-allocation`,
+				{
+					headers: {
+						Authorization: `Bearer ${token}`,
+						Accept: "application/json",
+					},
+					signal: abort.signal,
+				},
+			);
+
+			if (fetchId !== this._fetchId) return;
+
+			if (res.status === 404) {
+				this.state = {
+					status: "never_proposed",
+					profile,
+					last_approved_at: null,
+					last_approved_by: null,
+					error: null,
+				};
+				return;
+			}
+
+			if (!res.ok) {
+				this.state = {
+					status: "error",
+					profile,
+					last_approved_at: null,
+					last_approved_by: null,
+					error: `HTTP ${res.status}`,
+				};
+				return;
+			}
+
+			const data = await res.json();
+
+			if (fetchId !== this._fetchId) return;
+
+			this.state = {
+				status: data.has_active_approval ? "approved" : "pending_approval",
+				profile,
+				last_approved_at: data.last_approved_at ?? null,
+				last_approved_by: data.last_approved_by ?? null,
+				error: null,
+			};
+		} catch (err: unknown) {
+			if (abort.signal.aborted) return;
+			if (fetchId !== this._fetchId) return;
+			this.state = {
+				status: "error",
+				profile,
+				last_approved_at: null,
+				last_approved_by: null,
+				error: err instanceof Error ? err.message : "Unknown error",
+			};
+		}
+	}
+
+	get canBuild(): boolean {
+		return this.state.status === "approved";
+	}
+}
+
+export const approval = new WorkspaceApproval();


### PR DESCRIPTION
## Summary
- **D1 Approval Gate**: New `workspace-approval.svelte.ts` module + `StrategicApprovalBanner.svelte`. Blocks `runBuildJob` when strategic allocation is not approved. Reads `/profiles/{profile}/strategic-allocation` endpoint to determine approval status. 404 fallback resolves to "never_proposed" status.
- **D5 PortfolioPicker**: Replaces raw `<select>` with proper component. Empty state with create CTA, populated state with state badges + holdings count + keyboard navigation.
- **Race fix RC3**: `selectedPortfolio` converted from `$state`-in-`$effect` to `$derived`
- **Race fix RC4**: Two competing `$effect`s on `userSwitchedTab` unified into one

## Test plan
- [ ] Open `/allocation/conservative` — StrategicApprovalBanner shows approval status
- [ ] Click "Continue to Portfolio" on approved banner — navigates to PORTFOLIO tab
- [ ] PortfolioPicker shows populated list with state badges
- [ ] Arrow keys + Enter navigate and select in PortfolioPicker
- [ ] Empty state shows "Create your first model portfolio" button
- [ ] Click "Build" without approved strategic → error message (gate blocks)
- [ ] `svelte-check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)