### PR TITLE
feat(wealth): company_characteristics_compute worker (XBRL → stock-level chars) [PR-Q8A-v2]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ frontends/
   wealth/           ← SvelteKit "netz-wealth-os"
 ```
 
-**Database:** PostgreSQL 16 + TimescaleDB + pgvector. Managed via Timescale Cloud (prod) or docker-compose (dev). Redis 7 via Upstash (prod) or docker-compose (dev). Migrations via Alembic. App uses async asyncpg. Current migration head: `0173_factor_model_fits`.
+**Database:** PostgreSQL 16 + TimescaleDB + pgvector. Managed via Timescale Cloud (prod) or docker-compose (dev). Redis 7 via Upstash (prod) or docker-compose (dev). Migrations via Alembic. App uses async asyncpg. Current migration head: `0174_company_characteristics_monthly`.
 
 **Auth:** Clerk JWT v2. `organization_id` from `o.id` claim. RLS via `SET LOCAL app.current_organization_id`. Dev bypass: `X-DEV-ACTOR` header. **Tenant and user management is 100% via Clerk Dashboard** — no custom admin UI. Organizations, user invites, and role assignment (`ADMIN`, `INVESTMENT_TEAM`, `investor`) are all managed in Clerk. `ConfigService` defaults mean new tenants work immediately without provisioning.
 
@@ -234,7 +234,7 @@ Background workers ingest all external time-series data into hypertables. Routes
 | `sec_bulk_ingestion` | 900_050 | global | sec_etfs, sec_bdcs, sec_money_market_funds, sec_mmf_metrics, sec_registered_funds, strategy_label | SEC DERA bulk ZIPs (N-CEN, N-MFP, N-PORT, BDC) | Quarterly |
 | `form345_ingestion` | 900_051 | global | `sec_insider_transactions`, `sec_insider_sentiment` (MV) | SEC EDGAR Form 345 bulk TSV (insider buys/sells) | Quarterly |
 | `sec_xbrl_facts_ingestion` | 900_060 | global | `sec_xbrl_facts` | SEC XBRL Company Facts bulk (local) | On-demand (local dev) |
-| ~~`equity_characteristics_compute`~~ | ~~900_091~~ | global | `equity_characteristics_monthly` | _Removed — Tiingo worker deprecated. XBRL × nav replacement tracked in #286 (PR-Q8)._ | _pending_ |
+| `company_characteristics_compute` | 900_091 | global | `company_characteristics_monthly` | Computed (3 fundamentals-only Kelly-Pruitt-Su chars + 8 raw components from sec_xbrl_facts) | Daily |
 | `ipca_estimation` | 900_092 | global | `factor_model_fits` | Computed (Kelly-Pruitt-Su IPCA model on 6 chars) | Quarterly |
 | `universe_sync` | 900_070 | global | `instruments_universe` | SEC/ESMA catalog (auto-fetches company_tickers_mf.json) | Weekly |
 | `library_index_rebuild` | 900_080 | org | `wealth_library_index` | Self-heal cross-check via EXCEPT/MINUS vs source tables | Nightly |

--- a/backend/app/core/db/migrations/versions/0174_company_characteristics_monthly.py
+++ b/backend/app/core/db/migrations/versions/0174_company_characteristics_monthly.py
@@ -1,0 +1,79 @@
+"""company_characteristics_monthly — stock-level fundamentals from XBRL.
+
+Layer 1 of the Option B fund characteristics pipeline (issue #289).
+CIK-keyed table storing 8 raw components + 3 derived Kelly-Pruitt-Su
+fundamentals-only chars per fiscal period. Layer 2 (PR-Q8A-v3)
+aggregates these via N-PORT holdings to produce fund-level chars in
+``equity_characteristics_monthly``.
+
+Price-dependent chars (size, B/M, momentum) are NOT stored here — they
+are computed at the fund layer using N-PORT value_usd + fund NAV.
+
+Revision ID: 0174_company_characteristics_monthly
+Revises: 0173_factor_model_fits
+Create Date: 2026-04-25
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = '0174_company_characteristics_monthly'
+down_revision = '0173_factor_model_fits'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'company_characteristics_monthly',
+        sa.Column('cik', sa.BigInteger(), nullable=False),
+        sa.Column('period_end', sa.Date(), nullable=False),
+        sa.Column('fp', sa.Text(), nullable=True),
+        # Raw components
+        sa.Column('book_equity', sa.Numeric(), nullable=True),
+        sa.Column('total_assets', sa.Numeric(), nullable=True),
+        sa.Column('net_income_ttm', sa.Numeric(), nullable=True),
+        sa.Column('revenue', sa.Numeric(), nullable=True),
+        sa.Column('cost_of_revenue', sa.Numeric(), nullable=True),
+        sa.Column('gross_profit', sa.Numeric(), nullable=True),
+        sa.Column('capex_ttm', sa.Numeric(), nullable=True),
+        sa.Column('ppe_prior', sa.Numeric(), nullable=True),
+        sa.Column('shares_outstanding', sa.Numeric(), nullable=True),
+        # Derived characteristics (fundamentals-only)
+        sa.Column('quality_roa', sa.Numeric(), nullable=True),
+        sa.Column('investment_growth', sa.Numeric(), nullable=True),
+        sa.Column('profitability_gross', sa.Numeric(), nullable=True),
+        # Audit
+        sa.Column('source_filing_date', sa.Date(), nullable=True),
+        sa.Column('source_accn', sa.Text(), nullable=True),
+        sa.Column('computed_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('cik', 'period_end'),
+    )
+
+    # Convert to hypertable
+    op.execute("""
+        SELECT create_hypertable(
+            'company_characteristics_monthly',
+            'period_end',
+            chunk_time_interval => INTERVAL '1 year',
+            if_not_exists => TRUE
+        );
+    """)
+
+    # Indexes
+    op.create_index(
+        'idx_ccm_period_end',
+        'company_characteristics_monthly',
+        [sa.text('period_end DESC')],
+    )
+    op.create_index(
+        'idx_ccm_cik',
+        'company_characteristics_monthly',
+        ['cik'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('idx_ccm_cik', table_name='company_characteristics_monthly')
+    op.drop_index('idx_ccm_period_end', table_name='company_characteristics_monthly')
+    op.drop_table('company_characteristics_monthly')

--- a/backend/app/core/jobs/company_characteristics_compute.py
+++ b/backend/app/core/jobs/company_characteristics_compute.py
@@ -1,0 +1,381 @@
+"""company_characteristics_compute — stock-level fundamentals chars from XBRL.
+
+Advisory lock : 900_091
+Frequency     : daily
+Idempotent    : yes — ON CONFLICT (cik, period_end) DO UPDATE
+Scope         : global (no RLS)
+
+Layer 1 of the 2-layer Option B pipeline (issue #289). Computes 3
+fundamentals-only Kelly-Pruitt-Su characteristics + 8 raw components
+per CIK per fiscal period. Layer 2 (PR-Q8A-v3) aggregates these via
+N-PORT holdings to produce fund-level chars.
+
+Price-dependent chars (size_log_mkt_cap, book_to_market, mom_12_1)
+are NOT computed here — they are computed at the fund layer using
+N-PORT.value_usd as the market weight + the fund's own NAV series.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import structlog
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.engine import async_session_factory
+from app.domains.wealth.services.characteristics_derivation import (
+    derive_investment_growth,
+    derive_profitability_gross,
+    derive_quality_roa,
+)
+
+logger = structlog.get_logger()
+
+LOCK_ID = 900_091
+
+# XBRL concepts needed from sec_xbrl_facts
+_USGAAP_CONCEPTS = [
+    "StockholdersEquity",
+    "Assets",
+    "NetIncomeLoss",
+    "Revenues",
+    "RevenueFromContractWithCustomerExcludingAssessedTax",
+    "CostOfRevenue",
+    "CostOfGoodsAndServicesSold",
+    "PaymentsToAcquirePropertyPlantAndEquipment",
+    "PropertyPlantAndEquipmentNet",
+]
+
+_DEI_CONCEPT = "EntityCommonStockSharesOutstanding"
+
+# Quarterly fiscal periods for TTM aggregation
+_QUARTERLY_FPS = {"Q1", "Q2", "Q3", "Q4"}
+
+
+async def run_company_characteristics_compute(
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Entry point. Acquires advisory lock, computes chars, upserts rows."""
+    async with async_session_factory() as db:
+        acquired = await db.scalar(
+            text("SELECT pg_try_advisory_lock(:lock)"), {"lock": LOCK_ID}
+        )
+        if not acquired:
+            logger.info("company_characteristics_compute skip — lock held")
+            return {"status": "skipped", "reason": "lock_held"}
+        try:
+            return await _run(db, limit=limit, dry_run=dry_run)
+        finally:
+            await db.execute(
+                text("SELECT pg_advisory_unlock(:lock)"), {"lock": LOCK_ID}
+            )
+
+
+async def _run(
+    db: AsyncSession,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    # Get distinct CIKs that have us-gaap filings
+    limit_clause = f" LIMIT {int(limit)}" if limit else ""
+    result = await db.execute(text(
+        "SELECT DISTINCT cik FROM sec_xbrl_facts "
+        f"WHERE taxonomy = 'us-gaap'{limit_clause}"
+    ))
+    ciks = [r.cik for r in result.all()]
+    logger.info("company_chars_ciks_loaded", count=len(ciks))
+
+    if not ciks:
+        return {"status": "succeeded", "ciks_processed": 0, "rows_written": 0}
+
+    total_rows = 0
+    ciks_ok = 0
+    ciks_err = 0
+
+    for cik in ciks:
+        try:
+            rows = await _compute_cik(db, cik)
+            if rows and not dry_run:
+                written = await _upsert_rows(db, rows)
+                total_rows += written
+            elif rows:
+                total_rows += len(rows)
+            ciks_ok += 1
+        except Exception:
+            ciks_err += 1
+            await db.rollback()
+            logger.warning(
+                "company_chars_cik_failed",
+                cik=cik,
+                exc_info=True,
+            )
+
+    logger.info(
+        "company_characteristics_compute done",
+        ciks_ok=ciks_ok,
+        ciks_err=ciks_err,
+        rows_written=total_rows,
+    )
+    return {
+        "status": "succeeded",
+        "ciks_processed": ciks_ok,
+        "ciks_errors": ciks_err,
+        "rows_written": total_rows,
+    }
+
+
+async def _compute_cik(
+    db: AsyncSession,
+    cik: int,
+) -> list[dict[str, Any]]:
+    """Compute all characteristics for one CIK across all available periods."""
+    fundamentals = await _fetch_fundamentals(db, cik)
+    shares = await _fetch_shares_outstanding(db, cik)
+
+    if not fundamentals:
+        return []
+
+    sorted_dates = sorted(fundamentals.keys())
+    rows: list[dict[str, Any]] = []
+
+    for period_end in sorted_dates:
+        entry = fundamentals[period_end]
+
+        # Revenue fallback
+        revenue = entry.get("Revenues") or entry.get(
+            "RevenueFromContractWithCustomerExcludingAssessedTax"
+        )
+        # Cost of revenue fallback
+        cost_of_rev = entry.get("CostOfRevenue") or entry.get(
+            "CostOfGoodsAndServicesSold"
+        )
+        gross_profit = (revenue - cost_of_rev) if (revenue is not None and cost_of_rev is not None) else None
+
+        total_assets = entry.get("Assets")
+        book_equity = entry.get("StockholdersEquity")
+        shares_eom = _latest_value_as_of(shares, period_end)
+
+        # TTM: net_income
+        net_income_ttm = _compute_ttm(
+            sorted_dates, fundamentals, period_end, "NetIncomeLoss"
+        )
+        # TTM: capex
+        capex_ttm = _compute_ttm(
+            sorted_dates, fundamentals, period_end,
+            "PaymentsToAcquirePropertyPlantAndEquipment",
+        )
+        # PPE prior (year-ago)
+        ppe_prior = _yoy_value(
+            sorted_dates, fundamentals, period_end,
+            "PropertyPlantAndEquipmentNet",
+        )
+
+        # YoY total assets for investment_growth
+        total_assets_yoy = _yoy_value(
+            sorted_dates, fundamentals, period_end, "Assets"
+        )
+
+        # Derived chars (clamped — XBRL data quality issues can produce absurd ratios)
+        quality_roa = _clamp_ratio(derive_quality_roa(net_income_ttm, total_assets))
+        investment_growth = _clamp_ratio(derive_investment_growth(total_assets, total_assets_yoy))
+        profitability_gross = _clamp_ratio(derive_profitability_gross(gross_profit, revenue, cost_of_rev))
+
+        rows.append({
+            "cik": cik,
+            "period_end": period_end,
+            "fp": entry.get("fp"),
+            "book_equity": book_equity,
+            "total_assets": total_assets,
+            "net_income_ttm": net_income_ttm,
+            "revenue": revenue,
+            "cost_of_revenue": cost_of_rev,
+            "gross_profit": gross_profit,
+            "capex_ttm": capex_ttm,
+            "ppe_prior": ppe_prior,
+            "shares_outstanding": shares_eom,
+            "quality_roa": quality_roa,
+            "investment_growth": investment_growth,
+            "profitability_gross": profitability_gross,
+            "source_filing_date": entry.get("filed"),
+            "source_accn": entry.get("accn"),
+        })
+
+    return rows
+
+
+async def _fetch_fundamentals(
+    db: AsyncSession, cik: int
+) -> dict[date, dict[str, Any]]:
+    """Fetch deduped XBRL fundamentals for one CIK. Latest filing wins."""
+    concepts_sql = ", ".join(f"'{c}'" for c in _USGAAP_CONCEPTS)
+    sql = f"""
+        SELECT DISTINCT ON (cik, concept, period_end)
+               concept, period_end, val, fp, filed, accn
+        FROM sec_xbrl_facts
+        WHERE cik = :cik
+          AND taxonomy = 'us-gaap'
+          AND unit = 'USD'
+          AND concept IN ({concepts_sql})
+          AND val IS NOT NULL
+        ORDER BY cik, concept, period_end, filed DESC
+    """
+    result = await db.execute(text(sql), {"cik": cik})
+    rows = result.all()
+
+    by_period: dict[date, dict[str, Any]] = {}
+    for r in rows:
+        pe = r.period_end
+        if pe not in by_period:
+            by_period[pe] = {"filed": r.filed, "accn": r.accn, "fp": r.fp, "_fps": {}}
+        entry = by_period[pe]
+        entry[r.concept] = float(r.val)
+        # Store fp per concept (needed for TTM — XBRL quarterly vals are YTD, not incremental)
+        if r.fp:
+            entry["_fps"][r.concept] = r.fp
+        # Track latest filed + accn for audit
+        if r.filed and (entry["filed"] is None or r.filed > entry["filed"]):
+            entry["filed"] = r.filed
+            entry["accn"] = r.accn
+        # Keep fp from the most common observation
+        if r.fp:
+            entry["fp"] = r.fp
+
+    return by_period
+
+
+async def _fetch_shares_outstanding(
+    db: AsyncSession, cik: int
+) -> dict[date, float]:
+    """Shares outstanding from dei.EntityCommonStockSharesOutstanding."""
+    sql = """
+        SELECT DISTINCT ON (cik, period_end)
+               period_end, val
+        FROM sec_xbrl_facts
+        WHERE cik = :cik
+          AND taxonomy = 'dei'
+          AND concept = :concept
+          AND unit = 'shares'
+          AND val IS NOT NULL
+          AND val > 0
+        ORDER BY cik, period_end, filed DESC
+    """
+    result = await db.execute(text(sql), {"cik": cik, "concept": _DEI_CONCEPT})
+    return {r.period_end: float(r.val) for r in result.all()}
+
+
+def _clamp_ratio(val: float | None, bound: float = 100.0) -> float | None:
+    """Clamp derived ratio to [-bound, +bound]. Absurd values indicate XBRL data quality issues."""
+    if val is None:
+        return None
+    if val > bound or val < -bound:
+        return None
+    return val
+
+
+def _compute_ttm(
+    sorted_dates: list[date],
+    data: dict[date, dict],
+    as_of: date,
+    concept: str,
+) -> float | None:
+    """Compute trailing-twelve-months value for a flow concept.
+
+    Uses the most recent FY/CY value on or before as_of. XBRL quarterly
+    values (Q1/Q2/Q3) are cumulative YTD, NOT incremental — summing them
+    would double/triple count. The FY value is the authoritative annual
+    figure.
+    """
+    # Look for the most recent FY/CY value on or before as_of
+    # Use concept-level fp (stored in _fps dict) — the period-level fp
+    # may come from a different concept and mislead.
+    best = None
+    for d in sorted_dates:
+        if d <= as_of:
+            e = data[d]
+            concept_fp = e.get("_fps", {}).get(concept)
+            if concept_fp in ("FY", "CY") and concept in e:
+                best = e[concept]
+        else:
+            break
+    return best
+
+
+def _yoy_value(
+    sorted_dates: list[date],
+    data: dict[date, dict],
+    as_of: date,
+    concept: str,
+) -> float | None:
+    """Find the value of `concept` from ~12 months ago (year-over-year)."""
+    target = as_of - relativedelta(years=1)
+    best = None
+    for d in sorted_dates:
+        if d <= target:
+            best = d
+        else:
+            break
+    if best and concept in data[best]:
+        return data[best][concept]
+    return None
+
+
+def _latest_value_as_of(mapping: dict[date, float], as_of: date) -> float | None:
+    """Find the most recent value on or before as_of."""
+    best_val = None
+    for d in sorted(mapping.keys()):
+        if d <= as_of:
+            best_val = mapping[d]
+        else:
+            break
+    return best_val
+
+
+_UPSERT_SQL = """
+    INSERT INTO company_characteristics_monthly (
+        cik, period_end, fp,
+        book_equity, total_assets, net_income_ttm, revenue,
+        cost_of_revenue, gross_profit, capex_ttm, ppe_prior,
+        shares_outstanding,
+        quality_roa, investment_growth, profitability_gross,
+        source_filing_date, source_accn, computed_at
+    ) VALUES (
+        :cik, :period_end, :fp,
+        :book_equity, :total_assets, :net_income_ttm, :revenue,
+        :cost_of_revenue, :gross_profit, :capex_ttm, :ppe_prior,
+        :shares_outstanding,
+        :quality_roa, :investment_growth, :profitability_gross,
+        :source_filing_date, :source_accn, now()
+    )
+    ON CONFLICT (cik, period_end) DO UPDATE SET
+        fp = EXCLUDED.fp,
+        book_equity = EXCLUDED.book_equity,
+        total_assets = EXCLUDED.total_assets,
+        net_income_ttm = EXCLUDED.net_income_ttm,
+        revenue = EXCLUDED.revenue,
+        cost_of_revenue = EXCLUDED.cost_of_revenue,
+        gross_profit = EXCLUDED.gross_profit,
+        capex_ttm = EXCLUDED.capex_ttm,
+        ppe_prior = EXCLUDED.ppe_prior,
+        shares_outstanding = EXCLUDED.shares_outstanding,
+        quality_roa = EXCLUDED.quality_roa,
+        investment_growth = EXCLUDED.investment_growth,
+        profitability_gross = EXCLUDED.profitability_gross,
+        source_filing_date = EXCLUDED.source_filing_date,
+        source_accn = EXCLUDED.source_accn,
+        computed_at = now()
+"""
+
+
+async def _upsert_rows(db: AsyncSession, rows: list[dict[str, Any]]) -> int:
+    """Batch upsert rows. Returns count written."""
+    if not rows:
+        return 0
+    stmt = text(_UPSERT_SQL)
+    for row in rows:
+        await db.execute(stmt, row)
+    await db.commit()
+    return len(rows)

--- a/backend/scripts/backfill_cusip_issuer_cik.py
+++ b/backend/scripts/backfill_cusip_issuer_cik.py
@@ -1,0 +1,99 @@
+"""Backfill sec_cusip_ticker_map.issuer_cik from SEC company_tickers.json.
+
+Reads the SEC-published ticker->CIK map and updates rows in
+sec_cusip_ticker_map where issuer_cik IS NULL but ticker IS NOT NULL.
+Idempotent — safe to rerun. Reports before/after coverage.
+
+Usage:
+    python backend/scripts/backfill_cusip_issuer_cik.py
+
+Environment:
+    COMPANY_TICKERS_JSON  — path to company_tickers.json
+                            (default: C:\\Users\\Andrei\\Desktop\\EDGAR FILES\\company_tickers.json)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+from sqlalchemy import text
+
+# Allow running from repo root
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.core.db.engine import async_session_factory  # noqa: E402
+
+DEFAULT_PATH = Path(os.environ.get(
+    "COMPANY_TICKERS_JSON",
+    r"C:\Users\Andrei\Desktop\EDGAR FILES\company_tickers.json",
+))
+
+
+async def backfill(file_path: Path = DEFAULT_PATH) -> dict[str, int]:
+    if not file_path.exists():
+        raise FileNotFoundError(
+            f"company_tickers.json not found at {file_path}. "
+            f"Set COMPANY_TICKERS_JSON env var or download from "
+            f"https://www.sec.gov/files/company_tickers.json"
+        )
+
+    raw = json.loads(file_path.read_text(encoding="utf-8"))
+    ticker_to_cik: dict[str, int] = {
+        row["ticker"].upper(): int(row["cik_str"])
+        for row in raw.values()
+        if row.get("ticker")
+    }
+
+    async with async_session_factory() as db:
+        before = await db.scalar(text(
+            "SELECT COUNT(*) FROM sec_cusip_ticker_map WHERE issuer_cik IS NOT NULL"
+        ))
+
+        # Temp table for bulk join-update
+        await db.execute(text(
+            "CREATE TEMP TABLE tmp_ticker_cik (ticker TEXT PRIMARY KEY, cik BIGINT NOT NULL) "
+            "ON COMMIT DROP"
+        ))
+
+        # Batch insert into temp table
+        batch_size = 1000
+        items = list(ticker_to_cik.items())
+        for i in range(0, len(items), batch_size):
+            batch = items[i:i + batch_size]
+            values = ", ".join(
+                f"('{ticker}', {cik})" for ticker, cik in batch
+                if "'" not in ticker  # skip tickers with quotes (safety)
+            )
+            if values:
+                await db.execute(text(
+                    f"INSERT INTO tmp_ticker_cik (ticker, cik) VALUES {values} "
+                    f"ON CONFLICT (ticker) DO NOTHING"
+                ))
+
+        # Bulk update
+        result = await db.execute(text("""
+            UPDATE sec_cusip_ticker_map m
+            SET issuer_cik = t.cik::TEXT
+            FROM tmp_ticker_cik t
+            WHERE UPPER(m.ticker) = t.ticker
+              AND m.issuer_cik IS NULL
+              AND m.ticker IS NOT NULL
+        """))
+        updated = result.rowcount
+
+        await db.commit()
+
+        after = await db.scalar(text(
+            "SELECT COUNT(*) FROM sec_cusip_ticker_map WHERE issuer_cik IS NOT NULL"
+        ))
+
+    print(f"backfill: {before} -> {after} (+{updated} rows updated)")
+    return {"before": before, "after": after, "updated": updated}
+
+
+if __name__ == "__main__":
+    asyncio.run(backfill())

--- a/backend/tests/integration/test_company_characteristics_compute.py
+++ b/backend/tests/integration/test_company_characteristics_compute.py
@@ -1,0 +1,313 @@
+"""Integration tests for company_characteristics_compute worker.
+
+Covers 5 acceptance gates:
+    - basic_population: synthetic XBRL → correct rows + math
+    - restatement_dedup: later filing wins
+    - idempotent_rerun: ON CONFLICT UPDATE, no duplicates
+    - concept_fallback: RevenueFromContract... fills in for missing Revenues
+    - unit_filter: CNY observations ignored (only USD)
+
+Requires a running Postgres with sec_xbrl_facts table and migration 0174
+applied. Skipped otherwise. Self-seeding — no dev_seed_local dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_TEST_CIK_A = 9999901
+_TEST_CIK_B = 9999902
+_TEST_CIK_C = 9999903  # concept fallback
+_TEST_CIK_D = 9999904  # unit filter
+
+
+def _get_session_factory():
+    try:
+        from app.core.db.engine import async_session_factory
+        return async_session_factory
+    except Exception as exc:
+        pytest.skip(f"Cannot import session factory: {exc}")
+
+
+async def _cleanup(db, ciks: list[int]):
+    """Remove test data from both tables."""
+    from sqlalchemy import text
+    cik_list = ", ".join(str(c) for c in ciks)
+    await db.execute(text(
+        f"DELETE FROM company_characteristics_monthly WHERE cik IN ({cik_list})"
+    ))
+    await db.execute(text(
+        f"DELETE FROM sec_xbrl_facts WHERE cik IN ({cik_list})"
+    ))
+    await db.commit()
+
+
+async def _seed_xbrl(db, cik: int, concept: str, period_end: date,
+                     val: float, filed: date, taxonomy: str = "us-gaap",
+                     unit: str = "USD", fp: str = "FY",
+                     accn: str = "0000000000-00-000001",
+                     form: str = "10-K"):
+    from sqlalchemy import text
+    await db.execute(text("""
+        INSERT INTO sec_xbrl_facts (cik, taxonomy, concept, unit, period_end, val, fp, filed, accn, form)
+        VALUES (:cik, :taxonomy, :concept, :unit, :period_end, :val, :fp, :filed, :accn, :form)
+        ON CONFLICT DO NOTHING
+    """), {
+        "cik": cik, "taxonomy": taxonomy, "concept": concept, "unit": unit,
+        "period_end": period_end, "val": val, "fp": fp, "filed": filed,
+        "accn": accn, "form": form,
+    })
+
+
+async def _seed_basic_cik(db, cik: int, period_end: date, filed: date,
+                          assets: float = 1000.0, equity: float = 400.0,
+                          net_income: float = 100.0, revenue: float = 500.0,
+                          cost_rev: float = 300.0, fp: str = "FY",
+                          accn_suffix: str = "001"):
+    """Seed one CIK with a full set of fundamentals for one period."""
+    accn = f"0000000000-00-0000{accn_suffix}"
+    concepts = [
+        ("Assets", assets),
+        ("StockholdersEquity", equity),
+        ("NetIncomeLoss", net_income),
+        ("Revenues", revenue),
+        ("CostOfRevenue", cost_rev),
+    ]
+    for concept, val in concepts:
+        await _seed_xbrl(db, cik, concept, period_end, val, filed,
+                         fp=fp, accn=accn)
+
+
+async def _run_worker_for_ciks(ciks: list[int]):
+    """Run the worker with a CIK filter by limiting to a small universe."""
+    factory = _get_session_factory()
+    async with factory() as db:
+        from app.core.jobs.company_characteristics_compute import (
+            _compute_cik,
+            _upsert_rows,
+        )
+        for cik in ciks:
+            rows = await _compute_cik(db, cik)
+            if rows:
+                await _upsert_rows(db, rows)
+
+
+async def _count_rows(db, cik: int) -> int:
+    from sqlalchemy import text
+    return await db.scalar(text(
+        "SELECT COUNT(*) FROM company_characteristics_monthly WHERE cik = :cik"
+    ), {"cik": cik})
+
+
+async def _get_rows(db, cik: int) -> list:
+    from sqlalchemy import text
+    result = await db.execute(text(
+        "SELECT * FROM company_characteristics_monthly WHERE cik = :cik ORDER BY period_end"
+    ), {"cik": cik})
+    return result.all()
+
+
+# ---------- Test 1: basic population ----------
+
+def test_basic_population():
+    """Seed 2 CIKs × 4 periods → assert 8 rows with correct math."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db, [_TEST_CIK_A, _TEST_CIK_B])
+
+            periods = [
+                date(2022, 3, 31), date(2022, 6, 30),
+                date(2022, 9, 30), date(2022, 12, 31),
+            ]
+            for cik in [_TEST_CIK_A, _TEST_CIK_B]:
+                for i, pe in enumerate(periods):
+                    filed = date(2023, 2, 15)
+                    await _seed_basic_cik(
+                        db, cik, pe, filed,
+                        assets=1000.0 + i * 100,
+                        equity=400.0,
+                        net_income=100.0,
+                        revenue=500.0,
+                        cost_rev=300.0,
+                        fp="FY" if i == 3 else f"Q{i+1}",
+                        accn_suffix=f"{cik % 100:02d}{i}",
+                    )
+            await db.commit()
+
+        # Run worker
+        await _run_worker_for_ciks([_TEST_CIK_A, _TEST_CIK_B])
+
+        # Verify
+        async with factory() as db:
+            count_a = await _count_rows(db, _TEST_CIK_A)
+            count_b = await _count_rows(db, _TEST_CIK_B)
+            assert count_a == 4, f"Expected 4 rows for CIK A, got {count_a}"
+            assert count_b == 4, f"Expected 4 rows for CIK B, got {count_b}"
+
+            rows = await _get_rows(db, _TEST_CIK_A)
+            # Check FY period (last one, assets=1300)
+            fy_row = [r for r in rows if r.period_end == date(2022, 12, 31)][0]
+            assert fy_row.total_assets == 1300.0
+            assert fy_row.book_equity == 400.0
+            assert fy_row.revenue == 500.0
+            # gross_profit = 500 - 300 = 200
+            assert fy_row.gross_profit == 200.0
+            # profitability_gross = 200 / 500 = 0.4
+            assert abs(float(fy_row.profitability_gross) - 0.4) < 0.001
+            # quality_roa = net_income_ttm / total_assets
+            # For FY, net_income_ttm = 100 (FY value)
+            if fy_row.net_income_ttm is not None:
+                expected_roa = 100.0 / 1300.0
+                assert abs(float(fy_row.quality_roa) - expected_roa) < 0.001
+
+            # Cleanup
+            await _cleanup(db, [_TEST_CIK_A, _TEST_CIK_B])
+
+    asyncio.get_event_loop().run_until_complete(_test())
+
+
+# ---------- Test 2: restatement dedup ----------
+
+def test_restatement_dedup():
+    """Two observations same (cik, concept, period_end) — later filed wins."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db, [_TEST_CIK_A])
+
+            pe = date(2023, 12, 31)
+            # First filing: Assets = 900
+            await _seed_xbrl(db, _TEST_CIK_A, "Assets", pe, 900.0,
+                             filed=date(2024, 2, 1),
+                             accn="0000000000-24-000001")
+            # Restatement: Assets = 950 (filed later)
+            await _seed_xbrl(db, _TEST_CIK_A, "Assets", pe, 950.0,
+                             filed=date(2024, 5, 1),
+                             accn="0000000000-24-000002")
+            # Other concepts needed for a row
+            await _seed_xbrl(db, _TEST_CIK_A, "NetIncomeLoss", pe, 80.0,
+                             filed=date(2024, 2, 1),
+                             accn="0000000000-24-000001")
+            await db.commit()
+
+        await _run_worker_for_ciks([_TEST_CIK_A])
+
+        async with factory() as db:
+            rows = await _get_rows(db, _TEST_CIK_A)
+            assert len(rows) >= 1
+            row = [r for r in rows if r.period_end == pe][0]
+            # Should use the restated value (950), not original (900)
+            assert float(row.total_assets) == 950.0
+            await _cleanup(db, [_TEST_CIK_A])
+
+    asyncio.get_event_loop().run_until_complete(_test())
+
+
+# ---------- Test 3: idempotent rerun ----------
+
+def test_idempotent_rerun():
+    """Running worker twice produces same row count (ON CONFLICT UPDATE)."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db, [_TEST_CIK_A])
+            await _seed_basic_cik(db, _TEST_CIK_A, date(2023, 12, 31),
+                                  date(2024, 2, 15))
+            await db.commit()
+
+        # First run
+        await _run_worker_for_ciks([_TEST_CIK_A])
+        async with factory() as db:
+            count1 = await _count_rows(db, _TEST_CIK_A)
+
+        # Second run
+        await _run_worker_for_ciks([_TEST_CIK_A])
+        async with factory() as db:
+            count2 = await _count_rows(db, _TEST_CIK_A)
+            assert count1 == count2, f"Idempotency violated: {count1} vs {count2}"
+            await _cleanup(db, [_TEST_CIK_A])
+
+    asyncio.get_event_loop().run_until_complete(_test())
+
+
+# ---------- Test 4: concept fallback ----------
+
+def test_concept_fallback():
+    """CIK with no Revenues but with RevenueFromContract... → revenue populated."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db, [_TEST_CIK_C])
+
+            pe = date(2023, 12, 31)
+            filed = date(2024, 2, 15)
+            accn = "0000000000-24-000010"
+            # NO Revenues — use fallback
+            await _seed_xbrl(db, _TEST_CIK_C,
+                             "RevenueFromContractWithCustomerExcludingAssessedTax",
+                             pe, 750.0, filed, accn=accn)
+            await _seed_xbrl(db, _TEST_CIK_C, "CostOfRevenue", pe, 450.0,
+                             filed, accn=accn)
+            await _seed_xbrl(db, _TEST_CIK_C, "Assets", pe, 2000.0,
+                             filed, accn=accn)
+            await db.commit()
+
+        await _run_worker_for_ciks([_TEST_CIK_C])
+
+        async with factory() as db:
+            rows = await _get_rows(db, _TEST_CIK_C)
+            assert len(rows) >= 1
+            row = [r for r in rows if r.period_end == pe][0]
+            assert float(row.revenue) == 750.0
+            # gross_profit = 750 - 450 = 300
+            assert float(row.gross_profit) == 300.0
+            # profitability_gross = 300 / 750 = 0.4
+            assert abs(float(row.profitability_gross) - 0.4) < 0.001
+            await _cleanup(db, [_TEST_CIK_C])
+
+    asyncio.get_event_loop().run_until_complete(_test())
+
+
+# ---------- Test 5: unit filter ----------
+
+def test_unit_filter():
+    """CNY observations are ignored — only USD wins."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db, [_TEST_CIK_D])
+
+            pe = date(2023, 12, 31)
+            filed = date(2024, 2, 15)
+            # Assets in CNY — should be ignored
+            await _seed_xbrl(db, _TEST_CIK_D, "Assets", pe, 99999.0,
+                             filed, unit="CNY",
+                             accn="0000000000-24-000020")
+            # Assets in USD — should be used
+            await _seed_xbrl(db, _TEST_CIK_D, "Assets", pe, 5000.0,
+                             filed, unit="USD",
+                             accn="0000000000-24-000021")
+            await db.commit()
+
+        await _run_worker_for_ciks([_TEST_CIK_D])
+
+        async with factory() as db:
+            rows = await _get_rows(db, _TEST_CIK_D)
+            if rows:
+                row = [r for r in rows if r.period_end == pe][0]
+                # Should be the USD value, not the CNY value
+                assert float(row.total_assets) == 5000.0
+            await _cleanup(db, [_TEST_CIK_D])
+
+    asyncio.get_event_loop().run_until_complete(_test())


### PR DESCRIPTION
## Summary

Layer 1 of the Option B fund characteristics pipeline (issue #289). Stock-level (CIK-keyed) fundamentals + 3 derived Kelly-Pruitt-Su chars from \`sec_xbrl_facts\` only — no price data needed at this layer. Layer 2 (PR-Q8A-v3) will aggregate these via N-PORT holdings to produce fund-level chars in \`equity_characteristics_monthly\`.

Replaces the closed PR #290 (which used wrong granularity — fund-CIK direct JOIN only matched 5 BDCs/REITs).

## Architecture

| Layer | Table | Keyed on | Status |
|---|---|---|---|
| 1 — company-level (this PR) | \`company_characteristics_monthly\` | \`(cik, period_end)\` | ✅ this PR |
| 2 — fund-level | \`equity_characteristics_monthly\` | \`(instrument_id, as_of)\` | next PR-Q8A-v3 |

## Changes

1. **Migration 0174** — \`company_characteristics_monthly\` hypertable (8 raw components + 3 derived chars + audit metadata)
2. **Backfill script** \`backfill_cusip_issuer_cik.py\` — populates \`sec_cusip_ticker_map.issuer_cik\` from SEC company_tickers.json
3. **Worker** \`company_characteristics_compute.py\` (lock 900_091) — iterates CIKs in sec_xbrl_facts, computes per-CIK chars
4. **Integration test** with 5 cases: basic, restatement dedup, idempotency, concept fallback, unit filter
5. **CLAUDE.md** — worker row restored, migration head bumped to 0174

## Issues caught & fixed during implementation

These three findings deserve highlight — they're the kind of subtle bugs that produce silently-wrong quant data:

1. **NUMERIC(10,4) overflow** — derived chars exceeded precision for edge-case XBRL data. Fixed: columns widened to unbounded NUMERIC + \`_clamp_ratio()\` nullifies values outside ±100.
2. **TTM double-counting** — XBRL quarterly NetIncomeLoss is **cumulative YTD, NOT incremental**. Summing Q1+Q2+Q3+Q4 would 3-4× the actual annual figure. Fixed: TTM uses only FY/CY values (the authoritative annual figure).
3. **Concept-level fp tracking** — fiscal-period tag at the period level could be overwritten by a different concept's tag, causing TTM to miss valid FY values. Fixed: \`_fps\` dict stores fp per concept.

## Smoke run (limit=500)

- 448 CIKs processed, **21,744 rows written**, 0 errors
- AAPL (CIK 320193): ROA 0.30, GP margin 0.48, book equity \$88B, total assets \$379B ✅ (matches public knowledge)
- MSFT (CIK 789019): ROA 0.15, GP margin 0.69, total assets \$665B ✅
- Full pytest: 4,932 passed, 6 pre-existing failures unchanged from main, **0 new failures**

## Backfill coverage note

Coverage reached 8,046 / 33,368 (24%) — short of the targeted ~20k. Reason: \`company_tickers.json\` covers ~13k 10-K filers, but many CUSIPs in \`sec_cusip_ticker_map\` have tickers for non-10-K entities (funds, ETFs) that don't appear in that file. Additional sources (N-CEN, ESMA) could increase coverage in a follow-up. Acceptable for v3 — aggregation works with whatever coverage we have, since holdings without CIK match are dropped from aggregation (transparent skip).

## Test plan

- [x] Integration tests: 5/5 passed
- [x] Smoke run: limit=500 produces 21,744 rows
- [x] AAPL ROA ~30%, gross margin ~48% (matches public)
- [x] MSFT ROA ~15%, gross margin ~69% (matches public)
- [x] Backfill: 5,123 → 8,046 (+2,923 CIKs added)
- [x] Full pytest: 0 new failures

## Follow-ups

- **PR-Q8A-v3**: \`fund_characteristics_aggregator\` worker — N-PORT holdings × company_characteristics → fund-level \`equity_characteristics_monthly\` (portfolio-level ratios, fund's own NAV for momentum)
- **PR-Q8B**: terminal \`/research\` route consuming the existing endpoints
- **Coverage improvement**: ingest N-CEN / ESMA fund identifiers to raise \`sec_cusip_ticker_map.issuer_cik\` past 60%

Closes (in part) #289.

🤖 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>