### PR TITLE
PR-Q93 — fast_approve UUID double-cast P1 (fast-track approval blocker)

### DIFF
--- a/backend/app/domains/wealth/routes/universe.py
+++ b/backend/app/domains/wealth/routes/universe.py
@@ -625,7 +625,7 @@ async def fast_approve(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> FastApproveResponse:
     """Approve liquid funds directly from the screener in one click.
 
@@ -683,10 +683,13 @@ async def fast_approve(
             approved.append(str(iid))
             continue
 
-        # Create new instruments_org row with approved status
+        # Create new instruments_org row with approved status.
+        # PR-Q93: org_id is already uuid.UUID (returned by get_org_id);
+        # the previous uuid.UUID(org_id) cast crashed with
+        # "'UUID' object has no attribute 'replace'".
         new_org = InstrumentOrg(
             instrument_id=iid,
-            organization_id=uuid.UUID(org_id),
+            organization_id=org_id,
             block_id=body.block_id,
             approval_status="approved",
         )


### PR DESCRIPTION
## Summary

P1 hotfix: \`POST /api/v1/universe/fast-approve\` crashed with \`'UUID' object has no attribute 'replace'\` on every call, blocking the entry point for liquid funds (ETF / mutual fund / MMF / UCITS) into the org universe.

## Root cause

\`\`\`python
async def fast_approve(
    ...
    org_id: str = Depends(get_org_id),   # WRONG — get_org_id returns uuid.UUID
) -> ...:
    ...
    organization_id=uuid.UUID(org_id),   # crash: UUID has no .replace
\`\`\`

Author was misled by the annotation. Python type hints don't coerce; \`org_id\` was always \`uuid.UUID\` at runtime, and the \`uuid.UUID(...)\` constructor calls \`.replace('urn:', '')\` on its input.

## Fix

- Annotation: \`org_id: uuid.UUID\` (matches \`get_org_id\` contract)
- Cast removed: \`organization_id=org_id\` (already correct type)

## Discovery

Found during PR-Q91/Q92 smoke test (Caminho A end-to-end via uvicorn local). LEMA.L (Amundi MSCI EM ETF) refused to import to org universe — no liquid fund could fast-track in production either.

## Validation

\`\`\`
POST /api/v1/universe/fast-approve
{"instrument_ids":["ac9fe8de-...","5e15389e-..."],"block_id":"em_equity"}
=> 200 {"approved":["...","..."],"rejected_dd_required":[]}
\`\`\`

Idempotency confirmed (SPY already approved, treated as success).

## Stacked PRs

- Base: \`pr-q92-audit-events-global-events-stacked\` (#392)
- Q92 base: \`pr-q91-ucits-data-gate\` (#391)
- All three auto-rebase to main when Q91 merges.

## Test plan

- [x] Manual HTTP smoke confirms 200 + correct payload
- [x] \`make lint\` clean
- [ ] Unit test for the route handler (out of scope — would require FastAPI TestClient setup; manual smoke is sufficient evidence for a 1-line fix)

## Follow-ups

- **Q94** — sweep other 12+ routes with \`org_id: str = Depends(get_org_id)\` annotation. They don't crash today (they don't try to cast), but the annotation is a footgun for the next maintainer.
- **Q95** — \`/screener/catalog\` silently ignores unknown query params (caught \`?text=\` typo as no filter, returned 52k results). Consider Pydantic strict query validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)