### PR TITLE
fix(wealth): align nav_monthly_returns_agg consumers to canonical schema (sparkline + analysis_returns)

### DIFF
--- a/backend/app/domains/wealth/queries/analysis_returns.py
+++ b/backend/app/domains/wealth/queries/analysis_returns.py
@@ -45,20 +45,19 @@ async def _nav_series(
 async def _monthly_returns(
     db: AsyncSession, instrument_id: str, window: Window,
 ) -> list[dict[str, Any]]:
-    # nav_monthly_returns_agg real columns (verified against live schema):
-    # instrument_id, month, nav_open, nav_close, trading_days,
-    # avg_daily_return, daily_volatility. Compound return is computed
-    # inline as (nav_close / nav_open) - 1 with a NULLIF guard to avoid
-    # divide-by-zero on stale-NAV instruments. The earlier implementation
-    # referenced columns (``compound_return``, ``compound_log_return``,
-    # ``min_nav``, ``max_nav``) that do not exist — it blew up in
-    # production but was shielded from tests by the pre-existing
-    # ``asyncio.gather`` short-circuit in ``fetch_returns_risk``.
+    # nav_monthly_returns_agg columns (per migrations 0049/0069 — the
+    # canonical schema present in dev, CI, and any DB walked through
+    # alembic upgrade head): instrument_id, month, compound_log_return,
+    # compound_return, trading_days, min_nav, max_nav.
+    # An older comment here claimed the live schema differed (nav_open,
+    # nav_close, avg_daily_return, daily_volatility) — that was historical
+    # drift from a manual matview alteration; the canonical migration
+    # schema is now the authoritative source. Use compound_return directly.
     sql = f"""
         SELECT
             month,
             trading_days,
-            (nav_close / NULLIF(nav_open, 0)) - 1 AS compound_return
+            compound_return
         FROM nav_monthly_returns_agg
         WHERE instrument_id = :id
           AND month >= NOW() - INTERVAL '{WINDOW_INTERVAL[window]}'

--- a/backend/app/domains/wealth/routes/screener.py
+++ b/backend/app/domains/wealth/routes/screener.py
@@ -507,11 +507,16 @@ async def get_screener_sparklines(
 ) -> dict[str, list[SparklinePoint]]:
     """Return monthly NAV data for a batch of instruments.
 
-    Reads from ``nav_monthly_returns_agg`` CAGG. Returns at most
-    ``months`` data points per instrument, ordered chronologically.
-    Instruments with no data are omitted from the response dict.
-    Capped at 100 instrument IDs per request (frontend sends visible
-    rows only, ~40 from virtualization).
+    Reads ``compound_return`` from the ``nav_monthly_returns_agg`` CAGG
+    and reconstructs a normalised NAV curve (starting at 100 per instrument,
+    compounding monthly). Absolute NAV values are not historical — the
+    curve's shape is what the frontend plots. See migration 0069 for why
+    nav_close/nav_open were removed from the matview.
+
+    Returns at most ``months`` data points per instrument, ordered
+    chronologically. Instruments with no data are omitted. Capped at 100
+    instrument IDs per request (frontend sends visible rows only, ~40 from
+    virtualization).
     """
     if len(body.instrument_ids) > 100:
         raise HTTPException(
@@ -524,14 +529,18 @@ async def get_screener_sparklines(
     ids = [str(iid) for iid in body.instrument_ids]
     months = min(max(body.months, 1), 120)  # clamp to 1-120
 
+    # Migration 0069 redefined nav_monthly_returns_agg and removed the
+    # nav_close / nav_open columns — only compound_return remains. Reconstruct
+    # a normalised NAV curve server-side (start at 100, compound each month)
+    # so the frontend contract stays stable. Sparklines are decorative — the
+    # curve shape is what matters, not the absolute NAV value.
     result = await db.execute(
         text(
             """
             SELECT
                 instrument_id::text AS instrument_id,
                 month,
-                nav_close,
-                (nav_close / NULLIF(nav_open, 0)) - 1 AS return_1m
+                compound_return
             FROM nav_monthly_returns_agg
             WHERE instrument_id = ANY(:ids)
               AND month >= NOW() - make_interval(months => :months)
@@ -543,12 +552,18 @@ async def get_screener_sparklines(
     rows = result.mappings().all()
 
     out: dict[str, list[SparklinePoint]] = {}
+    cumulative: dict[str, float] = {}  # per-instrument running NAV
     for r in rows:
         iid = str(r["instrument_id"])
+        ret = float(r["compound_return"]) if r["compound_return"] is not None else 0.0
+        # Start each instrument's curve at 100; compound each month.
+        prev = cumulative.get(iid, 100.0)
+        nav_close = prev if iid not in cumulative else prev * (1.0 + ret)
+        cumulative[iid] = nav_close
         point = SparklinePoint(
             month=r["month"].isoformat() if hasattr(r["month"], "isoformat") else str(r["month"]),
-            nav_close=float(r["nav_close"]) if r["nav_close"] is not None else 0.0,
-            return_1m=float(r["return_1m"]) if r["return_1m"] is not None else None,
+            nav_close=nav_close,
+            return_1m=ret if r["compound_return"] is not None else None,
         )
         out.setdefault(iid, []).append(point)
 


### PR DESCRIPTION
## Summary

Two production code paths queried \`nav_monthly_returns_agg\` columns (\`nav_close\`, \`nav_open\`) that don't exist in the canonical schema defined by migrations 0049/0069. Both paths failed with \`UndefinedColumnError\` on any DB walked through \`alembic upgrade head\` (dev, CI, fresh deployments).

A historical comment claimed the live schema differed (\`nav_open, nav_close, avg_daily_return, daily_volatility\`) — that came from a manual matview alteration that has since been reset. The canonical migration schema (\`compound_log_return, compound_return, trading_days, min_nav, max_nav\`) is now the authoritative source for dev and CI.

## Changes

### 1. Sparkline route — reconstruct normalised NAV curve (commit 90fbef8a)
\`/api/v1/screener/sparklines\` queried \`nav_close\` / \`nav_open\` from the matview. Switches to \`compound_return\` and reconstructs a normalised NAV curve server-side (start at 100, compound monthly). Frontend contract (\`SparklinePoint.nav_close\` + \`return_1m\`) preserved — sparklines are decorative; curve shape is what's plotted.

### 2. \`_monthly_returns\` query — use compound_return directly (commit cd2252f2)
\`backend/app/domains/wealth/queries/analysis_returns.py::_monthly_returns\` had the same bug AND a misleading comment claiming the live schema differed. Replaces the broken \`(nav_close / NULLIF(nav_open, 0)) - 1\` derivation with a direct \`SELECT compound_return\`. Updates the comment block to document the canonical schema and the historical drift.

## Test plan

- [x] \`pytest tests/wealth/routes/test_screener_integration.py -k sparkline -v\` → 3 passed (2 of 3 were already passing; \`test_sparkline_nonexistent_ids_omitted\` was failing pre-fix)
- [x] \`pytest tests/wealth/routes/test_discovery_analysis.py -v\` → 4 skipped (all integration-gated on SEC seed; the \`_monthly_returns\` code path has no live test coverage on fresh DB, so this commit is shape-only there)
- [x] No frontend changes needed — \`SparklinePoint\` shape unchanged

## Discovered during

B1 pytest triage (#278). Originally scoped to just the sparkline endpoint, but the agent stop-condition flagged the \`_monthly_returns\` site as same root cause — bundled here since both fixes are mechanically identical.

## Follow-ups

After this PR + #283 (Batch 4 matview refresh), only \`tests/integration/test_equity_characteristics_worker.*\` (3 errors + 1 fail, Cluster C) remains in the test-backend baseline — that's a worker refactor (Tiingo → XBRL), tracked for a dedicated PR.