### PR TITLE
fix(wealth): PR-Q83 — Tier 0 hotfix — watchlist_batch worker dead due to InstrumentOrg approval_status mismatch

### DIFF
--- a/backend/app/domains/wealth/workers/watchlist_batch.py
+++ b/backend/app/domains/wealth/workers/watchlist_batch.py
@@ -22,6 +22,7 @@ from app.core.config.config_service import ConfigService
 from app.core.db.engine import async_session_factory
 from app.core.tenancy.middleware import set_rls_context
 from app.domains.wealth.models.instrument import Instrument
+from app.domains.wealth.models.instrument_org import InstrumentOrg
 from app.domains.wealth.models.screening_result import ScreeningResult, ScreeningRun
 
 logger = structlog.get_logger(__name__)
@@ -67,11 +68,16 @@ async def _execute_watchlist_check(db: AsyncSession, org_id: uuid.UUID) -> dict:
     config_l2 = (await config_svc.get("liquid_funds", "screening_layer2", org_id)).value
     config_l3 = (await config_svc.get("liquid_funds", "screening_layer3", org_id)).value
 
-    # 3. Load watchlist-tagged instruments (evaluation targets)
+    # 3. Load watchlist-tagged instruments (evaluation targets).
+    # approval_status lives on InstrumentOrg (org-scoped); Instrument is the
+    # global catalog. RLS on instruments_org filters by organization_id
+    # automatically via set_rls_context above.
     result = await db.execute(
-        select(Instrument).where(
+        select(Instrument)
+        .join(InstrumentOrg, InstrumentOrg.instrument_id == Instrument.instrument_id)
+        .where(
             Instrument.is_active.is_(True),
-            Instrument.approval_status == "watchlist",
+            InstrumentOrg.approval_status == "watchlist",
         ),
     )
     watchlist_instruments = result.scalars().all()


### PR DESCRIPTION
## Tier 0 emergency — third silent dead worker discovered this session

\`watchlist_batch.py:74\` used \`Instrument.approval_status\`, but the \`Instrument\` model maps to \`instruments_universe\` (global catalog) which does NOT have \`approval_status\`. That column lives on \`InstrumentOrg\` (\`instruments_org\`, org-scoped, RLS-protected). Result: \`AttributeError\` on every invocation — worker has been dead in production since the schema split.

## Pattern observed

Three Tier 0 silent dead workers discovered in this single session:

| Worker | Bug | Discovered |
|---|---|---|
| Q63 Layer 3 | Wired but dead in production | 2026-04-27 |
| Q75 \`robust_sharpe\` | AttributeError on first fund | 2026-04-28 (this session) |
| Q83 \`watchlist_batch\` | AttributeError on \`Instrument.approval_status\` | 2026-04-28 (this session) |

**Root systemic cause:** no CI integration test exercises worker entrypoints with a real \`org_id\` against the docker DB. Backlog item should add smoke tests for every worker (\`risk_calc\`, \`global_risk_metrics\`, \`screening_batch\`, \`watchlist_batch\`, etc.) — invoke \`asyncio.run(run_X(org_id))\` with one seeded fund, expect exit 0.

## Fix

JOIN \`InstrumentOrg\` on \`instrument_id\` and filter by \`InstrumentOrg.approval_status == 'watchlist'\`. RLS already filters by \`organization_id\` automatically (set via \`set_rls_context(db, org_id)\` earlier in \`run_watchlist_check\`).

## Validation

Smoke test against tenant \`403d8392-ebfa-5890-b740-45da49c556eb\`:
\`\`\`json
{\"status\": \"completed\", \"total_screened\": 0}
\`\`\`

Worker executes cleanly. \`total_screened: 0\` is expected — no instruments tagged \`approval_status='watchlist'\` in \`instruments_org\` for this tenant yet (early stage, manual tagging pending downstream). Worker is now alive and will detect transitions (PASS→FAIL, WATCHLIST→PASS) correctly when tagging begins.

## Test plan

- [x] Lint clean (\`ruff check backend/app/domains/wealth/workers/watchlist_batch.py\`)
- [x] Local smoke run against docker DB
- [ ] CI green
- [ ] Backlog: add CI smoke test for all wealth workers (Q-future)

🤖 Generated with [Claude Code](https://claude.com/claude-code)