### PR TITLE
fix(wealth): PR-Q98 — apply_rebalance_proposal role gate (Crit)

### DIFF
--- a/backend/app/domains/wealth/routes/rebalancing.py
+++ b/backend/app/domains/wealth/routes/rebalancing.py
@@ -28,10 +28,20 @@ from app.domains.wealth.models.model_portfolio_nav import ModelPortfolioNav
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 from app.domains.wealth.models.rebalance import RebalanceEvent
 from app.domains.wealth.schemas.portfolio import PortfolioSnapshotRead
+from app.shared.enums import Role
 
 logger = structlog.get_logger()
 
 router = APIRouter(prefix="/rebalancing", tags=["rebalancing"])
+
+
+def _require_ic_role(actor: Actor) -> None:
+    """Verify actor has INVESTMENT_TEAM or ADMIN role."""
+    if not actor.has_role(Role.INVESTMENT_TEAM):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Investment Committee role required",
+        )
 
 
 @router.post(
@@ -61,6 +71,8 @@ async def apply_rebalance_proposal(
     5. Mark proposal as 'applied' with audit trail
     6. Return the created PortfolioSnapshot
     """
+    _require_ic_role(actor)
+
     # ── 1. Load and validate proposal ──
     stmt = (
         select(RebalanceEvent)

--- a/backend/tests/wealth/routes/test_apply_rebalance_role_gate.py
+++ b/backend/tests/wealth/routes/test_apply_rebalance_role_gate.py
@@ -1,0 +1,56 @@
+"""Role gate tests for POST /rebalancing/proposals/{id}/apply.
+
+PR-Q98: Verify that investor-role users are rejected (403) and
+IC-role users pass the role gate (not 403).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+_PROPOSAL_ID = str(uuid.uuid4())
+
+
+def _investor_header() -> dict[str, str]:
+    """Dev actor header with INVESTOR role (read-only)."""
+    return {
+        "X-DEV-ACTOR": (
+            '{"actor_id": "investor-user", "roles": ["INVESTOR"],'
+            ' "fund_ids": [], "org_id": "00000000-0000-0000-0000-000000000001"}'
+        ),
+    }
+
+
+def _ic_header() -> dict[str, str]:
+    """Dev actor header with INVESTMENT_TEAM role."""
+    return {
+        "X-DEV-ACTOR": (
+            '{"actor_id": "ic-user", "roles": ["INVESTMENT_TEAM"],'
+            ' "fund_ids": [], "org_id": "00000000-0000-0000-0000-000000000001"}'
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_apply_rebalance_rejects_investor_role(client: AsyncClient):
+    """INVESTOR role must be rejected with 403 — privilege escalation guard."""
+    resp = await client.post(
+        f"/api/v1/rebalancing/proposals/{_PROPOSAL_ID}/apply",
+        headers=_investor_header(),
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_apply_rebalance_accepts_ic_role(client: AsyncClient):
+    """INVESTMENT_TEAM role passes role gate — 404 expected (no seeded proposal)."""
+    resp = await client.post(
+        f"/api/v1/rebalancing/proposals/{_PROPOSAL_ID}/apply",
+        headers=_ic_header(),
+    )
+    # Role gate passed; handler returns 404 because proposal doesn't exist
+    assert resp.status_code != 403
+    assert resp.status_code in (200, 202, 404)


### PR DESCRIPTION
## Wave 6 Session 09 — Finding C-08 (Crit, ESCALATED from High)

**Jury verdict (GPT-5.5, 2026-04-28):**
> `apply_rebalance_proposal` depends only on `get_current_user`, `get_actor`, and `get_org_id` at `rebalancing.py:47-53`; there is no `require_role` or local role helper. The body mutates model portfolio selection at `106-114`, creates a new `PortfolioSnapshot` at `121-132`, writes a NAV breakpoint at `139-152`, and marks the proposal applied at `154-168`. **This is a mutating route that changes IC-level portfolio allocation, so missing role enforcement is a privilege escalation and always Crit.**

## Changes

| Metric | Value |
|---|---|
| Files | 2 |
| LoC | +68 |
| Tests | 2 passing |

## Severity rationale

§3.1 institutional convention — privilege escalation on mutating route. Investor-role users (read-only intent) could apply rebalance proposals, changing entire portfolio allocation.

## Tenant-visible behavior change

Investor users currently able to apply rebalance proposals will receive HTTP 403 after merge. IC team continues unaffected.

## Stage 4 reminder

Codex Auto Review will trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)