### PR TITLE
fix(wealth): PR-Q70 — Codex P1 max_drawdown units + watchlist peer cohort full universe

### DIFF
--- a/backend/app/domains/wealth/routes/screener.py
+++ b/backend/app/domains/wealth/routes/screener.py
@@ -705,7 +705,7 @@ async def trigger_screening(
         else:
             metric_dicts_by_id[inst.instrument_id] = {
                 "sharpe_ratio": _safe_float(rm.sharpe_1y),
-                "max_drawdown": _safe_float(rm.max_drawdown_1y),
+                "max_drawdown": _safe_float(rm.max_drawdown_1y, scale=100),
                 "pct_positive_months": _safe_float(getattr(rm, "pct_positive_months", None)),
                 "annual_volatility_pct": _safe_float(rm.volatility_1y, scale=100),
             }

--- a/backend/app/domains/wealth/workers/screening_batch.py
+++ b/backend/app/domains/wealth/workers/screening_batch.py
@@ -160,7 +160,7 @@ async def _execute_batch(db: AsyncSession, org_id: uuid.UUID) -> dict:
         else:
             metric_dicts_by_id[i.instrument_id] = {
                 "sharpe_ratio": _safe_float(rm.sharpe_1y),
-                "max_drawdown": _safe_float(rm.max_drawdown_1y),
+                "max_drawdown": _safe_float(rm.max_drawdown_1y, scale=100),
                 "pct_positive_months": _safe_float(getattr(rm, "pct_positive_months", None)),
                 "annual_volatility_pct": _safe_float(rm.volatility_1y, scale=100),
             }

--- a/backend/app/domains/wealth/workers/watchlist_batch.py
+++ b/backend/app/domains/wealth/workers/watchlist_batch.py
@@ -67,32 +67,38 @@ async def _execute_watchlist_check(db: AsyncSession, org_id: uuid.UUID) -> dict:
     config_l2 = (await config_svc.get("liquid_funds", "screening_layer2", org_id)).value
     config_l3 = (await config_svc.get("liquid_funds", "screening_layer3", org_id)).value
 
-    # 3. Load all watchlisted instruments
+    # 3. Load watchlist-tagged instruments (evaluation targets)
     result = await db.execute(
         select(Instrument).where(
             Instrument.is_active.is_(True),
             Instrument.approval_status == "watchlist",
         ),
     )
-    instruments = result.scalars().all()
+    watchlist_instruments = result.scalars().all()
 
-    if not instruments:
+    if not watchlist_instruments:
         logger.info("watchlist_check_empty", reason="no watchlisted instruments")
         return {"status": "completed", "total_screened": 0}
 
-    # Load latest fund_risk_metrics for each instrument (global table, no RLS)
+    # 3b. Load full active universe for peer cohort baseline
+    universe_result = await db.execute(
+        select(Instrument).where(Instrument.is_active.is_(True)),
+    )
+    universe_instruments = universe_result.scalars().all()
+
+    # Load latest fund_risk_metrics for full universe (global table, no RLS)
     from app.domains.wealth.models.risk import FundRiskMetrics
 
-    instrument_ids = [i.instrument_id for i in instruments]
+    universe_ids = [i.instrument_id for i in universe_instruments]
     rm_res = await db.execute(
         select(FundRiskMetrics)
-        .where(FundRiskMetrics.instrument_id.in_(instrument_ids))
+        .where(FundRiskMetrics.instrument_id.in_(universe_ids))
         .distinct(FundRiskMetrics.instrument_id)
         .order_by(FundRiskMetrics.instrument_id, FundRiskMetrics.calc_date.desc()),
     )
     risk_metrics_by_id = {rm.instrument_id: rm for rm in rm_res.scalars().all()}
 
-    # Build per-instrument metric dicts for cohort peer_values
+    # Build per-instrument metric dicts for cohort peer_values (FULL universe)
     from app.domains.wealth.services.screener_peer_values_builder import (
         METRIC_NAMES_BY_TYPE,
         build_per_instrument_peer_values,
@@ -113,7 +119,7 @@ async def _execute_watchlist_check(db: AsyncSession, org_id: uuid.UUID) -> dict:
             return None
 
     metric_dicts_by_id: dict[uuid.UUID, dict[str, float | None]] = {}
-    for i in instruments:
+    for i in universe_instruments:
         rm = risk_metrics_by_id.get(i.instrument_id)
         attrs = dict(i.attributes) if i.attributes else {}
         asset_class = attrs.get("asset_class", "")
@@ -148,18 +154,19 @@ async def _execute_watchlist_check(db: AsyncSession, org_id: uuid.UUID) -> dict:
         else:
             metric_dicts_by_id[i.instrument_id] = {
                 "sharpe_ratio": _safe_float(rm.sharpe_1y),
-                "max_drawdown": _safe_float(rm.max_drawdown_1y),
+                "max_drawdown": _safe_float(rm.max_drawdown_1y, scale=100),
                 "pct_positive_months": _safe_float(getattr(rm, "pct_positive_months", None)),
                 "annual_volatility_pct": _safe_float(rm.volatility_1y, scale=100),
             }
 
+    # Build cohort dicts from FULL universe (true market-relative rank)
     inst_dicts_for_cohorts = [
         {
             "instrument_id": i.instrument_id,
             "instrument_type": i.instrument_type,
             "attributes": dict(i.attributes) if i.attributes else {},
         }
-        for i in instruments
+        for i in universe_instruments
     ]
 
     peer_values_by_id = build_per_instrument_peer_values(
@@ -214,7 +221,7 @@ async def _execute_watchlist_check(db: AsyncSession, org_id: uuid.UUID) -> dict:
             data_period_days=0,
         )
 
-    # Extract scalar data before crossing async/thread boundary
+    # Extract scalar data before crossing async/thread boundary (watchlist subset only)
     instrument_dicts = [
         {
             "instrument_id": i.instrument_id,
@@ -228,11 +235,11 @@ async def _execute_watchlist_check(db: AsyncSession, org_id: uuid.UUID) -> dict:
             ),
             "peer_values": peer_values_by_id.get(i.instrument_id, {}),
         }
-        for i in instruments
+        for i in watchlist_instruments
     ]
 
     # 4. Fetch previous screening outcomes for comparison
-    instrument_ids = [i.instrument_id for i in instruments]
+    instrument_ids = [i.instrument_id for i in watchlist_instruments]
     prev_results = await db.execute(
         select(ScreeningResult.instrument_id, ScreeningResult.overall_status).where(
             ScreeningResult.instrument_id.in_(instrument_ids),

--- a/backend/tests/integration/test_screening_batch_max_drawdown_units.py
+++ b/backend/tests/integration/test_screening_batch_max_drawdown_units.py
@@ -1,0 +1,70 @@
+"""Codex catch #2 — max_drawdown unit alignment between metric_dicts and QuantMetrics.
+
+PR-Q70: metric_dicts_by_id["max_drawdown"] was stored as raw decimal (-0.15)
+while QuantMetrics.max_drawdown_pct was built with *100 (-15.0). composite_score
+then compared fund's whole-percent value against decimal peer cohort, causing
+every fund with real drawdown to rank at top percentile on the drawdown component.
+
+Post-Q70: both metric_dicts and QuantMetrics use whole percent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vertical_engines.wealth.screener.quant_metrics import composite_score
+
+
+def test_metric_dicts_max_drawdown_in_whole_percent_scale() -> None:
+    """metric_dicts max_drawdown must be whole percent (matches QuantMetrics.max_drawdown_pct).
+
+    Simulates the _safe_float(rm.max_drawdown_1y, scale=100) call in screening_batch.
+    Pre-Q70: raw decimal (-0.15). Post-Q70: whole percent (-15.0).
+    """
+    raw_decimal = -0.15
+    scaled = raw_decimal * 100.0
+    assert scaled == pytest.approx(-15.0)
+
+
+def test_composite_score_consistent_drawdown_units() -> None:
+    """End-to-end: build peer_values from N funds + score one fund.
+
+    All values in whole-percent scale. Fund at median drawdown should rank
+    near 50th percentile — NOT at 100% (the pre-Q70 top-inversion bug).
+    """
+    # 5 funds with max_drawdown in whole percent (scaled from decimal)
+    peer_drawdowns = [-30.0, -20.0, -15.0, -10.0, -5.0]  # whole %
+
+    # Fund at median drawdown (-15.0%)
+    metrics = {"max_drawdown": -15.0}
+    peer_values = {"max_drawdown": peer_drawdowns}
+    weights = {"max_drawdown": 1.0}
+
+    score = composite_score(metrics, peer_values, weights)
+    assert score is not None
+
+    # max_drawdown is NOT in lower_is_better (negative values already sort correctly).
+    # -15.0 is the median peer → should rank near 0.40–0.60, not at 1.0.
+    assert 0.30 <= score <= 0.70, (
+        f"Fund at median drawdown should rank mid-cohort, got {score:.3f}"
+    )
+
+
+def test_unit_mismatch_would_produce_extreme_rank() -> None:
+    """Demonstrate the pre-Q70 bug: decimal fund vs whole-percent peers.
+
+    Fund at -0.15 (decimal, unscaled) against whole-percent peers.
+    Would clip to upper bound and rank at top (wrong).
+    """
+    # Pre-Q70 bug scenario: fund metric in decimal, peers in whole percent
+    bug_metrics = {"max_drawdown": -0.15}  # decimal (pre-Q70 bug)
+    peer_values = {"max_drawdown": [-30.0, -20.0, -15.0, -10.0, -5.0]}  # whole %
+    weights = {"max_drawdown": 1.0}
+
+    score = composite_score(bug_metrics, peer_values, weights)
+    assert score is not None
+    # -0.15 clips to upper bound (-5.0) → ranks at TOP of cohort
+    # This proves the bug: a deeply negative drawdown appears as best
+    assert score > 0.85, (
+        f"Bug scenario should produce artificially high rank, got {score:.3f}"
+    )

--- a/backend/tests/integration/test_watchlist_batch_full_universe_cohort.py
+++ b/backend/tests/integration/test_watchlist_batch_full_universe_cohort.py
@@ -1,0 +1,111 @@
+"""Codex catch #3 — watchlist peer cohort uses full universe, not watchlist subset.
+
+PR-Q70: watchlist_batch.py pre-filtered instruments to approval_status='watchlist'
+before building peer cohorts. A watchlist fund's percentile rank was computed
+against other watchlist funds (self-selected weak/borderline cohort), not the
+broader universe. Created artificial PASS/FAIL transitions driven by watchlist
+composition rather than true market-relative standing.
+
+Post-Q70: peer_values built from full active universe; evaluation targets
+restricted to watchlist subset.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.domains.wealth.services.screener_peer_values_builder import (
+    METRIC_NAMES_BY_TYPE,
+    build_per_instrument_peer_values,
+)
+
+
+def _make_instrument(
+    *, strategy_label: str = "Long/Short Equity",
+    instrument_type: str = "fund",
+) -> dict:
+    return {
+        "instrument_id": uuid.uuid4(),
+        "instrument_type": instrument_type,
+        "attributes": {"strategy_label": strategy_label},
+    }
+
+
+def test_watchlist_target_peer_values_from_full_universe() -> None:
+    """Watchlist fund's peer_values should reflect FULL universe, not watchlist subset.
+
+    Setup: 3 'watchlist' funds + 7 non-watchlist in same strategy_label cohort.
+    Build peer_values from full universe (10 instruments).
+    Assert: each watchlist fund sees all 10 cohort members in its peer values.
+    """
+    # 3 watchlist instruments
+    watchlist = [_make_instrument() for _ in range(3)]
+    # 7 non-watchlist (approved / pending / etc)
+    non_watchlist = [_make_instrument() for _ in range(7)]
+
+    full_universe = watchlist + non_watchlist
+
+    # Assign sharpe metrics to all 10
+    metric_dicts = {}
+    for idx, inst in enumerate(full_universe):
+        metric_dicts[inst["instrument_id"]] = {
+            "sharpe_ratio": 0.5 + idx * 0.1,
+            "max_drawdown": -(30 - idx * 2.0),
+            "pct_positive_months": 50.0 + idx,
+            "annual_volatility_pct": 10.0 + idx,
+        }
+
+    # Build peer_values from FULL universe (post-Q70 correct behavior)
+    full_peer_values = build_per_instrument_peer_values(
+        instruments=full_universe,
+        instrument_metrics_by_id=metric_dicts,
+        metric_names_by_type=METRIC_NAMES_BY_TYPE,
+    )
+
+    # Build peer_values from watchlist-only (pre-Q70 bug)
+    watchlist_only_peer_values = build_per_instrument_peer_values(
+        instruments=watchlist,
+        instrument_metrics_by_id={k: v for k, v in metric_dicts.items()
+                                  if k in {w["instrument_id"] for w in watchlist}},
+        metric_names_by_type=METRIC_NAMES_BY_TYPE,
+    )
+
+    # Assert: full universe peer values have more data points
+    wl_id = watchlist[0]["instrument_id"]
+    full_sharpe_peers = full_peer_values.get(wl_id, {}).get("sharpe_ratio", [])
+    wl_only_sharpe_peers = watchlist_only_peer_values.get(wl_id, {}).get("sharpe_ratio", [])
+
+    assert len(full_sharpe_peers) == 10, (
+        f"Full universe cohort should have 10 members, got {len(full_sharpe_peers)}"
+    )
+    assert len(wl_only_sharpe_peers) == 3, (
+        f"Watchlist-only cohort should have 3 members, got {len(wl_only_sharpe_peers)}"
+    )
+
+
+def test_watchlist_cohort_size_affects_percentile_rank() -> None:
+    """A fund's percentile rank differs between watchlist-only and full-universe cohorts.
+
+    Demonstrates that the restricted cohort produces a different (less meaningful) rank.
+    """
+    from vertical_engines.wealth.screener.quant_metrics import composite_score
+
+    # Fund at bottom of its 3-member watchlist cohort but mid-pack in 10-member universe
+    fund_metrics = {"sharpe_ratio": 0.5}
+
+    # Watchlist-only cohort: fund is the worst of 3
+    wl_peers = {"sharpe_ratio": [0.5, 0.7, 0.9]}
+    wl_score = composite_score(fund_metrics, wl_peers, {"sharpe_ratio": 1.0})
+
+    # Full universe cohort: fund is low but not extreme
+    full_peers = {"sharpe_ratio": [0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2]}
+    full_score = composite_score(fund_metrics, full_peers, {"sharpe_ratio": 1.0})
+
+    assert wl_score is not None
+    assert full_score is not None
+    # Full universe gives a more favorable (but accurate) rank since there are
+    # instruments below this fund
+    assert full_score > wl_score, (
+        f"Full universe rank ({full_score:.3f}) should differ from "
+        f"watchlist-only rank ({wl_score:.3f})"
+    )


### PR DESCRIPTION
Per docs/prompts/2026-04-28-pr-q70-max-drawdown-units-watchlist-cohort.md.

**Defects:**
- Codex catch #2 (P1 Crit/Crit): max_drawdown unit alignment in 3 callers (screening_batch + watchlist_batch + screener route). `_safe_float(rm.max_drawdown_1y, scale=100)`.
- Codex catch #3 (P2 → H/Crit): watchlist_batch peer cohort built from full active universe, not approval_status=watchlist subset. Watchlist funds now ranked against true market cohort.

**Tests:** 5 new + 225 pre-existing pass.
**Refs:** Codex review batch 2026-04-28 catches #2 + #3.