### PR TITLE
PR-Q32 — RU CVaR atom-splitting fix + test cleanup (F01) — closes Session 02

### DIFF
--- a/backend/quant_engine/cvar_service.py
+++ b/backend/quant_engine/cvar_service.py
@@ -346,23 +346,24 @@ def compute_cvar_from_returns(
 ) -> tuple[float, float]:
     """Compute CVaR and VaR from a returns array.
 
-    CVaR (Expected Shortfall) = mean of returns below VaR threshold.
-    Returns (cvar, var) as negative numbers (losses).
+    PR-Q32 F01: uses the exact Rockafellar-Uryasev empirical estimator
+    matching the LP objective at optimality:
+
+        VaR_α(L)  = inf{ ζ : P(L ≤ ζ) ≥ α }                       (upper-quantile)
+        CVaR_α(L) = ζ + (1/((1-α)·T)) · Σ max(L_i - ζ, 0)
+
+    where L = -returns. Returns (cvar, var) as negative numbers (return-space
+    losses), consistent with PR-Q13 sign convention.
     """
-    # Fix 5: return NaN for insufficient data instead of optimistic 0.0.
     if len(returns) < 5:
         return float("nan"), float("nan")
 
-    sorted_returns = np.sort(returns)
-    # Fix 8: use math.ceil for correct tail count and consistent VaR/CVaR.
-    # Round to 10 decimal places first to avoid floating-point edge cases
-    # (e.g. 20 * 0.05 = 1.0000000000000009 which ceil() rounds to 2).
-    n = len(sorted_returns)
-    tail_count = max(1, math.ceil(round(n * (1.0 - confidence), 10)))
-    var = float(sorted_returns[tail_count - 1])
-    cvar = float(sorted_returns[:tail_count].mean())
-
-    return cvar, var
+    # Convert to loss-space for the RU formulation, then negate result back.
+    losses = -returns
+    var_loss = float(np.quantile(losses, confidence, method="higher"))
+    u = np.maximum(losses - var_loss, 0.0)
+    cvar_loss = var_loss + u.sum() / ((1.0 - confidence) * len(losses))
+    return -float(cvar_loss), -float(var_loss)
 
 
 def get_cvar_utilization(cvar_current: float, cvar_limit: float) -> float:

--- a/backend/quant_engine/ru_cvar_lp.py
+++ b/backend/quant_engine/ru_cvar_lp.py
@@ -117,15 +117,23 @@ def realized_cvar_from_weights(
 ) -> float:
     """Empirical CVaR_alpha of a realized weight vector (post-solve check).
 
+    PR-Q32 F01: uses the exact Rockafellar-Uryasev empirical estimator,
+    matching the LP objective at optimality. The previous tail.mean()
+    diverged from the LP value when (1-alpha)*T was non-integer or when
+    probability mass clustered at VaR.
+
     Used for telemetry and tests — computes CVaR directly from the
     scenario matrix without re-solving an LP. Equivalent to the LP
     objective value at optimality.
     """
     T, _ = returns_scenarios.shape
     losses = -returns_scenarios @ weights
-    # Empirical VaR at level alpha = (1-alpha)-quantile of losses from above.
-    # For CVaR: average of losses exceeding VaR.
-    var_threshold = float(np.quantile(losses, alpha))
+
+    var_threshold = float(np.quantile(losses, alpha, method="higher"))
+    u = np.maximum(losses - var_threshold, 0.0)
+    cvar = var_threshold + u.sum() / ((1.0 - alpha) * T)
+
+    # Existing telemetry — kept for observability post-fix
     tail = losses[losses >= var_threshold]
     tail_count = int(tail.size)
     expected_tail_mass = (1.0 - alpha) * T
@@ -138,10 +146,7 @@ def realized_cvar_from_weights(
         var_threshold=var_threshold,
         tail_count_observed=tail_count,
         tail_count_expected=float(expected_tail_mass),
+        cvar_computed=float(cvar),
         loss_sign_convention="L_i = -R_i @ weights",
     )
-    if tail_count == 0:
-        return float(var_threshold)
-    # RU definition equivalent: CVaR = zeta + mean(max(L - zeta, 0)) / (1 - alpha)
-    # At zeta = VaR, this reduces to mean of tail losses when tail mass = (1-alpha).
-    return float(tail.mean())
+    return float(cvar)

--- a/backend/tests/quant_engine/test_cvar_constraint_regression.py
+++ b/backend/tests/quant_engine/test_cvar_constraint_regression.py
@@ -163,3 +163,55 @@ def test_band_bounds_annualized() -> None:
         f"lower_at_cvar={band['lower_at_cvar']} — expected annualized magnitude"
     )
     assert band["upper_at_cvar"] > band["lower_at_cvar"] - 1e-6
+
+
+# ── PR-Q32 F01 — Exact RU empirical estimator ────────────────────────────
+
+
+def test_realized_cvar_matches_exact_ru_formula():
+    """PR-Q32 F01: realized_cvar_from_weights must equal the exact RU LP empirical
+    estimator, not the discretized tail.mean().
+
+    Reference: Gemini Stage 1 example. losses=[0,10,10,20], alpha=0.5.
+    Exact RU: var_threshold = quantile(losses, 0.5, 'higher') = 10.
+                u = max(losses - 10, 0) = [0, 0, 0, 10]
+                cvar = 10 + 10 / (0.5 * 4) = 10 + 5 = 15.0
+    Pre-fix tail.mean() = (10 + 10 + 20) / 3 = 13.333.
+    """
+    # losses = [0, 10, 10, 20] when w = [-1] and returns_scenarios = [[0], [-10], [-10], [-20]]
+    returns_scenarios = np.array([[0.0], [-10.0], [-10.0], [-20.0]])
+    weights = np.array([1.0])
+    cvar = realized_cvar_from_weights(weights, returns_scenarios, alpha=0.5)
+    assert cvar == pytest.approx(15.0, abs=1e-9), (
+        f"Exact RU LP estimator should give 15.0, got {cvar}. "
+        f"Pre-fix tail.mean() returned 13.333 — that was the bug."
+    )
+
+
+def test_realized_cvar_matches_lp_objective_at_optimality():
+    """PR-Q32 F01: post-solve verifier value must equal the LP objective value
+    at optimality within numerical tolerance, for any T and alpha.
+
+    Builds a small min-CVaR LP, solves it, and asserts the verifier matches.
+    """
+    import cvxpy as cp
+
+    from quant_engine.ru_cvar_lp import build_ru_cvar_objective
+
+    rng = np.random.default_rng(123)
+    T, N = 100, 3
+    R = rng.normal(0.0, 0.02, size=(T, N))
+
+    w = cp.Variable(N, nonneg=True)
+    cvar_expr, slack_cs, _zeta, _u = build_ru_cvar_objective(w, R, alpha=0.95)
+    prob = cp.Problem(cp.Minimize(cvar_expr), slack_cs + [cp.sum(w) == 1.0])
+    prob.solve(solver=cp.CLARABEL)
+
+    assert prob.status == "optimal", f"LP solve failed: status={prob.status}"
+    lp_objective = float(prob.value)
+    verifier = realized_cvar_from_weights(w.value, R, alpha=0.95)
+
+    assert verifier == pytest.approx(lp_objective, abs=1e-6), (
+        f"Verifier {verifier} must match LP objective {lp_objective} at optimality. "
+        f"This is the institutional invariant that PR-Q32 F01 enforces."
+    )

--- a/backend/tests/quant_engine/test_cvar_service.py
+++ b/backend/tests/quant_engine/test_cvar_service.py
@@ -278,3 +278,26 @@ def test_compute_cvar_filters_inf_consistent_with_tail_var():
     assert np.isfinite(result.var), f"VaR should be finite, got {result.var}"
     # n_obs reflects finite-filtered count (40), not nan-filtered (would be 42)
     assert result.n_obs == 40
+
+
+# ── PR-Q32 F01 — Exact RU empirical estimator ────────────────────────────
+
+
+def test_compute_cvar_from_returns_matches_exact_ru_formula():
+    """PR-Q32 F01: compute_cvar_from_returns uses exact RU empirical estimator.
+
+    Reference: T=5 returns with alpha=0.7 (target tail mass = 1.5). Pre-fix
+    used ceil(5 * 0.3) = 2 tail items, averaging 2 of the worst returns. Post-fix
+    uses the exact RU formula matching the LP minimum.
+    """
+    # Returns: [0.05, 0.04, 0.03, -0.02, -0.10] (T=5)
+    # Losses: [-0.05, -0.04, -0.03, 0.02, 0.10]
+    # confidence=0.7 → quantile(losses, 0.7, "higher") = 0.02 (3rd-worst loss)
+    # u = max(losses - 0.02, 0) = [0, 0, 0, 0, 0.08]
+    # cvar_loss = 0.02 + 0.08 / (0.3 * 5) = 0.02 + 0.0533 = 0.0733
+    # Returns negated: cvar = -0.0733, var = -0.02
+    returns = np.array([0.05, 0.04, 0.03, -0.02, -0.10])
+    cvar, var = compute_cvar_from_returns(returns, confidence=0.7)
+
+    assert cvar == pytest.approx(-0.0733, abs=1e-3)
+    assert var == pytest.approx(-0.02, abs=1e-9)

--- a/backend/tests/quant_engine/test_evt_pot_gpd.py
+++ b/backend/tests/quant_engine/test_evt_pot_gpd.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from scipy.stats import genpareto
 
-from quant_engine.evt.pot_gpd import extreme_var_evt
+from quant_engine.evt.pot_gpd import LMOMENTS_AVAILABLE, extreme_var_evt
 
 
 def test_gpd_synthetic_recovery():
@@ -114,6 +114,10 @@ def test_ground_truth_simple():
     assert pytest.approx(res.var_99, abs=0.01) == expected_var_99
 
 
+@pytest.mark.skipif(
+    not LMOMENTS_AVAILABLE,
+    reason="lmoments3 not installed; test requires L-moments fallback to be available",
+)
 def test_mle_failure_fallback_lmoments(monkeypatch):
     """Test 7: MLE failure path -> L-moments fallback invoked."""
     from scipy.stats import genpareto


### PR DESCRIPTION
## Summary

Wave 6 Session 02 — **Tier 3 math correctness** fix. Closes Session 02 remediation surface (Q30 + Q31 + Q32 = all 6 TPs shipped).

| Item | Tier | Fix |
|---|---|---|
| **F01** | Tier 3 (Math Med / Inst Med, jury-adjudicated) | Both \`compute_cvar_from_returns\` and \`realized_cvar_from_weights\` now use \`np.quantile(method='higher')\` + exact RU formula matching the LP objective at optimality |
| **OOS-6** (side-effect) | — | Removal of \`if tail_count == 0: return var_threshold\` silent-degraded path is naturally absorbed by the new RU formula |
| **Test cleanup** (F01-unrelated, bundled) | env-conditional | \`test_mle_failure_fallback_lmoments\` decorated with \`@pytest.mark.skipif(not LMOMENTS_AVAILABLE, ...)\` per post-Q31 investigation |

## Why

The optimizer construction itself uses exact RU LP via \`build_ru_cvar_constraints\` / \`build_ru_cvar_objective\` (\`optimizer_service.py:869, 1081\`) — that was always correct. The bug only impacted:
- Post-solve verification at \`optimizer_service.py:714, 843, 909, 1129, 1133\`
- \`risk_calc\` worker output to \`fund_risk_metrics\` hypertable
- DD report tail-risk sections, stress scenarios, long-form reports

Magnitude: ~3% bias at T≥100 (institutional construction range), up to 35% at T=21.

## New formula

\`\`\`
VaR_α(L)  = inf{ ζ : P(L ≤ ζ) ≥ α }                       (upper-quantile)
CVaR_α(L) = ζ + (1/((1-α)·T)) · Σ max(L_i - ζ, 0)
\`\`\`

Implementation: \`np.quantile(losses, alpha, method='higher')\` + exact RU sum.

## Backfill

- \`fund_risk_metrics\` hypertable: \`risk_calc\` worker (lock 900_007) recomputes daily. Next scheduled run after merge produces updated CVaR values.
- **No manual backfill required** — natural one-cycle lag is acceptable.
- Already-issued DD reports / fact sheets remain sticky.

## Methodology source

\`docs/audits/audit-validation-session02.md\` F01 — Stage 3 triage by Opus 4.7 after 3-stage audit (Opus 4.6 + Gemini 3.1 Pro discovery, GPT 5.4 jury, 100% verdict accuracy).

\`docs/prompts/2026-04-26-pre-existing-failures-investigation-post-q31.md\` — investigation report classifying \`test_mle_failure_fallback_lmoments\` as env-conditional (\`lmoments3\` in \`[ai]\` extras; CI has it).

## Test plan

- [x] 3 new tests pass: \`test_realized_cvar_matches_exact_ru_formula\` (Gemini's [0,10,10,20] α=0.5 → 15.0), \`test_realized_cvar_matches_lp_objective_at_optimality\` (verifier == LP objective invariant), \`test_compute_cvar_from_returns_matches_exact_ru_formula\` (T=5, α=0.7)
- [x] 101/101 CVaR + EVT tests pass
- [x] **No existing assertions needed tolerance updates** — T=120 at α=0.95 has integer tail mass (6); pre/post formulas agree there
- [x] Pre-existing failures unrelated to this PR scope: \`openfigi\` API key, \`prefilter\`, \`correlation_dedup\` (separate investigation thread per institutional procedure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)