### PR TITLE
fix(wealth): PR-Q76 — Tier 0 hotfix — screener Layer 1 100% reject due to plural/singular naming mismatch

### DIFF
--- a/backend/app/core/db/migrations/versions/0185_esma_ucits_structure_backfill.py
+++ b/backend/app/core/db/migrations/versions/0185_esma_ucits_structure_backfill.py
@@ -1,0 +1,44 @@
+"""Backfill structure='UCITS' for ESMA-origin funds in instruments_universe.
+
+Revision ID: 0185_esma_ucits_structure_backfill
+Revises: 0184_factor_source_blocks
+Create Date: 2026-04-28
+
+PR-Q77 — Screener Layer 1 rejected 100% of 2,932 UCITS funds at
+allowed_structure because instruments_universe.attributes.structure was
+never populated for ESMA-origin funds. universe_sync.py Phase 4 wrote
+domicile and fund_subtype but omitted structure.
+
+ESMA Register is exclusively UCITS by regulatory design (esma_funds.fund_type
+has single value 'UCITS' across all rows). Hard-coding structure='UCITS' is
+the deterministic mapping. SICAV refinement is backlog.
+
+Idempotent: WHERE clause filters rows already populated.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0185_esma_ucits_structure_backfill"
+down_revision: str | None = "0184_factor_source_blocks"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        UPDATE instruments_universe
+        SET attributes = attributes || jsonb_build_object('structure', 'UCITS')
+        WHERE attributes->>'fund_subtype' = 'ucits'
+          AND (attributes->>'structure' IS NULL OR attributes->>'structure' = '')
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        UPDATE instruments_universe
+        SET attributes = attributes - 'structure'
+        WHERE attributes->>'fund_subtype' = 'ucits'
+          AND attributes->>'structure' = 'UCITS'
+    """)

--- a/backend/app/core/db/migrations/versions/0186_screener_criterion_key_singular.py
+++ b/backend/app/core/db/migrations/versions/0186_screener_criterion_key_singular.py
@@ -1,0 +1,172 @@
+"""Rename screener criterion keys from plural to singular to match data schema.
+
+Layer 1: allowed_domiciles → allowed_domicile, allowed_structures → allowed_structure,
+         allowed_exchanges → allowed_exchange.
+Layer 2: allowed_strategies → allowed_strategy_label (data key is strategy_label).
+
+Root cause: layer_evaluator.py:174 strips "allowed_" prefix and looks up the
+remaining string as an exact key in JSONB attributes. Config used plural forms
+("domiciles", "structures") but data stores singular ("domicile", "structure").
+Result: 100% Layer 1 reject in production (6851/6851 instruments failed).
+
+Idempotent: uses jsonb_path_exists guard — re-running is safe.
+
+Revision ID: 0186_screener_criterion_key_singular
+Revises: 0185_esma_ucits_structure_backfill
+Create Date: 2026-04-28
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0186_screener_criterion_key_singular"
+down_revision: str | None = "0185_esma_ucits_structure_backfill"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# ── Key renames per config_type ──────────────────────────────────────
+
+_L1_RENAMES = {
+    # (parent_path, old_key, new_key)
+    ("fund", "allowed_domiciles", "allowed_domicile"),
+    ("fund", "allowed_structures", "allowed_structure"),
+    ("equity", "allowed_exchanges", "allowed_exchange"),
+}
+
+_L2_RENAMES = {
+    # ALTERNATIVES block criteria
+    ("blocks", "ALTERNATIVES", "criteria", "allowed_strategies", "allowed_strategy_label"),
+}
+
+
+def _rename_jsonb_key(
+    table: str,
+    config_type: str,
+    path_parts: tuple[str, ...],
+    old_key: str,
+    new_key: str,
+    extra_where: str = "",
+) -> str:
+    """Build idempotent SQL to rename a JSONB key at an arbitrary depth."""
+    # Build the jsonb_path_exists guard for the OLD key
+    jp_parts = ".".join(path_parts) + f".{old_key}" if path_parts else old_key
+    jsonpath = f"$.{jp_parts}"
+
+    # Build nested jsonb_set to add new key then remove old key
+    # Step 1: extract value at old path
+    old_accessor = "".join(f"->'{p}'" for p in path_parts) + f"->'{old_key}'"
+    # Step 2: set new key at same parent path
+    new_path = "'{" + ",".join(path_parts) + f",{new_key}" + "}'"
+    # Step 3: remove old key via #- operator
+    remove_path = "'{" + ",".join(path_parts) + f",{old_key}" + "}'"
+
+    where_clause = f"config_type = '{config_type}'"
+    if extra_where:
+        where_clause += f" AND {extra_where}"
+
+    return f"""
+UPDATE {table}
+SET config = (config #- {remove_path})::jsonb || jsonb_build_object()
+WHERE {where_clause}
+  AND jsonb_path_exists(config, '{jsonpath}');
+
+UPDATE {table}
+SET config = jsonb_set(
+    config,
+    {new_path},
+    (SELECT config{old_accessor} FROM {table} t2 WHERE t2.id = {table}.id)
+)
+WHERE {where_clause}
+  AND jsonb_path_exists(config, '{jsonpath}');
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # ── Layer 1: vertical_config_defaults ────────────────────────────
+    for parent, old_key, new_key in _L1_RENAMES:
+        # Add new key with value from old key, then remove old key
+        # Idempotent: only runs if old key exists
+        bind.execute(sa.text(f"""
+            UPDATE vertical_config_defaults
+            SET config = jsonb_set(
+                config #- '{{{parent},{old_key}}}',
+                '{{{parent},{new_key}}}',
+                config->'{parent}'->'{old_key}'
+            )
+            WHERE vertical = 'liquid_funds'
+              AND config_type = 'screening_layer1'
+              AND jsonb_path_exists(config, '$.{parent}.{old_key}')
+        """))
+
+    # ── Layer 1: vertical_config_overrides ───────────────────────────
+    for parent, old_key, new_key in _L1_RENAMES:
+        bind.execute(sa.text(f"""
+            UPDATE vertical_config_overrides
+            SET config = jsonb_set(
+                config #- '{{{parent},{old_key}}}',
+                '{{{parent},{new_key}}}',
+                config->'{parent}'->'{old_key}'
+            )
+            WHERE config_type = 'screening_layer1'
+              AND jsonb_path_exists(config, '$.{parent}.{old_key}')
+        """))
+
+    # ── Layer 2: allowed_strategies → allowed_strategy_label ─────────
+    for table in ("vertical_config_defaults", "vertical_config_overrides"):
+        bind.execute(sa.text(f"""
+            UPDATE {table}
+            SET config = jsonb_set(
+                config #- '{{blocks,ALTERNATIVES,criteria,allowed_strategies}}',
+                '{{blocks,ALTERNATIVES,criteria,allowed_strategy_label}}',
+                config->'blocks'->'ALTERNATIVES'->'criteria'->'allowed_strategies'
+            )
+            WHERE config_type = 'screening_layer2'
+              AND jsonb_path_exists(config, '$.blocks.ALTERNATIVES.criteria.allowed_strategies')
+        """))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    # ── Layer 1: reverse renames ─────────────────────────────────────
+    for parent, old_key, new_key in _L1_RENAMES:
+        # Reverse: new_key → old_key
+        bind.execute(sa.text(f"""
+            UPDATE vertical_config_defaults
+            SET config = jsonb_set(
+                config #- '{{{parent},{new_key}}}',
+                '{{{parent},{old_key}}}',
+                config->'{parent}'->'{new_key}'
+            )
+            WHERE vertical = 'liquid_funds'
+              AND config_type = 'screening_layer1'
+              AND jsonb_path_exists(config, '$.{parent}.{new_key}')
+        """))
+
+        bind.execute(sa.text(f"""
+            UPDATE vertical_config_overrides
+            SET config = jsonb_set(
+                config #- '{{{parent},{new_key}}}',
+                '{{{parent},{old_key}}}',
+                config->'{parent}'->'{new_key}'
+            )
+            WHERE config_type = 'screening_layer1'
+              AND jsonb_path_exists(config, '$.{parent}.{new_key}')
+        """))
+
+    # ── Layer 2: reverse rename ──────────────────────────────────────
+    for table in ("vertical_config_defaults", "vertical_config_overrides"):
+        bind.execute(sa.text(f"""
+            UPDATE {table}
+            SET config = jsonb_set(
+                config #- '{{blocks,ALTERNATIVES,criteria,allowed_strategy_label}}',
+                '{{blocks,ALTERNATIVES,criteria,allowed_strategies}}',
+                config->'blocks'->'ALTERNATIVES'->'criteria'->'allowed_strategy_label'
+            )
+            WHERE config_type = 'screening_layer2'
+              AND jsonb_path_exists(config, '$.blocks.ALTERNATIVES.criteria.allowed_strategy_label')
+        """))

--- a/backend/app/domains/wealth/workers/universe_sync.py
+++ b/backend/app/domains/wealth/workers/universe_sync.py
@@ -445,6 +445,7 @@ async def _sync_esma_funds(db: AsyncSession) -> dict[str, Any]:
             jsonb_build_object(
                 'fund_lei', ef.lei,
                 'fund_subtype', 'ucits',
+                'structure', 'UCITS',
                 'strategy_label', ef.strategy_label,
                 'domicile', ef.domicile,
                 'esma_manager_id', ef.esma_manager_id,

--- a/backend/tests/test_screener.py
+++ b/backend/tests/test_screener.py
@@ -47,7 +47,7 @@ def layer1_config():
         "fund": {
             "min_aum_usd": 100_000_000,
             "min_track_record_years": 3,
-            "allowed_domiciles": ["IE", "LU", "KY", "US", "GB"],
+            "allowed_domicile": ["IE", "LU", "KY", "US", "GB"],
         },
         "bond": {
             "min_credit_rating": "BBB-",
@@ -55,7 +55,7 @@ def layer1_config():
         },
         "equity": {
             "min_market_cap_usd": 1_000_000_000,
-            "allowed_exchanges": ["NYSE", "NASDAQ", "LSE"],
+            "allowed_exchange": ["NYSE", "NASDAQ", "LSE"],
         },
     }
 
@@ -120,8 +120,8 @@ def passing_fund_attrs():
     return {
         "aum_usd": "200000000",
         "track_record_years": "5",
-        "domiciles": "IE",
-        "structures": "UCITS",
+        "domicile": "IE",
+        "structure": "UCITS",
         "manager_name": "BlackRock",
         "inception_date": "2019-01-01",
     }
@@ -156,7 +156,7 @@ class TestLayerEvaluator:
         assert any("aum" in r.criterion for r in failed)
 
     def test_layer1_fund_fails_domicile(self, layer1_config, passing_fund_attrs):
-        attrs = {**passing_fund_attrs, "domiciles": "XX"}
+        attrs = {**passing_fund_attrs, "domicile": "XX"}
         evaluator = LayerEvaluator(layer1_config)
         results = evaluator.evaluate_layer1("fund", attrs, layer1_config)
         failed = [r for r in results if not r.passed]
@@ -178,13 +178,13 @@ class TestLayerEvaluator:
         assert any("credit_rating" in r.criterion for r in failed)
 
     def test_layer1_equity_passes(self, layer1_config):
-        attrs = {"market_cap_usd": "5000000000", "exchanges": "NYSE"}
+        attrs = {"market_cap_usd": "5000000000", "exchange": "NYSE"}
         evaluator = LayerEvaluator(layer1_config)
         results = evaluator.evaluate_layer1("equity", attrs, layer1_config)
         assert all(r.passed for r in results)
 
     def test_layer1_equity_fails_market_cap(self, layer1_config):
-        attrs = {"market_cap_usd": "500000000", "exchanges": "NYSE"}
+        attrs = {"market_cap_usd": "500000000", "exchange": "NYSE"}
         evaluator = LayerEvaluator(layer1_config)
         results = evaluator.evaluate_layer1("equity", attrs, layer1_config)
         failed = [r for r in results if not r.passed]

--- a/backend/tests/wealth/test_layer1_case_insensitive_allowed.py
+++ b/backend/tests/wealth/test_layer1_case_insensitive_allowed.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from vertical_engines.wealth.screener.layer_evaluator import LayerEvaluator
 
 
-def test_allowed_domiciles_case_insensitive_lowercase_attribute() -> None:
+def test_allowed_domicile_case_insensitive_lowercase_attribute() -> None:
     """Lowercase domicile attribute ('ie') matches uppercase allowed list ['IE']."""
     evaluator = LayerEvaluator({})
     result = evaluator._evaluate_criterion(
-        criterion="allowed_domiciles",
+        criterion="allowed_domicile",
         expected=["IE", "LU", "KY"],
-        attributes={"domiciles": "ie"},
+        attributes={"domicile": "ie"},
         instrument_type="fund",
         layer=1,
     )
@@ -19,13 +19,13 @@ def test_allowed_domiciles_case_insensitive_lowercase_attribute() -> None:
     assert result.passed is True
 
 
-def test_allowed_structures_case_insensitive() -> None:
+def test_allowed_structure_case_insensitive() -> None:
     """Lowercase structure 'ucits' matches uppercase allowed ['UCITS', 'CIS']."""
     evaluator = LayerEvaluator({})
     result = evaluator._evaluate_criterion(
-        criterion="allowed_structures",
+        criterion="allowed_structure",
         expected=["UCITS", "CIS"],
-        attributes={"structures": "ucits"},
+        attributes={"structure": "ucits"},
         instrument_type="fund",
         layer=1,
     )
@@ -33,13 +33,13 @@ def test_allowed_structures_case_insensitive() -> None:
     assert result.passed is True
 
 
-def test_allowed_exchanges_uppercase_attribute_unchanged() -> None:
+def test_allowed_exchange_uppercase_attribute_unchanged() -> None:
     """Uppercase attribute (production canonical) still passes — no regression."""
     evaluator = LayerEvaluator({})
     result = evaluator._evaluate_criterion(
-        criterion="allowed_exchanges",
+        criterion="allowed_exchange",
         expected=["NYSE", "NASDAQ"],
-        attributes={"exchanges": "NASDAQ"},
+        attributes={"exchange": "NASDAQ"},
         instrument_type="fund",
         layer=1,
     )
@@ -51,9 +51,9 @@ def test_allowed_value_not_in_list_still_fails() -> None:
     """Genuinely-not-allowed value (case-insensitive) still fails."""
     evaluator = LayerEvaluator({})
     result = evaluator._evaluate_criterion(
-        criterion="allowed_domiciles",
+        criterion="allowed_domicile",
         expected=["IE", "LU"],
-        attributes={"domiciles": "us"},
+        attributes={"domicile": "us"},
         instrument_type="fund",
         layer=1,
     )

--- a/backend/tests/wealth/test_within_watchlist_margin.py
+++ b/backend/tests/wealth/test_within_watchlist_margin.py
@@ -64,7 +64,7 @@ def test_boolean_failure_blocks_watchlist() -> None:
 def test_allowed_list_failure_blocks_watchlist() -> None:
     """Allowed list mismatch is non-numeric → FAIL."""
     results = [
-        _r("allowed_domiciles", "['IE', 'LU']", "KY", False),
+        _r("allowed_domicile", "['IE', 'LU']", "KY", False),
         _r("min_aum_usd", "100000000", "95000000", False),
     ]
     assert ScreenerService._within_watchlist_margin(results, {}) is False


### PR DESCRIPTION
## Summary

**Tier 0 — emergency hotfix.** Screener emitted 100% reject in production since deployment of Layer 1 config.

- **Root cause:** `layer_evaluator.py:174` strips `allowed_` prefix from criterion names and uses the remainder as an exact JSONB key lookup. Config used plural forms (`allowed_domiciles` → `domiciles`) but `instruments_universe.attributes` stores singular keys (`domicile`, `structure`, `exchange`). Every lookup returned `""` → 100% Layer 1 FAIL.
- **Fix:** Rename config criterion keys to singular form to match data schema. The generic `allowed_*` handler is left unchanged — it works correctly when criterion names align with data keys.

### Migration 0186 — Renamed keys

| Table | Config Path | Before | After |
|---|---|---|---|
| `vertical_config_defaults` | `config->'fund'` | `allowed_domiciles` | `allowed_domicile` |
| `vertical_config_defaults` | `config->'fund'` | `allowed_structures` | `allowed_structure` |
| `vertical_config_defaults` | `config->'equity'` | `allowed_exchanges` | `allowed_exchange` |
| `vertical_config_defaults` | `config->'blocks'->'ALTERNATIVES'->'criteria'` | `allowed_strategies` | `allowed_strategy_label` |
| `vertical_config_overrides` | same paths | same renames | same renames |

**`allowed_strategies` → `allowed_strategy_label`** (not `allowed_strategy`): the data key is `strategy_label`, not `strategy`. Simple de-pluralization would have created a different mismatch.

All renames are idempotent (`jsonb_path_exists` guard).

### NOT modified
- `layer_evaluator.py` — handler is correct by design
- `screening_batch.py` — doesn't touch config keys
- ConfigService — `deep_merge` is correct

## Smoke test results

### Default config (no org override) — **FIXED** ✅
```
{passed: 1426, watchlist: 1601, failed: 3824, instrument_count: 6851}
```
Distribution: 2544 fail L1 (AUM/domicile), 4307 scored (scores 0.006–0.991).

### Tenant 403d (org override) — vocabulary mismatch (PR-Q79)
```
{passed: 0, failed: 6851}
```
Key-name fix IS working (`allowed_domicile` → `actual: "US"`, `passed: true`). But org override `allowed_structure: ["UCITS","Cayman_LP","Delaware_LP","SICAV"]` excludes SEC structures (`"Mutual Fund"`, `"ETF"`, `"BDC"`). Vocabulary reconciliation = PR-Q79 scope.

## Test plan

- [x] `ruff check` — All checks passed
- [x] `mypy` — No new errors (pre-existing in unrelated files)
- [x] `pytest backend/tests/test_screener.py backend/tests/wealth/test_layer1_case_insensitive_allowed.py backend/tests/wealth/test_within_watchlist_margin.py` — **71/71 passed**
- [x] Migration apply — `alembic upgrade head` ✅
- [x] DB verification — keys renamed correctly, data preserved
- [x] Smoke test — passed > 0 confirmed (default config)
- [x] Pre-flight DB dry-run with ROLLBACK — verified before apply

## Backlog filed
- **PR-Q79** — org override vocabulary reconciliation (UCITS-purist → include SEC structures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)