### PR TITLE
feat(wealth): fund_characteristics_aggregator worker (N-PORT × company chars → fund-level) [PR-Q8A-v3]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ frontends/
   wealth/           ← SvelteKit "netz-wealth-os"
 ```
 
-**Database:** PostgreSQL 16 + TimescaleDB + pgvector. Managed via Timescale Cloud (prod) or docker-compose (dev). Redis 7 via Upstash (prod) or docker-compose (dev). Migrations via Alembic. App uses async asyncpg. Current migration head: `0174_company_characteristics_monthly`.
+**Database:** PostgreSQL 16 + TimescaleDB + pgvector. Managed via Timescale Cloud (prod) or docker-compose (dev). Redis 7 via Upstash (prod) or docker-compose (dev). Migrations via Alembic. App uses async asyncpg. Current migration head: `0175_add_issuer_cik_to_cusip_map`.
 
 **Auth:** Clerk JWT v2. `organization_id` from `o.id` claim. RLS via `SET LOCAL app.current_organization_id`. Dev bypass: `X-DEV-ACTOR` header. **Tenant and user management is 100% via Clerk Dashboard** — no custom admin UI. Organizations, user invites, and role assignment (`ADMIN`, `INVESTMENT_TEAM`, `investor`) are all managed in Clerk. `ConfigService` defaults mean new tenants work immediately without provisioning.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,7 @@ Background workers ingest all external time-series data into hypertables. Routes
 | `form345_ingestion` | 900_051 | global | `sec_insider_transactions`, `sec_insider_sentiment` (MV) | SEC EDGAR Form 345 bulk TSV (insider buys/sells) | Quarterly |
 | `sec_xbrl_facts_ingestion` | 900_060 | global | `sec_xbrl_facts` | SEC XBRL Company Facts bulk (local) | On-demand (local dev) |
 | `company_characteristics_compute` | 900_091 | global | `company_characteristics_monthly` | Computed (3 fundamentals-only Kelly-Pruitt-Su chars + 8 raw components from sec_xbrl_facts) | Daily |
+| `fund_characteristics_aggregator` | 900_093 | global | `equity_characteristics_monthly` | Aggregates company_characteristics_monthly via N-PORT holdings (portfolio-level ratios, fund's own NAV for momentum) | Daily |
 | `ipca_estimation` | 900_092 | global | `factor_model_fits` | Computed (Kelly-Pruitt-Su IPCA model on 6 chars) | Quarterly |
 | `universe_sync` | 900_070 | global | `instruments_universe` | SEC/ESMA catalog (auto-fetches company_tickers_mf.json) | Weekly |
 | `library_index_rebuild` | 900_080 | org | `wealth_library_index` | Self-heal cross-check via EXCEPT/MINUS vs source tables | Nightly |

--- a/backend/app/core/db/migrations/versions/0175_add_issuer_cik_to_cusip_map.py
+++ b/backend/app/core/db/migrations/versions/0175_add_issuer_cik_to_cusip_map.py
@@ -1,0 +1,41 @@
+"""Add issuer_cik column to sec_cusip_ticker_map.
+
+The column was originally added manually (ad-hoc ALTER TABLE) on the
+dev DB to support the CUSIP→CIK lookup chain consumed by PR-Q4.1
+holdings enrichment and PR-Q8A-v3 fund characteristics aggregation.
+It never made it into an alembic revision, so fresh DBs (CI, new
+deployments) lacked the column and the aggregator's JOIN failed with
+``UndefinedColumnError`` during integration tests.
+
+This migration formalises the column + its filtered btree index. Live
+prod/dev already have both — the IF NOT EXISTS guards make the
+migration idempotent there.
+
+Revision ID: 0175_add_issuer_cik_to_cusip_map
+Revises: 0174_company_characteristics_monthly
+Create Date: 2026-04-25
+
+"""
+from alembic import op
+
+revision = '0175_add_issuer_cik_to_cusip_map'
+down_revision = '0174_company_characteristics_monthly'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE sec_cusip_ticker_map
+        ADD COLUMN IF NOT EXISTS issuer_cik VARCHAR NULL
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_cusip_map_issuer_cik
+        ON sec_cusip_ticker_map (issuer_cik)
+        WHERE issuer_cik IS NOT NULL
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_cusip_map_issuer_cik")
+    op.execute("ALTER TABLE sec_cusip_ticker_map DROP COLUMN IF EXISTS issuer_cik")

--- a/backend/app/core/jobs/fund_characteristics_aggregator.py
+++ b/backend/app/core/jobs/fund_characteristics_aggregator.py
@@ -298,8 +298,14 @@ async def _aggregate_one_date(
     if not holdings:
         return None
 
-    # Accumulate portfolio-level numerators and denominators
-    sum_market_value = 0.0
+    # Accumulate portfolio-level numerators and denominators.
+    # Two market_value totals: one for size (ALL holdings, gives fund's full
+    # equity-sleeve AUM) and one for ratios (RESOLVED holdings only, so the
+    # B/M denominator matches the resolved-holdings numerator).
+    # Mixing them would bias B/M downward whenever shares_outstanding is
+    # missing for some holdings (numerator stays 0 but denominator inflates).
+    sum_market_value_size = 0.0       # ← all holdings (resolved + unresolved)
+    sum_market_value_resolved = 0.0   # ← resolved only (used for B/M)
     sum_book_equity = 0.0
     sum_total_assets = 0.0
     sum_net_income_ttm = 0.0
@@ -315,16 +321,17 @@ async def _aggregate_one_date(
         quantity = float(h.quantity) if h.quantity is not None else None
         shares_out = float(h.shares_outstanding) if h.shares_outstanding is not None else None
 
-        # Compute ownership fraction
-        if quantity is not None and shares_out is not None and shares_out > 0:
-            ownership_frac = quantity / shares_out
-        else:
-            # Fallback: skip this holding from ratio aggregation but still
-            # count its market_value for size_log_mkt_cap
-            sum_market_value += mv
+        # Always count market_value for size_log_mkt_cap, even when ownership
+        # cannot be resolved — size is the fund's equity-sleeve AUM, which
+        # exists regardless of whether per-share fundamentals do.
+        sum_market_value_size += mv
+
+        # Compute ownership fraction (skip ratio aggregation if missing)
+        if quantity is None or shares_out is None or shares_out <= 0:
             continue
 
-        sum_market_value += mv
+        ownership_frac = quantity / shares_out
+        sum_market_value_resolved += mv
 
         # Scale company-level values by ownership fraction
         if h.book_equity is not None:
@@ -351,12 +358,17 @@ async def _aggregate_one_date(
     if resolved_count == 0:
         return None
 
-    # Compute fund-level characteristics
-    size_log_mkt_cap = math.log(sum_market_value) if sum_market_value > 0 else None
+    # Compute fund-level characteristics.
+    # size uses the FULL market value (all holdings), so it represents the
+    # fund's actual equity AUM. The other ratios use the RESOLVED-only
+    # totals so numerator and denominator are over the same set of holdings.
+    size_log_mkt_cap = (
+        math.log(sum_market_value_size) if sum_market_value_size > 0 else None
+    )
 
     book_to_market = (
-        sum_book_equity / sum_market_value
-        if sum_market_value > 0
+        sum_book_equity / sum_market_value_resolved
+        if sum_market_value_resolved > 0
         else None
     )
 
@@ -482,7 +494,17 @@ async def _compute_bdc_direct(
 async def _load_nav_series(
     db: AsyncSession, instrument_id: Any,
 ) -> pd.Series:
-    """Load NAV time-series for an instrument as a DatetimeIndex pandas Series."""
+    """Load NAV time-series for an instrument as a month-end pandas Series.
+
+    nav_timeseries is stored at daily frequency (instrument_ingestion worker
+    pulls daily NAV from Yahoo Finance). For 12-1 momentum (Jegadeesh-Titman
+    convention) we need MONTHLY observations — derive_momentum_12_1 takes
+    iloc[-13:-1] expecting that to span 12 calendar months. Feeding it daily
+    data would give a 13-trading-day window (~2.5 weeks) instead of 12 months.
+
+    Resample to month-end last value here so any caller gets the correct
+    cadence for momentum / longitudinal characteristics.
+    """
     result = await db.execute(text("""
         SELECT nav_date, nav
         FROM nav_timeseries
@@ -497,7 +519,10 @@ async def _load_nav_series(
 
     dates = [r.nav_date for r in rows]
     values = [float(r.nav) for r in rows]
-    return pd.Series(values, index=pd.DatetimeIndex(dates))
+    daily = pd.Series(values, index=pd.DatetimeIndex(dates))
+    # Resample to month-end: last NAV of each month.
+    # 'ME' alias requires pandas >= 2.0; safe given backend runtime.
+    return daily.resample("ME").last().dropna()
 
 
 def _clamp(val: float | None, bound: float) -> float | None:

--- a/backend/app/core/jobs/fund_characteristics_aggregator.py
+++ b/backend/app/core/jobs/fund_characteristics_aggregator.py
@@ -1,0 +1,533 @@
+"""fund_characteristics_aggregator — fund-level Kelly-Pruitt-Su chars from N-PORT x company chars.
+
+Advisory lock : 900_093 (distinct from 900_091 used by company_characteristics_compute)
+Frequency     : daily (depends on company_characteristics_monthly being up-to-date)
+Idempotent    : yes — ON CONFLICT (instrument_id, as_of) DO UPDATE
+Scope         : global (no RLS) — equity_characteristics_monthly is shared
+
+Layer 2 of Option B (issue #289). For each fund's N-PORT report_date,
+aggregates the holdings' company-level characteristics using portfolio-
+level formulas (numerator/denominator weighted by ownership_fraction =
+nport.quantity / company.shares_outstanding).
+
+Three sub-pipelines:
+
+  1. ETF / open-end / closed-end / interval funds -> aggregate via N-PORT
+  2. BDCs -> direct XBRL (reuses Q8A-v1 pattern — read fund's own CIK
+     from sec_xbrl_facts; bypass N-PORT since BDC holdings are debt)
+  3. Skip MMFs and private funds (no N-PORT, no equity exposure)
+
+Momentum (mom_12_1) is computed directly from the fund's own NAV in
+nav_timeseries — NOT aggregated from holdings.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date
+from typing import Any
+
+import pandas as pd
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db.engine import async_session_factory
+from app.domains.wealth.services.characteristics_derivation import (
+    derive_momentum_12_1,
+)
+
+logger = structlog.get_logger()
+
+LOCK_ID = 900_093
+
+# N-PORT asset classes considered equity (for aggregation)
+_EQUITY_ASSET_CLASSES = ("EC", "EP")
+
+
+async def run_fund_characteristics_aggregator(
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Entry point. Acquires advisory lock, aggregates chars, upserts rows."""
+    async with async_session_factory() as db:
+        acquired = await db.scalar(
+            text("SELECT pg_try_advisory_lock(:lock)"), {"lock": LOCK_ID}
+        )
+        if not acquired:
+            logger.info("fund_characteristics_aggregator skip — lock held")
+            return {"status": "skipped", "reason": "lock_held"}
+        try:
+            return await _run(db, limit=limit, dry_run=dry_run)
+        finally:
+            await db.execute(
+                text("SELECT pg_advisory_unlock(:lock)"), {"lock": LOCK_ID}
+            )
+
+
+async def _run(
+    db: AsyncSession,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    funds = await _load_universe(db, limit=limit)
+    logger.info("fund_chars_universe_loaded", count=len(funds))
+
+    if not funds:
+        return {"status": "succeeded", "funds_processed": 0, "rows_written": 0}
+
+    total_rows = 0
+    funds_ok = 0
+    funds_err = 0
+    funds_skipped = 0
+
+    for fund in funds:
+        pipeline = _classify_fund(fund)
+        if pipeline == "skip":
+            funds_skipped += 1
+            continue
+
+        try:
+            if pipeline == "bdc_direct":
+                rows = await _compute_bdc_direct(db, fund)
+            else:
+                rows = await _compute_via_aggregation(db, fund)
+
+            if rows and not dry_run:
+                written = await _upsert_rows(db, rows)
+                total_rows += written
+            elif rows:
+                total_rows += len(rows)
+            funds_ok += 1
+        except Exception:
+            funds_err += 1
+            await db.rollback()
+            logger.warning(
+                "fund_chars_fund_failed",
+                instrument_id=str(fund["instrument_id"]),
+                ticker=fund.get("ticker"),
+                exc_info=True,
+            )
+
+    logger.info(
+        "fund_characteristics_aggregator done",
+        funds_ok=funds_ok,
+        funds_err=funds_err,
+        funds_skipped=funds_skipped,
+        rows_written=total_rows,
+    )
+    return {
+        "status": "succeeded",
+        "funds_processed": funds_ok,
+        "funds_skipped": funds_skipped,
+        "funds_errors": funds_err,
+        "rows_written": total_rows,
+    }
+
+
+async def _load_universe(
+    db: AsyncSession, limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Load funds eligible for characteristics aggregation.
+
+    Returns instruments that either:
+    - Have N-PORT holdings (ETF, mutual fund, closed-end, interval)
+    - Are BDCs (direct XBRL path, no N-PORT needed)
+    """
+    limit_clause = f" LIMIT {int(limit)}" if limit else ""
+    result = await db.execute(text(f"""
+        SELECT
+            i.instrument_id,
+            i.ticker,
+            i.asset_class,
+            i.attributes->>'sec_cik' AS sec_cik,
+            CASE
+                WHEN EXISTS (
+                    SELECT 1 FROM sec_bdcs b
+                    WHERE b.cik::text = i.attributes->>'sec_cik'
+                ) THEN 'bdc'
+                WHEN EXISTS (
+                    SELECT 1 FROM sec_money_market_funds m
+                    WHERE m.cik::text = i.attributes->>'sec_cik'
+                ) THEN 'mmf'
+                ELSE 'standard'
+            END AS fund_category
+        FROM instruments_universe i
+        WHERE i.attributes->>'sec_cik' IS NOT NULL
+          AND (
+              EXISTS (
+                  SELECT 1 FROM sec_nport_holdings n
+                  WHERE n.cik = i.attributes->>'sec_cik'
+              )
+              OR EXISTS (
+                  SELECT 1 FROM sec_bdcs b
+                  WHERE b.cik::text = i.attributes->>'sec_cik'
+              )
+          )
+        ORDER BY i.ticker NULLS LAST
+        {limit_clause}
+    """))
+    return [
+        {
+            "instrument_id": r.instrument_id,
+            "ticker": r.ticker,
+            "asset_class": r.asset_class,
+            "sec_cik": r.sec_cik,
+            "fund_category": r.fund_category,
+        }
+        for r in result.all()
+    ]
+
+
+def _classify_fund(fund: dict[str, Any]) -> str:
+    """Returns 'aggregate', 'bdc_direct', or 'skip'."""
+    cat = fund.get("fund_category", "standard")
+    if cat == "mmf":
+        return "skip"
+    if cat == "bdc":
+        return "bdc_direct"
+    return "aggregate"
+
+
+async def _compute_via_aggregation(
+    db: AsyncSession, fund: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Aggregate company chars over N-PORT equity holdings for one fund."""
+    sec_cik = fund["sec_cik"]
+    instrument_id = fund["instrument_id"]
+    ticker = fund.get("ticker") or ""
+
+    # Get all distinct N-PORT report dates for this fund
+    report_dates_result = await db.execute(text("""
+        SELECT DISTINCT report_date
+        FROM sec_nport_holdings
+        WHERE cik = :cik
+        ORDER BY report_date
+    """), {"cik": sec_cik})
+    report_dates = [r.report_date for r in report_dates_result.all()]
+
+    if not report_dates:
+        return []
+
+    # Load fund's NAV series for momentum calculation
+    nav_series = await _load_nav_series(db, instrument_id)
+
+    rows: list[dict[str, Any]] = []
+
+    for report_date in report_dates:
+        row = await _aggregate_one_date(
+            db, instrument_id, ticker, sec_cik, report_date, nav_series,
+        )
+        if row is not None:
+            rows.append(row)
+
+    return rows
+
+
+async def _aggregate_one_date(
+    db: AsyncSession,
+    instrument_id: Any,
+    ticker: str,
+    fund_cik: str,
+    report_date: date,
+    nav_series: pd.Series,
+) -> dict[str, Any] | None:
+    """Aggregate holdings for one (fund, report_date) into fund-level chars.
+
+    Join chain: sec_nport_holdings -> sec_cusip_ticker_map -> company_characteristics_monthly.
+    Uses portfolio-level ratios (sum numerator / sum denominator), not weighted mean of ratios.
+    """
+    # Fetch resolved holdings: N-PORT equity holdings with company chars
+    result = await db.execute(text("""
+        SELECT
+            n.cusip,
+            n.market_value,
+            n.quantity,
+            c.book_equity,
+            c.total_assets,
+            c.net_income_ttm,
+            c.revenue,
+            c.gross_profit,
+            c.capex_ttm,
+            c.ppe_prior,
+            c.shares_outstanding,
+            c.source_filing_date
+        FROM sec_nport_holdings n
+        JOIN sec_cusip_ticker_map m ON m.cusip = n.cusip
+        JOIN LATERAL (
+            SELECT book_equity, total_assets, net_income_ttm, revenue,
+                   gross_profit, capex_ttm, ppe_prior, shares_outstanding,
+                   source_filing_date
+            FROM company_characteristics_monthly
+            WHERE cik = m.issuer_cik::bigint
+              AND period_end <= :report_date
+            ORDER BY period_end DESC
+            LIMIT 1
+        ) c ON true
+        WHERE n.cik = :fund_cik
+          AND n.report_date = :report_date
+          AND n.asset_class IN ('EC', 'EP')
+          AND m.issuer_cik IS NOT NULL
+          AND n.market_value IS NOT NULL
+          AND n.market_value > 0
+    """), {
+        "fund_cik": fund_cik,
+        "report_date": report_date,
+    })
+    holdings = result.all()
+
+    if not holdings:
+        return None
+
+    # Accumulate portfolio-level numerators and denominators
+    sum_market_value = 0.0
+    sum_book_equity = 0.0
+    sum_total_assets = 0.0
+    sum_net_income_ttm = 0.0
+    sum_revenue = 0.0
+    sum_gross_profit = 0.0
+    sum_capex_ttm = 0.0
+    sum_ppe_prior = 0.0
+    resolved_count = 0
+    latest_filing_date = None
+
+    for h in holdings:
+        mv = float(h.market_value)
+        quantity = float(h.quantity) if h.quantity is not None else None
+        shares_out = float(h.shares_outstanding) if h.shares_outstanding is not None else None
+
+        # Compute ownership fraction
+        if quantity is not None and shares_out is not None and shares_out > 0:
+            ownership_frac = quantity / shares_out
+        else:
+            # Fallback: skip this holding from ratio aggregation but still
+            # count its market_value for size_log_mkt_cap
+            sum_market_value += mv
+            continue
+
+        sum_market_value += mv
+
+        # Scale company-level values by ownership fraction
+        if h.book_equity is not None:
+            sum_book_equity += float(h.book_equity) * ownership_frac
+        if h.total_assets is not None:
+            sum_total_assets += float(h.total_assets) * ownership_frac
+        if h.net_income_ttm is not None:
+            sum_net_income_ttm += float(h.net_income_ttm) * ownership_frac
+        if h.revenue is not None:
+            sum_revenue += float(h.revenue) * ownership_frac
+        if h.gross_profit is not None:
+            sum_gross_profit += float(h.gross_profit) * ownership_frac
+        if h.capex_ttm is not None:
+            sum_capex_ttm += float(h.capex_ttm) * ownership_frac
+        if h.ppe_prior is not None:
+            sum_ppe_prior += float(h.ppe_prior) * ownership_frac
+
+        resolved_count += 1
+
+        if h.source_filing_date is not None:
+            if latest_filing_date is None or h.source_filing_date > latest_filing_date:
+                latest_filing_date = h.source_filing_date
+
+    if resolved_count == 0:
+        return None
+
+    # Compute fund-level characteristics
+    size_log_mkt_cap = math.log(sum_market_value) if sum_market_value > 0 else None
+
+    book_to_market = (
+        sum_book_equity / sum_market_value
+        if sum_market_value > 0
+        else None
+    )
+
+    quality_roa = (
+        sum_net_income_ttm / sum_total_assets
+        if sum_total_assets > 0
+        else None
+    )
+
+    investment_growth = (
+        sum_capex_ttm / sum_ppe_prior
+        if sum_ppe_prior > 0
+        else None
+    )
+
+    profitability_gross = (
+        sum_gross_profit / sum_revenue
+        if sum_revenue > 0
+        else None
+    )
+
+    # Momentum from fund's own NAV (not aggregated from holdings)
+    mom_12_1 = derive_momentum_12_1(nav_series, report_date)
+
+    # Clamp ratios to catch data quality issues
+    book_to_market = _clamp(book_to_market, 50.0)
+    quality_roa = _clamp(quality_roa, 10.0)
+    investment_growth = _clamp(investment_growth, 100.0)
+    profitability_gross = _clamp(profitability_gross, 10.0)
+
+    return {
+        "instrument_id": instrument_id,
+        "ticker": ticker,
+        "as_of": report_date,
+        "size_log_mkt_cap": _round4(size_log_mkt_cap),
+        "book_to_market": _round4(book_to_market),
+        "mom_12_1": _round4(mom_12_1),
+        "quality_roa": _round4(quality_roa),
+        "investment_growth": _round4(investment_growth),
+        "profitability_gross": _round4(profitability_gross),
+        "source_filing_date": latest_filing_date,
+    }
+
+
+async def _compute_bdc_direct(
+    db: AsyncSession, fund: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Compute characteristics for a BDC using its own XBRL filings.
+
+    BDCs file 10-K/10-Q with standard us-gaap concepts. Their N-PORT
+    holdings are debt instruments, not equity — so we read the BDC's
+    own financial statements directly from company_characteristics_monthly
+    (if populated by the Layer 1 worker for this CIK).
+    """
+    sec_cik = fund["sec_cik"]
+    instrument_id = fund["instrument_id"]
+    ticker = fund.get("ticker") or ""
+
+    # Try to cast sec_cik to bigint for company_characteristics_monthly lookup
+    try:
+        cik_int = int(sec_cik)
+    except (ValueError, TypeError):
+        return []
+
+    result = await db.execute(text("""
+        SELECT period_end, book_equity, total_assets, net_income_ttm,
+               revenue, gross_profit, capex_ttm, ppe_prior,
+               quality_roa, investment_growth, profitability_gross,
+               source_filing_date
+        FROM company_characteristics_monthly
+        WHERE cik = :cik
+        ORDER BY period_end
+    """), {"cik": cik_int})
+    company_rows = result.all()
+
+    if not company_rows:
+        return []
+
+    # Load fund's NAV series for momentum
+    nav_series = await _load_nav_series(db, instrument_id)
+
+    rows: list[dict[str, Any]] = []
+    for cr in company_rows:
+        mom_12_1 = derive_momentum_12_1(nav_series, cr.period_end)
+
+        # For BDCs, size_log_mkt_cap is not directly available from XBRL.
+        # We approximate from total_assets (BDCs report at fair value).
+        size_log = (
+            math.log(float(cr.total_assets))
+            if cr.total_assets is not None and float(cr.total_assets) > 0
+            else None
+        )
+        book_to_market = (
+            float(cr.book_equity) / float(cr.total_assets)
+            if cr.book_equity is not None
+            and cr.total_assets is not None
+            and float(cr.total_assets) > 0
+            else None
+        )
+
+        rows.append({
+            "instrument_id": instrument_id,
+            "ticker": ticker,
+            "as_of": cr.period_end,
+            "size_log_mkt_cap": _round4(size_log),
+            "book_to_market": _round4(_clamp(book_to_market, 50.0)),
+            "mom_12_1": _round4(mom_12_1),
+            "quality_roa": _round4(_clamp(
+                float(cr.quality_roa) if cr.quality_roa is not None else None, 10.0
+            )),
+            "investment_growth": _round4(_clamp(
+                float(cr.investment_growth) if cr.investment_growth is not None else None, 100.0
+            )),
+            "profitability_gross": _round4(_clamp(
+                float(cr.profitability_gross) if cr.profitability_gross is not None else None, 10.0
+            )),
+            "source_filing_date": cr.source_filing_date,
+        })
+
+    return rows
+
+
+async def _load_nav_series(
+    db: AsyncSession, instrument_id: Any,
+) -> pd.Series:
+    """Load NAV time-series for an instrument as a DatetimeIndex pandas Series."""
+    result = await db.execute(text("""
+        SELECT nav_date, nav
+        FROM nav_timeseries
+        WHERE instrument_id = :iid
+          AND nav IS NOT NULL
+        ORDER BY nav_date
+    """), {"iid": instrument_id})
+    rows = result.all()
+
+    if not rows:
+        return pd.Series(dtype=float)
+
+    dates = [r.nav_date for r in rows]
+    values = [float(r.nav) for r in rows]
+    return pd.Series(values, index=pd.DatetimeIndex(dates))
+
+
+def _clamp(val: float | None, bound: float) -> float | None:
+    """Clamp to [-bound, +bound]. Returns None for absurd values."""
+    if val is None:
+        return None
+    if val > bound or val < -bound:
+        return None
+    return val
+
+
+def _round4(val: float | None) -> float | None:
+    """Round to 4 decimal places for NUMERIC(10,4) columns."""
+    if val is None:
+        return None
+    return round(val, 4)
+
+
+_UPSERT_SQL = """
+    INSERT INTO equity_characteristics_monthly (
+        instrument_id, ticker, as_of,
+        size_log_mkt_cap, book_to_market, mom_12_1,
+        quality_roa, investment_growth, profitability_gross,
+        source_filing_date, computed_at
+    ) VALUES (
+        :instrument_id, :ticker, :as_of,
+        :size_log_mkt_cap, :book_to_market, :mom_12_1,
+        :quality_roa, :investment_growth, :profitability_gross,
+        :source_filing_date, now()
+    )
+    ON CONFLICT (instrument_id, as_of) DO UPDATE SET
+        ticker = EXCLUDED.ticker,
+        size_log_mkt_cap = EXCLUDED.size_log_mkt_cap,
+        book_to_market = EXCLUDED.book_to_market,
+        mom_12_1 = EXCLUDED.mom_12_1,
+        quality_roa = EXCLUDED.quality_roa,
+        investment_growth = EXCLUDED.investment_growth,
+        profitability_gross = EXCLUDED.profitability_gross,
+        source_filing_date = EXCLUDED.source_filing_date,
+        computed_at = now()
+"""
+
+
+async def _upsert_rows(db: AsyncSession, rows: list[dict[str, Any]]) -> int:
+    """Batch upsert rows. Returns count written."""
+    if not rows:
+        return 0
+    stmt = text(_UPSERT_SQL)
+    for row in rows:
+        await db.execute(stmt, row)
+    await db.commit()
+    return len(rows)

--- a/backend/app/core/jobs/fund_characteristics_aggregator.py
+++ b/backend/app/core/jobs/fund_characteristics_aggregator.py
@@ -496,11 +496,14 @@ async def _load_nav_series(
 ) -> pd.Series:
     """Load NAV time-series for an instrument as a month-end pandas Series.
 
-    nav_timeseries is stored at daily frequency (instrument_ingestion worker
-    pulls daily NAV from Yahoo Finance). For 12-1 momentum (Jegadeesh-Titman
-    convention) we need MONTHLY observations — derive_momentum_12_1 takes
-    iloc[-13:-1] expecting that to span 12 calendar months. Feeding it daily
-    data would give a 13-trading-day window (~2.5 weeks) instead of 12 months.
+    nav_timeseries is populated at daily frequency by the
+    instrument_ingestion worker (lock 900_010), which pulls per-ticker
+    daily NAV via the Tiingo API (~15 years of history covered for the
+    universe). For 12-1 momentum (Jegadeesh-Titman convention) we need
+    MONTHLY observations — derive_momentum_12_1 takes iloc[-13:-1]
+    expecting that 13-element window to span 12 calendar months.
+    Feeding it the raw daily series would give a 13-trading-day window
+    (~2.5 weeks) instead of 12 months.
 
     Resample to month-end last value here so any caller gets the correct
     cadence for momentum / longitudinal characteristics.

--- a/backend/app/core/jobs/fund_characteristics_aggregator.py
+++ b/backend/app/core/jobs/fund_characteristics_aggregator.py
@@ -135,36 +135,53 @@ async def _load_universe(
     - Are BDCs (direct XBRL path, no N-PORT needed)
     """
     limit_clause = f" LIMIT {int(limit)}" if limit else ""
+    # CIK normalization: instruments_universe.attributes.sec_cik is stored
+    # as a string sometimes zero-padded ("0000884394" for SPY), sometimes
+    # not ("36405" for VTI). sec_nport_holdings.cik (text) and
+    # sec_bdcs/sec_money_market_funds.cik (varchar) are stored without
+    # padding. Casting both sides to BIGINT works but bypasses the btree
+    # index on n.cik causing seqscan on a 2M-row table (>2min queries).
+    # Instead, normalize the universe value via LTRIM(_, '0') to match
+    # the unpadded format — this preserves index lookups on the
+    # indexed columns. Match as text.
     result = await db.execute(text(f"""
+        WITH norm_universe AS (
+            SELECT
+                i.instrument_id,
+                i.ticker,
+                i.asset_class,
+                i.attributes->>'sec_cik' AS sec_cik_raw,
+                LTRIM(i.attributes->>'sec_cik', '0') AS sec_cik_norm
+            FROM instruments_universe i
+            WHERE i.attributes->>'sec_cik' IS NOT NULL
+              AND i.attributes->>'sec_cik' ~ '^[0-9]+$'
+        )
         SELECT
-            i.instrument_id,
-            i.ticker,
-            i.asset_class,
-            i.attributes->>'sec_cik' AS sec_cik,
+            u.instrument_id,
+            u.ticker,
+            u.asset_class,
+            u.sec_cik_norm AS sec_cik,
             CASE
                 WHEN EXISTS (
                     SELECT 1 FROM sec_bdcs b
-                    WHERE b.cik::text = i.attributes->>'sec_cik'
+                    WHERE b.cik = u.sec_cik_norm
                 ) THEN 'bdc'
                 WHEN EXISTS (
                     SELECT 1 FROM sec_money_market_funds m
-                    WHERE m.cik::text = i.attributes->>'sec_cik'
+                    WHERE m.cik = u.sec_cik_norm
                 ) THEN 'mmf'
                 ELSE 'standard'
             END AS fund_category
-        FROM instruments_universe i
-        WHERE i.attributes->>'sec_cik' IS NOT NULL
-          AND (
-              EXISTS (
+        FROM norm_universe u
+        WHERE EXISTS (
                   SELECT 1 FROM sec_nport_holdings n
-                  WHERE n.cik = i.attributes->>'sec_cik'
+                  WHERE n.cik = u.sec_cik_norm
               )
               OR EXISTS (
                   SELECT 1 FROM sec_bdcs b
-                  WHERE b.cik::text = i.attributes->>'sec_cik'
+                  WHERE b.cik = u.sec_cik_norm
               )
-          )
-        ORDER BY i.ticker NULLS LAST
+        ORDER BY u.ticker NULLS LAST
         {limit_clause}
     """))
     return [
@@ -197,7 +214,9 @@ async def _compute_via_aggregation(
     instrument_id = fund["instrument_id"]
     ticker = fund.get("ticker") or ""
 
-    # Get all distinct N-PORT report dates for this fund
+    # Get all distinct N-PORT report dates for this fund.
+    # sec_cik is normalized text (no leading zeros) from _load_universe.
+    # n.cik is text — direct equality preserves index usage.
     report_dates_result = await db.execute(text("""
         SELECT DISTINCT report_date
         FROM sec_nport_holdings

--- a/backend/tests/integration/test_fund_characteristics_aggregator.py
+++ b/backend/tests/integration/test_fund_characteristics_aggregator.py
@@ -1,0 +1,566 @@
+"""Integration tests for fund_characteristics_aggregator worker.
+
+Covers 7 acceptance gates:
+    - basic_aggregation: 1 fund with 3 equity holdings -> correct portfolio-level chars
+    - period_matching: picks latest company chars <= report_date
+    - unresolved_holding_skipped: holding with no issuer_cik is skipped, not error
+    - bdc_direct_path: BDC uses direct XBRL, not N-PORT aggregation
+    - momentum_from_fund_nav: mom_12_1 from fund's own NAV, not aggregated
+    - mmf_skipped: money market fund produces no output
+    - idempotent_rerun: second run upserts without duplicating
+
+Requires a running Postgres with migrations through 0174 applied.
+Self-seeding — no dev_seed_local dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import uuid
+from datetime import date, timedelta
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+# Synthetic test IDs
+_FUND_ID_A = uuid.UUID("aaaaaaaa-0001-0001-0001-aaaaaaaaaaaa")
+_FUND_ID_B = uuid.UUID("aaaaaaaa-0002-0002-0002-aaaaaaaaaaaa")  # BDC
+_FUND_ID_C = uuid.UUID("aaaaaaaa-0003-0003-0003-aaaaaaaaaaaa")  # MMF
+_FUND_ID_D = uuid.UUID("aaaaaaaa-0004-0004-0004-aaaaaaaaaaaa")  # momentum test
+
+_FUND_CIK_A = "9990001"
+_FUND_CIK_B = "9990002"
+_FUND_CIK_C = "9990003"
+_FUND_CIK_D = "9990004"
+
+_COMPANY_CIK_1 = 8880001
+_COMPANY_CIK_2 = 8880002
+_COMPANY_CIK_3 = 8880003
+
+_CUSIP_1 = "TSTCSP001"
+_CUSIP_2 = "TSTCSP002"
+_CUSIP_3 = "TSTCSP003"  # no issuer_cik — unresolved
+
+
+def _get_session_factory():
+    try:
+        from app.core.db.engine import async_session_factory
+        return async_session_factory
+    except Exception as exc:
+        pytest.skip(f"Cannot import session factory: {exc}")
+
+
+async def _cleanup(db):
+    """Remove all test data."""
+    from sqlalchemy import text
+    fund_ids = ", ".join(
+        f"'{x}'" for x in [_FUND_ID_A, _FUND_ID_B, _FUND_ID_C, _FUND_ID_D]
+    )
+    cik_list = ", ".join(str(c) for c in [_COMPANY_CIK_1, _COMPANY_CIK_2, _COMPANY_CIK_3])
+    fund_ciks = ", ".join(f"'{c}'" for c in [_FUND_CIK_A, _FUND_CIK_B, _FUND_CIK_C, _FUND_CIK_D])
+    cusips = ", ".join(f"'{c}'" for c in [_CUSIP_1, _CUSIP_2, _CUSIP_3])
+
+    await db.execute(text(
+        f"DELETE FROM equity_characteristics_monthly WHERE instrument_id IN ({fund_ids})"
+    ))
+    await db.execute(text(
+        f"DELETE FROM nav_timeseries WHERE instrument_id IN ({fund_ids})"
+    ))
+    await db.execute(text(
+        f"DELETE FROM sec_nport_holdings WHERE cik IN ({fund_ciks})"
+    ))
+    await db.execute(text(
+        f"DELETE FROM sec_cusip_ticker_map WHERE cusip IN ({cusips})"
+    ))
+    await db.execute(text(
+        f"DELETE FROM company_characteristics_monthly WHERE cik IN ({cik_list})"
+    ))
+    await db.execute(text(
+        f"DELETE FROM instruments_universe WHERE instrument_id IN ({fund_ids})"
+    ))
+    # Clean up BDC/MMF test rows (cik is varchar in both tables)
+    await db.execute(text(
+        f"DELETE FROM sec_bdcs WHERE cik IN ('{_FUND_CIK_B}')"
+    ))
+    await db.execute(text(
+        f"DELETE FROM sec_money_market_funds WHERE cik IN ('{_FUND_CIK_C}')"
+    ))
+    await db.commit()
+
+
+async def _seed_instrument(db, instrument_id, ticker, sec_cik, asset_class="equity"):
+    from sqlalchemy import text
+    attrs = {
+        "sec_cik": sec_cik,
+        "aum_usd": 1000000,
+        "manager_name": "Test Manager",
+        "inception_date": "2020-01-01",
+    }
+    import json
+    await db.execute(text("""
+        INSERT INTO instruments_universe (
+            instrument_id, instrument_type, name, ticker, asset_class,
+            geography, currency, attributes
+        ) VALUES (
+            :iid, 'fund', :name, :ticker, :asset_class,
+            'US', 'USD', CAST(:attrs AS jsonb)
+        )
+        ON CONFLICT (instrument_id) DO NOTHING
+    """), {
+        "iid": instrument_id,
+        "name": f"Test Fund {ticker}",
+        "ticker": ticker,
+        "asset_class": asset_class,
+        "attrs": json.dumps(attrs),
+    })
+
+
+async def _seed_nport_holding(db, cik, cusip, report_date, market_value, quantity,
+                              asset_class="EC"):
+    from sqlalchemy import text
+    await db.execute(text("""
+        INSERT INTO sec_nport_holdings (
+            report_date, cik, cusip, market_value, quantity, asset_class
+        ) VALUES (
+            :report_date, :cik, :cusip, :market_value, :quantity, :asset_class
+        )
+        ON CONFLICT DO NOTHING
+    """), {
+        "report_date": report_date,
+        "cik": cik,
+        "cusip": cusip,
+        "market_value": market_value,
+        "quantity": quantity,
+        "asset_class": asset_class,
+    })
+
+
+async def _seed_cusip_map(db, cusip, issuer_cik=None):
+    from sqlalchemy import text
+    await db.execute(text("""
+        INSERT INTO sec_cusip_ticker_map (cusip, issuer_cik, resolved_via)
+        VALUES (:cusip, :issuer_cik, 'test')
+        ON CONFLICT (cusip) DO NOTHING
+    """), {"cusip": cusip, "issuer_cik": issuer_cik})
+
+
+async def _seed_company_chars(db, cik, period_end,
+                              book_equity=400.0, total_assets=1000.0,
+                              net_income_ttm=100.0, revenue=500.0,
+                              gross_profit=200.0, capex_ttm=50.0,
+                              ppe_prior=300.0, shares_outstanding=1_000_000.0):
+    from sqlalchemy import text
+    quality_roa = net_income_ttm / total_assets if total_assets > 0 else None
+    profitability_gross = gross_profit / revenue if revenue > 0 else None
+    investment_growth = capex_ttm / ppe_prior if ppe_prior > 0 else None
+    await db.execute(text("""
+        INSERT INTO company_characteristics_monthly (
+            cik, period_end, book_equity, total_assets, net_income_ttm,
+            revenue, gross_profit, capex_ttm, ppe_prior, shares_outstanding,
+            quality_roa, investment_growth, profitability_gross,
+            source_filing_date, computed_at
+        ) VALUES (
+            :cik, :period_end, :book_equity, :total_assets, :net_income_ttm,
+            :revenue, :gross_profit, :capex_ttm, :ppe_prior, :shares_outstanding,
+            :quality_roa, :investment_growth, :profitability_gross,
+            :source_filing_date, now()
+        )
+        ON CONFLICT (cik, period_end) DO NOTHING
+    """), {
+        "cik": cik,
+        "period_end": period_end,
+        "book_equity": book_equity,
+        "total_assets": total_assets,
+        "net_income_ttm": net_income_ttm,
+        "revenue": revenue,
+        "gross_profit": gross_profit,
+        "capex_ttm": capex_ttm,
+        "ppe_prior": ppe_prior,
+        "shares_outstanding": shares_outstanding,
+        "quality_roa": quality_roa,
+        "investment_growth": investment_growth,
+        "profitability_gross": profitability_gross,
+        "source_filing_date": date(2024, 2, 15),
+    })
+
+
+async def _seed_nav(db, instrument_id, nav_date, nav_value):
+    from sqlalchemy import text
+    await db.execute(text("""
+        INSERT INTO nav_timeseries (instrument_id, nav_date, nav)
+        VALUES (:iid, :nav_date, :nav)
+        ON CONFLICT (instrument_id, nav_date) DO NOTHING
+    """), {"iid": instrument_id, "nav_date": nav_date, "nav": nav_value})
+
+
+async def _seed_bdc(db, cik):
+    from sqlalchemy import text
+    await db.execute(text("""
+        INSERT INTO sec_bdcs (series_id, cik, fund_name, ticker, strategy_label)
+        VALUES (:sid, :cik, 'Test BDC', 'TBDC', 'Private Credit')
+        ON CONFLICT DO NOTHING
+    """), {"sid": str(cik), "cik": str(cik)})
+
+
+async def _seed_mmf(db, cik):
+    from sqlalchemy import text
+    await db.execute(text("""
+        INSERT INTO sec_money_market_funds (series_id, cik, fund_name, mmf_category)
+        VALUES (:sid, :cik, 'Test MMF', 'Prime')
+        ON CONFLICT DO NOTHING
+    """), {"sid": str(cik), "cik": str(cik)})
+
+
+async def _get_fund_chars(db, instrument_id) -> list:
+    from sqlalchemy import text
+    result = await db.execute(text("""
+        SELECT * FROM equity_characteristics_monthly
+        WHERE instrument_id = :iid
+        ORDER BY as_of
+    """), {"iid": instrument_id})
+    return result.all()
+
+
+async def _run_aggregator_for_funds(fund_ids: list):
+    """Run the aggregator targeting specific funds via internal functions."""
+    factory = _get_session_factory()
+    async with factory() as db:
+        from app.core.jobs.fund_characteristics_aggregator import (
+            _classify_fund,
+            _compute_bdc_direct,
+            _compute_via_aggregation,
+            _load_universe,
+            _upsert_rows,
+        )
+        all_funds = await _load_universe(db)
+        target_ids = {str(fid) for fid in fund_ids}
+        for fund in all_funds:
+            if str(fund["instrument_id"]) not in target_ids:
+                continue
+            pipeline = _classify_fund(fund)
+            if pipeline == "skip":
+                continue
+            if pipeline == "bdc_direct":
+                rows = await _compute_bdc_direct(db, fund)
+            else:
+                rows = await _compute_via_aggregation(db, fund)
+            if rows:
+                await _upsert_rows(db, rows)
+
+
+# ---------- Test 1: basic_aggregation ----------
+
+def test_basic_aggregation():
+    """1 fund with 3 equity holdings, known company chars -> correct portfolio-level formulas."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db)
+
+            # Seed instrument
+            await _seed_instrument(db, _FUND_ID_A, "TFND", _FUND_CIK_A)
+
+            report_date = date(2024, 6, 30)
+
+            # Seed 3 holdings
+            # Holding 1: 10,000 shares of company 1 (1M shares outstanding)
+            await _seed_nport_holding(db, _FUND_CIK_A, _CUSIP_1, report_date,
+                                      market_value=500_000, quantity=10_000)
+            # Holding 2: 5,000 shares of company 2 (500k shares outstanding)
+            await _seed_nport_holding(db, _FUND_CIK_A, _CUSIP_2, report_date,
+                                      market_value=300_000, quantity=5_000)
+
+            # Seed CUSIP map
+            await _seed_cusip_map(db, _CUSIP_1, issuer_cik=f"{_COMPANY_CIK_1:010d}")
+            await _seed_cusip_map(db, _CUSIP_2, issuer_cik=f"{_COMPANY_CIK_2:010d}")
+
+            # Seed company characteristics
+            # Company 1: book_equity=400M, total_assets=1B, net_income_ttm=100M,
+            #            revenue=500M, gross_profit=200M, capex=50M, ppe_prior=300M,
+            #            shares_outstanding=1M
+            await _seed_company_chars(db, _COMPANY_CIK_1, date(2024, 3, 31),
+                                      book_equity=400_000_000, total_assets=1_000_000_000,
+                                      net_income_ttm=100_000_000, revenue=500_000_000,
+                                      gross_profit=200_000_000, capex_ttm=50_000_000,
+                                      ppe_prior=300_000_000, shares_outstanding=1_000_000)
+            # Company 2: book_equity=200M, total_assets=800M, net_income_ttm=80M,
+            #            revenue=400M, gross_profit=160M, capex=40M, ppe_prior=250M,
+            #            shares_outstanding=500k
+            await _seed_company_chars(db, _COMPANY_CIK_2, date(2024, 3, 31),
+                                      book_equity=200_000_000, total_assets=800_000_000,
+                                      net_income_ttm=80_000_000, revenue=400_000_000,
+                                      gross_profit=160_000_000, capex_ttm=40_000_000,
+                                      ppe_prior=250_000_000, shares_outstanding=500_000)
+            await db.commit()
+
+        # Run aggregator
+        await _run_aggregator_for_funds([_FUND_ID_A])
+
+        # Verify
+        async with factory() as db:
+            rows = await _get_fund_chars(db, _FUND_ID_A)
+            assert len(rows) == 1, f"Expected 1 row, got {len(rows)}"
+            row = rows[0]
+
+            # ownership_frac_1 = 10000 / 1_000_000 = 0.01
+            # ownership_frac_2 = 5000 / 500_000 = 0.01
+            # sum_market_value = 500_000 + 300_000 = 800_000
+            # sum_book_equity = 400M * 0.01 + 200M * 0.01 = 4M + 2M = 6M
+            # sum_total_assets = 1B * 0.01 + 800M * 0.01 = 10M + 8M = 18M
+            # sum_net_income = 100M * 0.01 + 80M * 0.01 = 1M + 0.8M = 1.8M
+            # sum_revenue = 500M * 0.01 + 400M * 0.01 = 5M + 4M = 9M
+            # sum_gross_profit = 200M * 0.01 + 160M * 0.01 = 2M + 1.6M = 3.6M
+
+            expected_size = round(math.log(800_000), 4)
+            expected_bm = round(6_000_000 / 800_000, 4)
+            expected_roa = round(1_800_000 / 18_000_000, 4)
+            expected_prof = round(3_600_000 / 9_000_000, 4)
+
+            assert abs(float(row.size_log_mkt_cap) - expected_size) < 0.01, \
+                f"size: {row.size_log_mkt_cap} vs {expected_size}"
+            assert abs(float(row.book_to_market) - expected_bm) < 0.01, \
+                f"B/M: {row.book_to_market} vs {expected_bm}"
+            assert abs(float(row.quality_roa) - expected_roa) < 0.001, \
+                f"ROA: {row.quality_roa} vs {expected_roa}"
+            assert abs(float(row.profitability_gross) - expected_prof) < 0.001, \
+                f"profitability: {row.profitability_gross} vs {expected_prof}"
+
+            await _cleanup(db)
+
+    asyncio.get_event_loop().run_until_complete(_test())
+
+
+# ---------- Test 2: period_matching ----------
+
+def test_period_matching():
+    """Company has chars at Q1 and Q3 only. N-PORT date is Q2 -> picks Q1."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db)
+            await _seed_instrument(db, _FUND_ID_A, "TFND", _FUND_CIK_A)
+
+            report_date = date(2024, 6, 30)  # Q2
+            await _seed_nport_holding(db, _FUND_CIK_A, _CUSIP_1, report_date,
+                                      market_value=500_000, quantity=10_000)
+            await _seed_cusip_map(db, _CUSIP_1, issuer_cik=f"{_COMPANY_CIK_1:010d}")
+
+            # Q1 chars (should be picked)
+            await _seed_company_chars(db, _COMPANY_CIK_1, date(2024, 3, 31),
+                                      book_equity=400_000_000, total_assets=1_000_000_000,
+                                      net_income_ttm=100_000_000, revenue=500_000_000,
+                                      gross_profit=200_000_000, shares_outstanding=1_000_000)
+            # Q3 chars (should NOT be picked — after report_date)
+            await _seed_company_chars(db, _COMPANY_CIK_1, date(2024, 9, 30),
+                                      book_equity=999_000_000, total_assets=2_000_000_000,
+                                      net_income_ttm=200_000_000, revenue=800_000_000,
+                                      gross_profit=400_000_000, shares_outstanding=1_000_000)
+            await db.commit()
+
+        await _run_aggregator_for_funds([_FUND_ID_A])
+
+        async with factory() as db:
+            rows = await _get_fund_chars(db, _FUND_ID_A)
+            assert len(rows) == 1
+            row = rows[0]
+            # ownership_frac = 10000 / 1_000_000 = 0.01
+            # book_equity = 400M * 0.01 = 4M (from Q1, NOT 999M from Q3)
+            expected_bm = round(4_000_000 / 500_000, 4)
+            assert abs(float(row.book_to_market) - expected_bm) < 0.01, \
+                f"B/M should use Q1 data: {row.book_to_market} vs {expected_bm}"
+            await _cleanup(db)
+
+    asyncio.get_event_loop().run_until_complete(_test())
+
+
+# ---------- Test 3: unresolved_holding_skipped ----------
+
+def test_unresolved_holding_skipped():
+    """Holding with no issuer_cik is skipped, doesn't error."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db)
+            await _seed_instrument(db, _FUND_ID_A, "TFND", _FUND_CIK_A)
+
+            report_date = date(2024, 6, 30)
+
+            # Holding 1: resolved
+            await _seed_nport_holding(db, _FUND_CIK_A, _CUSIP_1, report_date,
+                                      market_value=500_000, quantity=10_000)
+            await _seed_cusip_map(db, _CUSIP_1, issuer_cik=f"{_COMPANY_CIK_1:010d}")
+            await _seed_company_chars(db, _COMPANY_CIK_1, date(2024, 3, 31),
+                                      shares_outstanding=1_000_000)
+
+            # Holding 2: unresolved (no issuer_cik in map)
+            await _seed_nport_holding(db, _FUND_CIK_A, _CUSIP_3, report_date,
+                                      market_value=200_000, quantity=5_000)
+            await _seed_cusip_map(db, _CUSIP_3, issuer_cik=None)
+
+            await db.commit()
+
+        await _run_aggregator_for_funds([_FUND_ID_A])
+
+        async with factory() as db:
+            rows = await _get_fund_chars(db, _FUND_ID_A)
+            # Should produce output from resolved holding only
+            assert len(rows) == 1, f"Expected 1 row, got {len(rows)}"
+            # size_log_mkt_cap should reflect only the resolved holding's market_value
+            row = rows[0]
+            expected_size = round(math.log(500_000), 4)
+            assert abs(float(row.size_log_mkt_cap) - expected_size) < 0.01
+            await _cleanup(db)
+
+    asyncio.get_event_loop().run_until_complete(_test())
+
+
+# ---------- Test 4: bdc_direct_path ----------
+
+def test_bdc_direct_path():
+    """BDC uses direct XBRL path, NOT N-PORT aggregation."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db)
+
+            await _seed_instrument(db, _FUND_ID_B, "TBDC", _FUND_CIK_B)
+            # Register as BDC
+            await _seed_bdc(db, _FUND_CIK_B)
+
+            # Seed company chars for BDC's own CIK
+            bdc_cik_int = int(_FUND_CIK_B)
+            await _seed_company_chars(db, bdc_cik_int, date(2024, 3, 31),
+                                      book_equity=500_000_000, total_assets=2_000_000_000,
+                                      net_income_ttm=150_000_000, revenue=300_000_000,
+                                      gross_profit=180_000_000)
+            await db.commit()
+
+        await _run_aggregator_for_funds([_FUND_ID_B])
+
+        async with factory() as db:
+            rows = await _get_fund_chars(db, _FUND_ID_B)
+            assert len(rows) >= 1, f"BDC should have at least 1 row, got {len(rows)}"
+            row = rows[0]
+            # BDC uses total_assets for size approximation
+            expected_size = round(math.log(2_000_000_000), 4)
+            assert abs(float(row.size_log_mkt_cap) - expected_size) < 0.1
+            # quality_roa from company_chars directly
+            expected_roa = round(150_000_000 / 2_000_000_000, 4)
+            assert abs(float(row.quality_roa) - expected_roa) < 0.001
+            await _cleanup(db)
+
+    asyncio.get_event_loop().run_until_complete(_test())
+
+
+# ---------- Test 5: momentum_from_fund_nav ----------
+
+def test_momentum_from_fund_nav():
+    """mom_12_1 computed from fund's own NAV, not aggregated from holdings."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db)
+            await _seed_instrument(db, _FUND_ID_D, "TMOM", _FUND_CIK_D)
+
+            report_date = date(2024, 6, 30)
+            await _seed_nport_holding(db, _FUND_CIK_D, _CUSIP_1, report_date,
+                                      market_value=1_000_000, quantity=10_000)
+            await _seed_cusip_map(db, _CUSIP_1, issuer_cik=f"{_COMPANY_CIK_1:010d}")
+            await _seed_company_chars(db, _COMPANY_CIK_1, date(2024, 3, 31),
+                                      shares_outstanding=1_000_000)
+
+            # Seed 13 months of NAV data (t-13 to t-1 relative to report_date)
+            # NAV goes from 100 to 120 over 12 months -> 20% return
+            base_date = date(2023, 5, 31)  # 13 months before report_date
+            for i in range(14):
+                nav_date = base_date + timedelta(days=30 * i)
+                nav_value = 100.0 + (20.0 * i / 13.0)
+                await _seed_nav(db, _FUND_ID_D, nav_date, nav_value)
+            await db.commit()
+
+        await _run_aggregator_for_funds([_FUND_ID_D])
+
+        async with factory() as db:
+            rows = await _get_fund_chars(db, _FUND_ID_D)
+            assert len(rows) == 1
+            row = rows[0]
+            # mom_12_1 should be non-None (from NAV series)
+            assert row.mom_12_1 is not None, "mom_12_1 should be computed from fund NAV"
+            # Should be positive (NAV went up)
+            assert float(row.mom_12_1) > 0, f"Expected positive momentum, got {row.mom_12_1}"
+            await _cleanup(db)
+
+    asyncio.get_event_loop().run_until_complete(_test())
+
+
+# ---------- Test 6: mmf_skipped ----------
+
+def test_mmf_skipped():
+    """Money market fund produces no output row."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db)
+            await _seed_instrument(db, _FUND_ID_C, "TMMF", _FUND_CIK_C, asset_class="cash")
+            await _seed_mmf(db, _FUND_CIK_C)
+
+            # Seed N-PORT data so it would appear in universe if not filtered
+            report_date = date(2024, 6, 30)
+            await _seed_nport_holding(db, _FUND_CIK_C, _CUSIP_1, report_date,
+                                      market_value=1_000_000, quantity=1_000_000)
+            await _seed_cusip_map(db, _CUSIP_1, issuer_cik=f"{_COMPANY_CIK_1:010d}")
+            await _seed_company_chars(db, _COMPANY_CIK_1, date(2024, 3, 31),
+                                      shares_outstanding=1_000_000)
+            await db.commit()
+
+        await _run_aggregator_for_funds([_FUND_ID_C])
+
+        async with factory() as db:
+            rows = await _get_fund_chars(db, _FUND_ID_C)
+            assert len(rows) == 0, f"MMF should be skipped, got {len(rows)} rows"
+            await _cleanup(db)
+
+    asyncio.get_event_loop().run_until_complete(_test())
+
+
+# ---------- Test 7: idempotent_rerun ----------
+
+def test_idempotent_rerun():
+    """Running aggregator twice produces same row count (ON CONFLICT UPDATE)."""
+    factory = _get_session_factory()
+
+    async def _test():
+        async with factory() as db:
+            await _cleanup(db)
+            await _seed_instrument(db, _FUND_ID_A, "TFND", _FUND_CIK_A)
+
+            report_date = date(2024, 6, 30)
+            await _seed_nport_holding(db, _FUND_CIK_A, _CUSIP_1, report_date,
+                                      market_value=500_000, quantity=10_000)
+            await _seed_cusip_map(db, _CUSIP_1, issuer_cik=f"{_COMPANY_CIK_1:010d}")
+            await _seed_company_chars(db, _COMPANY_CIK_1, date(2024, 3, 31),
+                                      shares_outstanding=1_000_000)
+            await db.commit()
+
+        # First run
+        await _run_aggregator_for_funds([_FUND_ID_A])
+        async with factory() as db:
+            count1 = len(await _get_fund_chars(db, _FUND_ID_A))
+
+        # Second run
+        await _run_aggregator_for_funds([_FUND_ID_A])
+        async with factory() as db:
+            count2 = len(await _get_fund_chars(db, _FUND_ID_A))
+            assert count1 == count2, f"Idempotency violated: {count1} vs {count2}"
+            assert count1 > 0, "Should have produced at least 1 row"
+            await _cleanup(db)
+
+    asyncio.get_event_loop().run_until_complete(_test())


### PR DESCRIPTION
## Summary

Layer 2 of the Option B fund-characteristics pipeline (issue #289). Aggregates per-CIK fundamentals from `company_characteristics_monthly` over each fund's N-PORT holdings, producing per-fund Kelly-Pruitt-Su chars in `equity_characteristics_monthly`.

Closes #289 (data layer side — terminal UX comes in PR-Q8B).

## Architecture

```
sec_nport_holdings (fund positions, CUSIP-keyed)
   ↓ JOIN sec_cusip_ticker_map (issuer_cik, 24% coverage)
   ↓ JOIN company_characteristics_monthly (latest period_end ≤ report_date)
   → portfolio-level aggregation (Fama-French / CRSP convention)
   → equity_characteristics_monthly (instrument_id-keyed, output)
```

## Aggregation method

Hybrid: weighted mean for momentum (additive); portfolio-level numerator/denominator for B/M, ROA, investment_growth, profitability_gross. Holding scaling via `ownership_fraction = nport.quantity / company.shares_outstanding` so each holding contributes `ownership × company_metric`.

`mom_12_1` is computed directly from fund's own NAV in `nav_timeseries` — fund IS its own price series, no aggregation needed.

## Sub-pipelines

| Fund type | Path | Why |
|---|---|---|
| ETF, open-end, closed-end, interval | aggregate via N-PORT | Have N-PORT with equity holdings |
| BDC | direct XBRL (reuses Q8A-v1 logic) | File 10-K; holdings are debt not equity |
| MMF, private | skip | No N-PORT / no holdings |

## Coverage

- 4,763 funds with N-PORT filings (target population)
- 24% of CUSIPs in N-PORT have `issuer_cik` mapped — 76% of holdings silently skipped (transparent loss)
- BDCs covered via direct XBRL path

## Test plan

- [x] 7 integration test cases: aggregation, period matching, unresolved skip, BDC direct, NAV momentum, MMF skip, idempotency
- [x] Full pytest suite: 0 new failures (6 pre-existing on main)

## Follow-ups

- **PR-Q8B**: terminal `/research/[instrumentId]` route consuming `/api/v1/research/funds/{id}` (no backend changes needed — endpoint already exists, will return populated data after this merge)
- Coverage improvement: ingest more SEC tickers/CIKs into `sec_cusip_ticker_map` to raise the 24% match rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>