### PR TITLE
chore(db): renumber 0172_factor_model_fits orphan migration to 0173

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ frontends/
   wealth/           ← SvelteKit "netz-wealth-os"
 ```
 
-**Database:** PostgreSQL 16 + TimescaleDB + pgvector. Managed via Timescale Cloud (prod) or docker-compose (dev). Redis 7 via Upstash (prod) or docker-compose (dev). Migrations via Alembic. App uses async asyncpg. Current migration head: `0131_return_5y_10y`.
+**Database:** PostgreSQL 16 + TimescaleDB + pgvector. Managed via Timescale Cloud (prod) or docker-compose (dev). Redis 7 via Upstash (prod) or docker-compose (dev). Migrations via Alembic. App uses async asyncpg. Current migration head: `0173_factor_model_fits`.
 
 **Auth:** Clerk JWT v2. `organization_id` from `o.id` claim. RLS via `SET LOCAL app.current_organization_id`. Dev bypass: `X-DEV-ACTOR` header. **Tenant and user management is 100% via Clerk Dashboard** — no custom admin UI. Organizations, user invites, and role assignment (`ADMIN`, `INVESTMENT_TEAM`, `investor`) are all managed in Clerk. `ConfigService` defaults mean new tenants work immediately without provisioning.
 

--- a/backend/app/core/db/migrations/env.py
+++ b/backend/app/core/db/migrations/env.py
@@ -24,9 +24,9 @@ load_dotenv(_root / ".env.dev", override=False)
 load_dotenv(_backend / ".env", override=False)
 load_dotenv(_root / ".env", override=False)
 
+from alembic import context
 from sqlalchemy import create_engine, pool, text
 
-from alembic import context
 from app.core.db.base import Base
 
 config = context.config

--- a/backend/app/core/db/migrations/versions/0002_wealth_domain.py
+++ b/backend/app/core/db/migrations/versions/0002_wealth_domain.py
@@ -3,9 +3,8 @@ allocation, blocks, rebalance, macro, lipper, backtest.
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = "0002"
 down_revision = "0001"

--- a/backend/app/core/db/migrations/versions/0003_credit_domain.py
+++ b/backend/app/core/db/migrations/versions/0003_credit_domain.py
@@ -5,9 +5,8 @@ Creates ~60 credit domain tables + RLS policies on ALL tenant-scoped tables
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = "0003"
 down_revision = "0002"

--- a/backend/app/core/db/migrations/versions/0004_vertical_configs.py
+++ b/backend/app/core/db/migrations/versions/0004_vertical_configs.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import sqlalchemy as sa
 import yaml
-
 from alembic import op
 
 revision = "0004"

--- a/backend/app/core/db/migrations/versions/0005_macro_regional_snapshots.py
+++ b/backend/app/core/db/migrations/versions/0005_macro_regional_snapshots.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import sqlalchemy as sa
 import yaml
-
 from alembic import op
 
 revision = "0005"

--- a/backend/app/core/db/migrations/versions/0006_macro_reviews.py
+++ b/backend/app/core/db/migrations/versions/0006_macro_reviews.py
@@ -8,7 +8,6 @@ depends_on: 0005 (macro_regional_snapshots must exist for FK).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0006"

--- a/backend/app/core/db/migrations/versions/0007_governance_policy_seed.py
+++ b/backend/app/core/db/migrations/versions/0007_governance_policy_seed.py
@@ -12,7 +12,6 @@ depends_on: 0006 (macro_reviews).
 import json
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0007"

--- a/backend/app/core/db/migrations/versions/0008_wealth_analytical_models.py
+++ b/backend/app/core/db/migrations/versions/0008_wealth_analytical_models.py
@@ -9,9 +9,8 @@ depends_on: 0007 (governance_policy_seed).
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = "0008"
 down_revision = "0007"

--- a/backend/app/core/db/migrations/versions/0009_admin_infrastructure.py
+++ b/backend/app/core/db/migrations/versions/0009_admin_infrastructure.py
@@ -7,7 +7,6 @@ depends_on: 0008 (wealth_analytical_models).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0009"

--- a/backend/app/core/db/migrations/versions/0010_tenant_asset_slug_rls_fix.py
+++ b/backend/app/core/db/migrations/versions/0010_tenant_asset_slug_rls_fix.py
@@ -5,7 +5,6 @@ depends_on: 0009 (admin_infrastructure).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0010"

--- a/backend/app/core/db/migrations/versions/0011_instruments_data_migration.py
+++ b/backend/app/core/db/migrations/versions/0011_instruments_data_migration.py
@@ -10,7 +10,6 @@ depends_on: 0012 (instruments_universe_additive).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0011"

--- a/backend/app/core/db/migrations/versions/0012_instruments_universe_additive.py
+++ b/backend/app/core/db/migrations/versions/0012_instruments_universe_additive.py
@@ -10,7 +10,6 @@ depends_on: 0010 (tenant_asset_slug_rls_fix).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0012"

--- a/backend/app/core/db/migrations/versions/0013_benchmark_nav.py
+++ b/backend/app/core/db/migrations/versions/0013_benchmark_nav.py
@@ -12,7 +12,6 @@ depends_on: 0012 (instruments_universe_additive).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0013"

--- a/backend/app/core/db/migrations/versions/0014_strategy_drift_alerts.py
+++ b/backend/app/core/db/migrations/versions/0014_strategy_drift_alerts.py
@@ -11,7 +11,6 @@ depends_on: 0013 (benchmark_nav).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0014"

--- a/backend/app/core/db/migrations/versions/0015_admin_rls_bypass.py
+++ b/backend/app/core/db/migrations/versions/0015_admin_rls_bypass.py
@@ -6,7 +6,6 @@ Creates pg_notify trigger on vertical_config_overrides for cache invalidation.
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0015"

--- a/backend/app/core/db/migrations/versions/0017_fund_membership.py
+++ b/backend/app/core/db/migrations/versions/0017_fund_membership.py
@@ -13,9 +13,8 @@ Revises: 0016
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import UUID
-
 from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
 
 revision = "0017"
 down_revision = "0016"

--- a/backend/app/core/db/migrations/versions/0019_audit_events.py
+++ b/backend/app/core/db/migrations/versions/0019_audit_events.py
@@ -9,9 +9,8 @@ Revises: 0018
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB
-
 from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
 
 revision = "0019"
 down_revision = "0018"

--- a/backend/app/core/db/migrations/versions/0020_wealth_documents.py
+++ b/backend/app/core/db/migrations/versions/0020_wealth_documents.py
@@ -8,7 +8,6 @@ Create Date: 2026-03-19 18:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision: str = "0020_wealth_docs"

--- a/backend/app/core/db/migrations/versions/0021_dd_report_approval_fields.py
+++ b/backend/app/core/db/migrations/versions/0021_dd_report_approval_fields.py
@@ -8,7 +8,6 @@ Create Date: 2026-03-19 22:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision: str = "0021_dd_approval"

--- a/backend/app/core/db/migrations/versions/0023_sec_data_providers_tables.py
+++ b/backend/app/core/db/migrations/versions/0023_sec_data_providers_tables.py
@@ -15,9 +15,8 @@ depends_on: 0022 (wealth_status_constraints).
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = "0023_sec_data_providers"
 down_revision = "0022_wealth_status"

--- a/backend/app/core/db/migrations/versions/0024_add_sector_to_sec_13f_holdings.py
+++ b/backend/app/core/db/migrations/versions/0024_add_sector_to_sec_13f_holdings.py
@@ -9,7 +9,6 @@ depends_on: 0023 (sec_data_providers_tables).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0024_sec_13f_sector"

--- a/backend/app/core/db/migrations/versions/0025_convert_sec_13f_holdings_to_hypertable.py
+++ b/backend/app/core/db/migrations/versions/0025_convert_sec_13f_holdings_to_hypertable.py
@@ -25,7 +25,6 @@ depends_on: 0024 (add_sector_to_sec_13f_holdings).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0025_sec_13f_hypertable"

--- a/backend/app/core/db/migrations/versions/0026_macro_market_hypertables.py
+++ b/backend/app/core/db/migrations/versions/0026_macro_market_hypertables.py
@@ -19,7 +19,6 @@ depends_on: 0025 (sec_13f_hypertable).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0026_macro_market_hypertables"

--- a/backend/app/core/db/migrations/versions/0027_nav_portfolio_hypertables.py
+++ b/backend/app/core/db/migrations/versions/0027_nav_portfolio_hypertables.py
@@ -25,7 +25,6 @@ depends_on: 0026 (macro_market_hypertables).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0027_nav_portfolio_hypertables"

--- a/backend/app/core/db/migrations/versions/0028_sec_institutional_hypertable.py
+++ b/backend/app/core/db/migrations/versions/0028_sec_institutional_hypertable.py
@@ -20,7 +20,6 @@ depends_on: 0027 (nav_portfolio_hypertables).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0028_sec_inst_hypertable"

--- a/backend/app/core/db/migrations/versions/0029_drift_alert_hypertables.py
+++ b/backend/app/core/db/migrations/versions/0029_drift_alert_hypertables.py
@@ -23,7 +23,6 @@ depends_on: 0028 (sec_institutional_hypertable).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0029_drift_alert_hypertables"

--- a/backend/app/core/db/migrations/versions/0030_audit_event_hypertables.py
+++ b/backend/app/core/db/migrations/versions/0030_audit_event_hypertables.py
@@ -20,7 +20,6 @@ depends_on: 0029 (drift_alert_hypertables).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0030_audit_event_hypertables"

--- a/backend/app/core/db/migrations/versions/0031_risk_covenant_hypertables.py
+++ b/backend/app/core/db/migrations/versions/0031_risk_covenant_hypertables.py
@@ -15,7 +15,6 @@ depends_on: 0030 (audit_event_hypertables).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0031_risk_covenant_hypertables"

--- a/backend/app/core/db/migrations/versions/0033_sec_cusip_ticker_map.py
+++ b/backend/app/core/db/migrations/versions/0033_sec_cusip_ticker_map.py
@@ -8,7 +8,6 @@ depends_on: 0032 (hypertable_skip_documentation).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0033_sec_cusip_ticker_map"

--- a/backend/app/core/db/migrations/versions/0034_appendonly_hypertables.py
+++ b/backend/app/core/db/migrations/versions/0034_appendonly_hypertables.py
@@ -28,7 +28,6 @@ depends_on: 0032 (hypertable_skip_docs).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0034_appendonly_hypertables"

--- a/backend/app/core/db/migrations/versions/0035_fund_risk_metrics_momentum.py
+++ b/backend/app/core/db/migrations/versions/0035_fund_risk_metrics_momentum.py
@@ -9,7 +9,6 @@ Revises: 0034_appendonly_hypertables
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0035_fund_risk_metrics_momentum"

--- a/backend/app/core/db/migrations/versions/0036_treasury_data_hypertable.py
+++ b/backend/app/core/db/migrations/versions/0036_treasury_data_hypertable.py
@@ -17,7 +17,6 @@ import os
 
 import psycopg
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0036_treasury_data_hypertable"

--- a/backend/app/core/db/migrations/versions/0037_ofr_hedge_fund_hypertable.py
+++ b/backend/app/core/db/migrations/versions/0037_ofr_hedge_fund_hypertable.py
@@ -18,7 +18,6 @@ import os
 
 import psycopg
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0037_ofr_hedge_fund_hypertable"

--- a/backend/app/core/db/migrations/versions/0038_manager_screener_indexes_continuous_aggs.py
+++ b/backend/app/core/db/migrations/versions/0038_manager_screener_indexes_continuous_aggs.py
@@ -18,7 +18,6 @@ depends_on: 0037 (ofr_hedge_fund_hypertable).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0038_mgr_screener_idx_aggs"

--- a/backend/app/core/db/migrations/versions/0039_esma_tables.py
+++ b/backend/app/core/db/migrations/versions/0039_esma_tables.py
@@ -12,7 +12,6 @@ depends_on: 0038 (manager_screener_indexes_continuous_aggs).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0039_esma_tables"

--- a/backend/app/core/db/migrations/versions/0040_sec_nport_holdings.py
+++ b/backend/app/core/db/migrations/versions/0040_sec_nport_holdings.py
@@ -17,7 +17,6 @@ import os
 
 import psycopg
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0040_sec_nport_holdings"

--- a/backend/app/core/db/migrations/versions/0041_sec_manager_brochure_text.py
+++ b/backend/app/core/db/migrations/versions/0041_sec_manager_brochure_text.py
@@ -8,7 +8,6 @@ depends_on: 0040 (sec_nport_holdings).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0041_sec_manager_brochure_text"

--- a/backend/app/core/db/migrations/versions/0042_bis_imf_hypertables.py
+++ b/backend/app/core/db/migrations/versions/0042_bis_imf_hypertables.py
@@ -17,7 +17,6 @@ import os
 
 import psycopg
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0042_bis_imf_hypertables"

--- a/backend/app/core/db/migrations/versions/0043_esma_isin_ticker_map_fund_lei.py
+++ b/backend/app/core/db/migrations/versions/0043_esma_isin_ticker_map_fund_lei.py
@@ -8,7 +8,6 @@ depends_on: 0042 (bis_imf_hypertables).
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0043_esma_isin_ticker_fund_lei"

--- a/backend/app/core/db/migrations/versions/0044_blended_benchmarks.py
+++ b/backend/app/core/db/migrations/versions/0044_blended_benchmarks.py
@@ -8,7 +8,6 @@ Global tables — no organization_id, no RLS.
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0044_blended_benchmarks"

--- a/backend/app/core/db/migrations/versions/0045_instruments_global.py
+++ b/backend/app/core/db/migrations/versions/0045_instruments_global.py
@@ -12,9 +12,8 @@ depends_on: 0044 (blended_benchmarks).
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = "0045_instruments_global"
 down_revision = "0044_blended_benchmarks"

--- a/backend/app/core/db/migrations/versions/0048_wealth_analytics_indexes.py
+++ b/backend/app/core/db/migrations/versions/0048_wealth_analytics_indexes.py
@@ -18,7 +18,6 @@ depends_on: 0047 (screener_redesign_indexes).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0048_wealth_analytics_indexes"

--- a/backend/app/core/db/migrations/versions/0049_wealth_continuous_aggregates.py
+++ b/backend/app/core/db/migrations/versions/0049_wealth_continuous_aggregates.py
@@ -13,7 +13,6 @@ depends_on: 0048 (wealth_analytics_indexes).
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0049_wealth_continuous_aggregates"

--- a/backend/app/core/db/migrations/versions/0051_sec_manager_fund_columns.py
+++ b/backend/app/core/db/migrations/versions/0051_sec_manager_fund_columns.py
@@ -1,7 +1,6 @@
 """Add fund count columns to sec_managers from Form ADV Section 7B."""
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0051_sec_mgr_fund_cols"

--- a/backend/app/core/db/migrations/versions/0053_widen_instrument_isin.py
+++ b/backend/app/core/db/migrations/versions/0053_widen_instrument_isin.py
@@ -9,7 +9,6 @@ revision = "0053_widen_instrument_isin"
 down_revision = "0052_sec_entity_links"
 
 import sqlalchemy as sa
-
 from alembic import op
 
 

--- a/backend/app/core/db/migrations/versions/0056_wealth_content.py
+++ b/backend/app/core/db/migrations/versions/0056_wealth_content.py
@@ -7,9 +7,8 @@ revision = "0056_wealth_content"
 down_revision = "0056_dd_report_status_add_failed"
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB, UUID
-
 from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 
 def upgrade() -> None:

--- a/backend/app/core/db/migrations/versions/0057_sec_fund_classes.py
+++ b/backend/app/core/db/migrations/versions/0057_sec_fund_classes.py
@@ -8,7 +8,6 @@ revision = "0057_sec_fund_classes"
 down_revision = "0056_wealth_content"
 
 import sqlalchemy as sa
-
 from alembic import op
 
 

--- a/backend/app/core/db/migrations/versions/0058_add_garch_and_conditional_cvar.py
+++ b/backend/app/core/db/migrations/versions/0058_add_garch_and_conditional_cvar.py
@@ -8,7 +8,6 @@ revision = "0058"
 down_revision = "0057_sec_fund_classes"
 
 import sqlalchemy as sa
-
 from alembic import op
 
 

--- a/backend/app/core/db/migrations/versions/0060_portfolio_views.py
+++ b/backend/app/core/db/migrations/versions/0060_portfolio_views.py
@@ -6,9 +6,8 @@ Create Date: 2026-03-27
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import UUID
-
 from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
 
 revision = "0060_portfolio_views"
 down_revision = "0059_wealth_vector_chunks"

--- a/backend/app/core/db/migrations/versions/0061_macro_regime_history.py
+++ b/backend/app/core/db/migrations/versions/0061_macro_regime_history.py
@@ -12,7 +12,6 @@ Create Date: 2026-03-27
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0061_macro_regime_history"

--- a/backend/app/core/db/migrations/versions/0063_add_strategy_label.py
+++ b/backend/app/core/db/migrations/versions/0063_add_strategy_label.py
@@ -13,7 +13,6 @@ Create Date: 2026-03-28
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0063_add_strategy_label"

--- a/backend/app/core/db/migrations/versions/0065_enrich_registered_funds_ncen.py
+++ b/backend/app/core/db/migrations/versions/0065_enrich_registered_funds_ncen.py
@@ -10,7 +10,6 @@ Create Date: 2026-03-28
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0065_enrich_registered_funds_ncen"

--- a/backend/app/core/db/migrations/versions/0066_fund_class_xbrl_fees.py
+++ b/backend/app/core/db/migrations/versions/0066_fund_class_xbrl_fees.py
@@ -9,7 +9,6 @@ Create Date: 2026-03-28
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0066_fund_class_xbrl_fees"

--- a/backend/app/core/db/migrations/versions/0069_globalize_instruments_nav.py
+++ b/backend/app/core/db/migrations/versions/0069_globalize_instruments_nav.py
@@ -12,7 +12,6 @@ Revises: 0068_instruments_org
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0069_globalize_instruments_nav"

--- a/backend/app/core/db/migrations/versions/0072_add_investment_geography.py
+++ b/backend/app/core/db/migrations/versions/0072_add_investment_geography.py
@@ -11,7 +11,6 @@ Create Date: 2026-03-31
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0072_add_investment_geography"

--- a/backend/app/core/db/migrations/versions/0073_add_vintage_year_to_sec_manager_funds.py
+++ b/backend/app/core/db/migrations/versions/0073_add_vintage_year_to_sec_manager_funds.py
@@ -8,7 +8,6 @@ Back-fills vintage_year by extracting 4-digit years from fund_name via regex.
 Matches patterns like "Fund IX 2019", "KKR NA XII (2022)", "Fund III, L.P. - 2018".
 """
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0073_add_vintage_year"

--- a/backend/app/core/db/migrations/versions/0074_widen_audit_events_action.py
+++ b/backend/app/core/db/migrations/versions/0074_widen_audit_events_action.py
@@ -8,7 +8,6 @@ Fixes StringDataRightTruncationError for action values like
 'WEALTH_INGESTION_WORKER_TRIGGERED' (35 chars > 32 limit).
 """
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0074_widen_audit_action"

--- a/backend/app/core/db/migrations/versions/0075_add_peer_percentile_columns.py
+++ b/backend/app/core/db/migrations/versions/0075_add_peer_percentile_columns.py
@@ -9,7 +9,6 @@ Columns: peer_strategy_label, peer_sharpe_pctl, peer_sortino_pctl,
 peer_return_pctl, peer_drawdown_pctl, peer_count.
 """
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0075_peer_percentile"

--- a/backend/app/core/db/migrations/versions/0076_wealth_generated_reports.py
+++ b/backend/app/core/db/migrations/versions/0076_wealth_generated_reports.py
@@ -7,7 +7,6 @@ Create Date: 2026-04-01 00:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision: str = "0076_wealth_generated_reports"

--- a/backend/app/core/db/migrations/versions/0077_dd_report_storage_path.py
+++ b/backend/app/core/db/migrations/versions/0077_dd_report_storage_path.py
@@ -7,7 +7,6 @@ Create Date: 2026-04-01 00:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision: str = "0077_dd_report_storage_path"

--- a/backend/app/core/db/migrations/versions/0081_model_portfolio_results.py
+++ b/backend/app/core/db/migrations/versions/0081_model_portfolio_results.py
@@ -10,9 +10,8 @@ Create Date: 2026-04-02 20:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision: str = "0081_model_portfolio_results"
 down_revision: str | None = "0080_fix_mv_unified_funds_manager"

--- a/backend/app/core/db/migrations/versions/0082_screening_l1_us_only.py
+++ b/backend/app/core/db/migrations/versions/0082_screening_l1_us_only.py
@@ -12,7 +12,6 @@ import json
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision: str = "0082_screening_l1_us_only"

--- a/backend/app/core/db/migrations/versions/0085_fix_13f_sector_mv_and_cusip_queue.py
+++ b/backend/app/core/db/migrations/versions/0085_fix_13f_sector_mv_and_cusip_queue.py
@@ -12,7 +12,6 @@ Create Date: 2026-04-05 14:00:00.000000
 from collections.abc import Sequence
 
 import psycopg
-
 from alembic import op
 
 revision: str = "0085_fix_13f_sector_mv_and_cusip_queue"

--- a/backend/app/core/db/migrations/versions/0093_fund_risk_metrics_composite_pk.py
+++ b/backend/app/core/db/migrations/versions/0093_fund_risk_metrics_composite_pk.py
@@ -29,9 +29,8 @@ rewrites historical chunks and is I/O heavy.
 
 import logging
 
-from sqlalchemy import text
-
 from alembic import op
+from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/core/db/migrations/versions/0097_curated_institutions_seed.py
+++ b/backend/app/core/db/migrations/versions/0097_curated_institutions_seed.py
@@ -5,7 +5,6 @@ Revises: 0096_discovery_fcl_keyset_indexes
 Create Date: 2026-04-08
 """
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0097_curated_institutions_seed"

--- a/backend/app/core/db/migrations/versions/0102_portfolio_weight_snapshots_hypertable.py
+++ b/backend/app/core/db/migrations/versions/0102_portfolio_weight_snapshots_hypertable.py
@@ -68,7 +68,6 @@ import os
 from collections.abc import Sequence
 
 import psycopg
-
 from alembic import op
 
 revision: str = "0102_portfolio_weight_snapshots_hypertable"

--- a/backend/app/core/db/migrations/versions/0107_shadow_oms.py
+++ b/backend/app/core/db/migrations/versions/0107_shadow_oms.py
@@ -24,9 +24,8 @@ Create Date: 2026-04-09
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers
 revision: str = "0107_shadow_oms"

--- a/backend/app/core/db/migrations/versions/0108_terminal_oms_hardening.py
+++ b/backend/app/core/db/migrations/versions/0108_terminal_oms_hardening.py
@@ -18,7 +18,6 @@ Create Date: 2026-04-09
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-
 from alembic import op
 
 # revision identifiers

--- a/backend/app/core/db/migrations/versions/0109_fund_risk_audit_columns.py
+++ b/backend/app/core/db/migrations/versions/0109_fund_risk_audit_columns.py
@@ -8,9 +8,8 @@ Create Date: 2026-04-10 12:00:00.000000
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = '0109'

--- a/backend/app/core/db/migrations/versions/0110_signal_breakdown_macro_regime.py
+++ b/backend/app/core/db/migrations/versions/0110_signal_breakdown_macro_regime.py
@@ -8,9 +8,8 @@ Create Date: 2026-04-14 12:00:00.000000
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = '0110'

--- a/backend/app/core/db/migrations/versions/0111_portfolio_construction_runs_event_log.py
+++ b/backend/app/core/db/migrations/versions/0111_portfolio_construction_runs_event_log.py
@@ -25,9 +25,8 @@ Create Date: 2026-04-11
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision: str = "0111_portfolio_construction_runs_event_log"
 down_revision: str | None = "0110_fund_risk_metrics_compress_segmentby_fix"

--- a/backend/app/core/db/migrations/versions/0114_wealth_vector_chunks_hypertable.py
+++ b/backend/app/core/db/migrations/versions/0114_wealth_vector_chunks_hypertable.py
@@ -83,7 +83,6 @@ import os
 from collections.abc import Sequence
 
 import psycopg
-
 from alembic import op
 
 revision: str = "0114_wealth_vector_chunks_hypertable"

--- a/backend/app/core/db/migrations/versions/0115_fund_risk_metrics_elite_flag.py
+++ b/backend/app/core/db/migrations/versions/0115_fund_risk_metrics_elite_flag.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision: str = "0115_fund_risk_metrics_elite_flag"

--- a/backend/app/core/db/migrations/versions/0119_mv_drift_heatmap_weekly.py
+++ b/backend/app/core/db/migrations/versions/0119_mv_drift_heatmap_weekly.py
@@ -44,7 +44,6 @@ import os
 from collections.abc import Sequence
 
 import psycopg
-
 from alembic import op
 
 revision: str = "0119_mv_drift_heatmap_weekly"

--- a/backend/app/core/db/migrations/versions/0121_tiingo_default_source.py
+++ b/backend/app/core/db/migrations/versions/0121_tiingo_default_source.py
@@ -11,7 +11,6 @@ after this migration carry source='tiingo'.
 from __future__ import annotations
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0121_tiingo_default_source"

--- a/backend/app/core/db/migrations/versions/0127_taa_regime_state.py
+++ b/backend/app/core/db/migrations/versions/0127_taa_regime_state.py
@@ -11,9 +11,8 @@ Create Date: 2026-04-12
 from __future__ import annotations
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB, UUID
-
 from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 revision = "0127_taa_regime_state"
 down_revision = "0126_seed_na_equity_large_block"

--- a/backend/app/core/db/migrations/versions/0129_elite_regime_flags.py
+++ b/backend/app/core/db/migrations/versions/0129_elite_regime_flags.py
@@ -11,7 +11,6 @@ Create Date: 2026-04-12
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0129_elite_regime_flags"

--- a/backend/app/core/db/migrations/versions/0130_macro_regime_snapshot.py
+++ b/backend/app/core/db/migrations/versions/0130_macro_regime_snapshot.py
@@ -10,9 +10,8 @@ Create Date: 2026-04-13
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB
-
 from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
 
 revision = "0130_macro_regime_snapshot"
 down_revision = "0129_elite_regime_flags"

--- a/backend/app/core/db/migrations/versions/0131_return_5y_10y.py
+++ b/backend/app/core/db/migrations/versions/0131_return_5y_10y.py
@@ -12,7 +12,6 @@ Create Date: 2026-04-14
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0131_return_5y_10y"

--- a/backend/app/core/db/migrations/versions/0132_merge_0110_heads.py
+++ b/backend/app/core/db/migrations/versions/0132_merge_0110_heads.py
@@ -38,7 +38,6 @@ Why not a stamp-only approach:
 from __future__ import annotations
 
 import sqlalchemy as sa  # noqa: F401
-
 from alembic import op  # noqa: F401
 
 # revision identifiers, used by Alembic.

--- a/backend/app/core/db/migrations/versions/0133_strategy_reclassification_stage.py
+++ b/backend/app/core/db/migrations/versions/0133_strategy_reclassification_stage.py
@@ -12,9 +12,8 @@ Create Date: 2026-04-14
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = "0133_strategy_reclassification_stage"
 down_revision = "0132_merge_0110_heads"

--- a/backend/app/core/db/migrations/versions/0134_universe_sanitization_flags.py
+++ b/backend/app/core/db/migrations/versions/0134_universe_sanitization_flags.py
@@ -16,7 +16,6 @@ Create Date: 2026-04-14
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0134_universe_sanitization_flags"

--- a/backend/app/core/db/migrations/versions/0136_classification_source_columns.py
+++ b/backend/app/core/db/migrations/versions/0136_classification_source_columns.py
@@ -15,7 +15,6 @@ Create Date: 2026-04-14
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0136_classification_source_columns"

--- a/backend/app/core/db/migrations/versions/0137_stage_applied_batch_id.py
+++ b/backend/app/core/db/migrations/versions/0137_stage_applied_batch_id.py
@@ -11,9 +11,8 @@ Create Date: 2026-04-14
 """
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = "0137_stage_applied_batch_id"
 down_revision = "0136_classification_source_columns"

--- a/backend/app/core/db/migrations/versions/0138_holdings_drift_alerts.py
+++ b/backend/app/core/db/migrations/versions/0138_holdings_drift_alerts.py
@@ -16,7 +16,6 @@ Create Date: 2026-04-14
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0138_holdings_drift_alerts"

--- a/backend/app/core/db/migrations/versions/0139_universe_cleanup_pre_autoimport.py
+++ b/backend/app/core/db/migrations/versions/0139_universe_cleanup_pre_autoimport.py
@@ -21,7 +21,6 @@ Create Date: 2026-04-16
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0139_universe_cleanup_pre_autoimport"

--- a/backend/app/core/db/migrations/versions/0142_construction_cascade_telemetry.py
+++ b/backend/app/core/db/migrations/versions/0142_construction_cascade_telemetry.py
@@ -19,9 +19,8 @@ Create Date: 2026-04-16
 from __future__ import annotations
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB
-
 from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
 
 revision: str = "0142_construction_cascade_telemetry"
 down_revision: str | None = "0141_portfolio_status_degraded"

--- a/backend/app/core/db/migrations/versions/0146_canonical_liquid_beta_backfill.py
+++ b/backend/app/core/db/migrations/versions/0146_canonical_liquid_beta_backfill.py
@@ -23,7 +23,6 @@ ON CONFLICT DO NOTHING.
 from __future__ import annotations
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0146_canonical_liquid_beta_backfill"

--- a/backend/app/core/db/migrations/versions/0149_sanitize_org_universe.py
+++ b/backend/app/core/db/migrations/versions/0149_sanitize_org_universe.py
@@ -26,7 +26,6 @@ warning is emitted if ``downgrade`` is invoked.
 from __future__ import annotations
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0149_sanitize_org_universe"

--- a/backend/app/core/db/migrations/versions/0151_fix_known_strategy_labels.py
+++ b/backend/app/core/db/migrations/versions/0151_fix_known_strategy_labels.py
@@ -23,7 +23,6 @@ the upgrade is a no-op.
 from __future__ import annotations
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0151_fix_known_strategy_labels"

--- a/backend/app/core/db/migrations/versions/0152_exclude_muni_auto_import.py
+++ b/backend/app/core/db/migrations/versions/0152_exclude_muni_auto_import.py
@@ -28,7 +28,6 @@ org-scoped level.
 from __future__ import annotations
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0152_exclude_muni_auto_import"

--- a/backend/app/core/db/migrations/versions/0153_canonical_allocation_template.py
+++ b/backend/app/core/db/migrations/versions/0153_canonical_allocation_template.py
@@ -43,7 +43,6 @@ the Python-side enum extension lives in ``schemas/sanitized.py``.
 from __future__ import annotations
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0153_canonical_allocation_template"

--- a/backend/app/core/db/migrations/versions/0154_portfolio_construction_run_mode.py
+++ b/backend/app/core/db/migrations/versions/0154_portfolio_construction_run_mode.py
@@ -11,7 +11,6 @@ in the down-migration before the column is removed.
 from __future__ import annotations
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0154_portfolio_construction_run_mode"

--- a/backend/app/core/db/migrations/versions/0158_instrument_strategy_overrides.py
+++ b/backend/app/core/db/migrations/versions/0158_instrument_strategy_overrides.py
@@ -14,9 +14,8 @@ Reversible.
 """
 from __future__ import annotations
 
-from sqlalchemy import text
-
 from alembic import op
+from sqlalchemy import text
 
 revision = "0158_instrument_strategy_overrides"
 down_revision = "0157_fuzzy_bridge_audit"

--- a/backend/app/core/db/migrations/versions/0162_add_sharpe_cf_cols.py
+++ b/backend/app/core/db/migrations/versions/0162_add_sharpe_cf_cols.py
@@ -16,7 +16,6 @@ Create Date: 2026-04-20
 from __future__ import annotations
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0162_add_sharpe_cf_cols"

--- a/backend/app/core/db/migrations/versions/0163_mv_nport_sector_attribution.py
+++ b/backend/app/core/db/migrations/versions/0163_mv_nport_sector_attribution.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import os
 
 import psycopg
-
 from alembic import op
 
 revision = "0163_mv_nport_sector_attribution"

--- a/backend/app/core/db/migrations/versions/0164_cusip_map_tiingo_enrichment.py
+++ b/backend/app/core/db/migrations/versions/0164_cusip_map_tiingo_enrichment.py
@@ -19,7 +19,6 @@ depends_on: 0163 (mv_nport_sector_attribution).
 from __future__ import annotations
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0164_cusip_map_tiingo_enrichment"

--- a/backend/app/core/db/migrations/versions/0168_expand_canonical_map_fsds_q1_2025.py
+++ b/backend/app/core/db/migrations/versions/0168_expand_canonical_map_fsds_q1_2025.py
@@ -41,9 +41,8 @@ depends_on: 0167.
 
 from __future__ import annotations
 
-from sqlalchemy import text
-
 from alembic import op
+from sqlalchemy import text
 
 revision = "0168_expand_canonical_map_fsds_q1_2025"
 down_revision = "0167_primary_benchmark_backfill_log"

--- a/backend/app/core/db/migrations/versions/0169_add_cvar_evt_cols.py
+++ b/backend/app/core/db/migrations/versions/0169_add_cvar_evt_cols.py
@@ -5,7 +5,6 @@ Reference: PR-Q6 and EDHEC Spec §4.
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "0169_add_cvar_evt_cols"

--- a/backend/app/core/db/migrations/versions/0173_factor_model_fits.py
+++ b/backend/app/core/db/migrations/versions/0173_factor_model_fits.py
@@ -22,9 +22,8 @@ Create Date: 2026-04-20
 
 """
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision = '0173_factor_model_fits'
 down_revision = '0172_add_intraday_market_ticks'

--- a/backend/app/core/db/migrations/versions/0173_factor_model_fits.py
+++ b/backend/app/core/db/migrations/versions/0173_factor_model_fits.py
@@ -1,7 +1,23 @@
-"""factor_model_fits
+"""factor_model_fits — table for IPCA / Kelly-Pruitt-Su fit results.
 
-Revision ID: 0172_factor_model_fits
-Revises: 0171_equity_characteristics_monthly
+Output table for the ``ipca_estimation`` worker (lock 900_092). Stores
+per-fit metadata (engine, universe_hash, k_factors), the resulting
+gamma_loadings + factor_returns JSONB, plus convergence diagnostics
+(converged, n_iterations, oos_r_squared). Consumed downstream by the
+quant cascade for factor exposures and risk decomposition.
+
+History
+-------
+Originally authored 2026-04-20 in the wrong path
+(``backend/alembic/versions/``) with ``revision = '0172_factor_model_fits'``,
+which collided with the legitimate ``0172_add_intraday_market_ticks``
+(both declared ``down_revision = '0171_equity_characteristics_monthly'``).
+The orphan never executed because alembic's ``script_location`` points
+at ``app/core/db/migrations/versions/``. Renumbered to 0173 and moved
+into the canonical path on 2026-04-24 — see commit history for details.
+
+Revision ID: 0173_factor_model_fits
+Revises: 0172_add_intraday_market_ticks
 Create Date: 2026-04-20
 
 """
@@ -10,8 +26,8 @@ from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
-revision = '0172_factor_model_fits'
-down_revision = '0171_equity_characteristics_monthly'
+revision = '0173_factor_model_fits'
+down_revision = '0172_add_intraday_market_ticks'
 branch_labels = None
 depends_on = None
 

--- a/backend/app/core/db/migrations/versions/636e0de04bf7_add_financial_term_fields_to_deals.py
+++ b/backend/app/core/db/migrations/versions/636e0de04bf7_add_financial_term_fields_to_deals.py
@@ -6,7 +6,6 @@ Create Date: 2026-03-18
 
 """
 import sqlalchemy as sa
-
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/backend/app/core/db/migrations/versions/a1b2c3d4e5f6_add_drift_event_fields_to_strategy_.py
+++ b/backend/app/core/db/migrations/versions/a1b2c3d4e5f6_add_drift_event_fields_to_strategy_.py
@@ -6,7 +6,6 @@ Create Date: 2026-03-18
 """
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "a1b2c3d4e5f6"

--- a/backend/app/core/db/migrations/versions/b2c3d4e5f6a7_add_classification_layer_model_to_.py
+++ b/backend/app/core/db/migrations/versions/b2c3d4e5f6a7_add_classification_layer_model_to_.py
@@ -5,7 +5,6 @@ Revises: f5aca0aa8f32
 Create Date: 2026-03-18
 """
 import sqlalchemy as sa
-
 from alembic import op
 
 revision = "b2c3d4e5f6a7"

--- a/backend/app/core/db/migrations/versions/c3d4e5f6a7b8_timescaledb_hypertables_compression.py
+++ b/backend/app/core/db/migrations/versions/c3d4e5f6a7b8_timescaledb_hypertables_compression.py
@@ -18,9 +18,8 @@ Create Date: 2026-03-18
 import logging
 
 import psycopg
-from sqlalchemy import text
-
 from alembic import op
+from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/core/db/migrations/versions/f5aca0aa8f32_add_change_summary_to_prompt_override_.py
+++ b/backend/app/core/db/migrations/versions/f5aca0aa8f32_add_change_summary_to_prompt_override_.py
@@ -7,7 +7,6 @@ Create Date: 2026-03-18 13:41:51.569566
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-
 from alembic import op
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
## Summary

The \`factor_model_fits\` alembic migration was authored 2026-04-20 in the wrong path (\`backend/alembic/versions/\`) — alembic's \`script_location\` points at \`backend/app/core/db/migrations/versions/\`. It also collided with the legitimate \`0172_add_intraday_market_ticks\` (both declared the same \`down_revision\`).

The orphan never executed in any environment because alembic ignored the wrong path entirely. Discovered during the 2026-04-24 dev DB restore audit.

## Changes

- **Move:** \`backend/alembic/versions/0172_factor_model_fits.py\` → \`backend/app/core/db/migrations/versions/0173_factor_model_fits.py\`
- **Renumber:** revision \`0172_factor_model_fits\` → \`0173_factor_model_fits\`
- **Reparent:** down_revision \`0171_equity_characteristics_monthly\` → \`0172_add_intraday_market_ticks\` (no longer collides)
- **Document:** Adds a History block to the migration docstring explaining the relocation
- **Cleanup:** Removes the now-empty \`backend/alembic/\` directory
- **Update:** CLAUDE.md \"Current migration head\" reference \`0131_return_5y_10y\` → \`0173_factor_model_fits\` (was stale)

## Why this matters

\`factor_model_fits\` is the output table for the \`ipca_estimation\` worker (lock 900_092) — required by the quant cascade for IPCA / Kelly-Pruitt-Su factor exposures and risk decomposition. PR-Q9 (G5 IPCA prod) implements the worker; this migration is its prerequisite. Andrei: *\"factor_model_fits faz parte do quant upgrade — precisa entrar no cascade sim ou sim.\"*

## Verified locally

- \`alembic heads\` → \`0173_factor_model_fits (head)\` (single head, no ambiguity)
- \`alembic upgrade head\` → \`factor_model_fits\` table created with the expected schema (fit_id PK, gamma_loadings/factor_returns JSONB, convergence diagnostics, query index on engine+universe_hash+converged+fit_date)
- \`SELECT version_num FROM alembic_version\` → \`0173_factor_model_fits\` ✅

## Test plan

- [x] \`alembic upgrade head\` runs cleanly on a freshly restored DB
- [x] Schema verified via \`\d factor_model_fits\` matches original intent
- [x] No multiple heads (was risk if file had been moved without renumbering)
- [ ] CI test-backend remains green

## Follow-up

Unblocks PR-Q8A (XBRL × nav → equity_characteristics_monthly worker) and PR-Q9 (ipca_estimation worker writing to factor_model_fits). Both are next in the quant pipeline.