### PR TITLE
fix(quant): PR-Q48 — composite NAV weight_sum invariant guard (S05-F08)

### DIFF
--- a/backend/quant_engine/benchmark_composite_service.py
+++ b/backend/quant_engine/benchmark_composite_service.py
@@ -62,6 +62,17 @@ def compute_composite_nav(
     if weight_sum <= 0:
         return []
 
+    # ── F08 fix: weights must sum to ~1.0 per §3.4 contract ─────────
+    # A composite benchmark by definition allocates 100% across constituents.
+    # Tolerance 1e-4 absorbs float rounding; anything beyond is a caller
+    # input bug that would silently scale the composite return series.
+    if abs(weight_sum - 1.0) > 1e-4:
+        raise ValueError(
+            f"block_weights must sum to 1.0 (within 1e-4); got {weight_sum:.6f}. "
+            f"§3.4 contract: composite benchmark weights are by definition "
+            f"a unit allocation. Caller must normalize or correct input."
+        )
+
     # ── F01 fix: enforce latest-common-inception start date ─────────
     # A fixed-weight composite cannot exist before all constituents have
     # data.  Earlier dates would require phantom 100% weight on the

--- a/backend/quant_engine/benchmark_composite_service.py
+++ b/backend/quant_engine/benchmark_composite_service.py
@@ -18,6 +18,10 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger(__name__)
+
 
 @dataclass(frozen=True, slots=True)
 class NavRow:
@@ -54,13 +58,50 @@ def compute_composite_nav(
     if not block_weights or not benchmark_navs:
         return []
 
-    # Collect all returns by date across blocks
+    weight_sum = sum(block_weights.values())
+    if weight_sum <= 0:
+        return []
+
+    # ── F01 fix: enforce latest-common-inception start date ─────────
+    # A fixed-weight composite cannot exist before all constituents have
+    # data.  Earlier dates would require phantom 100% weight on the
+    # present blocks (invalid) or synthetic backfill (out of scope).
+    block_min_dates: dict[str, date] = {}
+    for block_id, rows in benchmark_navs.items():
+        if block_id not in block_weights:
+            continue
+        if not rows:
+            logger.warning(
+                "composite_block_missing_navs",
+                block_id=block_id,
+                weight=block_weights.get(block_id),
+            )
+            continue
+        dates_in_block = [row["nav_date"] for row in rows if row.get("return_1d") is not None]
+        if dates_in_block:
+            block_min_dates[block_id] = min(dates_in_block)
+
+    # Require ALL weighted blocks to have NAVs; otherwise composite is undefined.
+    blocks_with_data = set(block_min_dates.keys())
+    blocks_required = set(block_weights.keys())
+    if blocks_required - blocks_with_data:
+        logger.warning(
+            "composite_blocks_without_navs",
+            missing=sorted(blocks_required - blocks_with_data),
+        )
+        return []
+
+    latest_inception = max(block_min_dates.values())
+
+    # Collect all returns by date across blocks, filtered to >= latest_inception
     returns_by_date: dict[date, dict[str, float]] = {}
     for block_id, rows in benchmark_navs.items():
         if block_id not in block_weights:
             continue
         for row in rows:
             d = row["nav_date"]
+            if d < latest_inception:
+                continue
             r = row.get("return_1d")
             if r is not None:
                 returns_by_date.setdefault(d, {})[block_id] = float(r)
@@ -68,13 +109,12 @@ def compute_composite_nav(
     if not returns_by_date:
         return []
 
-    weight_sum = sum(block_weights.values())
-    if weight_sum <= 0:
-        return []
-
     sorted_dates = sorted(returns_by_date.keys())
     current_nav = inception_nav
     result: list[NavRow] = []
+
+    # ── F01 fix: minimum active-weight threshold for renormalization ──
+    ACTIVE_WEIGHT_FLOOR_PCT = 0.5  # require >= 50% of weight present
 
     for d in sorted_dates:
         day_returns = returns_by_date[d]
@@ -89,6 +129,25 @@ def compute_composite_nav(
 
         # Renormalize if some blocks missing for this day
         if active_weight > 0 and active_weight < weight_sum * 0.999:
+            if active_weight < weight_sum * ACTIVE_WEIGHT_FLOOR_PCT:
+                # Insufficient coverage — skip to avoid return-side
+                # forward-fill amplification.
+                logger.warning(
+                    "composite_day_skipped_insufficient_active_weight",
+                    nav_date=d,
+                    active_weight=active_weight,
+                    weight_sum=weight_sum,
+                    active_pct=active_weight / weight_sum,
+                )
+                continue
+            # Above threshold: renormalize with telemetry
+            logger.info(
+                "composite_day_renormalized",
+                nav_date=d,
+                active_weight=active_weight,
+                weight_sum=weight_sum,
+                active_pct=active_weight / weight_sum,
+            )
             composite_return = composite_return * (weight_sum / active_weight)
 
         current_nav = current_nav * (1.0 + composite_return)

--- a/backend/quant_engine/monte_carlo_service.py
+++ b/backend/quant_engine/monte_carlo_service.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import numpy as np
+import structlog
+
+logger = structlog.get_logger()
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +29,8 @@ class MonteCarloResult:
     std: float = 0.0
     historical_value: float = 0.0
     confidence_bars: list[dict[str, object]] = field(default_factory=list)
+    degraded: bool = False
+    degraded_reason: str | None = None
 
 
 def _block_bootstrap_paths(
@@ -170,14 +175,45 @@ def run_monte_carlo(
         Random seed for reproducibility.
 
     """
-    if len(daily_returns) < 42:
+    n = len(daily_returns)
+    if n < 42:
         return MonteCarloResult(
             n_simulations=0,
             statistic=statistic,
+            degraded=True,
+            degraded_reason=f"insufficient_history: T={n} (min 42)",
         )
 
     if horizons is None:
         horizons = [252, 756, 1260, 1764, 2520]
+
+    # ── S05-F04 fix: T-to-horizon ratio guard ────────────────────────
+    # Block bootstrap with T close to block_size and horizon >> T
+    # produces percentile bands cycling the same few monthly windows
+    # rather than genuine diversification.  Calibrate guard at:
+    #   T < min(max_horizon * 0.1, 252)
+    # 10% of horizon is conservative for monthly-block bootstrap;
+    # 252 cap allows short funds to still produce 1Y projections.
+    max_horizon = max(horizons)
+    min_t_required = min(int(max_horizon * 0.1), 252)
+    if n < min_t_required:
+        logger.warning(
+            "monte_carlo_t_to_horizon_ratio_insufficient",
+            T=n,
+            max_horizon=max_horizon,
+            min_t_required=min_t_required,
+            ratio_pct=round(100 * n / max_horizon, 2),
+        )
+        return MonteCarloResult(
+            n_simulations=0,
+            statistic=statistic,
+            degraded=True,
+            degraded_reason=(
+                f"insufficient_history_for_horizon: T={n}, max_horizon={max_horizon}; "
+                f"need T >= {min_t_required} (10% of horizon, capped at 252) "
+                f"for non-degenerate block bootstrap"
+            ),
+        )
 
     rng = np.random.RandomState(seed)
 

--- a/backend/tests/quant_engine/test_benchmark_composite_phantom_history.py
+++ b/backend/tests/quant_engine/test_benchmark_composite_phantom_history.py
@@ -1,0 +1,161 @@
+"""Regression tests for S05-F01: composite NAV phantom history + day-level renormalization.
+
+Two complementary defects in compute_composite_nav:
+1. Phantom history from earliest-inception start date (Gemini angle)
+2. Day-level renormalization without active-weight floor (Opus angle)
+
+Both confirmed by GPT-5.4 + GPT-5.5 dual jury with line-level trace.
+Stage 3 triage: TP Tier 1 (Math High / Inst High).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from quant_engine.benchmark_composite_service import compute_composite_nav
+
+
+def _nav(nav_date: date, return_1d: float) -> dict:
+    """Build a nav dict matching the benchmark_navs input shape."""
+    return {"nav_date": nav_date, "return_1d": return_1d}
+
+
+# ── Regression tests for S05-F01 angle 1 (phantom history) ──────────────
+
+
+class TestPhantomHistoryElimination:
+    """Composite must start at latest common inception, not earliest."""
+
+    def test_composite_starts_at_latest_common_inception_date(self) -> None:
+        """Block A 2020-01-01→05; Block B 2020-01-03→05.
+        Composite must start 2020-01-03 (3 dates, not 5)."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [
+                _nav(date(2020, 1, 1), 0.01),
+                _nav(date(2020, 1, 2), 0.02),
+                _nav(date(2020, 1, 3), 0.01),
+                _nav(date(2020, 1, 4), 0.005),
+                _nav(date(2020, 1, 5), -0.01),
+            ],
+            "b": [
+                _nav(date(2020, 1, 3), 0.003),
+                _nav(date(2020, 1, 4), 0.001),
+                _nav(date(2020, 1, 5), -0.002),
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert len(result) == 3, f"expected 3 dates >= 2020-01-03, got {len(result)}"
+        assert result[0].nav_date == date(2020, 1, 3)
+        assert all(r.nav_date >= date(2020, 1, 3) for r in result)
+
+    def test_composite_returns_empty_when_block_missing_from_navs(self) -> None:
+        """If a required block has no key in benchmark_navs, composite is undefined."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs: dict = {
+            "a": [_nav(date(2020, 1, 3), 0.01)],
+            # "b" missing entirely
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result == []
+
+    def test_composite_returns_empty_when_block_has_empty_rows(self) -> None:
+        """If a required block has key but empty list, composite is undefined."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [_nav(date(2020, 1, 3), 0.01)],
+            "b": [],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result == []
+
+
+# ── Regression tests for S05-F01 angle 2 (day-level renorm threshold) ──
+
+
+class TestDayLevelRenormThreshold:
+    """Day-level renormalization requires >= 50% active weight."""
+
+    def test_low_active_weight_day_skipped(self) -> None:
+        """30% active weight (<50% floor) must be skipped, not renormalized.
+        Pre-fix: 0.3*0.02 / 0.3 = 0.02 reported as composite.
+        Post-fix: day skipped."""
+        block_weights = {"a": 0.3, "b": 0.7}
+        benchmark_navs = {
+            "a": [
+                _nav(date(2020, 1, 2), 0.01),
+                _nav(date(2020, 1, 3), 0.02),
+            ],
+            "b": [
+                _nav(date(2020, 1, 2), 0.005),
+                # Missing 2020-01-03 — 30% active < 50% floor
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        # 2020-01-02 included (full coverage). 2020-01-03 skipped.
+        assert len(result) == 1
+        assert result[0].nav_date == date(2020, 1, 2)
+
+    def test_high_active_weight_day_renormalized(self) -> None:
+        """60% active weight (>=50% floor) IS renormalized.
+        Block A 60% present + Block B 40% missing → composite = A's return
+        scaled to full weight."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [
+                _nav(date(2020, 1, 2), 0.01),
+                _nav(date(2020, 1, 3), 0.02),
+            ],
+            "b": [
+                _nav(date(2020, 1, 2), 0.005),
+                # Missing 2020-01-03 — 60% active, above 50% floor
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert len(result) == 2
+        # Day 1: full coverage: 0.6*0.01 + 0.4*0.005 = 0.008
+        assert result[0].nav_date == date(2020, 1, 2)
+        assert result[0].daily_return == pytest.approx(0.008, abs=1e-9)
+        # Day 2: 60% active, renormalized: 0.6*0.02 / 0.6 = 0.02
+        assert result[1].nav_date == date(2020, 1, 3)
+        assert result[1].daily_return == pytest.approx(0.02, abs=1e-9)
+
+
+# ── Existing-behavior preservation (control tests) ─────────────────────
+
+
+class TestControlPreservation:
+    """Verify unchanged behavior for healthy scenarios."""
+
+    def test_full_coverage_returns_unchanged(self) -> None:
+        """All days full coverage → composite = weighted sum."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [_nav(date(2020, 1, 1), 0.01), _nav(date(2020, 1, 2), 0.02)],
+            "b": [_nav(date(2020, 1, 1), 0.005), _nav(date(2020, 1, 2), 0.003)],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert len(result) == 2
+        # Day 1: 0.6*0.01 + 0.4*0.005 = 0.008
+        assert result[0].daily_return == pytest.approx(0.008, abs=1e-9)
+        # Day 2: 0.6*0.02 + 0.4*0.003 = 0.0132
+        assert result[1].daily_return == pytest.approx(0.0132, abs=1e-9)
+
+    def test_inception_nav_default_preserved(self) -> None:
+        """inception_nav=1000 IS the local convention (F13 REFUTED)."""
+        block_weights = {"a": 1.0}
+        benchmark_navs = {"a": [_nav(date(2020, 1, 1), 0.0)]}
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result[0].nav == 1000.0
+
+    def test_zero_weight_sum_returns_empty(self) -> None:
+        """Existing guard preserved."""
+        block_weights = {"a": 0.0, "b": 0.0}
+        benchmark_navs = {
+            "a": [_nav(date(2020, 1, 1), 0.01)],
+            "b": [_nav(date(2020, 1, 1), 0.01)],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result == []

--- a/backend/tests/quant_engine/test_benchmark_composite_weight_sum.py
+++ b/backend/tests/quant_engine/test_benchmark_composite_weight_sum.py
@@ -1,0 +1,113 @@
+"""Regression tests for S05-F08 — composite NAV weight_sum ≈ 1.0 invariant.
+
+§3.4 contract: weights must sum to 1.0 within tolerance (1e-4).
+Previously only validated weight_sum > 0; weights summing to 0.5 silently
+produced composite at 50% intended scale.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from quant_engine.benchmark_composite_service import compute_composite_nav
+
+
+def _nav(nav_date: date, return_1d: float) -> dict:
+    """Helper: build a single benchmark NAV dict row."""
+    return {"nav_date": nav_date, "return_1d": return_1d}
+
+
+# ── Regression tests for S05-F08 (Tier 3) ──────────────────────────────────
+
+
+def test_weights_summing_below_tolerance_raises():
+    """Weights summing to 0.5 must raise ValueError, not silently produce
+    composite at 50% intended scale."""
+    block_weights = {"a": 0.3, "b": 0.2}  # sum = 0.5
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    with pytest.raises(ValueError, match="must sum to 1.0"):
+        compute_composite_nav(block_weights, navs)
+
+
+def test_weights_summing_above_tolerance_raises():
+    """Weights summing to 1.2 must raise."""
+    block_weights = {"a": 0.7, "b": 0.5}  # sum = 1.2
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    with pytest.raises(ValueError, match="must sum to 1.0"):
+        compute_composite_nav(block_weights, navs)
+
+
+def test_weights_at_unit_pass():
+    """Control: weights summing to exactly 1.0 should work."""
+    block_weights = {"a": 0.6, "b": 0.4}
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    result = compute_composite_nav(block_weights, navs)
+    assert len(result) == 1
+    assert result[0].daily_return == pytest.approx(0.01, abs=1e-9)
+
+
+def test_weights_within_1e_minus_4_tolerance_pass():
+    """Tolerance: 1.00009 should pass (within 1e-4)."""
+    block_weights = {"a": 0.60005, "b": 0.40004}  # sum = 1.00009
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    # Should not raise
+    result = compute_composite_nav(block_weights, navs)
+    assert len(result) == 1
+
+
+def test_weights_just_outside_1e_minus_4_tolerance_raises():
+    """Boundary: 1.0002 (+2e-4 above) should raise."""
+    block_weights = {"a": 0.6001, "b": 0.4001}  # sum = 1.0002
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    with pytest.raises(ValueError, match="must sum to 1.0"):
+        compute_composite_nav(block_weights, navs)
+
+
+def test_error_message_includes_actual_weight_sum():
+    """Error message must include the offending sum for debuggability."""
+    block_weights = {"a": 0.3, "b": 0.2}
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    with pytest.raises(ValueError) as exc_info:
+        compute_composite_nav(block_weights, navs)
+    assert "0.5" in str(exc_info.value) or "0.500" in str(exc_info.value)
+
+
+# ── Existing-behavior preservation ─────────────────────────────────────
+
+
+def test_zero_weight_sum_returns_empty():
+    """Existing guard preserved: weight_sum <= 0 → empty result."""
+    block_weights = {"a": 0.0, "b": 0.0}
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    result = compute_composite_nav(block_weights, navs)
+    assert result == []
+
+
+def test_negative_weight_sum_returns_empty():
+    block_weights = {"a": -0.1}
+    navs = {"a": [_nav(date(2020, 1, 1), 0.01)]}
+    result = compute_composite_nav(block_weights, navs)
+    assert result == []

--- a/backend/tests/quant_engine/test_monte_carlo_short_history_degeneracy.py
+++ b/backend/tests/quant_engine/test_monte_carlo_short_history_degeneracy.py
@@ -1,0 +1,106 @@
+"""Regression tests for S05-F04 (Tier 1) — MC short-history + long-horizon
+block bootstrap degeneracy.
+
+T close to block_size + horizon >> T causes block bootstrap to cycle the same
+few monthly windows of input data, producing meaningless percentile bands.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from quant_engine.monte_carlo_service import (
+    MonteCarloResult,
+    run_monte_carlo,
+)
+
+# ── Regression tests for S05-F04 (Tier 1) ──────────────────────────────────
+
+
+def test_short_history_long_horizon_returns_degraded():
+    """T=42, horizon=2520 (10Y) → block bootstrap would cycle ~22 windows
+    of 42-day history. Must return degraded=True with explicit reason."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 42)
+    result = run_monte_carlo(daily, horizons=[2520], seed=42)
+    assert result.degraded is True
+    assert result.n_simulations == 0
+    assert result.degraded_reason is not None
+    assert "horizon" in result.degraded_reason.lower()
+
+
+def test_short_history_short_horizon_runs_normally():
+    """T=42 + 1Y horizon (252 days) should NOT degrade — 42/252 = 16.7%
+    sample richness, above 10% floor."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 42)
+    result = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=100)
+    assert result.degraded is False
+    assert result.degraded_reason is None
+    assert result.n_simulations > 0
+
+
+def test_long_history_long_horizon_runs_normally():
+    """T=300, horizon=2520. T/horizon = 11.9% > 10% floor. Should run."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 300)
+    result = run_monte_carlo(daily, horizons=[2520], seed=42, n_simulations=100)
+    assert result.degraded is False
+    assert result.n_simulations > 0
+
+
+def test_just_above_floor_runs_normally():
+    """Boundary: T = min(max_horizon * 0.1, 252) exactly. Must not degrade."""
+    # max_horizon=2520 → min_t_required = min(252, 252) = 252
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 252)
+    result = run_monte_carlo(daily, horizons=[2520], seed=42, n_simulations=100)
+    assert result.degraded is False
+
+
+def test_just_below_floor_degrades():
+    """Boundary: T = min_t_required - 1. Must degrade."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 251)
+    result = run_monte_carlo(daily, horizons=[2520], seed=42)
+    assert result.degraded is True
+
+
+def test_t_below_42_still_degrades():
+    """Existing T<42 guard preserved (S05-F03 angle covered by Q47 too)."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 30)
+    result = run_monte_carlo(daily, horizons=[252], seed=42)
+    assert result.degraded is True
+    assert result.n_simulations == 0
+
+
+def test_degraded_reason_includes_diagnostic_numbers():
+    """degraded_reason must include T and horizon for operator forensics."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 42)
+    result = run_monte_carlo(daily, horizons=[2520], seed=42)
+    assert result.degraded is True
+    assert "42" in result.degraded_reason or "T=42" in result.degraded_reason
+    assert "2520" in result.degraded_reason
+
+
+# ── Existing-behavior preservation (control tests) ─────────────────────
+
+
+def test_dataclass_default_degraded_false():
+    """Existing callers using positional/default-only init: degraded=False."""
+    r = MonteCarloResult(n_simulations=10000, statistic="max_drawdown")
+    assert r.degraded is False
+    assert r.degraded_reason is None
+
+
+def test_seed_propagation_unchanged():
+    """Existing behavior: same seed produces same output (control)."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 300)
+    r1 = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=100)
+    r2 = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=100)
+    if r1.n_simulations > 0 and r2.n_simulations > 0:
+        assert r1.mean == r2.mean
+        assert r1.std == r2.std

--- a/backend/tests/test_benchmark_composite_service.py
+++ b/backend/tests/test_benchmark_composite_service.py
@@ -51,22 +51,36 @@ class TestComputeCompositeNav:
         assert result[0].daily_return == pytest.approx(0.016, abs=1e-8)
         assert result[0].nav == pytest.approx(1016.0, abs=1e-8)
 
-    def test_missing_block_renormalized(self) -> None:
-        """If a block has no data for a day, return is renormalized."""
+    def test_missing_block_returns_empty(self) -> None:
+        """If a required block has no data at all, composite is undefined (Q45)."""
         block_weights = {"a": 0.5, "b": 0.5}
         benchmark_navs = {
             "a": [
                 {"nav_date": date(2024, 1, 2), "return_1d": 0.04},
             ],
-            # "b" has no data for this date
+            # "b" entirely absent — composite undefined
         }
         result = compute_composite_nav(block_weights, benchmark_navs, inception_nav=1000.0)
+        assert result == []
 
-        # Only block "a" is active: R_raw = 0.5 * 0.04 = 0.02
-        # Renormalize: R = 0.02 * (1.0 / 0.5) = 0.04
-        assert len(result) == 1
-        assert result[0].daily_return == pytest.approx(0.04, abs=1e-8)
-        assert result[0].nav == pytest.approx(1040.0, abs=1e-8)
+    def test_day_level_renormalization_above_floor(self) -> None:
+        """Block present for all dates but missing on single day: renormalized
+        if active_weight >= 50% floor (Q45 day-level fix)."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [
+                {"nav_date": date(2024, 1, 2), "return_1d": 0.01},
+                {"nav_date": date(2024, 1, 3), "return_1d": 0.04},
+            ],
+            "b": [
+                {"nav_date": date(2024, 1, 2), "return_1d": 0.005},
+                # Missing 2024-01-03 — 60% active, above 50% floor
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs, inception_nav=1000.0)
+        assert len(result) == 2
+        # Day 2: 60% active → renormalized: 0.6*0.04 / 0.6 = 0.04
+        assert result[1].daily_return == pytest.approx(0.04, abs=1e-8)
 
     def test_empty_inputs_return_empty(self) -> None:
         """Empty weights or empty NAVs return empty list."""


### PR DESCRIPTION
## Summary
`compute_composite_nav` now raises `ValueError` when block weights don't sum to 1.0 (within 1e-4 tolerance). Previously silent at any sum > 0.

- Tier 3 (Math Med / Inst Med) — promoted by GPT-5.5 from 5.4's Low/Low.
- Wave 6 Session 05.

## Wave 6 Session 05 Stage 3 triage
- Stage 1 unique find: Opus 4.6
- Stage 2 jury: GPT-5.4 DOWNGRADED Low/Low; GPT-5.5 CONFIRMED Med/Med
- Stage 3 (Opus 4.7) sided with 5.5 (defense-in-depth per Q33 lesson)
- Reference: `docs/audits/audit-validation-session05.md` S05-F08

## Behavior change
| Input | Before | After |
|---|---|---|
| Weights summing to 1.0 (exact) | works | works (unchanged) |
| Weights summing to 1.00009 | works | works (within tolerance) |
| Weights summing to 0.5 | composite at 50% scale silently | `ValueError("must sum to 1.0...")` |
| Weights summing to 1.2 | composite at 120% scale silently | `ValueError` |
| Weights summing to 1.0002 | works | `ValueError` (just outside tolerance) |
| Weights summing to 0 (existing guard) | `[]` | `[]` (unchanged) |

## Test plan
- [x] Below-tolerance sum → ValueError
- [x] Above-tolerance sum → ValueError
- [x] Exact 1.0 → passes
- [x] Within 1e-4 tolerance → passes
- [x] Just outside tolerance → ValueError
- [x] Error message includes actual sum
- [x] Zero/negative sum → existing empty-result guard preserved
- [x] Pre-existing benchmark composite tests pass (8/8)
- [x] `ruff check` + `mypy` clean

## Blast radius
Test-only blast in production paths — `benchmark_resolver` produces unit-summing weights by construction (verified during Q45 caller audit). Any future caller passing non-unit weights will now see explicit ValueError instead of silent benchmark scaling bias.

## Pre-flight reverse-subsumption check
- All existing test fixtures use unit-summing weights (0.6+0.4, 0.5+0.5, 0.3+0.7, 1.0)
- `test_benchmark_composite_service.py:88` passes `{"a": 0.5}` with empty navs — returns `[]` at `not benchmark_navs` guard before weight check (safe)
- Production callers: `fact_sheet_engine`, `long_form_report_engine`, `monthly_report_engine` — all derive weights through `benchmark_resolver`
- No fixture relies on non-unit weights; no production caller passes non-unit weights

## Dependencies
Branch based on Q45+Q46 (not yet merged to main). F08 fix is position-independent — inserts after `weight_sum <= 0` guard present in all versions.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>