### PR TITLE
fix(quant): PR-Q60 — peer percentile mid-rank + min-N guard (S07-F10+F09) — Tier 1 bundle

### DIFF
--- a/backend/quant_engine/peer_group_service.py
+++ b/backend/quant_engine/peer_group_service.py
@@ -34,6 +34,8 @@ class PeerGroupResult:
     strategy_label: str
     peer_count: int = 0
     rankings: list[PeerRanking] = field(default_factory=list)
+    degraded: bool = False
+    degraded_reason: str | None = None
 
 
 # Metrics where higher values are better (ascending rank)
@@ -51,21 +53,31 @@ _HIGHER_IS_BETTER_DEFAULTS: dict[str, bool] = {
     "manager_score": True,
 }
 
+MIN_PEER_COHORT_SIZE = 10  # institutional norm for fund peer benchmarking
+# (worker-side guard in risk_calc uses MIN_PEERS=5 — see Q60 PR body)
+
 
 def _percentile_rank(value: float, peers: np.ndarray, higher_is_better: bool) -> float:
-    """Compute percentile rank (0-100).
+    """Compute percentile rank (0-100) using the mid-rank convention for ties.
 
     For higher_is_better=True, higher percentile means better performance.
     For higher_is_better=False (e.g. max_drawdown), lower value → higher percentile.
+
+    Tie handling: each tied value contributes 0.5 to the rank (the
+    institutional / Morningstar peer-percentile convention). All-tied
+    cohorts therefore rank at the median (50.0) rather than 100.0.
     """
     if len(peers) == 0:
         return 50.0
 
     if higher_is_better:
-        rank = float(np.sum(peers <= value)) / len(peers) * 100
+        below = float(np.sum(peers < value))
+        equal = float(np.sum(peers == value))
     else:
-        rank = float(np.sum(peers >= value)) / len(peers) * 100
+        below = float(np.sum(peers > value))
+        equal = float(np.sum(peers == value))
 
+    rank = (below + 0.5 * equal) / len(peers) * 100.0
     return round(rank, 2)
 
 
@@ -111,14 +123,24 @@ def compute_peer_rankings(
 
     hib = {**_HIGHER_IS_BETTER_DEFAULTS, **(higher_is_better or {})}
 
-    if len(peer_metrics) < 1:
+    if len(peer_metrics) < MIN_PEER_COHORT_SIZE:
         return PeerGroupResult(
             strategy_label=strategy_label,
-            peer_count=0,
+            peer_count=len(peer_metrics),
             rankings=[
-                PeerRanking(metric_name=m, value=fund_metrics.get(m))
+                PeerRanking(
+                    metric_name=m,
+                    value=fund_metrics.get(m),
+                    percentile=50.0,
+                    quartile=2,
+                )
                 for m in metrics_to_rank
             ],
+            degraded=True,
+            degraded_reason=(
+                f"insufficient_peer_cohort: N={len(peer_metrics)} "
+                f"(min {MIN_PEER_COHORT_SIZE} required; ranking suppressed to median)"
+            ),
         )
 
     rankings: list[PeerRanking] = []

--- a/backend/tests/quant_engine/test_peer_group_mid_rank_min_n.py
+++ b/backend/tests/quant_engine/test_peer_group_mid_rank_min_n.py
@@ -1,0 +1,127 @@
+"""Regression tests for S07-F10 (mid-rank ties) + S07-F09 (min-N guard)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quant_engine.peer_group_service import (
+    MIN_PEER_COHORT_SIZE,
+    _percentile_rank,
+    compute_peer_rankings,
+)
+
+# ── F10: mid-rank convention ────────────────────────────────────────────
+
+
+def test_all_tied_higher_is_better_ranks_at_median() -> None:
+    """4 funds all tied → all rank at 50, not 100. Higher-is-better."""
+    rank = _percentile_rank(0.0, np.array([0.0, 0.0, 0.0, 0.0]), higher_is_better=True)
+    assert rank == 50.0
+
+
+def test_all_tied_lower_is_better_ranks_at_median() -> None:
+    """4 funds all tied at zero drawdown → 50, not 100. Lower-is-better."""
+    rank = _percentile_rank(0.0, np.array([0.0, 0.0, 0.0, 0.0]), higher_is_better=False)
+    assert rank == 50.0
+
+
+def test_single_best_ranks_at_100() -> None:
+    """Strict top → 100."""
+    rank = _percentile_rank(10.0, np.array([1.0, 2.0, 3.0]), higher_is_better=True)
+    assert rank == 100.0
+
+
+def test_single_worst_ranks_at_0() -> None:
+    """Strict bottom → 0."""
+    rank = _percentile_rank(0.0, np.array([1.0, 2.0, 3.0]), higher_is_better=True)
+    assert rank == 0.0
+
+
+def test_partial_tie_higher_is_better() -> None:
+    """3 peers [1, 2, 2], value=2 (tied with one) → mid-rank.
+    below=1, equal=2 → (1 + 1.0)/3 * 100 ≈ 66.67."""
+    rank = _percentile_rank(2.0, np.array([1.0, 2.0, 2.0]), higher_is_better=True)
+    assert rank == pytest.approx(66.67, abs=0.01)
+
+
+def test_partial_tie_lower_is_better() -> None:
+    """Lower-is-better: peers [1, 2, 2], value=2 → above=0, equal=2 → (0 + 1.0)/3 ≈ 33.33."""
+    rank = _percentile_rank(2.0, np.array([1.0, 2.0, 2.0]), higher_is_better=False)
+    assert rank == pytest.approx(33.33, abs=0.01)
+
+
+def test_empty_peers_returns_50() -> None:
+    """No peers → median sentinel."""
+    rank = _percentile_rank(1.0, np.array([]), higher_is_better=True)
+    assert rank == 50.0
+
+
+# ── F09: min-N guard ───────────────────────────────────────────────────
+
+
+def _mk_peer(sharpe: float, ret: float = 0.05, dd: float = -0.05) -> dict:
+    return {
+        "sharpe_1y": sharpe,
+        "sortino_1y": sharpe * 1.1,
+        "return_1y": ret,
+        "max_drawdown_1y": dd,
+        "volatility_1y": 0.10,
+        "alpha_1y": 0.01,
+        "manager_score": 50.0,
+    }
+
+
+def test_thin_cohort_returns_degraded_with_median_percentile() -> None:
+    """N=2 cohort → degraded result with all percentiles at 50.0."""
+    fund = _mk_peer(1.5)
+    peers = [_mk_peer(1.4)]  # N=1 peer + the fund itself in queries
+    result = compute_peer_rankings(fund, peers, strategy_label="Niche EM Debt")
+    assert result.peer_count == 1
+    assert result.degraded is True
+    assert "insufficient_peer_cohort" in (result.degraded_reason or "")
+    for ranking in result.rankings:
+        assert ranking.percentile == 50.0
+        assert ranking.quartile == 2
+
+
+def test_below_min_cohort_returns_degraded() -> None:
+    """N just below MIN_PEER_COHORT_SIZE → degraded."""
+    fund = _mk_peer(1.5)
+    peers = [_mk_peer(1.0 + i * 0.1) for i in range(MIN_PEER_COHORT_SIZE - 1)]
+    result = compute_peer_rankings(fund, peers, strategy_label="Tiny Cohort")
+    assert result.degraded is True
+
+
+def test_at_min_cohort_returns_full_ranking() -> None:
+    """N exactly at MIN_PEER_COHORT_SIZE → full ranking, not degraded."""
+    fund = _mk_peer(2.5)
+    peers = [_mk_peer(1.0 + i * 0.1) for i in range(MIN_PEER_COHORT_SIZE)]
+    result = compute_peer_rankings(fund, peers, strategy_label="Adequate Cohort")
+    assert result.degraded is False
+    # Sharpe 2.5 strictly above all peers (max 1.9) → 100th percentile
+    sharpe_ranking = next(r for r in result.rankings if r.metric_name == "sharpe_1y")
+    assert sharpe_ranking.percentile is not None
+    assert sharpe_ranking.percentile == 100.0
+
+
+def test_zero_peers_returns_degraded_unchanged() -> None:
+    """N=0 path preserved (was the only pre-fix guard)."""
+    fund = _mk_peer(1.5)
+    result = compute_peer_rankings(fund, [], strategy_label="Empty")
+    assert result.peer_count == 0
+    # Pre-fix code returned no degraded flag; post-fix the new `< MIN_PEER_COHORT_SIZE`
+    # guard catches N=0 too and surfaces degraded.
+    assert result.degraded is True
+
+
+# ── F10 end-to-end via compute_peer_rankings ───────────────────────────
+
+
+def test_all_tied_cohort_via_compute_peer_rankings_ranks_at_median() -> None:
+    """End-to-end: cohort all tied at sharpe=1.0 → fund at 50, not 100."""
+    fund = _mk_peer(1.0)
+    peers = [_mk_peer(1.0) for _ in range(MIN_PEER_COHORT_SIZE)]
+    result = compute_peer_rankings(fund, peers, strategy_label="All Tied")
+    sharpe_ranking = next(r for r in result.rankings if r.metric_name == "sharpe_1y")
+    assert sharpe_ranking.percentile == pytest.approx(50.0, abs=0.5)

--- a/backend/tests/test_peer_group_service.py
+++ b/backend/tests/test_peer_group_service.py
@@ -160,6 +160,7 @@ class TestEdgeCases:
         )
         assert result.peer_count == 0
         assert len(result.rankings) == 7
+        assert result.degraded is True
 
     def test_fund_metric_none(self):
         """Fund with None metric should still produce ranking (value=None)."""


### PR DESCRIPTION
## Summary

Two institutional ranking convention fixes in `peer_group_service.py`:

- **S07-F10 (Tier 1 H/H):** `_percentile_rank` inflated tied cohorts to 100th percentile. Replaced with **mid-rank convention** (`(below + 0.5 * equal) / N * 100`) — tied cohorts now rank at the median (50.0), matching Morningstar/institutional standard. **DIRECT CONTRADICTION won by Gemini** over Opus Invariant #13.
- **S07-F09 (Tier 3 M/M):** `compute_peer_rankings` only guarded `< 1`. Added `MIN_PEER_COHORT_SIZE = 10` — thin cohorts (N<10) return `degraded=True` with percentiles capped at 50.0.

### Behavior table

| Scenario | Before | After |
|---|---|---|
| 4 funds all at drawdown=0 (lower-is-better) | All rank 100th pctl | All rank 50th pctl |
| Fund tied with 1 peer (N=2) | Full-confidence 100th pctl | degraded=True, 50th pctl |
| N=9 cohort | Full ranking | degraded=True, 50th pctl |
| N=10+ cohort, no ties | Full ranking | Full ranking (unchanged) |
| Strict top (no ties) | 100th pctl | 100th pctl (unchanged) |

### Worker-vs-library calibration divergence

`risk_calc.py:2279-2323` uses `MIN_PEERS=5`. Library now uses `MIN_PEER_COHORT_SIZE=10` (institutional norm). **Follow-up reconciliation** recommended in Q57-suite cleanup PR — not touched here.

`risk_calc.py:2400-2405` uses the same biased `arr <= value` formula for stored peer percentiles. **Flagged for separate remediation** — should land before Session 07 closeout.

### Pre-flight greps

**No tests encoded old 100-on-tie behavior** — clean. Existing `test_no_peers` updated to assert `degraded=True`.

### Caller reachability (verified)

- `analytics.py:1022` — `compute_peer_rankings` consumer (scoring route)
- `sec_funds.py:638` — separate local `_percentile_rank` (out of scope, different module)
- `risk_calc.py:2279` — worker-side `MIN_PEERS=5` guard (divergence flagged above)

### Dataclass extension

`PeerGroupResult` gains `degraded: bool = False` and `degraded_reason: str | None = None`. Backward compatible — all existing callers construct without new kwargs.

### Backfill

`risk_calc` + `global_risk_metrics` workers (locks 900_007, 900_071) must re-run post-merge to re-bucket `fund_risk_metrics.peer_percentile_*` columns.

## Stage 3 triage

- **S07-F10:** TP — Gemini unique, DIRECT CONTRADICTION sustained over Opus Invariant #13. Wave 6 tally now **2-1 Gemini**.
- **S07-F09:** TP — Gemini unique, downgraded H/Crit → M/M (worker already has MIN_PEERS=5).
- Bundled: same module + same institutional convention class.
- Parallel-safe with Q57 + Q58 (zero file overlap).

## Test plan

- [x] 12 new regression tests (7 mid-rank + 4 min-N + 1 end-to-end)
- [x] 16 existing `test_peer_group_service.py` tests pass
- [x] 87 peer-related tests pass (`-k peer`)
- [x] 37 scoring tests pass
- [x] ruff clean
- [x] mypy: pre-existing `ndarray` type-arg warning only (not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)