### PR TITLE
fix(quant): PR-Q71 — Codex expense_ratio ambiguous band observability (Q57 follow-up)

### DIFF
--- a/backend/quant_engine/expense_ratio_validator.py
+++ b/backend/quant_engine/expense_ratio_validator.py
@@ -66,6 +66,10 @@ def to_decimal_fraction(value: Any) -> float | None:
     lower than the false-negative cost (treating 0.5 % as 50 %, which
     collapsed fee_efficiency to 0 for ~60 % of index/ETF funds).
 
+    Q71 follow-up: emits ``expense_ratio_ambiguous_percent_or_fraction`` warning
+    log when input falls in this band, restoring observability that pre-Q57
+    provided via ``expense_ratio_clamped_above_max``.
+
     After conversion the result is clamped into the
     ``[MIN_REASONABLE_EXPENSE_RATIO, MAX_REASONABLE_EXPENSE_RATIO]``
     interval. Values outside the interval emit a warning log and are
@@ -89,6 +93,24 @@ def to_decimal_fraction(value: Any) -> float | None:
     elif abs_v > MAX_REASONABLE_EXPENSE_RATIO:
         fraction = v / 100.0     # whole percent → fraction
         source_scale = "percent"
+        # Q71 fix: emit observability for the (0.15, 1.0] ambiguous band.
+        # Per Q57 design, we treat these as whole percent (dominant N-CEN case).
+        # But a value of e.g. 0.20 could ALSO be a malformed XBRL fraction (= 20% ER).
+        # Pre-Q57 the malformed-fraction case clamped to MAX_REASONABLE_EXPENSE_RATIO
+        # with warning; post-Q57 we silently divide by 100. Restore the warning
+        # so production audit can detect ingestion-source data quality issues.
+        if abs_v <= 1.0:
+            logger.warning(
+                "expense_ratio_ambiguous_percent_or_fraction",
+                raw=value,
+                interpreted_as_percent=fraction,
+                note=(
+                    "Input in (0.15, 1.0] band — assumed whole percent per Q57 "
+                    "convention. If source was XBRL fraction, value would have "
+                    "represented a high-fee outlier (>15%) and would have been "
+                    "clamped pre-Q57. Verify upstream source convention."
+                ),
+            )
     else:
         fraction = v             # already a fraction
         source_scale = "fraction"

--- a/backend/tests/quant_engine/test_expense_ratio_band_observability.py
+++ b/backend/tests/quant_engine/test_expense_ratio_band_observability.py
@@ -1,0 +1,72 @@
+"""Codex catch #5 — observability for (0.15, 1.0] ambiguous band (PR-Q71)."""
+
+from __future__ import annotations
+
+import pytest
+import structlog.testing
+
+from quant_engine.expense_ratio_validator import to_decimal_fraction
+
+
+def test_input_in_ambiguous_band_emits_warning():
+    """0.20 in (0.15, 1.0] band → warning emitted, conversion proceeds."""
+    with structlog.testing.capture_logs() as logs:
+        result = to_decimal_fraction(0.20)
+    assert result == pytest.approx(0.002)  # treated as 0.2% percent
+    assert any(
+        entry.get("event") == "expense_ratio_ambiguous_percent_or_fraction"
+        for entry in logs
+    )
+
+
+def test_input_just_above_threshold_emits_warning():
+    """0.16 (just above MAX_REASONABLE_EXPENSE_RATIO) → warning."""
+    with structlog.testing.capture_logs() as logs:
+        to_decimal_fraction(0.16)
+    assert any(
+        "ambiguous" in entry.get("event", "").lower()
+        for entry in logs
+    )
+
+
+def test_input_at_one_emits_warning():
+    """1.0 (boundary of band) → warning."""
+    with structlog.testing.capture_logs() as logs:
+        to_decimal_fraction(1.0)
+    # 1.0 is treated as percent → 0.01 fraction
+    assert any(
+        "ambiguous" in entry.get("event", "").lower()
+        for entry in logs
+    )
+
+
+def test_input_above_one_no_band_warning():
+    """1.5 (above ambiguous band, clearly whole percent) → no ambiguity warning."""
+    with structlog.testing.capture_logs() as logs:
+        to_decimal_fraction(1.5)
+    assert not any(
+        "expense_ratio_ambiguous" in entry.get("event", "")
+        for entry in logs
+    )
+
+
+def test_input_below_threshold_no_warning():
+    """0.10 (below MAX_REASONABLE_EXPENSE_RATIO, fraction branch) → no warning."""
+    with structlog.testing.capture_logs() as logs:
+        to_decimal_fraction(0.10)
+    assert not any(
+        "expense_ratio_ambiguous" in entry.get("event", "")
+        for entry in logs
+    )
+
+
+def test_input_in_band_still_converts_to_percent_per_q57():
+    """Conversion behavior post-Q57 unchanged — only observability added."""
+    result = to_decimal_fraction(0.5)
+    assert result == pytest.approx(0.005)  # N-CEN 0.5% → 0.005 fraction (Q57 behavior)
+
+
+def test_basis_points_unchanged():
+    """bps branch (>100) — no ambiguity warning, normal conversion."""
+    result = to_decimal_fraction(150.0)
+    assert result == pytest.approx(0.015)  # 150 bps → 1.5%


### PR DESCRIPTION
## Summary

- Adds `expense_ratio_ambiguous_percent_or_fraction` warning log when `to_decimal_fraction` input falls in the `(0.15, 1.0]` ambiguous band — restores observability lost by Q57's threshold change
- Conversion behavior unchanged (Q57's trade-off stands — dominant N-CEN case still correctly handled as whole percent)
- Docstring updated to document Q71 follow-up

## Context

Q57 changed the percent-vs-fraction threshold from `> 1.0` to `> 0.15` to fix the dominant case (N-CEN `0.5` = 0.5%). Codex Auto Review caught that inputs in `(0.15, 1.0]` lost their pre-Q57 observability (formerly clamped with warning, now silently divided by 100).

## Test plan

- [x] 7 new tests in `test_expense_ratio_band_observability.py` — band warning presence/absence, conversion correctness, boundary conditions
- [x] 19 existing Q57 regression tests pass unchanged
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)