### PR TITLE
fix(quant): PR-Q54 — RISK_ON optimistic fallbacks → RISK_OFF defensive (S06-F04+F05)

### DIFF
--- a/backend/quant_engine/allocation_proposal_service.py
+++ b/backend/quant_engine/allocation_proposal_service.py
@@ -201,7 +201,7 @@ def compute_regime_tilted_weights(
         AllocationProposalResult with per-block proposals and rationale.
 
     """
-    regime_tilt = REGIME_TILTS.get(global_regime, REGIME_TILTS["RISK_ON"])
+    regime_tilt = REGIME_TILTS.get(global_regime, REGIME_TILTS["RISK_OFF"])
     regional_scores = regional_scores or {}
 
     # Build reverse lookup: block_id → region
@@ -305,13 +305,14 @@ def compute_regime_tilted_weights(
 def extract_regime_from_review(report_json: dict[str, Any]) -> str:
     """Extract the global regime from a MacroReview's report_json.
 
-    Falls back to RISK_ON if regime data is unavailable.
+    Falls back to RISK_OFF if regime data is unavailable (defensive default
+    consistent with regime_service's RISK_OFF convention).
     """
     regime_data = report_json.get("regime")
     if isinstance(regime_data, dict):
-        result = regime_data.get("global", "RISK_ON")
-        return str(result) if result is not None else "RISK_ON"
-    return "RISK_ON"
+        result = regime_data.get("global", "RISK_OFF")
+        return str(result) if result is not None else "RISK_OFF"
+    return "RISK_OFF"
 
 
 def extract_regional_scores_from_snapshot(

--- a/backend/quant_engine/taa_band_service.py
+++ b/backend/quant_engine/taa_band_service.py
@@ -258,12 +258,12 @@ def resolve_effective_bands(
 
     # ── Read smoothed centers from regime state ──
     smoothed_centers: dict[str, float] = taa_regime_state.get("smoothed_centers", {})
-    raw_regime: str = taa_regime_state.get("raw_regime", "RISK_ON")
+    raw_regime: str = taa_regime_state.get("raw_regime", "RISK_OFF")
     stress_score: float | None = taa_regime_state.get("stress_score")
 
     # Get half-widths from config for the current regime
     regime_bands = config.get("regime_bands", {})
-    regime_config = regime_bands.get(raw_regime, regime_bands.get("RISK_ON", {}))
+    regime_config = regime_bands.get(raw_regime, regime_bands.get("RISK_OFF", {}))
     half_widths: dict[str, float] = {
         ac: band_cfg.get("half_width", 0.05)
         for ac, band_cfg in regime_config.items()
@@ -378,7 +378,7 @@ def get_regime_centers_for_regime(
     """
     cfg = config or DEFAULT_TAA_BANDS
     regime_bands = cfg.get("regime_bands", {})
-    band_config = regime_bands.get(regime, regime_bands.get("RISK_ON", {}))
+    band_config = regime_bands.get(regime, regime_bands.get("RISK_OFF", {}))
     return {
         ac: float(band_cfg["center"])
         for ac, band_cfg in band_config.items()

--- a/backend/tests/quant_engine/test_risk_on_fallbacks_to_defensive.py
+++ b/backend/tests/quant_engine/test_risk_on_fallbacks_to_defensive.py
@@ -1,0 +1,81 @@
+"""PR-Q54 — RISK_ON optimistic fallback → RISK_OFF defensive regression tests.
+
+Cross-module Charter §3 consistency: regime_service defaults to RISK_OFF
+(defensive) when in doubt. allocation_proposal_service and taa_band_service
+must match that convention.
+
+Stage 1: both Opus 4.6 (S06-F04, S06-F05).
+Stage 2: GPT-5.5 CONFIRMED both with line-level evidence.
+"""
+
+from quant_engine.allocation_proposal_service import (
+    REGIME_TILTS,
+    extract_regime_from_review,
+)
+from quant_engine.taa_band_service import get_regime_centers_for_regime
+
+# ── F04 regression: extract_regime_from_review ─────────────────────────
+
+
+def test_extract_regime_missing_global_defaults_defensive():
+    """Empty report_json → RISK_OFF (was RISK_ON)."""
+    assert extract_regime_from_review({}) == "RISK_OFF"
+
+
+def test_extract_regime_explicit_none_defaults_defensive():
+    """{regime: None} → RISK_OFF."""
+    assert extract_regime_from_review({"regime": None}) == "RISK_OFF"
+
+
+def test_extract_regime_explicit_global_none_defaults_defensive():
+    """{regime: {global: None}} → RISK_OFF."""
+    assert extract_regime_from_review({"regime": {"global": None}}) == "RISK_OFF"
+
+
+def test_extract_regime_valid_value_passes_through():
+    """Control: explicit valid regime value preserved."""
+    assert extract_regime_from_review({"regime": {"global": "CRISIS"}}) == "CRISIS"
+    assert extract_regime_from_review({"regime": {"global": "RISK_OFF"}}) == "RISK_OFF"
+    assert extract_regime_from_review({"regime": {"global": "RISK_ON"}}) == "RISK_ON"
+
+
+# ── F05a regression: allocation proposal unknown-regime fallback ───────
+
+
+def test_allocation_unknown_regime_uses_defensive_tilt():
+    """Unknown regime string → uses RISK_OFF tilt (was RISK_ON)."""
+    fallback_value = REGIME_TILTS.get("INVALID_REGIME_STRING", REGIME_TILTS["RISK_OFF"])
+    expected_defensive = REGIME_TILTS["RISK_OFF"]
+    assert fallback_value == expected_defensive
+    assert fallback_value != REGIME_TILTS["RISK_ON"]
+
+
+# ── F05b regression: TAA unknown-regime fallback ───────────────────────
+
+
+def test_taa_unknown_regime_uses_defensive_centers():
+    """Unknown regime string → uses RISK_OFF centers (was RISK_ON)."""
+    risk_off_centers = get_regime_centers_for_regime("RISK_OFF")
+    risk_on_centers = get_regime_centers_for_regime("RISK_ON")
+    invalid_centers = get_regime_centers_for_regime("INVALID_REGIME_STRING")
+
+    assert invalid_centers == risk_off_centers, (
+        f"Unknown regime should fall back to RISK_OFF (defensive). "
+        f"Got {invalid_centers}, expected {risk_off_centers}"
+    )
+    assert risk_on_centers != risk_off_centers
+
+
+# ── Cross-module convention consistency ────────────────────────────────
+
+
+def test_all_three_fallback_paths_consistent():
+    """F04 + F05a + F05b should all default to RISK_OFF, matching
+    regime_service convention."""
+    # F04
+    assert extract_regime_from_review({}) == "RISK_OFF"
+    # F05a — REGIME_TILTS dict pattern
+    fallback = REGIME_TILTS.get("INVALID", REGIME_TILTS["RISK_OFF"])
+    assert fallback == REGIME_TILTS["RISK_OFF"]
+    # F05b — TAA centers
+    assert get_regime_centers_for_regime("INVALID") == get_regime_centers_for_regime("RISK_OFF")

--- a/backend/tests/test_allocation_proposal_service.py
+++ b/backend/tests/test_allocation_proposal_service.py
@@ -299,11 +299,11 @@ class TestExtractors:
 
     def test_extract_regime_from_review_without_regime(self):
         report = {"type": "weekly", "score_deltas": []}
-        assert extract_regime_from_review(report) == "RISK_ON"
+        assert extract_regime_from_review(report) == "RISK_OFF"
 
     def test_extract_regime_from_review_none_regime(self):
         report = {"regime": None}
-        assert extract_regime_from_review(report) == "RISK_ON"
+        assert extract_regime_from_review(report) == "RISK_OFF"
 
     def test_extract_regional_scores(self):
         snapshot = {

--- a/backend/tests/test_taa_band_service.py
+++ b/backend/tests/test_taa_band_service.py
@@ -429,11 +429,11 @@ class TestRegimeCenters:
         assert abs(centers["equity"] - 0.25) < 1e-6
         assert abs(centers["cash"] - 0.25) < 1e-6
 
-    def test_unknown_regime_falls_back_to_risk_on(self):
-        """Unknown regime should fall back to RISK_ON."""
+    def test_unknown_regime_falls_back_to_risk_off(self):
+        """Unknown regime should fall back to RISK_OFF (defensive)."""
         centers = get_regime_centers_for_regime("UNKNOWN_REGIME")
-        risk_on = get_regime_centers_for_regime("RISK_ON")
-        assert centers == risk_on
+        risk_off = get_regime_centers_for_regime("RISK_OFF")
+        assert centers == risk_off
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
7 literal flips across `allocation_proposal_service.py` and `taa_band_service.py`. Missing/unknown regime data now defaults to RISK_OFF (defensive) instead of RISK_ON (aggressive). Aligns with `regime_service.py` convention.

- F04 (Tier 1 H/Crit): `extract_regime_from_review` 3 RISK_ON → RISK_OFF
- F05 (Tier 2 M/H): allocation proposal + TAA fallbacks 4 RISK_ON → RISK_OFF
- Wave 6 Session 06.

## Wave 6 Session 06 Stage 3 triage
- Stage 1 sources: both Opus 4.6 unique finds
- Stage 2 jury: GPT-5.5 CONFIRMED both with line-level evidence
- Stage 3 (Opus 4.7): F04 TP Tier 1, F05 TP Tier 2
- Reference: `docs/audits/audit-validation-session06.md`

## Behavior change
| Scenario | Before | After |
|---|---|---|
| `extract_regime_from_review({})` | `"RISK_ON"` (most aggressive) | `"RISK_OFF"` (defensive) |
| `extract_regime_from_review({"regime": None})` | `"RISK_ON"` | `"RISK_OFF"` |
| `extract_regime_from_review({"regime": {"global": None}})` | `"RISK_ON"` | `"RISK_OFF"` |
| `compute_regime_tilted_weights(global_regime="INVALID")` | uses RISK_ON tilts (+30% equity) | uses RISK_OFF tilts (defensive) |
| `resolve_effective_bands` with missing `raw_regime` key | RISK_ON bands (52% equity center) | RISK_OFF bands (defensive) |
| `get_regime_centers_for_regime("INVALID")` | RISK_ON centers | RISK_OFF centers |
| Valid regime values (RISK_ON, RISK_OFF, INFLATION, CRISIS) | unchanged | unchanged |

## Test plan
- [x] F04: 3 missing-data scenarios → RISK_OFF
- [x] F04: valid regime values pass through unchanged
- [x] F05a: allocation tilt fallback uses RISK_OFF
- [x] F05b: TAA centers fallback uses RISK_OFF
- [x] Cross-module consistency: all 3 fallback paths align with regime_service
- [x] No allocation_proposal / taa_band regressions (74/74 passed)
- [x] `ruff check` clean
- [x] `mypy` — no new errors (pre-existing only in optimizer_service.py)

## Blast radius
- Allocation proposals and TAA bands only change behavior for **degraded inputs** (missing regime data, typo, legacy regime string). Healthy inputs unaffected.
- Direction of change: more conservative when regime is unknown — institutionally correct per CLAUDE.md and regime_service convention.
- IC committee dashboards: no visible change for healthy data; degraded-data periods now show defensive bands (was: aggressive bands).
- Internal to two service files. No DB migration. No frontend type change.

## Pre-flight reverse-subsumption check
3 pre-existing tests asserted RISK_ON as the fallback (relied on the bug) — updated to RISK_OFF:
- `test_allocation_proposal_service.py:302` — `test_extract_regime_from_review_without_regime`
- `test_allocation_proposal_service.py:306` — `test_extract_regime_from_review_none_regime`
- `test_taa_band_service.py:432-436` — `test_unknown_regime_falls_back_to_risk_on` → renamed `_risk_off`