### PR TITLE
fix(quant): PR-Q59 — ScoringResult dataclass + degraded surface (S07-F05+F07)

### DIFF
--- a/backend/app/domains/wealth/workers/risk_calc.py
+++ b/backend/app/domains/wealth/workers/risk_calc.py
@@ -1267,7 +1267,7 @@ def _score_metrics(
         else:
             alt_profile = _resolve_alt_profile_from_strategy(strategy_label)
 
-    score_val, components = compute_fund_score(
+    scoring_result = compute_fund_score(
         adapter,
         flows_momentum_score=flows,
         config=scoring_config,
@@ -1278,11 +1278,18 @@ def _score_metrics(
         alt_metrics=alt_adapter,
         alt_profile=alt_profile,
     )
-    metrics["manager_score"] = round(score_val, 2)
+    metrics["manager_score"] = round(scoring_result.score, 2)
+    components = dict(scoring_result.components)
     # Store alt_profile in score_components for frontend rendering
     if alt_profile:
         components["_alt_profile"] = alt_profile
     metrics["score_components"] = components
+    if scoring_result.degraded:
+        logger.info(
+            "scoring_degraded",
+            asset_class=asset_class,
+            reasons=scoring_result.degraded_reasons,
+        )
 
 
 REGIME_DETECTION_LOCK_ID = 900_130

--- a/backend/quant_engine/scoring_service.py
+++ b/backend/quant_engine/scoring_service.py
@@ -9,6 +9,7 @@ Config is injected as parameter by callers via ConfigService.get("liquid_funds",
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any, Protocol
 
@@ -17,6 +18,30 @@ import structlog
 from quant_engine.expense_ratio_validator import to_decimal_fraction
 
 logger = structlog.get_logger()
+
+
+@dataclass(frozen=True, slots=True)
+class ScoringResult:
+    """Structured score with provenance.
+
+    Attributes:
+        score: composite 0-100 score.
+        components: per-component sub-scores (0-100 each).
+        degraded: True when at least one component was synthesized from a
+            fallback (missing input filled with peer_median - 5.0) OR when
+            the dispatch fell through to a model that doesn't match the
+            stated asset_class.
+        degraded_reasons: structured list of reasons. Each reason is a
+            short slug + optional context. Examples:
+                - "asset_class_metrics_missing:cash"
+                - "synthesized_component:risk_adjusted_return"
+            Empty list when degraded=False.
+    """
+
+    score: float
+    components: dict[str, float] = field(default_factory=dict)
+    degraded: bool = False
+    degraded_reasons: list[str] = field(default_factory=list)
 
 
 class RiskMetrics(Protocol):
@@ -246,6 +271,22 @@ def _peaked_score(value: float | None, target: float, half_range: float) -> floa
     return max(0.0, 100.0 * (1.0 - distance / half_range))
 
 
+def _normalize_with_provenance(
+    value: float | None,
+    min_val: float,
+    max_val: float,
+    peer_median: float | None = None,
+) -> tuple[float, bool]:
+    """Same as _normalize but returns (score, was_synthesized)."""
+    if value is None or not math.isfinite(value):
+        if peer_median is not None:
+            return max(0.0, min(100.0, peer_median - 5.0)), True
+        return 45.0, True
+    if max_val == min_val:
+        return 50.0, False
+    return max(0.0, min(100.0, (value - min_val) / (max_val - min_val) * 100)), False
+
+
 def _normalize(
     value: float | None,
     min_val: float,
@@ -259,13 +300,8 @@ def _normalize(
         opaque/short-history funds vs. transparent peers with mediocre scores.
       - If no peer_median, falls back to 45.0 (below midpoint, slight penalty).
     """
-    if value is None or not math.isfinite(value):
-        if peer_median is not None:
-            return max(0.0, min(100.0, peer_median - 5.0))
-        return 45.0
-    if max_val == min_val:
-        return 50.0
-    return max(0.0, min(100.0, (value - min_val) / (max_val - min_val) * 100))
+    score, _ = _normalize_with_provenance(value, min_val, max_val, peer_median)
+    return score
 
 
 def _resolve_sharpe_input(
@@ -312,24 +348,43 @@ def _compute_fee_efficiency(
     return max(0.0, fee_pm - 5.0) if fee_pm is not None else 45.0
 
 
+def _compute_fee_efficiency_with_provenance(
+    expense_ratio_pct: float | None,
+    peer_medians: dict[str, float] | None = None,
+) -> tuple[float, bool]:
+    """Fee efficiency with synthesis tracking."""
+    pm = peer_medians or {}
+    er_fraction = to_decimal_fraction(expense_ratio_pct)
+    if er_fraction is not None and math.isfinite(float(er_fraction)):
+        er_human_pct = float(er_fraction) * 100.0
+        return max(0.0, 100.0 - er_human_pct * 50.0), False
+    fee_pm = pm.get("fee_efficiency")
+    score = max(0.0, fee_pm - 5.0) if fee_pm is not None else 45.0
+    return score, True
+
+
 def _compute_fi_score(
     fi: FIMetrics,
     config: dict[str, Any] | None,
     expense_ratio_pct: float | None,
     peer_medians: dict[str, float] | None,
-) -> tuple[float, dict[str, float]]:
-    """Compute FI-specific composite score. Returns (score, components).
+) -> ScoringResult:
+    """Compute FI-specific composite score.
 
     Five components: yield_consistency, duration_management, spread_capture,
     duration_adjusted_drawdown, fee_efficiency.
     """
     pm = peer_medians or {}
     components: dict[str, float] = {}
+    synthesized: list[str] = []
 
     # yield_consistency: trailing 12m income return proxy
     # Range: 0% yield (worst) to 8% yield (best for IG).
     yp = float(fi.yield_proxy_12m) if fi.yield_proxy_12m is not None else None
-    components["yield_consistency"] = _normalize(yp, 0.0, 0.08, pm.get("yield_consistency"))
+    val, was_synth = _normalize_with_provenance(yp, 0.0, 0.08, pm.get("yield_consistency"))
+    components["yield_consistency"] = val
+    if was_synth:
+        synthesized.append("yield_consistency")
 
     # duration_management: empirical duration vs target center.
     # Config-driven: duration_center and duration_half_range.
@@ -344,23 +399,32 @@ def _compute_fi_score(
         deviation = abs(dur - dur_center) / max(dur_half_range, 0.1)
         components["duration_management"] = max(0.0, min(100.0, (1 - deviation) * 100))
     else:
+        synthesized.append("duration_management")
         components["duration_management"] = pm.get("duration_management", 45.0)
 
     # spread_capture: credit beta as proxy for spread capture skill.
     # Peaked at credit_beta = 1.0; symmetric ±1.0 half-range.
     # Higher and lower betas penalized equally — moderate exposure is the institutional ideal.
     cb = float(fi.credit_beta) if fi.credit_beta is not None else None
+    if cb is None or not math.isfinite(cb):
+        synthesized.append("spread_capture")
     components["spread_capture"] = _peaked_score(cb, target=1.0, half_range=1.0)
 
     # duration_adjusted_drawdown: drawdown per unit of duration.
     # Range: -5.0 (terrible) to 0.0 (no drawdown). Higher is better.
     dad = float(fi.duration_adj_drawdown_1y) if fi.duration_adj_drawdown_1y is not None else None
-    components["duration_adjusted_drawdown"] = _normalize(
+    val, was_synth = _normalize_with_provenance(
         dad, -5.0, 0.0, pm.get("duration_adjusted_drawdown"),
     )
+    components["duration_adjusted_drawdown"] = val
+    if was_synth:
+        synthesized.append("duration_adjusted_drawdown")
 
     # fee_efficiency: same logic as equity
-    components["fee_efficiency"] = _compute_fee_efficiency(expense_ratio_pct, pm)
+    fee_val, fee_synth = _compute_fee_efficiency_with_provenance(expense_ratio_pct, pm)
+    components["fee_efficiency"] = fee_val
+    if fee_synth:
+        synthesized.append("fee_efficiency")
 
     weights = resolve_scoring_weights(config, asset_class="fixed_income")
 
@@ -372,7 +436,14 @@ def _compute_fi_score(
         )
 
     score = sum(components[k] * w for k, w in weights.items())
-    return round(score, 2), {k: round(v, 2) for k, v in components.items()}
+    rounded_components = {k: round(v, 2) for k, v in components.items()}
+    degraded_reasons = [f"synthesized_component:{name}" for name in synthesized]
+    return ScoringResult(
+        score=round(score, 2),
+        components=rounded_components,
+        degraded=len(synthesized) > 0,
+        degraded_reasons=degraded_reasons,
+    )
 
 
 def _compute_cash_score(
@@ -380,14 +451,15 @@ def _compute_cash_score(
     config: dict[str, Any] | None,
     expense_ratio_pct: float | None,
     peer_medians: dict[str, float] | None,
-) -> tuple[float, dict[str, float]]:
-    """Compute Cash/MMF-specific composite score. Returns (score, components).
+) -> ScoringResult:
+    """Compute Cash/MMF-specific composite score.
 
     Five components: yield_vs_risk_free, nav_stability, liquidity_quality,
     maturity_discipline, fee_efficiency.
     """
     pm = peer_medians or {}
     components: dict[str, float] = {}
+    synthesized: list[str] = []
 
     # yield_vs_risk_free: absolute spread over policy rate (handles negative rates).
     # 0 pp → 50, 5 pp → 100, -5 pp → 0. Continuous across the zero boundary.
@@ -395,10 +467,14 @@ def _compute_cash_score(
     ffr = float(cash.fed_funds_rate_at_calc) if cash.fed_funds_rate_at_calc is not None else None
     if yld is not None and ffr is not None and math.isfinite(ffr):
         spread_pp = (yld - ffr) * 100.0  # percentage points
-        components["yield_vs_risk_free"] = _normalize(
+        val, was_synth = _normalize_with_provenance(
             spread_pp, -5.0, 5.0, pm.get("yield_vs_risk_free"),
         )
+        components["yield_vs_risk_free"] = val
+        if was_synth:
+            synthesized.append("yield_vs_risk_free")
     else:
+        synthesized.append("yield_vs_risk_free")
         components["yield_vs_risk_free"] = pm.get("yield_vs_risk_free", 45.0)
 
     # nav_stability: deviation from $1.00 par value
@@ -408,16 +484,21 @@ def _compute_cash_score(
         stability = max(0.0, 1.0 - deviation * 1000)  # 0.001 deviation = 0 score
         components["nav_stability"] = stability * 100
     else:
+        synthesized.append("nav_stability")
         components["nav_stability"] = pm.get("nav_stability", 45.0)
 
     # liquidity_quality: weekly liquid assets %
     wl = float(cash.pct_weekly_liquid) if cash.pct_weekly_liquid is not None else None
     if wl is not None:
         # Range 30% (SEC 2a-7 regulatory min) to 100%
-        components["liquidity_quality"] = _normalize(
+        val, was_synth = _normalize_with_provenance(
             wl, 30.0, 100.0, pm.get("liquidity_quality"),
         )
+        components["liquidity_quality"] = val
+        if was_synth:
+            synthesized.append("liquidity_quality")
     else:
+        synthesized.append("liquidity_quality")
         components["liquidity_quality"] = pm.get("liquidity_quality", 45.0)
 
     # maturity_discipline: lower WAM = less interest rate risk = better
@@ -427,10 +508,14 @@ def _compute_cash_score(
         wam_score = max(0.0, (1.0 - wam / 60.0)) * 100
         components["maturity_discipline"] = wam_score
     else:
+        synthesized.append("maturity_discipline")
         components["maturity_discipline"] = pm.get("maturity_discipline", 45.0)
 
     # fee_efficiency: same logic as equity/FI
-    components["fee_efficiency"] = _compute_fee_efficiency(expense_ratio_pct, pm)
+    fee_val, fee_synth = _compute_fee_efficiency_with_provenance(expense_ratio_pct, pm)
+    components["fee_efficiency"] = fee_val
+    if fee_synth:
+        synthesized.append("fee_efficiency")
 
     weights = resolve_scoring_weights(config, asset_class="cash")
 
@@ -442,7 +527,14 @@ def _compute_cash_score(
         )
 
     score = sum(components[k] * w for k, w in weights.items())
-    return round(score, 2), {k: round(v, 2) for k, v in components.items()}
+    rounded_components = {k: round(v, 2) for k, v in components.items()}
+    degraded_reasons = [f"synthesized_component:{name}" for name in synthesized]
+    return ScoringResult(
+        score=round(score, 2),
+        components=rounded_components,
+        degraded=len(synthesized) > 0,
+        degraded_reasons=degraded_reasons,
+    )
 
 
 def _compute_alternatives_score(
@@ -451,14 +543,15 @@ def _compute_alternatives_score(
     config: dict[str, Any] | None,
     expense_ratio_pct: float | None,
     peer_medians: dict[str, float] | None,
-) -> tuple[float, dict[str, float]]:
-    """Compute Alternatives composite score. Returns (score, components).
+) -> ScoringResult:
+    """Compute Alternatives composite score.
 
     Profile-specific weights determine which components matter most.
     All components are computed for all alt funds; weights select relevance.
     """
     pm = peer_medians or {}
     components: dict[str, float] = {}
+    synthesized: list[str] = []
 
     # diversification_value: 1 - abs(equity_correlation_252d)
     # Empirical p50 div_value = 0.23 (median alt corr = 0.77).
@@ -466,8 +559,12 @@ def _compute_alternatives_score(
     eq_corr = float(alt.equity_correlation_252d) if alt.equity_correlation_252d is not None else None
     if eq_corr is not None:
         div_value = 1.0 - abs(eq_corr)
-        components["diversification_value"] = _normalize(div_value, 0.0, 0.50, pm.get("diversification_value"))
+        val, was_synth = _normalize_with_provenance(div_value, 0.0, 0.50, pm.get("diversification_value"))
+        components["diversification_value"] = val
+        if was_synth:
+            synthesized.append("diversification_value")
     else:
+        synthesized.append("diversification_value")
         components["diversification_value"] = pm.get("diversification_value", 45.0)
 
     # downside_protection: 1 - downside_capture_1y
@@ -475,46 +572,69 @@ def _compute_alternatives_score(
     dc = float(alt.downside_capture_1y) if alt.downside_capture_1y is not None else None
     if dc is not None:
         protection = 1.0 - dc
-        components["downside_protection"] = _normalize(protection, -1.0, 1.0, pm.get("downside_protection"))
+        val, was_synth = _normalize_with_provenance(protection, -1.0, 1.0, pm.get("downside_protection"))
+        components["downside_protection"] = val
+        if was_synth:
+            synthesized.append("downside_protection")
     else:
+        synthesized.append("downside_protection")
         components["downside_protection"] = pm.get("downside_protection", 45.0)
 
     # crisis_alpha: excess return vs benchmark during drawdown periods.
     # Empirical p10=-0.034, p50=+0.009, p90=+0.050.
     # Range [-0.06, 0.08] so p50 → score ~49.
     ca = float(alt.crisis_alpha_score) if alt.crisis_alpha_score is not None else None
-    components["crisis_alpha"] = _normalize(ca, -0.06, 0.08, pm.get("crisis_alpha"))
+    val, was_synth = _normalize_with_provenance(ca, -0.06, 0.08, pm.get("crisis_alpha"))
+    components["crisis_alpha"] = val
+    if was_synth:
+        synthesized.append("crisis_alpha")
 
     # inflation_hedge: inflation beta (regression of returns vs CPI changes).
     # Empirical p10=-11.03, p50=-5.84, p90=-1.82 (all negative).
     # Range [-12.0, 0.0] so p50 → score ~51.
     ib = float(alt.inflation_beta) if alt.inflation_beta is not None else None
-    components["inflation_hedge"] = _normalize(ib, -12.0, 0.0, pm.get("inflation_hedge"))
+    val, was_synth = _normalize_with_provenance(ib, -12.0, 0.0, pm.get("inflation_hedge"))
+    components["inflation_hedge"] = val
+    if was_synth:
+        synthesized.append("inflation_hedge")
 
     # income_generation: yield_proxy_12m (reused from FI for REITs)
     # Range: 0% to 10%.
     yp = float(alt.yield_proxy_12m) if alt.yield_proxy_12m is not None else None
-    components["income_generation"] = _normalize(yp, 0.0, 0.10, pm.get("income_generation"))
+    val, was_synth = _normalize_with_provenance(yp, 0.0, 0.10, pm.get("income_generation"))
+    components["income_generation"] = val
+    if was_synth:
+        synthesized.append("income_generation")
 
     # alpha_generation: sortino_1y (not Sharpe -- Sharpe penalizes upside vol).
     # Empirical p10=0.34, p50=2.53, p90=3.48.
     # Range [0.0, 5.0] so p50 → score ~51.
     sortino = float(alt.sortino_1y) if alt.sortino_1y is not None else None
-    components["alpha_generation"] = _normalize(sortino, 0.0, 5.0, pm.get("alpha_generation"))
+    val, was_synth = _normalize_with_provenance(sortino, 0.0, 5.0, pm.get("alpha_generation"))
+    components["alpha_generation"] = val
+    if was_synth:
+        synthesized.append("alpha_generation")
 
     # risk_adjusted_return: calmar_ratio_3y (return / max drawdown).
     # Empirical p10=0.32, p50=0.75, p90=1.35.
     # Range [0.0, 1.5] so p50 → score 50.
     calmar = float(alt.calmar_ratio_3y) if alt.calmar_ratio_3y is not None else None
-    components["risk_adjusted_return"] = _normalize(calmar, 0.0, 1.5, pm.get("risk_adjusted_return"))
+    val, was_synth = _normalize_with_provenance(calmar, 0.0, 1.5, pm.get("risk_adjusted_return"))
+    components["risk_adjusted_return"] = val
+    if was_synth:
+        synthesized.append("risk_adjusted_return")
 
     # drawdown_control: based on max_drawdown_3y directly (lower max DD → higher score).
     # Score 100 at max DD = 0%, score 0 at max DD = -50%.
     max_dd = float(alt.max_drawdown_3y) if alt.max_drawdown_3y is not None else None
     if max_dd is not None and math.isfinite(max_dd):
         drawdown_pct = abs(max_dd) * 100.0
-        components["drawdown_control"] = _normalize(-drawdown_pct, -50.0, 0.0, pm.get("drawdown_control"))
+        val, was_synth = _normalize_with_provenance(-drawdown_pct, -50.0, 0.0, pm.get("drawdown_control"))
+        components["drawdown_control"] = val
+        if was_synth:
+            synthesized.append("drawdown_control")
     else:
+        synthesized.append("drawdown_control")
         components["drawdown_control"] = 45.0
 
     # tracking_efficiency: lower tracking error = better (for gold passive exposure)
@@ -525,10 +645,14 @@ def _compute_alternatives_score(
         te_score = max(0.0, min(100.0, (1.0 - te / 0.05) * 100))
         components["tracking_efficiency"] = te_score
     else:
+        synthesized.append("tracking_efficiency")
         components["tracking_efficiency"] = pm.get("tracking_efficiency", 45.0)
 
     # fee_efficiency: shared formula
-    components["fee_efficiency"] = _compute_fee_efficiency(expense_ratio_pct, pm)
+    fee_val, fee_synth = _compute_fee_efficiency_with_provenance(expense_ratio_pct, pm)
+    components["fee_efficiency"] = fee_val
+    if fee_synth:
+        synthesized.append("fee_efficiency")
 
     weights = resolve_alt_profile_weights(profile, config)
 
@@ -543,7 +667,122 @@ def _compute_alternatives_score(
     # Only return components that carry weight in this profile.
     # Prevents nonsensical display (e.g., "Income Generation: 38" on a CTA fund).
     active_components = {k: round(v, 2) for k, v in components.items() if weights.get(k, 0) > 0}
-    return round(score, 2), active_components
+    # Filter degraded reasons to active components only
+    active_reasons = [
+        r for r in (f"synthesized_component:{name}" for name in synthesized)
+        if r.split(":", 1)[1] in active_components or not r.startswith("synthesized_component:")
+    ]
+    return ScoringResult(
+        score=round(score, 2),
+        components=active_components,
+        degraded=len(active_reasons) > 0,
+        degraded_reasons=active_reasons,
+    )
+
+
+def _compute_equity_score(
+    metrics: RiskMetrics,
+    flows_momentum_score: float | None,
+    config: dict[str, Any] | None,
+    expense_ratio_pct: float | None,
+    insider_sentiment_score: float | None,
+    peer_medians: dict[str, float] | None,
+) -> ScoringResult:
+    """Compute equity composite score with provenance tracking."""
+    pm = peer_medians or {}
+    components: dict[str, float] = {}
+    synthesized: list[str] = []
+
+    # S4-QW1: use ``is not None`` instead of truthy checks.
+    ret_1y = float(metrics.return_1y) if metrics.return_1y is not None else None
+    val, was_synth = _normalize_with_provenance(ret_1y, -0.20, 0.40, pm.get("return_consistency"))
+    components["return_consistency"] = val
+    if was_synth:
+        synthesized.append("return_consistency")
+
+    sharpe = _resolve_sharpe_input(metrics, config)
+    val, was_synth = _normalize_with_provenance(sharpe, -1.0, 3.0, pm.get("risk_adjusted_return"))
+    components["risk_adjusted_return"] = val
+    if was_synth:
+        synthesized.append("risk_adjusted_return")
+
+    dd = float(metrics.max_drawdown_1y) if metrics.max_drawdown_1y is not None else None
+    val, was_synth = _normalize_with_provenance(dd, -0.50, 0.0, pm.get("drawdown_control"))
+    components["drawdown_control"] = val
+    if was_synth:
+        synthesized.append("drawdown_control")
+
+    ir = float(metrics.information_ratio_1y) if metrics.information_ratio_1y is not None else None
+    val, was_synth = _normalize_with_provenance(ir, -1.0, 2.0, pm.get("information_ratio"))
+    components["information_ratio"] = val
+    if was_synth:
+        synthesized.append("information_ratio")
+
+    if flows_momentum_score is not None:
+        components["flows_momentum"] = _clamp_component_score(
+            flows_momentum_score, "flows_momentum",
+        )
+    else:
+        synthesized.append("flows_momentum")
+        components["flows_momentum"] = 45.0
+
+    # Fee efficiency — shared with FI path
+    fee_val, fee_synth = _compute_fee_efficiency_with_provenance(expense_ratio_pct, pm)
+    components["fee_efficiency"] = fee_val
+    if fee_synth:
+        synthesized.append("fee_efficiency")
+
+    weights = resolve_scoring_weights(config)
+
+    # Opt-in insider sentiment (activated when config includes "insider_sentiment" weight > 0)
+    if weights.get("insider_sentiment", 0) > 0:
+        if insider_sentiment_score is not None:
+            components["insider_sentiment"] = _clamp_component_score(
+                insider_sentiment_score, "insider_sentiment",
+            )
+        else:
+            synthesized.append("insider_sentiment")
+            components["insider_sentiment"] = 45.0  # missing-data fallback
+
+    missing = set(weights.keys()) - components.keys()
+    if missing:
+        raise ValueError(
+            f"compute_fund_score: weights reference components not provided: "
+            f"{sorted(missing)}. Caller must pass {{key}}_score kwargs for each."
+        )
+
+    score = sum(components[k] * w for k, w in weights.items())
+    rounded_components = {k: round(v, 2) for k, v in components.items()}
+    degraded_reasons = [f"synthesized_component:{name}" for name in synthesized]
+    return ScoringResult(
+        score=round(score, 2),
+        components=rounded_components,
+        degraded=len(synthesized) > 0,
+        degraded_reasons=degraded_reasons,
+    )
+
+
+def _equity_score_with_class_mismatch(
+    metrics: RiskMetrics,
+    flows_momentum_score: float | None,
+    config: dict[str, Any] | None,
+    expense_ratio_pct: float | None,
+    insider_sentiment_score: float | None,
+    peer_medians: dict[str, float] | None,
+    class_mismatch: str,
+) -> ScoringResult:
+    """Equity scoring with degraded flag for asset-class mismatch (F05 fix)."""
+    result = _compute_equity_score(
+        metrics, flows_momentum_score, config, expense_ratio_pct,
+        insider_sentiment_score, peer_medians,
+    )
+    reasons = [f"asset_class_metrics_missing:{class_mismatch}"] + list(result.degraded_reasons)
+    return ScoringResult(
+        score=result.score,
+        components=result.components,
+        degraded=True,
+        degraded_reasons=reasons,
+    )
 
 
 def compute_fund_score(
@@ -558,8 +797,8 @@ def compute_fund_score(
     cash_metrics: CashMetrics | None = None,
     alt_metrics: AltMetrics | None = None,
     alt_profile: str | None = None,
-) -> tuple[float, dict[str, float]]:
-    """Compute composite score from risk metrics. Returns (score, components).
+) -> ScoringResult:
+    """Compute composite score from risk metrics. Returns ScoringResult.
 
     Args:
         config: Scoring config dict from ConfigService.get("liquid_funds", "scoring").
@@ -575,79 +814,46 @@ def compute_fund_score(
         asset_class: "equity" (default), "fixed_income", "cash", or "alternatives".
                Determines scoring model.
         fi_metrics: Fixed income metrics. Required when asset_class="fixed_income".
-               Falls back to equity scoring if None.
         cash_metrics: Cash/MMF metrics. Required when asset_class="cash".
-               Falls back to equity scoring if None.
         alt_metrics: Alternatives metrics. Required when asset_class="alternatives".
-               Falls back to equity scoring if None.
         alt_profile: Alternatives profile name (reit, commodity, gold, hedge, cta,
                generic_alt). Determines weight distribution across components.
 
     """
-    # Dispatch to Alternatives scoring when asset_class is alternatives AND alt_metrics provided
-    if asset_class == "alternatives" and alt_metrics is not None:
+    # Dispatch to Alternatives scoring
+    if asset_class == "alternatives":
+        if alt_metrics is None:
+            return _equity_score_with_class_mismatch(
+                metrics, flows_momentum_score, config, expense_ratio_pct,
+                insider_sentiment_score, peer_medians,
+                class_mismatch="alternatives",
+            )
         return _compute_alternatives_score(
             alt_metrics, alt_profile or "generic_alt", config, expense_ratio_pct, peer_medians,
         )
 
-    # Dispatch to Cash scoring when asset_class is cash AND cash_metrics provided
-    if asset_class == "cash" and cash_metrics is not None:
+    # Dispatch to Cash scoring
+    if asset_class == "cash":
+        if cash_metrics is None:
+            return _equity_score_with_class_mismatch(
+                metrics, flows_momentum_score, config, expense_ratio_pct,
+                insider_sentiment_score, peer_medians,
+                class_mismatch="cash",
+            )
         return _compute_cash_score(cash_metrics, config, expense_ratio_pct, peer_medians)
 
-    # Dispatch to FI scoring when asset_class is fixed_income AND fi_metrics provided
-    if asset_class == "fixed_income" and fi_metrics is not None:
+    # Dispatch to FI scoring
+    if asset_class == "fixed_income":
+        if fi_metrics is None:
+            return _equity_score_with_class_mismatch(
+                metrics, flows_momentum_score, config, expense_ratio_pct,
+                insider_sentiment_score, peer_medians,
+                class_mismatch="fixed_income",
+            )
         return _compute_fi_score(fi_metrics, config, expense_ratio_pct, peer_medians)
 
-    pm = peer_medians or {}
-    components: dict[str, float] = {}
-
-    # S4-QW1: use ``is not None`` instead of truthy checks.
-    # ``Decimal("0.0")`` and ``float(0.0)`` are both falsy in Python, so the
-    # historical ``if metrics.return_1y:`` idiom treated a fund that
-    # **legitimately** returned exactly 0 % as "missing data" and assigned
-    # the peer-median minus 5 opacity penalty. The fund then fell several
-    # ranks below peers for a non-existent data gap. Strict ``is not None``
-    # distinguishes "value available and equal to zero" from "value
-    # unavailable".
-    ret_1y = float(metrics.return_1y) if metrics.return_1y is not None else None
-    components["return_consistency"] = _normalize(ret_1y, -0.20, 0.40, pm.get("return_consistency"))
-
-    sharpe = _resolve_sharpe_input(metrics, config)
-    components["risk_adjusted_return"] = _normalize(sharpe, -1.0, 3.0, pm.get("risk_adjusted_return"))
-
-    dd = float(metrics.max_drawdown_1y) if metrics.max_drawdown_1y is not None else None
-    components["drawdown_control"] = _normalize(dd, -0.50, 0.0, pm.get("drawdown_control"))
-
-    ir = float(metrics.information_ratio_1y) if metrics.information_ratio_1y is not None else None
-    components["information_ratio"] = _normalize(ir, -1.0, 2.0, pm.get("information_ratio"))
-
-    components["flows_momentum"] = (
-        _clamp_component_score(flows_momentum_score, "flows_momentum")
-        if flows_momentum_score is not None
-        else 45.0
+    # Equity (default)
+    return _compute_equity_score(
+        metrics, flows_momentum_score, config, expense_ratio_pct,
+        insider_sentiment_score, peer_medians,
     )
-
-    # Fee efficiency — shared with FI path
-    components["fee_efficiency"] = _compute_fee_efficiency(expense_ratio_pct, pm)
-
-    weights = resolve_scoring_weights(config)
-
-    # Opt-in insider sentiment (activated when config includes "insider_sentiment" weight > 0)
-    if weights.get("insider_sentiment", 0) > 0:
-        if insider_sentiment_score is not None:
-            components["insider_sentiment"] = _clamp_component_score(
-                insider_sentiment_score, "insider_sentiment",
-            )
-        else:
-            components["insider_sentiment"] = 45.0  # missing-data fallback
-
-    missing = set(weights.keys()) - components.keys()
-    if missing:
-        raise ValueError(
-            f"compute_fund_score: weights reference components not provided: "
-            f"{sorted(missing)}. Caller must pass {{key}}_score kwargs for each."
-        )
-
-    score = sum(components[k] * w for k, w in weights.items())
-
-    return round(score, 2), {k: round(v, 2) for k, v in components.items()}

--- a/backend/tests/e2e_smoke_test.py
+++ b/backend/tests/e2e_smoke_test.py
@@ -531,9 +531,9 @@ async def main() -> None:
                 max_drawdown_1y: float | None = -0.15
                 information_ratio_1y: float | None = 0.5
 
-            score, breakdown = compute_fund_score(MockRiskMetrics(), 50.0, None)
-            in_range = 0 <= score <= 100
-            ok("4.5 Scoring", f"score={score:.1f}, in_range={in_range}, breakdown={breakdown}")
+            result = compute_fund_score(MockRiskMetrics(), 50.0, None)
+            in_range = 0 <= result.score <= 100
+            ok("4.5 Scoring", f"score={result.score:.1f}, in_range={in_range}, breakdown={result.components}")
         except Exception as e:
             fail("4.5 Scoring", str(e))
 

--- a/backend/tests/quant_engine/test_scoring_correctness.py
+++ b/backend/tests/quant_engine/test_scoring_correctness.py
@@ -13,7 +13,6 @@ from typing import Any
 import pytest
 
 from quant_engine.scoring_service import (
-    ScoringResult,
     _clamp_component_score,
     _compute_alternatives_score,
     _compute_cash_score,

--- a/backend/tests/quant_engine/test_scoring_correctness.py
+++ b/backend/tests/quant_engine/test_scoring_correctness.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 from quant_engine.scoring_service import (
+    ScoringResult,
     _clamp_component_score,
     _compute_alternatives_score,
     _compute_cash_score,
@@ -213,13 +214,13 @@ def test_BUG_S4_spread_capture_peaked_at_one() -> None:
 
     # Verify in context: FI scoring with credit_beta = 1.0 should yield 100
     fi = _StubFIMetrics(credit_beta=1.0)
-    _, components = _compute_fi_score(fi, None, 0.005, None)
-    assert components["spread_capture"] == 100.0
+    result = _compute_fi_score(fi, None, 0.005, None)
+    assert result.components["spread_capture"] == 100.0
 
     # High credit_beta (2.5) should score low
     fi_high = _StubFIMetrics(credit_beta=2.5)
-    _, components_high = _compute_fi_score(fi_high, None, 0.005, None)
-    assert components_high["spread_capture"] < 50.0
+    result_high = _compute_fi_score(fi_high, None, 0.005, None)
+    assert result_high.components["spread_capture"] < 50.0
 
 
 # ── Fix 8 (BUG-S6) — External component scores not bounded ──────────
@@ -228,9 +229,9 @@ def test_BUG_S4_spread_capture_peaked_at_one() -> None:
 def test_BUG_S6_flows_momentum_clamped_to_100() -> None:
     """flows_momentum_score=500 must be clamped to 100, not passed through."""
     m = _StubRiskMetrics()
-    score, components = compute_fund_score(m, flows_momentum_score=500.0)
-    assert components["flows_momentum"] == 100.0, (
-        f"Expected clamped to 100, got {components['flows_momentum']}"
+    result = compute_fund_score(m, flows_momentum_score=500.0)
+    assert result.components["flows_momentum"] == 100.0, (
+        f"Expected clamped to 100, got {result.components['flows_momentum']}"
     )
 
 
@@ -246,8 +247,8 @@ def test_BUG_S6_non_finite_score_raises() -> None:
 def test_BUG_S7_zero_rate_continuous_score() -> None:
     """ffr=0.0 with yld=0.01 must produce a continuous score, not collapsed fallback."""
     cash = _StubCashMetrics(seven_day_net_yield=0.01, fed_funds_rate_at_calc=0.0)
-    _, components = _compute_cash_score(cash, None, 0.005, None)
-    score = components["yield_vs_risk_free"]
+    result = _compute_cash_score(cash, None, 0.005, None)
+    score = result.components["yield_vs_risk_free"]
     # Spread = 1.0 pp → normalized on [-5, 5] → (1+5)/10 * 100 = 60
     assert 55.0 < score < 65.0, f"Expected ~60 for 1pp spread, got {score}"
 
@@ -255,8 +256,8 @@ def test_BUG_S7_zero_rate_continuous_score() -> None:
 def test_BUG_S7_negative_rate_preserves_spread_sign() -> None:
     """ffr=-0.005 with yld=+0.001 must score above 50 (positive spread)."""
     cash = _StubCashMetrics(seven_day_net_yield=0.001, fed_funds_rate_at_calc=-0.005)
-    _, components = _compute_cash_score(cash, None, 0.005, None)
-    score = components["yield_vs_risk_free"]
+    result = _compute_cash_score(cash, None, 0.005, None)
+    score = result.components["yield_vs_risk_free"]
     # Spread = (0.001 - (-0.005)) * 100 = 0.6 pp → above midpoint
     assert score > 50.0, f"Expected > 50 for positive spread over negative rate, got {score}"
 
@@ -267,26 +268,26 @@ def test_BUG_S7_negative_rate_preserves_spread_sign() -> None:
 def test_BUG_S9_fi_missing_data_consistent_with_equity() -> None:
     """FI missing-data fallback must be 45.0, not 40.0 (45 - 5)."""
     fi = _StubFIMetrics(empirical_duration=None)
-    _, components = _compute_fi_score(fi, None, 0.005, None)
-    assert components["duration_management"] == 45.0, (
-        f"Expected 45.0 for missing FI data, got {components['duration_management']}"
+    result = _compute_fi_score(fi, None, 0.005, None)
+    assert result.components["duration_management"] == 45.0, (
+        f"Expected 45.0 for missing FI data, got {result.components['duration_management']}"
     )
 
 
 def test_BUG_S9_cash_missing_data_consistent() -> None:
     """Cash missing-data fallback must be 45.0, not 40.0."""
     cash = _StubCashMetrics(nav_per_share_mmf=None)
-    _, components = _compute_cash_score(cash, None, 0.005, None)
-    assert components["nav_stability"] == 45.0, (
-        f"Expected 45.0 for missing cash data, got {components['nav_stability']}"
+    result = _compute_cash_score(cash, None, 0.005, None)
+    assert result.components["nav_stability"] == 45.0, (
+        f"Expected 45.0 for missing cash data, got {result.components['nav_stability']}"
     )
 
 
 def test_BUG_S9_alt_missing_data_consistent() -> None:
     """Alt missing-data fallback must be 45.0, not 40.0."""
     alt = _StubAltMetrics(equity_correlation_252d=None)
-    _, components = _compute_alternatives_score(alt, "hedge", None, 0.005, None)
-    assert components.get("diversification_value", 45.0) == 45.0
+    result = _compute_alternatives_score(alt, "hedge", None, 0.005, None)
+    assert result.components.get("diversification_value", 45.0) == 45.0
 
 
 # ── Fix 11 (BUG-S11) — flows_momentum default 50 vs 45 ──────────────
@@ -295,9 +296,9 @@ def test_BUG_S9_alt_missing_data_consistent() -> None:
 def test_BUG_S11_flows_momentum_omitted_defaults_to_45() -> None:
     """Omitted flows_momentum_score must default to 45.0 (missing-data), not 50."""
     m = _StubRiskMetrics()
-    _, components = compute_fund_score(m)
-    assert components["flows_momentum"] == 45.0, (
-        f"Expected 45.0 for omitted flows_momentum, got {components['flows_momentum']}"
+    result = compute_fund_score(m)
+    assert result.components["flows_momentum"] == 45.0, (
+        f"Expected 45.0 for omitted flows_momentum, got {result.components['flows_momentum']}"
     )
 
 
@@ -311,18 +312,18 @@ def test_BUG_S10_drawdown_control_uses_max_drawdown_not_calmar() -> None:
     alt_low_dd = _StubAltMetrics(calmar_ratio_3y=0.8, max_drawdown_3y=-0.05)
     alt_high_dd = _StubAltMetrics(calmar_ratio_3y=0.8, max_drawdown_3y=-0.40)
 
-    _, comps_low = _compute_alternatives_score(alt_low_dd, "commodity", None, 0.005, None)
-    _, comps_high = _compute_alternatives_score(alt_high_dd, "commodity", None, 0.005, None)
+    result_low = _compute_alternatives_score(alt_low_dd, "commodity", None, 0.005, None)
+    result_high = _compute_alternatives_score(alt_high_dd, "commodity", None, 0.005, None)
 
     # Different max_drawdown → different drawdown_control (despite same calmar)
-    assert comps_low["drawdown_control"] > comps_high["drawdown_control"], (
+    assert result_low.components["drawdown_control"] > result_high.components["drawdown_control"], (
         f"Lower drawdown ({-0.05}) should score higher than {-0.40}, "
-        f"got {comps_low['drawdown_control']} vs {comps_high['drawdown_control']}"
+        f"got {result_low.components['drawdown_control']} vs {result_high.components['drawdown_control']}"
     )
 
 
 def test_BUG_S10_missing_max_drawdown_falls_to_45() -> None:
     """Missing max_drawdown_3y must produce 45.0, not inherit calmar score."""
     alt = _StubAltMetrics(calmar_ratio_3y=1.2, max_drawdown_3y=None)
-    _, comps = _compute_alternatives_score(alt, "commodity", None, 0.005, None)
-    assert comps["drawdown_control"] == 45.0
+    result = _compute_alternatives_score(alt, "commodity", None, 0.005, None)
+    assert result.components["drawdown_control"] == 45.0

--- a/backend/tests/quant_engine/test_scoring_result_dataclass.py
+++ b/backend/tests/quant_engine/test_scoring_result_dataclass.py
@@ -1,0 +1,218 @@
+"""Regression tests for S07-F05 (silent dispatch) + S07-F07 (degraded surface).
+
+PR-Q59: ScoringResult dataclass + degraded surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from quant_engine.scoring_service import (
+    ScoringResult,
+    compute_fund_score,
+)
+
+
+@dataclass
+class _RiskMetrics:
+    return_1y: float | None = 0.10
+    sharpe_1y: float | None = 1.2
+    sharpe_cf: float | None = None
+    max_drawdown_1y: float | None = -0.08
+    information_ratio_1y: float | None = 0.6
+
+
+@dataclass
+class _CashMetrics:
+    seven_day_net_yield: float | None = 5.30
+    fed_funds_rate_at_calc: float | None = 5.33
+    nav_per_share_mmf: float | None = 1.0000
+    pct_weekly_liquid: float | None = 85.0
+    weighted_avg_maturity_days: float | None = 15
+
+
+@dataclass
+class _FIMetrics:
+    empirical_duration: float | None = 6.0
+    credit_beta: float | None = 1.0
+    yield_proxy_12m: float | None = 0.05
+    duration_adj_drawdown_1y: float | None = -0.005
+
+
+@dataclass
+class _AltMetrics:
+    equity_correlation_252d: float | None = 0.2
+    downside_capture_1y: float | None = 0.5
+    upside_capture_1y: float | None = 0.7
+    crisis_alpha_score: float | None = 0.08
+    calmar_ratio_3y: float | None = 1.2
+    max_drawdown_3y: float | None = -0.10
+    sortino_1y: float | None = 1.5
+    inflation_beta: float | None = 1.8
+    yield_proxy_12m: float | None = 0.06
+    tracking_error_1y: float | None = 0.02
+
+
+def _equity_metrics_full() -> _RiskMetrics:
+    return _RiskMetrics()
+
+
+def _equity_metrics_partial() -> _RiskMetrics:
+    return _RiskMetrics(
+        return_1y=None,
+        sharpe_1y=1.2,
+        sharpe_cf=None,
+        max_drawdown_1y=-0.08,
+        information_ratio_1y=None,
+    )
+
+
+# ── F05: dispatch silent fallback ──────────────────────────────────────
+
+
+def test_cash_asset_class_with_metrics_returns_cash_score() -> None:
+    """asset_class=cash + cash_metrics present → cash scoring path."""
+    metrics = _equity_metrics_full()
+    cash_metrics = _CashMetrics()
+    result = compute_fund_score(
+        metrics, cash_metrics=cash_metrics, asset_class="cash",
+        expense_ratio_pct=0.001,
+    )
+    assert isinstance(result, ScoringResult)
+    assert "yield_vs_risk_free" in result.components
+    assert "return_consistency" not in result.components
+
+
+def test_cash_asset_class_without_metrics_marks_degraded() -> None:
+    """asset_class=cash + cash_metrics=None → degraded flag set, reason cites class mismatch."""
+    metrics = _equity_metrics_full()
+    result = compute_fund_score(metrics, cash_metrics=None, asset_class="cash")
+    assert isinstance(result, ScoringResult)
+    assert result.degraded is True
+    assert any("asset_class_metrics_missing:cash" in r for r in result.degraded_reasons)
+
+
+def test_fixed_income_asset_class_without_metrics_marks_degraded() -> None:
+    metrics = _equity_metrics_full()
+    result = compute_fund_score(metrics, fi_metrics=None, asset_class="fixed_income")
+    assert result.degraded is True
+    assert any("asset_class_metrics_missing:fixed_income" in r for r in result.degraded_reasons)
+
+
+def test_alternatives_asset_class_without_metrics_marks_degraded() -> None:
+    metrics = _equity_metrics_full()
+    result = compute_fund_score(metrics, alt_metrics=None, asset_class="alternatives")
+    assert result.degraded is True
+    assert any("asset_class_metrics_missing:alternatives" in r for r in result.degraded_reasons)
+
+
+def test_equity_asset_class_with_full_metrics_not_degraded() -> None:
+    """Default path: equity asset class + full metrics → not degraded."""
+    metrics = _equity_metrics_full()
+    result = compute_fund_score(
+        metrics, flows_momentum_score=60.0, expense_ratio_pct=0.005,
+        asset_class="equity",
+    )
+    assert result.degraded is False
+    assert result.degraded_reasons == []
+
+
+def test_class_mismatch_still_produces_equity_components() -> None:
+    """When asset_class mismatch triggers fallback, equity components are present."""
+    metrics = _equity_metrics_full()
+    result = compute_fund_score(metrics, cash_metrics=None, asset_class="cash")
+    assert "return_consistency" in result.components
+    assert "yield_vs_risk_free" not in result.components
+
+
+# ── F07: missing-data observability ────────────────────────────────────
+
+
+def test_partial_equity_metrics_marks_degraded_with_synthesized_components() -> None:
+    """Equity scoring with several fields None → degraded with synthesized reasons."""
+    metrics = _equity_metrics_partial()
+    result = compute_fund_score(metrics, asset_class="equity")
+    assert result.degraded is True
+    synthesized = [r for r in result.degraded_reasons if r.startswith("synthesized_component:")]
+    # return_1y=None, information_ratio_1y=None, flows_momentum=None (default), fee_efficiency=None (default)
+    assert len(synthesized) >= 3
+
+
+def test_score_still_produced_even_when_degraded() -> None:
+    """Even with full-fallback scoring, score is in [0, 100] (not None or NaN)."""
+    metrics = _equity_metrics_partial()
+    result = compute_fund_score(metrics, asset_class="equity")
+    assert 0.0 <= result.score <= 100.0
+
+
+def test_fi_scoring_tracks_synthesized_components() -> None:
+    """FI scoring with missing yield marks it as synthesized."""
+    fi = _FIMetrics(yield_proxy_12m=None)
+    result = compute_fund_score(
+        _equity_metrics_full(), asset_class="fixed_income", fi_metrics=fi,
+    )
+    assert result.degraded is True
+    assert "synthesized_component:yield_consistency" in result.degraded_reasons
+
+
+def test_cash_scoring_tracks_synthesized_components() -> None:
+    """Cash scoring with missing nav marks it as synthesized."""
+    cash = _CashMetrics(nav_per_share_mmf=None)
+    result = compute_fund_score(
+        _equity_metrics_full(), asset_class="cash", cash_metrics=cash,
+    )
+    assert result.degraded is True
+    assert "synthesized_component:nav_stability" in result.degraded_reasons
+
+
+def test_alt_scoring_tracks_synthesized_components() -> None:
+    """Alt scoring with all None metrics marks components as synthesized."""
+    alt = _AltMetrics(
+        equity_correlation_252d=None,
+        downside_capture_1y=None,
+        upside_capture_1y=None,
+        crisis_alpha_score=None,
+        calmar_ratio_3y=None,
+        max_drawdown_3y=None,
+        sortino_1y=None,
+        inflation_beta=None,
+        yield_proxy_12m=None,
+        tracking_error_1y=None,
+    )
+    result = compute_fund_score(
+        _equity_metrics_full(), asset_class="alternatives", alt_metrics=alt,
+    )
+    assert result.degraded is True
+    synthesized = [r for r in result.degraded_reasons if r.startswith("synthesized_component:")]
+    assert len(synthesized) >= 3
+
+
+# ── Backward compatibility ─────────────────────────────────────────────
+
+
+def test_components_dict_still_populated_for_dashboards() -> None:
+    """The components dict — used by every UI consumer — must still be populated."""
+    metrics = _equity_metrics_full()
+    result = compute_fund_score(metrics, asset_class="equity")
+    assert isinstance(result.components, dict)
+    assert "return_consistency" in result.components
+    assert "risk_adjusted_return" in result.components
+
+
+def test_score_equivalence_for_full_inputs() -> None:
+    """For fully-populated equity input, score must match pinned regression value."""
+    metrics = _equity_metrics_full()
+    result = compute_fund_score(
+        metrics, flows_momentum_score=60.0, expense_ratio_pct=0.005,
+        asset_class="equity",
+    )
+    assert result.score == pytest.approx(62.05, abs=0.5)
+
+
+def test_scoring_result_is_frozen() -> None:
+    """ScoringResult dataclass is immutable."""
+    result = compute_fund_score(_equity_metrics_full(), asset_class="equity")
+    with pytest.raises(AttributeError):
+        result.score = 99.0  # type: ignore[misc]

--- a/backend/tests/test_alt_scoring_dispatch.py
+++ b/backend/tests/test_alt_scoring_dispatch.py
@@ -102,13 +102,13 @@ class TestREITProfile:
             downside_capture_1y=0.6,        # Good protection
             inflation_beta=2.0,             # Good inflation hedge
         )
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="reit",
             expense_ratio_pct=0.005,
         )
-        assert "income_generation" in components
-        assert "diversification_value" in components
-        assert score > 50, f"Good REIT should score > 50, got {score}"
+        assert "income_generation" in result.components
+        assert "diversification_value" in result.components
+        assert result.score > 50, f"Good REIT should score > 50, got {result.score}"
 
 
 class TestCommodityProfile:
@@ -122,13 +122,13 @@ class TestCommodityProfile:
             crisis_alpha_score=0.15,        # Positive crisis alpha
             calmar_ratio_3y=1.0,            # Decent Calmar
         )
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="commodity",
             expense_ratio_pct=0.005,
         )
-        assert "inflation_hedge" in components
-        assert components["inflation_hedge"] > 70, "Strong inflation hedge should score > 70"
-        assert score > 55, f"Good commodity fund should score > 55, got {score}"
+        assert "inflation_hedge" in result.components
+        assert result.components["inflation_hedge"] > 70, "Strong inflation hedge should score > 70"
+        assert result.score > 55, f"Good commodity fund should score > 55, got {result.score}"
 
 
 class TestGoldProfile:
@@ -142,13 +142,13 @@ class TestGoldProfile:
             inflation_beta=1.5,             # Moderate inflation hedge
             tracking_error_1y=0.01,         # Low tracking error vs GLD
         )
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="gold",
             expense_ratio_pct=0.004,
         )
-        assert "crisis_alpha" in components
-        assert "tracking_efficiency" in components
-        assert score > 60, f"Good gold fund should score > 60, got {score}"
+        assert "crisis_alpha" in result.components
+        assert "tracking_efficiency" in result.components
+        assert result.score > 60, f"Good gold fund should score > 60, got {result.score}"
 
 
 class TestHedgeFundProfile:
@@ -162,14 +162,14 @@ class TestHedgeFundProfile:
             equity_correlation_252d=0.3,    # Low-moderate correlation
             crisis_alpha_score=0.10,        # p90+ crisis alpha
         )
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="hedge",
             expense_ratio_pct=0.020,  # 2% management fee typical for HFs
         )
-        assert "alpha_generation" in components
-        assert "downside_protection" in components
-        assert components["alpha_generation"] > 70, "Strong Sortino should produce high alpha_generation"
-        assert score > 50, f"Good hedge fund should score > 50, got {score}"
+        assert "alpha_generation" in result.components
+        assert "downside_protection" in result.components
+        assert result.components["alpha_generation"] > 70, "Strong Sortino should produce high alpha_generation"
+        assert result.score > 50, f"Good hedge fund should score > 50, got {result.score}"
 
 
 class TestCTAProfile:
@@ -182,13 +182,13 @@ class TestCTAProfile:
             equity_correlation_252d=-0.1,   # Negative correlation (ideal for CTA)
             calmar_ratio_3y=1.5,            # Good risk-adjusted return
         )
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="cta",
             expense_ratio_pct=0.015,
         )
-        assert "crisis_alpha" in components
+        assert "crisis_alpha" in result.components
         assert _DEFAULT_ALT_CTA_WEIGHTS["crisis_alpha"] == 0.40
-        assert score > 55, f"Good CTA should score > 55, got {score}"
+        assert result.score > 55, f"Good CTA should score > 55, got {result.score}"
 
 
 class TestGenericAltProfile:
@@ -197,13 +197,13 @@ class TestGenericAltProfile:
     def test_generic_scores_balanced(self) -> None:
         risk = _make_equity_metrics()
         alt = _make_alt_metrics()
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="generic_alt",
         )
-        assert isinstance(score, float)
-        assert "diversification_value" in components
-        assert "downside_protection" in components
-        assert "crisis_alpha" in components
+        assert isinstance(result.score, float)
+        assert "diversification_value" in result.components
+        assert "downside_protection" in result.components
+        assert "crisis_alpha" in result.components
 
 
 class TestAlternativesDispatch:
@@ -212,32 +212,32 @@ class TestAlternativesDispatch:
     def test_dispatch_produces_alt_components(self) -> None:
         risk = _make_equity_metrics()
         alt = _make_alt_metrics()
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt,
         )
-        assert "diversification_value" in components
-        assert "return_consistency" not in components, "Should NOT use equity components"
-        assert "yield_consistency" not in components, "Should NOT use FI components"
-        assert "yield_vs_risk_free" not in components, "Should NOT use cash components"
+        assert "diversification_value" in result.components
+        assert "return_consistency" not in result.components, "Should NOT use equity components"
+        assert "yield_consistency" not in result.components, "Should NOT use FI components"
+        assert "yield_vs_risk_free" not in result.components, "Should NOT use cash components"
 
     def test_fallback_to_equity_if_no_alt_metrics(self) -> None:
         risk = _make_equity_metrics()
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=None,
         )
-        assert "return_consistency" in components, "Should fall back to equity"
-        assert "diversification_value" not in components
+        assert "return_consistency" in result.components, "Should fall back to equity"
+        assert "diversification_value" not in result.components
 
     def test_default_profile_is_generic(self) -> None:
         risk = _make_equity_metrics()
         alt = _make_alt_metrics()
         # No alt_profile specified => generic_alt
-        score_default, _ = compute_fund_score(
+        score_default = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt,
-        )
-        score_explicit, _ = compute_fund_score(
+        ).score
+        score_explicit = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="generic_alt",
-        )
+        ).score
         assert score_default == score_explicit
 
 
@@ -276,13 +276,13 @@ class TestAlternativesVsEquityScoring:
             inflation_beta=2.0,             # Good inflation hedge
         )
 
-        equity_score, _ = compute_fund_score(
+        equity_score = compute_fund_score(
             risk, asset_class="equity", expense_ratio_pct=0.010,
-        )
-        alt_score, _ = compute_fund_score(
+        ).score
+        alt_score = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="hedge",
             expense_ratio_pct=0.010,
-        )
+        ).score
 
         assert alt_score > equity_score, (
             f"Alt model should score higher than equity model for a skilled alternatives fund. "
@@ -303,8 +303,8 @@ class TestAlternativesVsEquityScoring:
             yield_proxy_12m=None,
             tracking_error_1y=None,
         )
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt,
         )
         # Most components should get the 45-5=40 penalty
-        assert score < 50, f"All-None alt fund should score < 50, got {score}"
+        assert result.score < 50, f"All-None alt fund should score < 50, got {result.score}"

--- a/backend/tests/test_alt_scoring_integration.py
+++ b/backend/tests/test_alt_scoring_integration.py
@@ -211,23 +211,23 @@ class TestREITFundE2E:
             sortino_1y=0.7,
         )
 
-        equity_score, eq_comps = compute_fund_score(
+        equity_result = compute_fund_score(
             risk, asset_class="equity", expense_ratio_pct=0.008,
         )
-        alt_score, alt_comps = compute_fund_score(
+        alt_result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="reit",
             expense_ratio_pct=0.008,
         )
 
-        assert alt_score > equity_score, (
+        assert alt_result.score > equity_result.score, (
             f"REIT with strong income/diversification should score higher on alt model. "
-            f"Alt={alt_score}, Equity={equity_score}"
+            f"Alt={alt_result.score}, Equity={equity_result.score}"
         )
-        assert "income_generation" in alt_comps
-        assert "inflation_hedge" in alt_comps
+        assert "income_generation" in alt_result.components
+        assert "inflation_hedge" in alt_result.components
         # REIT profile weights
         for k in _DEFAULT_ALT_REIT_WEIGHTS:
-            assert k in alt_comps, f"REIT profile should include {k}"
+            assert k in alt_result.components, f"REIT profile should include {k}"
 
 
 # ── Commodity E2E: inflation_hedge component ─────────────────────────
@@ -246,17 +246,17 @@ class TestCommodityFundE2E:
             downside_capture_1y=0.5,
         )
 
-        score, comps = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="commodity",
             expense_ratio_pct=0.005,
         )
 
-        assert "inflation_hedge" in comps
+        assert "inflation_hedge" in result.components
         # With beta=3.5, inflation_hedge should score very high
-        assert comps["inflation_hedge"] > 70, (
-            f"inflation_beta=3.5 should produce inflation_hedge > 70, got {comps['inflation_hedge']}"
+        assert result.components["inflation_hedge"] > 70, (
+            f"inflation_beta=3.5 should produce inflation_hedge > 70, got {result.components['inflation_hedge']}"
         )
-        assert score > 50
+        assert result.score > 50
 
 
 # ── CTA E2E: crisis_alpha dominates ──────────────────────────────────
@@ -274,17 +274,17 @@ class TestCTAFundE2E:
             inflation_beta=0.5,             # Weak inflation hedge (irrelevant for CTA)
         )
 
-        score, comps = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="alternatives", alt_metrics=alt, alt_profile="cta",
             expense_ratio_pct=0.015,
         )
 
-        assert "crisis_alpha" in comps
+        assert "crisis_alpha" in result.components
         assert _DEFAULT_ALT_CTA_WEIGHTS["crisis_alpha"] == 0.40
         # Only crisis_alpha, diversification, risk_adjusted_return, fee_efficiency
-        assert "income_generation" not in comps, "CTA should not show income_generation"
-        assert "inflation_hedge" not in comps, "CTA should not show inflation_hedge"
-        assert score > 55, f"Strong CTA should score > 55, got {score}"
+        assert "income_generation" not in result.components, "CTA should not show income_generation"
+        assert "inflation_hedge" not in result.components, "CTA should not show inflation_hedge"
+        assert result.score > 55, f"Strong CTA should score > 55, got {result.score}"
 
 
 # ── ELITE Validation ─────────────────────────────────────────────────
@@ -315,17 +315,13 @@ class TestELITECrossAssetValidation:
 
         scores = {}
 
-        s, _ = compute_fund_score(risk, asset_class="equity")
-        scores["equity"] = s
+        scores["equity"] = compute_fund_score(risk, asset_class="equity").score
 
-        s, _ = compute_fund_score(risk, asset_class="fixed_income", fi_metrics=fi)
-        scores["fixed_income"] = s
+        scores["fixed_income"] = compute_fund_score(risk, asset_class="fixed_income", fi_metrics=fi).score
 
-        s, _ = compute_fund_score(risk, asset_class="cash", cash_metrics=cash)
-        scores["cash"] = s
+        scores["cash"] = compute_fund_score(risk, asset_class="cash", cash_metrics=cash).score
 
-        s, _ = compute_fund_score(risk, asset_class="alternatives", alt_metrics=alt, alt_profile="hedge")
-        scores["alternatives"] = s
+        scores["alternatives"] = compute_fund_score(risk, asset_class="alternatives", alt_metrics=alt, alt_profile="hedge").score
 
         for model, score in scores.items():
             assert 0 <= score <= 100, f"{model} score {score} out of range"
@@ -335,7 +331,7 @@ class TestELITECrossAssetValidation:
         """A 'good' fund in each class should score reasonably (> 40)."""
         # Good equity fund
         risk_eq = _make_equity_metrics(return_1y=0.15, sharpe_1y=1.5, max_drawdown_1y=-0.08)
-        s_eq, _ = compute_fund_score(risk_eq, asset_class="equity")
+        s_eq = compute_fund_score(risk_eq, asset_class="equity").score
 
         # Good alt fund
         risk_alt = _make_equity_metrics(return_1y=0.08, sharpe_1y=0.9)
@@ -343,7 +339,7 @@ class TestELITECrossAssetValidation:
             equity_correlation_252d=0.1, crisis_alpha_score=0.15,
             calmar_ratio_3y=1.5, sortino_1y=2.0, downside_capture_1y=0.3,
         )
-        s_alt, _ = compute_fund_score(risk_alt, asset_class="alternatives", alt_metrics=alt, alt_profile="hedge")
+        s_alt = compute_fund_score(risk_alt, asset_class="alternatives", alt_metrics=alt, alt_profile="hedge").score
 
         # Good cash fund
         cash = MagicMock()
@@ -353,7 +349,7 @@ class TestELITECrossAssetValidation:
         cash.pct_weekly_liquid = 70.0
         cash.weighted_avg_maturity_days = 15
         risk_cash = _make_equity_metrics()
-        s_cash, _ = compute_fund_score(risk_cash, asset_class="cash", cash_metrics=cash)
+        s_cash = compute_fund_score(risk_cash, asset_class="cash", cash_metrics=cash).score
 
         for label, score in [("equity", s_eq), ("alternatives", s_alt), ("cash", s_cash)]:
             assert score > 40, f"Good {label} fund should score > 40, got {score}"

--- a/backend/tests/test_cash_scoring.py
+++ b/backend/tests/test_cash_scoring.py
@@ -231,20 +231,22 @@ class TestScoringServiceCashDispatch:
             pct_weekly_liquid=85.0,
             weighted_avg_maturity_days=15,
         )
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="cash", cash_metrics=cash, expense_ratio_pct=0.15,
         )
-        assert "yield_vs_risk_free" in components, "Cash dispatch should use cash components"
-        assert "nav_stability" in components
-        assert "sharpe_ratio" not in components, "Cash dispatch should NOT use equity components"
+        assert "yield_vs_risk_free" in result.components, "Cash dispatch should use cash components"
+        assert "nav_stability" in result.components
+        assert "sharpe_ratio" not in result.components, "Cash dispatch should NOT use equity components"
 
     def test_cash_fallback_to_equity_if_no_metrics(self):
         risk = _RiskMetricsAdapter(return_1y=0.05, sharpe_1y=0.5, max_drawdown_1y=-0.01)
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="cash", cash_metrics=None,
         )
-        # Should fall through to equity scoring
-        assert "return_consistency" in components
+        # Should fall through to equity scoring (degraded, but still produces equity components)
+        assert result.degraded is True
+        assert "asset_class_metrics_missing:cash" in result.degraded_reasons
+        assert "return_consistency" in result.components
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -331,11 +333,11 @@ class TestCashVsEquityScoring:
             max_drawdown_1y=-0.0005,  # Near-zero drawdown
             information_ratio_1y=None,
         )
-        score_equity, comp_equity = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="equity",
         )
         # With None Sharpe, the equity model assigns opacity penalty
-        assert comp_equity["risk_adjusted_return"] == 45.0
+        assert result.components["risk_adjusted_return"] == 45.0
 
     def test_mmf_on_cash_model_uses_fundamentals(self):
         """Same MMF on cash model uses yield, NAV stability, liquidity, maturity."""
@@ -347,13 +349,13 @@ class TestCashVsEquityScoring:
             pct_weekly_liquid=85.0,
             weighted_avg_maturity_days=15,
         )
-        score_cash, comp_cash = compute_fund_score(
+        result = compute_fund_score(
             risk, asset_class="cash", cash_metrics=cash, expense_ratio_pct=0.15,
         )
-        assert "yield_vs_risk_free" in comp_cash
-        assert "nav_stability" in comp_cash
-        assert comp_cash["nav_stability"] == 100.0  # Perfect $1.00
-        assert score_cash > 50.0, f"Good MMF should score >50 on cash model, got {score_cash}"
+        assert "yield_vs_risk_free" in result.components
+        assert "nav_stability" in result.components
+        assert result.components["nav_stability"] == 100.0  # Perfect $1.00
+        assert result.score > 50.0, f"Good MMF should score >50 on cash model, got {result.score}"
 
     def test_cash_model_outperforms_equity_for_mmf(self):
         """The cash model should produce more meaningful differentiation
@@ -377,12 +379,12 @@ class TestCashVsEquityScoring:
             weighted_avg_maturity_days=55,
         )
 
-        score_strong, _ = compute_fund_score(
+        score_strong = compute_fund_score(
             risk, asset_class="cash", cash_metrics=cash_strong, expense_ratio_pct=0.10,
-        )
-        score_weak, _ = compute_fund_score(
+        ).score
+        score_weak = compute_fund_score(
             risk, asset_class="cash", cash_metrics=cash_weak, expense_ratio_pct=0.50,
-        )
+        ).score
 
         spread = score_strong - score_weak
         assert spread > 15.0, (

--- a/backend/tests/test_fi_scoring_dispatch.py
+++ b/backend/tests/test_fi_scoring_dispatch.py
@@ -17,7 +17,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from quant_engine.scoring_service import (
-    ScoringResult,
     _DEFAULT_FI_SCORING_WEIGHTS,
     _DEFAULT_SCORING_WEIGHTS,
     compute_fund_score,

--- a/backend/tests/test_fi_scoring_dispatch.py
+++ b/backend/tests/test_fi_scoring_dispatch.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from quant_engine.scoring_service import (
+    ScoringResult,
     _DEFAULT_FI_SCORING_WEIGHTS,
     _DEFAULT_SCORING_WEIGHTS,
     compute_fund_score,
@@ -63,7 +64,9 @@ class TestEquityPathUnchanged:
 
     def test_equity_components_produced(self) -> None:
         metrics = _make_equity_metrics()
-        score, components = compute_fund_score(metrics, asset_class="equity")
+        result = compute_fund_score(metrics, asset_class="equity")
+        score = result.score
+        components = result.components
         assert "return_consistency" in components
         assert "risk_adjusted_return" in components
         assert "drawdown_control" in components
@@ -77,8 +80,8 @@ class TestEquityPathUnchanged:
     def test_equity_score_same_without_asset_class_param(self) -> None:
         """Default asset_class='equity' produces same result as explicit."""
         metrics = _make_equity_metrics()
-        score_default, _ = compute_fund_score(metrics)
-        score_explicit, _ = compute_fund_score(metrics, asset_class="equity")
+        score_default = compute_fund_score(metrics).score
+        score_explicit = compute_fund_score(metrics, asset_class="equity").score
         assert score_default == score_explicit
 
 
@@ -98,10 +101,12 @@ class TestFIScoring:
             yield_proxy_12m=0.05,
             duration_adj_drawdown_1y=-0.005,  # excellent: -0.5% per unit duration
         )
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             equity_metrics, asset_class="fixed_income", fi_metrics=fi,
             expense_ratio_pct=0.005,  # 0.5% ER
         )
+        score = result.score
+        components = result.components
         assert score > 70, f"Good IG fund should score > 70, got {score}"
         assert "yield_consistency" in components
         assert "duration_management" in components
@@ -118,9 +123,9 @@ class TestFIScoring:
             yield_proxy_12m=0.02,
             duration_adj_drawdown_1y=-3.0,  # terrible: -3% per unit duration
         )
-        score, _ = compute_fund_score(
+        score = compute_fund_score(
             equity_metrics, asset_class="fixed_income", fi_metrics=fi,
-        )
+        ).score
         assert score < 50, f"Poor FI fund should score < 50, got {score}"
 
 
@@ -143,14 +148,14 @@ class TestFIvsEquityComparison:
             duration_adj_drawdown_1y=-0.005,
         )
 
-        equity_score, _ = compute_fund_score(
+        equity_score = compute_fund_score(
             equity_metrics, asset_class="equity",
             expense_ratio_pct=0.005,
-        )
-        fi_score, _ = compute_fund_score(
+        ).score
+        fi_score = compute_fund_score(
             equity_metrics, asset_class="fixed_income", fi_metrics=fi,
             expense_ratio_pct=0.005,
-        )
+        ).score
 
         assert fi_score > equity_score, (
             f"FI model should score higher than equity model for a skilled FI fund. "
@@ -172,10 +177,12 @@ class TestConfigOverride:
         }
         equity_metrics = _make_equity_metrics()
         fi = _make_fi_metrics()
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             equity_metrics, asset_class="fixed_income", fi_metrics=fi,
             config=custom_config,
         )
+        score = result.score
+        components = result.components
         assert isinstance(score, float)
         assert "yield_consistency" in components
 
@@ -184,9 +191,10 @@ class TestFallbackToEquity:
     def test_fi_asset_class_without_fi_metrics_falls_back(self) -> None:
         """If asset_class=fixed_income but fi_metrics=None, use equity scoring."""
         metrics = _make_equity_metrics()
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             metrics, asset_class="fixed_income", fi_metrics=None,
         )
+        components = result.components
         # Should produce equity components, not FI
         assert "return_consistency" in components
         assert "yield_consistency" not in components

--- a/backend/tests/test_fixed_income_e2e.py
+++ b/backend/tests/test_fixed_income_e2e.py
@@ -388,17 +388,21 @@ class TestFIScoringCredibilityFix:
         )
 
         # Score on FI model (no expense_ratio to isolate FI components)
-        fi_score, fi_components = compute_fund_score(
+        fi_result = compute_fund_score(
             risk_adapter,
             asset_class="fixed_income",
             fi_metrics=fi_adapter,
         )
+        fi_score = fi_result.score
+        fi_components = fi_result.components
 
         # Score on equity model (the broken old way)
-        eq_score, eq_components = compute_fund_score(
+        eq_result = compute_fund_score(
             risk_adapter,
             asset_class="equity",
         )
+        eq_score = eq_result.score
+        eq_components = eq_result.components
 
         # FI model should score significantly higher
         assert fi_score > 60, (
@@ -430,12 +434,14 @@ class TestFIScoringCredibilityFix:
             information_ratio_1y=-0.2,
         )
 
-        fi_score, fi_components = compute_fund_score(
+        fi_result = compute_fund_score(
             risk_adapter,
             asset_class="fixed_income",
             fi_metrics=fi_adapter,
             expense_ratio_pct=1.5,
         )
+        fi_score = fi_result.score
+        fi_components = fi_result.components
 
         assert fi_score < 50, (
             f"Bad FI fund should score <50 even on FI model, got {fi_score}. "
@@ -451,8 +457,12 @@ class TestFIScoringCredibilityFix:
             information_ratio_1y=1.2,
         )
 
-        score1, comp1 = compute_fund_score(risk_adapter, asset_class="equity")
-        score2, comp2 = compute_fund_score(risk_adapter, asset_class="equity")
+        result1 = compute_fund_score(risk_adapter, asset_class="equity")
+        result2 = compute_fund_score(risk_adapter, asset_class="equity")
+        score1 = result1.score
+        comp1 = result1.components
+        score2 = result2.score
+        comp2 = result2.components
 
         assert score1 == score2
         assert comp1 == comp2
@@ -465,11 +475,13 @@ class TestFIScoringCredibilityFix:
             return_1y=0.10, sharpe_1y=1.0,
             max_drawdown_1y=-0.12, information_ratio_1y=0.5,
         )
-        score, components = compute_fund_score(
+        result = compute_fund_score(
             risk_adapter,
             asset_class="fixed_income",
             fi_metrics=None,
         )
+        score = result.score
+        components = result.components
         assert "return_consistency" in components
         assert "yield_consistency" not in components
 

--- a/backend/tests/test_scoring_fee_efficiency.py
+++ b/backend/tests/test_scoring_fee_efficiency.py
@@ -52,13 +52,13 @@ class TestFeeEfficiency:
     def test_fee_efficiency_with_low_er(self):
         """expense_ratio_pct=0.00035 (0.035%) → fee_efficiency near 98.25."""
         metrics = _make_metrics()
-        _, components = compute_fund_score(metrics, expense_ratio_pct=0.00035)
+        components = compute_fund_score(metrics, expense_ratio_pct=0.00035).components
         assert abs(components["fee_efficiency"] - 98.25) < 0.01
 
     def test_fee_efficiency_with_high_er(self):
         """expense_ratio_pct=0.0152 (1.52%) → fee_efficiency near 24.0."""
         metrics = _make_metrics()
-        _, components = compute_fund_score(metrics, expense_ratio_pct=0.0152)
+        components = compute_fund_score(metrics, expense_ratio_pct=0.0152).components
         assert abs(components["fee_efficiency"] - 24.0) < 0.01
 
     def test_fee_efficiency_none_penalty(self):
@@ -69,25 +69,25 @@ class TestFeeEfficiency:
         fees are never disadvantaged against those that don't.
         """
         metrics = _make_metrics()
-        _, components = compute_fund_score(metrics, expense_ratio_pct=None)
+        components = compute_fund_score(metrics, expense_ratio_pct=None).components
         assert components["fee_efficiency"] == 45.0
 
     def test_fee_efficiency_2pct_is_zero(self):
         """expense_ratio_pct=0.02 (2.0%) → fee_efficiency == 0.0."""
         metrics = _make_metrics()
-        _, components = compute_fund_score(metrics, expense_ratio_pct=0.02)
+        components = compute_fund_score(metrics, expense_ratio_pct=0.02).components
         assert components["fee_efficiency"] == 0.0
 
     def test_fee_efficiency_zero_er_is_100(self):
         """expense_ratio_pct=0.0 → fee_efficiency == 100.0."""
         metrics = _make_metrics()
-        _, components = compute_fund_score(metrics, expense_ratio_pct=0.0)
+        components = compute_fund_score(metrics, expense_ratio_pct=0.0).components
         assert components["fee_efficiency"] == 100.0
 
     def test_fee_efficiency_above_2pct_clamped_to_zero(self):
         """expense_ratio_pct=0.03 (3.0%) → fee_efficiency == 0.0 (clamped by max(0, ...))."""
         metrics = _make_metrics()
-        _, components = compute_fund_score(metrics, expense_ratio_pct=0.03)
+        components = compute_fund_score(metrics, expense_ratio_pct=0.03).components
         assert components["fee_efficiency"] == 0.0
 
 
@@ -95,9 +95,9 @@ class TestInsiderSentiment:
     def test_insider_sentiment_opt_in_only(self):
         """Without insider_sentiment weight in config, param is ignored."""
         metrics = _make_metrics()
-        _, components = compute_fund_score(
+        components = compute_fund_score(
             metrics, insider_sentiment_score=80.0,
-        )
+        ).components
         assert "insider_sentiment" not in components
 
     def test_insider_sentiment_with_weight(self):
@@ -114,9 +114,9 @@ class TestInsiderSentiment:
                 "insider_sentiment": 0.05,
             },
         }
-        _, components = compute_fund_score(
+        components = compute_fund_score(
             metrics, config=config, insider_sentiment_score=80.0,
-        )
+        ).components
         assert "insider_sentiment" in components
         assert components["insider_sentiment"] == 80.0
 
@@ -134,9 +134,9 @@ class TestInsiderSentiment:
                 "insider_sentiment": 0.05,
             },
         }
-        _, components = compute_fund_score(
+        components = compute_fund_score(
             metrics, config=config, insider_sentiment_score=None,
-        )
+        ).components
         # When insider_sentiment weight > 0 but score is None, component is
         # present with missing-data fallback (45.0) — not silently absent.
         assert components["insider_sentiment"] == 45.0
@@ -157,13 +157,13 @@ class TestBackwardCompat:
     def test_positional_flows_momentum(self):
         """compute_fund_score(metrics, 50.0, None) still works."""
         metrics = _make_metrics()
-        score, components = compute_fund_score(metrics, 50.0, None)
-        assert isinstance(score, float)
-        assert "flows_momentum" in components
-        assert components["flows_momentum"] == 50.0
+        result = compute_fund_score(metrics, 50.0, None)
+        assert isinstance(result.score, float)
+        assert "flows_momentum" in result.components
+        assert result.components["flows_momentum"] == 50.0
 
     def test_score_range(self):
         """Score is between 0 and 100."""
         metrics = _make_metrics()
-        score, _ = compute_fund_score(metrics)
+        score = compute_fund_score(metrics).score
         assert 0.0 <= score <= 100.0

--- a/backend/vertical_engines/wealth/quant_analyzer.py
+++ b/backend/vertical_engines/wealth/quant_analyzer.py
@@ -120,14 +120,14 @@ class QuantAnalyzer:
 
         from quant_engine.scoring_service import RiskMetrics, compute_fund_score
 
-        score_val, components = compute_fund_score(
+        result = compute_fund_score(
             cast(RiskMetrics, risk),
             flows_momentum_score=50.0,
             config=self._config.get("scoring"),
         )
         return {
-            "manager_score": score_val,
-            "components": components,
+            "manager_score": result.score,
+            "components": result.components,
         }
 
     def _compute_peer_comparison(


### PR DESCRIPTION
## Summary

- Convert `compute_fund_score` return type from `tuple[float, dict[str, float]]` to structured `ScoringResult(score, components, degraded, degraded_reasons)` frozen dataclass
- **S07-F05 (Tier 1 H/H)**: When `asset_class` is cash/FI/alt but corresponding metrics arg is None, dispatch now explicitly marks result as degraded with `"asset_class_metrics_missing:<cls>"` instead of silently producing equity scores
- **S07-F07 (Tier 2 L/H, Critical inst)**: Added `_normalize_with_provenance` to track which components used synthesized fallback values. `degraded_reasons` aggregates `"synthesized_component:<name>"` entries

## API change

```python
# Before:
score, components = compute_fund_score(metrics, ...)

# After:
result = compute_fund_score(metrics, ...)
result.score        # float (0-100)
result.components   # dict[str, float]
result.degraded     # bool
result.degraded_reasons  # list[str]
```

## Behavior change table

| Scenario | Before | After |
|----------|--------|-------|
| `asset_class="cash"`, `cash_metrics=None` | Silent equity score (MMF gets ~70+) | `degraded=True`, `"asset_class_metrics_missing:cash"` |
| `asset_class="equity"`, `return_1y=None` | Component = `peer_median - 5` (looks real) | Same score + `"synthesized_component:return_consistency"` |
| `asset_class="equity"`, all inputs present | `(57.55, {...})` | `ScoringResult(57.55, {...}, degraded=False, [])` |

## Callers updated

- `vertical_engines/wealth/quant_analyzer.py:123` — dataclass attribute access
- `app/domains/wealth/workers/risk_calc.py:1270` — dataclass attribute access + structlog `scoring_degraded` log
- `tests/e2e_smoke_test.py:534` — dataclass attribute access
- 7 test files converted from tuple destructuring to dataclass access

## Pre-flight caller reachability

```
backend/quant_engine/scoring_service.py:690:def _compute_equity_score(
backend/quant_engine/scoring_service.py:800:def compute_fund_score(
backend/vertical_engines/wealth/quant_analyzer.py:121:  from quant_engine.scoring_service import RiskMetrics, compute_fund_score
backend/app/domains/wealth/workers/risk_calc.py:42:from quant_engine.scoring_service import compute_fund_score
backend/tests/e2e_smoke_test.py:525:  from quant_engine.scoring_service import compute_fund_score
```

All non-test callers updated. Zero remaining tuple destructuring.

## Test plan

- [x] 14 new tests in `test_scoring_result_dataclass.py` (F05 dispatch + F07 observability + backward compat + pinned regression)
- [x] 21 pre-existing tests in `test_scoring_correctness.py` — all pass
- [x] 16 tests in `test_scoring_fee_efficiency.py` — all pass
- [x] 13 tests in `test_fi_scoring_dispatch.py` — all pass
- [x] 18 tests in `test_cash_scoring.py` — all pass
- [x] 21 tests in `test_alt_scoring_dispatch.py` — all pass
- [x] 11 tests in `test_alt_scoring_integration.py` — all pass
- [x] 18 tests in `test_fixed_income_e2e.py` — all pass
- [x] Ruff lint: all checks passed
- [x] Mypy: no issues found

## Blast radius

- `scoring_service.py` — return type change (all 4 scorers + main entry point)
- 2 production callers, 1 smoke test, 7 test files
- **No database schema changes** — `fund_risk_metrics` unchanged
- **No scoring math changes** — identical values for fully-observed inputs (pinned at 62.05)

## Coordination

- **Wave 2 standalone** — must merge before Q61 + Q62 (both touch `scoring_service.py` in distinct sections)
- Wave 1 (Q57+Q58+Q60) already in main as of `cfded991`

🤖 Generated with [Claude Code](https://claude.com/claude-code)