### PR TITLE
PR-Q30 — EVT L-moments silent swap fix + sign convention test (F02 + F06)

### DIFF
--- a/backend/quant_engine/evt/pot_gpd.py
+++ b/backend/quant_engine/evt/pot_gpd.py
@@ -125,11 +125,14 @@ def extreme_var_evt(
     # Spec: Trigger when MLE does not converge OR CI of xi crosses 1.
     # Simplified trigger: xi >= 0.9 or not converged
     if (not converged or xi >= 0.9) and LMOMENTS_AVAILABLE:
-        xi_lm, beta_lm = _fit_gpd_lmoments(excesses)
-        if xi_lm < 1.0:
+        xi_lm, beta_lm, lm_converged = _fit_gpd_lmoments(excesses)
+        if lm_converged and xi_lm < 1.0:
             xi, beta = xi_lm, beta_lm
             method = "lmoments"
             converged = True
+        # else: keep MLE result with whatever flags it had.
+        # If MLE was non-converged and L-moments also failed, the downstream
+        # `degraded = not converged` branch (line 138) will mark the result degraded.
 
     # 7. Sanity check: Hill estimator
     k_hill = max(15, int(0.10 * len(losses)))
@@ -222,14 +225,24 @@ def _fit_gpd_mle(excesses: np.ndarray) -> tuple[float, float, bool]:
         return 0.0, float(np.std(excesses)), False
 
 
-def _fit_gpd_lmoments(excesses: np.ndarray) -> tuple[float, float]:
-    """Fit GPD using Method of L-moments."""
+def _fit_gpd_lmoments(excesses: np.ndarray) -> tuple[float, float, bool]:
+    """Fit GPD using Method of L-moments.
+
+    Returns
+    -------
+    (xi, beta, converged) :
+        ``xi``: shape parameter (positive = heavy tail, matching scipy genpareto).
+        ``beta``: scale parameter.
+        ``converged``: True if lmoments3.gpa.lmom_fit succeeded; False if the
+        fallback ``(0.0, std)`` was returned. Caller MUST gate on this flag
+        before substituting the MLE estimate (see PR-Q30 / Wave 6 Session 02 F02).
+    """
     try:
         paras = distr.gpa.lmom_fit(excesses)
-        return float(paras['c']), float(paras['scale'])
+        return float(paras['c']), float(paras['scale']), True
     except Exception as e:
         logger.warning("gpd_lmoments_fit_failed", error=str(e))
-        return 0.0, float(np.std(excesses))
+        return 0.0, float(np.std(excesses, ddof=1)), False
 
 
 def _fallback_to_normal(

--- a/backend/tests/quant_engine/test_evt_pot_gpd.py
+++ b/backend/tests/quant_engine/test_evt_pot_gpd.py
@@ -58,8 +58,8 @@ def test_infinite_mean_tail(monkeypatch):
         return 1.1, 0.0, 0.02
         
     def mock_fit_lm(*args, **kwargs):
-        return 1.1, 0.02
-        
+        return 1.1, 0.02, True  # PR-Q30: 3-tuple including converged=True
+
     monkeypatch.setattr(genpareto, "fit", mock_fit_mle)
     if pot_gpd.LMOMENTS_AVAILABLE:
         monkeypatch.setattr(pot_gpd, "_fit_gpd_lmoments", mock_fit_lm)
@@ -301,3 +301,127 @@ def test_risk_calc_evt_consumers_unaffected_by_q14():
     # And the new dict mirrors them.
     assert res.quantile_results[0.99] == (res.var_99, res.cvar_99)
     assert res.quantile_results[0.999] == (res.var_999, res.cvar_999)
+
+
+def test_lmoments_fallback_does_not_silently_swap_to_exponential(monkeypatch):
+    """PR-Q30 F02: when MLE produces xi>=0.9 AND L-moments raises exception,
+    code must NOT silently replace heavy-tail with exponential xi=0.
+
+    Setup: MLE returns xi=0.9 (heavy tail). _fit_gpd_lmoments mocked to return
+    (0.0, 1.0, False) — simulating the package raising and the fallback firing.
+    Caller must observe lm_converged=False and KEEP the MLE estimate xi=0.9.
+    """
+    from scipy.stats import genpareto
+
+    from quant_engine.evt import pot_gpd
+
+    def mock_fit_mle(*args, **kwargs):
+        return 0.9, 0.0, 0.02
+
+    def mock_fit_lm_failed(*args, **kwargs):
+        # Simulates the except block returning the fallback tuple
+        return 0.0, 1.0, False
+
+    monkeypatch.setattr(genpareto, "fit", mock_fit_mle)
+    if pot_gpd.LMOMENTS_AVAILABLE:
+        monkeypatch.setattr(pot_gpd, "_fit_gpd_lmoments", mock_fit_lm_failed)
+
+    # Synthesize losses with sufficient excesses
+    losses = np.concatenate([np.linspace(0.001, 0.05, 180), np.linspace(0.051, 0.10, 50)])
+    returns = -losses
+
+    res = extreme_var_evt(returns)
+
+    # CRITICAL ASSERTION: xi must remain at MLE's heavy-tail estimate (>= 0.5),
+    # NOT silently swapped to exponential 0.0.
+    assert res.fit.xi >= 0.5, (
+        f"Heavy-tail estimate {res.fit.xi} silently swapped to exponential "
+        f"despite L-moments fallback failure (xi=0.9 MLE was correct)."
+    )
+    # method should be "mle" since L-moments failed
+    assert res.fit.method == "mle"
+
+
+def test_lmoments_fallback_succeeds_when_lmoments_returns_valid_xi(monkeypatch):
+    """PR-Q30 F02 paired test: when MLE has xi>=0.9 AND _fit_gpd_lmoments
+    returns a valid xi<1.0 with converged=True, the swap is intentional and
+    the result should reflect the L-moments estimate.
+
+    This is the COMPLEMENT of test_lmoments_fallback_does_not_silently_swap...
+    to ensure we did not over-correct.
+    """
+    from scipy.stats import genpareto
+
+    from quant_engine.evt import pot_gpd
+
+    if not pot_gpd.LMOMENTS_AVAILABLE:
+        pytest.skip("lmoments3 not installed in this environment")
+
+    def mock_fit_mle(*args, **kwargs):
+        return 0.95, 0.0, 0.02  # MLE heavy-tail near boundary
+
+    def mock_fit_lm_ok(*args, **kwargs):
+        return 0.4, 0.05, True  # L-moments converges with milder estimate
+
+    monkeypatch.setattr(genpareto, "fit", mock_fit_mle)
+    monkeypatch.setattr(pot_gpd, "_fit_gpd_lmoments", mock_fit_lm_ok)
+
+    losses = np.concatenate([np.linspace(0.001, 0.05, 180), np.linspace(0.051, 0.10, 50)])
+    returns = -losses
+
+    res = extreme_var_evt(returns)
+
+    # When L-moments converges legitimately, result should reflect it
+    assert res.fit.method == "lmoments"
+    assert res.fit.xi == pytest.approx(0.4, abs=0.01)
+
+
+def test_lmoments_gpa_sign_convention_matches_scipy():
+    """PR-Q30 F06: lmoments3 GPA fit must return xi with same sign as scipy genpareto.
+
+    Both scipy.stats.genpareto.fit (`c` parameter) and lmoments3.distr.gpa.lmom_fit
+    (`paras['c']`) should follow the Pickands-Balkema-de Haan convention:
+    positive shape = heavy tail. If a future package upgrade flips this, this
+    test will fail and the orchestrator's CI will catch it.
+
+    The current sign convention is verified against synthetic heavy-tail data:
+    we generate samples from genpareto(c=0.5) and assert both estimators recover
+    a positive shape parameter.
+    """
+    from scipy.stats import genpareto
+
+    from quant_engine.evt.pot_gpd import LMOMENTS_AVAILABLE, _fit_gpd_lmoments, _fit_gpd_mle
+
+    if not LMOMENTS_AVAILABLE:
+        pytest.skip("lmoments3 not installed in this environment")
+
+    # Synthesize heavy-tail GPD samples: xi=0.5, beta=1.0, threshold u=0
+    rng = np.random.default_rng(42)
+    samples = genpareto(c=0.5, scale=1.0).rvs(size=2000, random_state=rng)
+    excesses = samples[samples > 0]  # POT step — keep only positive excesses
+
+    # MLE estimate
+    xi_mle, beta_mle, mle_converged = _fit_gpd_mle(excesses)
+
+    # L-moments estimate
+    xi_lm, beta_lm, lm_converged = _fit_gpd_lmoments(excesses)
+
+    # Both should converge for this clean synthetic
+    assert mle_converged, "MLE should converge on clean synthetic GPD samples"
+    assert lm_converged, "L-moments should converge on clean synthetic GPD samples"
+
+    # Both should agree on sign convention: heavy tail → positive xi
+    assert xi_mle > 0.1, f"MLE xi={xi_mle} should reflect heavy tail (>0.1) for c=0.5 input"
+    assert xi_lm > 0.1, (
+        f"L-moments xi={xi_lm} should reflect heavy tail (>0.1) for c=0.5 input. "
+        f"If this fails, the sign convention of lmoments3.distr.gpa has changed "
+        f"and the L-moments fallback path in pot_gpd.py silently inverts the "
+        f"shape parameter."
+    )
+
+    # And approximately agree (within reasonable noise)
+    assert abs(xi_mle - xi_lm) < 0.25, (
+        f"MLE xi={xi_mle} and L-moments xi={xi_lm} disagree materially. "
+        f"This may indicate a sign convention drift, scale parameter divergence, "
+        f"or a package version incompatibility."
+    )


### PR DESCRIPTION
## Summary

Wave 6 Session 02 — **Tier 1 fiduciary** fix. Sole Tier 1 finding of the session.

| Finding | Severity | Fix |
|---|---|---|
| **F02** | Math Critical / Inst Critical | \`_fit_gpd_lmoments\` returns 3-tuple \`(xi, beta, converged)\`; caller gates on \`lm_converged AND xi_lm < 1.0\`. When L-moments fails, MLE heavy-tail estimate preserved (was silently swapped to exponential xi=0). |
| **F06** | Test gap (Low/Low) | Added \`test_lmoments_gpa_sign_convention_matches_scipy\` regression guard against future \`lmoments3\` package upgrades flipping shape parameter sign. |

## Why this matters

For heavy-tail UCITS funds (EM debt, hedge fund crash exposure, growth equity) with true \`xi ∈ [0.5, 0.9]\`, the silent swap produced dramatically understated VaR_99 / CVaR_99. Charter §3 silent-corruption violation. The whole purpose of EVT POT is to **not** assume exponential decay — and the code was silently doing exactly that whenever the L-moments fallback fired.

## Changes (2 files, 153 LoC)

| File | Change | LoC |
|---|---|---|
| \`backend/quant_engine/evt/pot_gpd.py\` | \`_fit_gpd_lmoments\` signature: 2-tuple → 3-tuple; caller gates on \`lm_converged\`; sub-fix \`ddof=1\` in fallback std | ~25 |
| \`backend/tests/quant_engine/test_evt_pot_gpd.py\` | Updated \`test_infinite_mean_tail\` mock + 3 new tests (silent-swap guard, complement, sign-convention) | ~128 |

## Behavioral impact

Only affects funds where MLE returned \`xi >= 0.9\` AND \`_fit_gpd_lmoments\` raised an exception. Currently those funds have understated VaR_99 / CVaR_99 — fix produces materially **more conservative** tail estimates. **Single direction of change** = no false-tightening risk; institutionally favorable.

## Methodology source

\`docs/audits/audit-validation-session02.md\` F02 + F06 — Stage 3 triage by Opus 4.7 after 3-stage audit (Opus 4.6 + Gemini 3.1 Pro discovery, GPT 5.4 jury — 100% verdict accuracy).

## Test plan

- [x] All 11 acceptance criteria from PR prompt verified PASS
- [x] 4 tests in \`test_evt_pot_gpd.py\`: 1 updated (mock 3-tuple) + 3 new (silent-swap guard, complement, sign-convention)
- [x] 43/43 EVT/CVaR/GARCH tests pass
- [x] \`ruff check backend/\` clean
- [x] \`make check\`: lint ✓, architecture 31/31 ✓, 588 tests passed
- [x] 1 pre-existing flake (\`test_openfigi_no_api_key_returns_failure\`) unrelated — identity resolver module

🤖 Generated with [Claude Code](https://claude.com/claude-code)