### PR TITLE
fix(wealth): PR-Q68 — Session 08 cleanup terminus (S08-F08+F06+F07+F10) — closes Session 08

### DIFF
--- a/backend/tests/quant_engine/test_composite_score_mid_rank.py
+++ b/backend/tests/quant_engine/test_composite_score_mid_rank.py
@@ -18,21 +18,27 @@ def test_lower_is_better_tied_cohort_ranks_at_median() -> None:
     Note: all-identical peers (e.g. [0,0,0,0,0]) trigger the lo==hi
     variance guard and return None, so we use a cohort with spread
     but a tied majority to exercise mid-rank.
+
+    Q68: explicit lower_is_better — "max_drawdown_pct" removed from default
+    frozenset (dead key, see S08-F06).
     """
     metrics = {"max_drawdown_pct": 3.0}
     peers = {"max_drawdown_pct": [1.0, 3.0, 3.0, 3.0, 5.0]}
     weights = {"max_drawdown_pct": 1.0}
-    score = composite_score(metrics, peers, weights)
+    score = composite_score(metrics, peers, weights, lower_is_better=frozenset({"max_drawdown_pct"}))
     assert score == pytest.approx(0.50)
 
 
 def test_partial_tie_lower_is_better() -> None:
     """Lower-is-better, peers [1, 2, 2], value=2 → mid-rank.
-    count_less=1, count_equal=2 → (1 + 1.0)/3 ≈ 0.667, inverted to 0.333."""
+    count_less=1, count_equal=2 → (1 + 1.0)/3 ≈ 0.667, inverted to 0.333.
+
+    Q68: explicit lower_is_better (S08-F06 removed "max_drawdown_pct" from default).
+    """
     metrics = {"max_drawdown_pct": 2.0}
     peers = {"max_drawdown_pct": [1.0, 2.0, 2.0]}
     weights = {"max_drawdown_pct": 1.0}
-    score = composite_score(metrics, peers, weights)
+    score = composite_score(metrics, peers, weights, lower_is_better=frozenset({"max_drawdown_pct"}))
     assert score == pytest.approx(0.333, abs=0.01)
 
 
@@ -77,11 +83,14 @@ def test_no_tie_higher_is_better_unchanged() -> None:
 
 def test_no_tie_lower_is_better_unchanged() -> None:
     """Fund between peers with no ties, lower-is-better → same result pre/post fix.
-    fund=1.5 in peers [1, 2, 3, 5] → rank=0.25, inverted to 0.75."""
+    fund=1.5 in peers [1, 2, 3, 5] → rank=0.25, inverted to 0.75.
+
+    Q68: explicit lower_is_better (S08-F06 removed "max_drawdown_pct" from default).
+    """
     metrics = {"max_drawdown_pct": 1.5}
     peers = {"max_drawdown_pct": [1.0, 2.0, 3.0, 5.0]}
     weights = {"max_drawdown_pct": 1.0}
-    score = composite_score(metrics, peers, weights)
+    score = composite_score(metrics, peers, weights, lower_is_better=frozenset({"max_drawdown_pct"}))
     assert score == pytest.approx(0.75)
 
 
@@ -94,9 +103,11 @@ def test_mid_rank_matches_peer_group_service_convention() -> None:
     Symmetric tied cohort → 50th percentile in both.
     peer_group_service post-Q60 returns 50.0 (0-100 scale).
     composite_score returns 0.50 (0-1 scale) — equivalent semantics.
+
+    Q68: explicit lower_is_better (S08-F06 removed "max_drawdown_pct" from default).
     """
     metrics = {"max_drawdown_pct": 3.0}
     peers = {"max_drawdown_pct": [1.0, 3.0, 3.0, 3.0, 5.0]}
     weights = {"max_drawdown_pct": 1.0}
-    score = composite_score(metrics, peers, weights)
+    score = composite_score(metrics, peers, weights, lower_is_better=frozenset({"max_drawdown_pct"}))
     assert score == pytest.approx(0.50)

--- a/backend/tests/quant_engine/test_lower_is_better_cleanup.py
+++ b/backend/tests/quant_engine/test_lower_is_better_cleanup.py
@@ -1,0 +1,30 @@
+"""Regression tests for S08-F06 — lower_is_better key cleanup (PR-Q68).
+
+The frozenset previously contained "max_drawdown_pct" but the production
+metrics_dict uses key "max_drawdown" (not "max_drawdown_pct"), so the
+inversion never fired. The negative-sign convention of max_drawdown values
+made the un-inverted behavior accidentally correct. Q68 removes the dead
+entry to prevent future regression on a key alignment "fix"."""
+
+from __future__ import annotations
+
+from vertical_engines.wealth.screener.quant_metrics import composite_score
+
+
+def test_max_drawdown_with_negative_sign_no_inversion_correct() -> None:
+    """Production key "max_drawdown" with negative values: best drawdown
+    (least negative) ranks at high percentile WITHOUT inversion.
+
+    Pre-fix: lower_is_better contained "max_drawdown_pct" (key mismatch
+    meant inversion never fired, and that was correct).
+    Post-fix: frozenset doesn't contain max_drawdown_pct OR max_drawdown,
+    documenting that the negative-sign convention makes inversion unneeded.
+    """
+    metrics = {"max_drawdown": -0.05}  # best drawdown (least negative)
+    peers = {"max_drawdown": [-0.50, -0.30, -0.20, -0.10, -0.05]}  # negative scale
+    weights = {"max_drawdown": 1.0}
+    score = composite_score(metrics, peers, weights)
+    assert score is not None
+    # Best drawdown -0.05 should score at TOP percentile (>= 0.75).
+    # If inversion were applied, it would score at BOTTOM (incorrect).
+    assert score >= 0.75

--- a/backend/tests/test_layer_evaluator.py
+++ b/backend/tests/test_layer_evaluator.py
@@ -145,12 +145,31 @@ class TestLayer1:
         results = evaluator.evaluate_layer1("fund", {}, criteria)
         assert len(results) == 0
 
-    def test_numeric_field_with_usd_suffix(self, evaluator):
-        criteria = {"fund": {"min_aum": 100}}
+    def test_numeric_field_exact_suffix_match(self, evaluator):
+        """Q68 / S08-F10: criterion key must EXACTLY match the attribute key.
+        Pre-Q68 the _get_numeric helper had a fallback chain (field, field_usd,
+        field_pct) that silently picked the first match, causing unit-pollution
+        risk for ambiguous future criteria. Fallback removed — config criterion
+        names must use the explicit suffix that matches the attribute key.
+        """
+        criteria = {"fund": {"min_aum_usd": 100}}
         results = evaluator.evaluate_layer1(
             "fund", {"aum_usd": 200}, criteria,
         )
         assert results[0].passed is True
+
+    def test_numeric_field_unsuffixed_criterion_with_suffixed_attribute_fails(
+        self, evaluator,
+    ):
+        """Q68 / S08-F10 contract: unsuffixed criterion against suffixed
+        attribute returns actual='N/A' → FAIL. Pre-Q68 silently fell back
+        via the _usd / _pct chain. Post-Q68 caller must use exact suffix."""
+        criteria = {"fund": {"min_aum": 100}}  # unsuffixed criterion
+        results = evaluator.evaluate_layer1(
+            "fund", {"aum_usd": 200}, criteria,  # suffixed attribute
+        )
+        assert results[0].passed is False
+        assert results[0].actual == "N/A"
 
 
 # ── Layer 2 — mandate fit ────────────────────────────────────────

--- a/backend/tests/wealth/test_check_enrichment_changes_float_guard.py
+++ b/backend/tests/wealth/test_check_enrichment_changes_float_guard.py
@@ -1,0 +1,65 @@
+"""Regression tests for S08-F07 — check_enrichment_changes non-numeric guard."""
+
+from __future__ import annotations
+
+import uuid
+
+from vertical_engines.wealth.watchlist.service import WatchlistService
+
+
+def test_non_numeric_curr_expense_ratio_skipped_no_crash() -> None:
+    """curr_er = 'N/A' -> skip the fee delta check, no crash, no false alert."""
+    inst_id = uuid.uuid4()
+    instruments = [{
+        "instrument_id": inst_id,
+        "name": "Test Fund",
+        "attributes": {"expense_ratio_pct": "N/A"},
+    }]
+    previous = {inst_id: {"expense_ratio_pct": "0.005"}}
+    alerts = WatchlistService.check_enrichment_changes(instruments, previous)
+    # No crash; no fee alert (skipped). Strategy_label unchanged -> no alert either.
+    assert len(alerts) == 0
+
+
+def test_non_numeric_prev_expense_ratio_skipped() -> None:
+    """prev_er non-numeric -> skip."""
+    inst_id = uuid.uuid4()
+    instruments = [{
+        "instrument_id": inst_id,
+        "name": "Test Fund",
+        "attributes": {"expense_ratio_pct": "0.006"},
+    }]
+    previous = {inst_id: {"expense_ratio_pct": ""}}
+    alerts = WatchlistService.check_enrichment_changes(instruments, previous)
+    assert len(alerts) == 0
+
+
+def test_strategy_label_change_still_detected_when_fee_skipped() -> None:
+    """Even if expense_ratio is non-numeric (skipped), strategy_label change still alerts."""
+    inst_id = uuid.uuid4()
+    instruments = [{
+        "instrument_id": inst_id,
+        "name": "Test Fund",
+        "attributes": {"expense_ratio_pct": "N/A", "strategy_label": "Long/Short Equity"},
+    }]
+    previous = {inst_id: {"expense_ratio_pct": "0.005", "strategy_label": "Multi-Strategy"}}
+    alerts = WatchlistService.check_enrichment_changes(instruments, previous)
+    # Fee skipped; strategy alert fires.
+    assert len(alerts) == 1
+    assert alerts[0].direction == "enrichment_change"
+    assert "Strategy label" in alerts[0].message
+
+
+def test_valid_numeric_fee_increase_unchanged() -> None:
+    """Regression guard: valid numeric input still triggers fee alert when delta > 5bps."""
+    inst_id = uuid.uuid4()
+    instruments = [{
+        "instrument_id": inst_id,
+        "name": "Test Fund",
+        "attributes": {"expense_ratio_pct": 0.012},  # 1.2%
+    }]
+    previous = {inst_id: {"expense_ratio_pct": 0.005}}  # 0.5%
+    alerts = WatchlistService.check_enrichment_changes(instruments, previous)
+    # 0.012 - 0.005 = 0.007 > 0.0005 -> alert
+    assert len(alerts) == 1
+    assert "increased" in alerts[0].message.lower()

--- a/backend/tests/wealth/test_get_numeric_strict.py
+++ b/backend/tests/wealth/test_get_numeric_strict.py
@@ -1,0 +1,48 @@
+"""Regression tests for S08-F10 — _get_numeric strict field matching (no fallback)."""
+
+from __future__ import annotations
+
+from vertical_engines.wealth.screener.layer_evaluator import LayerEvaluator
+
+
+def test_exact_field_returns_value() -> None:
+    """Exact field name match returns the value."""
+    val = LayerEvaluator._get_numeric({"aum_usd": "100000000"}, "aum_usd")
+    assert val == 100_000_000.0
+
+
+def test_no_fallback_to_pct_suffix() -> None:
+    """Pre-fix: requesting 'aum' would fall back to 'aum_usd' or 'aum_pct'.
+    Post-fix: only exact match, returns None for missing field."""
+    val = LayerEvaluator._get_numeric({"aum_pct": "0.5"}, "aum")
+    assert val is None  # No fuzzy fallback to aum_pct
+
+
+def test_no_fallback_to_usd_suffix() -> None:
+    val = LayerEvaluator._get_numeric({"leverage_usd": "5000000"}, "leverage")
+    assert val is None  # No fuzzy fallback to leverage_usd
+
+
+def test_non_numeric_returns_none() -> None:
+    """Non-numeric value at exact field returns None (existing behavior)."""
+    val = LayerEvaluator._get_numeric({"aum_usd": "N/A"}, "aum_usd")
+    assert val is None
+
+
+def test_missing_field_returns_none() -> None:
+    val = LayerEvaluator._get_numeric({}, "aum_usd")
+    assert val is None
+
+
+def test_min_aum_usd_criterion_still_works_post_fix() -> None:
+    """End-to-end: criterion min_aum_usd with attribute aum_usd still evaluates."""
+    evaluator = LayerEvaluator({})
+    result = evaluator._evaluate_criterion(
+        criterion="min_aum_usd",
+        expected=100_000_000,
+        attributes={"aum_usd": 150_000_000},
+        instrument_type="fund",
+        layer=1,
+    )
+    assert result is not None
+    assert result.passed is True

--- a/backend/tests/wealth/test_layer1_case_insensitive_allowed.py
+++ b/backend/tests/wealth/test_layer1_case_insensitive_allowed.py
@@ -1,0 +1,75 @@
+"""Regression tests for S08-F08 — allowed_* criterion case-insensitive matching."""
+
+from __future__ import annotations
+
+from vertical_engines.wealth.screener.layer_evaluator import LayerEvaluator
+
+
+def test_allowed_domiciles_case_insensitive_lowercase_attribute() -> None:
+    """Lowercase domicile attribute ('ie') matches uppercase allowed list ['IE']."""
+    evaluator = LayerEvaluator({})
+    result = evaluator._evaluate_criterion(
+        criterion="allowed_domiciles",
+        expected=["IE", "LU", "KY"],
+        attributes={"domiciles": "ie"},
+        instrument_type="fund",
+        layer=1,
+    )
+    assert result is not None
+    assert result.passed is True
+
+
+def test_allowed_structures_case_insensitive() -> None:
+    """Lowercase structure 'ucits' matches uppercase allowed ['UCITS', 'CIS']."""
+    evaluator = LayerEvaluator({})
+    result = evaluator._evaluate_criterion(
+        criterion="allowed_structures",
+        expected=["UCITS", "CIS"],
+        attributes={"structures": "ucits"},
+        instrument_type="fund",
+        layer=1,
+    )
+    assert result is not None
+    assert result.passed is True
+
+
+def test_allowed_exchanges_uppercase_attribute_unchanged() -> None:
+    """Uppercase attribute (production canonical) still passes — no regression."""
+    evaluator = LayerEvaluator({})
+    result = evaluator._evaluate_criterion(
+        criterion="allowed_exchanges",
+        expected=["NYSE", "NASDAQ"],
+        attributes={"exchanges": "NASDAQ"},
+        instrument_type="fund",
+        layer=1,
+    )
+    assert result is not None
+    assert result.passed is True
+
+
+def test_allowed_value_not_in_list_still_fails() -> None:
+    """Genuinely-not-allowed value (case-insensitive) still fails."""
+    evaluator = LayerEvaluator({})
+    result = evaluator._evaluate_criterion(
+        criterion="allowed_domiciles",
+        expected=["IE", "LU"],
+        attributes={"domiciles": "us"},
+        instrument_type="fund",
+        layer=1,
+    )
+    assert result is not None
+    assert result.passed is False
+
+
+def test_allowed_scalar_expected_case_insensitive() -> None:
+    """Scalar (non-list) expected value also case-insensitive."""
+    evaluator = LayerEvaluator({})
+    result = evaluator._evaluate_criterion(
+        criterion="allowed_currency",
+        expected="USD",
+        attributes={"currency": "usd"},
+        instrument_type="fund",
+        layer=1,
+    )
+    assert result is not None
+    assert result.passed is True

--- a/backend/vertical_engines/wealth/screener/layer_evaluator.py
+++ b/backend/vertical_engines/wealth/screener/layer_evaluator.py
@@ -175,9 +175,9 @@ class LayerEvaluator:
             field_name = criterion[8:]  # strip "allowed_"
             actual_val = attributes.get(field_name, "")
             if isinstance(expected, list):
-                passed = str(actual_val) in [str(e) for e in expected]
+                passed = str(actual_val).lower() in [str(e).lower() for e in expected]
             else:
-                passed = str(actual_val) == str(expected)
+                passed = str(actual_val).lower() == str(expected).lower()
             return CriterionResult(
                 criterion=criterion,
                 expected=str(expected),
@@ -228,20 +228,20 @@ class LayerEvaluator:
 
     @staticmethod
     def _get_numeric(attributes: dict[str, Any], field_name: str) -> float | None:
-        """Try to extract a numeric value from attributes.
+        """Extract a numeric value from attributes by exact field name.
 
-        Handles both direct numeric values and string representations
-        (e.g., aum_usd stored as text in JSONB for precision).
+        Q68 / S08-F10: removed the legacy ``_usd`` / ``_pct`` suffix fallback
+        chain that could silently pick wrong-unit attributes for ambiguous
+        future criteria.  Config criteria must use the exact column suffix
+        (e.g. ``min_aum_usd``, ``min_yield_pct``).
         """
-        # Try multiple field name patterns
-        for key in (field_name, f"{field_name}_usd", f"{field_name}_pct"):
-            val = attributes.get(key)
-            if val is not None:
-                try:
-                    return float(val)
-                except (ValueError, TypeError):
-                    continue
-        return None
+        val = attributes.get(field_name)
+        if val is None:
+            return None
+        try:
+            return float(val)
+        except (ValueError, TypeError):
+            return None
 
 
 def determine_status(

--- a/backend/vertical_engines/wealth/screener/quant_metrics.py
+++ b/backend/vertical_engines/wealth/screener/quant_metrics.py
@@ -308,8 +308,12 @@ def composite_score(
 
     """
     if lower_is_better is None:
+        # Note: max_drawdown is stored as a NEGATIVE value (more-negative = worse).
+        # The natural sort order (and percentile rank) already puts the worst
+        # drawdown at the LOWEST percentile, so NO inversion is needed. Adding
+        # "max_drawdown" or "max_drawdown_pct" here would break correctness.
         lower_is_better = frozenset({
-            "max_drawdown_pct", "pe_ratio_ttm", "debt_to_equity",
+            "pe_ratio_ttm", "debt_to_equity",
             "annual_volatility_pct",
         })
 

--- a/backend/vertical_engines/wealth/watchlist/service.py
+++ b/backend/vertical_engines/wealth/watchlist/service.py
@@ -125,20 +125,29 @@ class WatchlistService:
             curr_er = current_attrs.get("expense_ratio_pct")
             prev_er = prev_attrs.get("expense_ratio_pct")
             if curr_er is not None and prev_er is not None:
-                delta = float(curr_er) - float(prev_er)
-                if delta > 0.0005:
-                    prev_human = float(prev_er) * 100.0
-                    curr_human = float(curr_er) * 100.0
-                    delta_bps = delta * 10000.0
-                    alerts.append(TransitionAlert(
-                        instrument_id=instrument_id,
-                        instrument_name=instrument_name,
-                        previous_outcome=f"ER {prev_human:.2f}%",
-                        new_outcome=f"ER {curr_human:.2f}%",
-                        direction="enrichment_change",
-                        message=f"Expense ratio increased by {delta_bps:.1f}bps ({prev_human:.2f}% → {curr_human:.2f}%)",
-                        detected_at=now,
-                    ))
+                try:
+                    curr_er_f = float(curr_er)
+                    prev_er_f = float(prev_er)
+                except (ValueError, TypeError):
+                    # Non-numeric expense_ratio_pct (e.g. "N/A", "" from sparse
+                    # ingestion) — skip fee delta check, continue to strategy_label.
+                    curr_er_f = None
+                    prev_er_f = None
+                if curr_er_f is not None and prev_er_f is not None:
+                    delta = curr_er_f - prev_er_f
+                    if delta > 0.0005:
+                        prev_human = prev_er_f * 100.0
+                        curr_human = curr_er_f * 100.0
+                        delta_bps = delta * 10000.0
+                        alerts.append(TransitionAlert(
+                            instrument_id=instrument_id,
+                            instrument_name=instrument_name,
+                            previous_outcome=f"ER {prev_human:.2f}%",
+                            new_outcome=f"ER {curr_human:.2f}%",
+                            direction="enrichment_change",
+                            message=f"Expense ratio increased by {delta_bps:.1f}bps ({prev_human:.2f}% → {curr_human:.2f}%)",
+                            detected_at=now,
+                        ))
 
             # Strategy label change detection
             curr_strat = current_attrs.get("strategy_label")


### PR DESCRIPTION
## Summary

Four small fixes closing Wave 6 Session 08 (combined diff: +277/-35 LoC).

- **S08-F08 (Tier 3 Med/Med):** `allowed_*` criterion handler now lowercases both sides of comparison — lowercase domicile `"ie"` matches `["IE", "LU", "KY"]`. Consistent with existing `geography` / `asset_class` handlers.
- **S08-F06 (Tier 4 Low/Low):** Removed dead `"max_drawdown_pct"` from default `lower_is_better` frozenset. Production uses key `"max_drawdown"` (not `_pct`), so inversion never fired. Negative-sign convention documented.
- **S08-F07 (Tier 4 Low/Low):** `check_enrichment_changes` wraps `float()` in try/except for non-numeric `expense_ratio_pct` (`"N/A"`, `""`). Prevents batch crash.
- **S08-F10 (Tier 4 Low/Low):** `_get_numeric` strict field matching — removed `_usd`/`_pct` suffix fallback chain. Pre-flight config grep confirmed no criterion relies on the fallback.

## Behavior change

- **F08:** Only real behavior change — funds with lowercase domicile/structure/exchange attributes will now correctly match allowed lists (FAIL → PASS where appropriate).
- **F06:** Zero behavior change (dead frozenset entry removed).
- **F07:** Zero behavior change in production (no current caller of `check_enrichment_changes`).
- **F10:** Zero behavior change (all current criteria use suffixed field names).

## Reverse-subsumption

Q64 `test_composite_score_mid_rank.py` tests used `"max_drawdown_pct"` with the default `lower_is_better`. Updated 4 tests to pass `lower_is_better` explicitly (same assertions, same intent — tests exercise mid-rank inversion, not default set contents).

## Test plan

- [x] 16 new tests across 4 files (5 F08 + 1 F06 + 4 F07 + 6 F10)
- [x] Q63-Q67 regression tests (42 passed)
- [x] Broader wealth/screener/watchlist suite (461 passed)
- [x] `ruff check` clean
- [x] `mypy` clean on modified files (pre-existing errors in unrelated transitive imports)

## Stage 3 triage

| Finding | Stage 1 | Jury | Tier | Fix |
|---------|---------|------|------|-----|
| F08 | Opus | CONFIRMED Med/Med | T3 | allowed_* .lower() |
| F06 | Opus | DOWNGRADED Low/Low | T4 | frozenset cleanup |
| F07 | Opus | DOWNGRADED Low/Low | T4 | try/except float guard |
| F10 | Gemini | DOWNGRADED Low/Low | T4 | remove suffix fallback |

**CLOSES SESSION 08.** Wave 6 cumulative: 9 of 14 sessions closed (64%).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>