### PR TITLE
fix(routes): PR-Q50 — MC caller handoff: filter None + deterministic seed (S05-F14)

### DIFF
--- a/backend/app/domains/wealth/routes/analytics.py
+++ b/backend/app/domains/wealth/routes/analytics.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import uuid
+import zlib
 from datetime import UTC, date, datetime
 
 import numpy as np
@@ -795,6 +796,26 @@ async def get_factor_analysis(
 # ---------------------------------------------------------------------------
 
 
+def _build_mc_inputs(
+    nav_rows: list,
+    entity_id: str,
+) -> tuple[np.ndarray, int]:
+    """Build daily_returns array (None-filtered) + deterministic seed."""
+    daily_returns = np.array([
+        r.daily_return for r in nav_rows
+        if r.daily_return is not None
+    ])
+    if len(nav_rows) >= 2:
+        seed_payload = (
+            f"{entity_id}|{len(nav_rows)}|"
+            f"{nav_rows[0].nav_date}|{nav_rows[-1].nav_date}"
+        )
+    else:
+        seed_payload = f"{entity_id}|{len(nav_rows)}"
+    mc_seed = int(zlib.crc32(seed_payload.encode("utf-8"))) & 0x7FFFFFFF
+    return daily_returns, mc_seed
+
+
 @router.post(
     "/monte-carlo",
     response_model=MonteCarloResponse,
@@ -857,16 +878,14 @@ async def run_monte_carlo_endpoint(
             detail=f"Insufficient NAV data: {len(nav_rows)} rows (need ≥ 42)",
         )
 
-    daily_returns = np.array([
-        r.daily_return if r.daily_return is not None else 0.0
-        for r in nav_rows
-    ])
+    daily_returns, mc_seed = _build_mc_inputs(nav_rows, str(entity_id))
 
     result = run_monte_carlo(
         daily_returns=daily_returns,
         n_simulations=body.n_simulations,
         horizons=body.horizons,
         statistic=body.statistic,
+        seed=mc_seed,
     )
 
     response_dict = {

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import math
 import uuid
+import zlib
 from datetime import date
 from decimal import Decimal
 from typing import Any, Final
@@ -4669,6 +4670,26 @@ async def get_nav_history(
 # ══════════════════════════════════════════════���════════════════════════
 
 
+def _build_mc_inputs(
+    nav_rows: list,
+    entity_id: str,
+) -> tuple[np.ndarray, int]:
+    """Build daily_returns array (None-filtered) + deterministic seed."""
+    daily_returns = np.array([
+        r.daily_return for r in nav_rows
+        if r.daily_return is not None
+    ])
+    if len(nav_rows) >= 2:
+        seed_payload = (
+            f"{entity_id}|{len(nav_rows)}|"
+            f"{nav_rows[0].nav_date}|{nav_rows[-1].nav_date}"
+        )
+    else:
+        seed_payload = f"{entity_id}|{len(nav_rows)}"
+    mc_seed = int(zlib.crc32(seed_payload.encode("utf-8"))) & 0x7FFFFFFF
+    return daily_returns, mc_seed
+
+
 @router.post(
     "/{portfolio_id}/monte-carlo",
     status_code=status.HTTP_202_ACCEPTED,
@@ -4725,10 +4746,7 @@ async def trigger_monte_carlo(
             detail=f"Insufficient NAV data: {len(nav_rows)} rows (need >= 42)",
         )
 
-    daily_returns = np.array([
-        r.daily_return if r.daily_return is not None else 0.0
-        for r in nav_rows
-    ])
+    daily_returns, mc_seed = _build_mc_inputs(nav_rows, str(portfolio_id))
 
     from quant_engine.monte_carlo_service import run_monte_carlo
 
@@ -4737,6 +4755,7 @@ async def trigger_monte_carlo(
         n_simulations=1000,
         statistic="return",
         horizons=[252, 756, 1260],
+        seed=mc_seed,
     )
 
     response = {

--- a/backend/tests/integration/test_analytics_monte_carlo_caller.py
+++ b/backend/tests/integration/test_analytics_monte_carlo_caller.py
@@ -1,0 +1,111 @@
+"""Caller-side regression tests for S05-F14 (analytics route MC caller).
+
+Validates:
+1. None daily_return values are filtered, not zero-substituted.
+2. Deterministic seed derived from entity_id + data window.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from app.domains.wealth.routes.analytics import _build_mc_inputs
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _make_nav_rows(
+    n: int,
+    *,
+    none_every: int | None = None,
+    base_date: date = date(2023, 1, 1),
+) -> list:
+    """Create mock NavRow-like objects with optional None daily_return."""
+    rows = []
+    for i in range(n):
+        if none_every and i % none_every == 0:
+            ret = None
+        else:
+            ret = 0.001 + i * 0.0001
+        rows.append(MagicMock(daily_return=ret, nav_date=base_date + timedelta(days=i)))
+    return rows
+
+
+# ── F14 angle 1: None values dropped, not zero-substituted ────────────
+
+
+def test_filters_none_daily_returns():
+    """100 rows with 20 None → array len=80, no synthetic zeros."""
+    nav_rows = _make_nav_rows(100, none_every=5)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "fund-abc")
+
+    assert len(daily_returns) == 80
+    assert 0.0 not in daily_returns.tolist()
+
+
+def test_all_valid_returns_preserved():
+    """When no None values, all rows pass through."""
+    nav_rows = _make_nav_rows(50)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "fund-xyz")
+
+    assert len(daily_returns) == 50
+
+
+def test_all_none_returns_empty_array():
+    """Edge case: all None → empty array (engine will catch T < 42)."""
+    nav_rows = _make_nav_rows(10, none_every=1)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "fund-empty")
+
+    assert len(daily_returns) == 0
+
+
+# ── F14 angle 2: deterministic seed from input ────────────────────────
+
+
+def test_seed_is_deterministic_for_same_inputs():
+    """Same entity_id + same nav window → same seed."""
+    nav_rows = _make_nav_rows(252)
+    _, seed1 = _build_mc_inputs(nav_rows, "fund-abc")
+    _, seed2 = _build_mc_inputs(nav_rows, "fund-abc")
+
+    assert seed1 == seed2
+
+
+def test_seed_differs_for_different_funds():
+    nav_rows = _make_nav_rows(252)
+    _, seed_a = _build_mc_inputs(nav_rows, "fund-A")
+    _, seed_b = _build_mc_inputs(nav_rows, "fund-B")
+
+    assert seed_a != seed_b
+
+
+def test_seed_differs_when_data_window_changes():
+    nav_rows_252 = _make_nav_rows(252)
+    nav_rows_253 = _make_nav_rows(253)
+    _, seed_252 = _build_mc_inputs(nav_rows_252, "fund-A")
+    _, seed_253 = _build_mc_inputs(nav_rows_253, "fund-A")
+
+    assert seed_252 != seed_253
+
+
+def test_seed_is_positive_int32():
+    """Seed must be positive and fit in 31 bits (0x7FFFFFFF mask)."""
+    nav_rows = _make_nav_rows(100)
+    _, seed = _build_mc_inputs(nav_rows, "fund-test")
+
+    assert seed >= 0
+    assert seed <= 0x7FFFFFFF
+
+
+def test_seed_with_single_row():
+    """Edge case: only 1 nav_row still produces valid seed."""
+    nav_rows = _make_nav_rows(1)
+    _, seed = _build_mc_inputs(nav_rows, "fund-single")
+
+    assert isinstance(seed, int)
+    assert seed >= 0

--- a/backend/tests/integration/test_model_portfolios_monte_carlo_caller.py
+++ b/backend/tests/integration/test_model_portfolios_monte_carlo_caller.py
@@ -1,0 +1,102 @@
+"""Caller-side regression tests for S05-F14 (model_portfolios route MC caller).
+
+Validates:
+1. None daily_return values are filtered, not zero-substituted.
+2. Deterministic seed derived from portfolio_id + data window.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from app.domains.wealth.routes.model_portfolios import _build_mc_inputs
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _make_nav_rows(
+    n: int,
+    *,
+    none_every: int | None = None,
+    base_date: date = date(2023, 1, 1),
+) -> list:
+    """Create mock NavRow-like objects with optional None daily_return."""
+    rows = []
+    for i in range(n):
+        if none_every and i % none_every == 0:
+            ret = None
+        else:
+            ret = 0.001 + i * 0.0001
+        rows.append(MagicMock(daily_return=ret, nav_date=base_date + timedelta(days=i)))
+    return rows
+
+
+# ── F14 angle 1: None values dropped, not zero-substituted ────────────
+
+
+def test_filters_none_daily_returns():
+    """100 rows with 20 None → array len=80, no synthetic zeros."""
+    nav_rows = _make_nav_rows(100, none_every=5)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "portfolio-abc")
+
+    assert len(daily_returns) == 80
+    assert 0.0 not in daily_returns.tolist()
+
+
+def test_all_valid_returns_preserved():
+    """When no None values, all rows pass through."""
+    nav_rows = _make_nav_rows(50)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "portfolio-xyz")
+
+    assert len(daily_returns) == 50
+
+
+def test_all_none_returns_empty_array():
+    """Edge case: all None → empty array (engine will catch T < 42)."""
+    nav_rows = _make_nav_rows(10, none_every=1)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "portfolio-empty")
+
+    assert len(daily_returns) == 0
+
+
+# ── F14 angle 2: deterministic seed from input ────────────────────────
+
+
+def test_seed_is_deterministic_for_same_inputs():
+    """Same portfolio_id + same nav window → same seed."""
+    nav_rows = _make_nav_rows(252)
+    _, seed1 = _build_mc_inputs(nav_rows, "portfolio-abc")
+    _, seed2 = _build_mc_inputs(nav_rows, "portfolio-abc")
+
+    assert seed1 == seed2
+
+
+def test_seed_differs_for_different_portfolios():
+    nav_rows = _make_nav_rows(252)
+    _, seed_a = _build_mc_inputs(nav_rows, "portfolio-A")
+    _, seed_b = _build_mc_inputs(nav_rows, "portfolio-B")
+
+    assert seed_a != seed_b
+
+
+def test_seed_differs_when_data_window_changes():
+    nav_rows_252 = _make_nav_rows(252)
+    nav_rows_253 = _make_nav_rows(253)
+    _, seed_252 = _build_mc_inputs(nav_rows_252, "portfolio-A")
+    _, seed_253 = _build_mc_inputs(nav_rows_253, "portfolio-A")
+
+    assert seed_252 != seed_253
+
+
+def test_seed_is_positive_int32():
+    """Seed must be positive and fit in 31 bits (0x7FFFFFFF mask)."""
+    nav_rows = _make_nav_rows(100)
+    _, seed = _build_mc_inputs(nav_rows, "portfolio-test")
+
+    assert seed >= 0
+    assert seed <= 0x7FFFFFFF


### PR DESCRIPTION
## Summary
Two caller-side fixes for Monte Carlo invocation in `analytics.py` and `model_portfolios.py`:
- None `daily_return` values now filtered (was: substituted with 0.0 → block bootstrap bias).
- Deterministic seed derived from request inputs via `zlib.crc32` (was: no seed → non-reproducible across requests).
- Extracted `_build_mc_inputs` helper in each route for clean unit testing.
- Closes Wave 6 Session 05 100% — was the last handoff item from S05-F14.

## Wave 6 Session 05 closure
- This is PR #7 of Session 05 (after Q44-Q49 engine fixes).
- Reference: `docs/audits/audit-validation-session05.md` S05-F14

## Behavior change
| Scenario | Before | After |
|---|---|---|
| `nav_rows` has 20 of 100 with `None` daily_return | array len=100 with 20 zeros injected | array len=80 (None filtered) |
| Same fund, same data window, two requests | non-deterministic MC bands | identical MC output |
| Different fund or different data window | (already different) | different (correct) |
| Insufficient T post-filter | `degraded=True` (engine Q46 guard) | unchanged (engine catches) |

## Test plan
- [x] None values filtered, not zero-substituted (8+7 tests)
- [x] Same inputs → same seed (reproducibility)
- [x] Different fund/portfolio → different seed
- [x] Different data window → different seed
- [x] Seed is positive int32 (0x7FFFFFFF mask)
- [x] No engine MC regressions (17 tests pass)
- [x] `ruff check` clean
- [x] `mypy` — 2 pre-existing errors only (unrelated to changes)

## Pre-flight reverse-subsumption check
- `grep -rn "daily_return.*0.0|else 0.0" backend/tests/` — no tests asserting on synthetic-zero behavior for MC callers
- `grep -rn "monte_carlo|run_monte_carlo" backend/tests/integration/` — no existing MC integration tests (before this PR)
- `grep -rn "/analytics/monte" backend/tests/` — no existing endpoint tests for MC route

No reverse-subsumption risk detected.

## Blast radius
- Two route handlers; both follow same fix pattern.
- MC results for funds with ANY None daily_return will shift (zeros no longer in distribution). Correct behavior; old behavior biased risk projections.
- All future MC requests for the same `(entity_id, data_window)` will be reproducible.
- No DB migration. No frontend type change.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: caller-side data filtering + seed derivation only. MC output changes are correctness improvements (less biased risk projections). Redis cache will naturally expire (1h TTL) and repopulate with corrected values.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>