### PR TITLE
feat(identity): PR-Q11 — emit ticker for UCITS in source 3

### DIFF
--- a/backend/app/core/jobs/identity_resolver.py
+++ b/backend/app/core/jobs/identity_resolver.py
@@ -559,6 +559,7 @@ async def _source_3_esma(
             text("""
                 SELECT
                     iu.instrument_id::text,
+                    iu.ticker AS iu_ticker,
                     ef.isin AS esma_isin,
                     ef.esma_manager_id,
                     em.lei
@@ -610,6 +611,15 @@ async def _source_3_esma(
                 sr.set("esma_manager_id", row.esma_manager_id)
             if row.lei:
                 sr.set("lei", row.lei)
+            # Andrei (2026-04-26): UCITS ticker matters institutionally for
+            # broker-facing identification; CUSIP 144A wrapper is not the
+            # primary need. Emit ticker from instruments_universe.ticker
+            # (which equals esma_funds.yahoo_ticker by ingestion contract)
+            # so that 2.929 UCITS get a usable ticker in instrument_identity.
+            # Authority: ESMA = 2 (per FIELD_AUTHORITY); SEC sources (3-4)
+            # never resolve UCITS so no real conflict.
+            if row.iu_ticker:
+                sr.set("ticker", row.iu_ticker)
 
             if sr.fields:
                 results[iid] = sr


### PR DESCRIPTION
## Summary

Worker source 3 already JOINs `instruments_universe.ticker` against `esma_funds.yahoo_ticker` for fund-LEI matching, but never extracted the ticker itself. Result: 2.929 UCITS rows resolved with LEI but NULL `ticker` in `instrument_identity`.

For Andrei's institutional context: **broker-facing UCITS ticker is the primary need**. CUSIP 144A wrapper is a separate custody-side problem (Pershing observed-source / manual top funds — out of scope here).

## Fix

Two-line change in source 3:

- `SELECT` exposes `iu.ticker AS iu_ticker`
- `sr.set("ticker", iu_ticker)` when present

Authority unchanged — `FIELD_AUTHORITY["ticker"]` has ESMA=2 < SEC sources (3, 4). SEC sources never resolve UCITS so no real conflict.

## Coverage diagnostic

```sql
SELECT COUNT(*) FROM instruments_universe
WHERE attributes ? 'esma_manager_id' AND ticker IS NOT NULL;
-- 2.930
```

vs current:

```sql
SELECT COUNT(*) FROM instrument_identity ii
JOIN instruments_universe iu ON iu.instrument_id = ii.instrument_id
WHERE iu.attributes ? 'esma_manager_id' AND ii.ticker IS NOT NULL;
-- 13 (only dual-listed picked up by OpenFIGI)
```

Expected post-merge: ~2.929 UCITS get usable ticker.

## Activation

```bash
docker exec netz-analysis-engine-db-1 psql -U netz -d netz_engine -c \
  "UPDATE instrument_identity SET last_resolved_at = NULL"
python backend/scripts/run_identity_resolver.py
```

## Out of scope

- CUSIP 144A wrapper resolution (separate problem; needs Pershing/CGS — not this PR)
- ISIN coverage for UCITS (PR-Q11B/Q11C with FIRDS XML)
- OpenFIGI exchCode='US' relaxation (would also help but adds dedupe complexity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)