### PR TITLE
fix(wealth): PR-Q93 — fast_approve UUID double-cast P1 (re-open)

### DIFF
--- a/backend/app/domains/wealth/routes/universe.py
+++ b/backend/app/domains/wealth/routes/universe.py
@@ -625,7 +625,7 @@ async def fast_approve(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> FastApproveResponse:
     """Approve liquid funds directly from the screener in one click.
 
@@ -683,10 +683,13 @@ async def fast_approve(
             approved.append(str(iid))
             continue
 
-        # Create new instruments_org row with approved status
+        # Create new instruments_org row with approved status.
+        # PR-Q93: org_id is already uuid.UUID (returned by get_org_id);
+        # the previous uuid.UUID(org_id) cast crashed with
+        # "'UUID' object has no attribute 'replace'".
         new_org = InstrumentOrg(
             instrument_id=iid,
-            organization_id=uuid.UUID(org_id),
+            organization_id=org_id,
             block_id=body.block_id,
             approval_status="approved",
         )


### PR DESCRIPTION
## Re-opened after PR #393 auto-closed

PR #393 was auto-closed by GitHub when the base branch (\`pr-q92-audit-events-global-events-stacked\`) was deleted on Q92 (#400) merge. Same auto-close pattern as #392 → #400. This is a fresh PR with the rebased Q93 commit, base=main.

## Summary

P1 hotfix: \`POST /api/v1/universe/fast-approve\` crashed with \`'UUID' object has no attribute 'replace'\` — \`org_id\` already \`uuid.UUID\` from \`Depends(get_org_id)\`, but \`uuid.UUID(org_id)\` cast was applied anyway. Fix: annotation matched + cast removed.

## Wave 6 Session 09 context

This was the seed finding for the broader C-03 sweep. PR-Q96 (#397, merged) covered the 5 remaining sites in instruments.py, content.py, builder.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)