### PR TITLE
fix(quant): PR-Q61 — FI duration_adjusted_drawdown bounds (S07-F08) — Tier 1 H/H

### DIFF
--- a/backend/quant_engine/scoring_service.py
+++ b/backend/quant_engine/scoring_service.py
@@ -411,10 +411,12 @@ def _compute_fi_score(
     components["spread_capture"] = _peaked_score(cb, target=1.0, half_range=1.0)
 
     # duration_adjusted_drawdown: drawdown per unit of duration.
-    # Range: -5.0 (terrible) to 0.0 (no drawdown). Higher is better.
+    # Bounds at decimal scale ([-0.05, 0]) — max_drawdown_1y is stored as a
+    # decimal fraction (-0.10 = -10%); dad ranges roughly [-0.05, 0] for
+    # realistic FI funds (10% drawdown over 2y duration → -0.05).
     dad = float(fi.duration_adj_drawdown_1y) if fi.duration_adj_drawdown_1y is not None else None
     val, was_synth = _normalize_with_provenance(
-        dad, -5.0, 0.0, pm.get("duration_adjusted_drawdown"),
+        dad, -0.05, 0.0, pm.get("duration_adjusted_drawdown"),
     )
     components["duration_adjusted_drawdown"] = val
     if was_synth:

--- a/backend/tests/quant_engine/test_fi_duration_adjusted_drawdown_bounds.py
+++ b/backend/tests/quant_engine/test_fi_duration_adjusted_drawdown_bounds.py
@@ -1,0 +1,75 @@
+"""Regression tests for S07-F08 — FI duration_adjusted_drawdown bounds.
+
+Pre-fix bug: bounds [-5.0, 0.0] vs decimal-scale dad → all realistic FI
+funds collapsed to 96-100 score range, destroying signal of a 25%-weight
+component."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from quant_engine.scoring_service import _compute_fi_score
+
+
+@dataclass
+class _FI:
+    empirical_duration: float | None = 5.0
+    credit_beta: float | None = 1.0
+    yield_proxy_12m: float | None = 0.04
+    duration_adj_drawdown_1y: float | None = -0.01
+
+
+def test_severe_drawdown_scores_low() -> None:
+    """Severe FI drawdown → low duration_adjusted_drawdown component (≤ 50)."""
+    fi = _FI(duration_adj_drawdown_1y=-0.03)  # dad = -0.03
+    result = _compute_fi_score(fi, None, 0.005, None)
+    score = result.components["duration_adjusted_drawdown"]
+    assert score <= 50.0, f"Severe drawdown should score ≤ 50, got {score}"
+
+
+def test_mild_drawdown_scores_high() -> None:
+    """Mild FI drawdown → high duration_adjusted_drawdown component (≥ 70)."""
+    fi = _FI(duration_adj_drawdown_1y=-0.003125)  # mild
+    result = _compute_fi_score(fi, None, 0.005, None)
+    score = result.components["duration_adjusted_drawdown"]
+    assert score >= 70.0, f"Mild drawdown should score ≥ 70, got {score}"
+
+
+def test_zero_drawdown_scores_at_top() -> None:
+    """Zero drawdown → top of range (100)."""
+    fi = _FI(duration_adj_drawdown_1y=0.0)
+    result = _compute_fi_score(fi, None, 0.005, None)
+    score = result.components["duration_adjusted_drawdown"]
+    assert score == pytest.approx(100.0)
+
+
+def test_at_or_beyond_lower_bound_clamps_to_zero() -> None:
+    """dad at or below -0.05 → clamps to 0."""
+    fi = _FI(duration_adj_drawdown_1y=-0.06)  # beyond -0.05
+    result = _compute_fi_score(fi, None, 0.005, None)
+    score = result.components["duration_adjusted_drawdown"]
+    assert score == pytest.approx(0.0)
+
+
+def test_signal_separation_severe_vs_mild() -> None:
+    """The component must distinguish severe from mild (≥ 25-pt gap).
+    Pre-fix: all funds compressed to 96-100 (≤ 4-pt gap)."""
+    severe = _compute_fi_score(_FI(duration_adj_drawdown_1y=-0.03), None, 0.005, None)
+    mild = _compute_fi_score(_FI(duration_adj_drawdown_1y=-0.003125), None, 0.005, None)
+    severe_score = severe.components["duration_adjusted_drawdown"]
+    mild_score = mild.components["duration_adjusted_drawdown"]
+    assert (mild_score - severe_score) >= 25.0, (
+        f"Signal separation insufficient: mild={mild_score}, severe={severe_score}, "
+        f"gap={mild_score - severe_score}"
+    )
+
+
+def test_composite_score_uses_corrected_bounds() -> None:
+    """End-to-end: severe FI fund composite must score below mild FI fund."""
+    severe = _compute_fi_score(_FI(duration_adj_drawdown_1y=-0.03), None, 0.005, None)
+    mild = _compute_fi_score(_FI(duration_adj_drawdown_1y=-0.003125), None, 0.005, None)
+    assert severe.score < mild.score, (
+        f"Severe ({severe.score}) should score below mild ({mild.score})"
+    )

--- a/backend/tests/test_fixed_income_e2e.py
+++ b/backend/tests/test_fixed_income_e2e.py
@@ -375,7 +375,7 @@ class TestFIScoringCredibilityFix:
             empirical_duration=6.0,
             credit_beta=1.2,
             yield_proxy_12m=0.05,  # 5% yield
-            duration_adj_drawdown_1y=-0.8,  # excellent: -0.8% per unit duration
+            duration_adj_drawdown_1y=-0.008,  # excellent: -0.8% per unit duration (decimal scale post-Q61)
         )
 
         # Same fund's equity metrics are mediocre:
@@ -425,7 +425,7 @@ class TestFIScoringCredibilityFix:
             empirical_duration=10.0,  # high duration
             credit_beta=3.5,  # excessive credit risk
             yield_proxy_12m=0.02,  # low yield
-            duration_adj_drawdown_1y=-2.5,  # terrible
+            duration_adj_drawdown_1y=-0.025,  # terrible: -2.5% per unit duration (decimal scale post-Q61)
         )
         risk_adapter = _RiskMetricsAdapter(
             return_1y=-0.05,


### PR DESCRIPTION
## Summary

- **One-line bound fix** in `_compute_fi_score`: `[-5.0, 0.0]` → `[-0.05, 0.0]` for `duration_adjusted_drawdown` normalization
- `max_drawdown_1y` is stored as a **decimal fraction** (`-0.10 = -10%`), so `dad = max_drawdown_1y / duration` ranges `[-0.05, 0]` for realistic FI funds
- Pre-fix: all FI funds collapsed to 96-100 score range on this 25%-weight component, destroying signal

## Stage 3 triage

- **Stage 1:** Gemini only (F05)
- **Stage 2 jury:** GPT-5.5 — CONFIRMED H/H after verifying `max_drawdown_1y` is decimal-scale in `fund_risk_metrics`
- **Stage 3 (Opus 4.7):** TP, Tier 1, parallel-safe with Q62

## Behavior change

| Scenario | `dad` | Pre-fix score | Post-fix score |
|----------|-------|--------------|----------------|
| Severe (max_dd=-0.15, dur=5) | -0.03 | 99.4 | 40.0 |
| Mild (max_dd=-0.0125, dur=4) | -0.003125 | 99.75 | 93.75 |
| **Signal separation** | — | **0.35 pt** | **53.75 pt** |
| Composite-weight impact | — | 0.09 pt | 13.44 pt |

## Caller reachability

```
scoring_service.py:846:    if asset_class == "fixed_income":
scoring_service.py:853:        return _compute_fi_score(fi_metrics, config, expense_ratio_pct, peer_medians)
```

## Test plan

- [x] 6 new regression tests in `test_fi_duration_adjusted_drawdown_bounds.py` (all pass)
- [x] 34 existing scoring tests pass (no regression)
- [x] `ruff check` — clean
- [x] `mypy` — clean

## Blast radius

- **Single line changed:** `scoring_service.py:419` (bound constant)
- **Comment block updated** (lines 413-416) for decimal-scale documentation
- **No other scorers touched** — equity, cash, alternatives unchanged
- **Parallel with Q62** (cash scorer) — zero line overlap

## Backfill

`risk_calc` + `global_risk_metrics` workers (locks 900_007, 900_071) must re-run post-merge. Coordinated with Q57 + Q58 + Q59 + Q60 backfill bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)