### PR TITLE
feat(wealth): PR-Q85 — UCITS ticker re-prioritization + Yahoo navPrice fallback

### DIFF
--- a/backend/app/core/db/migrations/versions/0191_q85_reprioritize_esma_tickers.py
+++ b/backend/app/core/db/migrations/versions/0191_q85_reprioritize_esma_tickers.py
@@ -1,0 +1,97 @@
+"""PR-Q85 — Re-prioritize UCITS ticker selection by exchange suffix.
+
+esma_isin_ticker_map has multiple listings per fund_lei (cross-listed
+share classes). Previous propagation to esma_funds.yahoo_ticker grabbed
+an arbitrary first listing, usually .LX (Luxembourg) which Yahoo Finance
+often returns 404 for. This migration re-resolves all tickers using
+exchange suffix priority: .L > .PA > .AS > .MI > .MC > .BR > .VI > .SW
+> .OL > .CO > .HE > .F > .LX.
+
+Only applies genuine exchange UPGRADES (new suffix priority < current
+suffix priority). Same-exchange ticker changes are skipped to avoid
+unnecessary churn. Idempotent via strict-less-than comparison.
+
+Revision ID: 0191_q85_reprioritize_esma_tickers
+Revises: 0190_screening_runs_allow_watchlist
+Create Date: 2026-04-28
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0191_q85_reprioritize_esma_tickers"
+down_revision: str | None = "0190_screening_runs_allow_watchlist"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Exchange suffix priority — lower = better liquidity / Yahoo coverage
+_PRIO_CASE = """
+    CASE
+        WHEN {col} LIKE '%.L'  THEN 1   -- LSE
+        WHEN {col} LIKE '%.PA' THEN 2   -- Euronext Paris
+        WHEN {col} LIKE '%.AS' THEN 3   -- Euronext Amsterdam
+        WHEN {col} LIKE '%.MI' THEN 4   -- Borsa Italiana
+        WHEN {col} LIKE '%.MC' THEN 5   -- Madrid
+        WHEN {col} LIKE '%.BR' THEN 6   -- Brussels
+        WHEN {col} LIKE '%.VI' THEN 7   -- Vienna
+        WHEN {col} LIKE '%.SW' THEN 8   -- SIX Swiss
+        WHEN {col} LIKE '%.OL' THEN 9   -- Oslo
+        WHEN {col} LIKE '%.CO' THEN 10  -- Copenhagen
+        WHEN {col} LIKE '%.HE' THEN 11  -- Helsinki
+        WHEN {col} LIKE '%.F'  THEN 12  -- Frankfurt
+        WHEN {col} LIKE '%.LX' THEN 13  -- Luxembourg (deprio)
+        ELSE 99
+    END
+""".strip()
+
+
+def upgrade() -> None:
+    prio_new = _PRIO_CASE.format(col="tm.yahoo_ticker")
+    prio_current = _PRIO_CASE.format(col="ef.yahoo_ticker")
+
+    # Step 1: Re-prioritize esma_funds.yahoo_ticker
+    op.execute(f"""
+        WITH ranked AS (
+            SELECT
+                fund_lei,
+                yahoo_ticker AS new_ticker,
+                {prio_new} AS new_prio,
+                ROW_NUMBER() OVER (
+                    PARTITION BY fund_lei
+                    ORDER BY {prio_new}, tm.yahoo_ticker
+                ) AS rn
+            FROM esma_isin_ticker_map AS tm
+            WHERE tm.is_tradeable = true
+              AND tm.fund_lei IS NOT NULL
+              AND tm.yahoo_ticker IS NOT NULL
+        )
+        UPDATE esma_funds AS ef
+        SET yahoo_ticker = ranked.new_ticker,
+            ticker_resolved_at = NOW()
+        FROM ranked
+        WHERE ef.lei = ranked.fund_lei
+          AND ranked.rn = 1
+          AND ranked.new_prio < ({prio_current})
+    """)
+
+    # Step 2: Propagate to instruments_universe (AUM worker reads this)
+    op.execute("""
+        UPDATE instruments_universe AS iu
+        SET ticker = ef.yahoo_ticker
+        FROM esma_isin_ticker_map tm
+        JOIN esma_funds ef ON ef.lei = tm.fund_lei
+        WHERE iu.attributes->>'fund_subtype' = 'ucits'
+          AND iu.ticker = tm.yahoo_ticker
+          AND tm.fund_lei IS NOT NULL
+          AND iu.ticker IS DISTINCT FROM ef.yahoo_ticker
+          AND NOT EXISTS (
+            SELECT 1 FROM instruments_universe iu2
+            WHERE iu2.ticker = ef.yahoo_ticker
+          )
+    """)
+
+
+def downgrade() -> None:
+    # Data migration — original tickers not preserved. No-op on downgrade.
+    pass

--- a/backend/app/domains/wealth/workers/esma_aum_sync.py
+++ b/backend/app/domains/wealth/workers/esma_aum_sync.py
@@ -360,11 +360,11 @@ async def _fetch_aum(
         )
         return _degraded(ticker, "yahoo_fetch_error")
 
-    total_assets = info.get("totalAssets")
     raw_currency = info.get("currency", "USD")
     currency = _CURRENCY_NORMALIZE.get(raw_currency, raw_currency)
 
-    if not total_assets or not isinstance(total_assets, (int, float)) or total_assets <= 0:
+    aum_native, aum_method = _extract_aum(info)
+    if aum_native is None:
         logger.debug(
             "esma_aum_sync.fund_degraded",
             lei=lei,
@@ -386,27 +386,58 @@ async def _fetch_aum(
         return _degraded(
             ticker,
             f"fx_unavailable_{currency}",
-            aum_native=float(total_assets),
+            aum_native=aum_native,
             currency=currency,
         )
 
-    aum_usd = round(float(total_assets) * fx_rate, 2)
+    aum_usd = round(aum_native * fx_rate, 2)
     logger.debug(
         "esma_aum_sync.fund_aum_fetched",
         lei=lei,
         ticker=ticker,
         aum_usd=aum_usd,
+        aum_method=aum_method,
         currency_native=currency,
         fx_rate=round(fx_rate, 6),
     )
     return {
         "ticker": ticker,
         "aum_usd": aum_usd,
-        "aum_native": float(total_assets),
+        "aum_native": aum_native,
         "aum_native_currency": currency,
+        "aum_method": aum_method,
         "aum_degraded": False,
         "aum_degraded_reason": None,
     }
+
+
+def _extract_aum(info: dict[str, Any]) -> tuple[float | None, str]:
+    """Extract AUM from Yahoo info dict with fallback to nav x shares.
+
+    Returns (aum, method). method in {'totalAssets', 'nav_x_shares', 'unavailable'}.
+    """
+    total_assets = info.get("totalAssets")
+    if (
+        total_assets is not None
+        and isinstance(total_assets, (int, float))
+        and total_assets > 0
+    ):
+        return float(total_assets), "totalAssets"
+
+    # Fallback: derive from navPrice x sharesOutstanding (typical for .L ETFs)
+    nav = info.get("navPrice") or info.get("regularMarketPrice")
+    shares = info.get("sharesOutstanding")
+    if (
+        nav is not None
+        and shares is not None
+        and isinstance(nav, (int, float))
+        and isinstance(shares, (int, float))
+        and nav > 0
+        and shares > 0
+    ):
+        return float(nav) * float(shares), "nav_x_shares"
+
+    return None, "unavailable"
 
 
 def _degraded(
@@ -473,6 +504,7 @@ async def _batch_update(
                     "aum_native": u["aum_native"],
                     "aum_native_currency": u["aum_native_currency"],
                     "aum_source": "yahoo_finance",
+                    "aum_method": u.get("aum_method", "totalAssets"),
                     "aum_fetched_at": now_str,
                     "aum_degraded": False,
                     "aum_degraded_reason": None,

--- a/backend/app/domains/wealth/workers/esma_ingestion.py
+++ b/backend/app/domains/wealth/workers/esma_ingestion.py
@@ -234,22 +234,45 @@ async def run_esma_ingestion() -> dict:
             await db.commit()
             ticker_count = sum(1 for r in resolutions if r.is_tradeable)
 
-            # Update yahoo_ticker on esma_funds for resolved ISINs
-            resolved_map = {
-                r.isin: r.yahoo_ticker
-                for r in resolutions
-                if r.yahoo_ticker
-            }
-            if resolved_map:
-                for lei_val, ticker in resolved_map.items():
-                    await db.execute(
-                        text(
-                            "UPDATE esma_funds SET yahoo_ticker = :ticker, "
-                            "ticker_resolved_at = :now WHERE lei = :lei",
-                        ),
-                        {"ticker": ticker, "now": now, "lei": lei_val},
-                    )
-                await db.commit()
+            # Propagate best ticker per fund using exchange suffix priority
+            # (PR-Q85: replaces arbitrary first-listing selection)
+            await db.execute(
+                text("""
+                    UPDATE esma_funds AS ef
+                    SET yahoo_ticker = best.yahoo_ticker,
+                        ticker_resolved_at = :now
+                    FROM (
+                        SELECT DISTINCT ON (fund_lei)
+                            fund_lei, yahoo_ticker
+                        FROM esma_isin_ticker_map
+                        WHERE is_tradeable = true
+                          AND fund_lei IS NOT NULL
+                          AND yahoo_ticker IS NOT NULL
+                        ORDER BY fund_lei,
+                            CASE
+                                WHEN yahoo_ticker LIKE '%.L'  THEN 1
+                                WHEN yahoo_ticker LIKE '%.PA' THEN 2
+                                WHEN yahoo_ticker LIKE '%.AS' THEN 3
+                                WHEN yahoo_ticker LIKE '%.MI' THEN 4
+                                WHEN yahoo_ticker LIKE '%.MC' THEN 5
+                                WHEN yahoo_ticker LIKE '%.BR' THEN 6
+                                WHEN yahoo_ticker LIKE '%.VI' THEN 7
+                                WHEN yahoo_ticker LIKE '%.SW' THEN 8
+                                WHEN yahoo_ticker LIKE '%.OL' THEN 9
+                                WHEN yahoo_ticker LIKE '%.CO' THEN 10
+                                WHEN yahoo_ticker LIKE '%.HE' THEN 11
+                                WHEN yahoo_ticker LIKE '%.F'  THEN 12
+                                WHEN yahoo_ticker LIKE '%.LX' THEN 13
+                                ELSE 99
+                            END,
+                            yahoo_ticker
+                    ) AS best
+                    WHERE ef.lei = best.fund_lei
+                      AND ef.yahoo_ticker IS DISTINCT FROM best.yahoo_ticker
+                """),
+                {"now": now},
+            )
+            await db.commit()
 
             summary = {
                 "status": "completed",


### PR DESCRIPTION
## Summary

FINDINGS Q78b identified two structural bugs limiting UCITS AUM coverage to 1.3% (39/2929):

**Strategy A — Ticker re-prioritization (migration 0191):**
- `esma_isin_ticker_map` has multiple cross-listings per `fund_lei`; propagation grabbed arbitrary first (usually `.LX`)
- New priority ordering: `.L > .PA > .AS > .MI > .MC > .BR > .VI > .SW > .OL > .CO > .HE > .F > .LX`
- **149 funds upgraded** to better exchanges (only genuine upgrades, no same-exchange churn)
- Also propagates to `instruments_universe.ticker` (AUM worker reads this)
- `esma_ingestion.py` Phase 4 replaced with `DISTINCT ON` priority-ordered query to prevent regression

**Strategy D — navPrice fallback (`esma_aum_sync.py`):**
- New `_extract_aum()`: tries `totalAssets` first, then `navPrice × sharesOutstanding`
- New observability field `aum_method` (`totalAssets` | `nav_x_shares`) in `instruments_universe.attributes`
- Yahoo rarely provides `sharesOutstanding` for UCITS ETFs, so fallback fires infrequently — but architecture is correct

### Pre-flight dry-run results

| Suffix | PRE | POST | Delta |
|--------|-----|------|-------|
| `.LX`  | 1942 | 1887 | -55 |
| `.PA`  | 213 | 285 | +72 |
| `.L`   | 25 | 66 | **+41** |
| `.VI`  | 89 | 96 | +7 |
| `.SW`  | 47 | 39 | -8 |

### Files changed
- `backend/app/core/db/migrations/versions/0191_q85_reprioritize_esma_tickers.py` — new migration
- `backend/app/domains/wealth/workers/esma_aum_sync.py` — `_extract_aum()` + `aum_method`
- `backend/app/domains/wealth/workers/esma_ingestion.py` — priority-ordered ticker propagation

### Out of scope
- Strategy B (LEI-as-ISIN bug at `esma_ingestion.py:196`) — future follow-up
- Strategy C (Irish UCITS seed table) — PR-Q87 parallel
- Central Bank of Ireland provider — PR-Q88+

## Test plan
- [x] Ruff lint — all checks passed
- [x] Mypy — no new errors (yfinance stubs pre-existing)
- [x] Pre-flight DB dry-run — UPDATE 149, suffix distribution verified
- [x] Migration applied — 0191_q85_reprioritize_esma_tickers at head
- [x] Worker smoke test (limit=100) — 2 new AUM populated, aum_method=totalAssets confirmed
- [x] CSPX.L sanity check — navPrice=None, sharesOutstanding=None (fallback doesnt fire, correct)
- [ ] Full worker run — in progress (~2800 candidates)

Generated with Claude Code