### PR TITLE
fix(wealth): PR-Q63 — Layer 3 wiring hotfix + min coverage gate (S08-F04+F01) — TIER 0 EMERGENCY

### DIFF
--- a/backend/app/domains/wealth/routes/screener.py
+++ b/backend/app/domains/wealth/routes/screener.py
@@ -625,9 +625,18 @@ async def trigger_screening(
     db.add(run)
     await db.flush()
 
-    # Batch-fetch latest risk metrics for FI attribute injection
+    # Batch-fetch latest risk metrics for quant_metrics + peer_values injection
     from app.domains.wealth.models.risk import FundRiskMetrics
-    from vertical_engines.wealth.screener.quant_metrics import FIQuantMetrics
+    from app.domains.wealth.services.screener_peer_values_builder import (
+        METRIC_NAMES_BY_TYPE,
+        build_per_instrument_peer_values,
+    )
+    from vertical_engines.wealth.screener.quant_metrics import (
+        AltQuantMetrics,
+        CashQuantMetrics,
+        FIQuantMetrics,
+        QuantMetrics,
+    )
 
     inst_ids = [row[0].instrument_id for row in rows]
     risk_metrics_map: dict[uuid.UUID, Any] = {}
@@ -641,34 +650,148 @@ async def trigger_screening(
         for rm in rm_res.scalars().all():
             risk_metrics_map[rm.instrument_id] = rm
 
+    # Load previous screening results for hysteresis
+    prev_status_res = await db.execute(
+        select(ScreeningResult).where(
+            ScreeningResult.instrument_id.in_(inst_ids),
+            ScreeningResult.is_current.is_(True),
+        ),
+    )
+    prev_status_map = {sr.instrument_id: sr.overall_status for sr in prev_status_res.scalars()}
+
+    def _safe_float(val: object, scale: float = 1.0) -> float | None:
+        if val is None:
+            return None
+        try:
+            return float(val) * scale
+        except (ValueError, TypeError):
+            return None
+
+    # Build metric dicts for peer cohort building
+    metric_dicts_by_id: dict[uuid.UUID, dict[str, float | None]] = {}
+    for row in rows:
+        inst = row[0]
+        rm = risk_metrics_map.get(inst.instrument_id)
+        attrs = dict(inst.attributes) if inst.attributes else {}
+        asset_class = attrs.get("asset_class", "")
+        if rm is None:
+            metric_dicts_by_id[inst.instrument_id] = {}
+            continue
+        if asset_class == "fixed_income":
+            metric_dicts_by_id[inst.instrument_id] = {
+                "empirical_duration": _safe_float(rm.empirical_duration),
+                "credit_beta": _safe_float(rm.credit_beta),
+                "yield_proxy_12m": _safe_float(rm.yield_proxy_12m),
+                "duration_adj_drawdown": _safe_float(rm.duration_adj_drawdown_1y),
+                "sharpe_ratio": _safe_float(rm.sharpe_1y),
+            }
+        elif asset_class == "cash":
+            metric_dicts_by_id[inst.instrument_id] = {
+                "yield_vs_risk_free": _safe_float(getattr(rm, "yield_vs_risk_free", None)),
+                "nav_stability": _safe_float(getattr(rm, "nav_stability", None)),
+                "liquidity_quality": _safe_float(getattr(rm, "liquidity_quality", None)),
+                "maturity_discipline": _safe_float(getattr(rm, "maturity_discipline", None)),
+                "fee_efficiency": _safe_float(getattr(rm, "fee_efficiency", None)),
+            }
+        elif asset_class == "alternatives":
+            metric_dicts_by_id[inst.instrument_id] = {
+                "diversification_value": _safe_float(getattr(rm, "diversification_value", None)),
+                "downside_protection": _safe_float(getattr(rm, "downside_protection", None)),
+                "crisis_alpha": _safe_float(getattr(rm, "crisis_alpha", None)),
+                "inflation_hedge": _safe_float(getattr(rm, "inflation_hedge", None)),
+                "risk_adjusted_return": _safe_float(rm.sharpe_1y),
+                "fee_efficiency": _safe_float(getattr(rm, "fee_efficiency", None)),
+            }
+        else:
+            metric_dicts_by_id[inst.instrument_id] = {
+                "sharpe_ratio": _safe_float(rm.sharpe_1y),
+                "max_drawdown": _safe_float(rm.max_drawdown_1y),
+                "pct_positive_months": _safe_float(getattr(rm, "pct_positive_months", None)),
+                "annual_volatility_pct": _safe_float(rm.volatility_1y, scale=100),
+            }
+
+    # Build per-instrument peer_values
+    inst_dicts_for_cohorts = [
+        {
+            "instrument_id": row[0].instrument_id,
+            "instrument_type": row[0].instrument_type,
+            "attributes": dict(row[0].attributes) if row[0].attributes else {},
+        }
+        for row in rows
+    ]
+    peer_values_by_id = build_per_instrument_peer_values(
+        instruments=inst_dicts_for_cohorts,
+        instrument_metrics_by_id=metric_dicts_by_id,
+        metric_names_by_type=METRIC_NAMES_BY_TYPE,
+    )
+
+    def _build_quant_metrics(
+        rm: object, attrs: dict,
+    ) -> QuantMetrics | FIQuantMetrics | CashQuantMetrics | AltQuantMetrics | None:
+        if rm is None:
+            return None
+        asset_class = attrs.get("asset_class", "")
+        if asset_class == "fixed_income":
+            if rm.empirical_duration is None and rm.credit_beta is None:
+                return None
+            return FIQuantMetrics(
+                empirical_duration=float(rm.empirical_duration or 0),
+                credit_beta=float(rm.credit_beta or 0),
+                yield_proxy_12m=float(rm.yield_proxy_12m or 0),
+                duration_adj_drawdown=float(rm.duration_adj_drawdown_1y or 0),
+                sharpe_ratio=float(rm.sharpe_1y or 0),
+                annual_return_pct=float(rm.return_1y or 0) * 100,
+                data_period_days=0,
+            )
+        if asset_class == "cash":
+            return CashQuantMetrics(
+                yield_vs_risk_free=float(getattr(rm, "yield_vs_risk_free", 0) or 0),
+                nav_stability=float(getattr(rm, "nav_stability", 0) or 0),
+                liquidity_quality=float(getattr(rm, "liquidity_quality", 0) or 0),
+                maturity_discipline=float(getattr(rm, "maturity_discipline", 0) or 0),
+                fee_efficiency=float(getattr(rm, "fee_efficiency", 0) or 0),
+                data_source="fund_risk_metrics",
+            )
+        if asset_class == "alternatives":
+            return AltQuantMetrics(
+                diversification_value=float(getattr(rm, "diversification_value", 0) or 0),
+                downside_protection=float(getattr(rm, "downside_protection", 0) or 0),
+                crisis_alpha=float(getattr(rm, "crisis_alpha", 0) or 0),
+                inflation_hedge=float(getattr(rm, "inflation_hedge", 0) or 0),
+                risk_adjusted_return=float(rm.sharpe_1y or 0),
+                fee_efficiency=float(getattr(rm, "fee_efficiency", 0) or 0),
+                alt_profile="generic_alt",
+            )
+        return QuantMetrics(
+            sharpe_ratio=float(rm.sharpe_1y or 0),
+            annual_volatility_pct=float(rm.volatility_1y or 0) * 100,
+            max_drawdown_pct=float(rm.max_drawdown_1y or 0) * 100,
+            pct_positive_months=float(getattr(rm, "pct_positive_months", 0) or 0),
+            annual_return_pct=float(rm.return_1y or 0) * 100,
+            data_period_days=0,
+        )
+
     # Extract instrument data for screening (cross async boundary safely)
     instrument_dicts = []
     for row in rows:
         inst = row[0]
         attrs = dict(inst.attributes) if inst.attributes else {}
+        rm = risk_metrics_map.get(inst.instrument_id)
         inst_dict: dict[str, Any] = {
             "instrument_id": inst.instrument_id,
             "instrument_type": inst.instrument_type,
             "attributes": attrs,
             "block_id": row.org_block_id,
+            "quant_metrics": _build_quant_metrics(rm, attrs),
+            "peer_values": peer_values_by_id.get(inst.instrument_id, {}),
+            "previous_status": prev_status_map.get(inst.instrument_id),
         }
 
-        # Inject FI metrics from fund_risk_metrics into attributes + quant_metrics
-        rm = risk_metrics_map.get(inst.instrument_id)
+        # Inject FI metrics into attributes for Layer 2 attribute checks
         if rm and attrs.get("asset_class") == "fixed_income":
             attrs["empirical_duration"] = float(rm.empirical_duration) if rm.empirical_duration is not None else None
             attrs["duration_r2"] = float(rm.empirical_duration_r2) if rm.empirical_duration_r2 is not None else None
             attrs["credit_beta"] = float(rm.credit_beta) if rm.credit_beta is not None else None
-            if rm.empirical_duration is not None and rm.credit_beta is not None:
-                inst_dict["quant_metrics"] = FIQuantMetrics(
-                    empirical_duration=float(rm.empirical_duration),
-                    credit_beta=float(rm.credit_beta),
-                    yield_proxy_12m=float(rm.yield_proxy_12m) if rm.yield_proxy_12m is not None else 0.0,
-                    duration_adj_drawdown=float(rm.duration_adj_drawdown_1y) if rm.duration_adj_drawdown_1y is not None else 0.0,
-                    sharpe_ratio=float(rm.sharpe_1y) if rm.sharpe_1y is not None else 0.0,
-                    annual_return_pct=float(rm.return_1y or 0) * 100,
-                    data_period_days=int(rm.data_points or 0),
-                )
 
         instrument_dicts.append(inst_dict)
 

--- a/backend/app/domains/wealth/services/screener_peer_values_builder.py
+++ b/backend/app/domains/wealth/services/screener_peer_values_builder.py
@@ -1,0 +1,153 @@
+"""Build peer_values cohorts for screener Layer 3.
+
+Cohorts are formed by strategy_label (matches peer_group_service convention
+post-Q60). For instruments without a strategy_label (e.g., bonds), fall back
+to instrument_type cohort.
+
+Pure logic — no DB. Caller provides instrument metadata + per-instrument
+risk metrics.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import defaultdict
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def build_peer_cohorts(
+    instruments: list[dict[str, Any]],
+) -> dict[str, list[uuid.UUID]]:
+    """Group instruments into peer cohorts.
+
+    Cohort key: strategy_label if present, else instrument_type.
+
+    Returns:
+        Dict of cohort_key -> list of instrument_id in that cohort.
+    """
+    cohorts: dict[str, list[uuid.UUID]] = defaultdict(list)
+    for inst in instruments:
+        attrs = inst.get("attributes", {}) or {}
+        strategy = attrs.get("strategy_label")
+        cohort_key = str(strategy) if strategy else f"type:{inst['instrument_type']}"
+        cohorts[cohort_key].append(inst["instrument_id"])
+    return dict(cohorts)
+
+
+def build_peer_values_for_cohort(
+    cohort_metrics: list[dict[str, float | None]],
+    metric_names: list[str],
+) -> dict[str, list[float]]:
+    """Build peer_values dict for a single cohort.
+
+    Args:
+        cohort_metrics: List of metric dicts for all instruments in the cohort.
+        metric_names: Metric names to extract.
+
+    Returns:
+        Dict of metric_name -> list of non-None values across cohort.
+    """
+    peer_values: dict[str, list[float]] = {name: [] for name in metric_names}
+    for metrics in cohort_metrics:
+        for name in metric_names:
+            val = metrics.get(name)
+            if val is not None:
+                try:
+                    fval = float(val)
+                except (ValueError, TypeError):
+                    continue
+                # Skip NaN values
+                if fval != fval:  # noqa: PLR0124
+                    continue
+                peer_values[name].append(fval)
+    return peer_values
+
+
+def build_per_instrument_peer_values(
+    instruments: list[dict[str, Any]],
+    instrument_metrics_by_id: dict[uuid.UUID, dict[str, float | None]],
+    metric_names_by_type: dict[str, list[str]],
+) -> dict[uuid.UUID, dict[str, list[float]]]:
+    """Build per-instrument peer_values mapping.
+
+    For each instrument, compute the peer_values dict from its cohort
+    (strategy_label-based or fallback to instrument_type).
+
+    Args:
+        instruments: List of instrument dicts (with instrument_id, instrument_type, attributes).
+        instrument_metrics_by_id: Map of instrument_id -> metric dict.
+        metric_names_by_type: Map of instrument_type -> list of metric names to include.
+
+    Returns:
+        Dict of instrument_id -> peer_values dict (metric_name -> list of cohort values).
+    """
+    cohorts = build_peer_cohorts(instruments)
+    inst_to_cohort: dict[uuid.UUID, str] = {}
+    for cohort_key, inst_ids in cohorts.items():
+        for inst_id in inst_ids:
+            inst_to_cohort[inst_id] = cohort_key
+
+    # Build lookup: instrument_id -> instrument dict
+    inst_by_id: dict[uuid.UUID, dict[str, Any]] = {
+        i["instrument_id"]: i for i in instruments
+    }
+
+    cohort_peer_values: dict[str, dict[str, list[float]]] = {}
+    for cohort_key, cohort_inst_ids in cohorts.items():
+        cohort_metrics = [
+            instrument_metrics_by_id.get(iid, {}) for iid in cohort_inst_ids
+        ]
+        # Determine metric names from the first instrument's type in the cohort
+        instrument_type = next(
+            (inst_by_id[iid]["instrument_type"] for iid in cohort_inst_ids if iid in inst_by_id),
+            "fund",
+        )
+        # Check for asset_class-specific metric names
+        first_inst = next((inst_by_id[iid] for iid in cohort_inst_ids if iid in inst_by_id), None)
+        if first_inst:
+            attrs = first_inst.get("attributes", {}) or {}
+            asset_class = attrs.get("asset_class", "")
+            if asset_class == "fixed_income":
+                instrument_type = "fund_fixed_income"
+            elif asset_class == "cash":
+                instrument_type = "fund_cash"
+            elif asset_class == "alternatives":
+                instrument_type = "fund_alternatives"
+
+        metric_names = metric_names_by_type.get(instrument_type, [])
+        cohort_peer_values[cohort_key] = build_peer_values_for_cohort(
+            cohort_metrics, metric_names,
+        )
+
+    result: dict[uuid.UUID, dict[str, list[float]]] = {}
+    for inst in instruments:
+        inst_id = inst["instrument_id"]
+        cohort_key = inst_to_cohort.get(inst_id)
+        if cohort_key:
+            result[inst_id] = cohort_peer_values[cohort_key]
+        else:
+            result[inst_id] = {}
+    return result
+
+
+# Metric names per instrument_type (matches ScreenerService._compute_layer3_score dispatch)
+METRIC_NAMES_BY_TYPE: dict[str, list[str]] = {
+    "fund": ["sharpe_ratio", "max_drawdown", "pct_positive_months", "annual_volatility_pct"],
+    "equity": ["sharpe_ratio", "max_drawdown", "pct_positive_months", "annual_volatility_pct"],
+    "bond": ["spread_vs_benchmark", "liquidity_score", "duration_efficiency"],
+    "fund_fixed_income": [
+        "empirical_duration", "credit_beta", "yield_proxy_12m",
+        "duration_adj_drawdown", "sharpe_ratio",
+    ],
+    "fund_cash": [
+        "yield_vs_risk_free", "nav_stability", "liquidity_quality",
+        "maturity_discipline", "fee_efficiency",
+    ],
+    "fund_alternatives": [
+        "diversification_value", "downside_protection", "crisis_alpha",
+        "inflation_hedge", "risk_adjusted_return", "fee_efficiency",
+    ],
+}

--- a/backend/app/domains/wealth/workers/screening_batch.py
+++ b/backend/app/domains/wealth/workers/screening_batch.py
@@ -82,13 +82,166 @@ async def _execute_batch(db: AsyncSession, org_id: uuid.UUID) -> dict:
         logger.info("No active instruments to screen")
         return {"status": "completed", "instrument_count": 0}
 
+    # Load latest fund_risk_metrics for each instrument (global table, no RLS)
+    from app.domains.wealth.models.risk import FundRiskMetrics
+
+    instrument_ids = [i.instrument_id for i in instruments]
+    rm_res = await db.execute(
+        select(FundRiskMetrics)
+        .where(FundRiskMetrics.instrument_id.in_(instrument_ids))
+        .distinct(FundRiskMetrics.instrument_id)
+        .order_by(FundRiskMetrics.instrument_id, FundRiskMetrics.calc_date.desc()),
+    )
+    risk_metrics_by_id = {rm.instrument_id: rm for rm in rm_res.scalars().all()}
+
+    # Load previous current screening_results for hysteresis
+    prev_result = await db.execute(
+        select(ScreeningResult).where(
+            ScreeningResult.instrument_id.in_(instrument_ids),
+            ScreeningResult.is_current.is_(True),
+        ),
+    )
+    prev_status_by_id = {sr.instrument_id: sr.overall_status for sr in prev_result.scalars()}
+
+    # Build per-instrument metric dicts for cohort peer_values
+    from app.domains.wealth.services.screener_peer_values_builder import (
+        METRIC_NAMES_BY_TYPE,
+        build_per_instrument_peer_values,
+    )
+    from vertical_engines.wealth.screener.quant_metrics import (
+        AltQuantMetrics,
+        CashQuantMetrics,
+        FIQuantMetrics,
+        QuantMetrics,
+    )
+
+    def _safe_float(val: object, scale: float = 1.0) -> float | None:
+        if val is None:
+            return None
+        try:
+            return float(val) * scale
+        except (ValueError, TypeError):
+            return None
+
+    # Build metric dicts (raw values for peer cohort building)
+    metric_dicts_by_id: dict[uuid.UUID, dict[str, float | None]] = {}
+    for i in instruments:
+        rm = risk_metrics_by_id.get(i.instrument_id)
+        attrs = dict(i.attributes) if i.attributes else {}
+        asset_class = attrs.get("asset_class", "")
+        if rm is None:
+            metric_dicts_by_id[i.instrument_id] = {}
+            continue
+        if asset_class == "fixed_income":
+            metric_dicts_by_id[i.instrument_id] = {
+                "empirical_duration": _safe_float(rm.empirical_duration),
+                "credit_beta": _safe_float(rm.credit_beta),
+                "yield_proxy_12m": _safe_float(rm.yield_proxy_12m),
+                "duration_adj_drawdown": _safe_float(rm.duration_adj_drawdown_1y),
+                "sharpe_ratio": _safe_float(rm.sharpe_1y),
+            }
+        elif asset_class == "cash":
+            metric_dicts_by_id[i.instrument_id] = {
+                "yield_vs_risk_free": _safe_float(getattr(rm, "yield_vs_risk_free", None)),
+                "nav_stability": _safe_float(getattr(rm, "nav_stability", None)),
+                "liquidity_quality": _safe_float(getattr(rm, "liquidity_quality", None)),
+                "maturity_discipline": _safe_float(getattr(rm, "maturity_discipline", None)),
+                "fee_efficiency": _safe_float(getattr(rm, "fee_efficiency", None)),
+            }
+        elif asset_class == "alternatives":
+            metric_dicts_by_id[i.instrument_id] = {
+                "diversification_value": _safe_float(getattr(rm, "diversification_value", None)),
+                "downside_protection": _safe_float(getattr(rm, "downside_protection", None)),
+                "crisis_alpha": _safe_float(getattr(rm, "crisis_alpha", None)),
+                "inflation_hedge": _safe_float(getattr(rm, "inflation_hedge", None)),
+                "risk_adjusted_return": _safe_float(rm.sharpe_1y),
+                "fee_efficiency": _safe_float(getattr(rm, "fee_efficiency", None)),
+            }
+        else:
+            metric_dicts_by_id[i.instrument_id] = {
+                "sharpe_ratio": _safe_float(rm.sharpe_1y),
+                "max_drawdown": _safe_float(rm.max_drawdown_1y),
+                "pct_positive_months": _safe_float(getattr(rm, "pct_positive_months", None)),
+                "annual_volatility_pct": _safe_float(rm.volatility_1y, scale=100),
+            }
+
+    # Build instrument dicts for cohort grouping
+    inst_dicts_for_cohorts = [
+        {
+            "instrument_id": i.instrument_id,
+            "instrument_type": i.instrument_type,
+            "attributes": dict(i.attributes) if i.attributes else {},
+        }
+        for i in instruments
+    ]
+
+    # Build per-instrument peer_values
+    peer_values_by_id = build_per_instrument_peer_values(
+        instruments=inst_dicts_for_cohorts,
+        instrument_metrics_by_id=metric_dicts_by_id,
+        metric_names_by_type=METRIC_NAMES_BY_TYPE,
+    )
+
+    def _build_quant_metrics(
+        rm: object, attrs: dict,
+    ) -> QuantMetrics | FIQuantMetrics | CashQuantMetrics | AltQuantMetrics | None:
+        if rm is None:
+            return None
+        asset_class = attrs.get("asset_class", "")
+        if asset_class == "fixed_income":
+            if rm.empirical_duration is None and rm.credit_beta is None:
+                return None
+            return FIQuantMetrics(
+                empirical_duration=float(rm.empirical_duration or 0),
+                credit_beta=float(rm.credit_beta or 0),
+                yield_proxy_12m=float(rm.yield_proxy_12m or 0),
+                duration_adj_drawdown=float(rm.duration_adj_drawdown_1y or 0),
+                sharpe_ratio=float(rm.sharpe_1y or 0),
+                annual_return_pct=float(rm.return_1y or 0) * 100,
+                data_period_days=0,
+            )
+        if asset_class == "cash":
+            return CashQuantMetrics(
+                yield_vs_risk_free=float(getattr(rm, "yield_vs_risk_free", 0) or 0),
+                nav_stability=float(getattr(rm, "nav_stability", 0) or 0),
+                liquidity_quality=float(getattr(rm, "liquidity_quality", 0) or 0),
+                maturity_discipline=float(getattr(rm, "maturity_discipline", 0) or 0),
+                fee_efficiency=float(getattr(rm, "fee_efficiency", 0) or 0),
+                data_source="fund_risk_metrics",
+            )
+        if asset_class == "alternatives":
+            return AltQuantMetrics(
+                diversification_value=float(getattr(rm, "diversification_value", 0) or 0),
+                downside_protection=float(getattr(rm, "downside_protection", 0) or 0),
+                crisis_alpha=float(getattr(rm, "crisis_alpha", 0) or 0),
+                inflation_hedge=float(getattr(rm, "inflation_hedge", 0) or 0),
+                risk_adjusted_return=float(rm.sharpe_1y or 0),
+                fee_efficiency=float(getattr(rm, "fee_efficiency", 0) or 0),
+                alt_profile="generic_alt",
+            )
+        # Default: equity/fund
+        return QuantMetrics(
+            sharpe_ratio=float(rm.sharpe_1y or 0),
+            annual_volatility_pct=float(rm.volatility_1y or 0) * 100,
+            max_drawdown_pct=float(rm.max_drawdown_1y or 0) * 100,
+            pct_positive_months=float(getattr(rm, "pct_positive_months", 0) or 0),
+            annual_return_pct=float(rm.return_1y or 0) * 100,
+            data_period_days=0,
+        )
+
     # Extract scalar data before crossing async/thread boundary
     instrument_dicts = [
         {
             "instrument_id": i.instrument_id,
             "instrument_type": i.instrument_type,
             "attributes": dict(i.attributes) if i.attributes else {},
-            "block_id": i.block_id,
+            "block_id": getattr(i, "block_id", None),
+            "quant_metrics": _build_quant_metrics(
+                risk_metrics_by_id.get(i.instrument_id),
+                dict(i.attributes) if i.attributes else {},
+            ),
+            "peer_values": peer_values_by_id.get(i.instrument_id, {}),
+            "previous_status": prev_status_by_id.get(i.instrument_id),
         }
         for i in instruments
     ]

--- a/backend/app/domains/wealth/workers/watchlist_batch.py
+++ b/backend/app/domains/wealth/workers/watchlist_batch.py
@@ -80,14 +80,153 @@ async def _execute_watchlist_check(db: AsyncSession, org_id: uuid.UUID) -> dict:
         logger.info("watchlist_check_empty", reason="no watchlisted instruments")
         return {"status": "completed", "total_screened": 0}
 
+    # Load latest fund_risk_metrics for each instrument (global table, no RLS)
+    from app.domains.wealth.models.risk import FundRiskMetrics
+
+    instrument_ids = [i.instrument_id for i in instruments]
+    rm_res = await db.execute(
+        select(FundRiskMetrics)
+        .where(FundRiskMetrics.instrument_id.in_(instrument_ids))
+        .distinct(FundRiskMetrics.instrument_id)
+        .order_by(FundRiskMetrics.instrument_id, FundRiskMetrics.calc_date.desc()),
+    )
+    risk_metrics_by_id = {rm.instrument_id: rm for rm in rm_res.scalars().all()}
+
+    # Build per-instrument metric dicts for cohort peer_values
+    from app.domains.wealth.services.screener_peer_values_builder import (
+        METRIC_NAMES_BY_TYPE,
+        build_per_instrument_peer_values,
+    )
+    from vertical_engines.wealth.screener.quant_metrics import (
+        AltQuantMetrics,
+        CashQuantMetrics,
+        FIQuantMetrics,
+        QuantMetrics,
+    )
+
+    def _safe_float(val: object, scale: float = 1.0) -> float | None:
+        if val is None:
+            return None
+        try:
+            return float(val) * scale
+        except (ValueError, TypeError):
+            return None
+
+    metric_dicts_by_id: dict[uuid.UUID, dict[str, float | None]] = {}
+    for i in instruments:
+        rm = risk_metrics_by_id.get(i.instrument_id)
+        attrs = dict(i.attributes) if i.attributes else {}
+        asset_class = attrs.get("asset_class", "")
+        if rm is None:
+            metric_dicts_by_id[i.instrument_id] = {}
+            continue
+        if asset_class == "fixed_income":
+            metric_dicts_by_id[i.instrument_id] = {
+                "empirical_duration": _safe_float(rm.empirical_duration),
+                "credit_beta": _safe_float(rm.credit_beta),
+                "yield_proxy_12m": _safe_float(rm.yield_proxy_12m),
+                "duration_adj_drawdown": _safe_float(rm.duration_adj_drawdown_1y),
+                "sharpe_ratio": _safe_float(rm.sharpe_1y),
+            }
+        elif asset_class == "cash":
+            metric_dicts_by_id[i.instrument_id] = {
+                "yield_vs_risk_free": _safe_float(getattr(rm, "yield_vs_risk_free", None)),
+                "nav_stability": _safe_float(getattr(rm, "nav_stability", None)),
+                "liquidity_quality": _safe_float(getattr(rm, "liquidity_quality", None)),
+                "maturity_discipline": _safe_float(getattr(rm, "maturity_discipline", None)),
+                "fee_efficiency": _safe_float(getattr(rm, "fee_efficiency", None)),
+            }
+        elif asset_class == "alternatives":
+            metric_dicts_by_id[i.instrument_id] = {
+                "diversification_value": _safe_float(getattr(rm, "diversification_value", None)),
+                "downside_protection": _safe_float(getattr(rm, "downside_protection", None)),
+                "crisis_alpha": _safe_float(getattr(rm, "crisis_alpha", None)),
+                "inflation_hedge": _safe_float(getattr(rm, "inflation_hedge", None)),
+                "risk_adjusted_return": _safe_float(rm.sharpe_1y),
+                "fee_efficiency": _safe_float(getattr(rm, "fee_efficiency", None)),
+            }
+        else:
+            metric_dicts_by_id[i.instrument_id] = {
+                "sharpe_ratio": _safe_float(rm.sharpe_1y),
+                "max_drawdown": _safe_float(rm.max_drawdown_1y),
+                "pct_positive_months": _safe_float(getattr(rm, "pct_positive_months", None)),
+                "annual_volatility_pct": _safe_float(rm.volatility_1y, scale=100),
+            }
+
+    inst_dicts_for_cohorts = [
+        {
+            "instrument_id": i.instrument_id,
+            "instrument_type": i.instrument_type,
+            "attributes": dict(i.attributes) if i.attributes else {},
+        }
+        for i in instruments
+    ]
+
+    peer_values_by_id = build_per_instrument_peer_values(
+        instruments=inst_dicts_for_cohorts,
+        instrument_metrics_by_id=metric_dicts_by_id,
+        metric_names_by_type=METRIC_NAMES_BY_TYPE,
+    )
+
+    def _build_quant_metrics(
+        rm: object, attrs: dict,
+    ) -> QuantMetrics | FIQuantMetrics | CashQuantMetrics | AltQuantMetrics | None:
+        if rm is None:
+            return None
+        asset_class = attrs.get("asset_class", "")
+        if asset_class == "fixed_income":
+            if rm.empirical_duration is None and rm.credit_beta is None:
+                return None
+            return FIQuantMetrics(
+                empirical_duration=float(rm.empirical_duration or 0),
+                credit_beta=float(rm.credit_beta or 0),
+                yield_proxy_12m=float(rm.yield_proxy_12m or 0),
+                duration_adj_drawdown=float(rm.duration_adj_drawdown_1y or 0),
+                sharpe_ratio=float(rm.sharpe_1y or 0),
+                annual_return_pct=float(rm.return_1y or 0) * 100,
+                data_period_days=0,
+            )
+        if asset_class == "cash":
+            return CashQuantMetrics(
+                yield_vs_risk_free=float(getattr(rm, "yield_vs_risk_free", 0) or 0),
+                nav_stability=float(getattr(rm, "nav_stability", 0) or 0),
+                liquidity_quality=float(getattr(rm, "liquidity_quality", 0) or 0),
+                maturity_discipline=float(getattr(rm, "maturity_discipline", 0) or 0),
+                fee_efficiency=float(getattr(rm, "fee_efficiency", 0) or 0),
+                data_source="fund_risk_metrics",
+            )
+        if asset_class == "alternatives":
+            return AltQuantMetrics(
+                diversification_value=float(getattr(rm, "diversification_value", 0) or 0),
+                downside_protection=float(getattr(rm, "downside_protection", 0) or 0),
+                crisis_alpha=float(getattr(rm, "crisis_alpha", 0) or 0),
+                inflation_hedge=float(getattr(rm, "inflation_hedge", 0) or 0),
+                risk_adjusted_return=float(rm.sharpe_1y or 0),
+                fee_efficiency=float(getattr(rm, "fee_efficiency", 0) or 0),
+                alt_profile="generic_alt",
+            )
+        return QuantMetrics(
+            sharpe_ratio=float(rm.sharpe_1y or 0),
+            annual_volatility_pct=float(rm.volatility_1y or 0) * 100,
+            max_drawdown_pct=float(rm.max_drawdown_1y or 0) * 100,
+            pct_positive_months=float(getattr(rm, "pct_positive_months", 0) or 0),
+            annual_return_pct=float(rm.return_1y or 0) * 100,
+            data_period_days=0,
+        )
+
     # Extract scalar data before crossing async/thread boundary
     instrument_dicts = [
         {
             "instrument_id": i.instrument_id,
             "instrument_type": i.instrument_type,
             "attributes": dict(i.attributes) if i.attributes else {},
-            "block_id": i.block_id,
+            "block_id": getattr(i, "block_id", None),
             "name": i.name,
+            "quant_metrics": _build_quant_metrics(
+                risk_metrics_by_id.get(i.instrument_id),
+                dict(i.attributes) if i.attributes else {},
+            ),
+            "peer_values": peer_values_by_id.get(i.instrument_id, {}),
         }
         for i in instruments
     ]
@@ -136,6 +275,9 @@ async def _execute_watchlist_check(db: AsyncSession, org_id: uuid.UUID) -> dict:
                 instrument_type=inst["instrument_type"],
                 attributes=inst.get("attributes", {}),
                 block_id=inst.get("block_id"),
+                quant_metrics=inst.get("quant_metrics"),
+                peer_values=inst.get("peer_values"),
+                previous_status=previous_outcomes.get(inst["instrument_id"]),
             )
             for inst in instrument_dicts
         ],

--- a/backend/tests/quant_engine/test_composite_score_min_coverage.py
+++ b/backend/tests/quant_engine/test_composite_score_min_coverage.py
@@ -1,0 +1,77 @@
+"""Regression tests for S08-F01 — composite_score minimum coverage gate."""
+
+from __future__ import annotations
+
+from vertical_engines.wealth.screener.quant_metrics import MIN_COVERAGE_RATIO, composite_score
+
+
+def test_thin_data_below_50pct_coverage_returns_none() -> None:
+    """Single metric out of 4 (25% coverage) -> None, not optimistic PASS."""
+    metrics = {"sharpe_ratio": 2.0}  # only 1 of 4 metrics
+    peers = {"sharpe_ratio": [0.5, 1.0, 1.5, 2.0, 2.5]}  # has peers
+    weights = {
+        "sharpe_ratio": 0.30, "max_drawdown": 0.25,
+        "pct_positive_months": 0.25, "annual_volatility_pct": 0.20,
+    }
+    result = composite_score(metrics, peers, weights)
+    assert result is None  # 30% coverage < 50% threshold
+
+
+def test_two_metrics_above_50pct_coverage_returns_score() -> None:
+    """2 of 4 metrics (55% coverage at boundary) -> score returned."""
+    metrics = {"sharpe_ratio": 2.0, "max_drawdown": -0.05}
+    peers = {
+        "sharpe_ratio": [0.5, 1.0, 1.5, 2.0, 2.5],
+        "max_drawdown": [-0.30, -0.20, -0.15, -0.10, -0.05],
+    }
+    weights = {
+        "sharpe_ratio": 0.30, "max_drawdown": 0.25,
+        "pct_positive_months": 0.25, "annual_volatility_pct": 0.20,
+    }
+    result = composite_score(metrics, peers, weights)
+    assert result is not None  # 55% coverage >= 50% threshold
+
+
+def test_all_metrics_returns_full_score() -> None:
+    """All 4 metrics observed -> full score (100% coverage)."""
+    metrics = {
+        "sharpe_ratio": 2.0, "max_drawdown": -0.05,
+        "pct_positive_months": 0.75, "annual_volatility_pct": 12.0,
+    }
+    peers = {
+        "sharpe_ratio": [0.5, 1.0, 1.5, 2.0, 2.5],
+        "max_drawdown": [-0.30, -0.20, -0.15, -0.10, -0.05],
+        "pct_positive_months": [0.40, 0.50, 0.60, 0.70, 0.75],
+        "annual_volatility_pct": [25.0, 18.0, 15.0, 12.0, 10.0],
+    }
+    weights = {
+        "sharpe_ratio": 0.30, "max_drawdown": 0.25,
+        "pct_positive_months": 0.25, "annual_volatility_pct": 0.20,
+    }
+    result = composite_score(metrics, peers, weights)
+    assert result is not None
+    assert 0.0 <= result <= 1.0
+
+
+def test_zero_total_weight_returns_none() -> None:
+    """No metric has both value AND peers -> None (existing behavior preserved)."""
+    metrics = {"sharpe_ratio": 2.0}
+    peers = {}  # no peer data
+    weights = {"sharpe_ratio": 1.0}
+    result = composite_score(metrics, peers, weights)
+    assert result is None
+
+
+def test_min_coverage_constant_is_documented() -> None:
+    """MIN_COVERAGE_RATIO is exported as module constant for audit."""
+    assert MIN_COVERAGE_RATIO == 0.50
+
+
+def test_exactly_50pct_coverage_returns_score() -> None:
+    """Exactly 50% weight coverage -> at boundary, returns score (not strict less-than)."""
+    metrics = {"sharpe_ratio": 1.5}
+    peers = {"sharpe_ratio": [0.5, 1.0, 1.5, 2.0, 2.5]}
+    weights = {"sharpe_ratio": 0.50, "max_drawdown": 0.50}
+    result = composite_score(metrics, peers, weights)
+    # 50% coverage is NOT < 50%, so score should be returned
+    assert result is not None

--- a/backend/tests/services/test_screener_peer_values_builder.py
+++ b/backend/tests/services/test_screener_peer_values_builder.py
@@ -1,0 +1,127 @@
+"""Unit tests for the peer cohort builder (S08-F04 wiring helper)."""
+
+from __future__ import annotations
+
+import uuid
+
+from app.domains.wealth.services.screener_peer_values_builder import (
+    METRIC_NAMES_BY_TYPE,
+    build_peer_cohorts,
+    build_peer_values_for_cohort,
+    build_per_instrument_peer_values,
+)
+
+
+def test_build_peer_cohorts_groups_by_strategy_label() -> None:
+    instruments = [
+        {"instrument_id": uuid.uuid4(), "instrument_type": "fund",
+         "attributes": {"strategy_label": "Long/Short Equity"}},
+        {"instrument_id": uuid.uuid4(), "instrument_type": "fund",
+         "attributes": {"strategy_label": "Long/Short Equity"}},
+        {"instrument_id": uuid.uuid4(), "instrument_type": "fund",
+         "attributes": {"strategy_label": "Private Credit"}},
+    ]
+    cohorts = build_peer_cohorts(instruments)
+    assert "Long/Short Equity" in cohorts
+    assert "Private Credit" in cohorts
+    assert len(cohorts["Long/Short Equity"]) == 2
+    assert len(cohorts["Private Credit"]) == 1
+
+
+def test_build_peer_cohorts_falls_back_to_instrument_type() -> None:
+    instruments = [
+        {"instrument_id": uuid.uuid4(), "instrument_type": "bond",
+         "attributes": {}},
+        {"instrument_id": uuid.uuid4(), "instrument_type": "bond",
+         "attributes": {}},
+    ]
+    cohorts = build_peer_cohorts(instruments)
+    assert "type:bond" in cohorts
+    assert len(cohorts["type:bond"]) == 2
+
+
+def test_build_peer_cohorts_none_attributes() -> None:
+    instruments = [
+        {"instrument_id": uuid.uuid4(), "instrument_type": "fund",
+         "attributes": None},
+    ]
+    cohorts = build_peer_cohorts(instruments)
+    assert "type:fund" in cohorts
+
+
+def test_build_peer_values_for_cohort_filters_none_and_nan() -> None:
+    cohort_metrics = [
+        {"sharpe_ratio": 1.5, "max_drawdown": -0.1},
+        {"sharpe_ratio": None, "max_drawdown": -0.05},
+        {"sharpe_ratio": 2.0, "max_drawdown": float("nan")},
+    ]
+    result = build_peer_values_for_cohort(cohort_metrics, ["sharpe_ratio", "max_drawdown"])
+    assert result["sharpe_ratio"] == [1.5, 2.0]
+    assert -0.1 in result["max_drawdown"] and -0.05 in result["max_drawdown"]
+    # NaN excluded
+    assert len(result["max_drawdown"]) == 2
+
+
+def test_metric_names_by_type_covers_all_dispatch_branches() -> None:
+    """Confirm METRIC_NAMES_BY_TYPE matches ScreenerService._compute_layer3_score dispatch."""
+    expected_types = {"fund", "equity", "bond", "fund_fixed_income", "fund_cash", "fund_alternatives"}
+    assert expected_types.issubset(METRIC_NAMES_BY_TYPE.keys())
+
+
+def test_per_instrument_mapping_complete() -> None:
+    """Every instrument should get a peer_values entry."""
+    inst_a = {"instrument_id": uuid.uuid4(), "instrument_type": "fund",
+              "attributes": {"strategy_label": "EM Equity"}}
+    inst_b = {"instrument_id": uuid.uuid4(), "instrument_type": "fund",
+              "attributes": {"strategy_label": "EM Equity"}}
+    metrics = {
+        inst_a["instrument_id"]: {"sharpe_ratio": 1.5, "max_drawdown": -0.10,
+                                   "pct_positive_months": 0.65, "annual_volatility_pct": 14.0},
+        inst_b["instrument_id"]: {"sharpe_ratio": 1.2, "max_drawdown": -0.15,
+                                   "pct_positive_months": 0.55, "annual_volatility_pct": 16.0},
+    }
+    result = build_per_instrument_peer_values(
+        [inst_a, inst_b], metrics, METRIC_NAMES_BY_TYPE,
+    )
+    assert inst_a["instrument_id"] in result
+    assert inst_b["instrument_id"] in result
+    # Both share the EM Equity cohort -> identical peer_values
+    assert result[inst_a["instrument_id"]] == result[inst_b["instrument_id"]]
+    # Cohort has 2 funds -> 2 values per metric
+    assert len(result[inst_a["instrument_id"]]["sharpe_ratio"]) == 2
+
+
+def test_per_instrument_empty_metrics() -> None:
+    """Instruments with no risk metrics get empty peer_values."""
+    inst_a = {"instrument_id": uuid.uuid4(), "instrument_type": "fund",
+              "attributes": {}}
+    result = build_per_instrument_peer_values(
+        [inst_a], {}, METRIC_NAMES_BY_TYPE,
+    )
+    assert inst_a["instrument_id"] in result
+    # All metric lists should be empty
+    for values in result[inst_a["instrument_id"]].values():
+        assert values == []
+
+
+def test_fi_cohort_uses_correct_metric_names() -> None:
+    """FI instruments should use fund_fixed_income metric names."""
+    inst_a = {"instrument_id": uuid.uuid4(), "instrument_type": "fund",
+              "attributes": {"asset_class": "fixed_income", "strategy_label": "FI Core"}}
+    inst_b = {"instrument_id": uuid.uuid4(), "instrument_type": "fund",
+              "attributes": {"asset_class": "fixed_income", "strategy_label": "FI Core"}}
+    metrics = {
+        inst_a["instrument_id"]: {"empirical_duration": 5.2, "credit_beta": 0.8,
+                                   "yield_proxy_12m": 0.04, "duration_adj_drawdown": -0.02,
+                                   "sharpe_ratio": 1.1},
+        inst_b["instrument_id"]: {"empirical_duration": 3.1, "credit_beta": 0.5,
+                                   "yield_proxy_12m": 0.03, "duration_adj_drawdown": -0.01,
+                                   "sharpe_ratio": 0.9},
+    }
+    result = build_per_instrument_peer_values(
+        [inst_a, inst_b], metrics, METRIC_NAMES_BY_TYPE,
+    )
+    peer_vals = result[inst_a["instrument_id"]]
+    assert "empirical_duration" in peer_vals
+    assert "credit_beta" in peer_vals
+    assert len(peer_vals["empirical_duration"]) == 2

--- a/backend/vertical_engines/wealth/screener/quant_metrics.py
+++ b/backend/vertical_engines/wealth/screener/quant_metrics.py
@@ -26,6 +26,12 @@ from quant_engine.return_statistics_service import (
 
 logger = structlog.get_logger(__name__)
 
+# S08-F01: Minimum fraction of configured weight that must be observable
+# before composite_score returns a real score. Below this threshold the
+# composite is dominated by 1-2 metrics and loses its multi-dimensional
+# screening intent. Funds below coverage land in WATCHLIST (caller gets None).
+MIN_COVERAGE_RATIO = 0.50
+
 # Extreme-return cut-off historically applied by the screener. Daily
 # returns above ~50% are almost always corporate-action artefacts (splits,
 # mergers, dividends booked as price moves) rather than real performance.
@@ -329,5 +335,12 @@ def composite_score(
     if total_weight == 0:
         return None
 
-    # Normalize by actual weight used (handle missing metrics gracefully)
+    # S08-F01: minimum coverage gate — prevent thin-data silent promotion
+    configured_total = sum(weights.values())
+    if configured_total > 0:
+        coverage_ratio = total_weight / configured_total
+        if coverage_ratio < MIN_COVERAGE_RATIO:
+            return None
+
+    # Normalize by actual weight used (handle missing metrics gracefully above coverage threshold)
     return round(score / total_weight, 4)

--- a/backend/vertical_engines/wealth/watchlist/service.py
+++ b/backend/vertical_engines/wealth/watchlist/service.py
@@ -62,6 +62,9 @@ class WatchlistService:
                     instrument_type=inst["instrument_type"],
                     attributes=inst.get("attributes", {}),
                     block_id=inst.get("block_id"),
+                    quant_metrics=inst.get("quant_metrics"),
+                    peer_values=inst.get("peer_values"),
+                    previous_status=previous_outcome,
                 )
             except Exception:
                 logger.warning(


### PR DESCRIPTION
## Summary

**TIER 0 INSTITUTIONAL EMERGENCY HOTFIX** — Layer 3 screening has been dead in production since deployment.

- **S08-F04 (Crit/Crit):** Three production callers (`screening_batch`, `watchlist_batch`, screener route) invoke `screen_instrument` WITHOUT `peer_values` injection. `composite_score` with empty peers returns `None` for every metric → `_compute_layer3_score` returns `None` → `determine_status(None)` returns `"WATCHLIST"`. **Every fund passing L1+L2 lands in WATCHLIST. Zero quantitative discrimination.**
- **S08-F01 (Crit/Crit):** `composite_score` renormalizes by accumulated weight — a fund with 1/4 metrics observable scores at that single metric's percentile rank (silent thin-data promotion). Dormant while F04 was unfixed; becomes active with F04 fix.
- Both fixes must land together — without F01's gate, F04's wiring would activate the silent corruption.

### Changes

| File | Change |
|------|--------|
| `screener_peer_values_builder.py` (NEW) | Pure-logic helper: builds strategy_label cohorts (fallback to instrument_type), extracts per-cohort peer_values |
| `quant_metrics.py` | `MIN_COVERAGE_RATIO = 0.50` constant + coverage gate in `composite_score` |
| `screening_batch.py` | Load `fund_risk_metrics` + previous `screening_results`, build `QuantMetrics` + `peer_values`, pass all 3 new kwargs |
| `watchlist_batch.py` | Same wiring pattern as screening_batch |
| `screener.py` (route) | Extend FI-only injection to all asset classes + peer_values + previous_status |
| `watchlist/service.py` | Pass-through `quant_metrics`, `peer_values`, `previous_status` to `screen_instrument` |

### Behavior change

| Before | After |
|--------|-------|
| All L1+L2-passing funds → WATCHLIST (Layer 3 dead) | Funds with ≥50% metric coverage get real composite scores → PASS/FAIL/WATCHLIST |
| `composite_score(1/4 metrics)` → perfect score possible | `composite_score(1/4 metrics)` → None (below MIN_COVERAGE_RATIO) |
| IC dashboards: all-WATCHLIST | IC dashboards: real quantitative discrimination |

### Blast radius

**Massive** — first-ever real Layer 3 traffic. After deploy, `screening_batch` worker produces cascade of WATCHLIST → PASS/FAIL transitions. IC committee should be informed.

### Missing FundRiskMetrics columns

Cash metrics (`yield_vs_risk_free`, `nav_stability`, `liquidity_quality`, `maturity_discipline`) and alternatives metrics (`diversification_value`, `downside_protection`, `crisis_alpha`, `inflation_hedge`) use `getattr(rm, "field", None)` defensively. These fields don't exist on `FundRiskMetrics` yet — cash/alt funds will get `None` composite scores (→ WATCHLIST) until dedicated risk_calc passes are implemented. Equity/fund and FI paths are fully functional.

### Stage 3 verification

- Stage 1: Both models (Opus 4.6 + Gemini 3.1 Pro) convergent on F04 and F01
- Stage 2: GPT-5.5 jury — both CONFIRMED Crit/Crit, no downgrades
- Stage 3: Opus 4.7 — TPs, Tier 0 emergency scope
- Orchestrator grep verified: 3 callers omit `peer_values`, `composite_score` returns None

## Test plan

- [x] 6 new tests: `test_composite_score_min_coverage.py` — coverage gate boundary cases (thin data → None, 50% boundary → score, full coverage → score)
- [x] 8 new tests: `test_screener_peer_values_builder.py` — cohort grouping, NaN filtering, FI metric dispatch, empty metrics
- [x] 85 existing screener + watchlist tests pass (zero regressions)
- [x] 737 quant_engine tests pass (1 pre-existing pareto failure, unrelated)
- [x] 18 FI E2E tests pass
- [x] 6 FI drawdown bounds tests pass (composite_score regression)
- [x] Lint clean on all 8 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)