### PR TITLE
fix(identity): PR-Q11 follow-up — field length + ESMA LEI/ISIN routing

### DIFF
--- a/backend/app/core/config/settings.py
+++ b/backend/app/core/config/settings.py
@@ -76,6 +76,7 @@ class Settings(BaseSettings):
     # ── External APIs ────────────────────────────────────────
     fred_api_key: str = ""
     tiingo_api_key: str = ""
+    openfigi_api_key: str = ""
     companyfacts_dir: Path | None = None
 
     # ── Data Commons (free key from https://apikeys.datacommons.org/) ──

--- a/backend/app/core/jobs/identity_resolver.py
+++ b/backend/app/core/jobs/identity_resolver.py
@@ -579,8 +579,31 @@ async def _source_3_esma(
             sr = SourceResult(source_name)
             iid = row.instrument_id
 
-            if row.esma_isin:
-                sr.set("isin", row.esma_isin)
+            # esma_funds.isin is corrupted: it stores LEIs (20 chars) for many
+            # rows, not ISINs. Detect format and route to the correct field.
+            # Real ISINs are 12 chars matching ^[A-Z]{2}[A-Z0-9]{9}[0-9]$;
+            # anything 20-char alphanumeric is a LEI; everything else is logged
+            # and dropped. This is a defensive heuristic — the canonical fix
+            # lives upstream in the ESMA ingestion worker (separate ticket).
+            val = row.esma_isin
+            if val:
+                if (
+                    len(val) == 12
+                    and val.isascii()
+                    and val[:2].isalpha()
+                    and val.isalnum()
+                    and val[-1].isdigit()
+                ):
+                    sr.set("isin", val)
+                elif len(val) == 20 and val.isascii() and val.isalnum():
+                    sr.set("lei", val)
+                else:
+                    logger.info(
+                        "identity_resolver.esma_isin_unrecognized",
+                        value_preview=val[:30],
+                        value_length=len(val),
+                    )
+
             if row.esma_manager_id:
                 sr.set("esma_manager_id", row.esma_manager_id)
             if row.lei:

--- a/backend/app/core/jobs/identity_resolver.py
+++ b/backend/app/core/jobs/identity_resolver.py
@@ -23,6 +23,8 @@ import structlog
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config.settings import settings
+
 logger = structlog.get_logger(__name__)
 
 IDENTITY_RESOLVER_LOCK_ID = 900_110
@@ -722,7 +724,9 @@ async def _source_5_openfigi(
     source_name = "openfigi"
     results: dict[str, SourceResult] = {}
 
-    api_key = os.environ.get("OPENFIGI_API_KEY", "")
+    # Settings loads .env via Pydantic; falling back to os.environ keeps the
+    # legacy contract for direct env-var injection in CI/Railway.
+    api_key = settings.openfigi_api_key or os.environ.get("OPENFIGI_API_KEY", "")
     if not api_key:
         logger.warning("identity_resolver.openfigi_no_api_key")
         return results, False

--- a/backend/app/core/jobs/identity_resolver.py
+++ b/backend/app/core/jobs/identity_resolver.py
@@ -69,6 +69,31 @@ FIELD_AUTHORITY: dict[str, dict[str, int]] = {
 # ---------------------------------------------------------------------------
 
 
+# Per-field VARCHAR length limits from instrument_identity schema (migration 0177).
+# Sources occasionally emit values that exceed these limits (e.g. OpenFIGI may
+# return a composite ticker like "TICKER:EXCH:MIC" that is too wide). Without
+# pre-validation those rows fail the whole INSERT with StringDataRightTruncationError
+# and the entire instrument's identity row is lost.
+_FIELD_MAX_LENGTH: dict[str, int] = {
+    "cik_padded": 10,
+    "cik_unpadded": 10,
+    "sec_series_id": 15,
+    "sec_class_id": 15,
+    "sec_crd": 10,
+    "sec_private_fund_id": 50,
+    "cusip_8": 8,
+    "cusip_9": 9,
+    "isin": 12,
+    "sedol": 7,
+    "figi": 12,
+    "ticker": 20,
+    "ticker_exchange": 20,
+    "mic": 4,
+    "lei": 20,
+    "esma_manager_id": 20,
+}
+
+
 class SourceResult:
     """Container for identity fields discovered by a single source."""
 
@@ -77,8 +102,20 @@ class SourceResult:
         self.fields: dict[str, str | None] = {}
 
     def set(self, field: str, value: str | None) -> None:
-        if value is not None:
-            self.fields[field] = value
+        if value is None:
+            return
+        max_len = _FIELD_MAX_LENGTH.get(field)
+        if max_len is not None and len(value) > max_len:
+            logger.warning(
+                "identity_resolver.field_too_long",
+                source=self.source_name,
+                field=field,
+                value_length=len(value),
+                max_length=max_len,
+                value_preview=value[:50],
+            )
+            return
+        self.fields[field] = value
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three correctness fixes surfaced by the worker first-run after #313 merge.

### Fix 1 — Field length validation in SourceResult.set

Worker raised `StringDataRightTruncationError: value too long for type character varying(12)` repeatedly. Cause: `SourceResult.set()` stored raw values without length validation; one over-length value aborted the whole INSERT, dropping all of that instrument's identity fields.

Now `_FIELD_MAX_LENGTH` mirrors the schema. Over-length values emit `identity_resolver.field_too_long` (with source, field, length, max_length, 50-char preview) and are skipped; the rest of the row upserts normally.

### Fix 2 — Route ESMA "isin" column by detected format (LEI vs ISIN)

Worker first-run produced **0 ISIN coverage** despite 2.929 ESMA `yahoo_ticker` matches. Diagnostic showed all 10.436 `esma_funds.isin` values are 20-char LEIs, not 12-char ISO 6166 ISINs. Documented data-quality issue in the upstream ESMA ingestion (separate ticket).

Per OpenFIGI `/v3/mapping` documentation, LEI is **not** an accepted idType — only security-level identifiers (26 idTypes covering ISIN, CUSIP, SEDOL, ticker, etc.). Silently writing LEI into `instrument_identity.isin` would be operationally incorrect.

Source 3 inspects each value:
- 12 chars matching ISO 6166 → `instrument_identity.isin`
- 20 alphanumeric chars → `instrument_identity.lei`
- anything else → logged and skipped

### Fix 3 — Declare `openfigi_api_key` in settings.py

Worker reported `identity_resolver.openfigi_no_api_key` despite `OPENFIGI_API_KEY` being in `.env`. Pydantic only loads `.env` values for declared settings fields; the variable was never lifted into `os.environ`.

`openfigi_api_key: str = ""` added to settings (alongside `fred_api_key`, `tiingo_api_key`). Source 5 reads `settings.openfigi_api_key or os.environ.get(...)` — Pydantic path preferred, env-var injection preserved for CI/Railway.

## Expected re-run effect

| Field | Before | After |
|---|---:|---:|
| `cik_padded` | 6.027 | 6.027 (unchanged) |
| `lei` | 0 | **~2.929** (from ESMA routing fix) |
| `isin` | 0 | populates via OpenFIGI ticker→ISIN mapping (Fix 1 + Fix 3 unblock) |
| `figi` / `cusip_9` | 0 | populates via OpenFIGI |
| `unresolved` | 0 | unchanged |

## Test plan

- [x] `ruff check backend/` clean
- [ ] CI green (3 commits)
- [ ] Re-run worker locally; confirm:
  - `identity_resolver.field_too_long` warnings list which exact OpenFIGI fields overflow
  - `lei` count > 0
  - `isin` / `figi` / `cusip_9` populated for US-listed instruments

## Out of scope

- ✗ Fixing the ESMA ingestion that mislabeled LEI as ISIN (separate ticket — real ISINs need re-extraction from ESMA FIRDS source data)
- ✗ Schema width changes (12 chars is correct for ISIN per ISO 6166)

## Follow-up tickets after merge

- [ ] ESMA ingestion fix: rename `esma_funds.isin` → `esma_funds.lei`, re-ingest real ISIN from FIRDS XML

🤖 Generated with [Claude Code](https://claude.com/claude-code)