### PR TITLE
fix(quant): PR-Q47 — charter §3 degraded surface bundle (S05-F02+F03)

### DIFF
--- a/backend/quant_engine/benchmark_composite_service.py
+++ b/backend/quant_engine/benchmark_composite_service.py
@@ -18,6 +18,10 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger(__name__)
+
 
 @dataclass(frozen=True, slots=True)
 class NavRow:
@@ -54,13 +58,50 @@ def compute_composite_nav(
     if not block_weights or not benchmark_navs:
         return []
 
-    # Collect all returns by date across blocks
+    weight_sum = sum(block_weights.values())
+    if weight_sum <= 0:
+        return []
+
+    # ── F01 fix: enforce latest-common-inception start date ─────────
+    # A fixed-weight composite cannot exist before all constituents have
+    # data.  Earlier dates would require phantom 100% weight on the
+    # present blocks (invalid) or synthetic backfill (out of scope).
+    block_min_dates: dict[str, date] = {}
+    for block_id, rows in benchmark_navs.items():
+        if block_id not in block_weights:
+            continue
+        if not rows:
+            logger.warning(
+                "composite_block_missing_navs",
+                block_id=block_id,
+                weight=block_weights.get(block_id),
+            )
+            continue
+        dates_in_block = [row["nav_date"] for row in rows if row.get("return_1d") is not None]
+        if dates_in_block:
+            block_min_dates[block_id] = min(dates_in_block)
+
+    # Require ALL weighted blocks to have NAVs; otherwise composite is undefined.
+    blocks_with_data = set(block_min_dates.keys())
+    blocks_required = set(block_weights.keys())
+    if blocks_required - blocks_with_data:
+        logger.warning(
+            "composite_blocks_without_navs",
+            missing=sorted(blocks_required - blocks_with_data),
+        )
+        return []
+
+    latest_inception = max(block_min_dates.values())
+
+    # Collect all returns by date across blocks, filtered to >= latest_inception
     returns_by_date: dict[date, dict[str, float]] = {}
     for block_id, rows in benchmark_navs.items():
         if block_id not in block_weights:
             continue
         for row in rows:
             d = row["nav_date"]
+            if d < latest_inception:
+                continue
             r = row.get("return_1d")
             if r is not None:
                 returns_by_date.setdefault(d, {})[block_id] = float(r)
@@ -68,13 +109,12 @@ def compute_composite_nav(
     if not returns_by_date:
         return []
 
-    weight_sum = sum(block_weights.values())
-    if weight_sum <= 0:
-        return []
-
     sorted_dates = sorted(returns_by_date.keys())
     current_nav = inception_nav
     result: list[NavRow] = []
+
+    # ── F01 fix: minimum active-weight threshold for renormalization ──
+    ACTIVE_WEIGHT_FLOOR_PCT = 0.5  # require >= 50% of weight present
 
     for d in sorted_dates:
         day_returns = returns_by_date[d]
@@ -89,6 +129,25 @@ def compute_composite_nav(
 
         # Renormalize if some blocks missing for this day
         if active_weight > 0 and active_weight < weight_sum * 0.999:
+            if active_weight < weight_sum * ACTIVE_WEIGHT_FLOOR_PCT:
+                # Insufficient coverage — skip to avoid return-side
+                # forward-fill amplification.
+                logger.warning(
+                    "composite_day_skipped_insufficient_active_weight",
+                    nav_date=d,
+                    active_weight=active_weight,
+                    weight_sum=weight_sum,
+                    active_pct=active_weight / weight_sum,
+                )
+                continue
+            # Above threshold: renormalize with telemetry
+            logger.info(
+                "composite_day_renormalized",
+                nav_date=d,
+                active_weight=active_weight,
+                weight_sum=weight_sum,
+                active_pct=active_weight / weight_sum,
+            )
             composite_return = composite_return * (weight_sum / active_weight)
 
         current_nav = current_nav * (1.0 + composite_return)

--- a/backend/quant_engine/data_commons_service.py
+++ b/backend/quant_engine/data_commons_service.py
@@ -85,6 +85,15 @@ _DEMOGRAPHIC_VARIABLES = [
 ]
 
 
+class DataCommonsAPIError(Exception):
+    """Raised when Data Commons API call fails (network, rate limit, 5xx).
+
+    Distinct from valid empty response (entity has no data for the
+    requested variable). Callers should distinguish to avoid Charter \u00a73
+    silent corruption \u2014 empty data displayed as fact when API was down.
+    """
+
+
 class DataCommonsService:
     """Data Commons API client using the official Python library.
 
@@ -148,8 +157,12 @@ class DataCommonsService:
                             })
             return records
         except Exception as e:
-            logger.warning("data_commons observation fetch failed", error=str(e))
-            return []
+            logger.warning(
+                "data_commons_observation_fetch_failed",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            raise DataCommonsAPIError(f"observation fetch failed: {e}") from e
 
     def _resolve_entity_sync(self, name: str, entity_type: str = "State") -> str | None:
         """Sync resolve a place name to a DCID."""
@@ -197,11 +210,12 @@ class DataCommonsService:
             return results
         except Exception as e:
             logger.warning(
-                "data_commons geo hierarchy failed",
+                "data_commons_geo_hierarchy_failed",
                 parent=parent_dcid,
                 error=str(e),
+                error_type=type(e).__name__,
             )
-            return []
+            raise DataCommonsAPIError(f"geo hierarchy fetch failed: {e}") from e
 
     def _fetch_demographic_profile_sync(self, geo_dcid: str) -> dict[str, Any]:
         """Sync fetch demographic profile for a geography."""
@@ -239,16 +253,16 @@ class DataCommonsService:
                 "median_income": values.get("Median_Income_Household"),
                 "unemployment_rate": values.get("UnemploymentRate_Person"),
             }
+        except DataCommonsAPIError:
+            raise
         except Exception as e:
-            logger.warning("data_commons demographic profile failed", geo=geo_dcid, error=str(e))
-            return {
-                "geo_dcid": geo_dcid,
-                "geo_name": "",
-                "population": None,
-                "median_age": None,
-                "median_income": None,
-                "unemployment_rate": None,
-            }
+            logger.warning(
+                "data_commons_demographic_profile_failed",
+                geo=geo_dcid,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+            raise DataCommonsAPIError(f"demographic profile fetch failed: {e}") from e
 
     # ── Public async methods ──────────────────────────────────────
 

--- a/backend/quant_engine/monte_carlo_service.py
+++ b/backend/quant_engine/monte_carlo_service.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import numpy as np
+import structlog
+
+logger = structlog.get_logger()
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +29,8 @@ class MonteCarloResult:
     std: float = 0.0
     historical_value: float = 0.0
     confidence_bars: list[dict[str, object]] = field(default_factory=list)
+    degraded: bool = False
+    degraded_reason: str | None = None
 
 
 def _block_bootstrap_paths(
@@ -170,14 +175,45 @@ def run_monte_carlo(
         Random seed for reproducibility.
 
     """
-    if len(daily_returns) < 42:
+    n = len(daily_returns)
+    if n < 42:
         return MonteCarloResult(
             n_simulations=0,
             statistic=statistic,
+            degraded=True,
+            degraded_reason=f"insufficient_history: T={n} (min 42)",
         )
 
     if horizons is None:
         horizons = [252, 756, 1260, 1764, 2520]
+
+    # ── S05-F04 fix: T-to-horizon ratio guard ────────────────────────
+    # Block bootstrap with T close to block_size and horizon >> T
+    # produces percentile bands cycling the same few monthly windows
+    # rather than genuine diversification.  Calibrate guard at:
+    #   T < min(max_horizon * 0.1, 252)
+    # 10% of horizon is conservative for monthly-block bootstrap;
+    # 252 cap allows short funds to still produce 1Y projections.
+    max_horizon = max(horizons)
+    min_t_required = min(int(max_horizon * 0.1), 252)
+    if n < min_t_required:
+        logger.warning(
+            "monte_carlo_t_to_horizon_ratio_insufficient",
+            T=n,
+            max_horizon=max_horizon,
+            min_t_required=min_t_required,
+            ratio_pct=round(100 * n / max_horizon, 2),
+        )
+        return MonteCarloResult(
+            n_simulations=0,
+            statistic=statistic,
+            degraded=True,
+            degraded_reason=(
+                f"insufficient_history_for_horizon: T={n}, max_horizon={max_horizon}; "
+                f"need T >= {min_t_required} (10% of horizon, capped at 252) "
+                f"for non-degenerate block bootstrap"
+            ),
+        )
 
     rng = np.random.RandomState(seed)
 

--- a/backend/quant_engine/monte_carlo_service.py
+++ b/backend/quant_engine/monte_carlo_service.py
@@ -74,7 +74,7 @@ def _compute_statistic(
     simulated_returns: np.ndarray,
     statistic: str,
     risk_free_rate: float,
-) -> np.ndarray:
+) -> tuple[np.ndarray, int]:
     """Compute the chosen statistic for each simulation path.
 
     Parameters
@@ -86,9 +86,16 @@ def _compute_statistic(
     risk_free_rate : float
         Annualized risk-free rate.
 
+    Returns
+    -------
+    tuple[np.ndarray, int]
+        (statistic_values, zero_variance_count). The count is only
+        meaningful for statistic="sharpe"; 0 for other statistics.
+
     """
     n_sims = simulated_returns.shape[0]
     results = np.empty(n_sims)
+    zero_var_count = 0
 
     if statistic == "max_drawdown":
         for i in range(n_sims):
@@ -111,12 +118,13 @@ def _compute_statistic(
                 results[i] = mean_excess / std_excess * np.sqrt(252)
             else:
                 results[i] = 0.0
+                zero_var_count += 1
 
     else:
         msg = f"Unknown statistic: {statistic}"
         raise ValueError(msg)
 
-    return results
+    return results, zero_var_count
 
 
 def _historical_statistic(
@@ -223,7 +231,7 @@ def run_monte_carlo(
         daily_returns, n_simulations, primary_horizon, block_size=21, rng=rng,
     )
 
-    sim_stats = _compute_statistic(paths, statistic, risk_free_rate)
+    sim_stats, primary_zero_var_count = _compute_statistic(paths, statistic, risk_free_rate)
 
     # Percentile distribution
     pctl_keys = ["1st", "5th", "10th", "25th", "50th", "75th", "90th", "95th", "99th"]
@@ -242,7 +250,7 @@ def run_monte_carlo(
         h_paths = paths[:, :h] if h <= primary_horizon else _block_bootstrap_paths(
             daily_returns, n_simulations, h, block_size=21, rng=rng,
         )
-        h_stats = _compute_statistic(h_paths, statistic, risk_free_rate)
+        h_stats, _ = _compute_statistic(h_paths, statistic, risk_free_rate)
 
         label = f"{h // 252}Y" if h >= 252 else f"{h}D"
         confidence_bars.append({
@@ -258,6 +266,17 @@ def run_monte_carlo(
             "mean": round(float(np.mean(h_stats)), 8),
         })
 
+    # ── S05-F02 fix: detect mass zero-variance Sharpe collapse ────────
+    # Per-path zero-variance is acceptable on rare numerical edge cases,
+    # but if a substantial fraction of paths produced zero-variance Sharpe,
+    # the input was effectively flat-NAV and the result is uninformative.
+    _ZERO_VARIANCE_MASS_THRESHOLD = 0.5
+    is_mass_zero_var = (
+        statistic == "sharpe"
+        and n_simulations > 0
+        and primary_zero_var_count / n_simulations > _ZERO_VARIANCE_MASS_THRESHOLD
+    )
+
     return MonteCarloResult(
         n_simulations=n_simulations,
         statistic=statistic,
@@ -267,4 +286,11 @@ def run_monte_carlo(
         std=round(float(np.std(sim_stats, ddof=1)), 8),
         historical_value=round(hist_value, 8),
         confidence_bars=confidence_bars,
+        degraded=is_mass_zero_var,
+        degraded_reason=(
+            f"zero_variance_collapse: {primary_zero_var_count}/{n_simulations} "
+            f"paths produced zero-variance Sharpe (threshold "
+            f"{_ZERO_VARIANCE_MASS_THRESHOLD:.0%}); "
+            f"input returns may be flat or numerically degenerate"
+        ) if is_mass_zero_var else None,
     )

--- a/backend/tests/quant_engine/test_benchmark_composite_phantom_history.py
+++ b/backend/tests/quant_engine/test_benchmark_composite_phantom_history.py
@@ -1,0 +1,161 @@
+"""Regression tests for S05-F01: composite NAV phantom history + day-level renormalization.
+
+Two complementary defects in compute_composite_nav:
+1. Phantom history from earliest-inception start date (Gemini angle)
+2. Day-level renormalization without active-weight floor (Opus angle)
+
+Both confirmed by GPT-5.4 + GPT-5.5 dual jury with line-level trace.
+Stage 3 triage: TP Tier 1 (Math High / Inst High).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from quant_engine.benchmark_composite_service import compute_composite_nav
+
+
+def _nav(nav_date: date, return_1d: float) -> dict:
+    """Build a nav dict matching the benchmark_navs input shape."""
+    return {"nav_date": nav_date, "return_1d": return_1d}
+
+
+# ── Regression tests for S05-F01 angle 1 (phantom history) ──────────────
+
+
+class TestPhantomHistoryElimination:
+    """Composite must start at latest common inception, not earliest."""
+
+    def test_composite_starts_at_latest_common_inception_date(self) -> None:
+        """Block A 2020-01-01→05; Block B 2020-01-03→05.
+        Composite must start 2020-01-03 (3 dates, not 5)."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [
+                _nav(date(2020, 1, 1), 0.01),
+                _nav(date(2020, 1, 2), 0.02),
+                _nav(date(2020, 1, 3), 0.01),
+                _nav(date(2020, 1, 4), 0.005),
+                _nav(date(2020, 1, 5), -0.01),
+            ],
+            "b": [
+                _nav(date(2020, 1, 3), 0.003),
+                _nav(date(2020, 1, 4), 0.001),
+                _nav(date(2020, 1, 5), -0.002),
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert len(result) == 3, f"expected 3 dates >= 2020-01-03, got {len(result)}"
+        assert result[0].nav_date == date(2020, 1, 3)
+        assert all(r.nav_date >= date(2020, 1, 3) for r in result)
+
+    def test_composite_returns_empty_when_block_missing_from_navs(self) -> None:
+        """If a required block has no key in benchmark_navs, composite is undefined."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs: dict = {
+            "a": [_nav(date(2020, 1, 3), 0.01)],
+            # "b" missing entirely
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result == []
+
+    def test_composite_returns_empty_when_block_has_empty_rows(self) -> None:
+        """If a required block has key but empty list, composite is undefined."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [_nav(date(2020, 1, 3), 0.01)],
+            "b": [],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result == []
+
+
+# ── Regression tests for S05-F01 angle 2 (day-level renorm threshold) ──
+
+
+class TestDayLevelRenormThreshold:
+    """Day-level renormalization requires >= 50% active weight."""
+
+    def test_low_active_weight_day_skipped(self) -> None:
+        """30% active weight (<50% floor) must be skipped, not renormalized.
+        Pre-fix: 0.3*0.02 / 0.3 = 0.02 reported as composite.
+        Post-fix: day skipped."""
+        block_weights = {"a": 0.3, "b": 0.7}
+        benchmark_navs = {
+            "a": [
+                _nav(date(2020, 1, 2), 0.01),
+                _nav(date(2020, 1, 3), 0.02),
+            ],
+            "b": [
+                _nav(date(2020, 1, 2), 0.005),
+                # Missing 2020-01-03 — 30% active < 50% floor
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        # 2020-01-02 included (full coverage). 2020-01-03 skipped.
+        assert len(result) == 1
+        assert result[0].nav_date == date(2020, 1, 2)
+
+    def test_high_active_weight_day_renormalized(self) -> None:
+        """60% active weight (>=50% floor) IS renormalized.
+        Block A 60% present + Block B 40% missing → composite = A's return
+        scaled to full weight."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [
+                _nav(date(2020, 1, 2), 0.01),
+                _nav(date(2020, 1, 3), 0.02),
+            ],
+            "b": [
+                _nav(date(2020, 1, 2), 0.005),
+                # Missing 2020-01-03 — 60% active, above 50% floor
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert len(result) == 2
+        # Day 1: full coverage: 0.6*0.01 + 0.4*0.005 = 0.008
+        assert result[0].nav_date == date(2020, 1, 2)
+        assert result[0].daily_return == pytest.approx(0.008, abs=1e-9)
+        # Day 2: 60% active, renormalized: 0.6*0.02 / 0.6 = 0.02
+        assert result[1].nav_date == date(2020, 1, 3)
+        assert result[1].daily_return == pytest.approx(0.02, abs=1e-9)
+
+
+# ── Existing-behavior preservation (control tests) ─────────────────────
+
+
+class TestControlPreservation:
+    """Verify unchanged behavior for healthy scenarios."""
+
+    def test_full_coverage_returns_unchanged(self) -> None:
+        """All days full coverage → composite = weighted sum."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [_nav(date(2020, 1, 1), 0.01), _nav(date(2020, 1, 2), 0.02)],
+            "b": [_nav(date(2020, 1, 1), 0.005), _nav(date(2020, 1, 2), 0.003)],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert len(result) == 2
+        # Day 1: 0.6*0.01 + 0.4*0.005 = 0.008
+        assert result[0].daily_return == pytest.approx(0.008, abs=1e-9)
+        # Day 2: 0.6*0.02 + 0.4*0.003 = 0.0132
+        assert result[1].daily_return == pytest.approx(0.0132, abs=1e-9)
+
+    def test_inception_nav_default_preserved(self) -> None:
+        """inception_nav=1000 IS the local convention (F13 REFUTED)."""
+        block_weights = {"a": 1.0}
+        benchmark_navs = {"a": [_nav(date(2020, 1, 1), 0.0)]}
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result[0].nav == 1000.0
+
+    def test_zero_weight_sum_returns_empty(self) -> None:
+        """Existing guard preserved."""
+        block_weights = {"a": 0.0, "b": 0.0}
+        benchmark_navs = {
+            "a": [_nav(date(2020, 1, 1), 0.01)],
+            "b": [_nav(date(2020, 1, 1), 0.01)],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs)
+        assert result == []

--- a/backend/tests/quant_engine/test_data_commons_api_error.py
+++ b/backend/tests/quant_engine/test_data_commons_api_error.py
@@ -1,0 +1,83 @@
+"""F03 regression: Data Commons API failure distinguishable from valid empty (S05-F03).
+
+Validates that API failures raise DataCommonsAPIError instead of
+silently returning empty lists/dicts, while valid empty responses
+still return [] correctly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quant_engine.data_commons_service import (
+    DataCommonsAPIError,
+    DataCommonsService,
+)
+
+
+def _mock_client() -> MagicMock:
+    return MagicMock()
+
+
+# ── F03 regression: API failure distinguishable from valid empty ──────────
+
+
+@pytest.mark.asyncio
+async def test_observation_fetch_api_failure_raises():
+    """Network failure -> DataCommonsAPIError, NOT silent []."""
+    svc = DataCommonsService(api_key="test")
+    mock_dc = _mock_client()
+    mock_dc.observation.fetch.side_effect = ConnectionError("simulated network failure")
+
+    with patch.object(svc, "_get_client", return_value=mock_dc):
+        with pytest.raises(DataCommonsAPIError, match="observation fetch failed"):
+            await svc.fetch_economic_indicators(
+                entity_dcids=["geoId/06"],
+                variables=["UnemploymentRate_Person"],
+            )
+
+
+@pytest.mark.asyncio
+async def test_observation_fetch_valid_empty_returns_empty_list():
+    """Valid 'no data' response -> [], NOT exception."""
+    svc = DataCommonsService(api_key="test")
+    mock_dc = _mock_client()
+    mock_response = MagicMock()
+    mock_response.to_dict.return_value = {"byVariable": {}}
+    mock_dc.observation.fetch.return_value = mock_response
+
+    with patch.object(svc, "_get_client", return_value=mock_dc):
+        result = await svc.fetch_economic_indicators(
+            entity_dcids=["geoId/99999"],
+            variables=["UnemploymentRate_Person"],
+        )
+    assert result == []  # valid empty, not error
+
+
+@pytest.mark.asyncio
+async def test_geo_hierarchy_api_failure_raises():
+    """Geo hierarchy API failure -> DataCommonsAPIError."""
+    svc = DataCommonsService(api_key="test")
+    mock_dc = _mock_client()
+    mock_dc.node.fetch_place_children.side_effect = TimeoutError("simulated timeout")
+
+    with patch.object(svc, "_get_client", return_value=mock_dc):
+        with pytest.raises(DataCommonsAPIError, match="geo hierarchy fetch failed"):
+            await svc.fetch_geographic_hierarchy(
+                parent_dcid="country/USA",
+                child_type="State",
+            )
+
+
+@pytest.mark.asyncio
+async def test_demographic_profile_api_failure_raises():
+    """Demographic profile failure -> DataCommonsAPIError."""
+    svc = DataCommonsService(api_key="test")
+    mock_dc = _mock_client()
+    mock_dc.node.fetch_entity_names.side_effect = ConnectionError("down")
+
+    with patch.object(svc, "_get_client", return_value=mock_dc):
+        with pytest.raises(DataCommonsAPIError, match="demographic profile fetch failed"):
+            await svc.fetch_demographic_profile(geo_dcid="geoId/06")

--- a/backend/tests/quant_engine/test_monte_carlo_short_history_degeneracy.py
+++ b/backend/tests/quant_engine/test_monte_carlo_short_history_degeneracy.py
@@ -1,0 +1,106 @@
+"""Regression tests for S05-F04 (Tier 1) — MC short-history + long-horizon
+block bootstrap degeneracy.
+
+T close to block_size + horizon >> T causes block bootstrap to cycle the same
+few monthly windows of input data, producing meaningless percentile bands.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from quant_engine.monte_carlo_service import (
+    MonteCarloResult,
+    run_monte_carlo,
+)
+
+# ── Regression tests for S05-F04 (Tier 1) ──────────────────────────────────
+
+
+def test_short_history_long_horizon_returns_degraded():
+    """T=42, horizon=2520 (10Y) → block bootstrap would cycle ~22 windows
+    of 42-day history. Must return degraded=True with explicit reason."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 42)
+    result = run_monte_carlo(daily, horizons=[2520], seed=42)
+    assert result.degraded is True
+    assert result.n_simulations == 0
+    assert result.degraded_reason is not None
+    assert "horizon" in result.degraded_reason.lower()
+
+
+def test_short_history_short_horizon_runs_normally():
+    """T=42 + 1Y horizon (252 days) should NOT degrade — 42/252 = 16.7%
+    sample richness, above 10% floor."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 42)
+    result = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=100)
+    assert result.degraded is False
+    assert result.degraded_reason is None
+    assert result.n_simulations > 0
+
+
+def test_long_history_long_horizon_runs_normally():
+    """T=300, horizon=2520. T/horizon = 11.9% > 10% floor. Should run."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 300)
+    result = run_monte_carlo(daily, horizons=[2520], seed=42, n_simulations=100)
+    assert result.degraded is False
+    assert result.n_simulations > 0
+
+
+def test_just_above_floor_runs_normally():
+    """Boundary: T = min(max_horizon * 0.1, 252) exactly. Must not degrade."""
+    # max_horizon=2520 → min_t_required = min(252, 252) = 252
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 252)
+    result = run_monte_carlo(daily, horizons=[2520], seed=42, n_simulations=100)
+    assert result.degraded is False
+
+
+def test_just_below_floor_degrades():
+    """Boundary: T = min_t_required - 1. Must degrade."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 251)
+    result = run_monte_carlo(daily, horizons=[2520], seed=42)
+    assert result.degraded is True
+
+
+def test_t_below_42_still_degrades():
+    """Existing T<42 guard preserved (S05-F03 angle covered by Q47 too)."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 30)
+    result = run_monte_carlo(daily, horizons=[252], seed=42)
+    assert result.degraded is True
+    assert result.n_simulations == 0
+
+
+def test_degraded_reason_includes_diagnostic_numbers():
+    """degraded_reason must include T and horizon for operator forensics."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 42)
+    result = run_monte_carlo(daily, horizons=[2520], seed=42)
+    assert result.degraded is True
+    assert "42" in result.degraded_reason or "T=42" in result.degraded_reason
+    assert "2520" in result.degraded_reason
+
+
+# ── Existing-behavior preservation (control tests) ─────────────────────
+
+
+def test_dataclass_default_degraded_false():
+    """Existing callers using positional/default-only init: degraded=False."""
+    r = MonteCarloResult(n_simulations=10000, statistic="max_drawdown")
+    assert r.degraded is False
+    assert r.degraded_reason is None
+
+
+def test_seed_propagation_unchanged():
+    """Existing behavior: same seed produces same output (control)."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0003, 0.01, 300)
+    r1 = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=100)
+    r2 = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=100)
+    if r1.n_simulations > 0 and r2.n_simulations > 0:
+        assert r1.mean == r2.mean
+        assert r1.std == r2.std

--- a/backend/tests/quant_engine/test_monte_carlo_zero_variance_degraded.py
+++ b/backend/tests/quant_engine/test_monte_carlo_zero_variance_degraded.py
@@ -1,0 +1,58 @@
+"""F02 regression: MC zero-variance Sharpe degraded surface (S05-F02).
+
+Validates that mass zero-variance collapse across simulated paths
+surfaces degraded=True on MonteCarloResult, while partial or
+non-Sharpe statistics remain unaffected.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from quant_engine.monte_carlo_service import (
+    MonteCarloResult,
+    run_monte_carlo,
+)
+
+
+def test_flat_nav_sharpe_returns_degraded():
+    """All-zero daily returns + statistic='sharpe' -> most paths
+    produce zero-variance Sharpe. Run must surface degraded=True."""
+    daily = np.zeros(300)  # T=300, well above thresholds, but flat
+    result = run_monte_carlo(daily, horizons=[252], seed=42, statistic="sharpe")
+    assert isinstance(result, MonteCarloResult)
+    assert result.degraded is True
+    assert result.degraded_reason is not None
+    assert "zero_variance" in result.degraded_reason.lower()
+    # Not gated to n_simulations=0 — run completed, just degraded
+    assert result.n_simulations > 0
+
+
+def test_flat_nav_max_drawdown_not_degraded_for_zero_variance_reason():
+    """statistic='max_drawdown' is not affected by zero-variance —
+    flat NAV produces zero drawdown legitimately. Should NOT degrade
+    on the zero-variance path (other guards may still degrade)."""
+    daily = np.zeros(300)
+    result = run_monte_carlo(daily, horizons=[252], seed=42, statistic="max_drawdown")
+    # If degraded for some other reason (e.g., insufficient T), that's fine.
+    # The point: degraded_reason should NOT mention zero_variance for max_drawdown.
+    if result.degraded:
+        assert "zero_variance" not in (result.degraded_reason or "").lower()
+
+
+def test_normal_distribution_sharpe_not_degraded():
+    """Healthy non-flat returns + statistic='sharpe' -> degraded=False."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0005, 0.01, 300)
+    result = run_monte_carlo(daily, horizons=[252], seed=42, statistic="sharpe")
+    assert result.degraded is False
+    assert result.n_simulations > 0
+
+
+def test_partial_zero_variance_below_threshold_not_degraded():
+    """Most paths informative, a few zero-variance -> run not degraded."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0005, 0.01, 300)
+    # With healthy input, < 50% paths should hit zero-variance
+    result = run_monte_carlo(daily, horizons=[252], seed=42, statistic="sharpe")
+    assert result.degraded is False

--- a/backend/tests/test_benchmark_composite_service.py
+++ b/backend/tests/test_benchmark_composite_service.py
@@ -51,22 +51,36 @@ class TestComputeCompositeNav:
         assert result[0].daily_return == pytest.approx(0.016, abs=1e-8)
         assert result[0].nav == pytest.approx(1016.0, abs=1e-8)
 
-    def test_missing_block_renormalized(self) -> None:
-        """If a block has no data for a day, return is renormalized."""
+    def test_missing_block_returns_empty(self) -> None:
+        """If a required block has no data at all, composite is undefined (Q45)."""
         block_weights = {"a": 0.5, "b": 0.5}
         benchmark_navs = {
             "a": [
                 {"nav_date": date(2024, 1, 2), "return_1d": 0.04},
             ],
-            # "b" has no data for this date
+            # "b" entirely absent — composite undefined
         }
         result = compute_composite_nav(block_weights, benchmark_navs, inception_nav=1000.0)
+        assert result == []
 
-        # Only block "a" is active: R_raw = 0.5 * 0.04 = 0.02
-        # Renormalize: R = 0.02 * (1.0 / 0.5) = 0.04
-        assert len(result) == 1
-        assert result[0].daily_return == pytest.approx(0.04, abs=1e-8)
-        assert result[0].nav == pytest.approx(1040.0, abs=1e-8)
+    def test_day_level_renormalization_above_floor(self) -> None:
+        """Block present for all dates but missing on single day: renormalized
+        if active_weight >= 50% floor (Q45 day-level fix)."""
+        block_weights = {"a": 0.6, "b": 0.4}
+        benchmark_navs = {
+            "a": [
+                {"nav_date": date(2024, 1, 2), "return_1d": 0.01},
+                {"nav_date": date(2024, 1, 3), "return_1d": 0.04},
+            ],
+            "b": [
+                {"nav_date": date(2024, 1, 2), "return_1d": 0.005},
+                # Missing 2024-01-03 — 60% active, above 50% floor
+            ],
+        }
+        result = compute_composite_nav(block_weights, benchmark_navs, inception_nav=1000.0)
+        assert len(result) == 2
+        # Day 2: 60% active → renormalized: 0.6*0.04 / 0.6 = 0.04
+        assert result[1].daily_return == pytest.approx(0.04, abs=1e-8)
 
     def test_empty_inputs_return_empty(self) -> None:
         """Empty weights or empty NAVs return empty list."""

--- a/backend/tests/test_data_commons_service.py
+++ b/backend/tests/test_data_commons_service.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from quant_engine.data_commons_service import (
+    DataCommonsAPIError,
     DataCommonsService,
     DemographicProfile,
     EconomicObservation,
@@ -75,19 +76,19 @@ class TestFetchEconomicIndicators:
         assert result[0].value == 4.2
 
     @pytest.mark.asyncio
-    async def test_returns_empty_on_error(self) -> None:
+    async def test_raises_on_api_error(self) -> None:
+        """API failure → DataCommonsAPIError, NOT silent [] (F03 fix)."""
         svc = DataCommonsService(api_key="test-key")
 
         mock_dc = _mock_client()
         mock_dc.observation.fetch.side_effect = Exception("API error")
 
         with patch.object(svc, "_get_client", return_value=mock_dc):
-            result = await svc.fetch_economic_indicators(
-                entity_dcids=["geoId/06"],
-                variables=["Count_Person"],
-            )
-
-        assert result == []
+            with pytest.raises(DataCommonsAPIError, match="observation fetch failed"):
+                await svc.fetch_economic_indicators(
+                    entity_dcids=["geoId/06"],
+                    variables=["Count_Person"],
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -131,18 +132,16 @@ class TestFetchDemographicProfile:
         assert result.unemployment_rate == 4.2
 
     @pytest.mark.asyncio
-    async def test_returns_nulls_on_error(self) -> None:
+    async def test_raises_on_api_error(self) -> None:
+        """API failure → DataCommonsAPIError, NOT silent nulls (F03 fix)."""
         svc = DataCommonsService(api_key="test-key")
 
         mock_dc = _mock_client()
         mock_dc.node.fetch_entity_names.side_effect = Exception("Network error")
 
         with patch.object(svc, "_get_client", return_value=mock_dc):
-            result = await svc.fetch_demographic_profile("geoId/06")
-
-        assert isinstance(result, DemographicProfile)
-        assert result.population is None
-        assert result.median_income is None
+            with pytest.raises(DataCommonsAPIError):
+                await svc.fetch_demographic_profile("geoId/06")
 
 
 # ---------------------------------------------------------------------------
@@ -227,13 +226,13 @@ class TestFetchGeographicHierarchy:
         assert result[0].name == "Alameda County"
 
     @pytest.mark.asyncio
-    async def test_returns_empty_on_error(self) -> None:
+    async def test_raises_on_api_error(self) -> None:
+        """API failure → DataCommonsAPIError, NOT silent [] (F03 fix)."""
         svc = DataCommonsService(api_key="test-key")
 
         mock_dc = _mock_client()
         mock_dc.node.fetch_place_children.side_effect = Exception("Fail")
 
         with patch.object(svc, "_get_client", return_value=mock_dc):
-            result = await svc.fetch_geographic_hierarchy("geoId/06")
-
-        assert result == []
+            with pytest.raises(DataCommonsAPIError):
+                await svc.fetch_geographic_hierarchy("geoId/06")


### PR DESCRIPTION
## Summary
- F02: Monte Carlo `MonteCarloResult.degraded=True` when > 50% of paths produce zero-variance Sharpe (mass numerical collapse).
- F03: Data Commons API failures now raise `DataCommonsAPIError` (was: silent `[]` indistinguishable from valid empty).
- Tier 2 bundle of Wave 6 Session 05.

## Wave 6 Session 05 Stage 3 triage
- F02 + F03: convergent across Opus + Gemini Stage 1; both juries CONFIRMED high confidence.
- Reference: `docs/audits/audit-validation-session05.md` (S05-F02, S05-F03)

## Behavior change
| Scenario | Before | After |
|---|---|---|
| MC: all-flat returns + Sharpe statistic | silent `mean=0.0` | `degraded=True, reason="zero_variance_collapse..."` |
| MC: healthy mixed returns + Sharpe | unchanged | unchanged |
| MC: max_drawdown statistic | unchanged | unchanged (no zero-variance gate) |
| Data Commons: API timeout / connection error | silent `[]` | `DataCommonsAPIError` |
| Data Commons: valid "no data for entity" | `[]` | `[]` (unchanged — correctly empty) |

## Test plan
- [x] MC flat NAV + Sharpe → degraded
- [x] MC flat NAV + max_drawdown → not degraded for zero-variance
- [x] MC healthy returns + Sharpe → not degraded
- [x] MC partial zero-variance below threshold → not degraded
- [x] Data Commons API failure → DataCommonsAPIError
- [x] Data Commons valid empty → []
- [x] Data Commons demographic API failure → DataCommonsAPIError
- [x] Data Commons geo hierarchy API failure → DataCommonsAPIError
- [x] Existing tests updated for F03 (3 reverse-subsumption fixes)
- [x] Q46 regression tests pass (9/9)
- [x] `ruff check` clean
- [x] `mypy` clean (no new errors)

## Blast radius
- MC consumers (`analytics.py`, `model_portfolios.py`): can now read `degraded`/`degraded_reason` fields. Existing `n_simulations` checks unaffected. UI rendering of degraded state is **handoff item**.
- Data Commons consumers: only `e2e_smoke_test.py` (env-gated). No production callers yet. **Handoff items** flagged below.

## Handoff items
1. `quant_queries.py` callers of `MonteCarloResult` should render degraded state in operator UI.
2. Lifespan / dependency injection for Data Commons should catch `DataCommonsAPIError` at startup if instance health-check is performed.
3. IC memo macro section + DD report macro context: catch + render "API unavailable" placeholder.

## Pre-flight reverse-subsumption check
3 existing tests relied on silent-empty behavior (the bug being fixed):
- `TestFetchEconomicIndicators::test_returns_empty_on_error` → updated to `test_raises_on_api_error`
- `TestFetchDemographicProfile::test_returns_nulls_on_error` → updated to `test_raises_on_api_error`
- `TestFetchGeographicHierarchy::test_returns_empty_on_error` → updated to `test_raises_on_api_error`

## Dependencies
- Based on `fix/q46-mc-short-history-degeneracy` (PR-Q46) — uses `degraded`/`degraded_reason` fields added by Q46.