### PR TITLE
fix(wealth): PR-Q94 — universe_sync ON CONFLICT omits is_active reactivation (Crit)

### DIFF
--- a/backend/app/domains/wealth/workers/universe_sync.py
+++ b/backend/app/domains/wealth/workers/universe_sync.py
@@ -218,6 +218,7 @@ async def _sync_sec_etfs(db: AsyncSession) -> dict[str, Any]:
         WHERE e.ticker IS NOT NULL
         ON CONFLICT (ticker) DO UPDATE SET
             name = EXCLUDED.name,
+            is_active = EXCLUDED.is_active,
             attributes = instruments_universe.attributes || EXCLUDED.attributes,
             updated_at = now()
     """.replace("__ASSET_CLASS__", _asset_class_case("e.strategy_label"))
@@ -295,6 +296,7 @@ async def _sync_sec_mf_series(db: AsyncSession) -> dict[str, Any]:
         FROM canonical c
         ON CONFLICT (ticker) DO UPDATE SET
             name = EXCLUDED.name,
+            is_active = EXCLUDED.is_active,
             attributes = instruments_universe.attributes || EXCLUDED.attributes,
             updated_at = now()
     """.replace("__ASSET_CLASS__", _asset_class_case("c.strategy_label"))
@@ -309,8 +311,25 @@ async def _sync_sec_mf_series(db: AsyncSession) -> dict[str, Any]:
 
 
 async def _sync_sec_registered(db: AsyncSession) -> dict[str, Any]:
-    """Upsert SEC registered funds that have a direct ticker (supplements Phase 2)."""
+    """Upsert SEC registered funds that have a direct ticker (supplements Phase 2).
+
+    sec_registered_funds can have duplicate tickers (multiple CIKs sharing one
+    ticker), so DISTINCT ON (ticker) is required before INSERT to avoid
+    'ON CONFLICT DO UPDATE cannot affect row a second time' errors.  The
+    NOT EXISTS guard skips tickers already present; ON CONFLICT DO UPDATE SET
+    is_active = true handles the reactivation path for instruments previously
+    deactivated by _deactivate_no_nav.
+    """
     _sql = """
+        WITH deduped AS (
+            SELECT DISTINCT ON (rf.ticker)
+                rf.fund_name, rf.cik, rf.ticker, rf.crd_number, rf.fund_type,
+                rf.strategy_label, rf.is_index, rf.is_target_date,
+                rf.is_fund_of_fund, rf.inception_date
+            FROM sec_registered_funds rf
+            WHERE rf.ticker IS NOT NULL
+            ORDER BY rf.ticker, rf.cik
+        )
         INSERT INTO instruments_universe (
             instrument_id, instrument_type, name, isin, ticker,
             asset_class, geography, currency, is_active, attributes
@@ -318,34 +337,32 @@ async def _sync_sec_registered(db: AsyncSession) -> dict[str, Any]:
         SELECT
             gen_random_uuid(),
             'fund',
-            rf.fund_name,
-            rf.cik,
-            rf.ticker,
+            d.fund_name,
+            d.cik,
+            d.ticker,
             __ASSET_CLASS__,
             'north_america',
             'USD',
             true,
             jsonb_build_object(
-                'sec_cik', rf.cik,
-                'sec_crd', rf.crd_number,
-                'fund_subtype', rf.fund_type,
+                'sec_cik', d.cik,
+                'sec_crd', d.crd_number,
+                'fund_subtype', d.fund_type,
                 'sec_universe', 'registered_us',
-                'strategy_label', rf.strategy_label,
-                'is_index', rf.is_index,
-                'is_target_date', rf.is_target_date,
-                'is_fund_of_fund', rf.is_fund_of_fund,
+                'strategy_label', d.strategy_label,
+                'is_index', d.is_index,
+                'is_target_date', d.is_target_date,
+                'is_fund_of_fund', d.is_fund_of_fund,
                 'aum_usd', NULL,
-                'manager_name', rf.fund_name,
-                'inception_date', rf.inception_date,
+                'manager_name', d.fund_name,
+                'inception_date', d.inception_date,
                 'source', 'universe_sync'
             )
-        FROM sec_registered_funds rf
-        WHERE rf.ticker IS NOT NULL
-          AND NOT EXISTS (
-              SELECT 1 FROM instruments_universe iu WHERE iu.ticker = rf.ticker
-          )
-        ON CONFLICT (ticker) DO NOTHING
-    """.replace("__ASSET_CLASS__", _asset_class_case("rf.strategy_label"))
+        FROM deduped d
+        ON CONFLICT (ticker) DO UPDATE SET
+            is_active = true,
+            updated_at = now()
+    """.replace("__ASSET_CLASS__", _asset_class_case("d.strategy_label"))
     result = cast(CursorResult[Any], await db.execute(text(_sql)))
     await db.commit()
     count = result.rowcount
@@ -391,6 +408,7 @@ async def _sync_sec_bdcs(db: AsyncSession) -> dict[str, Any]:
         WHERE b.ticker IS NOT NULL
         ON CONFLICT (ticker) DO UPDATE SET
             name = EXCLUDED.name,
+            is_active = EXCLUDED.is_active,
             attributes = instruments_universe.attributes || EXCLUDED.attributes,
             updated_at = now()
     """)))
@@ -464,6 +482,7 @@ async def _sync_esma_funds(db: AsyncSession) -> dict[str, Any]:
         WHERE ef.yahoo_ticker IS NOT NULL
         ON CONFLICT (ticker) DO UPDATE SET
             name = EXCLUDED.name,
+            is_active = EXCLUDED.is_active,
             attributes = instruments_universe.attributes || EXCLUDED.attributes,
             updated_at = now()
     """.replace("__ASSET_CLASS__", _asset_class_case("ef.strategy_label"))
@@ -538,6 +557,7 @@ async def _sync_sec_mmfs(db: AsyncSession) -> dict[str, Any]:
         FROM mmf_with_ticker t
         ON CONFLICT (ticker) DO UPDATE SET
             name = EXCLUDED.name,
+            is_active = EXCLUDED.is_active,
             asset_class = 'cash',
             attributes = instruments_universe.attributes || EXCLUDED.attributes,
             updated_at = now()

--- a/backend/tests/wealth/workers/test_universe_sync_reactivation.py
+++ b/backend/tests/wealth/workers/test_universe_sync_reactivation.py
@@ -1,0 +1,424 @@
+"""Test is_active reactivation across all universe_sync phases (PR-Q94).
+
+Wave 6 Session 09 C-01: _deactivate_no_nav flips is_active=false for instruments
+lacking nav_timeseries rows. All ON CONFLICT DO UPDATE SET clauses must restore
+is_active=true on the next sync run once NAV arrives.
+
+Tests for ETF, Registered, and BDC call the actual sync functions end-to-end.
+Tests for ESMA and MMF exercise the ON CONFLICT SQL pattern directly because
+the full sync functions process all rows in the source tables and pre-existing
+data quality issues (duplicate yahoo_tickers via esma_securities JOIN, composite
+FK on sec_fund_classes) would cause spurious failures unrelated to the fix.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import text
+
+from app.core.db.engine import async_session_factory
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+async def _get_is_active(db, ticker: str) -> bool | None:
+    """Read is_active for a given ticker in instruments_universe."""
+    row = (
+        await db.execute(
+            text("SELECT is_active FROM instruments_universe WHERE ticker = :t"),
+            {"t": ticker},
+        )
+    ).first()
+    return row[0] if row else None
+
+
+async def _get_instrument_id(db, ticker: str) -> uuid.UUID | None:
+    """Read instrument_id for a given ticker in instruments_universe."""
+    row = (
+        await db.execute(
+            text("SELECT instrument_id FROM instruments_universe WHERE ticker = :t"),
+            {"t": ticker},
+        )
+    ).first()
+    return row[0] if row else None
+
+
+async def _insert_nav_row(db, instrument_id: uuid.UUID) -> None:
+    """Insert a single nav_timeseries row for the instrument."""
+    await db.execute(
+        text("""
+            INSERT INTO nav_timeseries (instrument_id, nav_date, nav, return_1d)
+            VALUES (:iid, :d, :nav, :ret)
+            ON CONFLICT (instrument_id, nav_date) DO NOTHING
+        """),
+        {
+            "iid": instrument_id,
+            "d": date.today() - timedelta(days=1),
+            "nav": Decimal("100.00"),
+            "ret": Decimal("0.001"),
+        },
+    )
+
+
+async def _cleanup_ticker(db, ticker: str) -> None:
+    """Remove all test data for a ticker (FK-safe order).
+
+    Rolls back any failed transaction before running cleanup DML.
+    """
+    await db.rollback()
+    iid_row = (
+        await db.execute(
+            text("SELECT instrument_id FROM instruments_universe WHERE ticker = :t"),
+            {"t": ticker},
+        )
+    ).first()
+    if iid_row:
+        iid = iid_row[0]
+        await db.execute(
+            text("DELETE FROM nav_timeseries WHERE instrument_id = :iid"),
+            {"iid": iid},
+        )
+    await db.execute(
+        text("DELETE FROM instruments_universe WHERE ticker = :t"),
+        {"t": ticker},
+    )
+    await db.commit()
+
+
+# ── Phase 1: SEC ETFs ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sec_etf_reactivation_after_deactivate():
+    """is_active restored to true when ETF is re-synced after deactivation."""
+    from app.domains.wealth.workers.universe_sync import (
+        _deactivate_no_nav,
+        _sync_sec_etfs,
+    )
+
+    ticker = "Q94ETF"
+
+    async with async_session_factory() as db:
+        try:
+            # Seed sec_etfs source row
+            await db.execute(
+                text("""
+                    INSERT INTO sec_etfs (series_id, cik, fund_name, ticker, strategy_label)
+                    VALUES (:sid, :cik, :name, :ticker, :strat)
+                    ON CONFLICT (series_id) DO NOTHING
+                """),
+                {
+                    "sid": "S000099901",
+                    "cik": "0009990001",
+                    "name": "Q94 Test ETF",
+                    "ticker": ticker,
+                    "strat": "Large Cap Equity",
+                },
+            )
+            await db.commit()
+
+            # Phase 1: sync creates instrument with is_active=true
+            await _sync_sec_etfs(db)
+            assert await _get_is_active(db, ticker) is True
+
+            # Deactivate (no NAV rows exist)
+            await _deactivate_no_nav(db)
+            assert await _get_is_active(db, ticker) is False
+
+            # Insert NAV row
+            iid = await _get_instrument_id(db, ticker)
+            assert iid is not None
+            await _insert_nav_row(db, iid)
+            await db.commit()
+
+            # Re-run sync: is_active restored via ON CONFLICT UPDATE
+            await _sync_sec_etfs(db)
+            assert await _get_is_active(db, ticker) is True
+        finally:
+            await _cleanup_ticker(db, ticker)
+            await db.execute(
+                text("DELETE FROM sec_etfs WHERE series_id = :sid"),
+                {"sid": "S000099901"},
+            )
+            await db.commit()
+
+
+# ── Phase 3: SEC Registered Funds ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sec_registered_reactivation_after_deactivate():
+    """is_active restored to true when registered fund is re-synced after deactivation.
+
+    _sync_sec_registered was previously DO NOTHING, converted to DO UPDATE SET
+    is_active = true by PR-Q94 (with DISTINCT ON to handle duplicate tickers
+    across CIKs) so that deactivated instruments are reactivated on re-sync.
+    """
+    from app.domains.wealth.workers.universe_sync import (
+        _deactivate_no_nav,
+        _sync_sec_registered,
+    )
+
+    ticker = "Q94REG"
+
+    async with async_session_factory() as db:
+        try:
+            # Seed sec_registered_funds source row
+            await db.execute(
+                text("""
+                    INSERT INTO sec_registered_funds (cik, fund_name, ticker, strategy_label, fund_type)
+                    VALUES (:cik, :name, :ticker, :strat, :ftype)
+                    ON CONFLICT (cik) DO NOTHING
+                """),
+                {
+                    "cik": "0009990002",
+                    "name": "Q94 Test Registered Fund",
+                    "ticker": ticker,
+                    "strat": "Growth Equity",
+                    "ftype": "mutual_fund",
+                },
+            )
+            await db.commit()
+
+            # Phase 3: sync creates instrument with is_active=true
+            await _sync_sec_registered(db)
+            assert await _get_is_active(db, ticker) is True
+
+            # Deactivate (no NAV rows exist)
+            await _deactivate_no_nav(db)
+            assert await _get_is_active(db, ticker) is False
+
+            # Insert NAV row
+            iid = await _get_instrument_id(db, ticker)
+            assert iid is not None
+            await _insert_nav_row(db, iid)
+            await db.commit()
+
+            # Re-run sync: is_active restored via ON CONFLICT DO UPDATE
+            await _sync_sec_registered(db)
+            assert await _get_is_active(db, ticker) is True
+        finally:
+            await _cleanup_ticker(db, ticker)
+            await db.execute(
+                text("DELETE FROM sec_registered_funds WHERE cik = :cik"),
+                {"cik": "0009990002"},
+            )
+            await db.commit()
+
+
+# ── Phase 3b: SEC BDCs ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sec_bdc_reactivation_after_deactivate():
+    """is_active restored to true when BDC is re-synced after deactivation."""
+    from app.domains.wealth.workers.universe_sync import (
+        _deactivate_no_nav,
+        _sync_sec_bdcs,
+    )
+
+    ticker = "Q94BDC"
+
+    async with async_session_factory() as db:
+        try:
+            # Seed sec_bdcs source row
+            await db.execute(
+                text("""
+                    INSERT INTO sec_bdcs (series_id, cik, fund_name, ticker, strategy_label)
+                    VALUES (:sid, :cik, :name, :ticker, :strat)
+                    ON CONFLICT (series_id) DO NOTHING
+                """),
+                {
+                    "sid": "S000099903",
+                    "cik": "0009990003",
+                    "name": "Q94 Test BDC",
+                    "ticker": ticker,
+                    "strat": "Private Credit",
+                },
+            )
+            await db.commit()
+
+            # Phase 3b: sync creates instrument with is_active=true
+            await _sync_sec_bdcs(db)
+            assert await _get_is_active(db, ticker) is True
+
+            # Deactivate (no NAV rows exist)
+            await _deactivate_no_nav(db)
+            assert await _get_is_active(db, ticker) is False
+
+            # Insert NAV row
+            iid = await _get_instrument_id(db, ticker)
+            assert iid is not None
+            await _insert_nav_row(db, iid)
+            await db.commit()
+
+            # Re-run sync: is_active restored via ON CONFLICT UPDATE
+            await _sync_sec_bdcs(db)
+            assert await _get_is_active(db, ticker) is True
+        finally:
+            await _cleanup_ticker(db, ticker)
+            await db.execute(
+                text("DELETE FROM sec_bdcs WHERE series_id = :sid"),
+                {"sid": "S000099903"},
+            )
+            await db.commit()
+
+
+# ── Phase 4: ESMA UCITS (SQL mechanism test) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_esma_fund_reactivation_after_deactivate():
+    """is_active restored to true via ESMA ON CONFLICT clause after deactivation.
+
+    Tests the ON CONFLICT SQL mechanism directly rather than calling
+    _sync_esma_funds end-to-end, because the full sync processes all
+    esma_funds rows and pre-existing duplicate yahoo_tickers (via the
+    esma_securities LEFT JOIN) cause CardinalityViolation unrelated to
+    this fix. The SQL pattern tested here is identical to the one in
+    _sync_esma_funds.
+    """
+    from app.domains.wealth.workers.universe_sync import _deactivate_no_nav
+
+    ticker = "Q94E.L"
+
+    async with async_session_factory() as db:
+        try:
+            # Step 1: Insert instrument directly (simulates initial sync)
+            await db.execute(
+                text("""
+                    INSERT INTO instruments_universe
+                        (instrument_id, instrument_type, name, ticker,
+                         asset_class, geography, currency, is_active, attributes)
+                    VALUES
+                        (gen_random_uuid(), 'fund', 'Q94 Test UCITS Fund', :ticker,
+                         'equity', 'dm_europe', 'EUR', true,
+                         '{"fund_lei": "Q94D00000000000LEI01", "fund_subtype": "ucits",
+                           "aum_usd": null, "manager_name": "Q94 ManCo",
+                           "inception_date": null, "source": "universe_sync"}'::jsonb)
+                    ON CONFLICT (ticker) DO NOTHING
+                """),
+                {"ticker": ticker},
+            )
+            await db.commit()
+            assert await _get_is_active(db, ticker) is True
+
+            # Step 2: Deactivate (no NAV rows exist)
+            await _deactivate_no_nav(db)
+            assert await _get_is_active(db, ticker) is False
+
+            # Step 3: Insert NAV row
+            iid = await _get_instrument_id(db, ticker)
+            assert iid is not None
+            await _insert_nav_row(db, iid)
+            await db.commit()
+
+            # Step 4: Re-upsert using ESMA ON CONFLICT pattern (is_active = EXCLUDED.is_active)
+            await db.execute(
+                text("""
+                    INSERT INTO instruments_universe
+                        (instrument_id, instrument_type, name, ticker,
+                         asset_class, geography, currency, is_active, attributes)
+                    VALUES
+                        (gen_random_uuid(), 'fund', 'Q94 Test UCITS Fund', :ticker,
+                         'equity', 'dm_europe', 'EUR', true,
+                         '{"fund_lei": "Q94D00000000000LEI01", "fund_subtype": "ucits",
+                           "aum_usd": null, "manager_name": "Q94 ManCo",
+                           "inception_date": null, "source": "universe_sync"}'::jsonb)
+                    ON CONFLICT (ticker) DO UPDATE SET
+                        name = EXCLUDED.name,
+                        is_active = EXCLUDED.is_active,
+                        attributes = instruments_universe.attributes || EXCLUDED.attributes,
+                        updated_at = now()
+                """),
+                {"ticker": ticker},
+            )
+            await db.commit()
+
+            # Assert: is_active restored to true
+            assert await _get_is_active(db, ticker) is True
+        finally:
+            await _cleanup_ticker(db, ticker)
+
+
+# ── Phase 5: SEC Money Market Funds (SQL mechanism test) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_sec_mmf_reactivation_after_deactivate():
+    """is_active restored to true via MMF ON CONFLICT clause after deactivation.
+
+    Tests the ON CONFLICT SQL mechanism directly rather than calling
+    _sync_sec_mmfs end-to-end, because seeding the MMF source tables
+    requires satisfying a composite FK (sec_fund_classes.cik → sec_registered_funds.cik)
+    which would create excessive coupling to unrelated table state.
+    The SQL pattern tested here is identical to the one in _sync_sec_mmfs.
+    """
+    from app.domains.wealth.workers.universe_sync import _deactivate_no_nav
+
+    ticker = "Q94MMF"
+
+    async with async_session_factory() as db:
+        try:
+            # Step 1: Insert instrument directly (simulates initial sync)
+            await db.execute(
+                text("""
+                    INSERT INTO instruments_universe
+                        (instrument_id, instrument_type, name, ticker,
+                         asset_class, geography, currency, is_active, attributes)
+                    VALUES
+                        (gen_random_uuid(), 'fund', 'Q94 Test MMF', :ticker,
+                         'cash', 'north_america', 'USD', true,
+                         '{"series_id": "S000099905", "fund_subtype": "mmf",
+                           "sec_universe": "money_market", "strategy_label": "Money Market",
+                           "aum_usd": null, "manager_name": "Q94 MMF Manager",
+                           "inception_date": null, "source": "universe_sync"}'::jsonb)
+                    ON CONFLICT (ticker) DO NOTHING
+                """),
+                {"ticker": ticker},
+            )
+            await db.commit()
+            assert await _get_is_active(db, ticker) is True
+
+            # Step 2: Deactivate (no NAV rows exist)
+            await _deactivate_no_nav(db)
+            assert await _get_is_active(db, ticker) is False
+
+            # Step 3: Insert NAV row
+            iid = await _get_instrument_id(db, ticker)
+            assert iid is not None
+            await _insert_nav_row(db, iid)
+            await db.commit()
+
+            # Step 4: Re-upsert using MMF ON CONFLICT pattern (is_active = EXCLUDED.is_active)
+            await db.execute(
+                text("""
+                    INSERT INTO instruments_universe
+                        (instrument_id, instrument_type, name, ticker,
+                         asset_class, geography, currency, is_active, attributes)
+                    VALUES
+                        (gen_random_uuid(), 'fund', 'Q94 Test MMF', :ticker,
+                         'cash', 'north_america', 'USD', true,
+                         '{"series_id": "S000099905", "fund_subtype": "mmf",
+                           "sec_universe": "money_market", "strategy_label": "Money Market",
+                           "aum_usd": null, "manager_name": "Q94 MMF Manager",
+                           "inception_date": null, "source": "universe_sync"}'::jsonb)
+                    ON CONFLICT (ticker) DO UPDATE SET
+                        name = EXCLUDED.name,
+                        is_active = EXCLUDED.is_active,
+                        asset_class = 'cash',
+                        attributes = instruments_universe.attributes || EXCLUDED.attributes,
+                        updated_at = now()
+                """),
+                {"ticker": ticker},
+            )
+            await db.commit()
+
+            # Assert: is_active restored to true
+            assert await _get_is_active(db, ticker) is True
+        finally:
+            await _cleanup_ticker(db, ticker)


### PR DESCRIPTION
## Wave 6 Session 09 — Finding C-01 (Crit, CONFIRMED)

**Jury verdict (GPT-5.5, 2026-04-28):**
> The five upserts at `universe_sync.py:219-222`, `296-299`, `392-395`, `465-468`, `539-543` update names/attributes/timestamps but never restore `is_active`. The deactivation step sets `is_active=false` for instruments without NAV at `561-569`, while the docstring at `557-559` explicitly promises reactivation on the next upsert. PR-Q91 was only a partial one-time UCITS recovery; it does not fix the recurring ON CONFLICT behavior. **This is permanent catalog-state corruption until manual data repair, so Crit is appropriate.**

## Changes

| Metric | Value |
|---|---|
| Files | 2 |
| LoC | +464 / -20 |
| Tests | 5 passing |

## Severity rationale

§3.1 institutional convention — permanent state corruption requiring manual SQL repair. Affects ~6,174 NAV-bearing instruments. SPY (2,516 NAV rows) confirmed stuck at `is_active=false` empirically during smoke-test 2026-04-28.

## Stage 4 reminder

Codex Auto Review will trigger on this PR. P1 catches → standalone hotfix immediately. P2 catches → bundle into adjacent PR.

## References

- Stage 3 prompt: `docs/prompts/2026-04-28-session-09-stage3-remediation-pr-prompts.md` (PR #394, pending merge to main)
- Stage 2 jury verdict: `docs/audits/2026-04-28-wave6-session09-stage2-jury.md` (in PR #394)
- Roadmap: `docs/investigations/2026-04-25-quant-wealth-audit-roadmap.md` §5 Session 09

🤖 Generated with [Claude Code](https://claude.com/claude-code)