### PR TITLE
fix(identity): PR-Q11 — OpenFIGI source uses httpx, not aiohttp

### DIFF
--- a/backend/app/core/jobs/identity_resolver.py
+++ b/backend/app/core/jobs/identity_resolver.py
@@ -690,30 +690,34 @@ async def _openfigi_batch_request(
     tickers: list[dict[str, str]],
     api_key: str,
 ) -> list[dict | None]:
-    """Send a batch of up to 100 items to OpenFIGI /v3/mapping."""
-    import aiohttp
+    """Send a batch of up to 100 items to OpenFIGI /v3/mapping.
+
+    Uses httpx (project standard, declared in pyproject.toml). Earlier
+    iteration used aiohttp by mistake — that module is not a project
+    dependency and caused 100% provider-gate circuit-open failures during
+    the first worker run.
+    """
+    import httpx
 
     headers = {
         "Content-Type": "application/json",
         "X-OPENFIGI-APIKEY": api_key,
     }
 
-    async with aiohttp.ClientSession() as session:
-        async with session.post(
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
             OPENFIGI_ENDPOINT,
             json=tickers,
             headers=headers,
-            timeout=aiohttp.ClientTimeout(total=30),
-        ) as resp:
-            if resp.status != 200:
-                text_body = await resp.text()
-                logger.warning(
-                    "openfigi.request_failed",
-                    status=resp.status,
-                    body=text_body[:200],
-                )
-                return [None] * len(tickers)
-            return await resp.json()
+        )
+        if resp.status_code != 200:
+            logger.warning(
+                "openfigi.request_failed",
+                status=resp.status_code,
+                body=resp.text[:200],
+            )
+            return [None] * len(tickers)
+        return resp.json()
 
 
 async def _source_5_openfigi(


### PR DESCRIPTION
## Summary

Worker first-run after #318 produced zero `instrument_identity.{isin, figi, cusip}` despite OpenFIGI key being correctly loaded. Diagnose: source 5 used `aiohttp` which is not a project dependency.

```
2026-04-26 09:40:08 [warning] identity_resolver.openfigi_batch_error
  error="No module named 'aiohttp'"
[... 10x ...]
2026-04-26 09:40:08 [warning] provider_gate_opened name=openfigi failures=10
2026-04-26 09:40:08 [warning] identity_resolver.openfigi_batch_error
  error="provider 'openfigi' circuit is open"
```

Worker hit ExternalProviderGate `failure_threshold=10`, opened circuit, rest of the run silently skipped OpenFIGI.

## Fix

Migrate `_openfigi_batch_request` from `aiohttp` to `httpx`. Same 30s timeout, same 200-status path, same warning telemetry. `httpx` is declared in `pyproject.toml` and already used elsewhere (`firds_service.py`, etc).

## Why the bug landed

Bug introduced by Opus 4.6 in PR #313 Phase 3 (OpenFIGI source). Lint and import-linter pass because both libraries are valid Python; the failure is only observable at runtime when the module is missing. Tests covered the OpenFIGI flow with mocks, never exercising real import.

## Test plan

- [x] `ruff check backend/` clean
- [ ] CI green
- [ ] After merge, re-run worker locally with:
  ```bash
  docker exec netz-analysis-engine-db-1 psql -U netz -d netz_engine -c \
    "UPDATE instrument_identity SET last_resolved_at = NULL"
  python backend/scripts/run_identity_resolver.py 2>&1 | tee identity_v4.log
  ```
- [ ] Validate post-run: `has_figi`, `has_isin`, `has_cusip` populate for US-listed instruments (~thousands)

## Out of scope

- Tests update — existing OpenFIGI tests mock `_openfigi_batch_request` directly, no httpx vs aiohttp boundary in mock layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)