### PR TITLE
fix(wealth): PR-Q97 — drift_check RLS context + lock try/finally (Crit + High batch)

### DIFF
--- a/backend/app/domains/admin/routes/worker_registry.py
+++ b/backend/app/domains/admin/routes/worker_registry.py
@@ -81,11 +81,11 @@ def _build_registry() -> dict[str, tuple[Callable[..., Awaitable[Any]], str, int
         "brochure_download": (run_brochure_download, "global", _BULK),
         "brochure_extract": (run_brochure_extract, "global", _BULK),
         "wealth_embedding": (run_wealth_embedding, "global", _BULK),
-        "drift_check": (run_drift_check, "global", _LIGHT),
         "regime_fit": (run_regime_fit, "global", _LIGHT),
         "fast_track_eviction": (run_fast_track_eviction, "global", _LIGHT),
         # ── Org-scoped workers (dispatched per active org) ────
         "instrument_ingestion": (run_instrument_ingestion, "global", _HEAVY),
+        "drift_check": (run_drift_check, "org", _LIGHT),
         "risk_calc": (run_risk_calc, "org", _HEAVY),
         "portfolio_eval": (run_portfolio_eval, "org", _LIGHT),
         "portfolio_nav_synthesizer": (run_portfolio_nav_synthesizer, "org", _LIGHT),

--- a/backend/app/domains/wealth/workers/drift_check.py
+++ b/backend/app/domains/wealth/workers/drift_check.py
@@ -1,19 +1,24 @@
 """Drift monitoring worker — checks allocation drift for all profiles.
 
 Usage:
-    python -m app.workers.drift_check
+    Called by the worker dispatcher per active organization.
 
 Computes drift for all 3 profiles and creates rebalance events
 when drift exceeds configured thresholds. Uses PostgreSQL advisory
 lock to prevent concurrent pipeline runs from creating duplicates.
+
+Org-scoped: receives ``org_id`` and sets RLS context before any
+query touching tenant-scoped tables (PortfolioSnapshot, RebalanceEvent).
 """
 
 import asyncio
+import uuid
 
 import structlog
 from sqlalchemy import text
 
 from app.core.db.engine import async_session_factory as async_session
+from app.core.tenancy.middleware import set_rls_context
 from app.domains.wealth.services.quant_queries import compute_drift, create_system_rebalance_event
 
 logger = structlog.get_logger()
@@ -22,16 +27,21 @@ PROFILES = ["conservative", "moderate", "growth"]
 PIPELINE_LOCK_ID = 42  # Advisory lock ID for pipeline serialization
 
 
-async def run_drift_check() -> dict[str, str]:
+async def run_drift_check(org_id: uuid.UUID) -> dict[str, str]:
     """Check allocation drift for all profiles.
 
     Creates rebalance events when drift exceeds thresholds.
     Uses advisory lock to prevent concurrent pipeline runs.
+
+    Args:
+        org_id: Organization UUID — sets RLS context for tenant isolation.
     """
-    logger.info("Starting drift check")
+    logger.info("Starting drift check", org_id=str(org_id))
     results: dict[str, str] = {}
 
     async with async_session() as db:
+        await set_rls_context(db, org_id)
+
         # Non-blocking advisory lock — skip if another pipeline is running
         lock_result = await db.execute(text(f"SELECT pg_try_advisory_lock({PIPELINE_LOCK_ID})"))
         acquired = lock_result.scalar()
@@ -39,23 +49,23 @@ async def run_drift_check() -> dict[str, str]:
             logger.info("Drift check already running, skipping")
             return results
 
-        # Load config once for all profiles (worker context, no RLS)
         try:
-            from sqlalchemy import select as sa_select
+            # Load config once for all profiles
+            try:
+                from sqlalchemy import select as sa_select
 
-            from app.core.config.models import VerticalConfigDefault
+                from app.core.config.models import VerticalConfigDefault
 
-            cfg_result = await db.execute(
-                sa_select(VerticalConfigDefault.config).where(
-                    VerticalConfigDefault.vertical == "liquid_funds",
-                    VerticalConfigDefault.config_type == "calibration",
-                ),
-            )
-            config = cfg_result.scalar_one_or_none()
-        except Exception:
-            config = None
+                cfg_result = await db.execute(
+                    sa_select(VerticalConfigDefault.config).where(
+                        VerticalConfigDefault.vertical == "liquid_funds",
+                        VerticalConfigDefault.config_type == "calibration",
+                    ),
+                )
+                config = cfg_result.scalar_one_or_none()
+            except Exception:
+                config = None
 
-        try:
             for profile in PROFILES:
                 report = await compute_drift(db, profile, config=config)
                 results[profile] = report.overall_status
@@ -95,6 +105,8 @@ async def run_drift_check() -> dict[str, str]:
                     )
 
                 await db.commit()
+                # Re-set RLS after commit (transaction-scoped GUC is cleared)
+                await set_rls_context(db, org_id)
 
         finally:
             await db.execute(text(f"SELECT pg_advisory_unlock({PIPELINE_LOCK_ID})"))
@@ -104,4 +116,10 @@ async def run_drift_check() -> dict[str, str]:
 
 
 if __name__ == "__main__":
-    asyncio.run(run_drift_check())
+    # Standalone usage requires an org_id argument
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python -m app.workers.drift_check <org_id>")  # noqa: T201
+        sys.exit(1)
+    asyncio.run(run_drift_check(uuid.UUID(sys.argv[1])))

--- a/backend/tests/wealth/workers/test_drift_check_rls_and_lock.py
+++ b/backend/tests/wealth/workers/test_drift_check_rls_and_lock.py
@@ -1,0 +1,239 @@
+"""Tests for drift_check RLS context and advisory lock safety (PR-Q97).
+
+Validates:
+  C-05: run_drift_check requires org_id and sets RLS context
+  C-06: Advisory lock released on cancellation (outer try/finally)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domains.wealth.workers import drift_check as mod
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+class _FakeResult:
+    """Minimal result proxy for mocked session.execute()."""
+
+    def __init__(self, scalar_value=None):
+        self._scalar = scalar_value
+
+    def scalar(self):
+        return self._scalar
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+
+class _FakeSession:
+    """Fake async session that tracks execute/commit calls."""
+
+    def __init__(self, *, lock_acquired: bool = True, config_error: bool = False):
+        self._lock_acquired = lock_acquired
+        self._config_error = config_error
+        self.executed_sql: list[str] = []
+        self.commits = 0
+        self.rls_org_ids: list[str] = []
+
+    async def execute(self, stmt, params=None):
+        sql = str(stmt)
+        self.executed_sql.append(sql)
+
+        if "set_config" in sql and "app.current_organization_id" in sql:
+            if params:
+                self.rls_org_ids.append(params.get("oid", ""))
+            return _FakeResult()
+
+        if "pg_try_advisory_lock" in sql:
+            return _FakeResult(scalar_value=self._lock_acquired)
+
+        if "pg_advisory_unlock" in sql:
+            return _FakeResult(scalar_value=True)
+
+        if "vertical_config_defaults" in sql.lower():
+            if self._config_error:
+                raise RuntimeError("Simulated config load failure")
+            return _FakeResult(scalar_value=None)
+
+        return _FakeResult()
+
+    async def commit(self):
+        self.commits += 1
+
+
+def _make_session_factory(session: _FakeSession):
+    """Build an async context manager factory that yields the given session."""
+
+    @asynccontextmanager
+    async def factory():
+        yield session
+
+    return factory
+
+
+def _make_fake_report(*, rebalance: bool = False):
+    """Build a minimal drift report mock."""
+    report = MagicMock()
+    report.overall_status = "ok"
+    report.max_drift_pct = 0.01
+    report.rebalance_recommended = rebalance
+    report.estimated_turnover = 0.005
+    report.maintenance_trigger = 0.05
+    report.blocks = []
+    return report
+
+
+# ── Test: signature requires org_id ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_check_requires_org_id():
+    """C-05: run_drift_check() without org_id raises TypeError."""
+    with pytest.raises(TypeError):
+        await mod.run_drift_check()  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_drift_check_accepts_org_id():
+    """C-05: run_drift_check(org_id=...) executes without error."""
+    org_id = uuid.uuid4()
+    session = _FakeSession()
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(mod, "compute_drift", new_callable=AsyncMock, return_value=_make_fake_report()),
+    ):
+        result = await mod.run_drift_check(org_id)
+
+    assert isinstance(result, dict)
+
+
+# ── Test: RLS context set before queries ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_check_sets_rls_context():
+    """C-05: set_rls_context is called with org_id before any data query."""
+    org_id = uuid.uuid4()
+    session = _FakeSession()
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(mod, "compute_drift", new_callable=AsyncMock, return_value=_make_fake_report()),
+    ):
+        await mod.run_drift_check(org_id)
+
+    # RLS context must have been set at least once (before lock + after each commit)
+    assert len(session.rls_org_ids) >= 1
+    assert all(oid == str(org_id) for oid in session.rls_org_ids)
+
+    # RLS set_config must come BEFORE pg_try_advisory_lock
+    set_config_indices = [
+        i for i, sql in enumerate(session.executed_sql) if "set_config" in sql
+    ]
+    lock_indices = [
+        i for i, sql in enumerate(session.executed_sql) if "pg_try_advisory_lock" in sql
+    ]
+    assert set_config_indices, "set_config must be called"
+    assert lock_indices, "pg_try_advisory_lock must be called"
+    assert set_config_indices[0] < lock_indices[0], (
+        "set_rls_context must be called before pg_try_advisory_lock"
+    )
+
+
+# ── Test: lock released on cancellation / config error ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_check_lock_released_on_config_error():
+    """C-06: Advisory lock is released even when config load raises."""
+    org_id = uuid.uuid4()
+    session = _FakeSession(config_error=True)
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+    ):
+        # config_error causes RuntimeError inside the inner try/except,
+        # which sets config=None and continues. But we need to also mock
+        # compute_drift since there is no real DB.
+        with patch.object(
+            mod, "compute_drift", new_callable=AsyncMock, return_value=_make_fake_report(),
+        ):
+            result = await mod.run_drift_check(org_id)
+
+    # Lock must have been acquired AND released
+    lock_sqls = [sql for sql in session.executed_sql if "pg_try_advisory_lock" in sql]
+    unlock_sqls = [sql for sql in session.executed_sql if "pg_advisory_unlock" in sql]
+    assert len(lock_sqls) == 1, "Lock must be acquired once"
+    assert len(unlock_sqls) == 1, "Lock must be released once"
+    assert isinstance(result, dict)
+
+
+@pytest.mark.asyncio
+async def test_drift_check_lock_released_on_compute_drift_exception():
+    """C-06: Advisory lock is released when compute_drift raises."""
+    org_id = uuid.uuid4()
+    session = _FakeSession()
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(
+            mod, "compute_drift",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Simulated compute_drift failure"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="Simulated compute_drift failure"):
+            await mod.run_drift_check(org_id)
+
+    # Even after exception, lock must have been released
+    unlock_sqls = [sql for sql in session.executed_sql if "pg_advisory_unlock" in sql]
+    assert len(unlock_sqls) == 1, "Lock must be released even on exception"
+
+
+@pytest.mark.asyncio
+async def test_drift_check_lock_released_on_cancellation():
+    """C-06: Advisory lock is released on asyncio.CancelledError."""
+    org_id = uuid.uuid4()
+    session = _FakeSession()
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(
+            mod, "compute_drift",
+            new_callable=AsyncMock,
+            side_effect=asyncio.CancelledError(),
+        ),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await mod.run_drift_check(org_id)
+
+    # CancelledError is a BaseException — try/finally must still release lock
+    unlock_sqls = [sql for sql in session.executed_sql if "pg_advisory_unlock" in sql]
+    assert len(unlock_sqls) == 1, "Lock must be released even on CancelledError"
+
+
+# ── Test: lock not acquired → skip ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_check_skips_when_lock_busy():
+    """Lock not acquired → worker returns empty dict, no unlock called."""
+    org_id = uuid.uuid4()
+    session = _FakeSession(lock_acquired=False)
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+    ):
+        result = await mod.run_drift_check(org_id)
+
+    assert result == {}
+    unlock_sqls = [sql for sql in session.executed_sql if "pg_advisory_unlock" in sql]
+    assert len(unlock_sqls) == 0, "Lock was never acquired — unlock must not be called"


### PR DESCRIPTION
## Wave 6 Session 09 — Findings C-05 (Crit, ESCALATED) + C-06 (High, DOWNGRADED)

Batched because both target `workers/drift_check.py` and the test surface overlaps.

### C-05 — drift_check no RLS context (Crit, ESCALATED from High)

**Jury verdict (GPT-5.5):**
> `run_drift_check` takes no `org_id` at `drift_check.py:25` and opens `async_session()` directly at `34` without `set_rls_context`. It reads via `compute_drift` at `60`, which queries `PortfolioSnapshot` at `quant_queries.py:2236-2243`; that model is `OrganizationScopedMixin` at `portfolio.py:13`. It then creates a `RebalanceEvent` at `drift_check.py:78-90`, while `RebalanceEvent` is also org-scoped at `rebalance.py:13`. **Multi-tenant read/write ambiguity is always Crit under institutional convention.**

### C-06 — Advisory lock acquired outside immediate try/finally (High, DOWNGRADED from Gemini Crit)

**Jury verdict (GPT-5.5):**
> The lock is acquired at `drift_check.py:36-40`, but the first `try/finally` that unlocks it only starts at `58` and unlocks at `99-100`. A cancellation between lines `42-56` can bypass the unlock. The mechanism is valid and independent from C-05, but lock leaks requiring DB restart are at least High; this finding does not establish a guaranteed every-call production crash. **High is the defensible final severity.**

## Changes

| Metric | Value |
|---|---|
| Files | 3 |
| LoC | +275 / -18 |
| Tests | 7 passing |

## Severity rationale

C-05: §3.1 multi-tenant data leak. C-06: §3.2 lock leak requiring DB restart.

## API change

`run_drift_check` now requires `org_id: uuid.UUID` parameter (previously took none). Caller layer (scheduler / job runner) must iterate active orgs and call per-org. Mirrors `portfolio_eval.run_portfolio_eval(org_id)` pattern.

## Stage 4 reminder

Codex Auto Review will trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)