### PR TITLE
fix(wealth): PR-Q77 — ESMA UCITS structure enrichment in universe_sync Phase 4 + backfill

### DIFF
--- a/backend/app/core/db/migrations/versions/0185_esma_ucits_structure_backfill.py
+++ b/backend/app/core/db/migrations/versions/0185_esma_ucits_structure_backfill.py
@@ -1,0 +1,44 @@
+"""Backfill structure='UCITS' for ESMA-origin funds in instruments_universe.
+
+Revision ID: 0185_esma_ucits_structure_backfill
+Revises: 0184_factor_source_blocks
+Create Date: 2026-04-28
+
+PR-Q77 — Screener Layer 1 rejected 100% of 2,932 UCITS funds at
+allowed_structure because instruments_universe.attributes.structure was
+never populated for ESMA-origin funds. universe_sync.py Phase 4 wrote
+domicile and fund_subtype but omitted structure.
+
+ESMA Register is exclusively UCITS by regulatory design (esma_funds.fund_type
+has single value 'UCITS' across all rows). Hard-coding structure='UCITS' is
+the deterministic mapping. SICAV refinement is backlog.
+
+Idempotent: WHERE clause filters rows already populated.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0185_esma_ucits_structure_backfill"
+down_revision: str | None = "0184_factor_source_blocks"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        UPDATE instruments_universe
+        SET attributes = attributes || jsonb_build_object('structure', 'UCITS')
+        WHERE attributes->>'fund_subtype' = 'ucits'
+          AND (attributes->>'structure' IS NULL OR attributes->>'structure' = '')
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        UPDATE instruments_universe
+        SET attributes = attributes - 'structure'
+        WHERE attributes->>'fund_subtype' = 'ucits'
+          AND attributes->>'structure' = 'UCITS'
+    """)

--- a/backend/app/domains/wealth/workers/universe_sync.py
+++ b/backend/app/domains/wealth/workers/universe_sync.py
@@ -445,6 +445,7 @@ async def _sync_esma_funds(db: AsyncSession) -> dict[str, Any]:
             jsonb_build_object(
                 'fund_lei', ef.lei,
                 'fund_subtype', 'ucits',
+                'structure', 'UCITS',
                 'strategy_label', ef.strategy_label,
                 'domicile', ef.domicile,
                 'esma_manager_id', ef.esma_manager_id,


### PR DESCRIPTION
## Summary

**Tier 2 — institutional gating.** Screener Layer 1 rejected 100% of 2,932 UCITS funds at `allowed_structure` because `instruments_universe.attributes.structure` was never populated for ESMA-origin funds.

**Root cause:** `universe_sync.py` Phase 4 writes `domicile`, `fund_subtype`, `strategy_label` but omits `structure`. SEC funds receive structure via `backfill_screening_attrs.py` manual script, but ESMA funds had no equivalent path.

**Fix:** ESMA Register is exclusively UCITS by regulatory design (`esma_funds.fund_type` = `'UCITS'` across 10,436 rows). `structure='UCITS'` is the deterministic mapping.

Reference: [FINDINGS.md](docs/investigations/2026-04-28-screener-layer1-domicile-structure-empty-FINDINGS.md) §4.2

## Changes

- `universe_sync.py` Phase 4: add `'structure', 'UCITS'` to `jsonb_build_object` (+1 line)
- New migration `0185`: backfill 2,929 existing rows where `fund_subtype='ucits'` AND structure missing/empty

## Idempotency

```sql
WHERE attributes->>'fund_subtype' = 'ucits'
  AND (attributes->>'structure' IS NULL OR attributes->>'structure' = '')
```
Second run = 0 rows affected. Downgrade only removes `structure` where value is `'UCITS'`.

## Validation results

| Metric | Value |
|--------|-------|
| Total UCITS in instruments_universe | 2,932 |
| With `structure='UCITS'` post-migration | 2,929 (99.9%) |
| Edge cases preserved (pre-existing non-UCITS structure) | 3 (2× BG `Mutual Fund`, 1× LU `ETF`) |
| Side-effects on other fund_subtypes | 0 |

```
  structure  | count
-------------+-------
 Mutual Fund |  5062
 UCITS       |  2929
             |  1534
 ETF         |   932
 BDC         |    27
```

## Test plan

- [x] `ruff check` — passed
- [x] `mypy` — passed (pre-existing engine.py error only)
- [x] Pre-flight DB dry-run (BEGIN/ROLLBACK) — 2,929 rows, zero side-effects
- [x] Migration apply via `alembic upgrade head` — clean
- [x] Post-migration DB verification queries — confirmed

## Scope boundaries

- Only Phase 4 (ESMA/UCITS) modified — Phases 1/2/3/5/6 untouched
- No changes to `layer_evaluator.py`, `screening_batch.py`, or ConfigService
- SICAV refinement filed as backlog (requires legal name parsing)
- 3 edge cases (BG/LU with wrong structure) are data quality backlog — separate from this PR

## Downstream

- **PR-Q76** (naming fix `allowed_structures` → `allowed_structure`) must merge for screener to use the new data
- **PR-Q78** (AUM enrichment) addresses the remaining UCITS gating constraint (`min_aum_usd`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)