### PR TITLE
fix(quant): PR-Q72 — Codex P1 revert CPIAUCSL + PAYEMS pc1->lin (Q50-Q53 follow-up)

### DIFF
--- a/backend/quant_engine/regional_macro_service.py
+++ b/backend/quant_engine/regional_macro_service.py
@@ -114,8 +114,8 @@ REGION_SERIES: dict[str, list[SeriesSpec]] = {
     "US": [
         SeriesSpec("A191RL1Q225SBEA", "growth", "Real GDP Growth", "quarterly"),
         SeriesSpec("INDPRO", "growth", "Industrial Production", "monthly", units="pc1"),
-        SeriesSpec("PAYEMS", "growth", "Nonfarm Payrolls", "monthly", units="pc1"),
-        SeriesSpec("CPIAUCSL", "inflation", "CPI All Urban", "monthly", invert=True, units="pc1"),
+        SeriesSpec("PAYEMS", "growth", "Nonfarm Payrolls", "monthly"),
+        SeriesSpec("CPIAUCSL", "inflation", "CPI All Urban", "monthly", invert=True),
         SeriesSpec("PCEPILFE", "inflation", "Core PCE", "monthly", invert=True, units="pc1"),
         SeriesSpec("DFF", "monetary", "Fed Funds Rate", "daily", invert=True),
         SeriesSpec("DGS10", "monetary", "10Y Treasury", "daily"),

--- a/backend/tests/quant_engine/test_regional_macro_pc1_revert.py
+++ b/backend/tests/quant_engine/test_regional_macro_pc1_revert.py
@@ -1,0 +1,37 @@
+"""Codex catches #6 + #7 — CPIAUCSL + PAYEMS revert to lin units (PR-Q72)."""
+
+from __future__ import annotations
+
+from quant_engine.regional_macro_service import REGION_SERIES
+
+
+def test_cpiaucsl_uses_lin_units_post_q72_revert():
+    """CPIAUCSL must use 'lin' (default) units to preserve downstream consumers
+    that compute YoY/MoM from level data (regime_service.build_regime_inputs,
+    risk_calc._fetch_monthly_cpi_changes)."""
+    us_series = REGION_SERIES["US"]
+    cpi_spec = next((s for s in us_series if s.series_id == "CPIAUCSL"), None)
+    assert cpi_spec is not None
+    assert cpi_spec.units == "lin"  # default — Q72 revert from pc1
+
+
+def test_payems_uses_lin_units_post_q72_revert():
+    """PAYEMS must use 'lin' units (credit market_data applies mom_delta to levels)."""
+    us_series = REGION_SERIES["US"]
+    payems_spec = next((s for s in us_series if s.series_id == "PAYEMS"), None)
+    assert payems_spec is not None
+    assert payems_spec.units == "lin"
+
+
+def test_other_pc1_series_documented_status():
+    """Document which series still use pc1 post-Q72 for orchestrator audit."""
+    pc1_series = []
+    for region, specs in REGION_SERIES.items():
+        for spec in specs:
+            if spec.units == "pc1":
+                pc1_series.append((region, spec.series_id))
+    # Q72 leaves these on pc1 (downstream consumers not yet audited):
+    # INDPRO, PCEPILFE, JPNRGDPEXP, JPNCPIALLMINMEI, CHNCPIALLMINMEI,
+    # BRACPIALLMINMEI, INDCPIALLMINMEI, CLVMNACSCAB1GQEA19, CP0000EZ19M086NEST
+    # If a future audit reverts any of these, update this test.
+    assert len(pc1_series) >= 0  # smoke check; no strict count enforcement

--- a/docs/investigations/2026-04-28-s06-f10-redo-with-consumer-audit.md
+++ b/docs/investigations/2026-04-28-s06-f10-redo-with-consumer-audit.md
@@ -1,0 +1,28 @@
+# Backlog: S06-F10 percentile-rank redo with full downstream consumer audit
+
+**Created:** 2026-04-28 (post-Q72 partial revert)
+**Status:** OPEN
+
+**Original finding:** S06-F10 — `regional_macro_service` percentile-rank on non-stationary level series saturated all funds at 100% percentile (CPIAUCSL ~300, PAYEMS in millions).
+
+**Original fix (Q50-Q53 recovery, PR #356):** set `units="pc1"` on FRED fetch configs for non-stationary series. Stored YoY-percent values made percentile rank stationary.
+
+**Codex catch (2026-04-28):** Q50-Q53 didn't audit downstream consumers. CPIAUCSL + PAYEMS are read by `regime_service.build_regime_inputs()` (recomputes YoY from levels) and `risk_calc._fetch_monthly_cpi_changes()` (MoM from levels). Double-transform corrupted regime + risk computations.
+
+**Q72 partial revert:** CPIAUCSL + PAYEMS reverted to `units="lin"`. S06-F10 percentile-rank saturation regression accepted temporarily for these two series.
+
+**TODO redo approach:**
+
+1. Audit ALL downstream consumers of `macro_data` for the affected series:
+   - INDPRO, PAYEMS, CPIAUCSL, PCEPILFE
+   - CLVMNACSCAB1GQEA19, CP0000EZ19M086NEST
+   - JPNRGDPEXP, JPNCPIALLMINMEI, CHNCPIALLMINMEI
+   - BRACPIALLMINMEI, INDCPIALLMINMEI
+2. For each consumer, decide:
+   - Stop double-transform (read pc1 directly) — preferred
+   - Or: read from lin-stored series elsewhere
+3. Implement in-function YoY transform inside `regional_macro_service.score_global_indicators` / `score_region` for the percentile-rank purpose, so we don't need to mutate ingestion units
+4. Revert remaining `units="pc1"` settings if downstream consumers prefer level data
+5. New tests for each consumer ensuring no regression
+
+**Effort estimate:** 1-2 sprints (multi-file consumer audit + careful redo).


### PR DESCRIPTION
## Summary

Codex Auto Review catch #6 (P1 Crit/Crit) + catch #7 (P2 Med/H) on the Q50-Q53 recovery (PR #356). Q50-Q53 set `units="pc1"` on FRED fetch configs to fix S06-F10 percentile-rank saturation, but did not audit downstream consumers — CPIAUCSL + PAYEMS get double-transformed by `regime_service.build_regime_inputs()` and `risk_calc._fetch_monthly_cpi_changes()` (both assume `lin` and recompute YoY/MoM themselves).

**Production impact:** every regime classification + risk evaluation that depends on these CPI/PAYEMS computations is corrupted since Q50-Q53 deploy. Tier 0 institutional emergency for CPIAUCSL.

**Fix (Option A — partial revert):** set CPIAUCSL + PAYEMS back to default `lin` units. Accept temporary regression of S06-F10 percentile-rank saturation for these two series. Other Q50-Q53 series (INDPRO, PCEPILFE, GDPs, EM CPIs) remain on `pc1` — downstream consumer audit pending.

Why partial revert chosen over consumer-update:
- S06-F10 was signal dilution (percentile saturation, mensurable)
- Codex catch is silent corruption (regime decisions wrong)
- Trade Crit/Crit silent corruption for recoverable signal dilution

## Files

| File | LoC | Change |
|---|---|---|
| `backend/quant_engine/regional_macro_service.py` | +2/-2 | drop `units="pc1"` from PAYEMS + CPIAUCSL specs |
| `backend/tests/quant_engine/test_regional_macro_pc1_revert.py` | +37 | 3 new tests pinning the revert |
| `docs/investigations/2026-04-28-s06-f10-redo-with-consumer-audit.md` | +28 | backlog doc for proper redo (full consumer audit + in-function YoY transform) |

## Test plan

- [x] 3 new tests passing (CPIAUCSL=lin, PAYEMS=lin, pc1 series inventory)
- [x] Pre-existing `test_regional_macro_micro_fixes.py` green (6/6)
- [x] Pre-existing `test_regime_service.py` green (2/2)
- [x] Ruff clean on touched files

## Notes

- Stacked on top of PR-Q71 (#370). Will merge cleanly once Q71 merges to main.
- **Backfill mandatory** post-deploy: `macro_ingestion` worker re-run to repopulate `macro_data` with lin-transformed CPIAUCSL + PAYEMS. Bundle with Q70/Q71/Q73 backfill — single worker run resolves all four.
- Backlog filed: `docs/investigations/2026-04-28-s06-f10-redo-with-consumer-audit.md` documents the proper redo approach.

Refs: Codex review batch 2026-04-28 catches #6 + #7; PR #356 (Q50-Q53 recovery); audit-validation-session06.md (S06-F10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)