### PR TITLE
fix(wealth): PR-Q100+Q101 — approve_dd_report idempotency + DD trigger role gate (High batch)

### DIFF
--- a/backend/app/domains/wealth/routes/dd_reports.py
+++ b/backend/app/domains/wealth/routes/dd_reports.py
@@ -249,7 +249,7 @@ async def trigger_dd_report(
     fund_id: uuid.UUID,
     body: DDReportCreate | None = None,
     db: AsyncSession = Depends(get_db_with_rls),
-    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(require_role(Role.INVESTMENT_TEAM)),
     org_id: str = Depends(get_org_id),
 ) -> DDReportSummary:
     """Trigger async DD Report generation.
@@ -324,7 +324,7 @@ async def trigger_dd_report(
         status=DDReportStatus.generating.value,
         is_current=True,
         config_snapshot=body.config_overrides if body else None,
-        created_by=user.actor_id,
+        created_by=actor.actor_id,
     )
     db.add(report)
     await db.flush()
@@ -347,7 +347,7 @@ async def trigger_dd_report(
             report_id=str(report_id),
             fund_id=str(fund_id),
             org_id=str(org_id),
-            actor_id=user.actor_id,
+            actor_id=actor.actor_id,
             config=body.config_overrides if body else None,
             job_id=job_id,
         ),
@@ -440,7 +440,7 @@ async def regenerate_dd_report(
     report_id: uuid.UUID,
     body: DDReportRegenerate | None = None,
     db: AsyncSession = Depends(get_db_with_rls),
-    user: CurrentUser = Depends(get_current_user),
+    actor: Actor = Depends(require_role(Role.INVESTMENT_TEAM)),
     org_id: str = Depends(get_org_id),
 ) -> DDReportSummary:
     """Force regeneration of specific chapters or entire report."""
@@ -483,7 +483,7 @@ async def regenerate_dd_report(
             report_id=str(report_id),
             fund_id=str(report.instrument_id),
             org_id=str(org_id),
-            actor_id=user.actor_id,
+            actor_id=actor.actor_id,
             config=report.config_snapshot,
             job_id=job_id,
             force=True,
@@ -568,6 +568,17 @@ async def approve_dd_report(
     instrument_org = io_result.scalar_one_or_none()
     if instrument_org:
         instrument_org.approval_status = "approved"
+
+    # Clear prior is_current approval for idempotency (§3.2)
+    existing_approval = (await db.execute(
+        select(UniverseApproval).where(
+            UniverseApproval.instrument_id == report.instrument_id,
+            UniverseApproval.organization_id == report.organization_id,
+            UniverseApproval.is_current.is_(True),
+        ),
+    )).scalar_one_or_none()
+    if existing_approval:
+        existing_approval.is_current = False
 
     # Create UniverseApproval record for audit trail
     approval = UniverseApproval(

--- a/backend/tests/wealth/routes/test_dd_approve_idempotent.py
+++ b/backend/tests/wealth/routes/test_dd_approve_idempotent.py
@@ -1,0 +1,314 @@
+"""Idempotency tests for POST /dd-reports/{id}/approve (PR-Q100).
+
+Verifies that approve_dd_report clears prior is_current=True rows in
+universe_approvals before inserting the new approval.  Without this fix,
+re-approval after reject->regenerate would violate the partial unique
+index on (organization_id, instrument_id) WHERE is_current=true.
+
+Runs against real Docker-compose PostgreSQL.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from app.core.db.engine import async_session_factory
+
+# Deterministic test UUIDs (q100 prefix -- never conflicts with real tenants)
+_ORG_ID = uuid.UUID("01000000-0000-0000-0000-000000000001")
+_INSTRUMENT_ID = uuid.UUID("01000000-0000-0000-0000-000000000010")
+_INSTRUMENT_ORG_ID = uuid.UUID("01000000-0000-0000-0000-000000000011")
+_DD_REPORT_ID = uuid.UUID("01000000-0000-0000-0000-000000000020")
+_DD_CHAPTER_ID = uuid.UUID("01000000-0000-0000-0000-000000000030")
+_PRIOR_APPROVAL_ID = uuid.UUID("01000000-0000-0000-0000-000000000040")
+
+_CREATOR = "q100-creator"
+_APPROVER = "q100-approver"
+
+_DEV_HEADER = {
+    "X-DEV-ACTOR": json.dumps({
+        "actor_id": _APPROVER,
+        "roles": ["INVESTMENT_TEAM"],
+        "fund_ids": [],
+        "org_id": str(_ORG_ID),
+    }),
+}
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+# -- Fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+async def _seed_q100():
+    """Seed instrument, instruments_org, dd_report, dd_chapter, prior approval."""
+    async with async_session_factory() as db:
+        await db.execute(
+            text("SELECT set_config('app.current_organization_id', :oid, true)"),
+            {"oid": str(_ORG_ID)},
+        )
+
+        # instruments_universe (global, no RLS)
+        await db.execute(
+            text("""
+                INSERT INTO instruments_universe
+                    (instrument_id, instrument_type, name, ticker, asset_class,
+                     geography, currency, is_active, attributes)
+                VALUES
+                    (:iid, 'fund', 'Q100 Idempotency Test Fund', 'Q100T', 'equity',
+                     'US', 'USD', true,
+                     CAST(:attrs AS jsonb))
+                ON CONFLICT (instrument_id) DO NOTHING
+            """),
+            {
+                "iid": _INSTRUMENT_ID,
+                "attrs": json.dumps({
+                    "aum_usd": 500_000_000,
+                    "manager_name": "Q100 Test Manager",
+                    "inception_date": "2020-01-01",
+                }),
+            },
+        )
+
+        # instruments_org (org-scoped)
+        await db.execute(
+            text("""
+                INSERT INTO instruments_org
+                    (id, instrument_id, organization_id, block_id, approval_status)
+                VALUES
+                    (:ioid, :iid, :oid, NULL, 'pending')
+                ON CONFLICT (id) DO NOTHING
+            """),
+            {"ioid": _INSTRUMENT_ORG_ID, "iid": _INSTRUMENT_ID, "oid": _ORG_ID},
+        )
+
+        # dd_reports -- status=pending_approval, created_by != approver
+        await db.execute(
+            text("""
+                INSERT INTO dd_reports
+                    (id, instrument_id, organization_id, report_type, version,
+                     status, is_current, schema_version, created_by)
+                VALUES
+                    (:rid, :iid, :oid, 'dd_report', 1,
+                     'pending_approval', true, 1, :creator)
+                ON CONFLICT (id) DO NOTHING
+            """),
+            {
+                "rid": _DD_REPORT_ID,
+                "iid": _INSTRUMENT_ID,
+                "oid": _ORG_ID,
+                "creator": _CREATOR,
+            },
+        )
+
+        # dd_chapters (at least one, composite FK requires matching org_id)
+        await db.execute(
+            text("""
+                INSERT INTO dd_chapters
+                    (id, dd_report_id, organization_id, chapter_tag,
+                     chapter_order, content_md)
+                VALUES
+                    (:cid, :rid, :oid, 'summary', 1, '## Summary\nTest content.')
+                ON CONFLICT (id) DO NOTHING
+            """),
+            {
+                "cid": _DD_CHAPTER_ID,
+                "rid": _DD_REPORT_ID,
+                "oid": _ORG_ID,
+            },
+        )
+
+        # Pre-existing universe_approval with is_current=True (simulates
+        # prior approval that should be superseded on re-approval)
+        await db.execute(
+            text("""
+                INSERT INTO universe_approvals
+                    (id, instrument_id, organization_id, decision,
+                     is_current, created_by, decided_by)
+                VALUES
+                    (:aid, :iid, :oid, 'approved',
+                     true, :creator, :creator)
+                ON CONFLICT (id) DO NOTHING
+            """),
+            {
+                "aid": _PRIOR_APPROVAL_ID,
+                "iid": _INSTRUMENT_ID,
+                "oid": _ORG_ID,
+                "creator": _CREATOR,
+            },
+        )
+
+        await db.commit()
+
+    yield
+
+    # Teardown (FK-safe order)
+    async with async_session_factory() as db:
+        await db.execute(
+            text("DELETE FROM universe_approvals WHERE organization_id = :oid"),
+            {"oid": _ORG_ID},
+        )
+        await db.execute(
+            text("DELETE FROM dd_chapters WHERE organization_id = :oid"),
+            {"oid": _ORG_ID},
+        )
+        await db.execute(
+            text("DELETE FROM dd_reports WHERE organization_id = :oid"),
+            {"oid": _ORG_ID},
+        )
+        await db.execute(
+            text("DELETE FROM instruments_org WHERE organization_id = :oid"),
+            {"oid": _ORG_ID},
+        )
+        await db.execute(
+            text("DELETE FROM instruments_universe WHERE instrument_id = :iid"),
+            {"iid": _INSTRUMENT_ID},
+        )
+        await db.commit()
+
+
+@pytest.fixture(scope="module")
+async def q100_client():
+    """Async HTTP client for DD report route testing."""
+    from app.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+# -- Tests -------------------------------------------------------------------
+
+
+async def test_dd_approve_clears_prior_current_approval(
+    _seed_q100,
+    q100_client: AsyncClient,
+):
+    """Approving a DD report when a prior is_current=True approval exists
+    must clear the prior row and insert a new is_current=True row.
+
+    After approval: exactly 1 is_current=True, at least 1 is_current=False.
+    No IntegrityError on the partial unique index.
+    """
+    resp = await q100_client.post(
+        f"/api/v1/dd-reports/{_DD_REPORT_ID}/approve",
+        json={"rationale": "Approved after full committee review — idempotency test"},
+        headers=_DEV_HEADER,
+    )
+    assert resp.status_code == 200, f"Approval failed: {resp.text}"
+
+    # Verify DB state
+    async with async_session_factory() as db:
+        await db.execute(
+            text("SELECT set_config('app.current_organization_id', :oid, true)"),
+            {"oid": str(_ORG_ID)},
+        )
+
+        current = await db.execute(
+            text("""
+                SELECT count(*) FROM universe_approvals
+                WHERE instrument_id = :iid
+                  AND organization_id = :oid
+                  AND is_current = true
+            """),
+            {"iid": _INSTRUMENT_ID, "oid": _ORG_ID},
+        )
+        current_count = current.scalar_one()
+
+        historical = await db.execute(
+            text("""
+                SELECT count(*) FROM universe_approvals
+                WHERE instrument_id = :iid
+                  AND organization_id = :oid
+                  AND is_current = false
+            """),
+            {"iid": _INSTRUMENT_ID, "oid": _ORG_ID},
+        )
+        historical_count = historical.scalar_one()
+
+    assert current_count == 1, (
+        f"Expected exactly 1 is_current=True approval, got {current_count}"
+    )
+    assert historical_count >= 1, (
+        f"Expected at least 1 is_current=False (the prior approval), got {historical_count}"
+    )
+
+
+async def test_dd_approve_after_reject_regenerate_cycle(
+    _seed_q100,
+    q100_client: AsyncClient,
+):
+    """Simulates reject -> regenerate -> re-approve cycle.
+
+    After the first test already approved, we reset the report to
+    pending_approval and approve again.  Must still yield exactly 1
+    is_current=True row (the latest approval).
+    """
+    # Reset report to pending_approval for re-approval
+    async with async_session_factory() as db:
+        await db.execute(
+            text("SELECT set_config('app.current_organization_id', :oid, true)"),
+            {"oid": str(_ORG_ID)},
+        )
+        await db.execute(
+            text("""
+                UPDATE dd_reports
+                SET status = 'pending_approval',
+                    approved_by = NULL,
+                    approved_at = NULL,
+                    rejection_reason = NULL
+                WHERE id = :rid
+            """),
+            {"rid": _DD_REPORT_ID},
+        )
+        await db.commit()
+
+    # Second approval
+    resp = await q100_client.post(
+        f"/api/v1/dd-reports/{_DD_REPORT_ID}/approve",
+        json={"rationale": "Re-approved after reject-regenerate cycle — idempotency test"},
+        headers=_DEV_HEADER,
+    )
+    assert resp.status_code == 200, f"Re-approval failed: {resp.text}"
+
+    # Verify DB state: exactly 1 is_current=True
+    async with async_session_factory() as db:
+        await db.execute(
+            text("SELECT set_config('app.current_organization_id', :oid, true)"),
+            {"oid": str(_ORG_ID)},
+        )
+
+        current = await db.execute(
+            text("""
+                SELECT count(*) FROM universe_approvals
+                WHERE instrument_id = :iid
+                  AND organization_id = :oid
+                  AND is_current = true
+            """),
+            {"iid": _INSTRUMENT_ID, "oid": _ORG_ID},
+        )
+        current_count = current.scalar_one()
+
+        total = await db.execute(
+            text("""
+                SELECT count(*) FROM universe_approvals
+                WHERE instrument_id = :iid
+                  AND organization_id = :oid
+            """),
+            {"iid": _INSTRUMENT_ID, "oid": _ORG_ID},
+        )
+        total_count = total.scalar_one()
+
+    assert current_count == 1, (
+        f"Expected exactly 1 is_current=True after re-approval, got {current_count}"
+    )
+    # Should have at least 3 rows total: seed + first approval + second approval
+    assert total_count >= 3, (
+        f"Expected at least 3 total approval rows, got {total_count}"
+    )

--- a/backend/tests/wealth/routes/test_dd_trigger_role_gate.py
+++ b/backend/tests/wealth/routes/test_dd_trigger_role_gate.py
@@ -1,0 +1,86 @@
+"""Role gate tests for DD trigger and regenerate endpoints.
+
+PR-Q101: Verify that investor-role users are rejected (403) on
+trigger_dd_report and regenerate_dd_report, while IC-role users
+pass the role gate.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+_FUND_ID = str(uuid.uuid4())
+_REPORT_ID = str(uuid.uuid4())
+
+
+def _investor_header() -> dict[str, str]:
+    """Dev actor header with INVESTOR role (read-only)."""
+    return {
+        "X-DEV-ACTOR": (
+            '{"actor_id": "investor-user", "roles": ["INVESTOR"],'
+            ' "fund_ids": [], "org_id": "00000000-0000-0000-0000-000000000001"}'
+        ),
+    }
+
+
+def _ic_header() -> dict[str, str]:
+    """Dev actor header with INVESTMENT_TEAM role."""
+    return {
+        "X-DEV-ACTOR": (
+            '{"actor_id": "ic-user", "roles": ["INVESTMENT_TEAM"],'
+            ' "fund_ids": [], "org_id": "00000000-0000-0000-0000-000000000001"}'
+        ),
+    }
+
+
+# ---- trigger_dd_report ----
+
+
+@pytest.mark.asyncio
+async def test_trigger_dd_report_rejects_investor_role(client: AsyncClient):
+    """INVESTOR role must be rejected with 403 on DD trigger."""
+    resp = await client.post(
+        f"/api/v1/dd-reports/funds/{_FUND_ID}",
+        headers=_investor_header(),
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_trigger_dd_report_accepts_investment_team(client: AsyncClient):
+    """INVESTMENT_TEAM role passes role gate -- 404 expected (no seeded fund)."""
+    resp = await client.post(
+        f"/api/v1/dd-reports/funds/{_FUND_ID}",
+        headers=_ic_header(),
+    )
+    # Role gate passed; handler returns 404 because fund doesn't exist
+    assert resp.status_code != 403
+    assert resp.status_code in (200, 202, 404)
+
+
+# ---- regenerate_dd_report ----
+
+
+@pytest.mark.asyncio
+async def test_regenerate_dd_report_rejects_investor_role(client: AsyncClient):
+    """INVESTOR role must be rejected with 403 on DD regenerate."""
+    resp = await client.post(
+        f"/api/v1/dd-reports/{_REPORT_ID}/regenerate",
+        headers=_investor_header(),
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_regenerate_dd_report_accepts_investment_team(client: AsyncClient):
+    """INVESTMENT_TEAM role passes role gate -- 404 expected (no seeded report)."""
+    resp = await client.post(
+        f"/api/v1/dd-reports/{_REPORT_ID}/regenerate",
+        headers=_ic_header(),
+    )
+    # Role gate passed; handler returns 404 because report doesn't exist
+    assert resp.status_code != 403
+    assert resp.status_code in (200, 202, 404)


### PR DESCRIPTION
## Wave 6 Session 09 — Findings C-07 + C-13 batched

Batched because both findings touch \`backend/app/domains/wealth/routes/dd_reports.py\` and the test surface overlaps. Sprint 2 agent commit boundaries placed both code fixes in commit Q100, with Q101's commit holding only the test file.

### C-07 — approve_dd_report idempotency (High, CONFIRMED)

**Jury verdict (GPT-5.5):**
> Gemini's checked invariant is wrong for the \`UniverseApproval\` branch. \`approve_dd_report\` creates a new \`UniverseApproval\` at \`dd_reports.py:572-583\` and there is no preceding query/update that clears prior current approvals. The model default is \`is_current=true\` at \`universe_approval.py:46-48\`, and the migration documents a unique current-approval index at \`0008:300-306\`. **This supports Opus's idempotency bug and a High severity crash/duplicate-current risk.**

### C-13 — DD trigger/regenerate role gate (High, ESCALATED from Med)

**Jury verdict (GPT-5.5):**
> \`trigger_dd_report\` at \`dd_reports.py:248-254\` and \`regenerate_dd_report\` at \`439-445\` require \`get_current_user\`/RLS but not \`require_role\`. Approve and rejection require \`Role.INVESTMENT_TEAM\`, showing the intended privilege boundary. **Because DD generation creates records and consumes LLM credits, this is unbounded external API spend by lower-privilege users.**

## Changes

| Metric | Value |
|---|---|
| Files | 2 (production + tests) |
| Tests | 6 passing (2 idempotency + 4 role gate) |

## Implementation

- **Q100 (C-07):** Query existing UniverseApproval rows where \`is_current=True\` for \`(organization_id, instrument_id)\`; UPDATE them to \`is_current=False\` BEFORE \`db.add(approval)\` (mirrors \`fast_track_approval\` pattern at \`screener.py:2949-2950\`)
- **Q101 (C-13):** \`trigger_dd_report\` and \`regenerate_dd_report\` now require \`Depends(require_role(Role.INVESTMENT_TEAM))\` (matches sibling approve/reject pattern in same file)

## Tenant-visible behavior change

Investor-role users that previously could trigger DD generation will receive HTTP 403. IC team unaffected.

## Stage 4 reminder

Codex Auto Review will trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)