### PR TITLE
PR-Q92 — audit_events global pipeline support + pandas FutureWarning

### DIFF
--- a/backend/app/core/db/audit.py
+++ b/backend/app/core/db/audit.py
@@ -49,12 +49,19 @@ async def write_audit_event(
     after: dict[str, Any] | None = None,
     access_level: str = "internal",
     organization_id: uuid.UUID | None = None,
+    allow_global: bool = False,
 ) -> None:
     """Write an audit event to the audit_events table.
 
     The caller must have an active RLS session (organization_id is set
     via SET LOCAL by get_db_with_rls). If organization_id is not passed
     explicitly, it is read from the current RLS context.
+
+    For events emitted by global pipelines (factor model, macro
+    ingestion, benchmark ingest) where no tenant context exists, pass
+    ``allow_global=True`` to opt into a NULL organization_id row. Without
+    the flag, missing context raises ValueError so tenant-scoped callers
+    can never silently produce orphan audit events.
     """
     # Resolve organization_id from RLS context if not provided
     if organization_id is None:
@@ -64,6 +71,13 @@ async def write_audit_event(
         org_str = row.scalar()
         if org_str:
             organization_id = uuid.UUID(org_str)
+
+    if organization_id is None and not allow_global:
+        raise ValueError(
+            f"audit event {action!r} on {entity_type}/{entity_id} has no "
+            "organization_id (RLS context empty). Pass allow_global=True "
+            "if this is a global pipeline event.",
+        )
 
     event = AuditEvent(
         organization_id=organization_id,

--- a/backend/app/core/db/migrations/versions/0195_q92_audit_events_global.py
+++ b/backend/app/core/db/migrations/versions/0195_q92_audit_events_global.py
@@ -1,0 +1,91 @@
+"""PR-Q92 — Allow audit_events.organization_id NULL for global events.
+
+Global pipelines (factor_model, macro ingestion, benchmark_ingest) have
+no tenant context — they compute over GLOBAL tables (benchmark_nav,
+macro_data) shared across all organizations. When these pipelines emit
+audit events, ``organization_id`` is unresolvable from RLS context and
+``write_audit_event`` was failing with NotNullViolationError.
+
+The error is currently swallowed by try/except in factor_model_service
+(emit ``factor_data_gap_audit_failed`` warning), so factor estimation
+continues — but the audit trail loses every global event.
+
+Fix:
+- Drop NOT NULL on ``audit_events.organization_id``.
+- ``audit_events`` has no RLS (verified: ``rowsecurity = false``, 0
+  policies), so nullable column is safe — tenant-scoped callers continue
+  passing the resolved UUID via ``get_db_with_rls`` SET LOCAL context.
+- Tenant-scoped queries already filter by ``organization_id`` in the
+  WHERE clause; NULL rows are naturally excluded.
+
+Revision ID: 0195_q92_audit_events_global
+Revises: 0194_q91_ucits_data_gate
+Create Date: 2026-04-28
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0195_q92_audit_events_global"
+down_revision: str | None = "0194_q91_ucits_data_gate"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 1. Drop NOT NULL on organization_id so global pipelines can audit.
+    op.execute("ALTER TABLE audit_events ALTER COLUMN organization_id DROP NOT NULL;")
+
+    # 2. Update the RLS policy (created in migration 0019) to permit
+    #    NULL organization_id rows for global pipeline events, while
+    #    keeping per-tenant isolation for the rest. The DROP+CREATE is
+    #    idempotent regardless of whether RLS is currently enabled on
+    #    the table — we don't toggle RLS state here because audit_events
+    #    is a TimescaleDB hypertable with columnstore enabled, and
+    #    ENABLE/FORCE ROW LEVEL SECURITY is blocked while columnstore is
+    #    on. Whatever RLS state exists is preserved.
+    op.execute("DROP POLICY IF EXISTS org_isolation ON audit_events;")
+    op.execute(
+        """
+        CREATE POLICY org_isolation ON audit_events
+            USING (
+                organization_id IS NULL
+                OR organization_id = (
+                    SELECT current_setting('app.current_organization_id', true)
+                )::uuid
+            )
+            WITH CHECK (
+                organization_id IS NULL
+                OR organization_id = (
+                    SELECT current_setting('app.current_organization_id', true)
+                )::uuid
+            );
+        """,
+    )
+
+
+def downgrade() -> None:
+    # Restore the 0019 policy (NULL rows excluded) before re-applying
+    # NOT NULL — otherwise the constraint rejects existing NULL rows.
+    op.execute("DROP POLICY IF EXISTS org_isolation ON audit_events;")
+    op.execute(
+        """
+        CREATE POLICY org_isolation ON audit_events
+            USING (
+                organization_id = (
+                    SELECT current_setting('app.current_organization_id', true)
+                )::uuid
+            )
+            WITH CHECK (
+                organization_id = (
+                    SELECT current_setting('app.current_organization_id', true)
+                )::uuid
+            );
+        """,
+    )
+    op.execute(
+        """
+        DELETE FROM audit_events WHERE organization_id IS NULL;
+        ALTER TABLE audit_events ALTER COLUMN organization_id SET NOT NULL;
+        """,
+    )

--- a/backend/quant_engine/factor_model_service.py
+++ b/backend/quant_engine/factor_model_service.py
@@ -151,7 +151,10 @@ async def build_fundamental_factor_returns(
         bench_levels = bench_levels.ffill(limit=_FACTOR_FFILL_LIMIT)
 
         # Compute simple returns from filled levels.
-        bench_returns = bench_levels.pct_change()
+        # PR-Q92: fill_method=None (pad default deprecated in pandas 2.x).
+        # Levels are already ffill-ed above with limit=_FACTOR_FFILL_LIMIT;
+        # pct_change should not fill again.
+        bench_returns = bench_levels.pct_change(fill_method=None)
     else:
         bench_returns = pd.DataFrame()
         authoritative_bench = pd.DataFrame()
@@ -204,7 +207,10 @@ async def build_fundamental_factor_returns(
         # PR-Q15 Fix 1: forward-fill macro LEVELS before computing returns.
         macro_levels = macro_levels.ffill(limit=_FACTOR_FFILL_LIMIT)
         # PR-Q15 Fix 6: simple returns (pct_change), not log returns.
-        macro_returns = macro_levels.pct_change()
+        # PR-Q92: fill_method=None (pad default deprecated in pandas 2.x).
+        # Levels are already ffill-ed above, so we don't want pct_change
+        # to fill again — pass None explicitly to silence the warning.
+        macro_returns = macro_levels.pct_change(fill_method=None)
     else:
         macro_returns = pd.DataFrame()
 
@@ -340,6 +346,7 @@ async def build_fundamental_factor_returns(
                     "lookback_start": start_date.isoformat(),
                     "lookback_end": end_date.isoformat(),
                 },
+                allow_global=True,
             )
         except Exception as audit_err:
             # Audit failure must not break estimation — log and continue
@@ -381,6 +388,7 @@ async def build_fundamental_factor_returns(
                     "last_dropped": last_drop,
                     "ffill_limit_days": _FACTOR_FFILL_LIMIT,
                 },
+                allow_global=True,
             )
         except Exception as audit_err:
             logger.warning("factor_data_gap_audit_failed", err=str(audit_err))

--- a/backend/tests/db/test_migration_0195_q92.py
+++ b/backend/tests/db/test_migration_0195_q92.py
@@ -1,0 +1,127 @@
+"""PR-Q92 — audit_events.organization_id nullable + allow_global gate.
+
+Validates the global-audit contract:
+- audit_events.organization_id can hold NULL for global pipeline events.
+- write_audit_event(allow_global=True) writes NULL successfully.
+- write_audit_event(allow_global=False, RLS empty) raises ValueError —
+  prevents tenant code from silently producing orphan audit rows.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from app.core.config import settings
+from app.core.db.audit import write_audit_event
+from app.core.db.engine import async_session_factory as async_session
+
+
+def _asyncpg_dsn() -> str:
+    return settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+
+
+@pytest.mark.asyncio
+async def test_audit_events_organization_id_is_nullable():
+    """organization_id must be NULLABLE post-migration 0195."""
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        is_nullable = await conn.fetchval(
+            """
+            SELECT is_nullable
+            FROM information_schema.columns
+            WHERE table_name = 'audit_events'
+              AND column_name = 'organization_id'
+            """
+        )
+    finally:
+        await conn.close()
+    assert is_nullable == "YES", (
+        "audit_events.organization_id must be nullable to support global "
+        "pipeline events (factor model, macro ingestion, benchmark_ingest)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_audit_event_allow_global_writes_null_org():
+    """allow_global=True writes a row with organization_id=NULL."""
+    async with async_session() as db:
+        await write_audit_event(
+            db,
+            action="test_q92_global",
+            entity_type="factor_model",
+            entity_id="test_global_event",
+            after={"smoke": "test"},
+            allow_global=True,
+        )
+        await db.commit()
+
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        row = await conn.fetchrow(
+            """
+            SELECT organization_id, action, entity_id
+            FROM audit_events
+            WHERE action = 'test_q92_global'
+              AND entity_id = 'test_global_event'
+            ORDER BY created_at DESC LIMIT 1
+            """
+        )
+        # Cleanup
+        await conn.execute(
+            "DELETE FROM audit_events WHERE action = 'test_q92_global'",
+        )
+    finally:
+        await conn.close()
+    assert row is not None, "global audit row was not persisted"
+    assert row["organization_id"] is None, (
+        "expected organization_id=NULL for global event"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_audit_event_without_global_flag_raises_when_no_org():
+    """allow_global=False (default) must raise when RLS context is empty —
+    prevents tenant code from silently producing orphan audit rows."""
+    async with async_session() as db:
+        with pytest.raises(ValueError, match="organization_id"):
+            await write_audit_event(
+                db,
+                action="test_q92_orphan_check",
+                entity_type="factor_model",
+                entity_id="should_never_persist",
+                after={"smoke": "negative"},
+                # allow_global omitted -> defaults to False
+            )
+
+
+@pytest.mark.asyncio
+async def test_factor_model_writes_global_audit_on_data_gap():
+    """End-to-end: factor model run produces at least one factor_data_gap
+    audit row with organization_id=NULL (no audit_failed warnings)."""
+    import datetime as dt
+
+    from quant_engine.factor_model_service import build_fundamental_factor_returns
+
+    end = dt.date(2026, 4, 28)
+    start = end - dt.timedelta(days=365)
+    async with async_session() as db:
+        await build_fundamental_factor_returns(db, start, end)
+        await db.commit()
+
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        count = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM audit_events
+            WHERE entity_type = 'factor_model'
+              AND organization_id IS NULL
+              AND created_at >= NOW() - INTERVAL '5 minutes'
+            """
+        )
+    finally:
+        await conn.close()
+    assert count >= 1, (
+        f"expected at least one factor_model audit row with org=NULL, got {count}"
+    )


### PR DESCRIPTION
## Summary

Three cleanup fixes that remove silent observability gap in global pipelines (factor model, macro ingestion, benchmark_ingest):

1. **`audit_events.organization_id` nullable** — was rejecting global events with `NotNullViolationError`; swallowed by try/except in `factor_model_service` so every `factor_skipped` / `factor_data_gap` event was silently discarded.
2. **RLS policy adapted** — `org_isolation` policy now permits `NULL organization_id` rows while keeping per-tenant isolation. Doesn't toggle RLS state because `audit_events` is hypertable with columnstore enabled.
3. **`write_audit_event(allow_global=True)`** — explicit opt-in flag; without it, missing RLS context now raises `ValueError` (was silently inserting rows that constraint then rejected).
4. **pandas `pct_change` FutureWarning** — `fill_method='pad'` deprecated; passing `fill_method=None` (correct since levels are already ffill-ed).

## Stacked on Q91

**Depends on #391 (PR-Q91)** — base branch is `pr-q91-ucits-data-gate`. Migration 0195 chains from 0194_q91_ucits_data_gate. Will auto-rebase to `main` when Q91 merges.

## Validation (local DB)

Before:
\`\`\`
factor_data_gap_audit_failed (every run)
FutureWarning: The default fill_method='pad' in DataFrame.pct_change is deprecated
\`\`\`

After:
\`\`\`
8 factors × 503 days
zero factor_data_gap_audit_failed
zero FutureWarning
audit row persisted with organization_id=NULL
\`\`\`

## Test plan

- [x] `tests/db/test_migration_0195_q92.py` — 4/4 invariants pass
  - `organization_id` is nullable
  - `allow_global=True` writes NULL row
  - `allow_global=False` raises `ValueError` when RLS context empty (prevents orphan rows)
  - End-to-end: factor model writes global audit on data gap
- [x] Existing RLS tests still green (28 tests in `test_rls.py` + `test_rls_audit.py`)
- [x] `make lint` clean
- [x] Migration upgrade + downgrade verified

## Follow-ups

- **Q93** — `audit_events` RLS state drift across environments. Migration 0019 declares RLS enabled but local Docker DB has `rowsecurity=false` (likely toggled when columnstore was enabled). CI/Timescale Cloud state unknown. Q93 would audit + reconcile.
- **Q94** — `allocation_blocks` 3 rows duplicates per `benchmark_ticker` (10.514 dedup waste in factor_model build). Schema cleanup.
- **Q95** — operational: `benchmark_ingest` worker last ran ~18 days ago. Investigate scheduler/cron config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)