### PR TITLE
fix(quant): PR-Q84 — Codex P2 — fix expense_ratio observability log unit mismatch

### DIFF
--- a/backend/quant_engine/expense_ratio_validator.py
+++ b/backend/quant_engine/expense_ratio_validator.py
@@ -103,7 +103,8 @@ def to_decimal_fraction(value: Any) -> float | None:
             logger.warning(
                 "expense_ratio_ambiguous_percent_or_fraction",
                 raw=value,
-                interpreted_as_percent=fraction,
+                interpreted_as_percent=v,
+                interpreted_as_fraction=fraction,
                 note=(
                     "Input in (0.15, 1.0] band — assumed whole percent per Q57 "
                     "convention. If source was XBRL fraction, value would have "


### PR DESCRIPTION
## Codex P2 catch on PR-Q71 (commit 6848ca40, merged 2026-04-28 04:10 UTC)

Q71 added warning log \`expense_ratio_ambiguous_percent_or_fraction\` for ambiguous (0.15, 1.0] band inputs. Field \`interpreted_as_percent\` emitted \`fraction\` (already divided by 100). For input \`0.20\`, log recorded \`0.002\` even though field name declared \"percent\" — defeating the audit observability the warning was designed to provide.

## Stacked branch dependency — IMPORTANT

This PR was created from \`fix/q82-codex-q77-downgrade-fix\` (Q82 amend) instead of main. The diff against main therefore includes Q82 commits (CLAUDE.md, 0185, 0189) plus the Q84 fix (1 line in expense_ratio_validator.py).

**Merge order:** Q82 #383 must merge first. After Q82 lands in main, this PR will auto-rebase down to its true 1-line change.

## Fix (the real Q84 change)

\`\`\`diff
-                interpreted_as_percent=fraction,
+                interpreted_as_percent=v,
+                interpreted_as_fraction=fraction,
\`\`\`

## Smoke test

Input \`0.20\`:
\`\`\`
interpreted_as_percent=0.2     # raw % value — actionable for audit
interpreted_as_fraction=0.002  # decimal form — for downstream tooling
raw=0.2
\`\`\`

Both fields now match their declared units.

## Test plan

- [x] Lint clean (\`ruff check\`)
- [x] Smoke test confirms semantic alignment
- [ ] Q82 #383 merged first
- [ ] CI green post-rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)