### PR TITLE
IPCA rail rank-transform + asset_class filter + dispatcher fixes [PR-Q10]

### DIFF
--- a/backend/app/core/db/migrations/versions/0176_add_asset_class_to_factor_model_fits.py
+++ b/backend/app/core/db/migrations/versions/0176_add_asset_class_to_factor_model_fits.py
@@ -1,0 +1,53 @@
+"""add asset_class column to factor_model_fits
+
+Splits the (panel-identifying) universe_hash from the (lookup-key)
+asset_class. Worker writes asset_class explicitly; rail filters by it.
+universe_hash remains MD5 of the panel for drift tracking.
+
+Revision ID: 0176_add_asset_class_to_factor_model_fits
+Revises: 0175_add_issuer_cik_to_cusip_map
+Create Date: 2026-04-25
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0176_add_asset_class_to_factor_model_fits"
+down_revision = "0175_add_issuer_cik_to_cusip_map"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "factor_model_fits",
+        sa.Column(
+            "asset_class",
+            sa.String(length=32),
+            nullable=False,
+            server_default="Equity",
+        ),
+    )
+    op.drop_index(
+        "ix_factor_model_fits_lookup",
+        table_name="factor_model_fits",
+    )
+    op.create_index(
+        "ix_factor_model_fits_lookup",
+        "factor_model_fits",
+        ["engine", "asset_class", "fit_date"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_factor_model_fits_lookup",
+        table_name="factor_model_fits",
+    )
+    op.create_index(
+        "ix_factor_model_fits_lookup",
+        "factor_model_fits",
+        ["engine", "universe_hash", "converged", "fit_date"],
+        unique=False,
+    )
+    op.drop_column("factor_model_fits", "asset_class")

--- a/backend/app/core/jobs/ipca_estimation.py
+++ b/backend/app/core/jobs/ipca_estimation.py
@@ -60,6 +60,7 @@ WHERE e.as_of <= :asof
 async def run_ipca_estimation(
     asof: date | None = None,
     min_panel_size: int = 300,
+    asset_class: str = "Equity",
 ) -> dict[str, Any]:
     """Entry point. Acquires advisory lock, builds panel, fits IPCA, persists."""
     if asof is None:
@@ -73,7 +74,7 @@ async def run_ipca_estimation(
             logger.info("ipca_estimation skip — lock held")
             return {"status": "skipped", "reason": "lock_held"}
         try:
-            return await _run(db, asof=asof, min_panel_size=min_panel_size)
+            return await _run(db, asof=asof, min_panel_size=min_panel_size, asset_class=asset_class)
         except Exception:
             await db.rollback()
             raise
@@ -90,6 +91,7 @@ async def _run(
     db: Any,
     asof: date,
     min_panel_size: int,
+    asset_class: str,
 ) -> dict[str, Any]:
     logger.info("ipca_estimation_started", asof=str(asof))
 
@@ -160,10 +162,11 @@ async def _run(
     try:
         stmt_old = text("""
             SELECT gamma_loadings FROM factor_model_fits
-            WHERE engine = 'ipca' AND universe_hash = :hash
+            WHERE engine = 'ipca' AND asset_class = :asset_class
+              AND universe_hash = :hash
             ORDER BY fit_date DESC LIMIT 1
         """)
-        res_old = await db.execute(stmt_old, {"hash": universe_hash})
+        res_old = await db.execute(stmt_old, {"asset_class": asset_class, "hash": universe_hash})
         row_old = res_old.first()
         if row_old and row_old.gamma_loadings:
             gamma_old_data = row_old.gamma_loadings
@@ -204,11 +207,11 @@ async def _run(
     await db.execute(
         text("""
             INSERT INTO factor_model_fits (
-                fit_id, engine, fit_date, universe_hash, k_factors,
+                fit_id, engine, fit_date, universe_hash, asset_class, k_factors,
                 gamma_loadings, factor_returns, oos_r_squared,
                 converged, n_iterations
             ) VALUES (
-                gen_random_uuid(), 'ipca', :fit_date, :hash, :k,
+                gen_random_uuid(), 'ipca', :fit_date, :hash, :asset_class, :k,
                 CAST(:gamma AS jsonb), CAST(:f_returns AS jsonb), :oos_r2,
                 :converged, :n_iter
             )
@@ -216,6 +219,7 @@ async def _run(
         {
             "fit_date": asof,
             "hash": universe_hash,
+            "asset_class": asset_class,
             "k": fit.K,
             "gamma": json.dumps(gamma_loadings),
             "f_returns": json.dumps(factor_returns_json),
@@ -236,6 +240,7 @@ async def _run(
         "n_instruments": len(instrument_ids),
         "n_obs": n_obs,
         "universe_hash": universe_hash,
+        "asset_class": asset_class,
         "drift": drift,
     }
     logger.info("ipca_estimation_completed", **summary)

--- a/backend/quant_engine/factor_model_ipca_service.py
+++ b/backend/quant_engine/factor_model_ipca_service.py
@@ -12,22 +12,9 @@ import structlog
 
 from quant_engine.factor_model_service import FactorModelResult
 from quant_engine.ipca.fit import IPCAFit, fit_ipca
+from quant_engine.ipca.preprocessing import rank_transform
 
 logger = structlog.get_logger()
-
-
-def _rank_transform(chars: pd.DataFrame) -> pd.DataFrame:
-    """Cross-sectional rank → [-0.5, +0.5] per period (KP-S 2019 convention).
-
-    Ranks each characteristic within each cross-section (per time period in
-    the MultiIndex level=1) and rescales to [-0.5, +0.5]. Robust to outliers
-    in heavy-tailed inputs like book_to_market and investment_growth.
-    Per-period ranking is leakage-free: train and test cross-sections are
-    entirely disjoint by date.
-    """
-    return chars.groupby(level=1).transform(
-        lambda g: g.rank(pct=True) - 0.5
-    )
 
 
 @dataclass(frozen=True)
@@ -61,7 +48,7 @@ def fit_universe(
     # Applied once on the full panel — groupby(level=1) ensures each
     # time period is ranked independently, so train/test splits by date
     # are leakage-free.
-    aligned_chars = _rank_transform(aligned_chars)
+    aligned_chars = rank_transform(aligned_chars)
 
     dates = pd.DatetimeIndex(np.unique(aligned_chars.index.get_level_values(1))).sort_values()
     

--- a/backend/quant_engine/ipca/preprocessing.py
+++ b/backend/quant_engine/ipca/preprocessing.py
@@ -1,0 +1,20 @@
+"""IPCA preprocessing helpers (KP-S 2019 conventions)."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def rank_transform(chars: pd.DataFrame) -> pd.DataFrame:
+    """Cross-sectional rank -> [-0.5, +0.5] per period.
+
+    Ranks each characteristic within each cross-section (per time period
+    in the MultiIndex level=1) and rescales to [-0.5, +0.5]. Robust to
+    outliers in heavy-tailed inputs like book_to_market and
+    investment_growth. Per-period ranking is leakage-free: train and
+    test cross-sections are entirely disjoint by date.
+
+    Input:  DataFrame with MultiIndex (instrument_id, as_of), one column
+            per characteristic. NaNs allowed (skipped by ``rank``).
+    Output: same shape, values in [-0.5, +0.5].
+    """
+    return chars.groupby(level=1).transform(lambda g: g.rank(pct=True) - 0.5)

--- a/backend/tests/integration/test_ipca_estimation.py
+++ b/backend/tests/integration/test_ipca_estimation.py
@@ -88,6 +88,7 @@ class TestIPCAEstimation:
             # converge in max_iter=200 on the real panel — accept either.
             assert isinstance(result["converged"], bool)
             assert result["n_instruments"] > 100
+            assert result["asset_class"] == "Equity"
 
             # Verify DB row
             async with factory() as db:

--- a/backend/tests/vertical_engines/wealth/test_attribution_ipca_rail.py
+++ b/backend/tests/vertical_engines/wealth/test_attribution_ipca_rail.py
@@ -68,8 +68,8 @@ async def test_ipca_rail_wins_when_oos_r2_high(mock_request):
 
 
 @pytest.mark.asyncio
-async def test_ipca_rail_skipped_when_oos_r2_low(mock_request):
-    """2. IPCA rail skipped when OOS R² < 0.50."""
+async def test_ipca_rail_skipped_when_rail_returns_none(mock_request):
+    """2. IPCA rail returns None → dispatcher falls through to next rail."""
     with patch("vertical_engines.wealth.attribution.service._run_ipca_rail") as mock_ipca:
         mock_ipca.return_value = None
         

--- a/backend/tests/vertical_engines/wealth/test_attribution_ipca_rail_unit.py
+++ b/backend/tests/vertical_engines/wealth/test_attribution_ipca_rail_unit.py
@@ -1,0 +1,340 @@
+"""Unit tests for IPCA rail rank-transform integration (PR-Q10).
+
+Tests the internal math of run_ipca_rail, not just the dispatcher mock
+surface. Verifies that the rail applies cross-sectional rank transform
+before building z_fund, and that the kill-switch threshold is correct.
+"""
+from __future__ import annotations
+
+from collections import namedtuple
+from datetime import date
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from quant_engine.ipca.fit import IPCAFit
+from vertical_engines.wealth.attribution.ipca_rail import run_ipca_rail
+from vertical_engines.wealth.attribution.models import AttributionRequest, IPCAResult
+
+
+def _make_request(**overrides) -> AttributionRequest:
+    defaults = dict(
+        fund_instrument_id=uuid4(),
+        asof=date(2026, 4, 19),
+        fund_asset_class="Equity",
+        fund_cik="0001234567",
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 4, 19),
+    )
+    defaults.update(overrides)
+    return AttributionRequest(**defaults)
+
+
+def _make_fit(oos_r_squared: float = 0.03, K: int = 6) -> IPCAFit:
+    return IPCAFit(
+        gamma=np.eye(K, dtype=np.float64),
+        factor_returns=np.random.default_rng(42).standard_normal((K, 20)),
+        K=K,
+        intercept=False,
+        r_squared=0.5,
+        oos_r_squared=oos_r_squared,
+        converged=True,
+        n_iterations=50,
+        dates=pd.date_range("2024-01-31", periods=20, freq="ME"),
+    )
+
+
+# Helper namedtuple to simulate DB rows
+_RefRow = namedtuple("_RefRow", ["ref_period"])
+_CSRow = namedtuple("_CSRow", ["instrument_id", "size", "value", "momentum", "quality", "investment", "profitability"])
+_HRow = namedtuple("_HRow", ["pct_of_nav", "instrument_id"])
+
+
+class _FakeResult:
+    """Minimal mock for sqlalchemy CursorResult."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return self._rows
+
+
+@pytest.mark.asyncio
+async def test_rank_transform_applied_before_z_fund():
+    """1. Rank transform is applied to chars before z_fund is built.
+
+    With Gamma = I_6, z_fund == ranked chars for the single holding.
+    Raw chars have values far outside [-0.5, +0.5]; after ranking they
+    must be within that band.
+    """
+    req = _make_request()
+    fit = _make_fit()
+    fund_id = req.fund_instrument_id
+    universe_id = uuid4()
+
+    ref_date = date(2026, 3, 31)
+    cs_rows = [
+        _CSRow(instrument_id=fund_id, size=100.0, value=0.0001, momentum=50.0, quality=0.9, investment=80.0, profitability=0.01),
+        _CSRow(instrument_id=universe_id, size=0.0, value=0.0, momentum=0.0, quality=0.0, investment=0.0, profitability=0.0),
+    ]
+    h_rows = [_HRow(pct_of_nav=10.0, instrument_id=fund_id)]
+
+    call_count = 0
+
+    async def mock_execute(stmt, params=None):
+        nonlocal call_count
+        call_count += 1
+        # load_latest_ipca_fit is patched, so db.execute calls are:
+        # 1: ref_period, 2: cross-section, 3: holdings, 4+: alpha estimation
+        if call_count == 1:
+            return _FakeResult([_RefRow(ref_period=ref_date)])
+        elif call_count == 2:
+            return _FakeResult(cs_rows)
+        elif call_count == 3:
+            return _FakeResult(h_rows)
+        return _FakeResult([])
+
+    db = AsyncMock()
+    db.execute = mock_execute
+
+    with patch("vertical_engines.wealth.attribution.ipca_rail.load_latest_ipca_fit", return_value=fit), \
+         patch("vertical_engines.wealth.attribution.ipca_rail.resolve_fund_cik", return_value="0001234567"), \
+         patch("vertical_engines.wealth.attribution.ipca_rail.latest_period_for_cik", return_value=date(2026, 3, 31)):
+        result = await run_ipca_rail(req, db)
+
+    assert result is not None
+    # With Gamma=I, factor_exposures == z_fund. Ranked values must be in [-0.5, +0.5].
+    for exp in result.factor_exposures:
+        assert -0.5 <= exp <= 0.5, f"factor exposure {exp} outside ranked range"
+
+
+@pytest.mark.asyncio
+async def test_ref_period_none_falls_back_to_option_a():
+    """2. ref_period=None falls back to Option A (not terminal None)."""
+    req = _make_request()
+    fit = _make_fit()
+
+    call_count = 0
+
+    async def mock_execute(stmt, params=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # ref_period query — no data
+            return _FakeResult([_RefRow(ref_period=None)])
+        return _FakeResult([])
+
+    db = AsyncMock()
+    db.execute = mock_execute
+
+    with patch("vertical_engines.wealth.attribution.ipca_rail.load_latest_ipca_fit", return_value=fit), \
+         patch("vertical_engines.wealth.attribution.ipca_rail.resolve_fund_cik", return_value="0001234567"), \
+         patch("vertical_engines.wealth.attribution.ipca_rail.latest_period_for_cik", return_value=date(2026, 3, 31)), \
+         patch("vertical_engines.wealth.attribution.ipca_rail._run_ipca_rail_option_a", new_callable=AsyncMock) as mock_opt_a:
+        mock_opt_a.return_value = None
+        await run_ipca_rail(req, db)
+        mock_opt_a.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_holdings_match_falls_back_to_option_a():
+    """3. Holdings with no chars at ref_period -> fallback to Option A."""
+    req = _make_request()
+    fit = _make_fit()
+
+    ref_date = date(2026, 3, 31)
+    unrelated_id = uuid4()
+    cs_rows = [
+        _CSRow(instrument_id=unrelated_id, size=1.0, value=1.0, momentum=1.0, quality=1.0, investment=1.0, profitability=1.0),
+    ]
+    holding_id = uuid4()
+    h_rows = [_HRow(pct_of_nav=10.0, instrument_id=holding_id)]
+
+    call_count = 0
+
+    async def mock_execute(stmt, params=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeResult([_RefRow(ref_period=ref_date)])
+        elif call_count == 2:
+            return _FakeResult(cs_rows)
+        elif call_count == 3:
+            return _FakeResult(h_rows)
+        return _FakeResult([])
+
+    db = AsyncMock()
+    db.execute = mock_execute
+
+    with patch("vertical_engines.wealth.attribution.ipca_rail.load_latest_ipca_fit", return_value=fit), \
+         patch("vertical_engines.wealth.attribution.ipca_rail.resolve_fund_cik", return_value="0001234567"), \
+         patch("vertical_engines.wealth.attribution.ipca_rail.latest_period_for_cik", return_value=date(2026, 3, 31)), \
+         patch("vertical_engines.wealth.attribution.ipca_rail._run_ipca_rail_option_a", new_callable=AsyncMock) as mock_opt_a:
+        mock_opt_a.return_value = None
+        result = await run_ipca_rail(req, db)
+        mock_opt_a.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_fires_on_zero_oos_r2():
+    """4. Kill switch fires on oos_r_squared = 0.0."""
+    req = _make_request()
+    fit = _make_fit(oos_r_squared=0.0)
+
+    with patch("vertical_engines.wealth.attribution.ipca_rail.load_latest_ipca_fit", return_value=fit):
+        db = AsyncMock()
+        result = await run_ipca_rail(req, db)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_passes_on_small_positive_oos_r2():
+    """5. Kill switch passes on small positive oos_r_squared (e.g. 0.003)."""
+    req = _make_request()
+    fit = _make_fit(oos_r_squared=0.003)
+
+    ref_date = date(2026, 3, 31)
+    fund_id = req.fund_instrument_id
+    cs_rows = [
+        _CSRow(instrument_id=fund_id, size=1.0, value=1.0, momentum=1.0, quality=1.0, investment=1.0, profitability=1.0),
+    ]
+    h_rows = [_HRow(pct_of_nav=10.0, instrument_id=fund_id)]
+
+    call_count = 0
+
+    async def mock_execute(stmt, params=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeResult([_RefRow(ref_period=ref_date)])
+        elif call_count == 2:
+            return _FakeResult(cs_rows)
+        elif call_count == 3:
+            return _FakeResult(h_rows)
+        return _FakeResult([])
+
+    db = AsyncMock()
+    db.execute = mock_execute
+
+    with patch("vertical_engines.wealth.attribution.ipca_rail.load_latest_ipca_fit", return_value=fit), \
+         patch("vertical_engines.wealth.attribution.ipca_rail.resolve_fund_cik", return_value="0001234567"), \
+         patch("vertical_engines.wealth.attribution.ipca_rail.latest_period_for_cik", return_value=date(2026, 3, 31)):
+        result = await run_ipca_rail(req, db)
+
+    # Rail proceeds (doesn't return None from kill switch).
+    # Result may be None due to alpha estimation mock returning empty rows,
+    # but it must NOT be None from the kill switch — verify by checking
+    # that db.execute was called (meaning we got past the threshold gate).
+    assert result is not None or call_count > 1, "Kill switch blocked at oos_r²=0.003"
+
+
+# ---------------------------------------------------------------------------
+# Tests 6-8: Dispatcher bug fixes (PR-Q10 batch 3)
+# ---------------------------------------------------------------------------
+
+def test_cik_variants_produces_both_forms():
+    """6. cik_variants returns (unpadded, zero-padded-10) for any input."""
+    from vertical_engines.wealth.attribution.holdings_based import cik_variants
+
+    assert cik_variants("36405") == ("36405", "0000036405")
+    assert cik_variants("0000036405") == ("36405", "0000036405")
+    assert cik_variants("0001234567") == ("1234567", "0001234567")
+    # Edge: all zeros
+    assert cik_variants("0000000000") == ("0", "0000000000")
+
+
+@pytest.mark.asyncio
+async def test_option_a_date_alignment():
+    """7. Option A aligns first-of-month NAV dates with end-of-month factor dates."""
+    from vertical_engines.wealth.attribution.ipca_rail import _run_ipca_rail_option_a
+
+    req = _make_request()
+    fit = _make_fit(K=4)
+    # Override dates to end-of-month (like real IPCA fits)
+    fit = IPCAFit(
+        gamma=fit.gamma[:, :4],  # 6×4
+        factor_returns=np.random.default_rng(99).standard_normal((4, 24)),
+        K=4,
+        intercept=False,
+        r_squared=0.5,
+        oos_r_squared=0.03,
+        converged=True,
+        n_iterations=50,
+        dates=pd.date_range("2024-01-31", periods=24, freq="ME"),
+    )
+
+    # Simulate nav rows with first-of-month dates (as produced by date_trunc)
+    _NavRow = namedtuple("_NavRow", ["month", "nav_eom"])
+    nav_rows = [
+        _NavRow(month=date(2023, m, 1), nav_eom=100.0 + m)
+        for m in range(1, 13)
+    ] + [
+        _NavRow(month=date(2024, m, 1), nav_eom=112.0 + m * 0.5)
+        for m in range(1, 13)
+    ]
+
+    async def mock_execute(stmt, params=None):
+        return _FakeResult(nav_rows)
+
+    db = AsyncMock()
+    db.execute = mock_execute
+
+    result = await _run_ipca_rail_option_a(req, db, fit)
+    assert result is not None, "Option A returned None — date alignment still broken"
+    assert len(result.factor_exposures) == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_scenario", ["no_cik", "no_period", "no_ref_period"])
+async def test_symmetric_option_a_fallback(failure_scenario):
+    """8. Every Option-B precondition failure falls back to Option A."""
+    from contextlib import ExitStack
+
+    req = _make_request()
+    fit = _make_fit()
+    sentinel = IPCAResult(
+        factor_names=["Sentinel"],
+        factor_exposures=[0.0],
+        factor_returns_contribution=[0.0],
+        alpha=0.0,
+        confidence=0.0,
+    )
+
+    _P = "vertical_engines.wealth.attribution.ipca_rail"
+
+    mock_opt_a = AsyncMock(return_value=sentinel)
+    patches_list = [
+        patch(f"{_P}.load_latest_ipca_fit", AsyncMock(return_value=fit)),
+        patch(f"{_P}._run_ipca_rail_option_a", mock_opt_a),
+    ]
+
+    if failure_scenario == "no_cik":
+        patches_list.append(patch(f"{_P}.resolve_fund_cik", AsyncMock(return_value=None)))
+    elif failure_scenario == "no_period":
+        patches_list.append(patch(f"{_P}.resolve_fund_cik", AsyncMock(return_value="0001234567")))
+        patches_list.append(patch(f"{_P}.latest_period_for_cik", AsyncMock(return_value=None)))
+    elif failure_scenario == "no_ref_period":
+        patches_list.append(patch(f"{_P}.resolve_fund_cik", AsyncMock(return_value="0001234567")))
+        patches_list.append(patch(f"{_P}.latest_period_for_cik", AsyncMock(return_value=date(2026, 3, 31))))
+
+    db = AsyncMock()
+    if failure_scenario == "no_ref_period":
+        async def mock_execute(stmt, params=None):
+            return _FakeResult([_RefRow(ref_period=None)])
+        db.execute = mock_execute
+
+    with ExitStack() as stack:
+        for p in patches_list:
+            stack.enter_context(p)
+        result = await run_ipca_rail(req, db)
+
+    assert result is sentinel, f"Expected Option A fallback for {failure_scenario}, got {result}"
+    mock_opt_a.assert_awaited_once()

--- a/backend/vertical_engines/wealth/attribution/holdings_based.py
+++ b/backend/vertical_engines/wealth/attribution/holdings_based.py
@@ -23,7 +23,7 @@ from datetime import date, timedelta
 from typing import TYPE_CHECKING, Any
 
 import structlog
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 
 from vertical_engines.wealth.attribution.models import (
     AttributionRequest,
@@ -35,6 +35,20 @@ if TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = structlog.get_logger()
+
+
+def cik_variants(cik: str) -> tuple[str, str]:
+    """Return (unpadded, zero-padded-10) candidates for CIK lookups.
+
+    ``sec_nport_holdings.cik`` is stored unpadded today (see
+    ``fund_characteristics_aggregator.py:138``). Other consumers may emit
+    padded form. Lookups should accept both via ``IN`` to preserve the
+    btree index — do not use SQL ``LTRIM``/``LPAD`` in WHERE, that
+    disables the index.
+    """
+    clean = cik.lstrip("0") or "0"
+    return (clean, clean.zfill(10))
+
 
 # Per PR-Q4 acceptance: N-PORT filings within 9 months of asof count as
 # fresh. N-PORT is monthly-reported but filed quarterly with 60-day lag.
@@ -76,15 +90,26 @@ async def resolve_fund_cik(
 
 
 async def latest_period_for_cik(
-    db: "AsyncSession", cik: str, not_before: date,
+    db: "AsyncSession", cik: str, not_before: date | None = None,
 ) -> date | None:
     """Return the latest matview period_of_report for this CIK, or None."""
-    row = (await db.execute(text("""
-        SELECT MAX(period_of_report)
-        FROM mv_nport_sector_attribution
-        WHERE filer_cik = :cik
-          AND period_of_report >= :not_before
-    """), {"cik": cik, "not_before": not_before})).first()
+    candidates = cik_variants(cik)
+    if not_before is not None:
+        stmt = text("""
+            SELECT MAX(period_of_report)
+            FROM mv_nport_sector_attribution
+            WHERE filer_cik IN :candidates
+              AND period_of_report >= :not_before
+        """).bindparams(bindparam("candidates", expanding=True))
+        params: dict = {"candidates": list(candidates), "not_before": not_before}
+    else:
+        stmt = text("""
+            SELECT MAX(period_of_report)
+            FROM mv_nport_sector_attribution
+            WHERE filer_cik IN :candidates
+        """).bindparams(bindparam("candidates", expanding=True))
+        params = {"candidates": list(candidates)}
+    row = (await db.execute(stmt, params)).first()
     if row is None:
         return None
     return row[0]

--- a/backend/vertical_engines/wealth/attribution/ipca_rail.py
+++ b/backend/vertical_engines/wealth/attribution/ipca_rail.py
@@ -7,11 +7,13 @@ import numpy as np
 import pandas as pd
 import statsmodels.api as sm
 import structlog
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from quant_engine.ipca.fit import IPCAFit
+from quant_engine.ipca.preprocessing import rank_transform
 from vertical_engines.wealth.attribution.holdings_based import (
+    cik_variants,
     latest_period_for_cik,
     resolve_fund_cik,
 )
@@ -23,13 +25,23 @@ logger = structlog.get_logger()
 async def load_latest_ipca_fit(
     db: AsyncSession, asset_class: str
 ) -> IPCAFit | None:
-    """Load latest converged IPCA fit for asset class."""
+    """Load latest IPCA fit for asset class.
+
+    Accepts fits that either converged cleanly OR hit max_iter but
+    produced positive predictive signal (oos_r² > 0). KP-S 2019
+    reports IPCA frequently converges asymptotically without clean
+    break in max_iter iterations on equity panels — refusing those
+    silently kills the rail in production.
+    """
     stmt = text(
         """
-        SELECT k_factors, gamma_loadings, factor_returns, oos_r_squared, converged, n_iterations
+        SELECT k_factors, gamma_loadings, factor_returns,
+               oos_r_squared, converged, n_iterations
         FROM factor_model_fits
-        WHERE engine = 'ipca' AND universe_hash = :asset_class AND converged = true
-        ORDER BY fit_date DESC
+        WHERE engine = 'ipca'
+          AND asset_class = :asset_class
+          AND (converged = true OR oos_r_squared > 0.0)
+        ORDER BY fit_date DESC, created_at DESC
         LIMIT 1
         """
     )
@@ -64,90 +76,101 @@ async def run_ipca_rail(request: AttributionRequest, db: AsyncSession) -> IPCARe
         return None
         
     fit = await load_latest_ipca_fit(db, request.fund_asset_class)
-    # WORKAROUND (PR-Q9 follow-up tracked in #295): the rail computes
-    # Gamma @ z_fund on raw characteristic values, but Gamma is now
-    # estimated on cross-sectionally rank-transformed inputs (per
-    # Kelly-Pruitt-Su 2019 / PR-Q9 fix commit 68b0cf88). Executing the
-    # rail without the matching rank transform on the rail side produces
-    # mathematically wrong factor exposures. The 0.50 threshold here is
-    # deliberately above realistic oos_r² values (KP-S band 0.02-0.05) so
-    # the rail short-circuits until the follow-up PR adds rank transform
-    # inside resolve_fund_cik / load_chars or wherever chars are sourced.
-    # DO NOT lower this threshold without first applying the rank
-    # transform — see docs/investigations/2026-04-25-pr-q9-oos-r2-zero-diagnosis.md §F.
-    if not fit or fit.oos_r_squared is None or fit.oos_r_squared < 0.50:
+    # IPCA validity gate. KP-S 2019 reports realistic out-of-sample R² in
+    # the 0.02-0.05 band on equity panels — accept any positive signal.
+    # A negative oos_r² means the model predicts worse than the historical
+    # mean, in which case the rail abstains and the dispatcher falls through.
+    if not fit or fit.oos_r_squared is None or fit.oos_r_squared <= 0.0:
         return None
 
     # Option B: Get fund CIK and latest holdings
     cik = await resolve_fund_cik(db, request.fund_instrument_id)
     if not cik:
-        return None
-        
+        return await _run_ipca_rail_option_a(request, db, fit)
+
     not_before = request.asof - timedelta(days=int(30.4375 * 9))
     period = await latest_period_for_cik(db, cik, not_before=not_before)
     if not period:
-        return None
+        return await _run_ipca_rail_option_a(request, db, fit)
 
-    # Fetch characteristics for top 10 holdings
-    stmt_chars = text(
+    # --- Reference period: latest cross-section date <= request.asof ---
+    stmt_ref = text(
+        "SELECT MAX(as_of) AS ref_period FROM equity_characteristics_monthly WHERE as_of <= :asof"
+    )
+    ref_row = (await db.execute(stmt_ref, {"asof": request.asof})).first()
+    ref_period = ref_row.ref_period if ref_row else None
+    if ref_period is None:
+        return await _run_ipca_rail_option_a(request, db, fit)
+
+    # --- Full cross-section at ref_period (for rank transform) ---
+    stmt_cs = text(
+        """
+        SELECT instrument_id,
+               size_log_mkt_cap   AS size,
+               book_to_market     AS value,
+               mom_12_1           AS momentum,
+               quality_roa        AS quality,
+               investment_growth  AS investment,
+               profitability_gross AS profitability
+        FROM equity_characteristics_monthly
+        WHERE as_of = :ref_period
+        """
+    )
+    res_cs = await db.execute(stmt_cs, {"ref_period": ref_period})
+    rows_cs = res_cs.all()
+    if not rows_cs:
+        return await _run_ipca_rail_option_a(request, db, fit)
+
+    char_cols = ["size", "value", "momentum", "quality", "investment", "profitability"]
+    cs_index = pd.MultiIndex.from_arrays(
+        [[str(r.instrument_id) for r in rows_cs], [ref_period] * len(rows_cs)],
+        names=["instrument_id", "as_of"],
+    )
+    cs_df = pd.DataFrame(
+        [{c: float(getattr(r, c) or 0.0) for c in char_cols} for r in rows_cs],
+        index=cs_index,
+    )
+    ranked_cs = rank_transform(cs_df)
+
+    # --- Top-10 holdings + instrument_id mapping ---
+    cik_candidates = cik_variants(cik)
+    stmt_holdings = text(
         """
         WITH top_holdings AS (
             SELECT cusip, pct_of_nav
             FROM sec_nport_holdings
-            WHERE cik = :cik AND report_date = :period
+            WHERE cik IN :candidates AND report_date = :period
               AND pct_of_nav IS NOT NULL AND pct_of_nav > 0
             ORDER BY pct_of_nav DESC
             LIMIT 10
-        ),
-        mapped_holdings AS (
-            SELECT h.cusip, h.pct_of_nav, COALESCE(iu1.instrument_id, iu2.instrument_id) AS instrument_id
-            FROM top_holdings h
-            LEFT JOIN instruments_universe iu1
-              ON iu1.attributes->>'cusip' = h.cusip
-            LEFT JOIN instruments_universe iu2
-              ON iu2.isin LIKE ('US' || h.cusip || '_')
-            WHERE COALESCE(iu1.instrument_id, iu2.instrument_id) IS NOT NULL
-        ),
-        latest_chars AS (
-            SELECT e.instrument_id,
-                   e.size_log_mkt_cap AS size,
-                   e.book_to_market AS value,
-                   e.mom_12_1 AS momentum,
-                   e.quality_roa AS quality,
-                   e.investment_growth AS investment,
-                   e.profitability_gross AS profitability,
-                   ROW_NUMBER() OVER(PARTITION BY e.instrument_id ORDER BY e.as_of DESC) as rn
-            FROM mapped_holdings m
-            JOIN equity_characteristics_monthly e ON e.instrument_id = m.instrument_id
-            WHERE e.as_of <= :asof
         )
-        SELECT m.pct_of_nav,
-               c.size, c.value, c.momentum, c.quality, c.investment, c.profitability
-        FROM mapped_holdings m
-        JOIN latest_chars c ON c.instrument_id = m.instrument_id AND c.rn = 1
+        SELECT h.pct_of_nav, COALESCE(iu1.instrument_id, iu2.instrument_id) AS instrument_id
+        FROM top_holdings h
+        LEFT JOIN instruments_universe iu1
+          ON iu1.attributes->>'cusip' = h.cusip
+        LEFT JOIN instruments_universe iu2
+          ON iu2.isin LIKE ('US' || h.cusip || '_')
+        WHERE COALESCE(iu1.instrument_id, iu2.instrument_id) IS NOT NULL
         """
-    )
-    res_chars = await db.execute(stmt_chars, {"cik": cik, "period": period, "asof": request.asof})
-    rows_chars = res_chars.all()
-    
-    if not rows_chars:
-        # Fallback to Option A if no holdings mapped
+    ).bindparams(bindparam("candidates", expanding=True))
+    res_h = await db.execute(stmt_holdings, {"candidates": list(cik_candidates), "period": period})
+    rows_h = res_h.all()
+    if not rows_h:
         return await _run_ipca_rail_option_a(request, db, fit)
 
-    # Compute z_fund (weighted average of characteristics)
-    total_weight = sum(float(r.pct_of_nav) for r in rows_chars)
+    # Inner-join holdings against ranked cross-section
+    holdings_ids = {str(r.instrument_id): float(r.pct_of_nav) for r in rows_h}
+    matched = ranked_cs.loc[ranked_cs.index.get_level_values(0).isin(holdings_ids)]
+    if matched.empty:
+        return await _run_ipca_rail_option_a(request, db, fit)
+
+    # Compute z_fund (weighted average of ranked characteristics)
+    weights = np.array([holdings_ids[iid] for iid in matched.index.get_level_values(0)])
+    total_weight = weights.sum()
     if total_weight == 0:
         return await _run_ipca_rail_option_a(request, db, fit)
-        
-    z_fund = np.zeros(6)
-    for r in rows_chars:
-        w = float(r.pct_of_nav) / total_weight
-        z_fund[0] += w * float(r.size or 0.0)
-        z_fund[1] += w * float(r.value or 0.0)
-        z_fund[2] += w * float(r.momentum or 0.0)
-        z_fund[3] += w * float(r.quality or 0.0)
-        z_fund[4] += w * float(r.investment or 0.0)
-        z_fund[5] += w * float(r.profitability or 0.0)
+
+    z_fund = (matched.values * (weights / total_weight)[:, None]).sum(axis=0)
 
     # Implied beta = Gamma' * z_fund
     beta = fit.gamma.T @ z_fund
@@ -171,7 +194,12 @@ async def run_ipca_rail(request: AttributionRequest, db: AsyncSession) -> IPCARe
     )
 
 async def _estimate_alpha_fixed_beta(request: AttributionRequest, db: AsyncSession, fit: IPCAFit, beta: np.ndarray) -> float:
-    """Estimate alpha as the mean residual: r_fund - beta' * f_t."""
+    """Estimate alpha as the mean residual: r_fund - beta' * f_t.
+
+    beta is in ranked-chars space (Gamma.T @ ranked_z_fund). The equation
+    still holds because factor_returns from the fit are also estimated in
+    ranked-chars space — units cancel in the dot product.
+    """
     # Fetch monthly returns for fund
     stmt = text(
         """
@@ -196,23 +224,26 @@ async def _estimate_alpha_fixed_beta(request: AttributionRequest, db: AsyncSessi
     fund_returns_df.set_index("month", inplace=True)
     fund_returns_df["return"] = fund_returns_df["nav"].pct_change()
     fund_returns_df.dropna(inplace=True)
-    
+    fund_returns_df.index = pd.to_datetime(fund_returns_df.index).to_period("M")
+    fund_returns_df = fund_returns_df[~fund_returns_df.index.duplicated(keep="last")]
+
     if fit.dates is None:
         return 0.0
 
     factor_df = pd.DataFrame(
         fit.factor_returns.T,
-        index=fit.dates.date, 
-        columns=[f"factor_{i}" for i in range(fit.K)]
+        index=pd.to_datetime(fit.dates).to_period("M"),
+        columns=[f"factor_{i}" for i in range(fit.K)],
     )
-    
+    factor_df = factor_df[~factor_df.index.duplicated(keep="last")]
+
     aligned = pd.concat([fund_returns_df["return"], factor_df], axis=1, join="inner")
     if len(aligned) < 12:
         return 0.0
-        
+
     y = aligned["return"].values
     X = aligned[[f"factor_{i}" for i in range(fit.K)]].values
-    
+
     # alpha = mean(y - X * beta)
     residuals = y - (X @ beta)
     return float(np.mean(residuals))
@@ -244,21 +275,24 @@ async def _run_ipca_rail_option_a(request: AttributionRequest, db: AsyncSession,
     fund_returns_df.set_index("month", inplace=True)
     fund_returns_df["return"] = fund_returns_df["nav"].pct_change()
     fund_returns_df.dropna(inplace=True)
-    
+    fund_returns_df.index = pd.to_datetime(fund_returns_df.index).to_period("M")
+    fund_returns_df = fund_returns_df[~fund_returns_df.index.duplicated(keep="last")]
+
     if fit.dates is None:
         return None
 
     factor_df = pd.DataFrame(
         fit.factor_returns.T,
-        index=fit.dates.date, # match index type with month
-        columns=[f"factor_{i}" for i in range(fit.K)]
+        index=pd.to_datetime(fit.dates).to_period("M"),
+        columns=[f"factor_{i}" for i in range(fit.K)],
     )
-    
+    factor_df = factor_df[~factor_df.index.duplicated(keep="last")]
+
     # Align fund returns and factor returns
     aligned = pd.concat([fund_returns_df["return"], factor_df], axis=1, join="inner")
     if len(aligned) < 12:
         return None
-        
+
     # Time-series regression: r_fund_t = α + β' f_t + ε_t
     y = aligned["return"].values
     X = aligned[[f"factor_{i}" for i in range(fit.K)]].values

--- a/backend/vertical_engines/wealth/attribution/ipca_rail.py
+++ b/backend/vertical_engines/wealth/attribution/ipca_rail.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -126,8 +127,22 @@ async def run_ipca_rail(request: AttributionRequest, db: AsyncSession) -> IPCARe
         [[str(r.instrument_id) for r in rows_cs], [ref_period] * len(rows_cs)],
         names=["instrument_id", "as_of"],
     )
+
+    def _safe_float(value: Any) -> float:
+        """Preserve None as NaN so rank_transform can skip it.
+
+        Coercing missing characteristics to 0.0 before ranking would
+        inject a spurious sentinel value into the cross-section: any
+        instrument with NULL chars would land at the bottom of every
+        rank, shifting every other instrument's percentile upward and
+        biasing z_fund / beta cross-sectionally — even for holdings
+        with complete data. The rank_transform helper's own contract
+        is 'NaNs allowed (skipped by rank)'; we honour that here.
+        """
+        return float("nan") if value is None else float(value)
+
     cs_df = pd.DataFrame(
-        [{c: float(getattr(r, c) or 0.0) for c in char_cols} for r in rows_cs],
+        [{c: _safe_float(getattr(r, c)) for c in char_cols} for r in rows_cs],
         index=cs_index,
     )
     ranked_cs = rank_transform(cs_df)
@@ -173,7 +188,15 @@ async def run_ipca_rail(request: AttributionRequest, db: AsyncSession) -> IPCARe
     if matched.empty:
         return await _run_ipca_rail_option_a(request, db, fit)
 
-    # Compute z_fund (weighted average of ranked characteristics)
+    # Compute z_fund (weighted average of ranked characteristics).
+    # rank_transform preserves NaN for instruments with NULL chars in the
+    # source panel; here we map any residual NaN to 0.0 (the midpoint of
+    # the [-0.5, +0.5] ranked space, i.e. cross-sectional median) so a
+    # holding with one missing char is treated as having neutral exposure
+    # on that factor rather than poisoning the entire weighted average
+    # with NaN. Holdings with all chars NaN still contribute zero tilt
+    # but retain their pct_of_nav weight.
+    matched = matched.fillna(0.0)
     weights = np.array([holdings_ids[iid] for iid in matched.index.get_level_values(0)])
     total_weight = weights.sum()
     if total_weight == 0:

--- a/backend/vertical_engines/wealth/attribution/ipca_rail.py
+++ b/backend/vertical_engines/wealth/attribution/ipca_rail.py
@@ -158,8 +158,17 @@ async def run_ipca_rail(request: AttributionRequest, db: AsyncSession) -> IPCARe
     if not rows_h:
         return await _run_ipca_rail_option_a(request, db, fit)
 
-    # Inner-join holdings against ranked cross-section
-    holdings_ids = {str(r.instrument_id): float(r.pct_of_nav) for r in rows_h}
+    # Inner-join holdings against ranked cross-section. Sum (not overwrite)
+    # weights when multiple holdings map to the same instrument_id — happens
+    # when dual share classes share an issuer-level instrument, when the
+    # instruments_universe has both 8-char and 9-char CUSIPs for the same
+    # security, or when N-PORT splits a position across multiple rows.
+    # A dict comprehension would silently drop earlier rows and underweight
+    # the instrument in z_fund / factor exposures.
+    holdings_ids: dict[str, float] = {}
+    for r in rows_h:
+        iid = str(r.instrument_id)
+        holdings_ids[iid] = holdings_ids.get(iid, 0.0) + float(r.pct_of_nav)
     matched = ranked_cs.loc[ranked_cs.index.get_level_values(0).isin(holdings_ids)]
     if matched.empty:
         return await _run_ipca_rail_option_a(request, db, fit)


### PR DESCRIPTION
## Summary

The IPCA worker (PR-Q9) estimates `Gamma` on cross-sectionally **rank-transformed** characteristics per Kelly–Pruitt–Su 2019, but the attribution rail was still feeding **raw** values into `Gamma @ z_fund` — producing wrong factor exposures. The rail was kill-switched at `oos_r² ≥ 0.50` (unreachable in practice) so the bad path never executed in production. This PR makes the rail apply the same rank transform the worker uses, then closes the contract gaps that surfaced during smoke testing.

`Closes #295.`

## What changed (3 batches in one commit)

### Batch 1 — Rank transform alignment (math)
- Extracted `_rank_transform` to shared `quant_engine/ipca/preprocessing.py` (single source of truth: worker + rail).
- `ipca_rail.py` Option B: fetches **full cross-section at `ref_period`**, applies `rank_transform`, inner-joins to top-10 holdings, builds `z_fund` from ranked values. `Gamma` and `z_fund` now live in the same `[-0.5, +0.5]` ranked space.
- Lowered kill-switch: `oos_r² ≥ 0.50` → `> 0.0` (KP-S realistic band is 0.02–0.05).

### Batch 2 — `factor_model_fits` contract
- Migration `0176_add_asset_class_to_factor_model_fits` (server_default `'Equity'` backfills existing rows).
- Worker `ipca_estimation` accepts `asset_class` parameter and writes the new column. `universe_hash` continues as MD5 panel-identity hash (correct semantic separation).
- Rail filters by `asset_class` instead of overloading `universe_hash`. Convergence relaxation: `(converged = true OR oos_r² > 0.0)` — accepts asymptotically-convergent fits (KP-S notes IPCA frequently hits `max_iter` on equity panels).

### Batch 3 — Dispatcher symmetric fallback
- `cik_variants(cik) -> (unpadded, padded)` helper in `holdings_based.py` resolves the `sec_nport_holdings.cik` unpadded vs `instruments_universe.attributes.sec_cik` padded mismatch via expanding `IN :candidates` (preserves btree index — no SQL `LTRIM`/`LPAD` in WHERE).
- Date alignment: `_run_ipca_rail_option_a` and `_estimate_alpha_fixed_beta` normalize both indexes to `pandas.PeriodIndex(freq='M')` before `pd.concat(..., join='inner')`. Fixes the silent zero-overlap caused by `date_trunc('month', nav_date)` (BOM) vs `fit.dates` (EOM).
- Symmetric Option A fallback: every Option-B precondition failure (`cik=None`, `period=None`, `ref_period=None`, holdings join empty) falls back to Option A. Only two terminal `return None` paths remain: fit-not-loaded and kill-switch.

## Smoke output (SPY, asof 2026-04-19)

```
PRE-FLIGHT OK: fit K=4 oos_r²=0.002084 converged=False dates=2019-09-30..2026-03-31
  gamma.shape=(6, 4) factor_returns.shape=(4, 81)

=== run_ipca_rail RESULT ===
factor_names:       ['Size', 'Value', 'Momentum', 'Quality']
factor_exposures:   [+0.0000, -0.2993, -0.0477, +0.6263]
factor_contribs:    [+0.0001, +0.0001, -0.0001, +0.0010]
alpha:              +0.011123
confidence (oos_r²): 0.002084

✅ Magnitude OK: max |factor_exposure| = 0.63 (banda esperada ~3)
```

Institutional read: Size ≈ 0 (broad-market), Value −0.30 (growth tilt — large-cap S&P weights MSFT/AAPL/NVDA), Momentum ≈ 0, Quality +0.63 (top-10 high-margin/low-leverage). Coherent with SPY's profile.

## Test plan

- [x] `make lint` clean
- [x] `make typecheck` clean
- [x] `make architecture` clean (import-linter)
- [x] 38 IPCA-related tests pass (10 rail + 28 quant)
- [x] 5 dispatcher tests pass (existing)
- [x] 5 + 3 = 8 unit tests in `test_attribution_ipca_rail_unit.py` (rank applied, ref_period None, holdings miss → Option A, kill switch 0.0, kill switch passes 0.003, CIK normalization both forms, Option A date alignment, parametrized 3-scenario fallback)
- [x] Smoke for SPY produces non-None `IPCAResult` with sensible magnitudes (output above)

## Files changed

```
backend/app/core/db/migrations/versions/0176_add_asset_class_to_factor_model_fits.py  (new)
backend/app/core/jobs/ipca_estimation.py
backend/quant_engine/factor_model_ipca_service.py
backend/quant_engine/ipca/preprocessing.py                                            (new)
backend/tests/integration/test_ipca_estimation.py
backend/tests/vertical_engines/wealth/test_attribution_ipca_rail.py
backend/tests/vertical_engines/wealth/test_attribution_ipca_rail_unit.py              (new)
backend/vertical_engines/wealth/attribution/holdings_based.py
backend/vertical_engines/wealth/attribution/ipca_rail.py
```

9 files / 574 ins / 109 del.

🤖 Generated with [Claude Code](https://claude.com/claude-code)