### PR TITLE
fix(quant): PR-Q45 — composite NAV phantom history + day renorm threshold (S05-F01)

### DIFF
--- a/backend/quant_engine/benchmark_composite_service.py
+++ b/backend/quant_engine/benchmark_composite_service.py
@@ -18,6 +18,10 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger(__name__)
+
 
 @dataclass(frozen=True, slots=True)
 class NavRow:
@@ -54,13 +58,50 @@ def compute_composite_nav(
     if not block_weights or not benchmark_navs:
         return []
 
-    # Collect all returns by date across blocks
+    weight_sum = sum(block_weights.values())
+    if weight_sum <= 0:
+        return []
+
+    # ── F01 fix: enforce latest-common-inception start date ─────────
+    # A fixed-weight composite cannot exist before all constituents have
+    # data.  Earlier dates would require phantom 100% weight on the
+    # present blocks (invalid) or synthetic backfill (out of scope).
+    block_min_dates: dict[str, date] = {}
+    for block_id, rows in benchmark_navs.items():
+        if block_id not in block_weights:
+            continue
+        if not rows:
+            logger.warning(
+                "composite_block_missing_navs",
+                block_id=block_id,
+                weight=block_weights.get(block_id),
+            )
+            continue
+        dates_in_block = [row["nav_date"] for row in rows if row.get("return_1d") is not None]
+        if dates_in_block:
+            block_min_dates[block_id] = min(dates_in_block)
+
+    # Require ALL weighted blocks to have NAVs; otherwise composite is undefined.
+    blocks_with_data = set(block_min_dates.keys())
+    blocks_required = set(block_weights.keys())
+    if blocks_required - blocks_with_data:
+        logger.warning(
+            "composite_blocks_without_navs",
+            missing=sorted(blocks_required - blocks_with_data),
+        )
+        return []
+
+    latest_inception = max(block_min_dates.values())
+
+    # Collect all returns by date across blocks, filtered to >= latest_inception
     returns_by_date: dict[date, dict[str, float]] = {}
     for block_id, rows in benchmark_navs.items():
         if block_id not in block_weights:
             continue
         for row in rows:
             d = row["nav_date"]
+            if d < latest_inception:
+                continue
             r = row.get("return_1d")
             if r is not None:
                 returns_by_date.setdefault(d, {})[block_id] = float(r)
@@ -68,13 +109,12 @@ def compute_composite_nav(
     if not returns_by_date:
         return []
 
-    weight_sum = sum(block_weights.values())
-    if weight_sum <= 0:
-        return []
-
     sorted_dates = sorted(returns_by_date.keys())
     current_nav = inception_nav
     result: list[NavRow] = []
+
+    # ── F01 fix: minimum active-weight threshold for renormalization ──
+    ACTIVE_WEIGHT_FLOOR_PCT = 0.5  # require >= 50% of weight present
 
     for d in sorted_dates:
         day_returns = returns_by_date[d]
@@ -89,6 +129,25 @@ def compute_composite_nav(
 
         # Renormalize if some blocks missing for this day
         if active_weight > 0 and active_weight < weight_sum * 0.999:
+            if active_weight < weight_sum * ACTIVE_WEIGHT_FLOOR_PCT:
+                # Insufficient coverage — skip to avoid return-side
+                # forward-fill amplification.
+                logger.warning(
+                    "composite_day_skipped_insufficient_active_weight",
+                    nav_date=d,
+                    active_weight=active_weight,
+                    weight_sum=weight_sum,
+                    active_pct=active_weight / weight_sum,
+                )
+                continue
+            # Above threshold: renormalize with telemetry
+            logger.info(
+                "composite_day_renormalized",
+                nav_date=d,
+                active_weight=active_weight,
+                weight_sum=weight_sum,
+                active_pct=active_weight / weight_sum,
+            )
             composite_return = composite_return * (weight_sum / active_weight)
 
         current_nav = current_nav * (1.0 + composite_return)

--- a/backend/tests/quant_engine/test_benchmark_composite_phantom_history.py
+++ b/backend/tests/quant_engine/test_benchmark_composite_phantom_history.py
@@ -1,0 +1,161 @@
+"""Regression tests for S05-F01: composite NAV phantom history + day-level renormalization.
+
+Two complementary defects in compute_composite_nav:
+1. Phantom history from earliest-inception start date (Gemini angle)
+2. Day-level renormalization without active-weight floor (Opus angle)
+
+Both confirmed by GPT-5.4 + GPT-5.5 dual jury with line-level trace.
+Stage 3 triage: TP Tier 1 (Math High / Inst High).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from quant_engine.benchmark_composite_service import compute_composite_nav
+
+
+def _nav(nav_date: date, return_1d: float) -> dict:
+    """Build a nav dict matching the benchmark_navs input shape."""
+    return {"nav_date": nav_date, "return_1d": return_1d}
+
+
+# ── Regression tests for S05-F01 angle 1 (phantom history) ──────────────
+
+
+class TestPhantomHistoryElimination:
+    """Composite must start at latest common inception, not earliest."""
+
+    def test_composite_starts_at_latest_common_inception_date(self) -> None:
+        """Block A 2020-01-01→05; Block B 2020-01-03→05.
+        Composite must start 2020-01-03 (3 dates, not 5)."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [
+                _nav(date(2020, 1, 1), 0.01),
+                _nav(date(2020, 1, 2), 0.02),
+                _nav(date(2020, 1, 3), 0.01),
+                _nav(date(2020, 1, 4), 0.005),
+                _nav(date(2020, 1, 5), -0.01),
+            ],
+            "b": [
+                _nav(date(2020, 1, 3), 0.003),
+                _nav(date(2020, 1, 4), 0.001),
+                _nav(date(2020, 1, 5), -0.002),
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert len(result) == 3, f"expected 3 dates >= 2020-01-03, got {len(result)}"
+        assert result[0].nav_date == date(2020, 1, 3)
+        assert all(r.nav_date >= date(2020, 1, 3) for r in result)
+
+    def test_composite_returns_empty_when_block_missing_from_navs(self) -> None:
+        """If a required block has no key in benchmark_navs, composite is undefined."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs: dict = {
+            "a": [_nav(date(2020, 1, 3), 0.01)],
+            # "b" missing entirely
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result == []
+
+    def test_composite_returns_empty_when_block_has_empty_rows(self) -> None:
+        """If a required block has key but empty list, composite is undefined."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [_nav(date(2020, 1, 3), 0.01)],
+            "b": [],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result == []
+
+
+# ── Regression tests for S05-F01 angle 2 (day-level renorm threshold) ──
+
+
+class TestDayLevelRenormThreshold:
+    """Day-level renormalization requires >= 50% active weight."""
+
+    def test_low_active_weight_day_skipped(self) -> None:
+        """30% active weight (<50% floor) must be skipped, not renormalized.
+        Pre-fix: 0.3*0.02 / 0.3 = 0.02 reported as composite.
+        Post-fix: day skipped."""
+        block_weights = {"a": 0.3, "b": 0.7}
+        benchmark_navs = {
+            "a": [
+                _nav(date(2020, 1, 2), 0.01),
+                _nav(date(2020, 1, 3), 0.02),
+            ],
+            "b": [
+                _nav(date(2020, 1, 2), 0.005),
+                # Missing 2020-01-03 — 30% active < 50% floor
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        # 2020-01-02 included (full coverage). 2020-01-03 skipped.
+        assert len(result) == 1
+        assert result[0].nav_date == date(2020, 1, 2)
+
+    def test_high_active_weight_day_renormalized(self) -> None:
+        """60% active weight (>=50% floor) IS renormalized.
+        Block A 60% present + Block B 40% missing → composite = A's return
+        scaled to full weight."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [
+                _nav(date(2020, 1, 2), 0.01),
+                _nav(date(2020, 1, 3), 0.02),
+            ],
+            "b": [
+                _nav(date(2020, 1, 2), 0.005),
+                # Missing 2020-01-03 — 60% active, above 50% floor
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert len(result) == 2
+        # Day 1: full coverage: 0.6*0.01 + 0.4*0.005 = 0.008
+        assert result[0].nav_date == date(2020, 1, 2)
+        assert result[0].daily_return == pytest.approx(0.008, abs=1e-9)
+        # Day 2: 60% active, renormalized: 0.6*0.02 / 0.6 = 0.02
+        assert result[1].nav_date == date(2020, 1, 3)
+        assert result[1].daily_return == pytest.approx(0.02, abs=1e-9)
+
+
+# ── Existing-behavior preservation (control tests) ─────────────────────
+
+
+class TestControlPreservation:
+    """Verify unchanged behavior for healthy scenarios."""
+
+    def test_full_coverage_returns_unchanged(self) -> None:
+        """All days full coverage → composite = weighted sum."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [_nav(date(2020, 1, 1), 0.01), _nav(date(2020, 1, 2), 0.02)],
+            "b": [_nav(date(2020, 1, 1), 0.005), _nav(date(2020, 1, 2), 0.003)],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert len(result) == 2
+        # Day 1: 0.6*0.01 + 0.4*0.005 = 0.008
+        assert result[0].daily_return == pytest.approx(0.008, abs=1e-9)
+        # Day 2: 0.6*0.02 + 0.4*0.003 = 0.0132
+        assert result[1].daily_return == pytest.approx(0.0132, abs=1e-9)
+
+    def test_inception_nav_default_preserved(self) -> None:
+        """inception_nav=1000 IS the local convention (F13 REFUTED)."""
+        block_weights = {"a": 1.0}
+        benchmark_navs = {"a": [_nav(date(2020, 1, 1), 0.0)]}
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result[0].nav == 1000.0
+
+    def test_zero_weight_sum_returns_empty(self) -> None:
+        """Existing guard preserved."""
+        block_weights = {"a": 0.0, "b": 0.0}
+        benchmark_navs = {
+            "a": [_nav(date(2020, 1, 1), 0.01)],
+            "b": [_nav(date(2020, 1, 1), 0.01)],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result == []

--- a/backend/tests/test_benchmark_composite_service.py
+++ b/backend/tests/test_benchmark_composite_service.py
@@ -51,22 +51,36 @@ class TestComputeCompositeNav:
         assert result[0].daily_return == pytest.approx(0.016, abs=1e-8)
         assert result[0].nav == pytest.approx(1016.0, abs=1e-8)
 
-    def test_missing_block_renormalized(self) -> None:
-        """If a block has no data for a day, return is renormalized."""
+    def test_missing_block_returns_empty(self) -> None:
+        """If a required block has no data at all, composite is undefined (Q45)."""
         block_weights = {"a": 0.5, "b": 0.5}
         benchmark_navs = {
             "a": [
                 {"nav_date": date(2024, 1, 2), "return_1d": 0.04},
             ],
-            # "b" has no data for this date
+            # "b" entirely absent — composite undefined
         }
         result = compute_composite_nav(block_weights, benchmark_navs, inception_nav=1000.0)
+        assert result == []
 
-        # Only block "a" is active: R_raw = 0.5 * 0.04 = 0.02
-        # Renormalize: R = 0.02 * (1.0 / 0.5) = 0.04
-        assert len(result) == 1
-        assert result[0].daily_return == pytest.approx(0.04, abs=1e-8)
-        assert result[0].nav == pytest.approx(1040.0, abs=1e-8)
+    def test_day_level_renormalization_above_floor(self) -> None:
+        """Block present for all dates but missing on single day: renormalized
+        if active_weight >= 50% floor (Q45 day-level fix)."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [
+                {"nav_date": date(2024, 1, 2), "return_1d": 0.01},
+                {"nav_date": date(2024, 1, 3), "return_1d": 0.04},
+            ],
+            "b": [
+                {"nav_date": date(2024, 1, 2), "return_1d": 0.005},
+                # Missing 2024-01-03 — 60% active, above 50% floor
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs, inception_nav=1000.0)
+        assert len(result) == 2
+        # Day 2: 60% active → renormalized: 0.6*0.04 / 0.6 = 0.04
+        assert result[1].daily_return == pytest.approx(0.04, abs=1e-8)
 
     def test_empty_inputs_return_empty(self) -> None:
         """Empty weights or empty NAVs return empty list."""


### PR DESCRIPTION
## Summary
Composite NAV computation now:
- Starts at latest common inception date across all constituents (no phantom history).
- Skips days with < 50% active weight (no return-side forward-fill amplification).
- Renormalizes days with 50-99.9% active weight with structured telemetry.
- Tier 1 (Math High / Inst High) of Wave 6 Session 05.

## Wave 6 Session 05 Stage 3 triage
- Stage 1: Opus 4.6 (day-level angle) + Gemini 3.1 Pro (history-level angle) convergent
- Stage 2 jury: GPT-5.4 CONFIRMED + GPT-5.5 CONFIRMED (both high confidence)
- Stage 3 (Opus 4.7): TP Tier 1
- Reference: `docs/audits/audit-validation-session05.md` S05-F01

## Behavior change
| Scenario | Before | After |
|---|---|---|
| Block A 10y + Block B 2y | composite spans 10y, first 8y = 100% A | composite spans 2y (B's inception onwards) |
| Day with 30% active weight + 2% return | composite +6.7% (renormalized) | day skipped, composite continues |
| Day with 60% active weight | renormalized silently | renormalized + telemetry log |
| Full-coverage day | weighted sum | unchanged |
| `inception_nav` default | 1000.0 | unchanged (F13 REFUTED — local convention) |

## Test plan
- [x] Composite starts at latest common inception (8 new tests)
- [x] Empty result if any required block has no NAVs
- [x] Low active-weight day (<50%) skipped
- [x] High active-weight day (50-99.9%) renormalized with telemetry
- [x] Full coverage unchanged (control)
- [x] inception_nav=1000 default preserved (F13 control)
- [x] Zero/negative weight_sum → empty (existing guard preserved)
- [x] Existing test updated: `test_missing_block_renormalized` → `test_missing_block_returns_empty` + new `test_day_level_renormalization_above_floor`
- [x] `ruff check` + `mypy` clean
- [x] 17/17 tests passing

## Pre-flight reverse-subsumption check
**Callers (no phantom-history dependency):**
- `fact_sheet_engine.py:167` — passes through `benchmark_resolver`, which only includes blocks with data
- `long_form_report_engine.py:370` — same pattern
- `monthly_report_engine.py:265` — same pattern
- `benchmark_resolver.py:9` — upstream resolver

**Existing test fixture updated:**
- `test_missing_block_renormalized` had block "b" entirely absent from `benchmark_navs` with expectation of renormalized result. Post-fix, block absent = composite undefined → `[]`. Renamed to `test_missing_block_returns_empty` and updated assertion. Added `test_day_level_renormalization_above_floor` to cover the day-level renormalization behavior with both blocks present but one missing on a specific day.

## Blast radius
- `compute_composite_nav` consumers (3 vertical engines + analytics): historical composite curves will start at later dates for portfolios with disjoint-history blocks. Correct behavior; old behavior was misrepresenting pre-inception data.
- Day-level skips will create gaps in composite series during severe data outages. Renderers should handle missing days gracefully.
- No DB migration. No frontend type change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)