### PR TITLE
feat(builder): telemetry surfacing + degraded acknowledgment (S2 D2+D3+D4)

### DIFF
--- a/frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
+++ b/frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
@@ -108,9 +108,6 @@
 		visitedTabs.add(activeTab);
 	});
 
-	/** ActivationBar unlocks only once every sub-tab has been visited. */
-	const allTabsVisited = $derived(visitedTabs.size === TABS.length);
-
 	function setActiveTab(t: TabId) {
 		visitedTabs.add(t);
 		activeTab = t;
@@ -269,7 +266,7 @@
 			{/key}
 		</div>
 
-		<ActivationBar {allTabsVisited} />
+		<ActivationBar />
 	</div>
 </div>
 

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/ActivationBar.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/ActivationBar.svelte
@@ -1,30 +1,70 @@
 <!--
   ActivationBar — Zone F fixed footer in the Builder right column.
 
-  Appears ONLY when: runPhase === "done" AND allTabsVisited === true.
-  Two buttons: Save as Draft + Send to Compliance (opens ConsequenceDialog).
+  Appears when: runPhase === "done" (no allTabsVisited gate).
+
+  Degraded-run handling:
+  - Degraded signals (cvar_infeasible_min_var, degraded_other,
+    proposal_cvar_infeasible): shows acknowledgment checkbox.
+    Activation blocked until checked.
+  - Hard-block signals (pre_solve_failure, block_coverage_insufficient,
+    template_incomplete, no_approved_allocation,
+    instrument_concentration_breach): activation disabled entirely.
+    Operator must fix the root cause.
+  - Optimal/robustness_fallback/proposal_ready: no gate.
 -->
 <script lang="ts">
 	import { fly } from "svelte/transition";
 	import { svelteTransitionFor } from "@investintell/ui";
 	import { workspace } from "../../../state/portfolio-workspace.svelte";
+	import { translateWinnerSignal } from "../../../utils/metric-translators";
+	import type { WinnerSignal } from "../../../types/cascade-telemetry";
 	import ConsequenceDialog from "./ConsequenceDialog.svelte";
 
-	interface Props {
-		allTabsVisited: boolean;
-	}
+	const visible = $derived(workspace.runPhase === "done");
 
-	let { allTabsVisited }: Props = $props();
+	const winnerSignal = $derived<WinnerSignal | null>(
+		(workspace.constructionRun?.cascade_telemetry?.winner_signal as WinnerSignal | undefined) ?? null,
+	);
 
-	const visible = $derived(workspace.runPhase === "done" && allTabsVisited);
+	const HARD_BLOCK_SIGNALS: ReadonlySet<string> = new Set([
+		"pre_solve_failure",
+		"block_coverage_insufficient",
+		"template_incomplete",
+		"no_approved_allocation",
+		"instrument_concentration_breach",
+	]);
+
+	const DEGRADED_SIGNALS: ReadonlySet<string> = new Set([
+		"cvar_infeasible_min_var",
+		"degraded_other",
+		"proposal_cvar_infeasible",
+	]);
+
+	const isHardBlocked = $derived(
+		winnerSignal != null && HARD_BLOCK_SIGNALS.has(winnerSignal),
+	);
+
+	const isDegraded = $derived(
+		winnerSignal != null && DEGRADED_SIGNALS.has(winnerSignal),
+	);
+
+	const signalTranslation = $derived(
+		winnerSignal ? translateWinnerSignal(winnerSignal) : null,
+	);
+
+	let degradedAcknowledged = $state(false);
+
+	const canActivate = $derived(
+		!isHardBlocked && (!isDegraded || degradedAcknowledged),
+	);
 
 	let showDialog = $state(false);
 	let successBanner = $state(false);
 
 	async function handleSaveDraft() {
 		// Draft is the current state — no explicit save needed beyond
-		// the already-persisted construction run. This is a UX affordance
-		// to reassure PMs their work is saved.
+		// the already-persisted construction run.
 	}
 
 	function handleActivateClick() {
@@ -42,13 +82,44 @@
 </script>
 
 {#if visible}
-	<div class="ab-bar" in:fly={{ y: 12, ...svelteTransitionFor("tail", { duration: "update" }) }}>
-		<button type="button" class="ab-btn ab-btn--secondary" onclick={handleSaveDraft}>
-			Save as Draft
-		</button>
-		<button type="button" class="ab-btn ab-btn--activate" onclick={handleActivateClick}>
-			SEND TO COMPLIANCE ▸
-		</button>
+	<div class="ab-root">
+		{#if isHardBlocked && signalTranslation}
+			<div class="ab-block-banner ab-block-banner--error">
+				<span class="ab-block-badge">BLOCKED</span>
+				<span class="ab-block-text">{signalTranslation.label}</span>
+			</div>
+		{/if}
+
+		{#if isDegraded && signalTranslation}
+			<div class="ab-block-banner ab-block-banner--warn">
+				<span class="ab-block-badge ab-block-badge--warn">DEGRADED</span>
+				<span class="ab-block-text">{signalTranslation.label}</span>
+			</div>
+			<label class="ab-ack">
+				<input
+					type="checkbox"
+					class="ab-ack-checkbox"
+					bind:checked={degradedAcknowledged}
+				/>
+				<span class="ab-ack-label">
+					I acknowledge the degraded construction outcome and wish to proceed
+				</span>
+			</label>
+		{/if}
+
+		<div class="ab-bar" in:fly={{ y: 12, ...svelteTransitionFor("tail", { duration: "update" }) }}>
+			<button type="button" class="ab-btn ab-btn--secondary" onclick={handleSaveDraft}>
+				Save as Draft
+			</button>
+			<button
+				type="button"
+				class="ab-btn ab-btn--activate"
+				disabled={!canActivate}
+				onclick={handleActivateClick}
+			>
+				{isHardBlocked ? "ACTIVATION BLOCKED" : "SEND TO COMPLIANCE ▸"}
+			</button>
+		</div>
 	</div>
 {/if}
 
@@ -63,10 +134,71 @@
 	<ConsequenceDialog
 		onclose={handleDialogClose}
 		onsuccess={handleActivateSuccess}
+		degradedAcknowledged={isDegraded && degradedAcknowledged}
+		winnerSignal={winnerSignal}
 	/>
 {/if}
 
 <style>
+	.ab-root {
+		flex-shrink: 0;
+	}
+
+	.ab-block-banner {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+	}
+
+	.ab-block-banner--error {
+		background: color-mix(in srgb, var(--terminal-status-error) 10%, transparent);
+		border-top: 1px solid var(--terminal-status-error);
+	}
+
+	.ab-block-banner--warn {
+		background: color-mix(in srgb, var(--terminal-accent-amber) 10%, transparent);
+		border-top: 1px solid var(--terminal-accent-amber);
+	}
+
+	.ab-block-badge {
+		font-weight: 700;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-status-error);
+		font-size: var(--terminal-text-9);
+	}
+
+	.ab-block-badge--warn {
+		color: var(--terminal-accent-amber);
+	}
+
+	.ab-block-text {
+		color: var(--terminal-fg-secondary);
+	}
+
+	.ab-ack {
+		display: flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-1) var(--terminal-space-3);
+		cursor: pointer;
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-10);
+		color: var(--terminal-fg-secondary);
+		background: color-mix(in srgb, var(--terminal-accent-amber) 5%, transparent);
+	}
+
+	.ab-ack-checkbox {
+		accent-color: var(--terminal-accent-amber);
+	}
+
+	.ab-ack-label {
+		user-select: none;
+	}
+
 	.ab-bar {
 		display: flex;
 		align-items: center;
@@ -113,8 +245,13 @@
 		letter-spacing: 0.06em;
 	}
 
-	.ab-btn--activate:hover {
+	.ab-btn--activate:hover:not(:disabled) {
 		filter: brightness(1.1);
+	}
+
+	.ab-btn--activate:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
 	}
 
 	.ab-btn:focus-visible {

--- a/packages/ii-terminal-core/src/lib/components/terminal/builder/ConsequenceDialog.svelte
+++ b/packages/ii-terminal-core/src/lib/components/terminal/builder/ConsequenceDialog.svelte
@@ -11,9 +11,11 @@
 	interface Props {
 		onclose: () => void;
 		onsuccess: () => void;
+		degradedAcknowledged?: boolean;
+		winnerSignal?: string | null;
 	}
 
-	let { onclose, onsuccess }: Props = $props();
+	let { onclose, onsuccess, degradedAcknowledged = false, winnerSignal = null }: Props = $props();
 
 	let confirmText = $state("");
 	let errorMessage = $state<string | null>(null);
@@ -65,7 +67,9 @@
 		errorMessage = null;
 
 		try {
-			await workspace.activatePortfolio();
+			await workspace.activatePortfolio(
+				degradedAcknowledged ? { degradedAcknowledged: true } : undefined,
+			);
 			onsuccess();
 		} catch (err) {
 			errorMessage = err instanceof Error ? err.message : "Activation failed";
@@ -94,6 +98,13 @@
 			This will move the portfolio to LIVE status. Active portfolios
 			are monitored daily for drift and trigger alerts.
 		</p>
+
+		{#if degradedAcknowledged && winnerSignal}
+			<p class="cd-degraded-notice">
+				This construction run has a degraded outcome. Your acknowledgment
+				will be recorded in the audit trail.
+			</p>
+		{/if}
 
 		<label class="cd-label" for="cd-confirm-input">
 			Type ACTIVATE to confirm
@@ -172,6 +183,15 @@
 		color: var(--terminal-fg-secondary);
 		line-height: 1.6;
 		margin: 0 0 var(--terminal-space-4);
+	}
+
+	.cd-degraded-notice {
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-accent-amber);
+		border: 1px solid var(--terminal-accent-amber);
+		padding: var(--terminal-space-2);
+		margin: 0 0 var(--terminal-space-4);
+		line-height: 1.5;
 	}
 
 	.cd-label {

--- a/packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts
@@ -1554,19 +1554,23 @@ export class PortfolioWorkspaceState {
 
 	// ── Portfolio Activation ────────────────────────────────────────────────
 
-	async activatePortfolio() {
+	async activatePortfolio(opts?: { degradedAcknowledged?: boolean }) {
 		if (!this._getToken || !this.portfolioId) return;
 		this.isActivating = true;
 		this.lastError = null;
 
 		try {
 			const api = this.api();
+			const metadata: Record<string, unknown> = {};
+			if (opts?.degradedAcknowledged) {
+				metadata.degraded_acknowledged = true;
+			}
 			const result = await api.post<ModelPortfolio>(
-				`/model-portfolios/${this.portfolioId}/activate`,
-				{},
+				`/model-portfolios/${this.portfolioId}/transitions`,
+				{ action: "activate", metadata },
 			);
 			this.portfolio = result;
-			this.advice = null; // advisor no longer relevant after activation
+			this.advice = null;
 		} catch (err) {
 			this.lastError = {
 				action: "activate",


### PR DESCRIPTION
## Summary
- **D2**: ActivationBar visible immediately when `runPhase === "done"` — removed `allTabsVisited` gate (was requiring visits to all 7 subtabs before showing the button)
- **D2b**: Degraded-run acknowledgment: winner_signal-based banners + checkbox for degraded signals, hard-block for fatal signals
- **D4**: `activatePortfolio()` now routes through `POST /transitions` with `action: "activate"` + `metadata.degraded_acknowledged`, matching the pre-flight 1b backend gate
- **D4 (plan correction)**: RiskBudgetPanel was already mounted inside CalibrationPanel — no change needed (plan assumed it was unmounted)

## Changes
- `ActivationBar.svelte`: full rewrite — degraded/hard-block banners, acknowledgment checkbox, disabled state
- `ConsequenceDialog.svelte`: accepts `degradedAcknowledged` + `winnerSignal` props, passes through to workspace
- `portfolio-workspace.svelte.ts`: `activatePortfolio` now uses transitions endpoint with metadata
- `PortfolioTabContent.svelte`: removed `allTabsVisited` prop from ActivationBar

## Test plan
- [ ] Build a portfolio → ActivationBar appears immediately (no tab visits needed)
- [ ] Build with degraded winner_signal → amber banner + checkbox appears
- [ ] Check checkbox → "SEND TO COMPLIANCE" button enables
- [ ] Build with hard-block signal → red banner + button disabled, no override possible
- [ ] ConsequenceDialog shows degraded notice when acknowledging degraded run
- [ ] `svelte-check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)