### PR TITLE
fix(test): B1 Batch 4 — refresh mv_fund_risk_latest for screener tests (7 tests)

### DIFF
--- a/backend/tests/wealth/routes/conftest.py
+++ b/backend/tests/wealth/routes/conftest.py
@@ -1,0 +1,34 @@
+"""Conftest for wealth route integration tests."""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from app.core.config.settings import settings
+
+
+def _asyncpg_dsn() -> str:
+    """Convert SQLAlchemy async DSN to plain asyncpg DSN."""
+    return settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def _refresh_screener_matviews():
+    """Ensure mv_fund_risk_latest is populated before screener tests.
+
+    Migration 0116 creates the matview and refreshes it once, but on a
+    fresh DB fund_risk_metrics is empty so the view stays 'unpopulated'.
+    Selecting from an unpopulated matview raises
+    ObjectNotInPrerequisiteStateError.  A single REFRESH (even to an
+    empty result set) puts the view into a valid state.
+
+    Uses a raw asyncpg connection (not the SQLAlchemy engine) to avoid
+    event-loop conflicts with the shared connection pool.
+    """
+    dsn = _asyncpg_dsn()
+    conn = await asyncpg.connect(dsn)
+    try:
+        await conn.execute("REFRESH MATERIALIZED VIEW mv_fund_risk_latest")
+    finally:
+        await conn.close()


### PR DESCRIPTION
## Summary

Fourth batch from B1 pytest triage (#278). Fixes Cluster H — 7 screener integration tests that fail on CI with `ObjectNotInPrerequisiteStateError` because `mv_fund_risk_latest` is unpopulated on fresh DBs.

### Root cause
Migration 0116 creates and refreshes the matview, but `fund_risk_metrics` is empty at migration time on fresh DBs, so the matview stays in an "unpopulated" state. Subsequent SELECTs raise `ObjectNotInPrerequisiteStateError`.

### Fix
Module-scoped autouse fixture in `tests/wealth/routes/conftest.py` that runs `REFRESH MATERIALIZED VIEW mv_fund_risk_latest` via raw asyncpg connection before wealth route tests. Uses asyncpg directly (not SQLAlchemy engine pool) to avoid event-loop conflicts with the shared connection pool.

Zero production code changes. Single file added.

## Test plan
- [x] 8/10 screener tests PASSED in isolation (2 remaining fail for unrelated reasons: `nav_close` column drift + empty pagination data)
- [x] Full suite: 4 failed + 3 errors (same as baseline — no regression)
- [x] No production code touched
- [x] Conftest does not interfere with other test modules

## Remaining failures (out of scope)
- `test_sparkline_nonexistent_ids_omitted` — `nav_close` column doesn't exist in `nav_monthly_returns_agg` (schema drift)
- `test_keyset_pagination_no_overlap` — empty DB has no data to paginate (seed data gap)

## Follow-ups
Remaining B1 batches per triage (#278):
- Batch 5: Cluster J (elite_ranking case convention)
- Batch 6: Cluster C (equity_characteristics worker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)