### PR TITLE
fix(wealth): PR-Q75 — Tier 0 hotfix — robust_sharpe AttributeError killing risk_calc + global_risk_metrics workers since 2026-04-20

### DIFF
--- a/backend/app/domains/wealth/workers/risk_calc.py
+++ b/backend/app/domains/wealth/workers/risk_calc.py
@@ -38,7 +38,7 @@ from quant_engine.return_statistics_service import (
     compute_sharpe_ratio,
     compute_sortino_ratio,
 )
-from quant_engine.scoring_components import robust_sharpe as _robust_sharpe_mod
+from quant_engine.scoring_components import robust_sharpe as _robust_sharpe
 from quant_engine.scoring_service import compute_fund_score
 from quant_engine.talib_momentum_service import (
     compute_flow_momentum,
@@ -593,7 +593,7 @@ def _compute_metrics_from_returns(
     # Uses daily returns over the 3y window when available, else the full
     # series, with periods_per_year=252 to match the daily sharpe_1y scale.
     cf_window = returns[-(3 * 252):] if len(returns) >= 3 * 252 else returns
-    cf_result = _robust_sharpe_mod.robust_sharpe(
+    cf_result = _robust_sharpe(
         cf_window,
         rf_rate=risk_free_rate / 252.0,
         periods_per_year=252,


### PR DESCRIPTION
## Tier 0 emergency — silent dead worker

`risk_calc.py:41` imported `robust_sharpe` (a function re-exported by `scoring_components/__init__.py`) under the alias `_robust_sharpe_mod`, then called `_robust_sharpe_mod.robust_sharpe(...)` at line 596 as if the alias were a module. Result: `AttributeError: 'function' object has no attribute 'robust_sharpe'` on the FIRST fund processed by every batch.

Both `risk_calc` (org-scoped, lock 900_007) and `run_global_risk_metrics` (entrypoint shared with `global_risk_metrics` worker, lock 900_071) crash with exit code 1 before writing any row to `fund_risk_metrics`.

## Impact

- **Origin:** PR-Q1 commit `825079bb`, 2026-04-20 01:20 BRT
- **Duration:** 8 days
- **Scope:** GLOBAL — `fund_risk_metrics` is a shared global table; every tenant has stale `sharpe_cf*`, `volatility_garch`, `vol_model`, GARCH/EWMA fallbacks, and every metric written below line 596
- **Severity class:** same as Q63 Layer 3 dead — silent dead worker, no CI signal

## Root cause / CI escape

`scoring_components/__init__.py:7` re-exports `robust_sharpe` as a function, which sets the same name on the package namespace and shadows the `robust_sharpe.py` submodule. `import quant_engine.scoring_components.robust_sharpe as m` therefore resolves to the function, not the submodule. Tests (`test_robust_sharpe.py`, `test_jackknife_se_textbook.py`) import the symbol directly from the submodule path so the typo never surfaces under pytest. There is no integration test that exercises the worker entrypoint.

## Fix

Minimal correct form — alias matches the imported shape (function), call site invokes it directly:

\`\`\`diff
- from quant_engine.scoring_components import robust_sharpe as _robust_sharpe_mod
+ from quant_engine.scoring_components import robust_sharpe as _robust_sharpe
\`\`\`
\`\`\`diff
-    cf_result = _robust_sharpe_mod.robust_sharpe(
+    cf_result = _robust_sharpe(
\`\`\`

## Validation

Local smoke run against docker DB:
- Cleared the `AttributeError`
- Worker passed line 596, processed batch of 5455 funds
- `fi_analytics_computed`, `cash_analytics_computed`, `alt_analytics_computed`, `scoring_degraded` log lines emitted as expected

## Test plan

- [x] Lint clean (`ruff check backend/app/domains/wealth/workers/risk_calc.py`)
- [x] Local smoke run of `risk_calc` worker against docker compose DB
- [ ] CI green
- [ ] Full backfill bundle Q57-Q74 retomado pós-merge (workers 2→5)

## Backlog follow-up

Open ticket: add CI smoke test for every worker entrypoint (`risk_calc`, `global_risk_metrics`, `screening_batch`, `watchlist_batch`, etc.) — invoke `python -m app.domains.wealth.workers.<worker>` against ephemeral docker DB with 1 seeded fund, expect exit 0. This is the SECOND silent dead worker discovered in 2 sessions (Q63 Layer 3 dead since deployment, Q75 robust_sharpe since 2026-04-20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)