### PR TITLE
PR-Q31 — Observability bundle: Inf filter + GARCH degraded + EVT reason (F03 + F04 + F05)

### DIFF
--- a/backend/quant_engine/cvar_service.py
+++ b/backend/quant_engine/cvar_service.py
@@ -148,7 +148,7 @@ def compute_cvar(
     Central entry point for all fund and portfolio CVaR calculations.
     All methods return return-space values (losses are negative).
     """
-    clean_returns = returns[~np.isnan(returns)]
+    clean_returns = returns[np.isfinite(returns)]
     n_obs = int(len(clean_returns))
 
     # Fix 10: early guard for insufficient observations across ALL methods.

--- a/backend/quant_engine/evt/pot_gpd.py
+++ b/backend/quant_engine/evt/pot_gpd.py
@@ -84,7 +84,7 @@ def extreme_var_evt(
     Follows the 11-step pipeline for institutional asset/wealth management.
     """
     # 1. Clean data
-    clean_returns = returns[~np.isnan(returns)]
+    clean_returns = returns[np.isfinite(returns)]
     if len(clean_returns) == 0:
         return _degraded_result(0.0, "no_data")
 
@@ -139,7 +139,7 @@ def extreme_var_evt(
     xi_hill = compute_hill_estimator(losses, k_hill)
     
     degraded = not converged
-    reason = None
+    reason = "gpd_fit_did_not_converge" if not converged else None
     
     if abs(xi_hill - xi) > 2 * abs(xi) and xi > 0.1:
          degraded = True

--- a/backend/quant_engine/garch_service.py
+++ b/backend/quant_engine/garch_service.py
@@ -141,6 +141,8 @@ def fit_garch(
                 log_likelihood=None,
                 converged=False,
                 vol_model="EWMA_0.94",
+                degraded=True,
+                degraded_reason="garch_did_not_converge",
             )
 
         # ── Fix 3 (BUG-G2): fail loud on missing param keys ──────────
@@ -235,4 +237,6 @@ def fit_garch(
             log_likelihood=None,
             converged=False,
             vol_model="EWMA_0.94",
+            degraded=True,
+            degraded_reason="garch_fit_failed",
         )

--- a/backend/tests/quant_engine/test_cvar_service.py
+++ b/backend/tests/quant_engine/test_cvar_service.py
@@ -255,3 +255,26 @@ def test_check_breach_status_uses_breach_epsilon_at_boundary() -> None:
     )
     # Status should be warning (utilization ≈ 100%), not breach.
     assert result.trigger_status == "warning"
+
+
+# ─── PR-Q31 F03 ────────────────────────────────────────────────────────────
+
+
+def test_compute_cvar_filters_inf_consistent_with_tail_var():
+    """PR-Q31 F03: ±Inf must be filtered out, matching tail_var_service / garch_service convention.
+
+    Pre-fix: ~np.isnan() lets ±Inf survive, producing nan/inf CVaR silently.
+    Post-fix: np.isfinite() drops them; CVaR computed over the finite subset.
+    """
+    # 40 finite returns + 2 Inf rows that must be filtered
+    returns = np.concatenate([
+        np.array([0.01, 0.02, -0.03, 0.05] * 10),  # 40 finite obs
+        np.array([np.inf, -np.inf]),
+    ])
+
+    result = compute_cvar(returns, confidence=0.95, method="historical")
+
+    assert np.isfinite(result.cvar), f"CVaR should be finite, got {result.cvar}"
+    assert np.isfinite(result.var), f"VaR should be finite, got {result.var}"
+    # n_obs reflects finite-filtered count (40), not nan-filtered (would be 42)
+    assert result.n_obs == 40

--- a/backend/tests/quant_engine/test_evt_pot_gpd.py
+++ b/backend/tests/quant_engine/test_evt_pot_gpd.py
@@ -425,3 +425,57 @@ def test_lmoments_gpa_sign_convention_matches_scipy():
         f"This may indicate a sign convention drift, scale parameter divergence, "
         f"or a package version incompatibility."
     )
+
+
+# ─── PR-Q31 F03 ────────────────────────────────────────────────────────────
+
+
+def test_extreme_var_evt_filters_inf_consistent_with_sibling_modules():
+    """PR-Q31 F03: ±Inf must be filtered before EVT POT to avoid undefined excesses.
+
+    Pre-fix: ~np.isnan() lets ±Inf survive; np.quantile on losses with +inf
+    returns inf as the threshold, producing degenerate excesses.
+    Post-fix: np.isfinite() drops them; EVT runs cleanly on finite subset.
+    """
+    # Sufficient finite returns to drive POT + 2 Inf rows
+    rng = np.random.default_rng(42)
+    finite_returns = rng.normal(0.0, 0.02, size=500)
+    returns = np.concatenate([finite_returns, np.array([np.inf, -np.inf])])
+
+    res = extreme_var_evt(returns)
+
+    # Result should not be degraded due to Inf survival (it may be degraded
+    # for legitimate POT reasons, but not because of Inf in the input)
+    assert np.isfinite(res.fit.u), f"Threshold u should be finite, got {res.fit.u}"
+    assert np.isfinite(res.var_99) or res.degraded, (
+        f"VaR_99 should be finite when not degraded; got {res.var_99}, degraded={res.degraded}"
+    )
+
+
+# ─── PR-Q31 F05 ────────────────────────────────────────────────────────────
+
+
+def test_evt_non_convergence_sets_degraded_reason(monkeypatch):
+    """PR-Q31 F05: when both MLE and L-moments fail, degraded_reason must be set
+    to 'gpd_fit_did_not_converge', not None.
+    """
+    from quant_engine.evt import pot_gpd
+
+    def mock_fit_mle(*args, **kwargs):
+        raise ValueError("synthetic MLE failure")
+
+    def mock_fit_lm_failed(*args, **kwargs):
+        return 0.0, 1.0, False  # post-PR-Q30 3-tuple, lm_converged=False
+
+    monkeypatch.setattr(genpareto, "fit", mock_fit_mle)
+    if pot_gpd.LMOMENTS_AVAILABLE:
+        monkeypatch.setattr(pot_gpd, "_fit_gpd_lmoments", mock_fit_lm_failed)
+
+    # Generate enough data to reach the convergence-check branch
+    losses = np.concatenate([np.linspace(0.001, 0.05, 180), np.linspace(0.051, 0.10, 50)])
+    returns = -losses
+
+    res = extreme_var_evt(returns)
+
+    assert res.degraded is True
+    assert res.degraded_reason == "gpd_fit_did_not_converge"

--- a/backend/tests/quant_engine/test_garch_correctness.py
+++ b/backend/tests/quant_engine/test_garch_correctness.py
@@ -166,3 +166,50 @@ def test_BUG_G5_percent_returns_input_raises():
 
     with pytest.raises(ValueError, match="returns appear to be in percent form"):
         fit_garch(percent_returns)
+
+
+# ─── PR-Q31 F04 ────────────────────────────────────────────────────────────
+
+
+def test_garch_non_convergence_sets_degraded():
+    """PR-Q31 F04: GARCH convergence_flag != 0 path must set degraded=True.
+
+    Pre-fix: returned degraded=False (default), masking pipeline failure.
+    Post-fix: degraded=True with degraded_reason='garch_did_not_converge'.
+    """
+    # Mock arch to return a non-converged result
+    mock_result = MagicMock()
+    mock_result.convergence_flag = 1
+    mock_model = MagicMock()
+    mock_model.fit.return_value = mock_result
+
+    rng = np.random.default_rng(42)
+    returns = rng.normal(0.0, 0.01, size=200)
+
+    with patch("arch.arch_model", return_value=mock_model):
+        result = fit_garch(returns)
+
+    assert result is not None
+    assert result.degraded is True
+    assert result.degraded_reason == "garch_did_not_converge"
+    assert result.volatility_garch is None
+    assert result.converged is False
+
+
+def test_garch_exception_path_sets_degraded():
+    """PR-Q31 F04: GARCH exception fallback must set degraded=True with reason='garch_fit_failed'."""
+    rng = np.random.default_rng(42)
+    returns = rng.normal(0.0, 0.01, size=200)
+
+    # Force arch_model to raise during fit
+    def _raise(*args, **kwargs):
+        raise RuntimeError("synthetic arch failure")
+
+    with patch("arch.arch_model", side_effect=_raise):
+        result = fit_garch(returns)
+
+    assert result is not None
+    assert result.degraded is True
+    assert result.degraded_reason == "garch_fit_failed"
+    assert result.volatility_garch is None
+    assert result.converged is False


### PR DESCRIPTION
## Summary

Wave 6 Session 02 observability bundle — 3 fixes addressing legacy-divergence and missing degraded-flag patterns identified by Stage 1 + Stage 2 jury (F03/F04/F05).

| Finding | Tier | Fix | File:line |
|---|---|---|---|
| **F03** | Tier 2 (Math Med / Inst High) | Replace \`~np.isnan\` with \`np.isfinite\` to filter \`±Inf\` consistent with sibling modules | \`cvar_service.py:151\`, \`evt/pot_gpd.py:87\` |
| **F04** | Tier 2 (Math Low / Inst High) | GARCH convergence_flag and exception paths set \`degraded=True\` (was inconsistent with 2 of 4 failure paths in same file) | \`garch_service.py:134-144\`, \`:226-238\` |
| **F05** | Tier 4 (Low/Low) | EVT non-convergence sets \`degraded_reason=\"gpd_fit_did_not_converge\"\` (was \`None\`) | \`evt/pot_gpd.py:138-139\` |

## Behavioral impact

Pure observability/legacy-divergence fixes. **No numeric change for funds with finite-only returns** (the vast majority). Funds with \`±Inf\` rows (rare, dirty data) now produce clean CVaR/EVT outputs instead of silent \`nan\`/\`inf\`. GARCH degraded state is now signaled consistently across all 4 failure paths.

## Methodology source

\`docs/audits/audit-validation-session02.md\` F03 + F04 + F05 — Stage 3 triage by Opus 4.7 after 3-stage audit (Opus 4.6 + Gemini 3.1 Pro discovery, GPT 5.4 jury — 100% verdict accuracy).

## Test plan

- [x] All acceptance criteria verified (5 fixes across 3 files)
- [x] 5 new tests (3 EVT/CVaR + 2 GARCH); 3 pass locally; 2 GARCH tests gated on \`arch\` package availability (CI-only, same gating as existing GARCH tests)
- [x] All existing CVaR + EVT tests pass
- [x] Pre-existing failures documented as unrelated (separate investigation thread): \`test_mle_failure_fallback_lmoments\` (env-conditional), \`yaml\`/\`pytest-asyncio\` (env hygiene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)