### PR TITLE
fix(test): B1 Batch 1 — manifests + allowlist + index assertion (6 tests)

### DIFF
--- a/backend/manifests/routes.json
+++ b/backend/manifests/routes.json
@@ -146,6 +146,11 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/admin/universe/auto-import/status",
+    "name": "get_status"
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/ai/activity",
     "name": "activity"
   },
@@ -866,6 +871,16 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/macro/cb-calendar",
+    "name": "get_cb_calendar"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/macro/cross-asset",
+    "name": "get_cross_asset"
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/macro/fred",
     "name": "get_fred_data"
   },
@@ -883,6 +898,16 @@
     "method": "GET",
     "path": "/api/v1/macro/regime",
     "name": "get_regime"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/macro/regime/trail",
+    "name": "get_regime_trail"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/macro/regional-regime",
+    "name": "get_regional_regime"
   },
   {
     "method": "GET",
@@ -968,6 +993,11 @@
     "method": "GET",
     "path": "/api/v1/market-data/dashboard-snapshot",
     "name": "dashboard_snapshot"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/market-data/events",
+    "name": "market_events"
   },
   {
     "method": "GET",
@@ -1111,6 +1141,21 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/portfolio/profiles/{profile}/approval-history",
+    "name": "get_approval_history"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/portfolio/profiles/{profile}/latest-proposal",
+    "name": "latest_proposal"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/portfolio/profiles/{profile}/strategic-allocation",
+    "name": "get_strategic_allocation"
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/portfolio/regime/current",
     "name": "get_current_regime_endpoint"
   },
@@ -1191,6 +1236,16 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/research/funds/{instrument_id}",
+    "name": "get_single_fund_research"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/research/scatter",
+    "name": "get_research_scatter"
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/risk/macro",
     "name": "get_macro"
   },
@@ -1236,6 +1291,11 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/screener/catalog/detail/{external_id}",
+    "name": "get_catalog_fund_detail_alias"
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/screener/catalog/elite",
     "name": "get_elite_catalog"
   },
@@ -1276,6 +1336,11 @@
   },
   {
     "method": "GET",
+    "path": "/api/v1/screener/peer-metrics/{fund_id}",
+    "name": "get_peer_metrics"
+  },
+  {
+    "method": "GET",
     "path": "/api/v1/screener/results",
     "name": "list_results"
   },
@@ -1312,6 +1377,11 @@
   {
     "method": "GET",
     "path": "/api/v1/search",
+    "name": "command_palette_search"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/search/global",
     "name": "global_search"
   },
   {
@@ -1458,6 +1528,11 @@
     "method": "GET",
     "path": "/api/v1/wealth/documents/{document_id}/preview-url",
     "name": "get_preview_url"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/wealth/entity-analytics/{entity_id}",
+    "name": "get_entity_analytics_alias"
   },
   {
     "method": "GET",
@@ -1628,6 +1703,11 @@
     "method": "POST",
     "path": "/api/v1/admin/tenants/{org_id}/seed",
     "name": "seed_tenant"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/universe/auto-import/run",
+    "name": "run_auto_import"
   },
   {
     "method": "POST",
@@ -2141,6 +2221,31 @@
   },
   {
     "method": "POST",
+    "path": "/api/v1/portfolio/profiles/{profile}/approve-proposal/{run_id}",
+    "name": "approve_proposal"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/portfolio/profiles/{profile}/propose-allocation",
+    "name": "propose_allocation"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/portfolio/profiles/{profile}/set-override",
+    "name": "set_override"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/portfolios/{id}/build",
+    "name": "build_portfolio"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/portfolios/{id}/preview-cvar",
+    "name": "preview_cvar"
+  },
+  {
+    "method": "POST",
     "path": "/api/v1/portfolios/{profile}/rebalance",
     "name": "trigger_rebalance"
   },
@@ -2168,6 +2273,11 @@
     "method": "POST",
     "path": "/api/v1/reporting/model-portfolios/{portfolio_id}/monthly-report",
     "name": "generate_monthly_report"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/research/correlation/matrix",
+    "name": "post_correlation_matrix"
   },
   {
     "method": "POST",
@@ -2398,6 +2508,11 @@
     "method": "POST",
     "path": "/api/v1/workers/run-sec-refresh",
     "name": "trigger_run_sec_refresh"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/workers/run-tiingo-enrichment",
+    "name": "trigger_run_tiingo_enrichment"
   },
   {
     "method": "POST",

--- a/backend/manifests/workers.json
+++ b/backend/manifests/workers.json
@@ -146,6 +146,11 @@
   },
   {
     "method": "POST",
+    "path": "/api/v1/workers/run-tiingo-enrichment",
+    "name": "trigger_run_tiingo_enrichment"
+  },
+  {
+    "method": "POST",
     "path": "/api/v1/workers/run-treasury-ingestion",
     "name": "trigger_run_treasury_ingestion"
   },

--- a/backend/tests/db/test_migration_0096.py
+++ b/backend/tests/db/test_migration_0096.py
@@ -29,16 +29,19 @@ async def test_sec_managers_aum_crd_index_exists():
 
 
 @pytest.mark.asyncio
-async def test_mv_unified_funds_mgr_aum_index_exists():
+async def test_mv_unified_funds_aum_index_exists():
+    # Originally idx_mv_unified_funds_mgr_aum (composite on manager_id, aum_usd)
+    # created by migration 0096. Subsequent matview rebuilds (latest: 0135)
+    # DROP CASCADE the view and recreate with idx_mv_unified_funds_aum (aum_usd only).
     conn = await asyncpg.connect(_asyncpg_dsn())
     try:
         row = await conn.fetchval(
             """
             SELECT indexname FROM pg_indexes
             WHERE tablename = 'mv_unified_funds'
-              AND indexname = 'idx_mv_unified_funds_mgr_aum'
+              AND indexname = 'idx_mv_unified_funds_aum'
             """
         )
     finally:
         await conn.close()
-    assert row == "idx_mv_unified_funds_mgr_aum"
+    assert row == "idx_mv_unified_funds_aum"

--- a/backend/tests/test_global_table_isolation.py
+++ b/backend/tests/test_global_table_isolation.py
@@ -160,6 +160,10 @@ ALLOWLISTED_GLOBAL_TABLE_CONSUMERS: dict[str, str] = {
     "data_providers/sec/thirteenf_service.py": "write — upserts Sec13fHolding and Sec13fDiff via async_session_factory (13F-HR ingestion, no RLS)",
     "data_providers/sec/institutional_service.py": "write — reads Sec13fHolding CUSIPs and upserts SecInstitutionalAllocation via async_session_factory (13F reverse lookup, no RLS)",
     "data_providers/sec/seed/populate_seed.py": "write — seed script upserts SecCusipTickerMap via async_session_factory (Phase 6 CUSIP→ticker mapping, no RLS)",
+    # ── Construction worker — reads global allocation template ────────────
+    "app/domains/wealth/workers/construction_run_executor.py": "read — reads AllocationBlock (global canonical template) to validate completeness before portfolio construction runs",
+    # ── Quant factor model — reads global instrument/macro data ───────────
+    "quant_engine/factor_model_service.py": "service — reads instrument/macro global tables for factor model estimation (shared across tenants)",
     # ── Tests ────────────────────────────────────────────────────────────────
     "tests/test_global_table_isolation.py": "test — this file",
     "tests/test_rls_audit.py": "test — imports GLOBAL_TABLES set (strings, not ORM models)",


### PR DESCRIPTION
## Summary

Quick-wins batch from the B1 pytest triage (see #278, report at docs/investigations/2026-04-24-pytest-b1-triage.md). Three independent mechanical fixes resolving 6 failing tests.

### Cluster G — routes/workers manifests (4 tests)
New routes and the `/workers/run-tiingo-enrichment` worker were added without regenerating the manifests. Runs the builder; commits updated `.json` files.

### Cluster F — global_table_isolation allowlist (1 test)
Adds `construction_run_executor.py` (PR-A25) and `factor_model_service.py` (IPCA) to the global-table consumer allowlist with rationale.

### Cluster E — mv_unified_funds index assertion (1 test)
Updates `test_migration_0096` to assert the current index name (`idx_mv_unified_funds_aum`) after matview rebuilds (latest: 0135) renamed it from `idx_mv_unified_funds_mgr_aum`. Adds a comment pointing to the renaming migration.

## Test plan
- [x] `pytest tests/test_manifest_freshness.py tests/test_global_table_isolation.py tests/db/test_migration_0096.py -v` → 36 passed
- [x] `pytest tests/` → 28 failed (down from 33 baseline), 4903 passed — no regressions

## Follow-ups (separate PRs)
Remaining clusters in the B1 cleanup:
- Batch 2: Clusters K + I + D (runtime self-gating + momentum decision)
- Batch 3: Clusters A + B (strategic_allocation seed + status enum update)
- Batch 4: Cluster H (screener matview refresh)
- Batch 5: Cluster J (case convention)
- Batch 6: Cluster C (worker refactor Tiingo → XBRL — R1, dedicated PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)