### PR TITLE
fix(quant): PR-Q57 — expense ratio threshold (S07-F03) — Tier 1 Crit/Crit

### DIFF
--- a/backend/quant_engine/expense_ratio_validator.py
+++ b/backend/quant_engine/expense_ratio_validator.py
@@ -50,8 +50,21 @@ def to_decimal_fraction(value: Any) -> float | None:
     * ``NaN`` / ``±inf`` → ``None`` (defensive — upstream sometimes
       emits these when a division collapses).
     * ``abs(value) > 100`` → assume basis points, divide by 10 000.
-    * ``abs(value) > 1.0`` → assume whole percent, divide by 100.
-    * Otherwise → already a decimal fraction, keep as-is.
+    * ``abs(value) > MAX_REASONABLE_EXPENSE_RATIO`` (0.15) → assume
+      whole percent, divide by 100.
+    * Otherwise (``[0, 0.15]``) → already a decimal fraction, keep
+      as-is.
+
+    **Band-ambiguity note (PR-Q57, S07-F03):** inputs in ``(0.15, 1.0]``
+    are now classified as whole percent rather than fraction. This fixes
+    the dominant defect class (N-CEN exports emitting ``0.5`` for 0.5 %)
+    but introduces a narrow ambiguity: a value like ``0.10`` intended as
+    a decimal fraction (= 10 %) would instead be treated as the whole
+    percent 0.10 % (= 0.001 fraction). In practice XBRL canonical
+    fractions in this range are extremely rare (virtually all lie below
+    0.05), and the false-positive cost (treating 10 % as 0.10 %) is far
+    lower than the false-negative cost (treating 0.5 % as 50 %, which
+    collapsed fee_efficiency to 0 for ~60 % of index/ETF funds).
 
     After conversion the result is clamped into the
     ``[MIN_REASONABLE_EXPENSE_RATIO, MAX_REASONABLE_EXPENSE_RATIO]``
@@ -73,7 +86,7 @@ def to_decimal_fraction(value: Any) -> float | None:
     if abs_v > 100.0:
         fraction = v / 10_000.0  # basis points → fraction
         source_scale = "bps"
-    elif abs_v > 1.0:
+    elif abs_v > MAX_REASONABLE_EXPENSE_RATIO:
         fraction = v / 100.0     # whole percent → fraction
         source_scale = "percent"
     else:

--- a/backend/tests/quant_engine/test_expense_ratio_validator_threshold.py
+++ b/backend/tests/quant_engine/test_expense_ratio_validator_threshold.py
@@ -1,0 +1,139 @@
+"""Regression tests for S07-F03 — expense ratio threshold (PR-Q57).
+
+The defect: `to_decimal_fraction` previously treated any `abs(value) <= 1.0`
+as already-a-fraction, silently inverting cheap N-CEN inputs (0.5 meaning 0.5%
+became 50% → clamped to 15%).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from quant_engine.expense_ratio_validator import (
+    MAX_REASONABLE_EXPENSE_RATIO,
+    to_decimal_fraction,
+)
+
+# ── F03 regression: the canonical defect ────────────────────────────────
+
+
+def test_ncen_sub_one_percent_treated_as_percent_not_fraction() -> None:
+    """0.5 (N-CEN: 0.5%) → 0.005 fraction, NOT 0.15 clamp from 0.5."""
+    assert to_decimal_fraction(0.5) == pytest.approx(0.005)
+
+
+def test_ncen_quarter_percent_treated_as_percent() -> None:
+    """0.25 (N-CEN: 0.25%) → 0.0025 fraction, NOT clamp from 0.25."""
+    assert to_decimal_fraction(0.25) == pytest.approx(0.0025)
+
+
+def test_ncen_threshold_boundary_just_above() -> None:
+    """0.16 (just above 0.15) → percent branch → 0.0016."""
+    assert to_decimal_fraction(0.16) == pytest.approx(0.0016)
+
+
+def test_ncen_threshold_boundary_exactly_at_max() -> None:
+    """0.15 (exactly at MAX_REASONABLE_EXPENSE_RATIO) → fraction branch → 0.15.
+
+    Decision rationale: the threshold uses STRICT > so 0.15 stays in the
+    fraction branch. A true 15% ER quoted as fraction is allowed; quoted as
+    whole percent (0.15 meaning 0.15%) it would be misclassified, but the
+    audit jury confirmed this band is dominated by XBRL fraction inputs.
+    """
+    assert to_decimal_fraction(0.15) == pytest.approx(0.15)
+
+
+# ── Pre-existing behavior (must still work) ─────────────────────────────
+
+
+def test_xbrl_canonical_fraction_unchanged() -> None:
+    """0.0125 (XBRL: 1.25%) → 0.0125 fraction (no scaling)."""
+    assert to_decimal_fraction(0.0125) == pytest.approx(0.0125)
+
+
+def test_xbrl_zero_fee_unchanged() -> None:
+    """0.0 → 0.0 fraction."""
+    assert to_decimal_fraction(0.0) == 0.0
+
+
+def test_whole_percent_above_one_unchanged() -> None:
+    """1.5 (whole percent: 1.5%) → 0.015 fraction."""
+    assert to_decimal_fraction(1.5) == pytest.approx(0.015)
+
+
+def test_whole_percent_two_percent_unchanged() -> None:
+    """2.0 (whole percent: 2.0%) → 0.02 fraction."""
+    assert to_decimal_fraction(2.0) == pytest.approx(0.02)
+
+
+def test_basis_points_above_one_hundred_unchanged() -> None:
+    """150 (bps: 1.5%) → 0.015 fraction."""
+    assert to_decimal_fraction(150) == pytest.approx(0.015)
+
+
+def test_basis_points_high_unchanged() -> None:
+    """800 (bps: 8.0%) → 0.08 fraction."""
+    assert to_decimal_fraction(800) == pytest.approx(0.08)
+
+
+# ── Sentinel handling unchanged ─────────────────────────────────────────
+
+
+def test_none_returns_none() -> None:
+    assert to_decimal_fraction(None) is None
+
+
+def test_nan_returns_none() -> None:
+    assert to_decimal_fraction(float("nan")) is None
+
+
+def test_inf_returns_none() -> None:
+    assert to_decimal_fraction(float("inf")) is None
+
+
+def test_non_numeric_returns_none() -> None:
+    assert to_decimal_fraction("not a number") is None
+
+
+def test_empty_string_returns_none() -> None:
+    assert to_decimal_fraction("") is None
+
+
+# ── Clamp behavior unchanged ────────────────────────────────────────────
+
+
+def test_clamp_above_max_still_works_for_truly_outlier_input() -> None:
+    """20.0 (whole percent: 20% — above MAX 15%) → clamped to 0.15."""
+    assert to_decimal_fraction(20.0) == MAX_REASONABLE_EXPENSE_RATIO
+
+
+def test_clamp_below_zero() -> None:
+    """Negative input → clamped to 0.0."""
+    assert to_decimal_fraction(-0.01) == 0.0
+
+
+# ── Caller-end regression: fee_efficiency computation ──────────────────
+
+
+def test_fee_efficiency_for_cheap_etf_post_fix() -> None:
+    """Conceptual: 0.5% ER → fraction 0.005 → er_human_pct 0.5 →
+    fee_efficiency = max(0, 100 - 0.5*50) = 75.
+
+    This test does NOT import the scoring service (kept loose-coupled);
+    it documents the post-fix expected outcome at the consumer end.
+    """
+    fraction = to_decimal_fraction(0.5)
+    assert fraction is not None
+    er_human_pct = fraction * 100.0
+    fee_efficiency = max(0.0, 100.0 - er_human_pct * 50.0)
+    assert fee_efficiency == pytest.approx(75.0)
+
+
+def test_fee_efficiency_for_typical_fund_unchanged() -> None:
+    """Conceptual: 1.5% ER → fraction 0.015 → er_human_pct 1.5 →
+    fee_efficiency = max(0, 100 - 1.5*50) = 25. Same pre/post fix."""
+    fraction = to_decimal_fraction(1.5)
+    assert fraction is not None
+    er_human_pct = fraction * 100.0
+    fee_efficiency = max(0.0, 100.0 - er_human_pct * 50.0)
+    assert fee_efficiency == pytest.approx(25.0)


### PR DESCRIPTION
## Summary
Lower `to_decimal_fraction` percent-vs-fraction threshold from `1.0` to `MAX_REASONABLE_EXPENSE_RATIO` (0.15). Closes Wave 6 Session 07 S07-F03 — the top-priority Tier 1 Crit/Crit finding affecting ~60% of the institutional / index / ETF universe.

## Wave 6 Session 07 Stage 3 triage
- Stage 1: Both (Gemini F01 + Opus F06 converged)
- Stage 2 jury (GPT-5.5): CONFIRMED Crit/Crit — production callers verified live in risk_calc.py + universe_sync.py
- Stage 3 (Opus 4.7): TP, Tier 1 standalone, top priority
- Reference: `docs/audits/audit-validation-session07.md`

## Behavior change
| Input | Pre-fix `to_decimal_fraction` | Post-fix |
|---|---|---|
| 0.5 (N-CEN: 0.5%) | 0.15 (clamped from 0.5) → fee_efficiency=0 | 0.005 → fee_efficiency=75 |
| 0.25 (N-CEN: 0.25%) | 0.15 (clamped) → fee_efficiency=0 | 0.0025 → fee_efficiency=87.5 |
| 0.16 (just above threshold) | 0.15 (clamped) → fee_efficiency=0 | 0.0016 → fee_efficiency=92 |
| 0.15 (exactly at max) | 0.15 → fee_efficiency=92.5 | 0.15 → fee_efficiency=92.5 (unchanged) |
| 0.0125 (XBRL: 1.25%) | 0.0125 (unchanged) | 0.0125 (unchanged) |
| 1.5 (N-CEN: 1.5%) | 0.015 (unchanged) | 0.015 (unchanged) |
| 150 (bps: 1.5%) | 0.015 (unchanged) | 0.015 (unchanged) |

## Test plan
- [x] N-CEN sub-1% inputs treated as percent (regression cases)
- [x] Threshold boundary at 0.15 (just above / exactly at)
- [x] XBRL fraction inputs unchanged
- [x] Whole-percent > 1.0 unchanged
- [x] Basis-points > 100 unchanged
- [x] Sentinel handling (None/NaN/inf/non-numeric) unchanged
- [x] Clamp behavior for truly-outlier inputs unchanged
- [x] Conceptual fee_efficiency end-to-end on 0.5% ER → 75 (post-fix expectation)
- [x] No regressions in scoring_service / fee_drag tests (110 scoring + 29 fee_drag = 139 pass)
- [x] `ruff check` + `mypy` clean

## Blast radius
- `risk_calc` worker (lock 900_007) — fee_efficiency component shifts for every fund whose stored expense_ratio_pct lands in `(0.15, 1.0]` (~60% of universe per audit).
- `global_risk_metrics` worker (lock 900_071) — same.
- `fund_risk_metrics` table — fee_efficiency column requires re-computation.
- `compute_fund_score` consumers (scoring API, IC dashboards, screener tier rankings) — composite scores shift for affected funds.
- No DB migration. No frontend type change. No optimizer impact (CLARABEL doesn't consume fee_efficiency directly).

## Backfill handoff
Post-merge, **re-run risk_calc + global_risk_metrics workers** to repopulate `fund_risk_metrics.fee_efficiency` for the universe.

## Pre-flight reverse-subsumption check
```
# grep for tests asserting on to_decimal_fraction with values in (0.15, 1.0]:
test_fi_scoring_dispatch.py:103: expense_ratio_pct=0.005  # already fraction, unaffected
test_cash_scoring.py:132: expense_ratio_pct=0.50  # passed to compute_cash_score, NOT to_decimal_fraction
test_cash_scoring.py:384: same
test_watchlist.py:521: expense_ratio_pct: 0.50  # dict fixture, not calling to_decimal_fraction

# grep for fee_efficiency==0 assertions:
test_scoring_fee_efficiency.py:79: expense_ratio_pct=0.02 (2.0%) → fee_efficiency==0.0  # 0.02 ≤ 0.15 → fraction, unchanged
test_scoring_fee_efficiency.py:91: expense_ratio_pct=0.03 (3.0%) → fee_efficiency==0.0  # 0.03 ≤ 0.15 → fraction, unchanged

# No test imports MAX_REASONABLE_EXPENSE_RATIO from tests/
→ No tests encode the bug. No reverse-subsumption.
```

## Caller-reachability verification
```
# risk_calc.py (confirmed live):
1856: er = (fund.attributes or {}).get("expense_ratio_pct")
1862: expense_ratio_pct=float(er) if er is not None else None,
2139: SELECT ticker, expense_ratio_pct
2145: er_map[row["ticker"]] = float(row["expense_ratio_pct"])
2152: expense_ratio_pct=er,

# universe_sync.py (confirmed live):
210: 'expense_ratio_pct', e.net_operating_expenses,
289: 'expense_ratio_pct', c.expense_ratio_pct,
384: 'expense_ratio_pct', b.net_operating_expenses,

# scoring_service.py (confirmed live):
307: er_fraction = to_decimal_fraction(expense_ratio_pct)
309: er_human_pct = float(er_fraction) * 100.0
310: return max(0.0, 100.0 - er_human_pct * 50.0)
```

## Deferred
The audit also proposed adding a `source_hint: Literal["xbrl", "ncen", "bps"]` parameter for robust per-caller disambiguation. Not implemented in Q57 — invasive (would require updating risk_calc + universe_sync + scoring callers, several of which mix sources per fund). The threshold fix already eliminates the silent inversion for the dominant defect class. If production telemetry post-deploy shows residual misclassification, hint-based disambiguation becomes a Wave 7+ enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)