### PR TITLE
fix(test): B1 Batch 3 — strategic_allocation seed + status enum (14 tests)

### DIFF
--- a/backend/tests/test_construct_end_to_end.py
+++ b/backend/tests/test_construct_end_to_end.py
@@ -39,6 +39,14 @@ from app.core.config import settings
 
 ORG_ID = "00000000-0000-0000-0000-000000000001"
 
+_CANONICAL_BLOCKS = (
+    "na_equity_large", "na_equity_growth", "na_equity_value", "na_equity_small",
+    "dm_europe_equity", "dm_asia_equity", "em_equity",
+    "fi_us_aggregate", "fi_us_treasury", "fi_us_short_term",
+    "fi_us_high_yield", "fi_us_tips", "fi_ig_corporate", "fi_em_debt",
+    "alt_real_estate", "alt_gold", "alt_commodities", "cash",
+)
+
 DEV_ACTOR_HEADER = {
     "X-DEV-ACTOR": json.dumps(
         {
@@ -143,9 +151,16 @@ _CONCENTRATED_OPTIMIZER_OUTPUT = {
 
 @pytest.fixture
 async def seeded_portfolio():
-    """Insert a ``model_portfolios`` row for the test org and yield its ID.
+    """Insert a ``model_portfolios`` row + 18 strategic_allocation rows
+    (one per canonical block, NULL weights) for the test org.
 
-    Cleans up the portfolio + its construction runs at teardown.
+    PR-A25's template-completeness gate (migration 0153) requires
+    strategic_allocation rows for every (org, profile, canonical_block)
+    tuple — without them the construction executor short-circuits to
+    'failed' with reason 'template_incomplete' before the optimizer runs.
+
+    Cleans up the portfolio + strategic_allocation + construction runs
+    at teardown.
     """
     portfolio_id = uuid.uuid4()
     conn = await asyncpg.connect(_asyncpg_dsn())
@@ -160,6 +175,39 @@ async def seeded_portfolio():
             """,
             portfolio_id, ORG_ID,
         )
+
+        # Clean up any stale strategic_allocation rows for this org+profile
+        # (e.g. from a prior interrupted test run).
+        await conn.execute(
+            "DELETE FROM strategic_allocation "
+            "WHERE organization_id = $1::uuid AND profile = 'moderate'",
+            ORG_ID,
+        )
+
+        # Insert ONE strategic_allocation row. The AFTER INSERT trigger
+        # (trg_enforce_allocation_template_sa) auto-creates the remaining
+        # 17 canonical blocks. Then UPDATE all 18 to set approved_at
+        # (PR-A26.2 realize-mode gate requires it).
+        await conn.execute(
+            """
+            INSERT INTO strategic_allocation (
+                allocation_id, organization_id, profile, block_id,
+                target_weight, effective_from,
+                excluded_from_portfolio, actor_source, created_at
+            ) VALUES (
+                gen_random_uuid(), $1::uuid, 'moderate', $2,
+                NULL, CURRENT_DATE,
+                false, 'test_fixture_seed', now()
+            )
+            """,
+            ORG_ID, _CANONICAL_BLOCKS[0],
+        )
+        await conn.execute(
+            "UPDATE strategic_allocation SET approved_at = now() "
+            "WHERE organization_id = $1::uuid AND profile = 'moderate'",
+            ORG_ID,
+        )
+
         yield portfolio_id
     finally:
         try:
@@ -174,6 +222,12 @@ async def seeded_portfolio():
             await conn.execute(
                 "DELETE FROM model_portfolios WHERE id = $1",
                 portfolio_id,
+            )
+            # Clean up ALL strategic_allocation rows (ours + trigger-created)
+            await conn.execute(
+                "DELETE FROM strategic_allocation "
+                "WHERE organization_id = $1::uuid AND profile = 'moderate'",
+                ORG_ID,
             )
         finally:
             await conn.close()

--- a/backend/tests/test_model_portfolio.py
+++ b/backend/tests/test_model_portfolio.py
@@ -299,11 +299,13 @@ class TestFundLevelOptimizer:
             constraints=constraints,
         )
 
-        # Should have re-optimized (Phase 2 or 3)
-        assert result.status in (
-            "optimal:cvar_constrained",
-            "optimal:min_variance_fallback",
-            "optimal:cvar_violated",  # worst case if all phases exhausted
+        # Post-A12 vocab: Phase 2 → "optimal", Phase 3 → "degraded".
+        # Check winning_phase for phase detail.
+        assert result.status in ("optimal", "degraded"), (
+            f"expected re-optimization, got status={result.status!r}"
+        )
+        assert result.winning_phase in ("phase_2_variance_capped", "phase_3_min_cvar"), (
+            f"expected Phase 2 or 3 to win, got {result.winning_phase!r}"
         )
         assert result.cvar_95 is not None
         # The re-optimized solution should have lower volatility than unconstrained

--- a/backend/tests/test_robust_optimizer.py
+++ b/backend/tests/test_robust_optimizer.py
@@ -50,7 +50,10 @@ async def test_robust_optimization_produces_result(simple_portfolio_inputs):
     )
 
     assert isinstance(result, FundOptimizationResult)
-    assert result.status.startswith("optimal")
+    assert result.status in ("optimal", "degraded"), (
+        f"expected cascade to resolve, got status={result.status!r} "
+        f"(winning_phase={result.winning_phase!r})"
+    )
     assert sum(result.weights.values()) == pytest.approx(1.0, abs=1e-4)
 
 
@@ -78,8 +81,14 @@ async def test_robust_vs_standard_differs(simple_portfolio_inputs):
         uncertainty_level=2.0,  # high uncertainty for visible difference
     )
 
-    assert standard.status.startswith("optimal")
-    assert robust.status.startswith("optimal")
+    assert standard.status in ("optimal", "degraded"), (
+        f"expected cascade to resolve, got status={standard.status!r} "
+        f"(winning_phase={standard.winning_phase!r})"
+    )
+    assert robust.status in ("optimal", "degraded"), (
+        f"expected cascade to resolve, got status={robust.status!r} "
+        f"(winning_phase={robust.winning_phase!r})"
+    )
     # With high uncertainty, robust should favor lower-risk allocation
     # (at minimum, weights should differ)
 
@@ -107,7 +116,13 @@ async def test_regime_cvar_multiplier_tightens_limit(simple_portfolio_inputs):
         regime_cvar_multiplier=0.5,  # very tight
     )
 
-    assert normal.status.startswith("optimal")
-    assert crisis.status.startswith("optimal")
+    assert normal.status in ("optimal", "degraded"), (
+        f"expected cascade to resolve, got status={normal.status!r} "
+        f"(winning_phase={normal.winning_phase!r})"
+    )
+    assert crisis.status in ("optimal", "degraded"), (
+        f"expected cascade to resolve, got status={crisis.status!r} "
+        f"(winning_phase={crisis.winning_phase!r})"
+    )
     # Crisis allocation should have lower or equal volatility
     # (tighter CVaR limit forces more conservative allocation)

--- a/backend/tests/test_turnover_penalty.py
+++ b/backend/tests/test_turnover_penalty.py
@@ -57,7 +57,9 @@ class TestTurnoverPenalty:
             current_weights=None,
             turnover_cost=0.001,
         )
-        assert result.status.startswith("optimal")
+        assert result.status in ("optimal", "degraded"), (
+            f"expected cascade to resolve, got status={result.status!r}"
+        )
         assert sum(result.weights.values()) == pytest.approx(1.0, abs=0.01)
 
     @pytest.mark.asyncio
@@ -88,8 +90,12 @@ class TestTurnoverPenalty:
             turnover_cost=0.01,  # significant penalty
         )
 
-        assert result_no_penalty.status.startswith("optimal")
-        assert result_with_penalty.status.startswith("optimal")
+        assert result_no_penalty.status in ("optimal", "degraded"), (
+            f"expected cascade to resolve, got status={result_no_penalty.status!r}"
+        )
+        assert result_with_penalty.status in ("optimal", "degraded"), (
+            f"expected cascade to resolve, got status={result_with_penalty.status!r}"
+        )
 
         # Compute turnover for both
         w_no = np.array([result_no_penalty.weights[f] for f in fund_ids])
@@ -116,7 +122,9 @@ class TestTurnoverPenalty:
             current_weights=current,
             turnover_cost=0.0,
         )
-        assert result.status.startswith("optimal")
+        assert result.status in ("optimal", "degraded"), (
+            f"expected cascade to resolve, got status={result.status!r}"
+        )
 
 
 class TestDeadBand:

--- a/backend/tests/wealth/test_load_universe_funds_prefilter.py
+++ b/backend/tests/wealth/test_load_universe_funds_prefilter.py
@@ -42,6 +42,14 @@ from app.domains.wealth.routes.model_portfolios import (
 
 pytestmark = pytest.mark.asyncio
 
+_CANONICAL_BLOCKS = (
+    "na_equity_large", "na_equity_growth", "na_equity_value", "na_equity_small",
+    "dm_europe_equity", "dm_asia_equity", "em_equity",
+    "fi_us_aggregate", "fi_us_treasury", "fi_us_short_term",
+    "fi_us_high_yield", "fi_us_tips", "fi_ig_corporate", "fi_em_debt",
+    "alt_real_estate", "alt_gold", "alt_commodities", "cash",
+)
+
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -492,6 +500,26 @@ async def test_executor_marks_heuristic_fallback_runs_as_degraded() -> None:
             )
             await db.flush()
 
+            # Seed ONE strategic_allocation row; the AFTER INSERT trigger
+            # (trg_enforce_allocation_template_sa) auto-creates the other
+            # 17 canonical blocks. Then UPDATE all to:
+            # - target_weight=NULL so the coverage gate (PR-A22) skips them
+            #   (query filters target_weight > 0)
+            # - approved_at=now() so the realize-mode gate (PR-A26.2) passes
+            await _seed_strategic_allocation(
+                db, org_id=org_id, profile="moderate",
+                block_id=_CANONICAL_BLOCKS[0],
+            )
+            await db.execute(
+                text(
+                    "UPDATE strategic_allocation "
+                    "SET approved_at = now(), target_weight = NULL "
+                    "WHERE organization_id = :org AND profile = 'moderate'"
+                ),
+                {"org": org_id},
+            )
+            await db.flush()
+
             with mock_patch(
                 "app.domains.wealth.routes.model_portfolios._run_construction_async",
                 new=_fake,
@@ -574,6 +602,26 @@ async def test_executor_marks_real_solver_runs_as_succeeded() -> None:
                     state_changed_by="test",
                     created_by="test",
                 ),
+            )
+            await db.flush()
+
+            # Seed ONE strategic_allocation row; the AFTER INSERT trigger
+            # (trg_enforce_allocation_template_sa) auto-creates the other
+            # 17 canonical blocks. Then UPDATE all to:
+            # - target_weight=NULL so the coverage gate (PR-A22) skips them
+            #   (query filters target_weight > 0)
+            # - approved_at=now() so the realize-mode gate (PR-A26.2) passes
+            await _seed_strategic_allocation(
+                db, org_id=org_id, profile="moderate",
+                block_id=_CANONICAL_BLOCKS[0],
+            )
+            await db.execute(
+                text(
+                    "UPDATE strategic_allocation "
+                    "SET approved_at = now(), target_weight = NULL "
+                    "WHERE organization_id = :org AND profile = 'moderate'"
+                ),
+                {"org": org_id},
             )
             await db.flush()
 


### PR DESCRIPTION
## Summary

Third batch from B1 pytest triage (#278). Two independent fixes across 14 failing tests. Zero production code changes.

### Cluster A — strategic_allocation seed in e2e fixtures (7 tests)
PR-A25's template gate (migration 0153) requires 18 canonical strategic_allocation rows per (org, profile) before optimization. PR-A26.2's realize-mode gate requires `approved_at IS NOT NULL`. The e2e fixture seeded only model_portfolios and hit both gates, failing with `status='failed'`.

Fix: insert one canonical block (trigger auto-creates 17 more), set `approved_at` on all 18, and use `target_weight=NULL` to bypass the coverage gate (PR-A22). Applies same pattern to 2 executor tests in test_load_universe_funds_prefilter.py.

### Cluster B — optimizer status enum drift (7 tests)
PR-A12 simplified `result.status` from compound strings (`optimal:cvar_constrained` etc.) to `optimal` / `degraded`. Seven tests still assert the old enum. Updates assertions to `in ("optimal", "degraded")`; where phase identity matters, asserts on `result.winning_phase`.

## Test plan
- [x] 14 target tests PASSED (65 passed, 1 skipped in target files)
- [x] Full suite: 23 failed → 9 failed (exact target)
- [x] No new regressions introduced

## Follow-ups
Remaining B1 batches:
- Batch 4: Cluster H (7 tests, screener matview)
- Batch 5: Cluster J (1 test, case convention)
- Batch 6: Cluster C (R1 worker refactor to XBRL — dedicated PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)