### PR TITLE
CVaR service correctness fixes (13 fixes from 3-model audit) [PR-Q13]

### DIFF
--- a/backend/quant_engine/cvar_service.py
+++ b/backend/quant_engine/cvar_service.py
@@ -428,9 +428,22 @@ def check_breach_status(
     )
     cvar_limit = profile_config["limit"]
 
+    # Fix 12: NaN cvar_current (from Fix 5 insufficient obs) must surface
+    # as a "degraded" status, not silently resolve to "ok" via NaN arithmetic.
+    if math.isnan(cvar_current):
+        return BreachStatus(
+            trigger_status="degraded",
+            cvar_current=cvar_current,
+            cvar_limit=cvar_limit,
+            cvar_utilized_pct=float("nan"),
+            consecutive_breach_days=0,
+        )
+
     utilization = get_cvar_utilization(cvar_current, cvar_limit)
 
-    if utilization >= 100.0:
+    # Fix 13: use same epsilon as classify_trigger_status to keep the
+    # consecutive-day counter consistent with the breach classification.
+    if utilization >= (100.0 + _BREACH_EPSILON):
         new_consecutive = consecutive_breach_days + 1
     else:
         new_consecutive = 0

--- a/backend/quant_engine/cvar_service.py
+++ b/backend/quant_engine/cvar_service.py
@@ -8,8 +8,14 @@ check_breach_status() accepts consecutive_breach_days as parameter —
 the caller (wealth portfolio_eval) pre-fetches from PortfolioSnapshot.
 
 Config is injected as parameter by callers via ConfigService.get("liquid_funds", "portfolio_profiles").
+
+Sign convention (PR-Q13): all methods return **return-space** values.
+Losses are negative (e.g. CVaR = -0.08 means 8% loss). This is
+consistent with the historical path and with check_breach_status()
+which compares cvar_current (negative) against cvar_limit (negative).
 """
 
+import math
 from dataclasses import dataclass
 from typing import Any, Literal, TypedDict
 
@@ -53,6 +59,11 @@ _DEFAULT_CVAR_CONFIG: dict[str, ProfileCVaRConfig] = {
         "breach_days": 5,
     },
 }
+
+# Floating-point tolerance for breach boundary detection.
+# Prevents false breaches when utilization is exactly at the 100% boundary
+# due to floating-point arithmetic (e.g. 100.0000000001).
+_BREACH_EPSILON = 1e-6
 
 
 def resolve_cvar_config(
@@ -135,9 +146,22 @@ def compute_cvar(
     """Compute CVaR using specified method.
 
     Central entry point for all fund and portfolio CVaR calculations.
+    All methods return return-space values (losses are negative).
     """
     clean_returns = returns[~np.isnan(returns)]
-    n_obs = len(clean_returns)
+    n_obs = int(len(clean_returns))
+
+    # Fix 10: early guard for insufficient observations across ALL methods.
+    if n_obs < 5:
+        return CVaRResult(
+            cvar=float("nan"),
+            var=float("nan"),
+            confidence=confidence,
+            method=method,
+            n_obs=n_obs,
+            degraded=True,
+            degraded_reason=f"insufficient_obs_{n_obs}",
+        )
 
     if method == "evt_pot":
         from quant_engine.evt.pot_gpd import extreme_var_evt
@@ -145,13 +169,8 @@ def compute_cvar(
         res = extreme_var_evt(clean_returns, quantiles=(confidence,))
 
         # PR-Q14: pot_gpd now exposes ``quantile_results`` keyed by the
-        # exact quantile passed in. Earlier versions of this branch
-        # silently mapped non-legacy quantiles (e.g. 0.95) to 99% legacy
-        # fields, which were not populated for that request and returned
-        # 0.0 — making the EVT path useless at the default confidence.
+        # exact quantile passed in.
         if confidence not in res.quantile_results:
-            # Degraded path may return an empty dict; surface that to the
-            # caller instead of silently returning a zeroed result.
             if not res.degraded:
                 logger.warning(
                     "evt_quantile_missing_unexpected",
@@ -161,6 +180,11 @@ def compute_cvar(
             var, cvar = 0.0, 0.0
         else:
             var, cvar = res.quantile_results[confidence]
+            # Fix 2: EVT returns loss-space (positive = loss magnitude).
+            # Convert to return-space (negative = loss) for consistency
+            # with historical and parametric paths.
+            var = -var
+            cvar = -cvar
 
         return CVaRResult(
             cvar=cvar,
@@ -178,13 +202,18 @@ def compute_cvar(
 
     if method == "parametric":
         from scipy.stats import norm
-        mu = np.mean(clean_returns)
-        sigma = np.std(clean_returns)
+
+        mu = float(np.mean(clean_returns))
+        # Fix 9: use sample std (ddof=1) instead of population std (ddof=0).
+        sigma = float(np.std(clean_returns, ddof=1))
         z = norm.ppf(1 - confidence)
-        var = -(mu + z * sigma)
         phi_z = norm.pdf(z)
-        cvar = -mu + sigma * phi_z / (1 - confidence)
-        
+        # Fix 1: return return-space values (negative for losses).
+        # z is negative (e.g. -1.6449 for 95%), so mu + z*sigma is negative
+        # for typical loss tails — exactly the return-space convention.
+        var = mu + z * sigma
+        cvar = mu - sigma * phi_z / (1 - confidence)
+
         return CVaRResult(
             cvar=float(cvar),
             var=float(var),
@@ -195,6 +224,19 @@ def compute_cvar(
 
     # Default: historical
     cvar_val, var_val = compute_cvar_from_returns(clean_returns, confidence)
+
+    # Fix 5/10: propagate NaN from insufficient obs as degraded.
+    if math.isnan(cvar_val):
+        return CVaRResult(
+            cvar=cvar_val,
+            var=var_val,
+            confidence=confidence,
+            method="historical",
+            n_obs=n_obs,
+            degraded=True,
+            degraded_reason=f"insufficient_obs_{n_obs}",
+        )
+
     return CVaRResult(
         cvar=cvar_val,
         var=var_val,
@@ -219,6 +261,18 @@ def compute_regime_cvar_audited(
     """
     audit_notes: list[str] = []
 
+    # Fix 6: validate regime_probs are probabilities in [0, 1].
+    if regime_probs.size > 0 and not np.all(
+        (regime_probs >= 0.0) & (regime_probs <= 1.0)
+    ):
+        raise ValueError(
+            f"regime_probs must be in [0, 1]; got range "
+            f"[{regime_probs.min():.4f}, {regime_probs.max():.4f}]"
+        )
+
+    # Fix 7: preserve original returns for unconditional fallback.
+    original_returns = returns
+
     if len(returns) != len(regime_probs):
         logger.warning(
             "regime_cvar_length_mismatch",
@@ -226,16 +280,19 @@ def compute_regime_cvar_audited(
             probs_len=len(regime_probs),
         )
         min_len = min(len(returns), len(regime_probs))
-        returns = returns[-min_len:]
+        aligned_returns = returns[-min_len:]
         regime_probs = regime_probs[-min_len:]
         audit_notes.append("length_mismatch_truncated")
+    else:
+        aligned_returns = returns
 
     stress_mask = regime_probs > regime_threshold
     n_stress = int(stress_mask.sum())
-    n_total = int(len(returns))
+    # Fix 7: report total from original history, not truncated alignment.
+    n_total = int(len(original_returns))
 
     if n_stress >= MIN_STRESS_OBSERVATIONS:
-        stress_returns = returns[stress_mask]
+        stress_returns = aligned_returns[stress_mask]
         is_conditional = True
         audit_notes.append("conditional")
     else:
@@ -244,7 +301,9 @@ def compute_regime_cvar_audited(
             n=n_stress,
             min_required=MIN_STRESS_OBSERVATIONS,
         )
-        stress_returns = returns
+        # Fix 7: unconditional fallback uses FULL original history,
+        # not the truncated alignment slice.
+        stress_returns = original_returns
         is_conditional = False
         audit_notes.append("insufficient_stress_obs_fallback_to_unconditional")
 
@@ -290,16 +349,18 @@ def compute_cvar_from_returns(
     CVaR (Expected Shortfall) = mean of returns below VaR threshold.
     Returns (cvar, var) as negative numbers (losses).
     """
+    # Fix 5: return NaN for insufficient data instead of optimistic 0.0.
     if len(returns) < 5:
-        return 0.0, 0.0
+        return float("nan"), float("nan")
 
     sorted_returns = np.sort(returns)
-    cutoff_idx = int(len(sorted_returns) * (1 - confidence))
-    if cutoff_idx == 0:
-        cutoff_idx = 1
-
-    var = float(sorted_returns[cutoff_idx])
-    cvar = float(sorted_returns[:cutoff_idx].mean())
+    # Fix 8: use math.ceil for correct tail count and consistent VaR/CVaR.
+    # Round to 10 decimal places first to avoid floating-point edge cases
+    # (e.g. 20 * 0.05 = 1.0000000000000009 which ceil() rounds to 2).
+    n = len(sorted_returns)
+    tail_count = max(1, math.ceil(round(n * (1.0 - confidence), 10)))
+    var = float(sorted_returns[tail_count - 1])
+    cvar = float(sorted_returns[:tail_count].mean())
 
     return cvar, var
 
@@ -307,12 +368,19 @@ def compute_cvar_from_returns(
 def get_cvar_utilization(cvar_current: float, cvar_limit: float) -> float:
     """Compute CVaR utilization as a percentage of the limit.
 
-    Both cvar_current and cvar_limit are negative numbers (losses).
-    Returns a positive percentage (0-100+).
+    Both cvar_current and cvar_limit are in return-space (negative = losses).
+    Returns a positive percentage (0-100+), clamped to 0 for gains.
     """
-    if cvar_limit == 0:
-        return 0.0
-    return abs(cvar_current / cvar_limit) * 100.0
+    # Fix 4: reject invalid limits (must be negative in return-space).
+    if cvar_limit >= 0:
+        raise ValueError(
+            f"cvar_limit must be negative (return-space loss limit), got {cvar_limit}"
+        )
+    # Fix 3: use ratio instead of abs() to correctly handle gains.
+    # When both are negative (loss case): ratio is positive → utilization > 0.
+    # When cvar_current > 0 (gain case): ratio is negative → clamped to 0.
+    ratio = cvar_current / cvar_limit
+    return max(0.0, ratio * 100.0)
 
 
 def classify_trigger_status(
@@ -322,7 +390,12 @@ def classify_trigger_status(
     breach_consecutive_days: int = 5,
 ) -> str:
     """Classify CVaR trigger status. Returns 'ok', 'warning', or 'breach'."""
-    if utilization_pct >= 100.0 and consecutive_days >= breach_consecutive_days:
+    # Fix 11: add epsilon tolerance to prevent false breaches from
+    # floating-point drift at the exact 100% boundary.
+    if (
+        utilization_pct >= (100.0 + _BREACH_EPSILON)
+        and consecutive_days >= breach_consecutive_days
+    ):
         return "breach"
     if utilization_pct >= warning_threshold_pct:
         return "warning"

--- a/backend/tests/quant_engine/test_cvar_service.py
+++ b/backend/tests/quant_engine/test_cvar_service.py
@@ -1,0 +1,203 @@
+"""PR-Q13 — CVaR service correctness regression tests.
+
+Each test targets a specific fix from the PR-Q13 spec. Tests are designed
+to fail against the pre-fix code and pass against the post-fix code.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from quant_engine.cvar_service import (
+    classify_trigger_status,
+    compute_cvar,
+    compute_cvar_from_returns,
+    compute_regime_cvar_audited,
+    get_cvar_utilization,
+)
+
+# ── Fix 1 — Parametric sign convention (return-space) ────────────────────
+
+def test_parametric_returns_negative_for_losses() -> None:
+    """Parametric CVaR/VaR must be negative for a loss-dominated distribution."""
+    rng = np.random.default_rng(42)
+    # Negative-mean distribution: mostly losses.
+    returns = rng.normal(loc=-0.02, scale=0.05, size=500)
+    result = compute_cvar(returns, confidence=0.95, method="parametric")
+    # Both VaR and CVaR should be negative (return-space: losses are negative).
+    assert result.var < 0, f"VaR should be negative for losses, got {result.var}"
+    assert result.cvar < 0, f"CVaR should be negative for losses, got {result.cvar}"
+    # CVaR should be more negative (worse) than VaR.
+    assert result.cvar < result.var, (
+        f"CVaR ({result.cvar}) should be <= VaR ({result.var})"
+    )
+
+
+# ── Fix 2 — EVT loss-space → return-space ────────────────────────────────
+
+def test_evt_pot_returns_negative_for_losses() -> None:
+    """EVT/POT CVaR/VaR must be negative (return-space) for loss distributions."""
+    rng = np.random.default_rng(42)
+    # Generate enough data with a fat left tail for EVT to fit.
+    returns = rng.normal(loc=-0.001, scale=0.02, size=1000)
+    result = compute_cvar(returns, confidence=0.95, method="evt_pot")
+    if result.degraded:
+        pytest.skip(f"EVT degraded: {result.degraded_reason}")
+    assert result.var < 0, f"EVT VaR should be negative, got {result.var}"
+    assert result.cvar < 0, f"EVT CVaR should be negative, got {result.cvar}"
+    assert result.cvar <= result.var, (
+        f"EVT CVaR ({result.cvar}) should be <= VaR ({result.var})"
+    )
+
+
+# ── Fix 3 — Utilization clamps gains to zero ─────────────────────────────
+
+def test_utilization_clamps_gain_to_zero() -> None:
+    """A positive cvar_current (gain in worst case) should yield 0% utilization."""
+    # cvar_current = +0.05 (gain), limit = -0.08 (loss limit).
+    util = get_cvar_utilization(cvar_current=0.05, cvar_limit=-0.08)
+    assert util == 0.0, f"Gain should yield 0% utilization, got {util}"
+
+
+# ── Fix 4 — Zero / positive cvar_limit raises ────────────────────────────
+
+def test_get_cvar_utilization_raises_on_zero_limit() -> None:
+    """cvar_limit=0 is a config error and must raise, not silently return 0."""
+    with pytest.raises(ValueError, match="must be negative"):
+        get_cvar_utilization(cvar_current=-0.05, cvar_limit=0.0)
+
+
+def test_get_cvar_utilization_raises_on_positive_limit() -> None:
+    """cvar_limit>0 is a sign-convention error and must raise."""
+    with pytest.raises(ValueError, match="must be negative"):
+        get_cvar_utilization(cvar_current=-0.05, cvar_limit=0.08)
+
+
+# ── Fixes 5 + 10 — Insufficient observations return NaN + degraded ───────
+
+def test_compute_cvar_returns_nan_when_insufficient_obs() -> None:
+    """< 5 observations must return NaN with degraded=True, not optimistic 0.0."""
+    returns = np.array([-0.01, -0.02, 0.01])
+    result = compute_cvar(returns, confidence=0.95, method="historical")
+    assert math.isnan(result.cvar), f"Expected NaN cvar, got {result.cvar}"
+    assert math.isnan(result.var), f"Expected NaN var, got {result.var}"
+    assert result.degraded is True
+    assert "insufficient_obs" in (result.degraded_reason or "")
+
+    # Also test parametric path (Fix 10).
+    result_p = compute_cvar(returns, confidence=0.95, method="parametric")
+    assert math.isnan(result_p.cvar)
+    assert result_p.degraded is True
+
+
+# ── Fix 6 — regime_probs validation ──────────────────────────────────────
+
+def test_compute_regime_cvar_raises_on_invalid_probs() -> None:
+    """Regime probs as percentages (0-100) must raise, not silently compute."""
+    rng = np.random.default_rng(42)
+    returns = rng.normal(loc=0, scale=0.02, size=120)
+    # Probs as percentages (40, 60, 80...) instead of [0, 1].
+    regime_probs = rng.uniform(20, 90, size=120)
+    with pytest.raises(ValueError, match="must be in \\[0, 1\\]"):
+        compute_regime_cvar_audited(returns, regime_probs)
+
+
+# ── Fix 7 — Unconditional fallback uses full history ─────────────────────
+
+def test_regime_unconditional_fallback_uses_full_history() -> None:
+    """When regime probs are shorter than returns and stress obs < 30,
+    the unconditional fallback must use the full 120m returns, not the
+    truncated 24m alignment slice."""
+    rng = np.random.default_rng(42)
+    full_returns = rng.normal(loc=-0.005, scale=0.04, size=120)
+    # Only 24 months of regime data — all low-stress (< 0.5).
+    regime_probs = rng.uniform(0.0, 0.3, size=24)
+
+    result = compute_regime_cvar_audited(full_returns, regime_probs)
+
+    # Should be unconditional fallback.
+    assert result.is_conditional is False
+    assert "insufficient_stress_obs_fallback_to_unconditional" in result.audit_note
+    # n_total_obs should reflect the FULL original history.
+    assert result.n_total_obs == 120, (
+        f"Expected n_total_obs=120 (full history), got {result.n_total_obs}"
+    )
+
+    # The CVaR value should match compute_cvar_from_returns on full 120m.
+    expected_cvar, _ = compute_cvar_from_returns(full_returns, 0.95)
+    assert abs(result.value - expected_cvar) < 1e-10, (
+        f"CVaR {result.value} != expected {expected_cvar} from full history"
+    )
+
+
+# ── Fix 8 — VaR index for small samples ──────────────────────────────────
+
+def test_var_index_for_small_samples() -> None:
+    """n=20, conf=0.95: tail_count=ceil(1.0)=1, so var=sorted[0] (the worst)."""
+    rng = np.random.default_rng(42)
+    returns = rng.normal(loc=0, scale=0.02, size=20)
+    sorted_returns = np.sort(returns)
+
+    cvar, var = compute_cvar_from_returns(returns, confidence=0.95)
+
+    # With 20 obs at 95%, tail_count = ceil(20 * 0.05) = ceil(1.0) = 1.
+    # VaR = sorted[0] (the single worst return).
+    assert var == float(sorted_returns[0]), (
+        f"VaR should be sorted[0]={sorted_returns[0]}, got {var}"
+    )
+    # CVaR = mean(sorted[:1]) = sorted[0] (same as VaR for single-obs tail).
+    assert cvar == float(sorted_returns[0])
+
+
+# ── Fix 9 — Parametric sigma uses ddof=1 ─────────────────────────────────
+
+def test_parametric_sigma_uses_ddof_one() -> None:
+    """Parametric path must use sample std (ddof=1), not population std (ddof=0)."""
+    rng = np.random.default_rng(42)
+    # Small sample where ddof=0 vs ddof=1 difference is material (~4.3% for n=12).
+    returns = rng.normal(loc=0.001, scale=0.03, size=12)
+
+    result = compute_cvar(returns, confidence=0.95, method="parametric")
+
+    # Compute expected with ddof=1 (sample std).
+    from scipy.stats import norm
+    mu = float(np.mean(returns))
+    sigma_sample = float(np.std(returns, ddof=1))
+    z = norm.ppf(0.05)
+    expected_var = mu + z * sigma_sample
+
+    assert abs(result.var - expected_var) < 1e-10, (
+        f"VaR {result.var} doesn't match ddof=1 expected {expected_var}"
+    )
+
+    # Verify it does NOT match ddof=0.
+    sigma_pop = float(np.std(returns, ddof=0))
+    wrong_var = mu + z * sigma_pop
+    assert abs(result.var - wrong_var) > 1e-6, (
+        "VaR should NOT match population std (ddof=0)"
+    )
+
+
+# ── Fix 11 — Breach float comparison with epsilon ────────────────────────
+
+def test_classify_trigger_status_handles_float_drift() -> None:
+    """Utilization at exactly 100.0 + tiny float drift should NOT trigger breach."""
+    # Simulate floating-point drift: 100.0 + 1e-10 (well within epsilon).
+    status = classify_trigger_status(
+        utilization_pct=100.0 + 1e-10,
+        consecutive_days=10,
+        breach_consecutive_days=5,
+    )
+    # Should be "warning" (100% utilization is at the boundary, not a breach).
+    assert status == "warning", f"Expected 'warning' at boundary, got '{status}'"
+
+    # But clearly above the threshold should still trigger breach.
+    status_above = classify_trigger_status(
+        utilization_pct=100.001,
+        consecutive_days=10,
+        breach_consecutive_days=5,
+    )
+    assert status_above == "breach", (
+        f"Expected 'breach' at 100.001%, got '{status_above}'"
+    )

--- a/backend/tests/quant_engine/test_cvar_service.py
+++ b/backend/tests/quant_engine/test_cvar_service.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from quant_engine.cvar_service import (
+    check_breach_status,
     classify_trigger_status,
     compute_cvar,
     compute_cvar_from_returns,
@@ -201,3 +202,56 @@ def test_classify_trigger_status_handles_float_drift() -> None:
     assert status_above == "breach", (
         f"Expected 'breach' at 100.001%, got '{status_above}'"
     )
+
+
+# ── Fix 12 — NaN cvar_current surfaces degraded BreachStatus ─────────────
+
+def test_check_breach_status_returns_degraded_on_nan_cvar() -> None:
+    """NaN cvar_current (from insufficient obs) must return trigger_status='degraded'."""
+    result = check_breach_status(
+        profile="conservative",
+        cvar_current=float("nan"),
+        consecutive_breach_days=3,
+    )
+    assert result.trigger_status == "degraded"
+    assert result.consecutive_breach_days == 0  # reset when degraded
+    assert math.isnan(result.cvar_utilized_pct)
+    assert math.isnan(result.cvar_current)
+
+
+# ── Fix 13 — check_breach_status uses epsilon for consecutive counter ─────
+
+def test_check_breach_status_uses_breach_epsilon_at_boundary() -> None:
+    """Utilization at 100 + tiny float drift should NOT increment consecutive days.
+
+    cvar_current / cvar_limit * 100 lands at ~100.0000005 due to float math.
+    Both the counter (Fix 13) and classify_trigger_status (Fix 11) must agree
+    this is NOT a breach.
+    """
+    # Construct values where ratio is just barely above 100% due to float drift.
+    # cvar_limit = -0.08, cvar_current = -0.08 * (1 + 5e-9) ≈ -0.0800000004
+    cvar_limit = -0.08
+    cvar_current = cvar_limit * (1.0 + 5e-9)  # tiny overshoot
+
+    result = check_breach_status(
+        profile="conservative",
+        cvar_current=cvar_current,
+        consecutive_breach_days=4,
+        config={
+            "conservative": {
+                "cvar": {
+                    "window_months": 12,
+                    "confidence": 0.95,
+                    "limit": cvar_limit,
+                    "warning_pct": 0.80,
+                    "breach_days": 5,
+                },
+            },
+        },
+    )
+    # Counter should NOT increment — the overshoot is within epsilon.
+    assert result.consecutive_breach_days == 0, (
+        f"Expected counter reset at boundary, got {result.consecutive_breach_days}"
+    )
+    # Status should be warning (utilization ≈ 100%), not breach.
+    assert result.trigger_status == "warning"

--- a/backend/tests/quant_engine/test_evt_pot_gpd.py
+++ b/backend/tests/quant_engine/test_evt_pot_gpd.py
@@ -243,7 +243,8 @@ def test_cvar_service_evt_integration():
 
     res = compute_cvar(returns, method="evt_pot", confidence=0.99)
     assert res.method == "evt_pot"
-    assert res.cvar > 0
+    # PR-Q13 Fix 2: compute_cvar now returns return-space (negative = loss).
+    assert res.cvar < 0
     assert res.evt_xi is not None
 
 
@@ -281,8 +282,9 @@ def test_compute_cvar_evt_default_confidence_no_longer_zeroes():
     assert res.method == "evt_pot"
     assert res.confidence == 0.95
     if not res.degraded:
-        assert res.cvar > 0, "EVT 0.95 returned zero — Q14 fix regressed"
-        assert res.var > 0
+        # PR-Q13 Fix 2: compute_cvar now returns return-space (negative = loss).
+        assert res.cvar < 0, "EVT 0.95 returned zero — Q14 fix regressed"
+        assert res.var < 0
 
 
 def test_risk_calc_evt_consumers_unaffected_by_q14():


### PR DESCRIPTION
## Summary

Applies 13 correctness fixes to `cvar_service.py` from a 3-model audit (GPT 5.5 + Gemini 3.1 Pro + Opus 4.6) of the CVaR computation path. All findings validated against source by senior reviewer; 11 originally identified plus 2 follow-ups (NaN propagation downstream + epsilon consistency) caught during local validation.

Standardizes the **return-space convention** (losses negative) across all 3 methods (historical / parametric / EVT/POT). Pre-PR-Q13, parametric and EVT returned positive loss-magnitudes while historical returned negative — `check_breach_status` was applying breach detection inconsistently depending on which method ran.

Depends on PR-Q14 (#299, already merged) for the EVT/POT `quantile_results` flexible dict.

## The 13 fixes

| # | Tier | Fix |
|---|---|---|
| 1 | 1 | Parametric path returns return-space (negative for losses) |
| 2 | 1 | EVT/POT loss-space → return-space negation in `compute_cvar` |
| 3 | 1 | `get_cvar_utilization` uses ratio + `max(0, ...)` instead of `abs()`, clamps gains to 0% |
| 4 | 2 | `cvar_limit >= 0` raises `ValueError` (was: silently returned `0.0` utilization on `cvar_limit=0`) |
| 5 | 2 | `<5 obs` returns `NaN` instead of `(0.0, 0.0)` (insufficient data is no longer optimistic) |
| 6 | 2 | `regime_probs` validated in `[0, 1]` (raises if percentages-as-numbers passed) |
| 7 | 2 | Unconditional fallback uses **full** original history, not the truncated alignment slice |
| 8 | 3 | VaR tail count uses `math.ceil(round(n*(1-c), 10))` for consistent VaR/CVaR boundary |
| 9 | 3 | Parametric `sigma` uses `ddof=1` (sample std), eliminating ~4.3% downward bias for n=12 |
| 10 | 3 | Early guard for insufficient obs across all methods (NaN with `degraded=True`) |
| 11 | 3 | `classify_trigger_status` uses `_BREACH_EPSILON = 1e-6` at 100% boundary |
| **12** | **2** | **`check_breach_status` returns `trigger_status="degraded"` on `NaN cvar_current`** (review follow-up) |
| **13** | **3** | **`check_breach_status` consecutive-day counter uses same `_BREACH_EPSILON`** (review follow-up) |

## Why fixes 12-13

After Fix 5 (NaN for insufficient obs) shipped, the senior reviewer traced NaN through downstream consumers:

```
compute_cvar_from_returns → returns NaN
  → check_breach_status(profile, NaN, ...)
     → get_cvar_utilization(NaN, -0.08) → NaN/-0.08 = NaN
     → max(0.0, NaN * 100) = 0.0  ← Python builtin: NaN compare False
     → consecutive_days = 0, trigger_status = "ok"  ← SILENTLY SWALLOWED
```

The original Fix 5 corrected the **source** but downstream consumers still treated NaN as "no risk." Fix 12 detects NaN at the entry of `check_breach_status` and surfaces `trigger_status="degraded"` so operators can distinguish "actually OK" from "couldn't compute." Fix 13 repairs an inconsistency where `classify_trigger_status` got the epsilon (Fix 11) but the counter check at `check_breach_status:433` didn't — the counter could ratchet up while classification refused to flag the breach.

## Sign convention now consistent

Post-PR-Q13, all 3 methods return **return-space**: losses are negative.

```python
res_hist = compute_cvar(returns, method="historical")    # cvar = -0.08 (8% loss)
res_para = compute_cvar(returns, method="parametric")    # cvar = -0.08 (8% loss)
res_evt  = compute_cvar(returns, method="evt_pot")       # cvar = -0.10 (10% loss tail)
```

Same sign for the same observed risk, regardless of method. `check_breach_status` and `get_cvar_utilization` now have a single, clean mental model.

## Test plan

```
13 new tests in test_cvar_service.py (created file)
3 existing assertions updated in test_evt_pot_gpd.py for return-space
236 CVaR / EVT / risk_calc / portfolio_eval / allocation tests pass
Lint + typecheck clean
```

Each new test maps 1:1 to a fix and was crafted to FAIL against unmodified code, PASS post-fix.

## Files changed

```
backend/quant_engine/cvar_service.py            +146 -33
backend/tests/quant_engine/test_cvar_service.py +257 -0   (new file)
backend/tests/quant_engine/test_evt_pot_gpd.py    +5 -3   (sign convention updates)
```

3 files, 408 insertions, 36 deletions across 2 commits.

## Methodological note

The 3-model audit produced 12 findings; 2 were false positives (Gemini and Opus both incorrectly inferred that `compute_cvar(method='evt_pot', confidence=0.95)` returned the 99% value relabeled — actually returned 0.0 due to a key-mismatch bug in `pot_gpd.py`, fixed by PR-Q14 #299). GPT 5.5 was the single model that called this correctly. The lesson encoded in the team's audit playbook: **agreement between two models is not validation — only reading the source code is.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)