### PR TITLE
PR-Q26 — Wave 6 Session 01 Tier 1 quant foundation fixes

### DIFF
--- a/backend/quant_engine/portfolio_metrics_service.py
+++ b/backend/quant_engine/portfolio_metrics_service.py
@@ -53,27 +53,26 @@ def aggregate(
     if len(portfolio_returns) == 0:
         return PortfolioMetrics()
 
+    from quant_engine.return_statistics_service import compute_sortino_ratio
+
     rf_daily = risk_free_rate / 252
     n = len(portfolio_returns)
 
     mean_r = float(np.mean(portfolio_returns))
     std_r = float(np.std(portfolio_returns, ddof=1))
 
-    # Annualized
-    ann_return = float(mean_r * 252)
+    # Annualized return: geometric (preserves true terminal wealth)
+    cum_return = float(np.prod(1.0 + portfolio_returns))
+    ann_return = float(cum_return ** (252 / n) - 1.0) if n > 0 else None
+
+    # Annualized volatility: arithmetic by sqrt(252) (variance scales linearly under iid)
     ann_vol = float(std_r * np.sqrt(252)) if std_r > 0 else None
 
     # Sharpe
     sharpe = float((mean_r - rf_daily) / std_r * np.sqrt(252)) if std_r > 0 else None
 
-    # Sortino (downside deviation)
-    downside = portfolio_returns[portfolio_returns < rf_daily] - rf_daily
-    downside_std = float(np.std(downside, ddof=1)) if len(downside) > 1 else None
-    sortino = (
-        float((mean_r - rf_daily) / downside_std * np.sqrt(252))
-        if downside_std and downside_std > 0
-        else None
-    )
+    # Sortino — delegate to canonical TDD helper
+    sortino = compute_sortino_ratio(portfolio_returns, risk_free_rate=risk_free_rate)
 
     # Max drawdown
     cum = np.cumprod(1.0 + portfolio_returns)

--- a/backend/quant_engine/return_statistics_service.py
+++ b/backend/quant_engine/return_statistics_service.py
@@ -75,26 +75,27 @@ def compute_sortino_ratio(
     trading_days_per_year: int = TRADING_DAYS_PER_YEAR,
     min_annualized_vol: float = MIN_ANNUALIZED_VOL,
 ) -> float | None:
-    """Annualised Sortino ratio (downside deviation denominator).
+    """Annualised Sortino ratio with canonical Target Downside Deviation.
 
-    Same canonical Netz formula as :func:`compute_sharpe_ratio`, but the
-    denominator only penalises **negative** excess returns. Returns
-    ``None`` when there are no losses (Sortino is undefined) or when the
-    annualised downside vol collapses below ``min_annualized_vol``.
+    Denominator: TDD = sqrt(mean(min(R - rf_daily, 0)²)) over full sample N.
+    Source: Spec §3.4. Replaces prior std(downside_excess) formulation which
+    was mathematically a "modified" Sortino that biased risk vs MAR.
     """
     if len(daily_returns) < 2:
         return None
-    excess = daily_returns - risk_free_rate / trading_days_per_year
-    downside = excess[excess < 0]
-    if len(downside) == 0:
+    rf_daily = risk_free_rate / trading_days_per_year
+    excess = daily_returns - rf_daily
+
+    # Target Downside Deviation: shortfall² over full sample
+    shortfall = np.minimum(excess, 0.0)
+    tdd = float(np.sqrt(np.mean(shortfall**2)))
+
+    if tdd == 0 or not np.isfinite(tdd):
         return None
-    downside_vol = float(np.std(downside, ddof=1))
-    if downside_vol == 0 or not np.isfinite(downside_vol):
+    annualized_tdd = tdd * np.sqrt(trading_days_per_year)
+    if annualized_tdd < min_annualized_vol:
         return None
-    annualized_downside_vol = downside_vol * np.sqrt(trading_days_per_year)
-    if annualized_downside_vol < min_annualized_vol:
-        return None
-    return float(np.mean(excess) / downside_vol * np.sqrt(trading_days_per_year))
+    return float(np.mean(excess) / tdd * np.sqrt(trading_days_per_year))
 
 
 @dataclass(frozen=True, slots=True)
@@ -198,7 +199,7 @@ def _compute_sterling_ratio(
         yearly_max_dds.append(float(np.min(dd_series)))
 
     avg_max_dd = np.mean(yearly_max_dds)
-    denominator = abs(avg_max_dd) - 0.10
+    denominator = abs(avg_max_dd - 0.10)
 
     if denominator <= 0:
         return None
@@ -297,14 +298,15 @@ def compute_return_statistics(
             beta = float(slope)
             r_sq = float(r_value**2)
 
-            # Treynor: (ann_return - Rf) / beta
-            ann_return = _annualize_monthly(arith_mean)
+            # Treynor: (ann_return - Rf) / beta — geometric annualization
+            ann_return = _annualize_monthly(geom_mean)
             if abs(beta) > 1e-10:
                 treynor = float((ann_return - risk_free_rate) / beta)
 
-            # Jensen alpha: mean(R) - Rf_monthly - beta * (mean(Rm) - Rf_monthly)
-            rf_monthly = (1 + risk_free_rate) ** (1 / 12) - 1
-            jensen = float(np.mean(r) - rf_monthly - beta * (np.mean(bm) - rf_monthly))
+            # Jensen alpha: annualized, simple Rf (matches §3.1 and adjacent Treynor scale)
+            rf_monthly = risk_free_rate / 12
+            monthly_alpha = float(np.mean(r) - rf_monthly - beta * (np.mean(bm) - rf_monthly))
+            jensen = monthly_alpha * 12
 
             # Proficiency ratios
             bm_up_mask = bm >= 0

--- a/backend/tests/test_model_portfolio.py
+++ b/backend/tests/test_model_portfolio.py
@@ -548,6 +548,42 @@ class TestPortfolioMetricsService:
         result = aggregate(returns, benchmark)
         assert result.information_ratio is not None
 
+    def test_annualized_return_is_geometric_not_arithmetic(self):
+        from quant_engine.portfolio_metrics_service import aggregate
+
+        rng = np.random.default_rng(42)
+        r = rng.normal(0.0004, 0.01, size=504)
+
+        result = aggregate(r)
+
+        cum = float(np.prod(1 + r))
+        expected_geom = cum ** (252 / len(r)) - 1
+        expected_arith = float(np.mean(r)) * 252
+
+        assert abs(result.annualized_return - round(expected_geom, 6)) < 1e-6
+        assert abs(result.annualized_return - expected_arith) > 0.001
+
+    def test_annualized_return_preserves_terminal_wealth(self):
+        """Alternating ±50%/+100%: true terminal wealth flat → 0% return."""
+        from quant_engine.portfolio_metrics_service import aggregate
+
+        r = np.array([-0.5, 1.0] * 252)  # 504 days
+        result = aggregate(r)
+        assert abs(result.annualized_return - 0.0) < 1e-6
+
+    def test_portfolio_metrics_sortino_matches_canonical(self):
+        from quant_engine.portfolio_metrics_service import aggregate
+        from quant_engine.return_statistics_service import compute_sortino_ratio
+
+        rng = np.random.default_rng(42)
+        r = rng.normal(0.0004, 0.012, size=504)
+        metrics = aggregate(r, risk_free_rate=0.04)
+        direct = compute_sortino_ratio(r, risk_free_rate=0.04)
+        if direct is not None:
+            assert metrics.sortino_ratio == round(direct, 4)
+        else:
+            assert metrics.sortino_ratio is None
+
 
 class TestQuantAnalyzerRewired:
     """Test QuantAnalyzer is no longer a scaffold."""

--- a/backend/tests/test_return_statistics_service.py
+++ b/backend/tests/test_return_statistics_service.py
@@ -13,6 +13,7 @@ from quant_engine.return_statistics_service import (
     _compute_sterling_ratio,
     _to_monthly_returns,
     compute_return_statistics,
+    compute_sortino_ratio,
 )
 
 # ── Fixtures ──────────────────────────────────────────────────────────
@@ -207,3 +208,83 @@ class TestComputeReturnStatistics:
             assert result.avg_monthly_gain >= 0
         if result.avg_monthly_loss is not None:
             assert result.avg_monthly_loss <= 0
+
+
+# ── F02: Sterling ratio parenthesization ─────────────────────────────
+
+
+def test_sterling_ratio_handles_low_drawdown_funds():
+    """Fund with steady returns has small DD (<10%); pre-fix returned None."""
+    daily = np.full(252, 0.0001)
+    result = compute_return_statistics(daily)
+    assert result.sterling_ratio is not None
+    assert result.sterling_ratio > 0
+
+
+# ── F03 + OOS-2: Sortino canonical TDD ──────────────────────────────
+
+
+def test_sortino_canonical_tdd():
+    """Identical losses: pre-fix returns None (np.std=0), post-fix returns finite."""
+    returns = np.array([-0.005, -0.005, -0.005, 0.001] * 65)  # ~260 days
+    result = compute_sortino_ratio(returns)
+    assert result is not None
+    assert result < 0
+
+
+def test_sortino_uses_full_sample_denominator():
+    """Single large loss + many zeros: TDD on full sample yields moderate Sortino."""
+    returns = np.concatenate([np.zeros(99), np.array([-0.10])])
+    result = compute_sortino_ratio(returns, risk_free_rate=0.0)
+    # Closed-form: TDD = sqrt(0.01/100) = 0.01
+    # Sortino = mean / TDD * sqrt(252) = (-0.001 / 0.01) * sqrt(252) ≈ -1.587
+    assert abs(result - (-0.001 / 0.01) * np.sqrt(252)) < 0.01
+
+
+# ── F07 + OOS-1: Treynor uses geometric mean ────────────────────────
+
+
+def test_treynor_uses_geometric_mean():
+    """Volatile returns: arith mean inflates Treynor; geom mean does not."""
+    from scipy import stats as sp_stats
+
+    rng = np.random.default_rng(42)
+    high_vol_pos = rng.normal(0.005, 0.02, size=21 * 12)
+    high_vol_neg = rng.normal(-0.004, 0.02, size=21 * 12)
+    daily = np.concatenate([high_vol_pos, high_vol_neg])
+    bench = daily * 0.7 + rng.normal(0.0, 0.005, size=len(daily))
+
+    result = compute_return_statistics(daily, benchmark_returns=bench, risk_free_rate=0.04)
+
+    monthly = _to_monthly_returns(daily)
+    geom = float(np.prod(1 + monthly) ** (1 / len(monthly)) - 1)
+    expected_ann_geom = (1 + geom) ** 12 - 1
+    arith = float(np.mean(monthly))
+    expected_ann_arith = (1 + arith) ** 12 - 1
+
+    # Verify the two annualizations differ materially (Jensen gap > 1pp)
+    assert abs(expected_ann_geom - expected_ann_arith) > 0.01
+
+    # Verify Treynor uses the geometric one
+    bm_monthly = _to_monthly_returns(bench)
+    n_common = min(len(monthly), len(bm_monthly))
+    slope, _, _, _, _ = sp_stats.linregress(bm_monthly[:n_common], monthly[:n_common])
+    expected_treynor = round((expected_ann_geom - 0.04) / slope, 4)
+    assert result.treynor_ratio == expected_treynor
+
+
+# ── F04: Jensen alpha annualized + simple Rf ─────────────────────────
+
+
+def test_jensen_alpha_is_annualized_with_simple_rf():
+    """Jensen output must be annualized to match Treynor scale."""
+    monthly_pattern = np.array([0.01, 0.005] * 13)  # 26 months
+    daily = np.repeat(monthly_pattern / 21, 21)[:546]
+    bench_monthly = monthly_pattern - 0.005
+    bench_daily = np.repeat(bench_monthly / 21, 21)[: len(daily)]
+
+    result = compute_return_statistics(daily, benchmark_returns=bench_daily, risk_free_rate=0.04)
+
+    # Annualized Jensen ≈ 12 × monthly outperformance ≈ 6% (with β-adjustment)
+    assert result.jensen_alpha is not None
+    assert 0.04 < result.jensen_alpha < 0.08


### PR DESCRIPTION
## Summary

5 Tier 1 correctness fixes from Wave 6 Session 01 audit (Returns / Drawdown / Rolling / Backtest / Portfolio Metrics foundation).

| Finding | Fix | File:line |
|---|---|---|
| **F02** | Sterling denominator parenthesization — `abs(avg_max_dd - 0.10)` not `abs(avg_max_dd) - 0.10` | `return_statistics_service.py:201` |
| **F03 + OOS-2** | Sortino canonical TDD — `sqrt(mean(min(R-MAR,0)²))` over full sample N | `return_statistics_service.py:71-97` |
| **F07 + OOS-1** | Treynor numerator uses geometric mean, not arithmetic | `return_statistics_service.py:301` |
| **F04** | Jensen alpha annualized (×12) + simple `rf/12` Rf — **BREAKING CHANGE** | `return_statistics_service.py:305-307` |
| **F08** | Portfolio `annualized_return` uses geometric compounding + Sortino delegates to canonical helper | `portfolio_metrics_service.py:56-79` |

## Breaking change

`jensen_alpha` values are now ~12× larger (annualized scale). No existing test assertions broke because they only checked `is not None`. Frontend label update to "Jensen alpha (annualized)" should ship as a follow-up PR.

## Methodology source

`docs/audits/audit-validation-session01.md` — Wave 6 Session 01 Stage 3 triage by Opus 4.7 after 3-stage audit protocol (Opus 4.6 + Gemini 3.1 Pro discovery, GPT 5.5 jury).

## Test plan

- [x] `make check` passes locally (86/86 affected tests passing, 0 regressions)
- [x] 8 new deterministic tests covering each fix
- [x] No existing test assertions broke
- [x] Pre-existing flakes documented as unrelated: `test_construction_cvar_invariant`, `test_load_universe_funds_prefilter`, `test_correlation_dedup_service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)