### PR TITLE
fix(quant): PR-Q44 — BL NaN/LinAlgError graceful handling (S05-F11)

### DIFF
--- a/backend/quant_engine/black_litterman_service.py
+++ b/backend/quant_engine/black_litterman_service.py
@@ -120,6 +120,19 @@ def compute_bl_posterior_multi_view(
             f"tau must be a positive finite scalar (typical: 0.025–0.10); got {tau}"
         )
 
+    # ── PR-Q44 (S05-F11 Tier 1): validate mu_prior + sigma finite ───────
+    mu_prior = np.asarray(mu_prior, dtype=np.float64)
+    if not np.all(np.isfinite(mu_prior)):
+        raise ValueError(
+            f"mu_prior contains non-finite values "
+            f"({int(np.sum(~np.isfinite(mu_prior)))} of {mu_prior.size}); "
+            f"caller must validate inputs before BL posterior computation"
+        )
+    if not np.all(np.isfinite(sigma)):
+        raise ValueError(
+            "sigma contains non-finite values; caller must validate covariance"
+        )
+
     n = sigma.shape[0]
 
     if views:
@@ -191,12 +204,26 @@ def compute_bl_posterior_multi_view(
     # Solve via linear systems — no np.linalg.inv in this module (PR-Q19 Fix 5).
     # sigma^{-1} via solve is numerically superior for near-singular covariance
     # (e.g. 12 funds in same Vanguard share-class family, cond ≈ 1e15).
-    tau_sigma_inv_mu = np.linalg.solve(tau * sigma, mu_prior)         # (τΣ)⁻¹ · μ
-    tau_sigma_inv_I = np.linalg.solve(tau * sigma, np.eye(n))         # (τΣ)⁻¹
+    try:
+        tau_sigma_inv_mu = np.linalg.solve(tau * sigma, mu_prior)         # (τΣ)⁻¹ · μ
+        tau_sigma_inv_I = np.linalg.solve(tau * sigma, np.eye(n))         # (τΣ)⁻¹
 
-    M = tau_sigma_inv_I + P_stack.T @ np.linalg.solve(Omega_reg, P_stack)
-    rhs = tau_sigma_inv_mu + P_stack.T @ np.linalg.solve(Omega_reg, Q_stack)
-    mu_post = np.linalg.solve(M, rhs)
+        M = tau_sigma_inv_I + P_stack.T @ np.linalg.solve(Omega_reg, P_stack)
+        rhs = tau_sigma_inv_mu + P_stack.T @ np.linalg.solve(Omega_reg, Q_stack)
+        mu_post = np.linalg.solve(M, rhs)
+    except np.linalg.LinAlgError as e:
+        raise ValueError(
+            f"BL posterior computation failed: singular or ill-conditioned matrix "
+            f"(prior covariance, view covariance, or posterior precision). "
+            f"Common cause: flat-NAV asset producing rank-deficient sigma. "
+            f"Original error: {e}"
+        ) from e
+
+    if not np.all(np.isfinite(mu_post)):
+        raise ValueError(
+            "BL posterior produced non-finite output despite finite inputs; "
+            "likely numerical instability in Σ or Ω inversion"
+        )
 
     logger.info(
         "bl_posterior_multi_view",

--- a/backend/tests/quant_engine/test_black_litterman_nan_linalg_safety.py
+++ b/backend/tests/quant_engine/test_black_litterman_nan_linalg_safety.py
@@ -1,0 +1,115 @@
+"""Regression tests for S05-F11 (Tier 1) — BL NaN propagation + LinAlgError.
+
+PR-Q44: Wave 6 Session 05 top-priority fix. Two charter §3 violations:
+  1. Empty-views path silently propagated NaN mu_prior to optimizer.
+  2. Singular sigma raised raw LinAlgError, crashing the worker.
+"""
+
+import numpy as np
+import pytest
+
+from quant_engine.black_litterman_service import (
+    View,
+    compute_bl_posterior_multi_view,
+)
+
+# ── Regression tests for S05-F11 (Tier 1) ──────────────────────────────────
+
+
+def test_nan_in_mu_prior_raises_valueerror_on_empty_views():
+    """Charter §3: empty-views path must not silently propagate NaN.
+    Pre-fix: returned [0.01, nan] silently. Post-fix: raises ValueError."""
+    mu_prior = np.array([0.01, np.nan])
+    sigma = np.eye(2) * 0.04
+    with pytest.raises(ValueError, match="non-finite"):
+        compute_bl_posterior_multi_view(mu_prior, sigma, views=[])
+
+
+def test_nan_in_mu_prior_raises_valueerror_on_populated_views():
+    """Same invariant on populated-views path."""
+    mu_prior = np.array([0.01, np.nan, 0.05])
+    sigma = np.eye(3) * 0.04
+    P = np.array([[1.0, 0.0, 0.0]])
+    Q = np.array([0.06])
+    Omega = np.array([[0.01]])
+    with pytest.raises(ValueError, match="non-finite"):
+        compute_bl_posterior_multi_view(
+            mu_prior, sigma, views=[View(P=P, Q=Q, Omega=Omega, source="ic_view")],
+        )
+
+
+def test_inf_in_mu_prior_raises_valueerror():
+    mu_prior = np.array([0.01, np.inf])
+    sigma = np.eye(2) * 0.04
+    with pytest.raises(ValueError, match="non-finite"):
+        compute_bl_posterior_multi_view(mu_prior, sigma, views=[])
+
+
+def test_singular_sigma_raises_valueerror_not_linalgerror():
+    """Charter §3: singular covariance must produce semantic ValueError,
+    not raw LinAlgError that crashes the worker."""
+    # Singular sigma: rank-deficient (flat-NAV asset producing zero-variance row)
+    sigma = np.array([
+        [0.04, 0.0, 0.0],
+        [0.0, 0.0, 0.0],   # ← zero row → singular
+        [0.0, 0.0, 0.04],
+    ])
+    mu_prior = np.array([0.05, 0.03, 0.07])
+    P = np.array([[1.0, 0.0, 0.0]])
+    Q = np.array([0.06])
+    Omega = np.array([[0.01]])
+
+    with pytest.raises(ValueError, match="singular|ill-conditioned|LinAlgError"):
+        compute_bl_posterior_multi_view(
+            mu_prior, sigma, views=[View(P=P, Q=Q, Omega=Omega, source="ic_view")],
+        )
+
+
+def test_nan_in_sigma_raises_valueerror():
+    mu_prior = np.array([0.01, 0.05])
+    sigma = np.array([[0.04, np.nan], [np.nan, 0.04]])
+    with pytest.raises(ValueError, match="non-finite"):
+        compute_bl_posterior_multi_view(mu_prior, sigma, views=[])
+
+
+# ── Existing-behavior preservation (control tests) ─────────────────────────
+
+
+def test_healthy_empty_views_returns_finite_prior():
+    """Control: healthy mu_prior + empty views returns prior unchanged."""
+    mu_prior = np.array([0.01, 0.05, 0.07])
+    sigma = np.eye(3) * 0.04
+    result = compute_bl_posterior_multi_view(mu_prior, sigma, views=[])
+    np.testing.assert_array_almost_equal(result, mu_prior, decimal=12)
+    assert np.all(np.isfinite(result))
+
+
+def test_healthy_single_absolute_view_produces_finite_posterior():
+    mu_prior = np.array([0.05, 0.03, 0.07])
+    sigma = np.eye(3) * 0.04
+    P = np.array([[1.0, 0.0, 0.0]])
+    Q = np.array([0.06])
+    Omega = np.array([[0.01]])
+    result = compute_bl_posterior_multi_view(
+        mu_prior, sigma, views=[View(P=P, Q=Q, Omega=Omega, source="ic_view")],
+    )
+    assert result.shape == (3,)
+    assert np.all(np.isfinite(result))
+
+
+def test_healthy_relative_view_shift_invariance_preserved():
+    """Existing invariant: relative views are shift-invariant in mu_prior."""
+    sigma = np.eye(2) * 0.04
+    P = np.array([[1.0, -1.0]])
+    Q = np.array([0.02])
+    Omega = np.array([[0.005]])
+    views = [View(P=P, Q=Q, Omega=Omega, source="data_view")]
+
+    mu_prior_a = np.array([0.05, 0.03])
+    mu_prior_b = mu_prior_a + 0.10  # shift by constant
+
+    result_a = compute_bl_posterior_multi_view(mu_prior_a, sigma, views)
+    result_b = compute_bl_posterior_multi_view(mu_prior_b, sigma, views)
+
+    # Difference between posteriors should equal the shift (relative-view invariance)
+    np.testing.assert_array_almost_equal(result_b - result_a, 0.10, decimal=10)


### PR DESCRIPTION
## Summary
Two charter §3 violations fixed in `compute_bl_posterior_multi_view`:
- Empty-views path now raises `ValueError` on NaN/Inf `mu_prior` (was: silent NaN propagation to optimizer).
- Populated-views path wraps `np.linalg.solve` with semantic `ValueError` (was: raw `LinAlgError` crashing worker on singular sigma).
- Tier 1 (Math High / Inst Critical) — top priority of Wave 6 Session 05.

## Wave 6 Session 05 Stage 3 triage
- Stage 1 unique find: Gemini 3.1 Pro
- Stage 2 jury: GPT-5.4 CONFIRMED + GPT-5.5 CONFIRMED (both with direct repro)
- Stage 3 (Opus 4.7): TP Tier 1
- Reference: `docs/audits/audit-validation-session05.md` S05-F11

## Behavior change
| Scenario | Before | After |
|---|---|---|
| Empty views + `mu_prior=[0.01, nan]` | returns `[0.01, nan]` silently | `ValueError("mu_prior contains non-finite values...")` |
| Populated views + singular sigma | raw `np.linalg.LinAlgError` → worker crash | `ValueError("BL posterior computation failed: singular or ill-conditioned matrix...")` |
| Healthy mu_prior + empty views | returns prior | unchanged |
| Healthy mu_prior + populated views | returns posterior | unchanged |
| Relative-view shift invariance | preserved | preserved (control test) |

## Test plan
- [x] NaN in mu_prior on empty-views → ValueError
- [x] NaN in mu_prior on populated-views → ValueError
- [x] Inf in mu_prior → ValueError
- [x] NaN in sigma → ValueError
- [x] Singular sigma → ValueError (NOT raw LinAlgError)
- [x] Healthy empty-views returns prior unchanged
- [x] Healthy populated-views returns finite posterior
- [x] Relative-view shift invariance preserved (control)
- [x] No quant_engine / quant_queries regressions
- [x] `ruff check` + `mypy` clean

## Pre-existing failures (not introduced by this PR)
- `test_confidence_0999_posterior_near_view` — Python 3.14 `float()` on 1×1 matrix in test fixture (not production code)
- `test_BUG_B8_quant_queries_override_zero_falls_back` — missing `pandas` in local env

## Blast radius
- Internal to `black_litterman_service.py`. No public signature change.
- Caller `quant_queries.py:1905` may now see ValueError where it previously got NaN result or worker crash. **Caller-side handoff (out of scope):** must add try/except deciding skip-BL vs fail-construction-run.
- DD report posterior-views narrative + IC committee BL tables: unchanged for healthy inputs; will surface explicit failure for corrupt inputs (correct behavior).
- No DB migration. No frontend type change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)