### PR TITLE
fix(wealth): PR-Q88 — Codex post-merge bundle (Q86 + Q85 follow-ups)

### DIFF
--- a/backend/app/core/db/migrations/versions/0190_screening_runs_allow_watchlist.py
+++ b/backend/app/core/db/migrations/versions/0190_screening_runs_allow_watchlist.py
@@ -30,6 +30,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Remap watchlist rows to 'batch' (closest semantic equivalent) before
+    # re-adding narrow constraint — preserves audit trail vs DELETE.
+    op.execute("UPDATE screening_runs SET run_type = 'batch' WHERE run_type = 'watchlist'")
     op.execute("ALTER TABLE screening_runs DROP CONSTRAINT IF EXISTS chk_run_type")
     op.execute("""
         ALTER TABLE screening_runs

--- a/backend/app/domains/wealth/workers/esma_ingestion.py
+++ b/backend/app/domains/wealth/workers/esma_ingestion.py
@@ -16,7 +16,7 @@ import os
 from datetime import UTC, datetime
 
 import structlog
-from sqlalchemy import text
+from sqlalchemy import func, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.core.db.engine import async_session_factory as async_session
@@ -211,6 +211,7 @@ async def run_esma_ingestion() -> dict:
                 values = [
                     {
                         "isin": r.isin,
+                        "fund_lei": r.isin,  # r.isin IS the LEI (isins = [f.lei ...])
                         "yahoo_ticker": r.yahoo_ticker,
                         "exchange": r.exchange,
                         "resolved_via": r.resolved_via,
@@ -224,6 +225,9 @@ async def run_esma_ingestion() -> dict:
                     index_elements=["isin"],
                     set_={
                         "yahoo_ticker": stmt.excluded.yahoo_ticker,
+                        "fund_lei": func.coalesce(
+                            EsmaIsinTickerMap.fund_lei, stmt.excluded.fund_lei,
+                        ),
                         "exchange": stmt.excluded.exchange,
                         "resolved_via": stmt.excluded.resolved_via,
                         "is_tradeable": stmt.excluded.is_tradeable,

--- a/backend/tests/wealth/workers/test_worker_smoke.py
+++ b/backend/tests/wealth/workers/test_worker_smoke.py
@@ -138,7 +138,7 @@ async def test_universe_sync_smoke(seeded_test_org):
     entrypoint imports cleanly and enters execution (no AttributeError/
     ImportError on the first call).
     """
-    from sqlalchemy.exc import DBAPIError, IntegrityError, ProgrammingError
+    from sqlalchemy.exc import DBAPIError, ProgrammingError
 
     from app.domains.wealth.workers.universe_sync import run_universe_sync
 
@@ -150,10 +150,14 @@ async def test_universe_sync_smoke(seeded_test_org):
     ):
         try:
             result = await run_universe_sync()
-        except (DBAPIError, IntegrityError, ProgrammingError):
-            # Data-dependent SQL failure mid-execution — worker is NOT dead,
-            # just encountering stale/inconsistent data in a later phase.
-            # The entrypoint works (imports OK, lock acquired, phases started).
+        except ProgrammingError:
+            # Column-missing / ORM-mismatch errors are exactly the silent-dead-worker
+            # pattern this suite is designed to detect — MUST propagate.
+            raise
+        except DBAPIError:
+            # Data-dependent SQL failure mid-execution (IntegrityError on seed data,
+            # InFailedSQLTransactionError cascade from a failed phase). Worker is NOT
+            # dead — it imports, acquires lock, and enters phases successfully.
             return
 
     assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

Three Codex Auto Review catches on PRs already merged into main (Q86 #385, Q85 #386):

- **[P2 C1]** `0190` downgrade rollback unsafe — remaps `watchlist` → `batch` before re-adding narrow CHECK constraint
- **[P1 C2]** `test_worker_smoke` swallowed `ProgrammingError` — now re-raises dead-worker errors while catching data-dependent `DBAPIError`
- **[P1 C3]** `esma_ingestion` Phase 4 not writing `fund_lei` — Q85 priority propagation excluded new resolutions

## Files changed (3)

| File | Catch | Change |
|---|---|---|
| `backend/app/core/db/migrations/versions/0190_screening_runs_allow_watchlist.py` | C1 | +3 lines (downgrade remap) |
| `backend/tests/wealth/workers/test_worker_smoke.py` | C2 | Narrow except: `ProgrammingError` re-raised, `DBAPIError` caught |
| `backend/app/domains/wealth/workers/esma_ingestion.py` | C3 | `fund_lei` added to Phase 4 INSERT + COALESCE ON CONFLICT |

## Validation

- [x] Lint clean (`ruff check` — all 3 files)
- [x] Mypy — no new errors (all pre-existing)
- [x] C1 dry-run: watchlist remap + constraint re-add succeeds (0 watchlist rows in dev, no violation)
- [x] C2 smoke suite: 7/7 PASSED (teardown ERROR is pre-existing FK cleanup)
- [x] C2 sanity: ProgrammingError propagates, DBAPIError caught (exception routing verified)
- [x] C3 fund_lei coverage: 6,251/6,251 rows have fund_lei (fix ensures new resolutions also populate it)
- [x] C1 rollback chain: blocked by 0193 (Q89 unrelated `chk_fund_attrs`) — dry-run validated 0190 logic in isolation

## Test plan

- [ ] CI passes (lint + test)
- [ ] Verify `grep fund_lei esma_ingestion.py` shows Phase 4 INSERT + ON CONFLICT SET
- [ ] Verify `ProgrammingError` import + re-raise in `test_worker_smoke.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)