### PR TITLE
garch_service correctness fixes (5 bugs) [PR-Q20]

### DIFF
--- a/backend/quant_engine/garch_service.py
+++ b/backend/quant_engine/garch_service.py
@@ -41,6 +41,26 @@ class GarchResult:
     log_likelihood: float | None
     converged: bool
     vol_model: str
+    degraded: bool = False
+    degraded_reason: str | None = None
+
+
+def _extract_garch_params(params: dict) -> tuple[float, float, float]:
+    """Extract (omega, alpha, beta) from arch fit. Raises if any key is missing."""
+    expected = {"omega", "alpha[1]", "beta[1]"}
+    missing = expected - set(params.keys())
+    if missing:
+        raise KeyError(
+            f"arch GARCH(1,1) params missing keys: {sorted(missing)}. "
+            f"Available: {sorted(params.keys())}. "
+            f"This usually means the arch package version is incompatible — "
+            f"check pip show arch and update _extract_garch_params if needed."
+        )
+    return (
+        float(params["omega"]),
+        float(params["alpha[1]"]),
+        float(params["beta[1]"]),
+    )
 
 
 def fit_garch(
@@ -52,7 +72,9 @@ def fit_garch(
     Parameters
     ----------
     returns : np.ndarray
-        (T,) daily returns (log or arithmetic).
+        (T,) daily returns (log or arithmetic) in **decimal** form
+        (e.g. 0.005 for +0.5%). This function multiplies by 100 internally
+        to match the ``arch`` package convention.
     trading_days_per_year : int
         Annualization factor.
 
@@ -62,9 +84,30 @@ def fit_garch(
         None if `arch` library is not installed or returns are too short.
 
     """
-    if len(returns) < 100:
-        logger.debug("garch_insufficient_data", n_obs=len(returns))
+    # ── Fix 4 (BUG-G3): filter NaN/Inf before length check ──────────
+    returns_arr = np.asarray(returns, dtype=np.float64)
+    finite_mask = np.isfinite(returns_arr)
+    if not finite_mask.all():
+        n_dropped = int((~finite_mask).sum())
+        returns_arr = returns_arr[finite_mask]
+        logger.info(
+            "garch_dropped_non_finite_observations",
+            n_dropped=n_dropped,
+            n_remaining=int(len(returns_arr)),
+        )
+
+    if len(returns_arr) < 100:
+        logger.debug("garch_insufficient_data", n_obs=len(returns_arr))
         return None
+
+    # ── Fix 5 (BUG-G5): reject percent-form returns ─────────���────────
+    returns_std = float(np.std(returns_arr))
+    if returns_std > 0.5:
+        raise ValueError(
+            f"fit_garch: returns appear to be in percent form (std={returns_std:.4f}). "
+            f"Pass returns as decimals (e.g., 0.005 for 0.5% daily move), not percents. "
+            f"This function multiplies by 100 internally to match arch package convention."
+        )
 
     try:
         from arch import arch_model
@@ -74,7 +117,7 @@ def fit_garch(
 
     try:
         # Scale returns to percentage for numerical stability (arch convention)
-        returns_pct = returns * 100.0
+        returns_pct = returns_arr * 100.0
 
         model = arch_model(
             returns_pct,
@@ -100,45 +143,73 @@ def fit_garch(
                 vol_model="EWMA_0.94",
             )
 
-        params = result.params
-        omega = float(params.get("omega", 0.0))
-        alpha = float(params.get("alpha[1]", 0.0))
-        beta = float(params.get("beta[1]", 0.0))
+        # ── Fix 3 (BUG-G2): fail loud on missing param keys ──────────
+        omega, alpha, beta = _extract_garch_params(result.params.to_dict())
         persistence = alpha + beta
 
         # 1-step-ahead forecast (in percentage^2)
         forecast = result.forecast(horizon=1)
         variance_1step = float(forecast.variance.values[-1, 0])
 
+        # ── Fix 2 (BUG-G4): guard NaN/negative variance ─────────────
+        if not np.isfinite(variance_1step) or variance_1step < 0:
+            logger.warning(
+                "garch_variance_1step_invalid",
+                variance_1step=(
+                    float(variance_1step)
+                    if np.isfinite(variance_1step)
+                    else "nan_or_inf"
+                ),
+            )
+            return GarchResult(
+                volatility_garch=None,
+                volatility_long_run=None,
+                omega=round(omega, 8),
+                alpha=round(alpha, 6),
+                beta=round(beta, 6),
+                persistence=round(persistence, 6),
+                log_likelihood=round(float(result.loglikelihood), 2),
+                converged=False,
+                vol_model="EWMA_0.94",
+                degraded=True,
+                degraded_reason="variance_1step_invalid",
+            )
+
         # Convert back from pct^2 to decimal and annualize
-        daily_vol = np.sqrt(variance_1step) / 100.0
+        daily_vol = np.sqrt(max(variance_1step, 0.0)) / 100.0
         annual_vol = daily_vol * np.sqrt(trading_days_per_year)
 
-        # ── Long-run (unconditional) volatility ───────────────────────────
-        # For a stationary GARCH(1,1) with α + β < 1 the unconditional
-        # variance is σ²_∞ = ω / (1 − α − β). This is the variance the
-        # process reverts to after every shock decays, and it's the right
-        # number for strategic-horizon consumers (scoring, strategic
-        # allocation, long-form DD).
-        #
-        # ``ω`` comes out of ``arch`` in the same units as the input
-        # (here: percentage squared, because we fed percentage returns).
-        # We therefore annualise through the same √(trading_days) ladder
-        # as the conditional vol to keep the two numbers comparable.
-        long_run_vol: float | None
-        stationary_gap = 1.0 - persistence
-        if stationary_gap > 1e-6:
-            long_run_daily_var_pct = omega / stationary_gap
-            long_run_daily_vol = np.sqrt(max(long_run_daily_var_pct, 0.0)) / 100.0
-            long_run_annual_vol = long_run_daily_vol * np.sqrt(trading_days_per_year)
-            long_run_vol = round(float(long_run_annual_vol), 6)
-        else:
-            # Non-stationary / IGARCH fit — no finite long-run variance.
+        # ── Fix 1 (BUG-G1): reject non-stationary fits ──────────────
+        is_stationary = persistence < 1.0 - 1e-6
+
+        if not is_stationary:
             logger.warning(
-                "garch_non_stationary_no_long_run_vol",
+                "garch_non_stationary_fit",
+                alpha=round(alpha, 6),
+                beta=round(beta, 6),
                 persistence=round(persistence, 6),
             )
-            long_run_vol = None
+            return GarchResult(
+                volatility_garch=None,
+                volatility_long_run=None,
+                omega=round(omega, 8),
+                alpha=round(alpha, 6),
+                beta=round(beta, 6),
+                persistence=round(persistence, 6),
+                log_likelihood=round(float(result.loglikelihood), 2),
+                converged=False,
+                vol_model="EWMA_0.94",
+                degraded=True,
+                degraded_reason="non_stationary_persistence_ge_1",
+            )
+
+        # ── Long-run (unconditional) volatility ───────────────────────
+        # σ²_∞ = ω / (1 − α − β), annualized same as conditional vol.
+        stationary_gap = 1.0 - persistence
+        long_run_daily_var_pct = omega / stationary_gap
+        long_run_daily_vol = np.sqrt(max(long_run_daily_var_pct, 0.0)) / 100.0
+        long_run_annual_vol = long_run_daily_vol * np.sqrt(trading_days_per_year)
+        long_run_vol = round(float(long_run_annual_vol), 6)
 
         return GarchResult(
             volatility_garch=round(float(annual_vol), 6),

--- a/backend/tests/quant_engine/test_garch_correctness.py
+++ b/backend/tests/quant_engine/test_garch_correctness.py
@@ -1,0 +1,168 @@
+"""Regression tests for PR-Q20 garch_service correctness fixes (5 bugs).
+
+Each test maps 1:1 with a fix in docs/prompts/2026-04-25-pr-q20-garch-correctness.md.
+DO NOT collapse multiple bug coverages into a single test — independence is the point.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from quant_engine.garch_service import _extract_garch_params, fit_garch
+
+# ─── Tier 2 ────────────────────────────────────────────────────────────────
+
+
+def test_BUG_G1_non_stationary_fit_returns_degraded():
+    """Non-stationary GARCH fit (α+β ≥ 1) must return degraded=True, volatility_garch=None.
+
+    Pre-fix: returned volatility_garch with converged=True even for explosive processes.
+    """
+    rng = np.random.default_rng(42)
+    returns = rng.normal(0.0003, 0.015, 500)
+
+    # Mock a converged result whose params yield persistence ≥ 1.0
+    mock_result = MagicMock()
+    mock_result.convergence_flag = 0
+    mock_result.params = MagicMock()
+    mock_result.params.to_dict.return_value = {
+        "omega": 0.01,
+        "alpha[1]": 0.20,
+        "beta[1]": 0.85,  # persistence = 1.05
+    }
+    mock_result.loglikelihood = -500.0
+    # forecast still provides a value — but we shouldn't trust it
+    mock_forecast = MagicMock()
+    mock_forecast.variance.values = np.array([[2.5]])
+    mock_result.forecast.return_value = mock_forecast
+
+    with patch("arch.arch_model") as mock_arch_model:
+        mock_model = MagicMock()
+        mock_model.fit.return_value = mock_result
+        mock_arch_model.return_value = mock_model
+
+        result = fit_garch(returns)
+
+    assert result is not None
+    assert result.degraded is True
+    assert result.degraded_reason == "non_stationary_persistence_ge_1"
+    assert result.volatility_garch is None
+    assert result.converged is False
+
+
+# ─── Tier 3 ────────────────────────────────────────────────────────────────
+
+
+def test_BUG_G4_negative_variance_1step_returns_degraded():
+    """Negative 1-step variance (numerical noise) must not produce NaN volatility.
+
+    Pre-fix: np.sqrt(-1e-15) → RuntimeWarning + NaN written to DB.
+    """
+    rng = np.random.default_rng(42)
+    returns = rng.normal(0.0003, 0.015, 500)
+
+    mock_result = MagicMock()
+    mock_result.convergence_flag = 0
+    mock_result.params = MagicMock()
+    mock_result.params.to_dict.return_value = {
+        "omega": 0.01,
+        "alpha[1]": 0.05,
+        "beta[1]": 0.90,  # persistence = 0.95, stationary
+    }
+    mock_result.loglikelihood = -500.0
+    mock_forecast = MagicMock()
+    mock_forecast.variance.values = np.array([[-1e-15]])  # tiny negative
+    mock_result.forecast.return_value = mock_forecast
+
+    with patch("arch.arch_model") as mock_arch_model:
+        mock_model = MagicMock()
+        mock_model.fit.return_value = mock_result
+        mock_arch_model.return_value = mock_model
+
+        result = fit_garch(returns)
+
+    assert result is not None
+    assert result.degraded is True
+    assert result.degraded_reason == "variance_1step_invalid"
+    assert result.volatility_garch is None
+    assert result.converged is False
+
+
+def test_BUG_G4_nan_variance_1step_returns_degraded():
+    """NaN 1-step variance must return degraded, not propagate NaN.
+
+    Pre-fix: round(nan, 6) = nan written to DB as volatility_garch.
+    """
+    rng = np.random.default_rng(42)
+    returns = rng.normal(0.0003, 0.015, 500)
+
+    mock_result = MagicMock()
+    mock_result.convergence_flag = 0
+    mock_result.params = MagicMock()
+    mock_result.params.to_dict.return_value = {
+        "omega": 0.01,
+        "alpha[1]": 0.05,
+        "beta[1]": 0.90,
+    }
+    mock_result.loglikelihood = -500.0
+    mock_forecast = MagicMock()
+    mock_forecast.variance.values = np.array([[float("nan")]])
+    mock_result.forecast.return_value = mock_forecast
+
+    with patch("arch.arch_model") as mock_arch_model:
+        mock_model = MagicMock()
+        mock_model.fit.return_value = mock_result
+        mock_arch_model.return_value = mock_model
+
+        result = fit_garch(returns)
+
+    assert result is not None
+    assert result.degraded is True
+    assert result.degraded_reason == "variance_1step_invalid"
+    assert result.volatility_garch is None
+
+
+# ─── Tier 4 ────────────────────────────────────────────────────────────────
+
+
+def test_BUG_G2_arch_param_rename_raises_keyerror():
+    """Missing param keys must raise KeyError, not silently default to 0.0.
+
+    Pre-fix: params.get("alpha[1]", 0.0) → zero-volatility fund → optimizer over-allocates.
+    """
+    incomplete_params = {"omega": 0.01, "alpha[1]": 0.05}  # missing beta[1]
+
+    with pytest.raises(KeyError, match="beta\\[1\\]"):
+        _extract_garch_params(incomplete_params)
+
+    # Also verify completely empty dict fails loud
+    with pytest.raises(KeyError, match="params missing keys"):
+        _extract_garch_params({})
+
+
+def test_BUG_G3_nan_returns_filtered_before_fit():
+    """Returns with NaN/Inf must be filtered; remaining count checked against min_obs.
+
+    Pre-fix: len([nan]*99 + [0.01]) = 100 → passed gate → degenerate fit.
+    """
+    # 95 NaN + 10 finite = 105 total, but only 10 finite → should return None
+    returns = np.concatenate([np.full(95, np.nan), np.random.default_rng(42).normal(0, 0.01, 10)])
+    assert len(returns) == 105  # would pass old gate
+
+    result = fit_garch(returns)
+    assert result is None  # only 10 finite obs < 100 min_obs
+
+
+def test_BUG_G5_percent_returns_input_raises():
+    """Passing percent-form returns (std > 0.5) must raise ValueError.
+
+    Pre-fix: returns * 100 → absurd ω, annualized vol ~5000%, no warning.
+    """
+    # Simulate percent returns: values like [0.5, -0.3, 0.7] meaning 50%, -30%, 70%
+    rng = np.random.default_rng(42)
+    percent_returns = rng.normal(0.5, 2.0, 200)  # std ≈ 2.0 >> 0.5
+
+    with pytest.raises(ValueError, match="returns appear to be in percent form"):
+        fit_garch(percent_returns)


### PR DESCRIPTION
## Summary

Applies **5 correctness fixes** to `backend/quant_engine/garch_service.py` from a 4-wave 3-model audit (GPT 5.5 + Gemini 3.1 Pro + Opus 4.6) validated by senior reviewer Opus 4.7. **Zero Tier 1, zero GRAYs** — smallest module of the audit wave (167 lines), cleanest sprint.

Output drives `volatility_garch` column on `fund_risk_metrics`, consumed by optimizer for forward-looking volatility estimates. Wrong values silently corrupt portfolio variance estimates.

## The 5 fixes

| # | BUG | Tier | Resolution |
|---|---|---|---|
| 1 | **BUG-G1** | T2 | Non-stationary fits (α+β≥1) now return `degraded=True, volatility_garch=None` instead of `converged=True` + explosive forecast. |
| 2 | **BUG-G4** | T3 | NaN/negative `variance_1step` guarded with `isfinite` + negative check → degraded result. Mirrors the existing guard in the long_run_vol path. |
| 3 | **BUG-G2** | T4 | `_extract_garch_params` raises KeyError on missing arch package keys (was silent zero-volatility on `arch` upgrade rename). |
| 4 | **BUG-G3** | T4 | NaN/Inf returns filtered before length check via `np.isfinite` mask. |
| 5 | **BUG-G5** | T4 | Reject `np.std(returns) > 0.5` with informative ValueError — catches percent-form returns passed where decimals expected. |

## Production impact

**Tier 2 (BUG-G1)** is the most-felt: explosive GARCH processes (α+β≥1) were silently shipped to the optimizer as "valid" forward-looking volatility. After fix, those funds get `volatility_garch=NULL` and the worker falls back to EWMA (already handled correctly in `risk_calc.py:612`).

**Tier 3 (BUG-G4)** and **Tier 4 (BUG-G3)** complete the NaN/edge-case hardening — small-negative variance noise (1e-15) and patchy-data inputs now produce degraded results instead of NaN-poisoning.

## Test plan

```
6 new regression tests in test_garch_correctness.py (all pass)
5 existing garch tests unaffected
ruff check backend/ clean
```

## Files changed

```
backend/quant_engine/garch_service.py                    5 fixes + GarchResult.degraded fields (back-compat default)
backend/tests/quant_engine/test_garch_correctness.py     (new — 6 regression tests)
```

2 commits: implementation + tests.

## GarchResult schema

Extended with `degraded: bool = False, degraded_reason: str | None = None` (back-compat — existing constructors keep working). Caller (`risk_calc.py`) already handles `volatility_garch=None` correctly via EWMA fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)