### PR TITLE
fix(quant): PR-Q48+Q49 recovery — Session 05 Tier 1+4 fixes (S05-F06+F07+F08+F12)

### DIFF
--- a/backend/quant_engine/benchmark_composite_service.py
+++ b/backend/quant_engine/benchmark_composite_service.py
@@ -62,6 +62,17 @@ def compute_composite_nav(
     if weight_sum <= 0:
         return []
 
+    # ── F08 fix: weights must sum to ~1.0 per §3.4 contract ─────────
+    # A composite benchmark by definition allocates 100% across constituents.
+    # Tolerance 1e-4 absorbs float rounding; anything beyond is a caller
+    # input bug that would silently scale the composite return series.
+    if abs(weight_sum - 1.0) > 1e-4:
+        raise ValueError(
+            f"block_weights must sum to 1.0 (within 1e-4); got {weight_sum:.6f}. "
+            f"§3.4 contract: composite benchmark weights are by definition "
+            f"a unit allocation. Caller must normalize or correct input."
+        )
+
     # ── F01 fix: enforce latest-common-inception start date ─────────
     # A fixed-weight composite cannot exist before all constituents have
     # data.  Earlier dates would require phantom 100% weight on the

--- a/backend/quant_engine/black_litterman_service.py
+++ b/backend/quant_engine/black_litterman_service.py
@@ -388,6 +388,12 @@ def compute_bl_returns(
             p_row[long_idx] = 1.0
             p_row[short_idx] = -1.0
         else:
+            logger.warning(
+                "bl_legacy_unknown_view_type_skipped",
+                view_index=i,
+                view_type=vtype,
+                note="legacy compute_bl_returns; production uses compute_bl_posterior_multi_view",
+            )
             continue
 
         # Idzorek-style omega mapping:
@@ -426,7 +432,7 @@ def compute_bl_returns(
     # extreme tilts.
     try:
         prior_view = P @ pi                              # (K,)
-        view_cov = P @ sigma @ P.T                       # (K, K)
+        view_cov = P @ (tau_eff * sigma) @ P.T              # (K, K) — τΣ, not Σ
         view_sigma = np.sqrt(np.maximum(np.diag(view_cov), 0.0))
         residual = np.abs(Q - prior_view)
         threshold = 3.0 * view_sigma

--- a/backend/quant_engine/monte_carlo_service.py
+++ b/backend/quant_engine/monte_carlo_service.py
@@ -38,20 +38,20 @@ def _block_bootstrap_paths(
     n_simulations: int,
     horizon: int,
     block_size: int = 21,
-    rng: np.random.RandomState | None = None,
+    rng: np.random.Generator | None = None,
 ) -> np.ndarray:
     """Generate bootstrapped return paths via block bootstrap.
 
     Returns (n_simulations, horizon) array of simulated daily returns.
     """
     if rng is None:
-        rng = np.random.RandomState()
+        rng = np.random.default_rng()
 
     n = len(daily_returns)
     n_blocks = (horizon + block_size - 1) // block_size
 
     # Pre-compute all block start indices
-    starts = rng.randint(0, n - block_size + 1, size=(n_simulations, n_blocks))
+    starts = rng.integers(0, n - block_size + 1, size=(n_simulations, n_blocks))
 
     paths = np.empty((n_simulations, n_blocks * block_size))
     for b in range(n_blocks):
@@ -223,7 +223,7 @@ def run_monte_carlo(
             ),
         )
 
-    rng = np.random.RandomState(seed)
+    rng = np.random.default_rng(seed)
 
     # Primary simulation at the longest horizon
     primary_horizon = max(horizons)

--- a/backend/tests/quant_engine/test_benchmark_composite_weight_sum.py
+++ b/backend/tests/quant_engine/test_benchmark_composite_weight_sum.py
@@ -1,0 +1,113 @@
+"""Regression tests for S05-F08 — composite NAV weight_sum ≈ 1.0 invariant.
+
+§3.4 contract: weights must sum to 1.0 within tolerance (1e-4).
+Previously only validated weight_sum > 0; weights summing to 0.5 silently
+produced composite at 50% intended scale.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from quant_engine.benchmark_composite_service import compute_composite_nav
+
+
+def _nav(nav_date: date, return_1d: float) -> dict:
+    """Helper: build a single benchmark NAV dict row."""
+    return {"nav_date": nav_date, "return_1d": return_1d}
+
+
+# ── Regression tests for S05-F08 (Tier 3) ──────────────────────────────────
+
+
+def test_weights_summing_below_tolerance_raises():
+    """Weights summing to 0.5 must raise ValueError, not silently produce
+    composite at 50% intended scale."""
+    block_weights = {"a": 0.3, "b": 0.2}  # sum = 0.5
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    with pytest.raises(ValueError, match="must sum to 1.0"):
+        compute_composite_nav(block_weights, navs)
+
+
+def test_weights_summing_above_tolerance_raises():
+    """Weights summing to 1.2 must raise."""
+    block_weights = {"a": 0.7, "b": 0.5}  # sum = 1.2
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    with pytest.raises(ValueError, match="must sum to 1.0"):
+        compute_composite_nav(block_weights, navs)
+
+
+def test_weights_at_unit_pass():
+    """Control: weights summing to exactly 1.0 should work."""
+    block_weights = {"a": 0.6, "b": 0.4}
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    result = compute_composite_nav(block_weights, navs)
+    assert len(result) == 1
+    assert result[0].daily_return == pytest.approx(0.01, abs=1e-9)
+
+
+def test_weights_within_1e_minus_4_tolerance_pass():
+    """Tolerance: 1.00009 should pass (within 1e-4)."""
+    block_weights = {"a": 0.60005, "b": 0.40004}  # sum = 1.00009
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    # Should not raise
+    result = compute_composite_nav(block_weights, navs)
+    assert len(result) == 1
+
+
+def test_weights_just_outside_1e_minus_4_tolerance_raises():
+    """Boundary: 1.0002 (+2e-4 above) should raise."""
+    block_weights = {"a": 0.6001, "b": 0.4001}  # sum = 1.0002
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    with pytest.raises(ValueError, match="must sum to 1.0"):
+        compute_composite_nav(block_weights, navs)
+
+
+def test_error_message_includes_actual_weight_sum():
+    """Error message must include the offending sum for debuggability."""
+    block_weights = {"a": 0.3, "b": 0.2}
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    with pytest.raises(ValueError) as exc_info:
+        compute_composite_nav(block_weights, navs)
+    assert "0.5" in str(exc_info.value) or "0.500" in str(exc_info.value)
+
+
+# ── Existing-behavior preservation ─────────────────────────────────────
+
+
+def test_zero_weight_sum_returns_empty():
+    """Existing guard preserved: weight_sum <= 0 → empty result."""
+    block_weights = {"a": 0.0, "b": 0.0}
+    navs = {
+        "a": [_nav(date(2020, 1, 1), 0.01)],
+        "b": [_nav(date(2020, 1, 1), 0.01)],
+    }
+    result = compute_composite_nav(block_weights, navs)
+    assert result == []
+
+
+def test_negative_weight_sum_returns_empty():
+    block_weights = {"a": -0.1}
+    navs = {"a": [_nav(date(2020, 1, 1), 0.01)]}
+    result = compute_composite_nav(block_weights, navs)
+    assert result == []

--- a/backend/tests/quant_engine/test_session05_tier4_cleanup.py
+++ b/backend/tests/quant_engine/test_session05_tier4_cleanup.py
@@ -1,0 +1,205 @@
+"""PR-Q49 — Wave 6 Session 05 Tier 4 cleanup regression tests.
+
+Covers three independent low-severity fixes:
+    F06: Legacy compute_bl_returns logs warning on unknown view types.
+    F07: Monte Carlo migrated RandomState -> default_rng (Generator API).
+    F12: He-Litterman consistency check uses tau-scaled covariance.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+import structlog
+
+from quant_engine.black_litterman_service import compute_bl_returns
+from quant_engine.monte_carlo_service import run_monte_carlo
+
+# ── structlog capture (same pattern as test_mu_trace_instrumentation) ────
+
+
+def _capture_structlog_events() -> tuple[list[dict[str, Any]], Any]:
+    events: list[dict[str, Any]] = []
+
+    def _capture(_logger: Any, _method: str, event_dict: dict[str, Any]) -> dict[str, Any]:
+        events.append(dict(event_dict))
+        return event_dict
+
+    return events, _capture
+
+
+@pytest.fixture
+def captured_log_events() -> list[dict[str, Any]]:
+    events, processor = _capture_structlog_events()
+    original = structlog.get_config()
+    structlog.configure(
+        processors=[processor, *original["processors"]],
+        wrapper_class=original["wrapper_class"],
+        context_class=original["context_class"],
+        logger_factory=original["logger_factory"],
+        cache_logger_on_first_use=False,
+    )
+    try:
+        yield events
+    finally:
+        structlog.configure(**original)
+
+
+# ── F06: legacy unknown view type warning ────────────────────────────────
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_legacy_unknown_view_type_logs_warning(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """compute_bl_returns must log warning (not silently skip) on unknown
+    view types."""
+    sigma = np.eye(2) * 0.04
+    w_mkt = np.array([0.5, 0.5])
+
+    views = [
+        {"type": "sector_tilt", "asset_idx": 0, "Q": 0.06, "confidence": 0.5},
+        {"type": "absolute", "asset_idx": 0, "Q": 0.06, "confidence": 0.5},
+    ]
+
+    result = compute_bl_returns(sigma, w_mkt, views=views)
+
+    # Function still returns a posterior (only the absolute view applied)
+    assert result.shape == (2,)
+    assert all(np.isfinite(result))
+
+    # Warning must have been emitted for the sector_tilt skip
+    skip_events = [
+        e for e in captured_log_events
+        if e.get("event") == "bl_legacy_unknown_view_type_skipped"
+    ]
+    assert len(skip_events) == 1
+    assert skip_events[0]["view_type"] == "sector_tilt"
+    assert skip_events[0]["view_index"] == 0
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_legacy_all_unknown_views_returns_equilibrium(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """If all views are unknown types, result equals equilibrium (pi)."""
+    sigma = np.eye(2) * 0.04
+    w_mkt = np.array([0.5, 0.5])
+
+    views = [
+        {"type": "bogus", "Q": 0.10, "confidence": 0.5},
+    ]
+
+    result = compute_bl_returns(sigma, w_mkt, views=views)
+    pi = 2.5 * sigma @ w_mkt
+    np.testing.assert_allclose(result, pi, atol=1e-10)
+
+    skip_events = [
+        e for e in captured_log_events
+        if e.get("event") == "bl_legacy_unknown_view_type_skipped"
+    ]
+    assert len(skip_events) == 1
+
+
+# ── F07: MC uses default_rng (Generator), not RandomState ───────────────
+
+
+def test_mc_seed_determinism_post_migration() -> None:
+    """Same seed must produce identical MC results after RandomState ->
+    default_rng migration."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0005, 0.01, 300)
+
+    r1 = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=200)
+    r2 = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=200)
+
+    assert r1.n_simulations > 0
+    assert r2.n_simulations > 0
+    assert r1.mean == r2.mean
+    assert r1.std == r2.std
+    assert r1.percentiles == r2.percentiles
+
+
+def test_mc_different_seeds_differ() -> None:
+    """Different seeds produce different results (sanity check)."""
+    rng = np.random.default_rng(42)
+    daily = rng.normal(0.0005, 0.01, 300)
+
+    r1 = run_monte_carlo(daily, horizons=[252], seed=42, n_simulations=200)
+    r2 = run_monte_carlo(daily, horizons=[252], seed=99, n_simulations=200)
+
+    assert r1.n_simulations > 0
+    assert r2.n_simulations > 0
+    # Very unlikely to be identical with different seeds
+    assert r1.mean != r2.mean
+
+
+# ── F12: He-Litterman tau-scaled consistency check ───────────────────────
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_he_litterman_warning_fires_with_tau_scaled_variance(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """With tau_eff scaling, a view 4 sigma from prior (under tau*Sigma)
+    should trigger the He-Litterman warning.
+
+    Pre-fix: warning used unscaled Sigma -> effective threshold was ~13.4 sigma
+    -> view at 0.9 sigma (under Sigma) never fired.
+    Post-fix: warning fires at documented 3 sigma threshold against tau*Sigma.
+
+    Setup:
+        sigma = diag(0.04, 0.04), tau_eff = 0.05
+        pi = 2.5 * sigma @ [0.5, 0.5] = [0.05, 0.05]
+        Under tau*Sigma: view_std = sqrt(0.05 * 0.04) = 0.04472
+        View Q = 0.05 + 0.18 = 0.23 -> z = 0.18 / 0.04472 ~ 4.02 > 3.0
+        Under plain Sigma (pre-fix): view_std = 0.2, z = 0.18/0.2 = 0.9 < 3.0
+    """
+    sigma = np.eye(2) * 0.04
+    w_mkt = np.array([0.5, 0.5])
+    tau_eff = 0.05
+
+    # View 4 sigma away from prior under tau*Sigma
+    views = [
+        {"type": "absolute", "asset_idx": 0, "Q": 0.23, "confidence": 0.5},
+    ]
+
+    result = compute_bl_returns(sigma, w_mkt, views=views, tau=tau_eff)
+    assert result.shape == (2,)
+
+    inconsistent_events = [
+        e for e in captured_log_events
+        if e.get("event") == "black_litterman_view_inconsistent_with_prior"
+    ]
+    assert len(inconsistent_events) == 1
+    assert inconsistent_events[0]["n_flagged"] == 1
+    # z-score should be ~4.0 under tau*Sigma
+    assert inconsistent_events[0]["max_z"] > 3.5
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_he_litterman_no_warning_for_mild_view(
+    captured_log_events: list[dict[str, Any]],
+) -> None:
+    """A view within 2 sigma (under tau*Sigma) should NOT trigger the
+    He-Litterman warning."""
+    sigma = np.eye(2) * 0.04
+    w_mkt = np.array([0.5, 0.5])
+    tau_eff = 0.05
+
+    # view_std under tau*Sigma = sqrt(0.05 * 0.04) = 0.04472
+    # 2 sigma = 0.0894; Q = 0.05 + 0.08 = 0.13 -> z ~ 1.79 < 3.0
+    views = [
+        {"type": "absolute", "asset_idx": 0, "Q": 0.13, "confidence": 0.5},
+    ]
+
+    result = compute_bl_returns(sigma, w_mkt, views=views, tau=tau_eff)
+    assert result.shape == (2,)
+
+    inconsistent_events = [
+        e for e in captured_log_events
+        if e.get("event") == "black_litterman_view_inconsistent_with_prior"
+    ]
+    assert len(inconsistent_events) == 0

--- a/backend/tests/test_monte_carlo_service.py
+++ b/backend/tests/test_monte_carlo_service.py
@@ -35,7 +35,7 @@ class TestBlockBootstrap:
         daily = _make_daily_returns()
         paths = _block_bootstrap_paths(
             daily, n_simulations=10, horizon=63, block_size=21,
-            rng=np.random.RandomState(0),
+            rng=np.random.default_rng(0),
         )
         original_set = set(daily.tolist())
         for i in range(paths.shape[0]):
@@ -47,7 +47,7 @@ class TestBlockBootstrap:
         daily = _make_daily_returns()
         paths = _block_bootstrap_paths(
             daily, n_simulations=1, horizon=42, block_size=21,
-            rng=np.random.RandomState(7),
+            rng=np.random.default_rng(7),
         )
         path = paths[0]
         # First block of 21 should appear contiguously in daily


### PR DESCRIPTION
## Summary

Recovery PR closing Session 05 audit. Replaces #345 (Q48) and #347 (Q49) which had stale branch bases that would have rolled back ~588 lines of regression tests for Q44/Q46/Q54/Q55/Q56 work already in main.

Surgically re-applies the 4 findings:

| Finding | Tier | File | Change |
|---|---|---|---|
| S05-F08 | T1 (Crit/Crit) | benchmark_composite_service.py | weight_sum 1.0 invariant guard |
| S05-F06 | T4 | black_litterman_service.py | warn on unknown view types in legacy compute_bl_returns |
| S05-F07 | T4 | monte_carlo_service.py | RandomState → default_rng (Generator API) |
| S05-F12 | T4 | black_litterman_service.py | He-Litterman consistency uses tau-scaled covariance |

## Test plan

- [x] 8 new tests in test_benchmark_composite_weight_sum.py — all pass
- [x] 6 new tests in test_session05_tier4_cleanup.py — all pass
- [x] 17 existing tests in test_monte_carlo_service.py — all pass after fixture RNG update
- [x] ruff check passes on all modified files
- [ ] CI verde

## Context

Q48 (#345) and Q49 (#347) PR branches diverged from main before Q44/Q46/Q54/Q55/Q56 landed via bundled commits. As-is they would delete:
- test_black_litterman_nan_linalg_safety.py (115 lines, Q44)
- test_data_commons_api_error.py (83 lines)
- test_monte_carlo_zero_variance_degraded.py (58 lines, Q46)
- test_regime_cleanup_terminus.py (77 lines, Q56)
- test_regional_macro_micro_fixes.py (174 lines, Q55)
- test_risk_on_fallbacks_to_defensive.py (81 lines, Q54)

Backup tag: \`backup/pre-merge-cleanup-2026-04-27\`

## Pre-existing failures noted

\`tests/quant_engine/test_optimizer_missing_expected_returns.py::test_optimize_portfolio_pareto_succeeds_with_complete_expected_returns\` failing on main pre-existing — unrelated to this PR. Tracked for follow-up.