### PR TITLE
fix(quant): PR-Q35 — Procrustes drift alignment + OAS degraded skip (F01 + F06)

### DIFF
--- a/backend/quant_engine/factor_model_service.py
+++ b/backend/quant_engine/factor_model_service.py
@@ -79,13 +79,28 @@ async def build_fundamental_factor_returns(
     benchmark_res = await db.execute(benchmark_stmt)
     benchmark_rows = benchmark_res.all()
 
-    # Defensive check for T6
+    # Defensive filter (PR-Q35 F06): OAS levels are not total returns. Previously
+    # raised ValueError, taking down the entire factor model fit. Per charter §3
+    # (degraded > crash), filter OAS rows defensively + record for the skipped
+    # accumulator so consumers see the degradation via FundamentalFactorFit.
+    # Reference: Wave 6 Session 03 F06, audit-validation-session03.md.
+    _oas_filtered: list[str] = []
     for row in benchmark_rows:
         ticker = getattr(row, "benchmark_ticker", row[1])
         if ticker in OAS_TICKERS:
-            raise ValueError(
-                f"OAS level is not a total return. Refusing to use {ticker} as credit factor."
-            )
+            _oas_filtered.append(ticker)
+
+    if _oas_filtered:
+        logger.warning(
+            "factor_returns_oas_level_filtered",
+            oas_tickers=sorted(set(_oas_filtered)),
+            rows_dropped=len(_oas_filtered),
+            reason="OAS levels are not total returns; filtered defensively (PR-Q35 F06)",
+        )
+        benchmark_rows = [
+            row for row in benchmark_rows
+            if getattr(row, "benchmark_ticker", row[1]) not in OAS_TICKERS
+        ]
 
     if benchmark_rows:
         bench_df = pd.DataFrame(
@@ -211,6 +226,16 @@ async def build_fundamental_factor_returns(
     # ── 4. Build factor series ────────────────────────────────────────────
     factors = pd.DataFrame(index=combined.index)
     skipped: list[dict[str, str]] = []
+
+    # PR-Q35 F06: record OAS-filtered tickers for downstream degraded propagation.
+    # These appear in factors.attrs["skipped"] at line 327, which feeds into
+    # FundamentalFactorFit.factors_skipped via the caller chain.
+    if _oas_filtered:
+        for ticker in sorted(set(_oas_filtered)):
+            skipped.append({
+                "name": f"oas_{ticker.lower()}",
+                "reason": "OAS level is not a total return; filtered defensively (PR-Q35 F06)",
+            })
 
     # 1. US equity beta (SPY)
     if "SPY" in combined.columns:

--- a/backend/quant_engine/ipca/drift_monitor.py
+++ b/backend/quant_engine/ipca/drift_monitor.py
@@ -14,24 +14,44 @@ def compute_gamma_drift(
     gamma_old: npt.NDArray[np.float64],
     gamma_new: npt.NDArray[np.float64],
 ) -> float:
-    """Compute relative Frobenius norm drift between two gamma matrices."""
+    """Compute Procrustes-aligned relative Frobenius norm drift between two gamma matrices.
+
+    PR-Q35 F01: IPCA factor loadings (Γ) are identified only up to an orthogonal
+    rotation (Kelly-Pruitt-Su 2019). The ALS solver may converge to different
+    rotations or sign flips across re-estimations. To measure true drift in the
+    spanned factor space, we apply orthogonal Procrustes alignment (Schönemann
+    1966) before computing the Frobenius norm.
+
+    Without this alignment, the previous code falsely flagged drift=2.0 for a
+    pure sign flip (gamma_new = -gamma_old), which is a valid IPCA equivalence
+    and should produce drift=0.0.
+
+    Reference: Wave 6 Session 03 F01, audit-validation-session03.md.
+    """
     if gamma_old.shape != gamma_new.shape:
         raise ValueError(
             f"Shape mismatch: gamma_old {gamma_old.shape} != gamma_new {gamma_new.shape}"
         )
-    
+
     norm_old = np.linalg.norm(gamma_old, ord="fro")
     if norm_old < 1e-12:
         return 0.0
 
-    diff = gamma_new - gamma_old
+    # PR-Q35 F01: orthogonal Procrustes alignment.
+    # Find rotation R minimizing ||gamma_new @ R - gamma_old||_F.
+    # Solution: R = U @ V^T where U Σ V^T = SVD(gamma_old^T @ gamma_new).
+    U, _, Vt = np.linalg.svd(gamma_old.T @ gamma_new)
+    R = U @ Vt
+    gamma_new_aligned = gamma_new @ R.T
+
+    diff = gamma_new_aligned - gamma_old
     drift = float(np.linalg.norm(diff, ord="fro") / norm_old)
-    
+
     if drift > _DRIFT_THRESHOLD:
         logger.warning(
             "ipca_gamma_drift_alert",
             drift=drift,
             threshold=_DRIFT_THRESHOLD,
         )
-    
+
     return drift

--- a/backend/tests/quant_engine/test_fundamental_factor_model.py
+++ b/backend/tests/quant_engine/test_fundamental_factor_model.py
@@ -314,20 +314,51 @@ async def test_k_equals_six_contract_with_stubbed_factor_returns(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_oas_level_is_never_used_as_credit_return():
-    """T6: Defensive test against OAS level change usage."""
+async def test_oas_level_is_filtered_not_crashed_on(monkeypatch):
+    """T6 (PR-Q35 F06): OAS levels filtered defensively without crashing.
+
+    Replaces previous test_oas_level_is_never_used_as_credit_return which
+    asserted pytest.raises(ValueError). Per Wave 6 Session 03 F06, the
+    defensive intent is preserved but the crash is replaced with degraded
+    skip pattern (charter §3 degraded > crash).
+
+    Verifies:
+    - build_fundamental_factor_returns does NOT raise ValueError
+    - OAS rows are filtered from the result
+    - skipped accumulator (factors.attrs["skipped"]) records the OAS filter
+    """
+    async def _noop_audit(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "quant_engine.factor_model_service.write_audit_event",
+        _noop_audit,
+    )
+
     db = AsyncMock()
-    # Mock return value including an OAS ticker
+    # Mock returns: one OAS row + one valid SPY row + empty macro
     db.execute.side_effect = [
         MagicMock(all=MagicMock(return_value=[
-            MagicMock(benchmark_ticker="BAMLH0A0HYM2"),
+            MagicMock(benchmark_ticker="BAMLH0A0HYM2", nav_date=date(2021, 1, 2), nav=8.5),
+            MagicMock(benchmark_ticker="SPY", nav_date=date(2021, 1, 2), nav=400.0),
         ])),
+        # Macro query returns empty
+        MagicMock(all=MagicMock(return_value=[])),
     ]
-    
-    with pytest.raises(ValueError, match="OAS level is not a total return"):
-        await build_fundamental_factor_returns(
-            db, date(2021, 1, 1), date(2021, 1, 2)
-        )
+
+    # Should NOT raise — degraded skip instead
+    result = await build_fundamental_factor_returns(
+        db, date(2021, 1, 1), date(2021, 1, 2)
+    )
+
+    # Result is a DataFrame with skipped attrs populated
+    assert result is not None
+    skipped = result.attrs.get("skipped", [])
+    skipped_names = [s["name"] for s in skipped]
+    assert any("oas" in n.lower() for n in skipped_names), (
+        f"OAS filter not recorded in skipped: {skipped_names}. "
+        f"F06 fix should append 'oas_*' entries when OAS rows are present."
+    )
 
 
 def test_residual_pca_not_fed_back_into_sigma():

--- a/backend/tests/quant_engine/test_ipca.py
+++ b/backend/tests/quant_engine/test_ipca.py
@@ -117,7 +117,8 @@ def test_drift_monitor_identical():
     """10. Drift monitor: two identical Γs → drift = 0."""
     g1 = np.random.randn(6, 3)
     drift = compute_gamma_drift(g1, g1)
-    assert drift == 0.0
+    # PR-Q35 F01: Procrustes SVD introduces ~1e-16 floating-point noise
+    assert drift == pytest.approx(0.0, abs=1e-10)
 
 def test_drift_monitor_scaled(caplog):
     """11. Drift monitor: Γ scaled by 2 → drift ≈ 1."""

--- a/backend/tests/quant_engine/test_ipca_drift_monitor.py
+++ b/backend/tests/quant_engine/test_ipca_drift_monitor.py
@@ -1,0 +1,78 @@
+"""Tests for IPCA gamma drift monitor (PR-Q35 F01: Procrustes alignment)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quant_engine.ipca.drift_monitor import compute_gamma_drift
+
+
+class TestProcrustesAlignment:
+    """PR-Q35 F01: drift must be invariant under orthogonal rotation / sign flip."""
+
+    def test_sign_flip_produces_zero_drift(self):
+        """Pure sign flip is a valid IPCA equivalence — drift must be 0.0, not 2.0."""
+        rng = np.random.default_rng(42)
+        gamma_old = rng.normal(0.0, 1.0, size=(10, 3))
+        gamma_new = -gamma_old
+
+        drift = compute_gamma_drift(gamma_old, gamma_new)
+
+        assert drift == pytest.approx(0.0, abs=1e-10), (
+            f"Sign flip should produce drift=0.0 (Procrustes-aligned), got {drift}. "
+            f"If ~2.0, F01 Procrustes alignment was not applied."
+        )
+
+    def test_orthogonal_rotation_produces_zero_drift(self):
+        """Arbitrary orthogonal rotation is a valid IPCA equivalence — drift must be 0.0."""
+        rng = np.random.default_rng(42)
+        gamma_old = rng.normal(0.0, 1.0, size=(10, 3))
+
+        # Random orthogonal matrix via QR decomposition
+        Q, _ = np.linalg.qr(rng.normal(0.0, 1.0, size=(3, 3)))
+        gamma_new = gamma_old @ Q
+
+        drift = compute_gamma_drift(gamma_old, gamma_new)
+
+        assert drift == pytest.approx(0.0, abs=1e-10), (
+            f"Orthogonal rotation should produce drift=0.0, got {drift}"
+        )
+
+    def test_real_drift_still_detected(self):
+        """A non-rotational change must still be detected as drift."""
+        rng = np.random.default_rng(42)
+        gamma_old = rng.normal(0.0, 1.0, size=(10, 3))
+        # Add genuine perturbation (not orthogonal)
+        gamma_new = gamma_old + rng.normal(0.0, 0.5, size=(10, 3))
+
+        drift = compute_gamma_drift(gamma_old, gamma_new)
+
+        # Drift should be substantial (> threshold) but not 0
+        assert drift > 0.1, f"Real drift not detected: {drift}"
+
+    def test_identical_matrices_zero_drift(self):
+        """gamma_new = gamma_old must produce drift=0.0."""
+        rng = np.random.default_rng(42)
+        gamma = rng.normal(0.0, 1.0, size=(10, 3))
+
+        drift = compute_gamma_drift(gamma, gamma.copy())
+
+        assert drift == pytest.approx(0.0, abs=1e-10)
+
+    def test_shape_mismatch_raises(self):
+        """Backward-compat: shape mismatch still raises ValueError."""
+        gamma_old = np.zeros((10, 3))
+        gamma_new = np.zeros((10, 4))
+
+        with pytest.raises(ValueError, match="Shape mismatch"):
+            compute_gamma_drift(gamma_old, gamma_new)
+
+    def test_zero_norm_old_returns_zero(self):
+        """Backward-compat: norm_old < 1e-12 returns 0.0 unchanged."""
+        gamma_old = np.zeros((10, 3))
+        gamma_new = np.ones((10, 3))
+
+        drift = compute_gamma_drift(gamma_old, gamma_new)
+
+        assert drift == 0.0


### PR DESCRIPTION
## Summary

**Audit campaign:** Wave 6 Session 03 (Covariance / Correlation / Factor Models / IPCA-PCA)
**Source:** `docs/audits/audit-validation-session03.md` F01 + F06 (both Tier 3)
**Predecessor:** PR-Q34 (#331 merged, F07 + F08 Tier 1 fundamentals)

### F01 — Procrustes alignment in `compute_gamma_drift` (Math Med / Inst Med)

- IPCA factor loadings (Γ) are identified only up to an orthogonal rotation (Kelly-Pruitt-Su 2019)
- The ALS solver may converge to different rotations/sign flips across re-estimations
- **Pre-fix:** `gamma_new = -gamma_old` → drift=2.0 (false positive)
- **Post-fix:** Procrustes alignment via SVD (Schönemann 1966) → drift=0.0 (correct)
- 6 new tests covering sign flip, orthogonal rotation, real drift detection, identity, shape mismatch, zero norm

### F06 — OAS degraded skip pattern (Math Low / Inst Med)

- `build_fundamental_factor_returns` previously raised `ValueError` when OAS tickers appeared in `benchmark_nav`
- Hard crash took down the entire factor model fit for ALL portfolios
- **Post-fix:** Charter §3 (degraded > crash) — OAS rows filtered defensively, recorded in `skipped` accumulator
- Defensive IN-clause probe preserved (defense-in-depth per PR-Q29)
- 1 updated test: asserts degraded skip instead of `ValueError`

## Files changed (5 files, +174 / -19)

- `backend/quant_engine/ipca/drift_monitor.py` — Procrustes SVD block (+3 lines core)
- `backend/quant_engine/factor_model_service.py` — OAS filter + skipped integration (+12 net)
- `backend/tests/quant_engine/test_ipca_drift_monitor.py` — 6 new tests (new file)
- `backend/tests/quant_engine/test_fundamental_factor_model.py` — 1 updated test (OAS)
- `backend/tests/quant_engine/test_ipca.py` — tolerance fix for Procrustes floating-point noise

## Pre-existing failures

- `test_construction_cvar_invariant` — integration test requiring running DB (not related)
- `test_render_allocation_pie` — flaky under full suite, passes in isolation on main

## Test plan

- [x] `test_sign_flip_produces_zero_drift` — drift=0.0 for `gamma_new=-gamma_old`
- [x] `test_orthogonal_rotation_produces_zero_drift` — drift=0.0 for random Q from QR
- [x] `test_real_drift_still_detected` — genuine perturbation detected
- [x] `test_identical_matrices_zero_drift` — identity case
- [x] `test_shape_mismatch_raises` — backward compat
- [x] `test_zero_norm_old_returns_zero` — backward compat
- [x] `test_oas_level_is_filtered_not_crashed_on` — no ValueError + skipped populated
- [x] All 15 pre-existing `test_fundamental_factor_model.py` tests pass
- [x] `ruff check backend/` — clean
- [x] `lint-imports` — 31 contracts kept
- [x] 5214 passed, 0 failed (excluding integration + known pre-existing flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)