### PR TITLE
feat(wealth): PR-Q80 — UCITS ETF tag enrichment (is_ucits_etf flag)

### DIFF
--- a/backend/app/core/db/migrations/versions/0188_ucits_etf_tag_backfill.py
+++ b/backend/app/core/db/migrations/versions/0188_ucits_etf_tag_backfill.py
@@ -1,0 +1,44 @@
+"""Backfill is_ucits_etf boolean tag on UCITS instruments.
+
+UCITS is a regulatory umbrella covering both ETFs (intraday tradeable on
+LSE/Xetra/Borsa/Euronext) and mutual funds (cut-off subscription T+1/T+2).
+This tag differentiates the two for UI badges, frontend filters, DD reports,
+and portfolio construction strategy. NOT a Layer 1 gate (Q79 removed
+structure-based gating).
+
+Derived from case-insensitive word-boundary regex on instrument name
+matching "ETF" or "exchange-traded".
+
+Idempotent: skips rows that already have the is_ucits_etf attribute.
+
+Revision ID: 0188_ucits_etf_tag_backfill
+Revises: 0187_screener_l1_remove_domicile_structure
+Create Date: 2026-04-28
+"""
+
+from alembic import op
+
+revision = "0188_ucits_etf_tag_backfill"
+down_revision = "0187_screener_l1_remove_domicile_structure"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        UPDATE instruments_universe
+        SET attributes = attributes || jsonb_build_object(
+            'is_ucits_etf',
+            name ~* '\\m(etf|exchange.traded)\\M'
+        )
+        WHERE attributes->>'fund_subtype' = 'ucits'
+          AND NOT (attributes ? 'is_ucits_etf')
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        UPDATE instruments_universe
+        SET attributes = attributes - 'is_ucits_etf'
+        WHERE attributes->>'fund_subtype' = 'ucits'
+    """)

--- a/backend/app/domains/wealth/workers/universe_sync.py
+++ b/backend/app/domains/wealth/workers/universe_sync.py
@@ -456,7 +456,7 @@ async def _sync_esma_funds(db: AsyncSession) -> dict[str, Any]:
                     ef.fund_name
                 ),
                 'inception_date', NULL,
-                'is_ucits_etf', (ef.fund_name ~* '\m(etf|exchange.traded)\M'),
+                'is_ucits_etf', (COALESCE(NULLIF(es.full_name, ''), ef.fund_name) ~* '\m(etf|exchange.traded)\M'),
                 'source', 'universe_sync'
             )
         FROM esma_funds ef

--- a/backend/app/domains/wealth/workers/universe_sync.py
+++ b/backend/app/domains/wealth/workers/universe_sync.py
@@ -456,6 +456,7 @@ async def _sync_esma_funds(db: AsyncSession) -> dict[str, Any]:
                     ef.fund_name
                 ),
                 'inception_date', NULL,
+                'is_ucits_etf', (ef.fund_name ~* '\m(etf|exchange.traded)\M'),
                 'source', 'universe_sync'
             )
         FROM esma_funds ef


### PR DESCRIPTION
## Summary

- **Tier 3** — informational/observability. No screener gate impact.
- Adds `is_ucits_etf` boolean tag to `instruments_universe.attributes` for `fund_subtype='ucits'`, differentiating UCITS ETFs (intraday tradeable on LSE/Xetra/Borsa/Euronext) from UCITS mutual funds (cut-off subscription T+1/T+2).
- Tag derived from case-insensitive word-boundary regex on fund name (`\m(etf|exchange.traded)\M`).
- **NOT a Layer 1 gate** — Q79 explicitly removed structure-based gating. Tag is for UI badges, frontend filters, DD reports, portfolio construction strategy.

## Changes

1. **`universe_sync.py` Phase 4** — adds `is_ucits_etf` to ESMA jsonb_build_object (1 line)
2. **Migration 0188** — backfills existing UCITS instruments (idempotent via `NOT (attributes ? 'is_ucits_etf')`)

## Validation results

| Metric | Value |
|--------|-------|
| Total UCITS | 2,932 |
| Tagged | 2,932 (100%) |
| is_etf = true | 368 (12.5%) |
| is_etf = false | 2,564 (87.5%) |

### Sample ETFs (true)
- UBS (LUX) FUND SOLUTIONS-UBS J.P. MORGAN USD EM IG SCREENED DIVERSIFIED BOND UCITS ETF
- XTRACKERS-WORLD SMALL CAP GREEN TRANSITION INNOVATORS UCITS ETF
- Expat Poland WIG20 UCITS ETF

### Sample mutuals (false)
- ROBECO CAPITAL GROWTH FUNDS-ROBECO QI EUROPEAN ACTIVE EQUITIES
- HSBC GLOBAL INVESTMENT FUNDS-EURO HIGH YIELD BOND
- THEMATICA-FUTURE MOBILITY

### Edge cases
- "TRACKER" in name → correctly `false` (Goldman Sachs Absolute Return Tracker Portfolio)
- Fund-of-ETFs wrappers (e.g. "La Française Systematic ETF Portfolio Global") → tagged `true` (~1-2 marginal cases, <0.5% FP rate, acceptable for Tier 3 tag)

## Test plan
- [x] Lint passes (`ruff check`)
- [x] Pre-flight DB dry-run (ROLLBACK) — distribution + samples verified
- [x] Migration 0188 applied — 100% coverage confirmed
- [x] Edge cases inspected — no false negatives, negligible FPs

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>