### PR TITLE
fix(wealth): PR-Q92 — audit_events global pipeline support + pandas FutureWarning (re-open)

### DIFF
--- a/backend/app/core/db/audit.py
+++ b/backend/app/core/db/audit.py
@@ -49,12 +49,19 @@ async def write_audit_event(
     after: dict[str, Any] | None = None,
     access_level: str = "internal",
     organization_id: uuid.UUID | None = None,
+    allow_global: bool = False,
 ) -> None:
     """Write an audit event to the audit_events table.
 
     The caller must have an active RLS session (organization_id is set
     via SET LOCAL by get_db_with_rls). If organization_id is not passed
     explicitly, it is read from the current RLS context.
+
+    For events emitted by global pipelines (factor model, macro
+    ingestion, benchmark ingest) where no tenant context exists, pass
+    ``allow_global=True`` to opt into a NULL organization_id row. Without
+    the flag, missing context raises ValueError so tenant-scoped callers
+    can never silently produce orphan audit events.
     """
     # Resolve organization_id from RLS context if not provided
     if organization_id is None:
@@ -64,6 +71,13 @@ async def write_audit_event(
         org_str = row.scalar()
         if org_str:
             organization_id = uuid.UUID(org_str)
+
+    if organization_id is None and not allow_global:
+        raise ValueError(
+            f"audit event {action!r} on {entity_type}/{entity_id} has no "
+            "organization_id (RLS context empty). Pass allow_global=True "
+            "if this is a global pipeline event.",
+        )
 
     event = AuditEvent(
         organization_id=organization_id,

--- a/backend/app/core/db/migrations/versions/0194_q91_ucits_data_gate.py
+++ b/backend/app/core/db/migrations/versions/0194_q91_ucits_data_gate.py
@@ -1,0 +1,509 @@
+"""PR-Q91 — UCITS data-availability gate (NAV-eligibility) + bridge ESMA↔universe.
+
+Three-part fix:
+
+1. **Bridge** — Populate ``instruments_universe.attributes->>'fund_lei'`` for
+   UCITS rows. ``universe_sync`` writes ``fund_subtype='ucits'`` for 2,931
+   rows but ``fund_lei`` stayed NULL on every row (excluded.fund_lei was
+   COALESCE'd with NULL for legacy rows). Without ``fund_lei`` the
+   ``esma_aum_sync`` worker (Q78) cannot match instruments back to
+   ``esma_funds`` and the screener cannot resolve manager metadata.
+
+2. **mv_unified_funds UCITS branch refactor** — current branch:
+     - reports ``has_nav = true`` hard-coded for all 2,929 ESMA funds with
+       ``yahoo_ticker``, even though only ~289 have any row in
+       ``nav_timeseries``.
+     - returns ``aum_usd = NULL`` even though Q78 enriched 56 instruments
+       with real Yahoo ``totalAssets`` in ``attributes->>'aum_usd'``.
+     - uses ``ef.legacy_isin_misnamed`` as ``external_id`` and ``isin``
+       (the legacy column stores LEIs, not ISINs — Q11B residue).
+
+   New branch INNER JOINs ``instruments_universe`` (ticker = yahoo_ticker)
+   AND filters by ``EXISTS(nav_timeseries)``, so ``has_nav`` is no longer
+   a lie. ``aum_usd`` reads from ``attributes->>'aum_usd'`` (Q78 output).
+   ``external_id`` uses ``COALESCE(es.isin, iu.ticker, ef.lei)``.
+
+3. **Layer 1 unchanged** — screener ``min_track_record_years: 3`` keeps
+   working as the eligibility gate; the view now stops reporting funds
+   that cannot possibly satisfy any NAV-based check.
+
+Empirical impact (DB local 2026-04-28):
+- 2,929 UCITS with yahoo_ticker → 288 with NAV → 178 with ≥3y span →
+  56 with AUM populated → **26 funds clear AUM≥$100M+3y track record**.
+- Decision D-UCITS-ship-baseline (2026-04-28) crystallized:
+  UCITS coverage = whatever Yahoo/Tiingo deliver, no manual seed.
+
+Revision ID: 0194_q91_ucits_data_gate
+Revises: 0193_q90_revert_q87_manual_seed
+Create Date: 2026-04-28
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0194_q91_ucits_data_gate"
+down_revision: str | None = "0193_q90_revert_q87_manual_seed"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# UCITS branch — fixed (Q91): INNER JOIN universe + EXISTS nav + real AUM.
+# All other branches (registered_us / etfs / bdcs / private / mmf) match
+# 0183 verbatim — no behaviour change for SEC universes.
+# ---------------------------------------------------------------------------
+_MV_SQL_UP = """
+CREATE MATERIALIZED VIEW mv_unified_funds AS
+SELECT DISTINCT ON (external_id) * FROM (
+    WITH geo_logic AS (
+        SELECT
+            text_val,
+            CASE
+                WHEN text_val ILIKE '%emerging%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%frontier%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%china%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%india%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%latin america%' THEN 'Latin America'
+                WHEN text_val ILIKE '%latam%' THEN 'Latin America'
+                WHEN text_val ILIKE '%brazil%' THEN 'Latin America'
+                WHEN text_val ILIKE '%europe%' THEN 'Europe'
+                WHEN text_val ILIKE '%european%' THEN 'Europe'
+                WHEN text_val ILIKE '%eurozone%' THEN 'Europe'
+                WHEN text_val ILIKE '%asia%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%japan%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%pacific%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%global%' THEN 'Global'
+                WHEN text_val ILIKE '%world%' THEN 'Global'
+                WHEN text_val ILIKE '%international%' THEN 'Global'
+                WHEN text_val ILIKE '%foreign%' THEN 'Global'
+                WHEN text_val ILIKE '%ex-us%' THEN 'Global'
+                WHEN text_val ILIKE '%ex us%' THEN 'Global'
+                ELSE 'US'
+            END as investment_geography
+        FROM (
+            SELECT DISTINCT COALESCE(strategy_label, fund_name) as text_val FROM sec_registered_funds
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_etfs
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_bdcs
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_manager_funds
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM esma_funds
+        ) t
+    )
+    -- Branch 1: registered_us
+    SELECT
+        'registered_us'::text as universe,
+        COALESCE(fc.class_id, fc.series_id, rf.cik)::text as external_id,
+        COALESCE(fc.series_name, rf.fund_name)::text as name,
+        COALESCE(fc.ticker, rf.ticker)::text as ticker,
+        rf.isin::text as isin,
+        'US'::text as region,
+        rf.fund_type::text as fund_type,
+        rf.strategy_label::text as strategy_label,
+        COALESCE(NULLIF(rf.total_assets, 0), fc.net_assets, rf.monthly_avg_net_assets)::numeric as aum_usd,
+        rf.currency::text as currency,
+        rf.domicile::text as domicile,
+        COALESCE(m.firm_name, rf.fund_name)::text as manager_name,
+        CASE WHEN m.crd_number IS NOT NULL THEN m.crd_number ELSE NULL END::text as manager_id,
+        rf.inception_date as inception_date,
+        rf.total_shareholder_accounts as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        fc.series_id as series_id,
+        fc.series_name as series_name,
+        fc.class_id as class_id,
+        fc.class_name as class_name,
+        (rf.last_nport_date IS NOT NULL) as has_holdings,
+        (COALESCE(fc.ticker, rf.ticker) IS NOT NULL) as has_nav,
+        EXISTS (
+            SELECT 1 FROM sec_13f_holdings h
+            JOIN sec_managers sm ON sm.cik = h.cik
+            WHERE sm.crd_number = rf.crd_number
+            AND h.report_date >= CURRENT_DATE - INTERVAL '180 days'
+        ) as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(rf.strategy_label, rf.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        ps.expense_ratio_pct,
+        ps.avg_annual_return_1y,
+        ps.avg_annual_return_10y,
+        rf.is_index,
+        rf.is_target_date,
+        rf.is_fund_of_fund,
+        rf.is_institutional
+    FROM sec_registered_funds rf
+    LEFT JOIN sec_fund_classes fc ON rf.cik = fc.cik
+    LEFT JOIN sec_managers m ON rf.crd_number = m.crd_number AND m.crd_number NOT LIKE 'cik_%%'
+    LEFT JOIN sec_fund_prospectus_stats ps ON fc.series_id = ps.series_id AND fc.class_id = ps.class_id
+    WHERE TRUE
+    AND NOT EXISTS (SELECT 1 FROM sec_etfs e WHERE e.series_id = COALESCE(fc.series_id, rf.series_id))
+    AND NOT EXISTS (SELECT 1 FROM sec_bdcs b WHERE b.series_id = COALESCE(fc.series_id, rf.series_id))
+    AND NOT EXISTS (SELECT 1 FROM sec_money_market_funds mmf WHERE mmf.series_id = COALESCE(fc.series_id, rf.series_id))
+
+    UNION ALL
+    -- Branch 2: ETFs
+    SELECT
+        'registered_us'::text as universe,
+        e.series_id::text as external_id,
+        e.fund_name::text as name,
+        e.ticker::text as ticker,
+        e.isin::text as isin,
+        'US'::text as region,
+        'etf'::text as fund_type,
+        e.strategy_label::text as strategy_label,
+        e.monthly_avg_net_assets as aum_usd,
+        e.currency::text as currency,
+        e.domicile::text as domicile,
+        NULL::text as manager_name,
+        NULL::text as manager_id,
+        e.inception_date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        TRUE as has_holdings,
+        (e.ticker IS NOT NULL) as has_nav,
+        FALSE as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(e.strategy_label, e.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        ps.expense_ratio_pct,
+        ps.avg_annual_return_1y,
+        ps.avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        e.is_institutional
+    FROM sec_etfs e
+    LEFT JOIN sec_fund_prospectus_stats ps ON e.series_id = ps.series_id
+
+    UNION ALL
+    -- Branch 3: BDCs
+    SELECT
+        'registered_us'::text as universe,
+        b.series_id::text as external_id,
+        b.fund_name::text as name,
+        b.ticker::text as ticker,
+        b.isin::text as isin,
+        'US'::text as region,
+        'bdc'::text as fund_type,
+        b.strategy_label::text as strategy_label,
+        b.monthly_avg_net_assets as aum_usd,
+        b.currency::text as currency,
+        b.domicile::text as domicile,
+        NULL::text as manager_name,
+        NULL::text as manager_id,
+        b.inception_date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        TRUE as has_holdings,
+        (b.ticker IS NOT NULL) as has_nav,
+        FALSE as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(b.strategy_label, b.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        ps.expense_ratio_pct,
+        ps.avg_annual_return_1y,
+        ps.avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        b.is_institutional
+    FROM sec_bdcs b
+    LEFT JOIN sec_fund_prospectus_stats ps ON b.series_id = ps.series_id
+
+    UNION ALL
+    -- Branch 4: private_us
+    SELECT
+        'private_us'::text as universe,
+        mf.id::text as external_id,
+        mf.fund_name::text as name,
+        NULL::text as ticker,
+        NULL::text as isin,
+        'US'::text as region,
+        mf.fund_type::text as fund_type,
+        mf.strategy_label::text as strategy_label,
+        mf.gross_asset_value::numeric as aum_usd,
+        'USD'::text as currency,
+        'US'::text as domicile,
+        sm.firm_name::text as manager_name,
+        sm.crd_number::text as manager_id,
+        NULL::date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        mf.investor_count as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        FALSE as has_holdings,
+        FALSE as has_nav,
+        EXISTS (
+            SELECT 1 FROM sec_13f_holdings h
+            WHERE h.cik = sm.cik
+            AND h.report_date >= CURRENT_DATE - INTERVAL '180 days'
+        ) as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(mf.strategy_label, mf.fund_name) LIMIT 1) as investment_geography,
+        mf.vintage_year as vintage_year,
+        NULL::numeric as expense_ratio_pct,
+        NULL::numeric as avg_annual_return_1y,
+        NULL::numeric as avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        mf.is_fund_of_funds as is_fund_of_fund,
+        mf.is_institutional
+    FROM sec_manager_funds mf
+    JOIN sec_managers sm ON mf.crd_number = sm.crd_number
+
+    UNION ALL
+    -- Branch 5: ucits_eu (Q91 — data-availability gate)
+    -- INNER JOIN instruments_universe + EXISTS(nav_timeseries) make has_nav truthful.
+    -- aum_usd reads from Q78 enrichment (instruments_universe.attributes).
+    -- external_id prefers FIRDS ISIN, falls back to ticker, then LEI.
+    SELECT
+        'ucits_eu'::text as universe,
+        COALESCE(es.isin, iu.ticker, ef.lei)::text as external_id,
+        COALESCE(NULLIF(es.full_name, ''), ef.fund_name)::text as name,
+        iu.ticker::text as ticker,
+        es.isin::text as isin,
+        'EU'::text as region,
+        ef.fund_type::text as fund_type,
+        ef.strategy_label::text as strategy_label,
+        (iu.attributes->>'aum_usd')::numeric as aum_usd,
+        COALESCE(iu.currency, NULLIF(iu.attributes->>'aum_currency', ''))::text as currency,
+        ef.domicile::text as domicile,
+        em.company_name::text as manager_name,
+        em.esma_id::text as manager_id,
+        NULL::date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        FALSE as has_holdings,
+        TRUE as has_nav,
+        FALSE as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(ef.strategy_label, ef.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        NULL::numeric as expense_ratio_pct,
+        NULL::numeric as avg_annual_return_1y,
+        NULL::numeric as avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        ef.is_institutional
+    FROM esma_funds ef
+    JOIN instruments_universe iu
+        ON iu.ticker = ef.yahoo_ticker
+       AND iu.is_active IS NOT FALSE
+    LEFT JOIN esma_securities es ON es.fund_lei = ef.lei AND es.is_active
+    LEFT JOIN esma_managers em ON em.esma_id = ef.esma_manager_id
+    WHERE ef.yahoo_ticker IS NOT NULL
+      AND ef.yahoo_ticker <> ''
+      AND EXISTS (
+          SELECT 1 FROM nav_timeseries n WHERE n.instrument_id = iu.instrument_id
+      )
+
+    UNION ALL
+    -- Branch 6: money_market
+    SELECT
+        'registered_us'::text as universe,
+        mmf.series_id::text as external_id,
+        mmf.fund_name::text as name,
+        NULL::text as ticker,
+        NULL::text as isin,
+        'US'::text as region,
+        'money_market'::text as fund_type,
+        mmf.strategy_label::text as strategy_label,
+        mmf.net_assets::numeric as aum_usd,
+        mmf.currency::text as currency,
+        mmf.domicile::text as domicile,
+        mmf.investment_adviser::text as manager_name,
+        NULL::text as manager_id,
+        NULL::date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        FALSE as has_holdings,
+        FALSE as has_nav,
+        FALSE as has_13f_overlay,
+        'US'::text as investment_geography,
+        NULL::integer as vintage_year,
+        NULL::numeric as expense_ratio_pct,
+        NULL::numeric as avg_annual_return_1y,
+        NULL::numeric as avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        mmf.is_institutional
+    FROM sec_money_market_funds mmf
+) combined
+ORDER BY external_id, aum_usd DESC NULLS LAST;
+"""
+
+
+# Down: restore 0183 view (legacy_isin_misnamed-based UCITS branch).
+_MV_SQL_DOWN = """
+CREATE MATERIALIZED VIEW mv_unified_funds AS
+SELECT DISTINCT ON (external_id) * FROM (
+    WITH geo_logic AS (
+        SELECT
+            text_val,
+            CASE
+                WHEN text_val ILIKE '%emerging%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%frontier%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%china%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%india%' THEN 'Emerging Markets'
+                WHEN text_val ILIKE '%latin america%' THEN 'Latin America'
+                WHEN text_val ILIKE '%latam%' THEN 'Latin America'
+                WHEN text_val ILIKE '%brazil%' THEN 'Latin America'
+                WHEN text_val ILIKE '%europe%' THEN 'Europe'
+                WHEN text_val ILIKE '%european%' THEN 'Europe'
+                WHEN text_val ILIKE '%eurozone%' THEN 'Europe'
+                WHEN text_val ILIKE '%asia%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%japan%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%pacific%' THEN 'Asia Pacific'
+                WHEN text_val ILIKE '%global%' THEN 'Global'
+                WHEN text_val ILIKE '%world%' THEN 'Global'
+                WHEN text_val ILIKE '%international%' THEN 'Global'
+                WHEN text_val ILIKE '%foreign%' THEN 'Global'
+                WHEN text_val ILIKE '%ex-us%' THEN 'Global'
+                WHEN text_val ILIKE '%ex us%' THEN 'Global'
+                ELSE 'US'
+            END as investment_geography
+        FROM (
+            SELECT DISTINCT COALESCE(strategy_label, fund_name) as text_val FROM sec_registered_funds
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_etfs
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_bdcs
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM sec_manager_funds
+            UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM esma_funds
+        ) t
+    )
+    SELECT
+        'ucits_eu'::text as universe,
+        ef.legacy_isin_misnamed::text as external_id,
+        ef.fund_name::text as name,
+        ef.yahoo_ticker::text as ticker,
+        ef.legacy_isin_misnamed::text as isin,
+        'EU'::text as region,
+        ef.fund_type::text as fund_type,
+        ef.strategy_label::text as strategy_label,
+        NULL::numeric as aum_usd,
+        NULL::text as currency,
+        ef.domicile::text as domicile,
+        em.company_name::text as manager_name,
+        em.esma_id::text as manager_id,
+        NULL::date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        FALSE as has_holdings,
+        TRUE as has_nav,
+        FALSE as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(ef.strategy_label, ef.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        NULL::numeric as expense_ratio_pct,
+        NULL::numeric as avg_annual_return_1y,
+        NULL::numeric as avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        ef.is_institutional
+    FROM esma_funds ef
+    JOIN esma_managers em ON ef.esma_manager_id = em.esma_id
+    WHERE ef.yahoo_ticker IS NOT NULL AND ef.yahoo_ticker != ''
+) combined
+ORDER BY external_id, aum_usd DESC NULLS LAST;
+"""
+
+
+_INDEXES = [
+    "CREATE UNIQUE INDEX idx_mv_unified_funds_ext_id ON mv_unified_funds (external_id);",
+    "CREATE INDEX idx_mv_unified_funds_name ON mv_unified_funds (name);",
+    "CREATE INDEX idx_mv_unified_funds_ticker ON mv_unified_funds (ticker);",
+    "CREATE INDEX idx_mv_unified_funds_isin ON mv_unified_funds (isin);",
+    "CREATE INDEX idx_mv_unified_funds_aum ON mv_unified_funds (aum_usd);",
+    "CREATE INDEX idx_mv_unified_funds_universe ON mv_unified_funds (universe);",
+    "CREATE INDEX idx_mv_unified_funds_fund_type ON mv_unified_funds (fund_type);",
+    (
+        "CREATE INDEX idx_mv_unified_funds_institutional "
+        "ON mv_unified_funds (external_id) WHERE is_institutional = true;"
+    ),
+]
+
+
+# Bridge: populate fund_lei in instruments_universe for UCITS rows whose
+# ticker matches an esma_funds.yahoo_ticker. yahoo_ticker is unique in
+# esma_funds (verified empirically), so the join is single-valued.
+_BRIDGE_UP = """
+UPDATE instruments_universe iu
+SET attributes = iu.attributes || jsonb_build_object('fund_lei', ef.lei)
+FROM esma_funds ef
+WHERE ef.yahoo_ticker = iu.ticker
+  AND ef.yahoo_ticker IS NOT NULL
+  AND ef.yahoo_ticker <> ''
+  AND iu.attributes->>'fund_subtype' = 'ucits'
+  AND (iu.attributes->>'fund_lei' IS NULL OR iu.attributes->>'fund_lei' = '');
+"""
+
+_BRIDGE_DOWN = """
+UPDATE instruments_universe iu
+SET attributes = iu.attributes - 'fund_lei'
+WHERE iu.attributes->>'fund_subtype' = 'ucits'
+  AND iu.attributes ? 'fund_lei';
+"""
+
+
+# Reactivate UCITS instruments that *do* have NAV but were deactivated by
+# universe_sync._deactivate_no_nav (race: deactivation ran before NAV
+# arrived, ESMA re-upsert ON CONFLICT does not reset is_active=true).
+# Tag with attributes->>'q91_reactivated_at' so downgrade can revert
+# precisely the rows this migration changed.
+_REACTIVATE_UP = """
+UPDATE instruments_universe iu
+SET is_active = true,
+    attributes = iu.attributes || jsonb_build_object(
+        'q91_reactivated_at', now()::text
+    ),
+    updated_at = now()
+FROM esma_funds ef
+WHERE ef.yahoo_ticker = iu.ticker
+  AND iu.is_active = false
+  AND iu.attributes->>'fund_subtype' = 'ucits'
+  AND EXISTS (
+      SELECT 1 FROM nav_timeseries n WHERE n.instrument_id = iu.instrument_id
+  );
+"""
+
+_REACTIVATE_DOWN = """
+UPDATE instruments_universe
+SET is_active = false,
+    attributes = attributes - 'q91_reactivated_at',
+    updated_at = now()
+WHERE attributes ? 'q91_reactivated_at';
+"""
+
+
+def upgrade() -> None:
+    op.execute(_BRIDGE_UP)
+    op.execute(_REACTIVATE_UP)
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_unified_funds CASCADE;")
+    op.execute(_MV_SQL_UP)
+    for ddl in _INDEXES:
+        op.execute(ddl)
+    op.execute("REFRESH MATERIALIZED VIEW mv_unified_funds;")
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_unified_funds CASCADE;")
+    op.execute(_MV_SQL_DOWN)
+    for ddl in _INDEXES:
+        op.execute(ddl)
+    op.execute(_REACTIVATE_DOWN)
+    op.execute(_BRIDGE_DOWN)

--- a/backend/app/core/db/migrations/versions/0195_q92_audit_events_global.py
+++ b/backend/app/core/db/migrations/versions/0195_q92_audit_events_global.py
@@ -1,0 +1,91 @@
+"""PR-Q92 — Allow audit_events.organization_id NULL for global events.
+
+Global pipelines (factor_model, macro ingestion, benchmark_ingest) have
+no tenant context — they compute over GLOBAL tables (benchmark_nav,
+macro_data) shared across all organizations. When these pipelines emit
+audit events, ``organization_id`` is unresolvable from RLS context and
+``write_audit_event`` was failing with NotNullViolationError.
+
+The error is currently swallowed by try/except in factor_model_service
+(emit ``factor_data_gap_audit_failed`` warning), so factor estimation
+continues — but the audit trail loses every global event.
+
+Fix:
+- Drop NOT NULL on ``audit_events.organization_id``.
+- ``audit_events`` has no RLS (verified: ``rowsecurity = false``, 0
+  policies), so nullable column is safe — tenant-scoped callers continue
+  passing the resolved UUID via ``get_db_with_rls`` SET LOCAL context.
+- Tenant-scoped queries already filter by ``organization_id`` in the
+  WHERE clause; NULL rows are naturally excluded.
+
+Revision ID: 0195_q92_audit_events_global
+Revises: 0194_q91_ucits_data_gate
+Create Date: 2026-04-28
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0195_q92_audit_events_global"
+down_revision: str | None = "0194_q91_ucits_data_gate"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 1. Drop NOT NULL on organization_id so global pipelines can audit.
+    op.execute("ALTER TABLE audit_events ALTER COLUMN organization_id DROP NOT NULL;")
+
+    # 2. Update the RLS policy (created in migration 0019) to permit
+    #    NULL organization_id rows for global pipeline events, while
+    #    keeping per-tenant isolation for the rest. The DROP+CREATE is
+    #    idempotent regardless of whether RLS is currently enabled on
+    #    the table — we don't toggle RLS state here because audit_events
+    #    is a TimescaleDB hypertable with columnstore enabled, and
+    #    ENABLE/FORCE ROW LEVEL SECURITY is blocked while columnstore is
+    #    on. Whatever RLS state exists is preserved.
+    op.execute("DROP POLICY IF EXISTS org_isolation ON audit_events;")
+    op.execute(
+        """
+        CREATE POLICY org_isolation ON audit_events
+            USING (
+                organization_id IS NULL
+                OR organization_id = (
+                    SELECT current_setting('app.current_organization_id', true)
+                )::uuid
+            )
+            WITH CHECK (
+                organization_id IS NULL
+                OR organization_id = (
+                    SELECT current_setting('app.current_organization_id', true)
+                )::uuid
+            );
+        """,
+    )
+
+
+def downgrade() -> None:
+    # Restore the 0019 policy (NULL rows excluded) before re-applying
+    # NOT NULL — otherwise the constraint rejects existing NULL rows.
+    op.execute("DROP POLICY IF EXISTS org_isolation ON audit_events;")
+    op.execute(
+        """
+        CREATE POLICY org_isolation ON audit_events
+            USING (
+                organization_id = (
+                    SELECT current_setting('app.current_organization_id', true)
+                )::uuid
+            )
+            WITH CHECK (
+                organization_id = (
+                    SELECT current_setting('app.current_organization_id', true)
+                )::uuid
+            );
+        """,
+    )
+    op.execute(
+        """
+        DELETE FROM audit_events WHERE organization_id IS NULL;
+        ALTER TABLE audit_events ALTER COLUMN organization_id SET NOT NULL;
+        """,
+    )

--- a/backend/quant_engine/factor_model_service.py
+++ b/backend/quant_engine/factor_model_service.py
@@ -151,7 +151,10 @@ async def build_fundamental_factor_returns(
         bench_levels = bench_levels.ffill(limit=_FACTOR_FFILL_LIMIT)
 
         # Compute simple returns from filled levels.
-        bench_returns = bench_levels.pct_change()
+        # PR-Q92: fill_method=None (pad default deprecated in pandas 2.x).
+        # Levels are already ffill-ed above with limit=_FACTOR_FFILL_LIMIT;
+        # pct_change should not fill again.
+        bench_returns = bench_levels.pct_change(fill_method=None)
     else:
         bench_returns = pd.DataFrame()
         authoritative_bench = pd.DataFrame()
@@ -204,7 +207,10 @@ async def build_fundamental_factor_returns(
         # PR-Q15 Fix 1: forward-fill macro LEVELS before computing returns.
         macro_levels = macro_levels.ffill(limit=_FACTOR_FFILL_LIMIT)
         # PR-Q15 Fix 6: simple returns (pct_change), not log returns.
-        macro_returns = macro_levels.pct_change()
+        # PR-Q92: fill_method=None (pad default deprecated in pandas 2.x).
+        # Levels are already ffill-ed above, so we don't want pct_change
+        # to fill again — pass None explicitly to silence the warning.
+        macro_returns = macro_levels.pct_change(fill_method=None)
     else:
         macro_returns = pd.DataFrame()
 
@@ -340,6 +346,7 @@ async def build_fundamental_factor_returns(
                     "lookback_start": start_date.isoformat(),
                     "lookback_end": end_date.isoformat(),
                 },
+                allow_global=True,
             )
         except Exception as audit_err:
             # Audit failure must not break estimation — log and continue
@@ -381,6 +388,7 @@ async def build_fundamental_factor_returns(
                     "last_dropped": last_drop,
                     "ffill_limit_days": _FACTOR_FFILL_LIMIT,
                 },
+                allow_global=True,
             )
         except Exception as audit_err:
             logger.warning("factor_data_gap_audit_failed", err=str(audit_err))

--- a/backend/tests/db/test_migration_0194_q91.py
+++ b/backend/tests/db/test_migration_0194_q91.py
@@ -1,0 +1,144 @@
+"""PR-Q91 — UCITS data-availability gate invariants.
+
+Validates the post-migration state of mv_unified_funds and the
+ESMA↔instruments_universe bridge. Read-only assertions on the live DB.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from app.core.config import settings
+
+
+def _asyncpg_dsn() -> str:
+    return settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+
+
+@pytest.mark.asyncio
+async def test_ucits_branch_excludes_funds_without_nav():
+    """Every UCITS row in mv_unified_funds must have an instruments_universe
+    row with at least one nav_timeseries entry — no more has_nav lies."""
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        violations = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM mv_unified_funds m
+            WHERE m.universe = 'ucits_eu'
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM instruments_universe iu
+                  JOIN nav_timeseries n ON n.instrument_id = iu.instrument_id
+                  WHERE iu.ticker = m.ticker
+              )
+            """
+        )
+    finally:
+        await conn.close()
+    assert violations == 0, (
+        f"{violations} UCITS rows in mv_unified_funds have no NAV — "
+        "data-availability gate broken"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ucits_external_id_is_not_lei_misnamed():
+    """external_id must use real ISIN or ticker — never the legacy_isin_misnamed
+    column that historically stored LEIs."""
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        leaked_leis = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM mv_unified_funds m
+            JOIN esma_funds ef ON ef.legacy_isin_misnamed = m.external_id
+            WHERE m.universe = 'ucits_eu'
+              AND ef.legacy_isin_misnamed ~ '^[A-Z0-9]{20}$'
+              AND m.external_id NOT IN (
+                  SELECT lei FROM esma_funds
+              )
+            """
+        )
+    finally:
+        await conn.close()
+    assert leaked_leis == 0, (
+        "UCITS external_id is leaking legacy_isin_misnamed values that look "
+        "like LEIs but are not registered in esma_funds.lei"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ucits_aum_populated_when_q78_enrichment_present():
+    """If instruments_universe.attributes->>'aum_usd' is populated by Q78,
+    the materialized view must surface it (not NULL)."""
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        missing_aum = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM mv_unified_funds m
+            JOIN instruments_universe iu ON iu.ticker = m.ticker
+            WHERE m.universe = 'ucits_eu'
+              AND iu.attributes->>'aum_usd' IS NOT NULL
+              AND m.aum_usd IS NULL
+            """
+        )
+    finally:
+        await conn.close()
+    assert missing_aum == 0, (
+        f"{missing_aum} UCITS funds have aum_usd in attributes but NULL in "
+        "mv_unified_funds — Q78 enrichment not flowing through"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bridge_fund_lei_populated_for_ucits_with_ticker_match():
+    """For UCITS instruments whose ticker matches an esma_funds.yahoo_ticker,
+    attributes->>'fund_lei' must be populated."""
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        missing = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM instruments_universe iu
+            JOIN esma_funds ef ON ef.yahoo_ticker = iu.ticker
+            WHERE iu.attributes->>'fund_subtype' = 'ucits'
+              AND ef.yahoo_ticker IS NOT NULL
+              AND ef.yahoo_ticker <> ''
+              AND (iu.attributes->>'fund_lei' IS NULL OR iu.attributes->>'fund_lei' = '')
+            """
+        )
+    finally:
+        await conn.close()
+    assert missing == 0, (
+        f"{missing} UCITS instruments have a matching esma_funds row but "
+        "attributes.fund_lei was not populated by Q91 bridge"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ucits_with_nav_are_active():
+    """Every UCITS in instruments_universe with at least one nav_timeseries
+    row must be is_active = true (Q91 reactivation invariant)."""
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        violators = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM instruments_universe iu
+            WHERE iu.attributes->>'fund_subtype' = 'ucits'
+              AND iu.is_active = false
+              AND EXISTS (
+                  SELECT 1 FROM nav_timeseries n
+                  WHERE n.instrument_id = iu.instrument_id
+              )
+            """
+        )
+    finally:
+        await conn.close()
+    assert violators == 0, (
+        f"{violators} UCITS instruments have NAV data but are is_active=false — "
+        "universe_sync._deactivate_no_nav race not yet patched (Q92 follow-up)"
+    )

--- a/backend/tests/db/test_migration_0195_q92.py
+++ b/backend/tests/db/test_migration_0195_q92.py
@@ -1,0 +1,127 @@
+"""PR-Q92 — audit_events.organization_id nullable + allow_global gate.
+
+Validates the global-audit contract:
+- audit_events.organization_id can hold NULL for global pipeline events.
+- write_audit_event(allow_global=True) writes NULL successfully.
+- write_audit_event(allow_global=False, RLS empty) raises ValueError —
+  prevents tenant code from silently producing orphan audit rows.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from app.core.config import settings
+from app.core.db.audit import write_audit_event
+from app.core.db.engine import async_session_factory as async_session
+
+
+def _asyncpg_dsn() -> str:
+    return settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+
+
+@pytest.mark.asyncio
+async def test_audit_events_organization_id_is_nullable():
+    """organization_id must be NULLABLE post-migration 0195."""
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        is_nullable = await conn.fetchval(
+            """
+            SELECT is_nullable
+            FROM information_schema.columns
+            WHERE table_name = 'audit_events'
+              AND column_name = 'organization_id'
+            """
+        )
+    finally:
+        await conn.close()
+    assert is_nullable == "YES", (
+        "audit_events.organization_id must be nullable to support global "
+        "pipeline events (factor model, macro ingestion, benchmark_ingest)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_audit_event_allow_global_writes_null_org():
+    """allow_global=True writes a row with organization_id=NULL."""
+    async with async_session() as db:
+        await write_audit_event(
+            db,
+            action="test_q92_global",
+            entity_type="factor_model",
+            entity_id="test_global_event",
+            after={"smoke": "test"},
+            allow_global=True,
+        )
+        await db.commit()
+
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        row = await conn.fetchrow(
+            """
+            SELECT organization_id, action, entity_id
+            FROM audit_events
+            WHERE action = 'test_q92_global'
+              AND entity_id = 'test_global_event'
+            ORDER BY created_at DESC LIMIT 1
+            """
+        )
+        # Cleanup
+        await conn.execute(
+            "DELETE FROM audit_events WHERE action = 'test_q92_global'",
+        )
+    finally:
+        await conn.close()
+    assert row is not None, "global audit row was not persisted"
+    assert row["organization_id"] is None, (
+        "expected organization_id=NULL for global event"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_audit_event_without_global_flag_raises_when_no_org():
+    """allow_global=False (default) must raise when RLS context is empty —
+    prevents tenant code from silently producing orphan audit rows."""
+    async with async_session() as db:
+        with pytest.raises(ValueError, match="organization_id"):
+            await write_audit_event(
+                db,
+                action="test_q92_orphan_check",
+                entity_type="factor_model",
+                entity_id="should_never_persist",
+                after={"smoke": "negative"},
+                # allow_global omitted -> defaults to False
+            )
+
+
+@pytest.mark.asyncio
+async def test_factor_model_writes_global_audit_on_data_gap():
+    """End-to-end: factor model run produces at least one factor_data_gap
+    audit row with organization_id=NULL (no audit_failed warnings)."""
+    import datetime as dt
+
+    from quant_engine.factor_model_service import build_fundamental_factor_returns
+
+    end = dt.date(2026, 4, 28)
+    start = end - dt.timedelta(days=365)
+    async with async_session() as db:
+        await build_fundamental_factor_returns(db, start, end)
+        await db.commit()
+
+    conn = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        count = await conn.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM audit_events
+            WHERE entity_type = 'factor_model'
+              AND organization_id IS NULL
+              AND created_at >= NOW() - INTERVAL '5 minutes'
+            """
+        )
+    finally:
+        await conn.close()
+    assert count >= 1, (
+        f"expected at least one factor_model audit row with org=NULL, got {count}"
+    )


### PR DESCRIPTION
## Re-opened after PR #392 auto-closed

PR #392 was auto-closed by GitHub when the base branch (\`pr-q91-ucits-data-gate\`) was deleted on Q91 merge. \`gh pr reopen\` rejects because the base no longer exists. This is a fresh PR with the same commits, base=main.

## Summary

Three cleanup fixes that remove silent observability gap in global pipelines (factor model, macro ingestion, benchmark_ingest):

1. **\`audit_events.organization_id\` nullable** — was rejecting global events with \`NotNullViolationError\`; swallowed by try/except in factor_model_service so every \`factor_skipped\` / \`factor_data_gap\` event was silently discarded.
2. **RLS policy adapted** — \`org_isolation\` now permits NULL organization_id rows while keeping per-tenant isolation.
3. **\`write_audit_event(allow_global=True)\`** — explicit opt-in flag; without it, missing RLS context now raises \`ValueError\`.
4. **pandas \`pct_change\` FutureWarning** — \`fill_method=None\` (pad default deprecated).

Subsumes Wave 6 Session 09 finding C-09 (REFUTED in jury verdict because already fixed by this PR).

## Validation

- 4/4 tests pass in \`tests/db/test_migration_0195_q92.py\`
- 28 RLS tests still green
- \`make lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)