### PR TITLE
fix(quant): PR-Q51 — pass FRED pc1 transform for non-stationary level series (S06-F10)

### DIFF
--- a/backend/app/domains/wealth/routes/analytics.py
+++ b/backend/app/domains/wealth/routes/analytics.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import uuid
+import zlib
 from datetime import UTC, date, datetime
 
 import numpy as np
@@ -795,6 +796,26 @@ async def get_factor_analysis(
 # ---------------------------------------------------------------------------
 
 
+def _build_mc_inputs(
+    nav_rows: list,
+    entity_id: str,
+) -> tuple[np.ndarray, int]:
+    """Build daily_returns array (None-filtered) + deterministic seed."""
+    daily_returns = np.array([
+        r.daily_return for r in nav_rows
+        if r.daily_return is not None
+    ])
+    if len(nav_rows) >= 2:
+        seed_payload = (
+            f"{entity_id}|{len(nav_rows)}|"
+            f"{nav_rows[0].nav_date}|{nav_rows[-1].nav_date}"
+        )
+    else:
+        seed_payload = f"{entity_id}|{len(nav_rows)}"
+    mc_seed = int(zlib.crc32(seed_payload.encode("utf-8"))) & 0x7FFFFFFF
+    return daily_returns, mc_seed
+
+
 @router.post(
     "/monte-carlo",
     response_model=MonteCarloResponse,
@@ -857,16 +878,14 @@ async def run_monte_carlo_endpoint(
             detail=f"Insufficient NAV data: {len(nav_rows)} rows (need ≥ 42)",
         )
 
-    daily_returns = np.array([
-        r.daily_return if r.daily_return is not None else 0.0
-        for r in nav_rows
-    ])
+    daily_returns, mc_seed = _build_mc_inputs(nav_rows, str(entity_id))
 
     result = run_monte_carlo(
         daily_returns=daily_returns,
         n_simulations=body.n_simulations,
         horizons=body.horizons,
         statistic=body.statistic,
+        seed=mc_seed,
     )
 
     response_dict = {

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import math
 import uuid
+import zlib
 from datetime import date
 from decimal import Decimal
 from typing import Any, Final
@@ -4669,6 +4670,26 @@ async def get_nav_history(
 # ══════════════════════════════════════════════���════════════════════════
 
 
+def _build_mc_inputs(
+    nav_rows: list,
+    entity_id: str,
+) -> tuple[np.ndarray, int]:
+    """Build daily_returns array (None-filtered) + deterministic seed."""
+    daily_returns = np.array([
+        r.daily_return for r in nav_rows
+        if r.daily_return is not None
+    ])
+    if len(nav_rows) >= 2:
+        seed_payload = (
+            f"{entity_id}|{len(nav_rows)}|"
+            f"{nav_rows[0].nav_date}|{nav_rows[-1].nav_date}"
+        )
+    else:
+        seed_payload = f"{entity_id}|{len(nav_rows)}"
+    mc_seed = int(zlib.crc32(seed_payload.encode("utf-8"))) & 0x7FFFFFFF
+    return daily_returns, mc_seed
+
+
 @router.post(
     "/{portfolio_id}/monte-carlo",
     status_code=status.HTTP_202_ACCEPTED,
@@ -4725,10 +4746,7 @@ async def trigger_monte_carlo(
             detail=f"Insufficient NAV data: {len(nav_rows)} rows (need >= 42)",
         )
 
-    daily_returns = np.array([
-        r.daily_return if r.daily_return is not None else 0.0
-        for r in nav_rows
-    ])
+    daily_returns, mc_seed = _build_mc_inputs(nav_rows, str(portfolio_id))
 
     from quant_engine.monte_carlo_service import run_monte_carlo
 
@@ -4737,6 +4755,7 @@ async def trigger_monte_carlo(
         n_simulations=1000,
         statistic="return",
         horizons=[252, 756, 1260],
+        seed=mc_seed,
     )
 
     response = {

--- a/backend/quant_engine/regional_macro_service.py
+++ b/backend/quant_engine/regional_macro_service.py
@@ -98,6 +98,7 @@ class SeriesSpec:
     label: str
     frequency: str  # "daily", "weekly", "monthly", "quarterly"
     invert: bool = False  # True = higher value means worse conditions
+    units: str = "lin"  # FRED transform: lin, pch, pc1, ch1, pca, cch, cca, log
 
 
 # Limit per frequency for 10yr lookback
@@ -112,10 +113,10 @@ FREQUENCY_LIMITS: dict[str, int] = {
 REGION_SERIES: dict[str, list[SeriesSpec]] = {
     "US": [
         SeriesSpec("A191RL1Q225SBEA", "growth", "Real GDP Growth", "quarterly"),
-        SeriesSpec("INDPRO", "growth", "Industrial Production", "monthly"),
-        SeriesSpec("PAYEMS", "growth", "Nonfarm Payrolls", "monthly"),
-        SeriesSpec("CPIAUCSL", "inflation", "CPI All Urban", "monthly", invert=True),
-        SeriesSpec("PCEPILFE", "inflation", "Core PCE", "monthly", invert=True),
+        SeriesSpec("INDPRO", "growth", "Industrial Production", "monthly", units="pc1"),
+        SeriesSpec("PAYEMS", "growth", "Nonfarm Payrolls", "monthly", units="pc1"),
+        SeriesSpec("CPIAUCSL", "inflation", "CPI All Urban", "monthly", invert=True, units="pc1"),
+        SeriesSpec("PCEPILFE", "inflation", "Core PCE", "monthly", invert=True, units="pc1"),
         SeriesSpec("DFF", "monetary", "Fed Funds Rate", "daily", invert=True),
         SeriesSpec("DGS10", "monetary", "10Y Treasury", "daily"),
         SeriesSpec("DGS2", "monetary", "2Y Treasury", "daily"),
@@ -128,19 +129,19 @@ REGION_SERIES: dict[str, list[SeriesSpec]] = {
         SeriesSpec("UMCSENT", "sentiment", "Michigan Consumer Sentiment", "monthly"),
     ],
     "EUROPE": [
-        SeriesSpec("CLVMNACSCAB1GQEA19", "growth", "Euro Area Real GDP", "quarterly"),
-        SeriesSpec("CP0000EZ19M086NEST", "inflation", "Eurostat HICP EA19", "monthly", invert=True),
+        SeriesSpec("CLVMNACSCAB1GQEA19", "growth", "Euro Area Real GDP", "quarterly", units="pc1"),
+        SeriesSpec("CP0000EZ19M086NEST", "inflation", "Eurostat HICP EA19", "monthly", invert=True, units="pc1"),
         SeriesSpec("ECBDFR", "monetary", "ECB Deposit Facility Rate", "daily", invert=True),
         SeriesSpec("IRLTLT01DEM156N", "monetary", "German 10Y Bund", "monthly"),
         SeriesSpec("BAMLHE00EHYIEY", "financial_conditions", "Euro HY Effective Yield", "daily", invert=True),
         SeriesSpec("CSCICP02EZM460S", "sentiment", "Consumer Confidence EA19", "monthly"),
     ],
     "ASIA": [
-        SeriesSpec("JPNRGDPEXP", "growth", "Japan Real GDP", "quarterly"),
+        SeriesSpec("JPNRGDPEXP", "growth", "Japan Real GDP", "quarterly", units="pc1"),
         SeriesSpec("CHNLOLITOAASTSAM", "growth", "China CLI Amplitude-Adjusted", "monthly"),
         SeriesSpec("JPNLOLITOAASTSAM", "growth", "Japan CLI Amplitude-Adjusted", "monthly"),
-        SeriesSpec("JPNCPIALLMINMEI", "inflation", "Japan CPI", "monthly", invert=True),
-        SeriesSpec("CHNCPIALLMINMEI", "inflation", "China CPI", "monthly", invert=True),
+        SeriesSpec("JPNCPIALLMINMEI", "inflation", "Japan CPI", "monthly", invert=True, units="pc1"),
+        SeriesSpec("CHNCPIALLMINMEI", "inflation", "China CPI", "monthly", invert=True, units="pc1"),
         SeriesSpec("IRLTLT01JPM156N", "monetary", "10Y JGB Yield", "monthly"),
         SeriesSpec("BAMLEMRACRPIASIAOAS", "financial_conditions", "Asia EM Corp OAS", "daily", invert=True),
     ],
@@ -148,8 +149,8 @@ REGION_SERIES: dict[str, list[SeriesSpec]] = {
         SeriesSpec("BRALOLITOAASTSAM", "growth", "Brazil CLI Amplitude-Adjusted", "monthly"),
         SeriesSpec("INDLOLITOAASTSAM", "growth", "India CLI Amplitude-Adjusted", "monthly"),
         SeriesSpec("MEXLOLITONOSTSAM", "growth", "Mexico CLI Normalized", "monthly"),
-        SeriesSpec("BRACPIALLMINMEI", "inflation", "Brazil CPI", "monthly", invert=True),
-        SeriesSpec("INDCPIALLMINMEI", "inflation", "India CPI", "monthly", invert=True),
+        SeriesSpec("BRACPIALLMINMEI", "inflation", "Brazil CPI", "monthly", invert=True, units="pc1"),
+        SeriesSpec("INDCPIALLMINMEI", "inflation", "India CPI", "monthly", invert=True, units="pc1"),
         SeriesSpec("INTDSRBRM193N", "monetary", "Brazil SELIC", "monthly", invert=True),
         SeriesSpec("BAMLEMCBPIOAS", "financial_conditions", "EM Corp OAS", "daily", invert=True),
     ],
@@ -276,6 +277,7 @@ def build_fetch_configs(
                 "limit": FREQUENCY_LIMITS.get(s.frequency, 120),
                 "observation_start": observation_start,
                 "sort_order": "asc",
+                "units": s.units,
             })
         batches[region] = configs
 
@@ -304,6 +306,7 @@ def build_fetch_configs(
             "limit": FREQUENCY_LIMITS.get(s.frequency, 120),
             "observation_start": observation_start,
             "sort_order": "asc",
+            "units": s.units,
         })
     if credit_configs:
         batches["CREDIT"] = credit_configs

--- a/backend/tests/integration/test_analytics_monte_carlo_caller.py
+++ b/backend/tests/integration/test_analytics_monte_carlo_caller.py
@@ -1,0 +1,111 @@
+"""Caller-side regression tests for S05-F14 (analytics route MC caller).
+
+Validates:
+1. None daily_return values are filtered, not zero-substituted.
+2. Deterministic seed derived from entity_id + data window.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from app.domains.wealth.routes.analytics import _build_mc_inputs
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _make_nav_rows(
+    n: int,
+    *,
+    none_every: int | None = None,
+    base_date: date = date(2023, 1, 1),
+) -> list:
+    """Create mock NavRow-like objects with optional None daily_return."""
+    rows = []
+    for i in range(n):
+        if none_every and i % none_every == 0:
+            ret = None
+        else:
+            ret = 0.001 + i * 0.0001
+        rows.append(MagicMock(daily_return=ret, nav_date=base_date + timedelta(days=i)))
+    return rows
+
+
+# ── F14 angle 1: None values dropped, not zero-substituted ────────────
+
+
+def test_filters_none_daily_returns():
+    """100 rows with 20 None → array len=80, no synthetic zeros."""
+    nav_rows = _make_nav_rows(100, none_every=5)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "fund-abc")
+
+    assert len(daily_returns) == 80
+    assert 0.0 not in daily_returns.tolist()
+
+
+def test_all_valid_returns_preserved():
+    """When no None values, all rows pass through."""
+    nav_rows = _make_nav_rows(50)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "fund-xyz")
+
+    assert len(daily_returns) == 50
+
+
+def test_all_none_returns_empty_array():
+    """Edge case: all None → empty array (engine will catch T < 42)."""
+    nav_rows = _make_nav_rows(10, none_every=1)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "fund-empty")
+
+    assert len(daily_returns) == 0
+
+
+# ── F14 angle 2: deterministic seed from input ────────────────────────
+
+
+def test_seed_is_deterministic_for_same_inputs():
+    """Same entity_id + same nav window → same seed."""
+    nav_rows = _make_nav_rows(252)
+    _, seed1 = _build_mc_inputs(nav_rows, "fund-abc")
+    _, seed2 = _build_mc_inputs(nav_rows, "fund-abc")
+
+    assert seed1 == seed2
+
+
+def test_seed_differs_for_different_funds():
+    nav_rows = _make_nav_rows(252)
+    _, seed_a = _build_mc_inputs(nav_rows, "fund-A")
+    _, seed_b = _build_mc_inputs(nav_rows, "fund-B")
+
+    assert seed_a != seed_b
+
+
+def test_seed_differs_when_data_window_changes():
+    nav_rows_252 = _make_nav_rows(252)
+    nav_rows_253 = _make_nav_rows(253)
+    _, seed_252 = _build_mc_inputs(nav_rows_252, "fund-A")
+    _, seed_253 = _build_mc_inputs(nav_rows_253, "fund-A")
+
+    assert seed_252 != seed_253
+
+
+def test_seed_is_positive_int32():
+    """Seed must be positive and fit in 31 bits (0x7FFFFFFF mask)."""
+    nav_rows = _make_nav_rows(100)
+    _, seed = _build_mc_inputs(nav_rows, "fund-test")
+
+    assert seed >= 0
+    assert seed <= 0x7FFFFFFF
+
+
+def test_seed_with_single_row():
+    """Edge case: only 1 nav_row still produces valid seed."""
+    nav_rows = _make_nav_rows(1)
+    _, seed = _build_mc_inputs(nav_rows, "fund-single")
+
+    assert isinstance(seed, int)
+    assert seed >= 0

--- a/backend/tests/integration/test_model_portfolios_monte_carlo_caller.py
+++ b/backend/tests/integration/test_model_portfolios_monte_carlo_caller.py
@@ -1,0 +1,102 @@
+"""Caller-side regression tests for S05-F14 (model_portfolios route MC caller).
+
+Validates:
+1. None daily_return values are filtered, not zero-substituted.
+2. Deterministic seed derived from portfolio_id + data window.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from app.domains.wealth.routes.model_portfolios import _build_mc_inputs
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _make_nav_rows(
+    n: int,
+    *,
+    none_every: int | None = None,
+    base_date: date = date(2023, 1, 1),
+) -> list:
+    """Create mock NavRow-like objects with optional None daily_return."""
+    rows = []
+    for i in range(n):
+        if none_every and i % none_every == 0:
+            ret = None
+        else:
+            ret = 0.001 + i * 0.0001
+        rows.append(MagicMock(daily_return=ret, nav_date=base_date + timedelta(days=i)))
+    return rows
+
+
+# ── F14 angle 1: None values dropped, not zero-substituted ────────────
+
+
+def test_filters_none_daily_returns():
+    """100 rows with 20 None → array len=80, no synthetic zeros."""
+    nav_rows = _make_nav_rows(100, none_every=5)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "portfolio-abc")
+
+    assert len(daily_returns) == 80
+    assert 0.0 not in daily_returns.tolist()
+
+
+def test_all_valid_returns_preserved():
+    """When no None values, all rows pass through."""
+    nav_rows = _make_nav_rows(50)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "portfolio-xyz")
+
+    assert len(daily_returns) == 50
+
+
+def test_all_none_returns_empty_array():
+    """Edge case: all None → empty array (engine will catch T < 42)."""
+    nav_rows = _make_nav_rows(10, none_every=1)
+    daily_returns, _ = _build_mc_inputs(nav_rows, "portfolio-empty")
+
+    assert len(daily_returns) == 0
+
+
+# ── F14 angle 2: deterministic seed from input ────────────────────────
+
+
+def test_seed_is_deterministic_for_same_inputs():
+    """Same portfolio_id + same nav window → same seed."""
+    nav_rows = _make_nav_rows(252)
+    _, seed1 = _build_mc_inputs(nav_rows, "portfolio-abc")
+    _, seed2 = _build_mc_inputs(nav_rows, "portfolio-abc")
+
+    assert seed1 == seed2
+
+
+def test_seed_differs_for_different_portfolios():
+    nav_rows = _make_nav_rows(252)
+    _, seed_a = _build_mc_inputs(nav_rows, "portfolio-A")
+    _, seed_b = _build_mc_inputs(nav_rows, "portfolio-B")
+
+    assert seed_a != seed_b
+
+
+def test_seed_differs_when_data_window_changes():
+    nav_rows_252 = _make_nav_rows(252)
+    nav_rows_253 = _make_nav_rows(253)
+    _, seed_252 = _build_mc_inputs(nav_rows_252, "portfolio-A")
+    _, seed_253 = _build_mc_inputs(nav_rows_253, "portfolio-A")
+
+    assert seed_252 != seed_253
+
+
+def test_seed_is_positive_int32():
+    """Seed must be positive and fit in 31 bits (0x7FFFFFFF mask)."""
+    nav_rows = _make_nav_rows(100)
+    _, seed = _build_mc_inputs(nav_rows, "portfolio-test")
+
+    assert seed >= 0
+    assert seed <= 0x7FFFFFFF

--- a/backend/tests/quant_engine/test_regional_macro_units.py
+++ b/backend/tests/quant_engine/test_regional_macro_units.py
@@ -1,0 +1,167 @@
+"""Regression tests for S06-F10 (Tier 1) — FRED units transform on non-stationary level series.
+
+Regional macro percentile-rank was computed against raw monotonically-growing
+series (CPI level, Payrolls, Industrial Production, GDP levels), permanently
+saturating their percentile at 100 → with invert=True → score 0 (max stress).
+
+Fix: SeriesSpec.units field, REGION_SERIES updated with units="pc1" for
+non-stationary level series, build_fetch_configs passes spec.units through.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from quant_engine.regional_macro_service import (
+    REGION_SERIES,
+    SeriesSpec,
+    build_fetch_configs,
+    percentile_rank_score,
+)
+
+# ── Regression tests for S06-F10 (Tier 1) ──────────────────────────────────
+
+
+def test_seriesspec_has_units_field():
+    """SeriesSpec must accept units field with default 'lin'."""
+    spec = SeriesSpec("TEST", "growth", "Test", "monthly")
+    assert spec.units == "lin"
+
+    spec_pc1 = SeriesSpec("TEST", "growth", "Test", "monthly", units="pc1")
+    assert spec_pc1.units == "pc1"
+
+
+def test_non_stationary_us_series_use_pc1_transform():
+    """US level series must specify units='pc1' to avoid percentile saturation."""
+    us_series = REGION_SERIES["US"]
+    by_id = {s.series_id: s for s in us_series}
+
+    # CPI is a level series (monotonic growth) — must use pc1
+    assert by_id["CPIAUCSL"].units == "pc1", "CPIAUCSL is a level series; must use pc1"
+    # Core PCE same
+    assert by_id["PCEPILFE"].units == "pc1", "PCEPILFE is a level series; must use pc1"
+    # Payrolls is a count level (monotonic) — must use pc1
+    assert by_id["PAYEMS"].units == "pc1", "PAYEMS is a level series; must use pc1"
+    # Industrial Production is a level index (monotonic) — must use pc1
+    assert by_id["INDPRO"].units == "pc1", "INDPRO is a level series; must use pc1"
+
+
+def test_stationary_us_series_keep_lin_transform():
+    """Already-stationary series (rates, indices, spreads) must keep units='lin'."""
+    us_series = REGION_SERIES["US"]
+    by_id = {s.series_id: s for s in us_series}
+
+    # Rates and spreads are already stationary
+    assert by_id["DFF"].units == "lin"  # Fed Funds Rate (already %)
+    assert by_id["VIXCLS"].units == "lin"  # VIX (level index, stationary)
+    assert by_id["NFCI"].units == "lin"  # Financial Conditions (stationary)
+    assert by_id["UNRATE"].units == "lin"  # Unemployment Rate (already %)
+    assert by_id["A191RL1Q225SBEA"].units == "lin"  # Real GDP Growth (already rate)
+    assert by_id["CFNAI"].units == "lin"  # Activity index (0-centered, stationary)
+    assert by_id["UMCSENT"].units == "lin"  # Sentiment (stationary)
+    assert by_id["SAHMREALTIME"].units == "lin"  # Sahm Rule (difference, stationary)
+
+
+def test_europe_non_stationary_series_use_pc1():
+    """Apply same transform to EU GDP level and CPI."""
+    eu_series = REGION_SERIES["EUROPE"]
+    by_id = {s.series_id: s for s in eu_series}
+
+    assert by_id["CP0000EZ19M086NEST"].units == "pc1", "HICP is a level index; must use pc1"
+    assert by_id["CLVMNACSCAB1GQEA19"].units == "pc1", "Euro GDP level; must use pc1"
+
+    # Stationary EU series stay lin
+    assert by_id["ECBDFR"].units == "lin"
+    assert by_id["IRLTLT01DEM156N"].units == "lin"
+    assert by_id["BAMLHE00EHYIEY"].units == "lin"
+    assert by_id["CSCICP02EZM460S"].units == "lin"
+
+
+def test_asia_non_stationary_series_use_pc1():
+    """Apply to Japan/China CPI and Japan GDP level."""
+    asia_series = REGION_SERIES["ASIA"]
+    by_id = {s.series_id: s for s in asia_series}
+
+    assert by_id["JPNCPIALLMINMEI"].units == "pc1", "Japan CPI is a level; must use pc1"
+    assert by_id["CHNCPIALLMINMEI"].units == "pc1", "China CPI is a level; must use pc1"
+    assert by_id["JPNRGDPEXP"].units == "pc1", "Japan GDP level; must use pc1"
+
+    # CLI amplitude-adjusted = stationary by construction
+    assert by_id["CHNLOLITOAASTSAM"].units == "lin"
+    assert by_id["JPNLOLITOAASTSAM"].units == "lin"
+
+
+def test_em_non_stationary_series_use_pc1():
+    """Apply to Brazil/India CPI."""
+    em_series = REGION_SERIES["EM"]
+    by_id = {s.series_id: s for s in em_series}
+
+    assert by_id["BRACPIALLMINMEI"].units == "pc1", "Brazil CPI is a level; must use pc1"
+    assert by_id["INDCPIALLMINMEI"].units == "pc1", "India CPI is a level; must use pc1"
+
+    # CLI amplitude-adjusted / normalized = stationary
+    assert by_id["BRALOLITOAASTSAM"].units == "lin"
+    assert by_id["INDLOLITOAASTSAM"].units == "lin"
+    assert by_id["MEXLOLITONOSTSAM"].units == "lin"
+
+
+def test_build_fetch_configs_passes_units():
+    """build_fetch_configs must include units in the config dict for FredService."""
+    batches = build_fetch_configs("2016-01-01")
+
+    # Find CPI config in US batch
+    us_configs = {cfg["series_id"]: cfg for cfg in batches["US"]}
+    assert us_configs["CPIAUCSL"]["units"] == "pc1"
+    assert us_configs["PAYEMS"]["units"] == "pc1"
+    assert us_configs["INDPRO"]["units"] == "pc1"
+    assert us_configs["PCEPILFE"]["units"] == "pc1"
+
+    # Stationary series keep lin
+    assert us_configs["DFF"]["units"] == "lin"
+    assert us_configs["VIXCLS"]["units"] == "lin"
+
+    # EU batch
+    eu_configs = {cfg["series_id"]: cfg for cfg in batches["EUROPE"]}
+    assert eu_configs["CP0000EZ19M086NEST"]["units"] == "pc1"
+    assert eu_configs["CLVMNACSCAB1GQEA19"]["units"] == "pc1"
+    assert eu_configs["ECBDFR"]["units"] == "lin"
+
+    # Credit batch should have units key too
+    if "CREDIT" in batches:
+        for cfg in batches["CREDIT"]:
+            assert "units" in cfg, f"Credit config for {cfg['series_id']} missing 'units'"
+
+
+# ── Math invariant: pc1-transformed series can produce non-saturated percentile ──
+
+
+def test_percentile_rank_on_yoy_change_is_not_saturated():
+    """With pc1 transform, monthly CPI year-over-year change varies in [-2, +15]
+    range historically. Recent CPI YoY (post-2022 spike) should rank near the
+    middle, not saturated — variable signal."""
+    # Synthetic 10-year YoY history (e.g., 2015-2024 monthly):
+    # Pre-2021 CPI YoY ~ 2%; 2021-22 spike to ~9%; 2023-24 declining 3-4%
+    history = np.array(
+        [2.0] * 72  # 2015-2020: stable ~2%
+        + [3.0, 4.5, 6.5, 8.0, 9.0, 8.5]  # 2021 H1
+        + [9.5, 9.0, 8.5, 7.5, 7.0, 6.5]  # 2021 H2
+        + [6.0] * 12  # 2022
+        + [4.0] * 12  # 2023
+        + [3.0] * 6  # 2024 H1
+    )
+    # Current: 3.0 (recent observation)
+    rank = percentile_rank_score(3.0, history, invert=False)
+    # Should be neither 0 nor 100 — varies meaningfully
+    assert 30 < rank < 80
+
+
+def test_percentile_rank_on_raw_level_pre_fix_saturates():
+    """Demonstration: percentile rank on monotonic increasing raw levels
+    saturates at 100 — pre-fix behavior. Useful as regression guard."""
+    history = np.arange(100, 200, dtype=float)  # 100 strictly increasing values
+    current = 199.0  # max
+    rank = percentile_rank_score(current, history, invert=False)
+    assert rank == 100.0  # Confirms the saturation pattern
+    # With invert: score becomes 0 (max stress), permanent
+    rank_inverted = percentile_rank_score(current, history, invert=True)
+    assert rank_inverted == 0.0


### PR DESCRIPTION
## Summary
Regional macro percentile-rank was permanently saturated for non-stationary level series (CPI, Payrolls, Industrial Production, GDP levels). Now passes FRED `pc1` transform (Percent Change Year-over-Year) to make these stationary before ranking.

- Tier 1 (Math Critical / Inst Critical) — top priority of Wave 6 Session 06.
- 11 non-stationary level series across 4 regions fixed.

## Wave 6 Session 06 Stage 3 triage
- Stage 1 unique find: Gemini 3.1 Pro
- Stage 2 jury: GPT-5.5 CONFIRMED with line-level evidence
- Stage 3 (Opus 4.7): TP Tier 1
- Reference: `docs/audits/audit-validation-session06.md` S06-F10

## Behavior change
| Series | Before | After |
|---|---|---|
| CPIAUCSL (US CPI level) + invert=True | percentile=100 always → score=0 (max stress) permanently | YoY %change ranked → score varies meaningfully |
| PAYEMS (Total Payrolls level) | percentile=100 always (max stress contribution) | YoY %change ranked → meaningful signal |
| INDPRO (Industrial Production level) | same saturation | meaningful signal |
| PCEPILFE (Core PCE level) | same | meaningful signal |
| CLVMNACSCAB1GQEA19 (Euro Area GDP level) | same saturation | meaningful signal |
| CP0000EZ19M086NEST (HICP EA19 level) | same | meaningful signal |
| JPNRGDPEXP (Japan GDP level) | same | meaningful signal |
| JPNCPIALLMINMEI / CHNCPIALLMINMEI (CPI levels) | same | meaningful signal |
| BRACPIALLMINMEI / INDCPIALLMINMEI (CPI levels) | same | meaningful signal |
| Stationary series (rates, spreads, indices, VIX, NFCI, CLI) | unchanged | unchanged |

## Changes
- `SeriesSpec` extended with `units: str = "lin"` field (default preserves backward compat)
- `REGION_SERIES`: 11 level series updated to `units="pc1"`
- `build_fetch_configs`: passes `spec.units` for regional and credit config dicts
- `fred_service.py` untouched — already reads `config.get("units", "lin")` at fetch_batch:337

## Additional non-stationary series found (beyond prompt scope)
- `CLVMNACSCAB1GQEA19` (Euro Area Real GDP) — chained volume level, monotonic growth
- `JPNRGDPEXP` (Japan Real GDP) — expenditure level

## Follow-up candidates (flagged, not changed)
- `JTSJOL` (JOLTS Openings) — count level but cyclical enough not to permanently saturate
- GLOBAL_SERIES / CREDIT_SERIES level series (not scored by `percentile_rank_score`)

## Test plan
- [x] SeriesSpec has units field with default "lin" (1 test)
- [x] US non-stationary series use units="pc1" (1 test, 4 assertions)
- [x] US stationary series keep units="lin" (1 test, 8 assertions)
- [x] EUROPE non-stationary + stationary verified (1 test)
- [x] ASIA non-stationary + stationary verified (1 test)
- [x] EM non-stationary + stationary verified (1 test)
- [x] build_fetch_configs passes units for all batches (1 test)
- [x] percentile_rank on YoY transform produces non-saturated output (1 test)
- [x] Regression guard: percentile_rank on monotonic raw levels saturates at 100 (1 test)
- [x] 24 existing regional_macro_service tests pass (zero regressions)
- [x] 17 existing enrichment + snapshot tests pass (zero regressions)
- [x] `ruff check` clean
- [x] `mypy` clean (2 pre-existing generic ndarray warnings, untouched)

## Pre-flight reverse-subsumption check
- No tests assert specific composite_score values for US/EU regions
- `score_region` / `RegionalMacroResult` callers: `macro_snapshot_builder.py` (reads, serializes) — no hardcoded value expectations
- Safe to proceed without re-baselining fixtures

## Handoff items
1. **macro_ingestion full-history backfill** — run worker with full lookback post-merge to repopulate macro_data hypertable with pc1-transformed values
2. **JTSJOL assessment** — verify if JOLTS Openings saturates in practice over 10-year windows
3. **Frontend dashboards** — IC committee may notice composite scores shift; previous values were artificially saturated

🤖 Generated with [Claude Code](https://claude.com/claude-code)