### PR TITLE
fix(wealth): PR-Q69 — _within_watchlist_margin NaN/inf rejection (Codex P1 hotfix)

### DIFF
--- a/backend/tests/wealth/test_within_watchlist_margin.py
+++ b/backend/tests/wealth/test_within_watchlist_margin.py
@@ -100,3 +100,35 @@ def test_just_inside_margin_grants_watchlist() -> None:
     """9% miss (just inside margin) → WATCHLIST."""
     results = [_r("min_aum_usd", "100000000", "91000000", False)]  # 9% miss
     assert ScreenerService._within_watchlist_margin(results, {}) is True
+
+
+# ── Q69 hotfix (Codex P1): NaN / inf rejection ─────────────────────────
+
+
+def test_nan_actual_blocks_watchlist() -> None:
+    """Q69: float('nan') for actual → conservative FAIL.
+    Pre-fix: nan parses, `nan > 0.10` is False → loop falls through →
+    has_failure=True → returned True (WATCHLIST). Post-fix: math.isfinite
+    rejects, returns False (FAIL).
+    """
+    results = [_r("min_aum_usd", "100000000", "nan", False)]
+    assert ScreenerService._within_watchlist_margin(results, {}) is False
+
+
+def test_nan_expected_blocks_watchlist() -> None:
+    """Q69: NaN expected (malformed config) → FAIL."""
+    results = [_r("min_aum_usd", "nan", "95000000", False)]
+    assert ScreenerService._within_watchlist_margin(results, {}) is False
+
+
+def test_inf_actual_blocks_watchlist() -> None:
+    """Q69: float('inf') → FAIL (margin would be inf > 0.10 True, but
+    isfinite check is more defensive and catches both -inf / +inf)."""
+    results = [_r("min_aum_usd", "100000000", "inf", False)]
+    assert ScreenerService._within_watchlist_margin(results, {}) is False
+
+
+def test_negative_inf_actual_blocks_watchlist() -> None:
+    """Q69: -inf rejected by isfinite."""
+    results = [_r("min_aum_usd", "100000000", "-inf", False)]
+    assert ScreenerService._within_watchlist_margin(results, {}) is False

--- a/backend/vertical_engines/wealth/screener/service.py
+++ b/backend/vertical_engines/wealth/screener/service.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -314,6 +315,11 @@ class ScreenerService:
                 actual = float(result.actual)
                 expected = float(result.expected)
             except (ValueError, TypeError):
+                return False
+            # Q69 hotfix (Codex P1): reject NaN / inf — float("nan") parses
+            # silently but `nan > 0.10` is False, which would have promoted
+            # malformed numeric failures to WATCHLIST instead of FAIL.
+            if not (math.isfinite(actual) and math.isfinite(expected)):
                 return False
             if expected == 0:
                 return False


### PR DESCRIPTION
## Summary

Codex P1 catch on Q65 (S08-F03 _within_watchlist_margin AND-logic). Q65 added the AND requirement for all numeric failures within margin, but \`float('nan')\` parses silently — \`nan > 0.10\` evaluates to False — and the loop falls through to \`return has_failure\` (True). NaN-from-upstream-division-by-zero or Inf-from-overflow could be silently promoted to WATCHLIST instead of FAIL.

## The fix

One-line addition after the float() parse:

\`\`\`python
if not (math.isfinite(actual) and math.isfinite(expected)):
    return False
\`\`\`

NaN, +inf, -inf all conservatively return False (FAIL).

## Coverage

4 new tests in \`test_within_watchlist_margin.py\`:
- \`test_nan_actual_blocks_watchlist\`
- \`test_nan_expected_blocks_watchlist\`
- \`test_inf_actual_blocks_watchlist\`
- \`test_negative_inf_actual_blocks_watchlist\`

15/15 existing + new tests pass. Lint clean.

## Production impact

Limited — typical Layer 2 attributes come from DB as valid floats or NULL, not NaN strings. But upstream computations involving divisions could surface NaN, and ingestion paths from CSV / external APIs might serialize NaN as 'nan' string. Defensive guard.

## Sequencing

Standalone hotfix. No dependencies. No other PR depends on this.

## Acknowledgment

Filed as Q69 hotfix per Codex review on PR #368 (Q68 cleanup terminus). Codex P1 badge.

Refs:
- PR #368 (Q68) — Session 08 cleanup terminus
- PR #365 → #364 (Q65) — original _within_watchlist_margin AND-logic fix
- docs/audits/audit-validation-session08.md (S08-F03)