### PR TITLE
fix(quant): PR-Q49 — Tier 4 cleanup terminus (S05-F06+F07+F12) — closes Session 05

### DIFF
--- a/backend/quant_engine/black_litterman_service.py
+++ b/backend/quant_engine/black_litterman_service.py
@@ -361,6 +361,12 @@ def compute_bl_returns(
             p_row[long_idx] = 1.0
             p_row[short_idx] = -1.0
         else:
+            logger.warning(
+                "bl_legacy_unknown_view_type_skipped",
+                view_index=i,
+                view_type=vtype,
+                note="legacy compute_bl_returns; production uses compute_bl_posterior_multi_view",
+            )
             continue
 
         # Idzorek-style omega mapping:
@@ -399,7 +405,7 @@ def compute_bl_returns(
     # extreme tilts.
     try:
         prior_view = P @ pi                              # (K,)
-        view_cov = P @ sigma @ P.T                       # (K, K)
+        view_cov = P @ (tau_eff * sigma) @ P.T              # (K, K) — τΣ, not Σ
         view_sigma = np.sqrt(np.maximum(np.diag(view_cov), 0.0))
         residual = np.abs(Q - prior_view)
         threshold = 3.0 * view_sigma

--- a/backend/quant_engine/monte_carlo_service.py
+++ b/backend/quant_engine/monte_carlo_service.py
@@ -33,20 +33,20 @@ def _block_bootstrap_paths(
     n_simulations: int,
     horizon: int,
     block_size: int = 21,
-    rng: np.random.RandomState | None = None,
+    rng: np.random.Generator | None = None,
 ) -> np.ndarray:
     """Generate bootstrapped return paths via block bootstrap.
 
     Returns (n_simulations, horizon) array of simulated daily returns.
     """
     if rng is None:
-        rng = np.random.RandomState()
+        rng = np.random.default_rng()
 
     n = len(daily_returns)
     n_blocks = (horizon + block_size - 1) // block_size
 
     # Pre-compute all block start indices
-    starts = rng.randint(0, n - block_size + 1, size=(n_simulations, n_blocks))
+    starts = rng.integers(0, n - block_size + 1, size=(n_simulations, n_blocks))
 
     paths = np.empty((n_simulations, n_blocks * block_size))
     for b in range(n_blocks):
@@ -179,7 +179,7 @@ def run_monte_carlo(
     if horizons is None:
         horizons = [252, 756, 1260, 1764, 2520]
 
-    rng = np.random.RandomState(seed)
+    rng = np.random.default_rng(seed)
 
     # Primary simulation at the longest horizon
     primary_horizon = max(horizons)

--- a/backend/tests/quant_engine/test_session05_tier4_cleanup.py
+++ b/backend/tests/quant_engine/test_session05_tier4_cleanup.py
@@ -1,0 +1,205 @@
+"""PR-Q49 — Wave 6 Session 05 Tier 4 cleanup regression tests.
+
+Covers three independent low-severity fixes:
+    F06: Legacy compute_bl_returns logs warning on unknown view types.
+    F07: Monte Carlo migrated RandomState -> default_rng (Generator API).
+    F12: He-Litterman consistency check uses tau-scaled covariance.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+import structlog
+
+from quant_engine.black_litterman_service import compute_bl_returns
+from quant_engine.monte_carlo_service import run_monte_carlo
+
+# ── structlog capture (same pattern as test_mu_trace_instrumentation) ────
+
+
+def _capture_structlog_events() -> tuple[list[dict[str, Any]], Any]:
+    events: list[dict[str, Any]] = []
+
+    def _capture(_logger: Any, _method: str, event_dict: dict[str, Any]) -> dict[str, Any]:
+        events.append(dict(event_dict))
+        return event_dict
+
+    return events, _capture
+
+
+@pytest.fixture
+def captured_log_events() -> list[dict[str, Any]]:
+    events, processor = _capture_structlog_events()
+    original = structlog.get_config()
+    structlog.configure(
+        processors=[processor, *original["processors"]],
+        wrapper_class=original["wrapper_class"],
+        context_class=original["context_class"],
+        logger_factory=original["logger_factory"],
+        cache_logger_on_first_use=False,
+    )
+    try:
+        yield events
+    finally:
+        structlog.configure(**original)
+
+
+# ── F06: legacy unknown view type warning ────────────────────────────────
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_legacy_unknown_view_type_logs_warning(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """compute_bl_returns must log warning (not silently skip) on unknown
+    view types."""
+    sigma = np.eye(2) * 0.04
+    w_mkt = np.array([0.5, 0.5])
+
+    views = [
+        {"type": "sector_tilt", "asset_idx": 0, "Q": 0.06, "confidence": 0.5},
+        {"type": "absolute", "asset_idx": 0, "Q": 0.06, "confidence": 0.5},
+    ]
+
+    result = compute_bl_returns(sigma, w_mkt, views=views)
+
+    # Function still returns a posterior (only the absolute view applied)
+    assert result.shape == (2,)
+    assert all(np.isfinite(result))
+
+    # Warning must have been emitted for the sector_tilt skip
+    skip_events = [
+        e for e in captured_log_events
+        if e.get("event") == "bl_legacy_unknown_view_type_skipped"
+    ]
+    assert len(skip_events) == 1
+    assert skip_events[0]["view_type"] == "sector_tilt"
+    assert skip_events[0]["view_index"] == 0
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_legacy_all_unknown_views_returns_equilibrium(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """If all views are unknown types, result equals equilibrium (pi)."""
+    sigma = np.eye(2) * 0.04
+    w_mkt = np.array([0.5, 0.5])
+
+    views = [
+        {"type": "bogus", "Q": 0.10, "confidence": 0.5},
+    ]
+
+    result = compute_bl_returns(sigma, w_mkt, views=views)
+    pi = 2.5 * sigma @ w_mkt
+    np.testing.assert_allclose(result, pi, atol=1e-10)
+
+    skip_events = [
+        e for e in captured_log_events
+        if e.get("event") == "bl_legacy_unknown_view_type_skipped"
+    ]
+    assert len(skip_events) == 1
+
+
+# ── F07: MC uses default_rng (Generator), not RandomState ───────────────
+
+
+def test_mc_seed_determinism_post_migration() -> None:
+    """Same seed must produce identical MC results after RandomState ->
+    default_rng migration."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0005, 0.01, 300)
+
+    r1 = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=200)
+    r2 = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=200)
+
+    assert r1.n_simulations > 0
+    assert r2.n_simulations > 0
+    assert r1.mean == r2.mean
+    assert r1.std == r2.std
+    assert r1.percentiles == r2.percentiles
+
+
+def test_mc_different_seeds_differ() -> None:
+    """Different seeds produce different results (sanity check)."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0005, 0.01, 300)
+
+    r1 = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=200)
+    r2 = run_monte_carlo(daily, horizons=[252], seed=99, n_simulations=200)
+
+    assert r1.n_simulations > 0
+    assert r2.n_simulations > 0
+    # Very unlikely to be identical with different seeds
+    assert r1.mean != r2.mean
+
+
+# ── F12: He-Litterman tau-scaled consistency check ───────────────────────
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_he_litterman_warning_fires_with_tau_scaled_variance(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """With tau_eff scaling, a view 4 sigma from prior (under tau*Sigma)
+    should trigger the He-Litterman warning.
+
+    Pre-fix: warning used unscaled Sigma -> effective threshold was ~13.4 sigma
+    -> view at 0.9 sigma (under Sigma) never fired.
+    Post-fix: warning fires at documented 3 sigma threshold against tau*Sigma.
+
+    Setup:
+        sigma = diag(0.04, 0.04), tau_eff = 0.05
+        pi = 2.5 * sigma @ [0.5, 0.5] = [0.05, 0.05]
+        Under tau*Sigma: view_std = sqrt(0.05 * 0.04) = 0.04472
+        View Q = 0.05 + 0.18 = 0.23 -> z = 0.18 / 0.04472 ~ 4.02 > 3.0
+        Under plain Sigma (pre-fix): view_std = 0.2, z = 0.18/0.2 = 0.9 < 3.0
+    """
+    sigma = np.eye(2) * 0.04
+    w_mkt = np.array([0.5, 0.5])
+    tau_eff = 0.05
+
+    # View 4 sigma away from prior under tau*Sigma
+    views = [
+        {"type": "absolute", "asset_idx": 0, "Q": 0.23, "confidence": 0.5},
+    ]
+
+    result = compute_bl_returns(sigma, w_mkt, views=views, tau=tau_eff)
+    assert result.shape == (2,)
+
+    inconsistent_events = [
+        e for e in captured_log_events
+        if e.get("event") == "black_litterman_view_inconsistent_with_prior"
+    ]
+    assert len(inconsistent_events) == 1
+    assert inconsistent_events[0]["n_flagged"] == 1
+    # z-score should be ~4.0 under tau*Sigma
+    assert inconsistent_events[0]["max_z"] > 3.5
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_he_litterman_no_warning_for_mild_view(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """A view within 2 sigma (under tau*Sigma) should NOT trigger the
+    He-Litterman warning."""
+    sigma = np.eye(2) * 0.04
+    w_mkt = np.array([0.5, 0.5])
+    tau_eff = 0.05
+
+    # view_std under tau*Sigma = sqrt(0.05 * 0.04) = 0.04472
+    # 2 sigma = 0.0894; Q = 0.05 + 0.08 = 0.13 -> z ~ 1.79 < 3.0
+    views = [
+        {"type": "absolute", "asset_idx": 0, "Q": 0.13, "confidence": 0.5},
+    ]
+
+    result = compute_bl_returns(sigma, w_mkt, views=views, tau=tau_eff)
+    assert result.shape == (2,)
+
+    inconsistent_events = [
+        e for e in captured_log_events
+        if e.get("event") == "black_litterman_view_inconsistent_with_prior"
+    ]
+    assert len(inconsistent_events) == 0

--- a/backend/tests/test_monte_carlo_service.py
+++ b/backend/tests/test_monte_carlo_service.py
@@ -17,7 +17,7 @@ from quant_engine.monte_carlo_service import (
 
 def _make_daily_returns(n_days: int = 504, seed: int = 42) -> np.ndarray:
     """Generate synthetic daily returns (~2 years)."""
-    rng = np.random.RandomState(seed)
+    rng = np.random.default_rng(seed)
     return rng.normal(0.0003, 0.01, n_days)
 
 
@@ -35,7 +35,7 @@ class TestBlockBootstrap:
         daily = _make_daily_returns()
         paths = _block_bootstrap_paths(
             daily, n_simulations=10, horizon=63, block_size=21,
-            rng=np.random.RandomState(0),
+            rng=np.random.default_rng(0),
         )
         original_set = set(daily.tolist())
         for i in range(paths.shape[0]):
@@ -47,7 +47,7 @@ class TestBlockBootstrap:
         daily = _make_daily_returns()
         paths = _block_bootstrap_paths(
             daily, n_simulations=1, horizon=42, block_size=21,
-            rng=np.random.RandomState(7),
+            rng=np.random.default_rng(7),
         )
         path = paths[0]
         # First block of 21 should appear contiguously in daily


### PR DESCRIPTION
## Summary
Three Tier 4 cleanup fixes — closes Wave 6 Session 05.

- F06: Legacy `compute_bl_returns` logs warning on unknown view types (was: silent skip).
- F07: Monte Carlo migrated `np.random.RandomState` → `np.random.default_rng` per §3.3 contract.
- F12: Legacy He-Litterman check uses `τΣ` instead of unscaled `Σ` (warning was practically disabled at 4.47× inflation).

## Wave 6 Session 05 Stage 3 triage
- F06 + F07 Opus 4.6 unique; F12 Gemini 3.1 Pro unique
- Both juries DOWNGRADED all three to Low/Low (deprecated path / convention)
- Stage 3 (Opus 4.7): all TPs Tier 4
- Reference: `docs/audits/audit-validation-session05.md`

## Behavior change
| Scenario | Before | After |
|---|---|---|
| Legacy BL view type unknown | silent skip | `logger.warning("bl_legacy_unknown_view_type_skipped")` |
| MC seed=N reproducibility | RandomState MT sequence | default_rng PCG64 sequence (different seq, same determinism) |
| Legacy He-Litterman 3σ threshold | acted as ~13.4σ (`1/√τ_eff` inflated) | fires at documented 3σ against `τΣ` |
| Production BL multi-view path | unchanged | unchanged |
| Production MC seeded path | RandomState | default_rng (different draws, same determinism) |
| MC unseeded production callers (handoff) | non-deterministic | non-deterministic (caller-side handoff S05-F14) |

## Test plan
- [x] F06: warning logged on unknown view types (2 tests)
- [x] F07: MC with seed reproducible across runs + different seeds differ (2 tests)
- [x] F12: He-Litterman warning fires at correct 3σ threshold + no false positive on mild view (2 tests)
- [x] Pre-existing BL tests: 38/38 pass (test_black_litterman, test_bl_correctness, test_black_litterman_multi_view)
- [x] Pre-existing MC tests: 17/17 pass (test_monte_carlo_service — 3 callsites updated RandomState→default_rng)
- [x] `ruff check` clean
- [x] `mypy` — 17 pre-existing ndarray type-arg warnings (same count on main, zero new)

## Pre-flight reverse-subsumption check
- F07: no tests assert on RandomState seed-output sequences; 3 test callsites in `test_monte_carlo_service.py` passed `RandomState` to internal `_block_bootstrap_paths` → updated to `default_rng`
- F06: `test_unknown_view_type_skipped` asserts equilibrium return on unknown type → still passes (warning added, skip preserved)
- F12: no tests assert on He-Litterman threshold behavior

## Blast radius
- Cached MC results (any persisted percentile bands) become stale due to F07 RNG change. Regenerate on next request — no correctness issue.
- Legacy `compute_bl_returns` is not called by production (production uses multi-view at `quant_queries.py`). F06 + F12 affect deprecated path only.
- No DB migration. No frontend type change.

## Session 05 closure
After this PR merges: 7 PRs (Q44-Q49) shipping all 9 in-engine TPs. 4 FPs (F05, F09, F10, F13) correctly refuted by jury. F14 caller-side fix queued as separate handoff PR.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: all three fixes affect either a deprecated legacy path (F06, F12) or convention alignment (F07). No production routing, no new API surface, no DB schema change.