### PR TITLE
fix(quant): PR-Q37 — negative risk_aversion override falls through to mandate (S04-F04)

### DIFF
--- a/backend/quant_engine/mandate_risk_aversion.py
+++ b/backend/quant_engine/mandate_risk_aversion.py
@@ -82,23 +82,23 @@ def resolve_risk_aversion(
                 value=risk_aversion,
             )
             # Fall through to mandate
-        else:
-            if risk_aversion < RA_MIN or risk_aversion > RA_MAX:
-                clamped = max(RA_MIN, min(RA_MAX, risk_aversion))
-                logger.warning(
-                    "risk_aversion_out_of_range_clamped",
-                    value=risk_aversion,
-                    clamped_to=clamped,
-                    range=(RA_MIN, RA_MAX),
-                )
-                return float(clamped)
-            if risk_aversion > 0:
-                return float(risk_aversion)
+        elif risk_aversion <= 0:
             logger.warning(
                 "non_positive_risk_aversion_discarded",
                 value=risk_aversion,
             )
             # Fall through to mandate
+        elif risk_aversion < RA_MIN or risk_aversion > RA_MAX:
+            clamped = max(RA_MIN, min(RA_MAX, risk_aversion))
+            logger.warning(
+                "risk_aversion_out_of_range_clamped",
+                value=risk_aversion,
+                clamped_to=clamped,
+                range=(RA_MIN, RA_MAX),
+            )
+            return float(clamped)
+        else:
+            return float(risk_aversion)
 
     if mandate:
         key = _normalise_mandate(mandate)

--- a/backend/tests/quant_engine/test_mandate_risk_aversion.py
+++ b/backend/tests/quant_engine/test_mandate_risk_aversion.py
@@ -95,3 +95,76 @@ def test_invariant_explicit_override_in_range_wins():
     assert resolve_risk_aversion(3.0, "aggressive") == 3.0
     assert resolve_risk_aversion(RA_MIN, "aggressive") == RA_MIN
     assert resolve_risk_aversion(RA_MAX, "aggressive") == RA_MAX
+
+
+# ── Regression tests for S04-F04 (Tier 1) ──────────────────────────────────
+
+
+def test_zero_override_falls_through_to_mandate():
+    """A zero risk_aversion override must NOT clamp to RA_MIN; it must fall
+    through to the mandate label. Conservative → 4.5, not 0.5."""
+    assert resolve_risk_aversion(0.0, "conservative") == 4.5
+
+
+def test_zero_override_no_mandate_returns_default():
+    """Zero override + no mandate → DEFAULT_RISK_AVERSION (2.5)."""
+    assert resolve_risk_aversion(0.0, None) == DEFAULT_RISK_AVERSION
+
+
+def test_negative_override_falls_through_to_mandate():
+    """Any negative risk_aversion override must fall through to mandate."""
+    assert resolve_risk_aversion(-1.0, "conservative") == 4.5
+    assert resolve_risk_aversion(-100.0, "aggressive") == 1.5
+
+
+def test_negative_override_no_mandate_returns_default():
+    assert resolve_risk_aversion(-1.0, None) == DEFAULT_RISK_AVERSION
+
+
+def test_negative_override_unknown_mandate_returns_default():
+    assert resolve_risk_aversion(-1.0, "made_up_mandate") == DEFAULT_RISK_AVERSION
+
+
+# ── Existing-behavior preservation (must continue to pass) ─────────────────
+
+
+def test_finite_in_range_override_returned_as_is():
+    """Positive in-range override is returned unchanged."""
+    assert resolve_risk_aversion(2.5, "conservative") == 2.5
+    assert resolve_risk_aversion(0.7, "aggressive") == 0.7
+
+
+def test_positive_below_min_clamps_to_min():
+    """Positive below RA_MIN clamps to RA_MIN (intended behavior, unchanged)."""
+    assert resolve_risk_aversion(0.3, "conservative") == RA_MIN
+    assert resolve_risk_aversion(0.1, None) == RA_MIN
+
+
+def test_above_max_clamps_to_max():
+    """Above RA_MAX clamps to RA_MAX (unchanged)."""
+    assert resolve_risk_aversion(15.0, "conservative") == RA_MAX
+    assert resolve_risk_aversion(100.0, None) == RA_MAX
+
+
+def test_nan_override_falls_through_to_mandate():
+    assert resolve_risk_aversion(float("nan"), "conservative") == 4.5
+    assert resolve_risk_aversion(float("nan"), None) == DEFAULT_RISK_AVERSION
+
+
+def test_inf_override_falls_through_to_mandate():
+    assert resolve_risk_aversion(float("inf"), "conservative") == 4.5
+    assert resolve_risk_aversion(float("-inf"), "conservative") == 4.5
+
+
+def test_no_override_returns_mandate():
+    assert resolve_risk_aversion(None, "conservative") == 4.5
+    assert resolve_risk_aversion(None, "moderate") == 2.5
+    assert resolve_risk_aversion(None, "aggressive") == 1.5
+
+
+def test_no_override_no_mandate_returns_default():
+    assert resolve_risk_aversion(None, None) == DEFAULT_RISK_AVERSION
+
+
+def test_unknown_mandate_returns_default():
+    assert resolve_risk_aversion(None, "speculative") == DEFAULT_RISK_AVERSION


### PR DESCRIPTION
## Summary
- Fixes `resolve_risk_aversion(0.0, "conservative")` returning 0.5 instead of falling through to mandate λ=4.5.
- Single-function reorder of override checks: non-positive and non-finite discards now happen before range-clamp.
- Tier 1 (Math Critical / Inst Critical) of Wave 6 Session 04.

## Wave 6 Session 04 Stage 3 triage
- Stage 1 unique find: Gemini 3.1 Pro
- Stage 1 dismissed by: Opus 4.6 ("Checked invariants #6", labeled unreachable branch as defensive)
- Stage 2 jury: GPT-5.4 CONFIRMED with executable trace
- Stage 3 (Opus 4.7): TP Tier 1
- Reference: `docs/audits/audit-validation-session04.md` S04-F04

## Behavior change
| Input | Before | After |
|---|---|---|
| `(0.0, "conservative")` | 0.5 | **4.5** |
| `(-1.0, "conservative")` | 0.5 | **4.5** |
| `(0.0, None)` | 0.5 | **2.5** |
| `(0.3, "conservative")` | 0.5 | 0.5 (unchanged, positive clamp) |
| `(2.5, "conservative")` | 2.5 | 2.5 (unchanged) |
| `(15.0, "conservative")` | 10.0 | 10.0 (unchanged, upper clamp) |
| `(NaN, "conservative")` | 4.5 | 4.5 (unchanged) |

## Test plan
- [x] 5 new regression tests for S04-F04 fail before fix, pass after
- [x] 8 existing-behavior preservation tests continue to pass
- [x] 28/28 test_mandate_risk_aversion.py pass
- [x] 564/564 quant_engine tests pass (0 regressions)
- [x] ruff check clean
- [x] mypy clean

## Blast radius
- Internal to mandate_risk_aversion.py — no signature change.
- Consumers: optimizer_service.py (max_sharpe MV-utility), black_litterman_service.py (posterior lambda). No callsite change required.
- No DB migration. No ConfigService change. No frontend change.