### PR TITLE
fix(test): B1 Batch 2 — self-gating + momentum test bug (4 tests)

### DIFF
--- a/backend/tests/domains/wealth/services/test_characteristics_derivation.py
+++ b/backend/tests/domains/wealth/services/test_characteristics_derivation.py
@@ -81,8 +81,15 @@ class TestDeriveMomentum12_1:
         assert derive_momentum_12_1(pd.Series(dtype=float), date(2024, 12, 31)) is None
 
     def test_zero_start_returns_none(self):
+        """When the 12-1 momentum window's start value is 0, the function
+        must return None (division by zero / undefined momentum).
+
+        The window is iloc[-13:-1] of the series, so we place the zero at
+        position 1 (index -13 from the tail) — the first element (index 0)
+        is dropped by the slice.
+        """
         dates = pd.date_range("2023-01-31", periods=14, freq="ME")
-        values = [0] + [100] * 13
+        values = [100, 0] + [100] * 12  # zero at position 1 = window start
         series = pd.Series(values, index=dates)
         as_of = dates[-1].date()
         assert derive_momentum_12_1(series, as_of) is None

--- a/backend/tests/wealth/queries/test_fund_resolver.py
+++ b/backend/tests/wealth/queries/test_fund_resolver.py
@@ -83,6 +83,19 @@ async def test_resolve_fund_class_id_walks_to_cik() -> None:
     CIK 318478. Stable MV row / stable sec_fund_classes row.
     """
     async with _fresh_session() as db:
+        # Runtime self-gate — these tests hardcode production-seeded SEC identifiers
+        # (class_id=C000000012, CIK=318478) that only exist after SEC ingestion workers
+        # have populated sec_fund_classes. On fresh DB / CI this data is absent.
+        exists = await db.scalar(
+            text("SELECT 1 FROM sec_fund_classes WHERE class_id = :c"),
+            {"c": "C000000012"},
+        )
+        if not exists:
+            pytest.skip(
+                "requires SEC catalog seed (class_id=C000000012 not found). "
+                "Run scripts/dev_seed_local.py or SEC ingestion workers to enable."
+            )
+
         fund = await resolve_fund(db, "C000000012")
         assert fund["universe"] == "registered_us"
         assert fund["cik"] == "318478"
@@ -222,6 +235,17 @@ async def test_resolve_fund_sibling_class_ticker_fallback() -> None:
     instrument_id via D.2 (sec_cik) or D.4 (sibling walk).
     """
     async with _fresh_session() as db:
+        # Runtime self-gate — same seed dependency as test_resolve_fund_class_id_walks_to_cik.
+        exists = await db.scalar(
+            text("SELECT 1 FROM sec_fund_classes WHERE class_id = :c"),
+            {"c": "C000000012"},
+        )
+        if not exists:
+            pytest.skip(
+                "requires SEC catalog seed (class_id=C000000012 not found). "
+                "Run scripts/dev_seed_local.py or SEC ingestion workers to enable."
+            )
+
         fund = await resolve_fund(db, "C000000012")
         assert fund["instrument_id"] is not None
         assert fund["effective_series_id"] == "S000000008"

--- a/backend/tests/wealth/test_load_universe_funds_prefilter.py
+++ b/backend/tests/wealth/test_load_universe_funds_prefilter.py
@@ -223,6 +223,21 @@ async def test_prefilter_reduces_to_target_cardinality() -> None:
     org_id = "403d8392-ebfa-5890-b740-45da49c556eb"
     async with async_session_factory() as db:
         await _set_rls(db, org_id)
+
+        # Runtime self-gate — the expected 200-400 band only holds when the
+        # org has its full production-cloned catalog (≥1000 instruments).
+        # On fresh CI / clean docker compose this is 0; skip rather than fail.
+        # Seed via scripts/dev_seed_local.py to enable.
+        inst_count = await db.scalar(
+            text("SELECT COUNT(*) FROM instruments_org WHERE organization_id = :o"),
+            {"o": org_id},
+        )
+        if inst_count < 1000:
+            pytest.skip(
+                f"requires dev-seeded DB (have {inst_count} instruments, "
+                f"need ≥1000). Run scripts/dev_seed_local.py to enable."
+            )
+
         funds = await _load_universe_funds(
             db, org_id, profile="conservative",
         )


### PR DESCRIPTION
## Summary

Second batch from the B1 pytest triage (#278). Three test-only fixes across 4 failing tests. Zero production code changes.

### Cluster K — prefilter cardinality self-gate (1 test)
`test_prefilter_reduces_to_target_cardinality` depends on the canonical dev org having ≥1000 instruments seeded via `scripts/dev_seed_local.py`. Adds a `pytest.skip()` guard that checks the count and skips with an actionable hint when absent.

### Cluster I — fund_resolver SEC-seeded tests (2 tests)
`test_resolve_fund_class_*` hardcode SEC identifiers (class_id=C000000012, CIK=318478) that only exist after SEC ingestion. Same self-gate pattern as Cluster K.

### Cluster D — momentum zero-start test slice bug (1 test)
`test_zero_start_returns_none` had a slice bug: the test put a zero at position 0 of a 14-element series, but `derive_momentum_12_1` uses `iloc[-13:-1]` which drops position 0. The function's `start_val <= 0 -> None` guard was never exercised, and the function correctly returned 0.0. Moves the zero to position 1 so it lands at window start. Function itself is unchanged (already correct).

## Test plan
- [x] `pytest <4 target tests> -v` → 3 skipped, 1 passed on fresh DB
- [x] `pytest tests/` → 27 baseline → 23 failed after this batch (4 move out of 'failed': 3 to 'skipped', 1 to 'passed')
- [x] No production code touched

## Follow-ups
Remaining B1 batches:
- Batch 3: Clusters A + B (14 tests, quant focus)
- Batch 4: Cluster H (7 tests, screener matview)
- Batch 5: Cluster J (1 test, case convention)
- Batch 6: Cluster C (R1 worker refactor to XBRL — dedicated PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)