### PR TITLE
feat(esma): PR-Q11B — ESMA identity correction + FIRDS share-class ingestion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ frontends/
   wealth/           ← SvelteKit "netz-wealth-os"
 ```
 
-**Database:** PostgreSQL 16 + TimescaleDB + pgvector. Managed via Timescale Cloud (prod) or docker-compose (dev). Redis 7 via Upstash (prod) or docker-compose (dev). Migrations via Alembic. App uses async asyncpg. Current migration head: `0175_add_issuer_cik_to_cusip_map`.
+**Database:** PostgreSQL 16 + TimescaleDB + pgvector. Managed via Timescale Cloud (prod) or docker-compose (dev). Redis 7 via Upstash (prod) or docker-compose (dev). Migrations via Alembic. App uses async asyncpg. Current migration head: `0183_mv_unified_funds_ucits_share_classes`.
 
 **Auth:** Clerk JWT v2. `organization_id` from `o.id` claim. RLS via `SET LOCAL app.current_organization_id`. Dev bypass: `X-DEV-ACTOR` header. **Tenant and user management is 100% via Clerk Dashboard** — no custom admin UI. Organizations, user invites, and role assignment (`ADMIN`, `INVESTMENT_TEAM`, `investor`) are all managed in Clerk. `ConfigService` defaults mean new tenants work immediately without provisioning.
 
@@ -152,7 +152,7 @@ Six non-negotiable principles enforced across the stack: **P1 Bounded**, **P2 Ba
 - **expire_on_commit=False:** Always. Prevents implicit I/O in async context.
 - **lazy="raise":** Set on ALL relationships. Forces explicit `selectinload()`/`joinedload()`.
 - **RLS subselect:** All RLS policies must use `(SELECT current_setting(...))` not bare `current_setting()`. Without subselect, per-row evaluation causes 1000x slowdown.
-- **Global tables:** `macro_data`, `allocation_blocks`, `vertical_config_defaults`, `benchmark_nav`, `macro_regional_snapshots`, `treasury_data`, `ofr_hedge_fund_data`, `bis_statistics`, `imf_weo_forecasts`, `sec_*` tables, `sec_insider_transactions`, `esma_funds`, `esma_managers`, `instruments_universe`, `nav_timeseries`, `sec_fund_prospectus_returns`, `sec_fund_prospectus_stats`, `fund_risk_metrics` have NO `organization_id`, NO RLS. They are shared across all tenants.
+- **Global tables:** `macro_data`, `allocation_blocks`, `vertical_config_defaults`, `benchmark_nav`, `macro_regional_snapshots`, `treasury_data`, `ofr_hedge_fund_data`, `bis_statistics`, `imf_weo_forecasts`, `sec_*` tables, `sec_insider_transactions`, `esma_funds`, `esma_managers`, `esma_securities`, `instruments_universe`, `nav_timeseries`, `sec_fund_prospectus_returns`, `sec_fund_prospectus_stats`, `fund_risk_metrics` have NO `organization_id`, NO RLS. They are shared across all tenants.
 - **`fund_risk_metrics`** is GLOBAL — pre-computed by `global_risk_metrics` worker (lock 900_071) for ALL active instruments in `instruments_universe`, including DTW drift (by strategy_label), 5Y/10Y annualized returns. `organization_id` column is nullable (NULL for global rows). RLS is disabled (hypertable compression incompatible). All tenants see the same risk metrics. Org-scoped `risk_calc` (lock 900_007) computes org-specific overrides (no DTW — handled globally). Routes must NOT filter by `organization_id` when reading risk metrics.
 - **`instruments_universe`** is a GLOBAL catalog (no RLS). Org-scoped instrument selection is via `instruments_org` (has RLS, `organization_id`, `block_id`, `approval_status`). The `Instrument` model has NO `organization_id`, `block_id`, or `approval_status` — those live on `InstrumentOrg`. All queries needing org-scoped instruments must JOIN `instruments_org`.
 - **`nav_timeseries`** is GLOBAL (no RLS, no `organization_id`). Prices are market data shared across all tenants. Org-scoping for NAV queries is via JOIN `instruments_org`.
@@ -230,6 +230,7 @@ Background workers ingest all external time-series data into hypertables. Routes
 | `portfolio_nav_synthesizer` | 900_030 | org | `model_portfolio_nav` (1mo chunks) | Computed (weighted NAV from nav_timeseries) | Daily |
 | `nport_fund_discovery` | 900_024 | global | `sec_registered_funds`, `sec_fund_classes` | SEC EDGAR N-PORT headers | Weekly |
 | `esma_ingestion` | — | global | `esma_funds`, `esma_managers` | ESMA Fund Register | Weekly |
+| `firds_ucits_security_sync` | crc32 | global | `esma_securities` | ESMA FIRDS FULINS_C (share-class ISINs filtered by esma_funds.lei) | Daily |
 | `wealth_embedding` | 900_041 | global | `wealth_vector_chunks` | OpenAI text-embedding-3-large (12 sources) | Daily |
 | `sec_bulk_ingestion` | 900_050 | global | sec_etfs, sec_bdcs, sec_money_market_funds, sec_mmf_metrics, sec_registered_funds, strategy_label | SEC DERA bulk ZIPs (N-CEN, N-MFP, N-PORT, BDC) | Quarterly |
 | `form345_ingestion` | 900_051 | global | `sec_insider_transactions`, `sec_insider_sentiment` (MV) | SEC EDGAR Form 345 bulk TSV (insider buys/sells) | Quarterly |
@@ -404,7 +405,7 @@ Canonical resolver for CIK / CUSIP / ticker / ISIN / FIGI / series_id / class_id
 |---|---|
 | SEC `company_tickers.json` (local) | CIK ↔ ticker (10-K filers) |
 | SEC `company_tickers_mf.json` | CIK ↔ series_id ↔ class_id ↔ ticker |
-| ESMA Fund Register (`esma_funds`) | ISIN ↔ esma_manager_id ↔ LEI |
+| ESMA Fund Register (`esma_funds`) | LEI (PK) ↔ esma_manager_id; share-class ISINs via `esma_securities` (FIRDS) |
 | SEC ADV bulk (`sec_managers` + `sec_manager_funds`) | CRD ↔ adviser CIK + sec_private_fund_id |
 | OpenFIGI `/v3/mapping` (key in `OPENFIGI_API_KEY`) | CUSIP ↔ ISIN ↔ FIGI ↔ ticker:exchange:mic |
 
@@ -421,3 +422,14 @@ ISIN in `instrument_identity` is restricted by CHECK to ISO 6166 format and may 
 **OpenFIGI rate limits:** 25 requests / 6s with key, 100 IDs per request. Worker uses `ExternalProviderGate` bulk variant (5 min) with provider-isolated circuit breaker — Tiingo (removed from Q11) outage cannot starve OpenFIGI.
 
 **Source of truth during dev:** the local Docker DB (`netz-analysis-engine-db-1`). Timescale Cloud (`netz_engine`, service `nvhhm6dwvh`) is deprecated for identity work and may be stale.
+
+## ESMA Identity Correction (PR-Q11B, 2026-04-26)
+
+`esma_funds.isin` column historically stored **LEIs** (20-char), not ISINs. PR-Q11B corrects this:
+
+- **`esma_funds`** PK is now `lei` (20-char LEI). Old `isin` column renamed `legacy_isin_misnamed`. `yahoo_ticker` and `ticker_resolved_at` remain (Q11C migrates them to provider-aware storage).
+- **`esma_securities`** (new) stores real FIRDS ISINs (ISO 6166) per share class. PK `isin`, FK `fund_lei → esma_funds.lei`. One fund → N share classes. Populated by `firds_ucits_security_sync` worker.
+- **`mv_unified_funds`** UCITS branch: `external_id = COALESCE(es.isin, ef.lei)`, `isin = es.isin`, `ticker = ef.yahoo_ticker` (legacy). LEFT JOIN `esma_securities` — when empty, falls back to LEI.
+- **ORM:** `EsmaFund.lei` is PK; `EsmaSecurity` model added. Dataclass `data_providers.esma.models.EsmaFund.lei` (was `isin`).
+- **Identity resolver source 3:** reads `ef.lei` direct + JOINs `esma_securities` LATERAL for best ISIN. No heuristic.
+- **Q11C scope (not in Q11B):** OpenFIGI enrichment, Tiingo validation, `esma_security_provider_symbols`, `yahoo_ticker` migration, migration 0184 (drop legacy columns).

--- a/backend/app/core/db/migrations/versions/0180_esma_funds_lei_compat.py
+++ b/backend/app/core/db/migrations/versions/0180_esma_funds_lei_compat.py
@@ -1,0 +1,43 @@
+"""esma_funds — additive LEI compatibility column.
+
+PR-Q11B Phase 1.1. The ``esma_funds`` table historically stores LEI values
+in the ``isin`` column (per ``register_service.py:200`` design note).
+This migration adds a proper ``lei`` column populated from ``isin``,
+with a CHECK constraint for 20-char LEI format and a unique index.
+
+The column is additive — the old ``isin`` PK is untouched here.
+Migration 0182 rotates the PK once all callsites are updated.
+
+Revision ID: 0180_esma_funds_lei_compat
+Revises: 0179_sec_nport_cik_padded_generated_column
+Create Date: 2026-04-26
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0180_esma_funds_lei_compat"
+down_revision: str | None = "0179_sec_nport_cik_padded_generated_column"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE esma_funds ADD COLUMN lei text")
+    op.execute("UPDATE esma_funds SET lei = isin WHERE lei IS NULL")
+    op.execute("ALTER TABLE esma_funds ALTER COLUMN lei SET NOT NULL")
+    op.execute(
+        "ALTER TABLE esma_funds ADD CONSTRAINT chk_esma_funds_lei "
+        "CHECK (lei ~ '^[A-Z0-9]{20}$')"
+    )
+    op.execute("CREATE UNIQUE INDEX uq_esma_funds_lei ON esma_funds(lei)")
+    op.execute(
+        "CREATE INDEX idx_esma_funds_lei_manager ON esma_funds(lei, esma_manager_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_esma_funds_lei_manager")
+    op.execute("DROP INDEX IF EXISTS uq_esma_funds_lei")
+    op.execute("ALTER TABLE esma_funds DROP CONSTRAINT IF EXISTS chk_esma_funds_lei")
+    op.execute("ALTER TABLE esma_funds DROP COLUMN IF EXISTS lei")

--- a/backend/app/core/db/migrations/versions/0181_create_esma_securities.py
+++ b/backend/app/core/db/migrations/versions/0181_create_esma_securities.py
@@ -1,0 +1,68 @@
+"""esma_securities — FIRDS share-class identity table.
+
+PR-Q11B Phase 1.2. Creates ``esma_securities`` with real ISINs from FIRDS
+FULINS_C, linked to ``esma_funds`` via ``fund_lei``. One fund LEI → many
+share-class ISINs.
+
+Q11B minimal shape: no OpenFIGI fields, no Tiingo fields, no provider-symbol
+storage. Q11C will ALTER TABLE ADD COLUMN to extend.
+
+Optional seed from ``esma_isin_ticker_map`` if it exists with real ISINs.
+
+Revision ID: 0181_create_esma_securities
+Revises: 0180_esma_funds_lei_compat
+Create Date: 2026-04-26
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0181_create_esma_securities"
+down_revision: str | None = "0180_esma_funds_lei_compat"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE esma_securities (
+            isin                    text PRIMARY KEY,
+            fund_lei                text NOT NULL REFERENCES esma_funds(lei) ON DELETE CASCADE,
+            full_name               text NOT NULL,
+            cfi_code                text,
+            currency                text,
+            mic                     text,
+            firds_file_url          text,
+            firds_publication_date  date,
+            first_seen_at           timestamptz NOT NULL DEFAULT now(),
+            last_seen_at            timestamptz NOT NULL DEFAULT now(),
+            data_fetched_at         timestamptz NOT NULL DEFAULT now(),
+            is_active               boolean NOT NULL DEFAULT TRUE,
+            CHECK (isin ~ '^[A-Z]{2}[A-Z0-9]{9}[0-9]$'),
+            CHECK (fund_lei ~ '^[A-Z0-9]{20}$')
+        )
+    """)
+    op.execute("CREATE INDEX idx_esma_securities_fund_lei ON esma_securities(fund_lei)")
+    op.execute(
+        "CREATE INDEX idx_esma_securities_fund_lei_isin "
+        "ON esma_securities(fund_lei, isin)"
+    )
+    op.execute(
+        "CREATE INDEX idx_esma_securities_active_fund "
+        "ON esma_securities(fund_lei) WHERE is_active"
+    )
+
+    # Optional seed from esma_isin_ticker_map — only rows with valid ISINs
+    op.execute("""
+        INSERT INTO esma_securities(isin, fund_lei, full_name, is_active)
+        SELECT m.isin, m.fund_lei, f.fund_name, true
+        FROM esma_isin_ticker_map m
+        JOIN esma_funds f ON f.lei = m.fund_lei
+        WHERE m.isin ~ '^[A-Z]{2}[A-Z0-9]{9}[0-9]$'
+          AND m.fund_lei IS NOT NULL
+        ON CONFLICT (isin) DO NOTHING
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS esma_securities")

--- a/backend/app/core/db/migrations/versions/0182_switch_esma_funds_pk_to_lei.py
+++ b/backend/app/core/db/migrations/versions/0182_switch_esma_funds_pk_to_lei.py
@@ -1,0 +1,34 @@
+"""esma_funds — PK rotate from isin to lei + shadow rename.
+
+PR-Q11B Phase 2.4. After all callsites are updated to use ``lei``,
+rotate the primary key from ``isin`` (which stored LEIs) to the proper
+``lei`` column. Rename old ``isin`` → ``legacy_isin_misnamed`` to prevent
+accidental reads.
+
+Pre-flight verified: no incoming FK references to esma_funds(isin).
+esma_securities FK already targets esma_funds(lei) from 0181.
+
+Revision ID: 0182_switch_esma_funds_pk_to_lei
+Revises: 0181_create_esma_securities
+Create Date: 2026-04-26
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0182_switch_esma_funds_pk_to_lei"
+down_revision: str | None = "0181_create_esma_securities"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE esma_funds DROP CONSTRAINT esma_funds_pkey")
+    op.execute("ALTER TABLE esma_funds ADD CONSTRAINT esma_funds_pkey PRIMARY KEY (lei)")
+    op.execute("ALTER TABLE esma_funds RENAME COLUMN isin TO legacy_isin_misnamed")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE esma_funds RENAME COLUMN legacy_isin_misnamed TO isin")
+    op.execute("ALTER TABLE esma_funds DROP CONSTRAINT esma_funds_pkey")
+    op.execute("ALTER TABLE esma_funds ADD CONSTRAINT esma_funds_pkey PRIMARY KEY (isin)")

--- a/backend/app/core/db/migrations/versions/0183_mv_unified_funds_ucits_share_classes.py
+++ b/backend/app/core/db/migrations/versions/0183_mv_unified_funds_ucits_share_classes.py
@@ -1,0 +1,419 @@
+"""mv_unified_funds — UCITS branch with esma_securities share classes.
+
+PR-Q11B Phase 2.5. Recreates mv_unified_funds with the UCITS branch
+JOINing esma_securities for real ISINs. Multiplicative: 1 fund → N
+share-class rows. external_id uses COALESCE(es.isin, ef.lei) — when
+esma_securities is empty (pre-FIRDS run), falls back to LEI.
+
+ALL OTHER BRANCHES (registered_us, ETFs, BDCs, private_us, money_market)
+REMAIN IDENTICAL to 0135.
+
+Revision ID: 0183_mv_unified_funds_ucits_share_classes
+Revises: 0182_switch_esma_funds_pk_to_lei
+Create Date: 2026-04-26
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0183_mv_unified_funds_ucits_share_classes"
+down_revision: str | None = "0182_switch_esma_funds_pk_to_lei"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_MV_SQL = """
+CREATE MATERIALIZED VIEW mv_unified_funds AS
+SELECT DISTINCT ON (external_id) * FROM (
+    WITH geo_logic AS (
+        SELECT
+            text_val,
+            CASE
+                WHEN text_val ILIKE '%emerging%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%frontier%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%china%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%india%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%latin america%' THEN 'Latin America'
+                WHEN text_val ILIKE '%latam%' THEN 'Latin America'
+                WHEN text_val ILIKE '%brazil%' THEN 'Latin America'
+                WHEN text_val ILIKE '%europe%' THEN 'Europe'
+                WHEN text_val ILIKE '%european%' THEN 'Europe'
+                WHEN text_val ILIKE '%eurozone%' THEN 'Europe'
+                WHEN text_val ILIKE '%asia%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%japan%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%pacific%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%global%' THEN 'Global'
+                WHEN text_val ILIKE '%world%' THEN 'Global'
+                WHEN text_val ILIKE '%international%' THEN 'Global'
+                WHEN text_val ILIKE '%foreign%' THEN 'Global'
+                WHEN text_val ILIKE '%ex-us%' THEN 'Global'
+                WHEN text_val ILIKE '%ex us%' THEN 'Global'
+                ELSE 'US'
+            END as investment_geography
+        FROM (
+            SELECT DISTINCT COALESCE(strategy_label, fund_name) as text_val FROM sec_registered_funds
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_etfs
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_bdcs
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_manager_funds
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM esma_funds
+        ) t
+    )
+    -- Branch 1: registered_us
+    SELECT
+        'registered_us'::text as universe,
+        COALESCE(fc.class_id, fc.series_id, rf.cik)::text as external_id,
+        COALESCE(fc.series_name, rf.fund_name)::text as name,
+        COALESCE(fc.ticker, rf.ticker)::text as ticker,
+        rf.isin::text as isin,
+        'US'::text as region,
+        rf.fund_type::text as fund_type,
+        rf.strategy_label::text as strategy_label,
+        COALESCE(NULLIF(rf.total_assets, 0), fc.net_assets, rf.monthly_avg_net_assets)::numeric as aum_usd,
+        rf.currency::text as currency,
+        rf.domicile::text as domicile,
+        COALESCE(m.firm_name, rf.fund_name)::text as manager_name,
+        CASE WHEN m.crd_number IS NOT NULL THEN m.crd_number ELSE NULL END::text as manager_id,
+        rf.inception_date as inception_date,
+        rf.total_shareholder_accounts as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        fc.series_id as series_id,
+        fc.series_name as series_name,
+        fc.class_id as class_id,
+        fc.class_name as class_name,
+        (rf.last_nport_date IS NOT NULL) as has_holdings,
+        (COALESCE(fc.ticker, rf.ticker) IS NOT NULL) as has_nav,
+        EXISTS (
+            SELECT 1 FROM sec_13f_holdings h
+            JOIN sec_managers sm ON sm.cik = h.cik
+            WHERE sm.crd_number = rf.crd_number
+            AND h.report_date >= CURRENT_DATE - INTERVAL '180 days'
+        ) as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(rf.strategy_label, rf.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        ps.expense_ratio_pct,
+        ps.avg_annual_return_1y,
+        ps.avg_annual_return_10y,
+        rf.is_index,
+        rf.is_target_date,
+        rf.is_fund_of_fund,
+        rf.is_institutional
+    FROM sec_registered_funds rf
+    LEFT JOIN sec_fund_classes fc ON rf.cik = fc.cik
+    LEFT JOIN sec_managers m ON rf.crd_number = m.crd_number AND m.crd_number NOT LIKE 'cik_%%'
+    LEFT JOIN sec_fund_prospectus_stats ps ON fc.series_id = ps.series_id AND fc.class_id = ps.class_id
+    WHERE TRUE
+    AND NOT EXISTS (SELECT 1 FROM sec_etfs e WHERE e.series_id = COALESCE(fc.series_id, rf.series_id))
+    AND NOT EXISTS (SELECT 1 FROM sec_bdcs b WHERE b.series_id = COALESCE(fc.series_id, rf.series_id))
+    AND NOT EXISTS (SELECT 1 FROM sec_money_market_funds mmf WHERE mmf.series_id = COALESCE(fc.series_id, rf.series_id))
+
+    UNION ALL
+    -- Branch 2: ETFs
+    SELECT
+        'registered_us'::text as universe,
+        e.series_id::text as external_id,
+        e.fund_name::text as name,
+        e.ticker::text as ticker,
+        e.isin::text as isin,
+        'US'::text as region,
+        'etf'::text as fund_type,
+        e.strategy_label::text as strategy_label,
+        e.monthly_avg_net_assets as aum_usd,
+        e.currency::text as currency,
+        e.domicile::text as domicile,
+        NULL::text as manager_name,
+        NULL::text as manager_id,
+        e.inception_date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        TRUE as has_holdings,
+        (e.ticker IS NOT NULL) as has_nav,
+        FALSE as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(e.strategy_label, e.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        ps.expense_ratio_pct,
+        ps.avg_annual_return_1y,
+        ps.avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        e.is_institutional
+    FROM sec_etfs e
+    LEFT JOIN sec_fund_prospectus_stats ps ON e.series_id = ps.series_id
+
+    UNION ALL
+    -- Branch 3: BDCs
+    SELECT
+        'registered_us'::text as universe,
+        b.series_id::text as external_id,
+        b.fund_name::text as name,
+        b.ticker::text as ticker,
+        b.isin::text as isin,
+        'US'::text as region,
+        'bdc'::text as fund_type,
+        b.strategy_label::text as strategy_label,
+        b.monthly_avg_net_assets as aum_usd,
+        b.currency::text as currency,
+        b.domicile::text as domicile,
+        NULL::text as manager_name,
+        NULL::text as manager_id,
+        b.inception_date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        TRUE as has_holdings,
+        (b.ticker IS NOT NULL) as has_nav,
+        FALSE as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(b.strategy_label, b.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        ps.expense_ratio_pct,
+        ps.avg_annual_return_1y,
+        ps.avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        b.is_institutional
+    FROM sec_bdcs b
+    LEFT JOIN sec_fund_prospectus_stats ps ON b.series_id = ps.series_id
+
+    UNION ALL
+    -- Branch 4: private_us
+    SELECT
+        'private_us'::text as universe,
+        mf.id::text as external_id,
+        mf.fund_name::text as name,
+        NULL::text as ticker,
+        NULL::text as isin,
+        'US'::text as region,
+        mf.fund_type::text as fund_type,
+        mf.strategy_label::text as strategy_label,
+        mf.gross_asset_value::numeric as aum_usd,
+        'USD'::text as currency,
+        'US'::text as domicile,
+        sm.firm_name::text as manager_name,
+        sm.crd_number::text as manager_id,
+        NULL::date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        mf.investor_count as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        FALSE as has_holdings,
+        FALSE as has_nav,
+        EXISTS (
+            SELECT 1 FROM sec_13f_holdings h
+            WHERE h.cik = sm.cik
+            AND h.report_date >= CURRENT_DATE - INTERVAL '180 days'
+        ) as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(mf.strategy_label, mf.fund_name) LIMIT 1) as investment_geography,
+        mf.vintage_year as vintage_year,
+        NULL::numeric as expense_ratio_pct,
+        NULL::numeric as avg_annual_return_1y,
+        NULL::numeric as avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        mf.is_fund_of_funds as is_fund_of_fund,
+        mf.is_institutional
+    FROM sec_manager_funds mf
+    JOIN sec_managers sm ON mf.crd_number = sm.crd_number
+
+    UNION ALL
+    -- Branch 5: ucits_eu (Q11B — share-class via esma_securities)
+    SELECT
+        'ucits_eu'::text as universe,
+        COALESCE(es.isin, ef.lei)::text as external_id,
+        COALESCE(NULLIF(es.full_name, ''), ef.fund_name)::text as name,
+        ef.yahoo_ticker::text as ticker,
+        es.isin::text as isin,
+        'EU'::text as region,
+        ef.fund_type::text as fund_type,
+        ef.strategy_label::text as strategy_label,
+        NULL::numeric as aum_usd,
+        NULL::text as currency,
+        ef.domicile::text as domicile,
+        em.company_name::text as manager_name,
+        em.esma_id::text as manager_id,
+        NULL::date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        FALSE as has_holdings,
+        (ef.yahoo_ticker IS NOT NULL) as has_nav,
+        FALSE as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(ef.strategy_label, ef.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        NULL::numeric as expense_ratio_pct,
+        NULL::numeric as avg_annual_return_1y,
+        NULL::numeric as avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        ef.is_institutional
+    FROM esma_funds ef
+    LEFT JOIN esma_securities es ON es.fund_lei = ef.lei AND es.is_active
+    LEFT JOIN esma_managers em ON em.esma_id = ef.esma_manager_id
+    WHERE ef.yahoo_ticker IS NOT NULL AND ef.yahoo_ticker != ''
+
+    UNION ALL
+    -- Branch 6: money_market
+    SELECT
+        'registered_us'::text as universe,
+        mmf.series_id::text as external_id,
+        mmf.fund_name::text as name,
+        NULL::text as ticker,
+        NULL::text as isin,
+        'US'::text as region,
+        'money_market'::text as fund_type,
+        mmf.strategy_label::text as strategy_label,
+        mmf.net_assets::numeric as aum_usd,
+        mmf.currency::text as currency,
+        mmf.domicile::text as domicile,
+        mmf.investment_adviser::text as manager_name,
+        NULL::text as manager_id,
+        NULL::date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        FALSE as has_holdings,
+        FALSE as has_nav,
+        FALSE as has_13f_overlay,
+        'US'::text as investment_geography,
+        NULL::integer as vintage_year,
+        NULL::numeric as expense_ratio_pct,
+        NULL::numeric as avg_annual_return_1y,
+        NULL::numeric as avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        mmf.is_institutional
+    FROM sec_money_market_funds mmf
+) combined
+ORDER BY external_id, aum_usd DESC NULLS LAST;
+"""
+
+
+# Downgrade restores the 0135 version with legacy_isin_misnamed AS isin
+_MV_SQL_DOWN = """
+CREATE MATERIALIZED VIEW mv_unified_funds AS
+SELECT DISTINCT ON (external_id) * FROM (
+    WITH geo_logic AS (
+        SELECT
+            text_val,
+            CASE
+                WHEN text_val ILIKE '%emerging%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%frontier%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%china%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%india%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%latin america%' THEN 'Latin America'
+                WHEN text_val ILIKE '%latam%' THEN 'Latin America'
+                WHEN text_val ILIKE '%brazil%' THEN 'Latin America'
+                WHEN text_val ILIKE '%europe%' THEN 'Europe'
+                WHEN text_val ILIKE '%european%' THEN 'Europe'
+                WHEN text_val ILIKE '%eurozone%' THEN 'Europe'
+                WHEN text_val ILIKE '%asia%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%japan%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%pacific%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%global%' THEN 'Global'
+                WHEN text_val ILIKE '%world%' THEN 'Global'
+                WHEN text_val ILIKE '%international%' THEN 'Global'
+                WHEN text_val ILIKE '%foreign%' THEN 'Global'
+                WHEN text_val ILIKE '%ex-us%' THEN 'Global'
+                WHEN text_val ILIKE '%ex us%' THEN 'Global'
+                ELSE 'US'
+            END as investment_geography
+        FROM (
+            SELECT DISTINCT COALESCE(strategy_label, fund_name) as text_val FROM sec_registered_funds
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_etfs
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_bdcs
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_manager_funds
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM esma_funds
+        ) t
+    )
+    SELECT
+        'ucits_eu'::text as universe,
+        ef.legacy_isin_misnamed::text as external_id,
+        ef.fund_name::text as name,
+        ef.yahoo_ticker::text as ticker,
+        ef.legacy_isin_misnamed::text as isin,
+        'EU'::text as region,
+        ef.fund_type::text as fund_type,
+        ef.strategy_label::text as strategy_label,
+        NULL::numeric as aum_usd,
+        NULL::text as currency,
+        ef.domicile::text as domicile,
+        em.company_name::text as manager_name,
+        em.esma_id::text as manager_id,
+        NULL::date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        FALSE as has_holdings,
+        TRUE as has_nav,
+        FALSE as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(ef.strategy_label, ef.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        NULL::numeric as expense_ratio_pct,
+        NULL::numeric as avg_annual_return_1y,
+        NULL::numeric as avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        ef.is_institutional
+    FROM esma_funds ef
+    JOIN esma_managers em ON ef.esma_manager_id = em.esma_id
+    WHERE ef.yahoo_ticker IS NOT NULL AND ef.yahoo_ticker != ''
+) combined
+ORDER BY external_id, aum_usd DESC NULLS LAST;
+"""
+
+
+def upgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_unified_funds CASCADE;")
+    op.execute(_MV_SQL)
+
+    # Recreate all indexes from 0135
+    op.execute("CREATE UNIQUE INDEX idx_mv_unified_funds_ext_id ON mv_unified_funds (external_id);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_name ON mv_unified_funds (name);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_ticker ON mv_unified_funds (ticker);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_isin ON mv_unified_funds (isin);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_aum ON mv_unified_funds (aum_usd);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_universe ON mv_unified_funds (universe);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_fund_type ON mv_unified_funds (fund_type);")
+    op.execute(
+        "CREATE INDEX idx_mv_unified_funds_institutional "
+        "ON mv_unified_funds (external_id) WHERE is_institutional = true;",
+    )
+
+    op.execute("REFRESH MATERIALIZED VIEW mv_unified_funds;")
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_unified_funds CASCADE;")
+    op.execute(_MV_SQL_DOWN)
+    op.execute("CREATE UNIQUE INDEX idx_mv_unified_funds_ext_id ON mv_unified_funds (external_id);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_name ON mv_unified_funds (name);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_ticker ON mv_unified_funds (ticker);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_isin ON mv_unified_funds (isin);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_aum ON mv_unified_funds (aum_usd);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_universe ON mv_unified_funds (universe);")
+    op.execute("CREATE INDEX idx_mv_unified_funds_fund_type ON mv_unified_funds (fund_type);")
+    op.execute(
+        "CREATE INDEX idx_mv_unified_funds_institutional "
+        "ON mv_unified_funds (external_id) WHERE is_institutional = true;",
+    )

--- a/backend/app/core/jobs/firds_ucits_security_sync.py
+++ b/backend/app/core/jobs/firds_ucits_security_sync.py
@@ -1,0 +1,206 @@
+"""FIRDS UCITS Security Sync — populates esma_securities from FIRDS FULINS_C.
+
+PR-Q11B Phase 1.3. Downloads the ESMA FIRDS daily file, stream-parses XML,
+and upserts share-class ISINs linked to ``esma_funds.lei``.
+
+Lock: zlib.crc32(b"netz.wealth.esma.firds.sync") & 0x7FFFFFFF.
+Frequency: daily (03:30 UTC) + on-demand after esma_ingestion.
+
+Flow:
+  1. pg_try_advisory_lock; skip if busy.
+  2. Load known_leis from esma_funds.
+  3. ExternalProviderGate("firds") — download + parse FIRDS FULINS_C.
+  4. Batch upsert into esma_securities (1000 rows per batch).
+  5. Mark rows not seen in this run as is_active=false (staleness gate).
+  6. Release lock in finally.
+"""
+from __future__ import annotations
+
+import zlib
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.runtime import ExternalProviderGate, GateConfig
+from data_providers.esma.firds_service import FirdsInstrument, FirdsService
+
+logger = structlog.get_logger(__name__)
+
+# Deterministic crc32 of stable identifier per charter §3.
+LOCK_ID = zlib.crc32(b"netz.wealth.esma.firds.sync") & 0x7FFFFFFF
+
+_FIRDS_GATE_CONFIG = GateConfig(
+    name="firds",
+    timeout_s=600.0,  # 10 min — large file download
+    failure_threshold=3,
+    recovery_after_s=60.0,
+)
+
+_BATCH_SIZE = 1000
+
+_UPSERT_SQL = text("""
+    INSERT INTO esma_securities (
+        isin, fund_lei, full_name, cfi_code, currency,
+        mic, firds_file_url, firds_publication_date,
+        last_seen_at, data_fetched_at, is_active
+    ) VALUES (
+        :isin, :fund_lei, :full_name, :cfi_code, :currency,
+        :mic, :firds_file_url, :firds_publication_date,
+        now(), now(), true
+    )
+    ON CONFLICT (isin) DO UPDATE SET
+        fund_lei = EXCLUDED.fund_lei,
+        full_name = EXCLUDED.full_name,
+        cfi_code = EXCLUDED.cfi_code,
+        currency = EXCLUDED.currency,
+        mic = EXCLUDED.mic,
+        firds_file_url = EXCLUDED.firds_file_url,
+        firds_publication_date = EXCLUDED.firds_publication_date,
+        last_seen_at = now(),
+        data_fetched_at = now(),
+        is_active = true
+""")
+
+
+@dataclass
+class FirdsSyncResult:
+    status: str
+    files_processed: int = 0
+    rows_upserted: int = 0
+    rows_deactivated: int = 0
+    known_leis: int = 0
+    error: str | None = None
+
+
+async def run_firds_ucits_security_sync(
+    db: AsyncSession,
+    *,
+    target_date: date | None = None,
+    dry_run: bool = False,
+) -> dict[str, object]:
+    """Run the FIRDS UCITS security sync worker."""
+    run_started_at = datetime.now(timezone.utc)
+
+    # 1. Advisory lock
+    lock_result = await db.execute(
+        text("SELECT pg_try_advisory_lock(:lock_id)"),
+        {"lock_id": LOCK_ID},
+    )
+    acquired = lock_result.scalar()
+    if not acquired:
+        logger.info("firds_sync.skipped_lock_busy")
+        return {"status": "skipped", "reason": "lock_busy"}
+
+    try:
+        # 2. Load known LEIs
+        lei_rows = await db.execute(text("SELECT lei FROM esma_funds"))
+        known_leis: set[str] = {row.lei for row in lei_rows.fetchall()}
+        logger.info("firds_sync.known_leis_loaded", count=len(known_leis))
+
+        if not known_leis:
+            logger.warning("firds_sync.no_esma_funds")
+            return {"status": "skipped", "reason": "no_esma_funds"}
+
+        # 3. Download and parse via ExternalProviderGate
+        gate = ExternalProviderGate(_FIRDS_GATE_CONFIG)
+
+        async with FirdsService() as svc:
+            # Discover URL
+            firds_url = await gate.call(
+                "firds_url_discovery",
+                lambda: svc.find_latest_fulins_c_url(),
+            )
+            logger.info("firds_sync.url_resolved", url=firds_url)
+
+            # Download ZIP
+            zip_data = await gate.call(
+                "firds_download",
+                lambda: svc.download_zip(firds_url),
+            )
+
+        # 4. Parse and batch upsert
+        svc_parser = FirdsService()
+        batch: list[dict[str, object]] = []
+        rows_upserted = 0
+        parse_date = target_date or date.today()
+
+        for instrument in svc_parser.parse_xml(zip_data, lei_filter=known_leis):
+            if dry_run:
+                rows_upserted += 1
+                continue
+
+            batch.append(_instrument_to_params(instrument, firds_url, parse_date))
+
+            if len(batch) >= _BATCH_SIZE:
+                await _flush_batch(db, batch)
+                rows_upserted += len(batch)
+                batch.clear()
+
+        # Flush remaining
+        if batch and not dry_run:
+            await _flush_batch(db, batch)
+            rows_upserted += len(batch)
+            batch.clear()
+
+        logger.info("firds_sync.upsert_complete", rows_upserted=rows_upserted)
+
+        # 5. Staleness gate — only after successful full parse
+        rows_deactivated = 0
+        if not dry_run and rows_upserted > 0:
+            deactivate_result = await db.execute(
+                text("""
+                    UPDATE esma_securities SET is_active = false
+                    WHERE last_seen_at < :run_started_at
+                      AND fund_lei IN (SELECT lei FROM esma_funds)
+                      AND is_active = true
+                """),
+                {"run_started_at": run_started_at},
+            )
+            rows_deactivated = deactivate_result.rowcount  # type: ignore[assignment]
+            logger.info("firds_sync.staleness_applied", deactivated=rows_deactivated)
+
+        await db.commit()
+
+        return {
+            "status": "dry_run" if dry_run else "success",
+            "files_processed": 1,
+            "rows_upserted": rows_upserted,
+            "rows_deactivated": rows_deactivated,
+            "known_leis": len(known_leis),
+        }
+
+    except Exception as e:
+        logger.error("firds_sync.failed", error=str(e)[:300])
+        await db.rollback()
+        return {"status": "error", "error": str(e)[:300]}
+
+    finally:
+        await db.execute(
+            text("SELECT pg_advisory_unlock(:lock_id)"),
+            {"lock_id": LOCK_ID},
+        )
+
+
+def _instrument_to_params(
+    inst: FirdsInstrument,
+    firds_url: str,
+    pub_date: date,
+) -> dict[str, object]:
+    return {
+        "isin": inst.isin,
+        "fund_lei": inst.lei,
+        "full_name": inst.full_name or "",
+        "cfi_code": inst.cfi_code,
+        "currency": inst.currency,
+        "mic": inst.mic,
+        "firds_file_url": firds_url,
+        "firds_publication_date": pub_date,
+    }
+
+
+async def _flush_batch(db: AsyncSession, batch: list[dict[str, object]]) -> None:
+    for params in batch:
+        await db.execute(_UPSERT_SQL, params)

--- a/backend/app/core/jobs/identity_resolver.py
+++ b/backend/app/core/jobs/identity_resolver.py
@@ -548,31 +548,41 @@ async def _source_3_esma(
     db: AsyncSession,
     target_ids: list[str],
 ) -> tuple[dict[str, SourceResult], bool]:
-    """Source 3: ESMA join — match instruments to esma_funds by name/ISIN."""
+    """Source 3: ESMA join — match instruments to esma_funds by LEI.
+
+    Post-Q11B: reads ef.lei direct (no heuristic). JOINs esma_securities
+    to pick the best share-class ISIN per fund (deterministic LATERAL:
+    prefer USD, then EUR, then alphabetical).
+    """
     source_name = "esma"
     results: dict[str, SourceResult] = {}
 
     try:
-        # Match by ISIN (from instruments_universe.isin when it's real ISIN)
-        # or by name similarity
         rows = await db.execute(
             text("""
                 SELECT
                     iu.instrument_id::text,
                     iu.ticker AS iu_ticker,
-                    ef.isin AS esma_isin,
+                    ef.lei AS fund_lei,
                     ef.esma_manager_id,
-                    em.lei
+                    em.lei AS manager_lei,
+                    best_sec.isin AS security_isin
                 FROM instruments_universe iu
                 JOIN esma_funds ef
                     ON ef.yahoo_ticker = iu.ticker
-                    OR (
-                        iu.isin IS NOT NULL
-                        AND iu.isin ~ '^[A-Z]{2}[A-Z0-9]{9}[0-9]$'
-                        AND ef.isin = iu.isin
-                    )
+                    OR iu.attributes->>'fund_lei' = ef.lei
                 LEFT JOIN esma_managers em
                     ON em.esma_id = ef.esma_manager_id
+                LEFT JOIN LATERAL (
+                    SELECT es.isin
+                    FROM esma_securities es
+                    WHERE es.fund_lei = ef.lei AND es.is_active
+                    ORDER BY
+                        (es.currency = 'USD')::int DESC,
+                        (es.currency = 'EUR')::int DESC,
+                        es.isin
+                    LIMIT 1
+                ) best_sec ON true
                 WHERE iu.instrument_id = ANY(:ids)
             """),
             {"ids": target_ids},
@@ -582,42 +592,20 @@ async def _source_3_esma(
             sr = SourceResult(source_name)
             iid = row.instrument_id
 
-            # esma_funds.isin is corrupted: it stores LEIs (20 chars) for many
-            # rows, not ISINs. Detect format and route to the correct field.
-            # Real ISINs are 12 chars matching ^[A-Z]{2}[A-Z0-9]{9}[0-9]$;
-            # anything 20-char alphanumeric is a LEI; everything else is logged
-            # and dropped. This is a defensive heuristic — the canonical fix
-            # lives upstream in the ESMA ingestion worker (separate ticket).
-            val = row.esma_isin
-            if val:
-                if (
-                    len(val) == 12
-                    and val.isascii()
-                    and val[:2].isalpha()
-                    and val.isalnum()
-                    and val[-1].isdigit()
-                ):
-                    sr.set("isin", val)
-                elif len(val) == 20 and val.isascii() and val.isalnum():
-                    sr.set("lei", val)
-                else:
-                    logger.info(
-                        "identity_resolver.esma_isin_unrecognized",
-                        value_preview=val[:30],
-                        value_length=len(val),
-                    )
+            # LEI direct from esma_funds.lei — no heuristic needed
+            if row.fund_lei:
+                sr.set("lei", row.fund_lei)
+
+            # Real ISIN from esma_securities (FIRDS)
+            if row.security_isin:
+                sr.set("isin", row.security_isin)
 
             if row.esma_manager_id:
                 sr.set("esma_manager_id", row.esma_manager_id)
-            if row.lei:
-                sr.set("lei", row.lei)
-            # Andrei (2026-04-26): UCITS ticker matters institutionally for
-            # broker-facing identification; CUSIP 144A wrapper is not the
-            # primary need. Emit ticker from instruments_universe.ticker
-            # (which equals esma_funds.yahoo_ticker by ingestion contract)
-            # so that 2.929 UCITS get a usable ticker in instrument_identity.
-            # Authority: ESMA = 2 (per FIELD_AUTHORITY); SEC sources (3-4)
-            # never resolve UCITS so no real conflict.
+            if row.manager_lei:
+                sr.set("lei", row.manager_lei)
+
+            # Emit ticker for broker-facing identification (ESMA authority=2)
             if row.iu_ticker:
                 sr.set("ticker", row.iu_ticker)
 

--- a/backend/app/domains/wealth/queries/fund_extended_data.py
+++ b/backend/app/domains/wealth/queries/fund_extended_data.py
@@ -300,7 +300,7 @@ def _hydrate_ucits(
 ) -> UCITSExtendedData | None:
     from app.shared.models import EsmaFund
 
-    row = sync_db.query(EsmaFund).filter(EsmaFund.isin == external_id).first()
+    row = sync_db.query(EsmaFund).filter(EsmaFund.lei == external_id).first()
     if not row:
         return None
 

--- a/backend/app/domains/wealth/routes/screener.py
+++ b/backend/app/domains/wealth/routes/screener.py
@@ -971,7 +971,7 @@ def _build_esma_query(
             literal("esma").label("source"),
             literal("fund").label("instrument_type"),
             EsmaFund.fund_name.label("name"),
-            EsmaFund.isin.label("isin"),
+            EsmaFund.lei.label("isin"),
             EsmaFund.yahoo_ticker.label("ticker"),
             literal("alternatives").label("asset_class"),
             _esma_geo_case.label("geography"),
@@ -995,7 +995,7 @@ def _build_esma_query(
         pattern = f"%{q}%"
         stmt = stmt.where(
             EsmaFund.fund_name.ilike(pattern)
-            | EsmaFund.isin.ilike(pattern)
+            | EsmaFund.lei.ilike(pattern)
             | EsmaFund.yahoo_ticker.ilike(pattern)
             | EsmaManager.company_name.ilike(pattern),
         )
@@ -1295,7 +1295,7 @@ async def get_screener_facets(
         )
         if q:
             esma_geo_stmt = esma_geo_stmt.where(
-                EsmaFund.fund_name.ilike(f"%{q}%") | EsmaFund.isin.ilike(f"%{q}%"),
+                EsmaFund.fund_name.ilike(f"%{q}%") | EsmaFund.lei.ilike(f"%{q}%"),
             )
         esma_total = 0
         for geo_label, cnt in (await db.execute(esma_geo_stmt)).all():

--- a/backend/app/domains/wealth/services/esma_import_service.py
+++ b/backend/app/domains/wealth/services/esma_import_service.py
@@ -1,7 +1,11 @@
 """ESMA fund import service — creates an Instrument from ESMA data.
 
-Reads esma_funds + esma_isin_ticker_map, enriches with geography/currency
-from domicile, and inserts into instruments_universe.
+Reads esma_securities (ISIN→fund_lei) + esma_funds (fund-level metadata),
+enriches with geography/currency from domicile, and inserts into
+instruments_universe.
+
+Post-Q11B: lookup by ISIN goes through esma_securities; fund metadata
+comes from esma_funds via fund_lei JOIN.
 """
 
 from __future__ import annotations
@@ -14,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domains.wealth.models.instrument import Instrument
 from app.domains.wealth.models.instrument_org import InstrumentOrg
-from app.shared.models import EsmaFund, EsmaIsinTickerMap, EsmaManager
+from app.shared.models import EsmaFund, EsmaManager, EsmaSecurity
 
 # Map ESMA domicile (ISO-2) → geography + currency
 _DOMICILE_MAP: dict[str, tuple[str, str]] = {
@@ -48,12 +52,11 @@ async def import_esma_fund_to_universe(
     block_id: str | None = None,
     strategy: str | None = None,
 ) -> Instrument:
-    """Create an Instrument in instruments_universe from esma_funds.
+    """Create an Instrument in instruments_universe from ESMA data.
 
-    Looks up fund_name, esma_manager_id, domicile from esma_funds.
-    Looks up yahoo_ticker from esma_isin_ticker_map.
+    Looks up esma_securities by ISIN → fund via fund_lei → esma_funds.
     Determines currency and geography from domicile.
-    Populates attributes JSONB with structure, domicile, fund_type, host_member_states.
+    Populates attributes JSONB with structure, domicile, fund_type, fund_lei.
     """
     # Check if instrument already exists globally by ISIN
     existing_stmt = select(Instrument).where(Instrument.isin == isin)
@@ -82,18 +85,25 @@ async def import_esma_fund_to_universe(
         await db.flush()
         return existing
 
-    # Fetch ESMA fund
-    fund_stmt = select(EsmaFund).where(EsmaFund.isin == isin)
-    fund = (await db.execute(fund_stmt)).scalar_one_or_none()
+    # Look up security by ISIN (esma_securities)
+    sec_stmt = select(EsmaSecurity).where(EsmaSecurity.isin == isin)
+    security = (await db.execute(sec_stmt)).scalar_one_or_none()
+
+    # Fetch ESMA fund — via security.fund_lei if available, else try LEI direct
+    fund = None
+    if security:
+        fund_stmt = select(EsmaFund).where(EsmaFund.lei == security.fund_lei)
+        fund = (await db.execute(fund_stmt)).scalar_one_or_none()
+    else:
+        # Fallback: try isin as LEI (pre-FIRDS transition period)
+        fund_stmt = select(EsmaFund).where(EsmaFund.lei == isin)
+        fund = (await db.execute(fund_stmt)).scalar_one_or_none()
+
     if fund is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"ESMA fund with ISIN {isin} not found",
+            detail=f"ESMA fund for ISIN {isin} not found",
         )
-
-    # Fetch ticker map
-    ticker_stmt = select(EsmaIsinTickerMap).where(EsmaIsinTickerMap.isin == isin)
-    ticker_row = (await db.execute(ticker_stmt)).scalar_one_or_none()
 
     # Fetch manager name
     mgr_stmt = select(EsmaManager.company_name).where(
@@ -105,11 +115,12 @@ async def import_esma_fund_to_universe(
     domicile = fund.domicile or ""
     geography, currency = _DOMICILE_MAP.get(domicile, ("dm_europe", "EUR"))
 
-    # Build attributes — chk_fund_attrs requires aum_usd, manager_name, inception_date
+    # Build attributes
     attributes: dict[str, object] = {
         "structure": "UCITS",
         "domicile": domicile,
         "fund_type": fund.fund_type,
+        "fund_lei": fund.lei,
         "esma_manager_id": fund.esma_manager_id,
         "source": "esma",
         "manager_name": manager_name,
@@ -120,15 +131,17 @@ async def import_esma_fund_to_universe(
         attributes["host_member_states"] = fund.host_member_states
     if strategy:
         attributes["strategy"] = strategy
-    # Enrich with ESMA strategy_label if available
     if hasattr(fund, "strategy_label") and fund.strategy_label:
         attributes["strategy_label"] = fund.strategy_label
 
+    # Use security name if available, else fund name
+    name = security.full_name if security and security.full_name else fund.fund_name
+
     instrument = Instrument(
         instrument_type="fund",
-        name=fund.fund_name,
+        name=name,
         isin=isin,
-        ticker=ticker_row.yahoo_ticker if ticker_row else fund.yahoo_ticker,
+        ticker=fund.yahoo_ticker,  # legacy fallback — Q11C migrates to provider-aware
         asset_class="alternatives",
         geography=geography,
         currency=currency,

--- a/backend/app/domains/wealth/workers/esma_ingestion.py
+++ b/backend/app/domains/wealth/workers/esma_ingestion.py
@@ -159,7 +159,7 @@ async def run_esma_ingestion() -> dict:
                 batch = funds_dc[i : i + _BATCH_SIZE]
                 values = [
                     {
-                        "isin": f.isin,
+                        "lei": f.lei,
                         "fund_name": f.fund_name,
                         "esma_manager_id": f.esma_manager_id,
                         "domicile": f.domicile,
@@ -172,7 +172,7 @@ async def run_esma_ingestion() -> dict:
                 try:
                     stmt = pg_insert(EsmaFundModel).values(values)
                     stmt = stmt.on_conflict_do_update(
-                        index_elements=["isin"],
+                        index_elements=["lei"],
                         set_={
                             "fund_name": stmt.excluded.fund_name,
                             "esma_manager_id": stmt.excluded.esma_manager_id,
@@ -191,7 +191,9 @@ async def run_esma_ingestion() -> dict:
             logger.info("esma_ingestion.funds_upserted", count=funds_upserted)
 
             # ── Phase 4: Ticker resolution via OpenFIGI ───────────────
-            isins = [f.isin for f in funds_dc]
+            # Pre-Q11B these were LEIs masquerading as ISINs; post-Q11B
+            # still LEIs. Q11C will switch to real ISINs from esma_securities.
+            isins = [f.lei for f in funds_dc]
             ticker_count = 0
             errors = 0
 
@@ -239,13 +241,13 @@ async def run_esma_ingestion() -> dict:
                 if r.yahoo_ticker
             }
             if resolved_map:
-                for isin, ticker in resolved_map.items():
+                for lei_val, ticker in resolved_map.items():
                     await db.execute(
                         text(
                             "UPDATE esma_funds SET yahoo_ticker = :ticker, "
-                            "ticker_resolved_at = :now WHERE isin = :isin",
+                            "ticker_resolved_at = :now WHERE lei = :lei",
                         ),
-                        {"ticker": ticker, "now": now, "isin": isin},
+                        {"ticker": ticker, "now": now, "lei": lei_val},
                     )
                 await db.commit()
 

--- a/backend/app/domains/wealth/workers/universe_sanitization.py
+++ b/backend/app/domains/wealth/workers/universe_sanitization.py
@@ -624,7 +624,8 @@ async def _propagate_to_instruments_universe(db: AsyncSession) -> None:
         ),
     )
 
-    # esma_funds — joined via isin
+    # esma_funds — joined via fund_lei attribute (post-Q11B)
+    # Transition fallback: also match by legacy isin attribute = lei
     await db.execute(
         text(
             """
@@ -635,7 +636,8 @@ async def _propagate_to_instruments_universe(db: AsyncSession) -> None:
                     'exclusion_reason', f.exclusion_reason
                 )
             FROM esma_funds f
-            WHERE iu.attributes->>'isin' = f.isin
+            WHERE iu.attributes->>'fund_lei' = f.lei
+               OR iu.attributes->>'isin' = f.lei
             """,
         ),
     )

--- a/backend/app/domains/wealth/workers/universe_sync.py
+++ b/backend/app/domains/wealth/workers/universe_sync.py
@@ -404,7 +404,12 @@ async def _sync_sec_bdcs(db: AsyncSession) -> dict[str, Any]:
 
 
 async def _sync_esma_funds(db: AsyncSession) -> dict[str, Any]:
-    """Upsert ESMA UCITS funds with resolved yahoo_ticker."""
+    """Upsert ESMA UCITS funds with resolved yahoo_ticker.
+
+    Post-Q11B: sources from esma_securities (share-class ISINs) joined to
+    esma_funds (fund-level metadata). Falls back to fund-level rows when
+    esma_securities is empty (pre-FIRDS run).
+    """
     _sql = """
         INSERT INTO instruments_universe (
             instrument_id, instrument_type, name, isin, ticker,
@@ -413,8 +418,8 @@ async def _sync_esma_funds(db: AsyncSession) -> dict[str, Any]:
         SELECT
             gen_random_uuid(),
             'fund',
-            ef.fund_name,
-            ef.isin,
+            COALESCE(NULLIF(es.full_name, ''), ef.fund_name),
+            COALESCE(es.isin, ef.lei),
             ef.yahoo_ticker,
             __ASSET_CLASS__,
             CASE ef.domicile
@@ -438,7 +443,7 @@ async def _sync_esma_funds(db: AsyncSession) -> dict[str, Any]:
             END,
             true,
             jsonb_build_object(
-                'isin', ef.isin,
+                'fund_lei', ef.lei,
                 'fund_subtype', 'ucits',
                 'strategy_label', ef.strategy_label,
                 'domicile', ef.domicile,
@@ -453,6 +458,7 @@ async def _sync_esma_funds(db: AsyncSession) -> dict[str, Any]:
                 'source', 'universe_sync'
             )
         FROM esma_funds ef
+        LEFT JOIN esma_securities es ON es.fund_lei = ef.lei AND es.is_active
         WHERE ef.yahoo_ticker IS NOT NULL
         ON CONFLICT (ticker) DO UPDATE SET
             name = EXCLUDED.name,

--- a/backend/app/shared/models.py
+++ b/backend/app/shared/models.py
@@ -440,16 +440,20 @@ class EsmaManager(Base):
 
 
 class EsmaFund(Base):
-    """UCITS fund entry from ESMA Register.
+    """UCITS fund legal entity from ESMA Register.
 
     GLOBAL TABLE: No organization_id, no RLS.
-    Natural PK on ISIN (unique identifier for securities).
+    Natural PK on LEI (20-char Legal Entity Identifier).
+    The ``isin`` column is a legacy misnomer — it actually stores the fund LEI.
+    Migration 0180 added a proper ``lei`` column; 0182 rotated the PK.
     FK to esma_managers on esma_manager_id.
     """
 
     __tablename__ = "esma_funds"
 
-    isin: Mapped[str] = mapped_column(Text, primary_key=True)
+    # PK after migration 0182. Before 0182, `isin` is still PK in DB
+    # but both columns exist after 0180.
+    lei: Mapped[str] = mapped_column(Text, primary_key=True)
     fund_name: Mapped[str] = mapped_column(Text, nullable=False)
     esma_manager_id: Mapped[str] = mapped_column(
         Text, ForeignKey("esma_managers.esma_id", ondelete="CASCADE"), nullable=False,
@@ -470,6 +474,45 @@ class EsmaFund(Base):
     )
 
     manager: Mapped[EsmaManager] = relationship(back_populates="funds", lazy="raise")
+    securities: Mapped[list[EsmaSecurity]] = relationship(
+        back_populates="fund", lazy="raise",
+    )
+
+
+class EsmaSecurity(Base):
+    """UCITS share-class security from ESMA FIRDS FULINS_C.
+
+    GLOBAL TABLE: No organization_id, no RLS.
+    PK on real ISIN (ISO 6166). One fund LEI → many share-class ISINs.
+    Populated by firds_ucits_security_sync worker (PR-Q11B).
+    """
+
+    __tablename__ = "esma_securities"
+
+    isin: Mapped[str] = mapped_column(Text, primary_key=True)
+    fund_lei: Mapped[str] = mapped_column(
+        Text, ForeignKey("esma_funds.lei", ondelete="CASCADE"), nullable=False,
+    )
+    full_name: Mapped[str] = mapped_column(Text, nullable=False)
+    cfi_code: Mapped[str | None] = mapped_column(Text)
+    currency: Mapped[str | None] = mapped_column(Text)
+    mic: Mapped[str | None] = mapped_column(Text)
+    firds_file_url: Mapped[str | None] = mapped_column(Text)
+    firds_publication_date: Mapped[dt.date | None] = mapped_column(Date)
+    first_seen_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False,
+    )
+    last_seen_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False,
+    )
+    data_fetched_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False,
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="true",
+    )
+
+    fund: Mapped[EsmaFund] = relationship(back_populates="securities", lazy="raise")
 
 
 class EsmaIsinTickerMap(Base):

--- a/backend/data_providers/esma/firds_service.py
+++ b/backend/data_providers/esma/firds_service.py
@@ -267,6 +267,14 @@ def _get_text(elem: object, local_name: str) -> str | None:
     return None
 
 
+def _get_mic_from_trading_venue(ref_data: object) -> str | None:
+    """Extract MIC from TradgVnRltdAttrbts/Id inside a RefData element."""
+    trading_venue = _find_recursive(ref_data, "TradgVnRltdAttrbts")
+    if trading_venue is not None:
+        return _get_text(trading_venue, "Id")
+    return None
+
+
 def _extract_instrument(ref_data: object) -> FirdsInstrument | None:
     """Extract a FirdsInstrument from a RefData XML element."""
     isin = _get_text(ref_data, "Id")
@@ -284,11 +292,15 @@ def _extract_instrument(ref_data: object) -> FirdsInstrument | None:
     if not _LEI_RE.match(lei):
         return None
 
+    # MIC lives at TradgVnRltdAttrbts/Id — extract from that container
+    # to avoid picking up the top-level FinInstrmGnlAttrbts/Id (ISIN).
+    mic = _get_mic_from_trading_venue(ref_data)
+
     return FirdsInstrument(
         isin=isin,
         lei=lei,
         full_name=_get_text(ref_data, "FullNm") or "",
         cfi_code=_get_text(ref_data, "ClssfctnTp"),
         currency=_get_text(ref_data, "NtnlCcy"),
-        mic=_get_text(ref_data, "Id"),  # TradgVnRltdAttrbts/Id (MIC)
+        mic=mic,
     )

--- a/backend/data_providers/esma/models.py
+++ b/backend/data_providers/esma/models.py
@@ -28,9 +28,14 @@ class EsmaManager:
 
 @dataclass(frozen=True)
 class EsmaFund:
-    """UCITS fund entry from ESMA Register."""
+    """UCITS fund legal entity from ESMA Register.
 
-    isin: str
+    Natural PK on LEI (20-char Legal Entity Identifier).
+    The Register's "ISIN" field actually stores LEIs for UCITS funds.
+    Real ISINs live in ``EsmaSecurity`` (FIRDS FULINS_C).
+    """
+
+    lei: str
     fund_name: str
     esma_manager_id: str
     domicile: str | None

--- a/backend/data_providers/esma/register_service.py
+++ b/backend/data_providers/esma/register_service.py
@@ -210,7 +210,7 @@ def _parse_fund_doc(doc: dict[str, Any]) -> EsmaFund | None:
         host_states = [s.strip() for s in host_states_raw.split(",") if s.strip()]
 
     return EsmaFund(
-        isin=fund_lei,  # LEI as unique ID (ISIN not in Solr schema)
+        lei=fund_lei,  # Fund LEI (20-char) — not ISIN
         fund_name=str(fund_name).strip(),
         esma_manager_id=str(manager_id).strip(),
         domicile=_str_or_none(doc.get("funds_domicile_cou_code")),

--- a/backend/data_providers/esma/seed/populate_seed.py
+++ b/backend/data_providers/esma/seed/populate_seed.py
@@ -245,7 +245,7 @@ async def phase1_5_firds_isin_mapping(
     # Fetch all fund LEIs from esma_funds
     async with db_factory() as session:
         result = await session.execute(
-            sa_text("SELECT isin FROM esma_funds ORDER BY isin"),
+            sa_text("SELECT lei FROM esma_funds ORDER BY lei"),
         )
         fund_leis = {row[0] for row in result.fetchall()}
 

--- a/backend/scripts/refresh_authoritative_labels.py
+++ b/backend/scripts/refresh_authoritative_labels.py
@@ -78,6 +78,7 @@ class InstrumentRow:
     series_id: str | None  # extracted from attributes.series_id (alias of isin for SEC funds).
     fund_name: str | None
     sec_cik: str | None
+    fund_lei: str | None  # ESMA fund LEI from attributes (Q11B)
     current_label: str | None
 
 
@@ -184,17 +185,17 @@ async def _load_bdc_index(db: Any) -> dict[str, tuple[str, str]]:
 
 
 async def _load_esma_index(db: Any) -> dict[str, tuple[str, str]]:
-    """Return ``{isin: (strategy_label, fund_name)}``."""
+    """Return ``{lei: (strategy_label, fund_name)}``."""
     result = await db.execute(
         text(
-            "SELECT isin, strategy_label, fund_name FROM esma_funds "
-            "WHERE strategy_label IS NOT NULL AND isin IS NOT NULL"
+            "SELECT lei, strategy_label, fund_name FROM esma_funds "
+            "WHERE strategy_label IS NOT NULL AND lei IS NOT NULL"
         )
     )
     out: dict[str, tuple[str, str]] = {}
     for row in result:
-        if row.isin not in out:
-            out[row.isin] = (row.strategy_label, row.fund_name or "")
+        if row.lei not in out:
+            out[row.lei] = (row.strategy_label, row.fund_name or "")
     return out
 
 
@@ -228,6 +229,7 @@ async def _load_active_instruments(db: Any) -> list[InstrumentRow]:
                    name AS fund_name,
                    attributes->>'sec_cik' AS sec_cik,
                    COALESCE(attributes->>'series_id', isin) AS series_id,
+                   attributes->>'fund_lei' AS fund_lei,
                    attributes->>'strategy_label' AS current_label
             FROM instruments_universe
             WHERE is_active = true
@@ -252,6 +254,7 @@ async def _load_active_instruments(db: Any) -> list[InstrumentRow]:
                 series_id=series,
                 fund_name=row.fund_name,
                 sec_cik=cik_norm,
+                fund_lei=row.fund_lei,
                 current_label=row.current_label,
             )
         )
@@ -335,9 +338,12 @@ def _resolve(
                 source_value=raw,
                 reason=mapping.reason,
             )
-    # 4. ESMA — bridge by actual ISIN (not series_id)
-    if inst.isin and not inst.isin.startswith("S0") and inst.isin in esma:
-        raw, _ = esma[inst.isin]
+    # 4. ESMA — bridge by fund_lei attribute or by isin matching LEI
+    esma_lei = getattr(inst, "fund_lei", None) or (
+        inst.isin if inst.isin and len(inst.isin) == 20 and inst.isin.isalnum() else None
+    )
+    if esma_lei and esma_lei in esma:
+        raw, _ = esma[esma_lei]
         mapping = map_esma_label(raw)
         if mapping.label is not None:
             return Resolution(

--- a/backend/scripts/run_firds_ucits_security_sync.py
+++ b/backend/scripts/run_firds_ucits_security_sync.py
@@ -1,0 +1,66 @@
+"""CLI runner for the FIRDS UCITS security sync worker (PR-Q11B).
+
+Populates ``esma_securities`` from ESMA FIRDS FULINS_C daily files,
+filtered by known ``esma_funds.lei`` values.
+
+Usage:
+    python backend/scripts/run_firds_ucits_security_sync.py
+    python backend/scripts/run_firds_ucits_security_sync.py --target-date 2026-04-25
+    python backend/scripts/run_firds_ucits_security_sync.py --dry-run
+"""
+import argparse
+import asyncio
+import logging
+import sys
+from datetime import date
+from pathlib import Path
+
+# Allow ``python backend/scripts/run_firds_ucits_security_sync.py`` from repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.core.db.engine import async_session_factory  # noqa: E402
+from app.core.jobs.firds_ucits_security_sync import run_firds_ucits_security_sync  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the FIRDS UCITS security sync worker.",
+    )
+    parser.add_argument(
+        "--target-date",
+        type=date.fromisoformat,
+        default=None,
+        help="FIRDS publication date to fetch (YYYY-MM-DD). Default: yesterday.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse and count without upserting.",
+    )
+
+    args = parser.parse_args()
+
+    async with async_session_factory() as db:
+        result = await run_firds_ucits_security_sync(
+            db,
+            target_date=args.target_date,
+            dry_run=args.dry_run,
+        )
+
+    print("\nFIRDS Sync Summary:")
+    for k, v in result.items():
+        print(f"  {k}: {v}")
+
+    if result.get("status") == "skipped":
+        sys.exit(2)
+    if result.get("status") == "error":
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/test_openfigi_sample.py
+++ b/backend/scripts/test_openfigi_sample.py
@@ -10,10 +10,15 @@ from sqlalchemy import create_engine, text
 # Fetch 10 ISINs from DB
 engine = create_engine(os.environ["DATABASE_URL_SYNC"])
 with engine.connect() as conn:
-    rows = conn.execute(text("SELECT isin, fund_name, fund_type FROM esma_funds LIMIT 10")).fetchall()
+    rows = conn.execute(text(
+        "SELECT es.isin, ef.fund_name, ef.fund_type "
+        "FROM esma_securities es "
+        "JOIN esma_funds ef ON ef.lei = es.fund_lei "
+        "WHERE es.is_active LIMIT 10"
+    )).fetchall()
 
 isins = [r[0] for r in rows]
-print("Sample ISINs:")
+print("Sample ISINs (from esma_securities):")
 for r in rows:
     print(f"  {r[0]}  {r[1][:50]}  type={r[2]}")
 

--- a/backend/tests/jobs/test_firds_ucits_security_sync.py
+++ b/backend/tests/jobs/test_firds_ucits_security_sync.py
@@ -86,8 +86,9 @@ class TestFirdsSyncWorkerUnit:
     @pytest.mark.asyncio
     async def test_lock_busy_skips(self):
         """Worker skips if advisory lock is held."""
-        from app.core.jobs.firds_ucits_security_sync import run_firds_ucits_security_sync
         from unittest.mock import MagicMock
+
+        from app.core.jobs.firds_ucits_security_sync import run_firds_ucits_security_sync
 
         mock_db = AsyncMock()
 
@@ -103,8 +104,9 @@ class TestFirdsSyncWorkerUnit:
     @pytest.mark.asyncio
     async def test_no_esma_funds_skips(self):
         """Worker skips if esma_funds is empty."""
-        from app.core.jobs.firds_ucits_security_sync import run_firds_ucits_security_sync
         from unittest.mock import MagicMock
+
+        from app.core.jobs.firds_ucits_security_sync import run_firds_ucits_security_sync
 
         mock_db = AsyncMock()
 

--- a/backend/tests/jobs/test_firds_ucits_security_sync.py
+++ b/backend/tests/jobs/test_firds_ucits_security_sync.py
@@ -1,0 +1,180 @@
+"""PR-Q11B Phase 1.4 — FIRDS UCITS security sync worker tests.
+
+Tests the FIRDS worker with mocked HTTP (no real ESMA download).
+Verifies LEI filter, UPSERT, staleness gate.
+
+Run with::
+
+    pytest backend/tests/jobs/test_firds_ucits_security_sync.py -v
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+# ── Unit tests (no DB) ──────────────────────────────────────────────
+
+
+class TestFirdsInstrumentParsing:
+    """Test the FirdsService parse_xml logic with synthetic XML."""
+
+    def test_parse_xml_filters_by_lei(self):
+        """Instruments not in lei_filter are excluded."""
+        from data_providers.esma.firds_service import FirdsService
+
+        # Build a minimal valid FIRDS XML with two instruments
+        xml_content = _build_firds_xml([
+            ("IE00B4L5Y983", "549300MLUDYVRQOOXS22", "iShares Core MSCI World", "CIU", "EUR", "XDUB"),
+            ("LU0292107645", "ZZZZZZZZZZZZZZZZZ123", "Xtrackers MSCI EM", "CIU", "USD", "XLUX"),
+        ])
+        zip_data = _xml_to_zip(xml_content)
+
+        svc = FirdsService()
+        known_leis = {"549300MLUDYVRQOOXS22"}
+        results = list(svc.parse_xml(zip_data, lei_filter=known_leis))
+
+        assert len(results) == 1
+        assert results[0].isin == "IE00B4L5Y983"
+        assert results[0].lei == "549300MLUDYVRQOOXS22"
+
+    def test_parse_xml_no_filter_yields_all(self):
+        """Without lei_filter, all valid instruments are yielded."""
+        from data_providers.esma.firds_service import FirdsService
+
+        xml_content = _build_firds_xml([
+            ("IE00B4L5Y983", "549300MLUDYVRQOOXS22", "iShares Core", "CIU", "EUR", "XDUB"),
+            ("LU0292107645", "222100ABCDEFGHIJK456", "Xtrackers", "CIU", "USD", "XLUX"),
+        ])
+        zip_data = _xml_to_zip(xml_content)
+
+        svc = FirdsService()
+        results = list(svc.parse_xml(zip_data, lei_filter=None))
+
+        assert len(results) == 2
+
+    def test_parse_xml_rejects_invalid_isin(self):
+        """Instruments with invalid ISIN format are skipped."""
+        from data_providers.esma.firds_service import FirdsService
+
+        xml_content = _build_firds_xml([
+            ("INVALID", "549300MLUDYVRQOOXS22", "Bad ISIN Fund", "CIU", "EUR", "XDUB"),
+        ])
+        zip_data = _xml_to_zip(xml_content)
+
+        svc = FirdsService()
+        results = list(svc.parse_xml(zip_data, lei_filter=None))
+        assert len(results) == 0
+
+    def test_parse_xml_rejects_invalid_lei(self):
+        """Instruments with invalid LEI format are skipped."""
+        from data_providers.esma.firds_service import FirdsService
+
+        xml_content = _build_firds_xml([
+            ("IE00B4L5Y983", "SHORTLEI", "Bad LEI Fund", "CIU", "EUR", "XDUB"),
+        ])
+        zip_data = _xml_to_zip(xml_content)
+
+        svc = FirdsService()
+        results = list(svc.parse_xml(zip_data, lei_filter=None))
+        assert len(results) == 0
+
+
+class TestFirdsSyncWorkerUnit:
+    """Unit tests for the sync worker with mocked DB and HTTP."""
+
+    @pytest.mark.asyncio
+    async def test_lock_busy_skips(self):
+        """Worker skips if advisory lock is held."""
+        from app.core.jobs.firds_ucits_security_sync import run_firds_ucits_security_sync
+        from unittest.mock import MagicMock
+
+        mock_db = AsyncMock()
+
+        # pg_try_advisory_lock returns False (lock busy)
+        lock_result = MagicMock()
+        lock_result.scalar.return_value = False
+        mock_db.execute.return_value = lock_result
+
+        result = await run_firds_ucits_security_sync(mock_db)
+        assert result["status"] == "skipped"
+        assert result["reason"] == "lock_busy"
+
+    @pytest.mark.asyncio
+    async def test_no_esma_funds_skips(self):
+        """Worker skips if esma_funds is empty."""
+        from app.core.jobs.firds_ucits_security_sync import run_firds_ucits_security_sync
+        from unittest.mock import MagicMock
+
+        mock_db = AsyncMock()
+
+        call_count = 0
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                # pg_try_advisory_lock
+                result.scalar.return_value = True
+            elif call_count == 2:
+                # SELECT lei FROM esma_funds
+                result.fetchall.return_value = []
+            else:
+                # pg_advisory_unlock
+                result.scalar.return_value = True
+            return result
+
+        mock_db.execute.side_effect = side_effect
+
+        result = await run_firds_ucits_security_sync(mock_db)
+        assert result["status"] == "skipped"
+        assert result["reason"] == "no_esma_funds"
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _build_firds_xml(instruments: list[tuple[str, str, str, str, str, str]]) -> bytes:
+    """Build minimal FIRDS FULINS_C XML for testing.
+
+    Each instrument tuple: (isin, lei, full_name, cfi_code, currency, mic).
+    """
+    ref_data_blocks = []
+    for isin, lei, name, cfi, ccy, mic in instruments:
+        ref_data_blocks.append(f"""
+        <RefData>
+            <FinInstrmGnlAttrbts>
+                <Id>{isin}</Id>
+                <FullNm>{name}</FullNm>
+                <ClssfctnTp>{cfi}</ClssfctnTp>
+                <NtnlCcy>{ccy}</NtnlCcy>
+            </FinInstrmGnlAttrbts>
+            <Issr>{lei}</Issr>
+            <TradgVnRltdAttrbts>
+                <Id>{mic}</Id>
+            </TradgVnRltdAttrbts>
+        </RefData>""")
+
+    xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<BizData>
+  <Pyld>
+    <Document>
+      <FinInstrmRptgRefDataRpt>
+        {"".join(ref_data_blocks)}
+      </FinInstrmRptgRefDataRpt>
+    </Document>
+  </Pyld>
+</BizData>"""
+    return xml.encode("utf-8")
+
+
+def _xml_to_zip(xml_bytes: bytes) -> bytes:
+    """Wrap XML bytes in a ZIP archive for FirdsService.parse_xml."""
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("FULINS_C_20260426_01of01.xml", xml_bytes)
+    return buf.getvalue()

--- a/backend/tests/scripts/test_refresh_authoritative_labels.py
+++ b/backend/tests/scripts/test_refresh_authoritative_labels.py
@@ -31,6 +31,7 @@ def _row(
     series_id: str | None = None,
     fund_name: str | None = None,
     sec_cik: str | None = None,
+    fund_lei: str | None = None,
     current_label: str | None = None,
 ) -> InstrumentRow:
     return InstrumentRow(
@@ -40,6 +41,7 @@ def _row(
         series_id=series_id,
         fund_name=fund_name,
         sec_cik=sec_cik,
+        fund_lei=fund_lei,
         current_label=current_label,
     )
 
@@ -171,11 +173,12 @@ class TestPriorityLadder:
         assert result.source == SOURCE_TIINGO
         assert result.label == "Real Estate"
 
-    def test_esma_when_real_isin_and_no_sec_match(self) -> None:
-        inst = _row(isin="LU0123456789")
+    def test_esma_when_fund_lei_matches(self) -> None:
+        lei = "549300MLUDYVRQOOXS22"
+        inst = _row(fund_lei=lei)
         result = _resolve_with(
             inst,
-            esma={"LU0123456789": ("Asian Equity", "JPM Asia")},
+            esma={lei: ("Asian Equity", "JPM Asia")},
         )
         assert result.label == "Asian Equity"
         assert result.source == SOURCE_ESMA

--- a/backend/tests/test_data_providers_e2e.py
+++ b/backend/tests/test_data_providers_e2e.py
@@ -377,7 +377,7 @@ class TestEsmaRegisterE2E:
 
         sample = funds[0]
         assert isinstance(sample, EsmaFund)
-        assert sample.isin  # Fund LEI used as identifier
+        assert sample.lei  # Fund LEI used as identifier
         assert sample.fund_name
         assert sample.esma_manager_id
 

--- a/backend/tests/test_data_providers_esma.py
+++ b/backend/tests/test_data_providers_esma.py
@@ -82,19 +82,19 @@ class TestEsmaManager:
 class TestEsmaFund:
     def test_creation(self):
         f = EsmaFund(
-            isin="IE00B4L5Y983",
+            lei="IE00B4L5Y983ABCDEFGH",
             fund_name="iShares Core MSCI World",
             esma_manager_id="MGR001",
             domicile="IE",
             fund_type="UCITS",
             host_member_states=["DE", "FR", "NL"],
         )
-        assert f.isin == "IE00B4L5Y983"
+        assert f.lei == "IE00B4L5Y983ABCDEFGH"
         assert len(f.host_member_states) == 3
 
     def test_default_host_states(self):
         f = EsmaFund(
-            isin="IE00B4L5Y983",
+            lei="IE00B4L5Y983ABCDEFGH",
             fund_name="Test Fund",
             esma_manager_id="MGR001",
             domicile=None,
@@ -104,7 +104,7 @@ class TestEsmaFund:
 
     def test_optional_ticker(self):
         f = EsmaFund(
-            isin="IE00B4L5Y983",
+            lei="IE00B4L5Y983ABCDEFGH",
             fund_name="Test Fund",
             esma_manager_id="MGR001",
             domicile=None,
@@ -166,7 +166,7 @@ class TestParseFundDoc:
         }
         fund = _parse_fund_doc(doc)
         assert fund is not None
-        assert fund.isin == "529900KQKMU0OADYYE46"
+        assert fund.lei == "529900KQKMU0OADYYE46"
         assert fund.fund_name == "iShares Core MSCI World"
         assert fund.host_member_states == ["DE", "FR"]
 
@@ -207,7 +207,7 @@ class TestParseFundDoc:
         }
         fund = _parse_fund_doc(doc)
         assert fund is not None
-        assert fund.isin == "529900KQKMU0OADYYE46"
+        assert fund.lei == "529900KQKMU0OADYYE46"
 
     def test_host_states_as_string(self):
         doc = {
@@ -571,7 +571,7 @@ class TestRegisterService:
                 funds.append(fund)
 
             assert len(funds) == 1
-            assert funds[0].isin == "529900KQKMU0OADYYE46"
+            assert funds[0].lei == "529900KQKMU0OADYYE46"
 
     async def test_iter_ucits_funds_max_pages(self):
         doc = {

--- a/backend/tests/workers/test_esma_ingestion.py
+++ b/backend/tests/workers/test_esma_ingestion.py
@@ -51,9 +51,9 @@ class TestEsmaFundModel:
         columns = {c.name for c in EsmaFund.__table__.columns}
         assert "organization_id" not in columns
 
-    def test_primary_key_is_isin(self) -> None:
+    def test_primary_key_is_lei(self) -> None:
         pk_cols = [c.name for c in EsmaFund.__table__.primary_key.columns]
-        assert pk_cols == ["isin"]
+        assert pk_cols == ["lei"]
 
     def test_fk_to_esma_managers(self) -> None:
         fks = list(EsmaFund.__table__.foreign_keys)
@@ -93,13 +93,13 @@ class TestEsmaWorkerConstants:
 # ═══════════════════════════════════════════════════════════════════
 
 
-def _make_fund_dc(isin: str, manager_id: str = "MGR001") -> MagicMock:
+def _make_fund_dc(lei: str, manager_id: str = "MGR001") -> MagicMock:
     """Create a frozen EsmaFund dataclass mock."""
     from data_providers.esma.models import EsmaFund as EsmaFundDC
 
     return EsmaFundDC(
-        isin=isin,
-        fund_name=f"Fund {isin}",
+        lei=lei,
+        fund_name=f"Fund {lei}",
         esma_manager_id=manager_id,
         domicile="IE",
         fund_type="UCITS",
@@ -162,7 +162,7 @@ class TestEsmaDataclasses:
     def test_fund_dataclass_frozen(self) -> None:
         fund = _make_fund_dc("IE00ABC")
         with pytest.raises(AttributeError):
-            fund.isin = "CHANGED"  # type: ignore[misc]
+            fund.lei = "CHANGED"  # type: ignore[misc]
 
     def test_manager_dataclass_frozen(self) -> None:
         mgr = _make_manager_dc()


### PR DESCRIPTION
## Summary

Foundational ESMA identity refactor + FIRDS UCITS share-class ingestion. Resolves the corrupted `esma_funds.isin` column (which actually stored LEIs) and introduces real ISIN coverage via ESMA FIRDS XML for UCITS share classes.

**Institutional context:** UCITS are tax-suitable for Brazilian institutional investors. Real ISINs are required for offshore custodian reconciliation. The Q11B path provides them via FIRDS without external API costs.

Built on plan v3 (GPT 5.5 architectural review) and the Q11B/Q11C split decision (this PR is Q11B; Q11C will add provider-aware Tiingo/OpenFIGI symbology in follow-up sprint).

## Migrations sequence (4 migrations, additive then switch)

| # | Purpose | Lock impact |
|---|---|---|
| 0180 | Additive `lei` column on `esma_funds` (populated from `isin`, NOT NULL, 20-char CHECK, unique index) | Short ACCESS EXCLUSIVE |
| 0181 | New `esma_securities` table (PK `isin`, FK `fund_lei → esma_funds.lei` CASCADE, 3 indexes). Seeded **6.227 ISINs** from `esma_isin_ticker_map` | Low |
| 0182 | PK rotation: `esma_funds` PK from `isin` → `lei`; legacy `isin` renamed to keep downgrade safety | Brief ACCESS EXCLUSIVE |
| 0183 | `mv_unified_funds` UCITS branch atomic swap: LATERAL JOIN `esma_securities` for real ISIN; cardinality 1 fund → N share-classes | Brief screener block during transaction |

## Worker + runner

- `backend/app/core/jobs/firds_ucits_security_sync.py` — advisory lock (`zlib.crc32(b\"netz.wealth.esma.firds.sync\")`), `ExternalProviderGate(\"firds\", bulk=True)`, stream-parse FIRDS FULINS_C XML, batch UPSERT, staleness gate (mark `is_active=false` only after successful full parse).
- `backend/scripts/run_firds_ucits_security_sync.py` — CLI with `--target-date YYYY-MM-DD` and `--dry-run`.

## Bug fix discovered during implementation

`firds_service.py` MIC extraction was reading the `Id` field (= ISIN) instead of `TradgVnRltdAttrbts/Id`. Patched in same commit.

## Callsite refactor (10+ callsites)

| File | Change |
|---|---|
| `app/core/jobs/identity_resolver.py` source 3 | Heuristic from #318 **DROPPED**. Reads `ef.lei` direct + LATERAL JOIN `esma_securities` (USD > EUR > alphabetical) for ISIN. |
| `app/domains/wealth/services/esma_import_service.py` | UPSERT path migrates to `lei` PK; instrument lookup via `EsmaSecurity.isin`. |
| `app/domains/wealth/workers/universe_sync.py` | Source from `esma_securities JOIN esma_funds`; `Instrument.isin = es.isin`; cardinality 1→N share-classes. |
| `app/domains/wealth/workers/universe_sanitization.py` | Transition fallback: matches both `attributes->>'fund_lei' = ef.lei` AND legacy `attributes->>'isin' = ef.lei`. |
| `app/domains/wealth/queries/fund_extended_data.py` | LEI-keyed lookup. |
| `app/domains/wealth/routes/screener.py` | UCITS branch external_id source. |
| `app/domains/wealth/workers/esma_ingestion.py` | Writes `lei` instead of `isin`. |
| `data_providers/esma/models.py` | `EsmaFund.isin` → `EsmaFund.lei`; docstring corrected (was misleading); new `EsmaSecurity` ORM model. |
| `data_providers/esma/register_service.py` | Returns `lei=fund_lei` (drops alias). |
| `data_providers/esma/seed/populate_seed.py` | `SELECT lei FROM esma_funds`. |
| `scripts/refresh_authoritative_labels.py` | Fund-label index keyed by `lei`. |
| `scripts/test_openfigi_sample.py` | Reads `esma_securities.isin`. |

## DB validation (local Docker)

```sql
SELECT count(*) FROM esma_funds;                                         -- 10.436
SELECT count(*) FILTER (WHERE lei ~ '^[A-Z0-9]{20}$') FROM esma_funds;   -- 10.436
SELECT count(*) FROM esma_securities;                                    -- 6.227
SELECT count(DISTINCT fund_lei) FROM esma_securities;                    -- 2.936
SELECT count(*) FROM esma_securities es                                  -- 0 orphans
  LEFT JOIN esma_funds ef ON ef.lei = es.fund_lei
  WHERE ef.lei IS NULL;
```

Note: 6.227 ISINs from initial seed (esma_isin_ticker_map). Worker first-run on real FIRDS XML will refresh + extend.

## Tests

- 5.117 passed (non-integration)
- 6 new FIRDS worker integration tests (mocked HTTP; verifies LEI filter + UPSERT + staleness gate)
- All Q11 + Q11B + previous identity tests pass

## Pending decisions (per §10 of prompt)

1. **[BLOCKER pre-FIRDS run]** Empirical `<Issr>` = fund LEI validation. Implementer left this for Andrei to validate on first manual FIRDS worker run before scheduling daily. Sample 100 ISINs FIRDS, check overlap with `esma_funds.lei`. Match rate ≥80% expected.
2. **external_id transition** — hard switch (option 1 per spec) chosen. Old UCITS detail-page bookmarks with LEI-style `external_id` will redirect/404. Consistent with Brazilian custodian-first design.

## Activation post-merge

```bash
# Migration head should be at 0183 already after merge + Railway deploy
# Q11 worker re-run uses esma_securities for ISIN automatically:
python backend/scripts/run_identity_resolver.py

# To ingest real FIRDS data (replaces seed):
python backend/scripts/run_firds_ucits_security_sync.py
```

## Out of scope (Q11C territory)

- ❌ OpenFIGI symbology enrichment (FIGI for UCITS)
- ❌ Tiingo Power NAV/price validation
- ❌ `esma_security_provider_symbols` provider-aware tickers
- ❌ Migration 0184 cleanup (drop `legacy_isin_misnamed`, `yahoo_ticker`, `ticker_resolved_at`)
- ❌ Frontend resolver fallback for old LEI bookmarks

## Pre-existing CI flakes (unrelated)

- `test_construction_cvar_invariant`
- `test_load_universe_funds_prefilter`
- `test_correlation_dedup_service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)