### PR TITLE
fix(wealth): PR-Q102 — Wave 6 S09 Med-severity batch (C-10/C-11/C-12/C-14)

### DIFF
--- a/backend/app/domains/wealth/routes/screener.py
+++ b/backend/app/domains/wealth/routes/screener.py
@@ -86,6 +86,55 @@ from app.shared.models import EsmaFund, EsmaManager, SecCusipTickerMap
 logger = structlog.get_logger(__name__)
 
 
+# ── C-12: reject unknown query params on catalog routes ──────────────
+
+
+def _strict_query_params(*allowed: str):
+    """FastAPI dependency that rejects unknown query parameters with 422.
+
+    Usage::
+
+        @router.get("/catalog")
+        async def get_catalog(
+            ...,
+            _strict: None = Depends(_strict_query_params("q", "region", ...)),
+        ):
+    """
+    allowed_set = frozenset(allowed)
+
+    async def _check(request: Request) -> None:
+        unknown = set(request.query_params.keys()) - allowed_set
+        if unknown:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unknown query parameter(s): {', '.join(sorted(unknown))}",
+            )
+
+    return Depends(_check)
+
+
+_CATALOG_PARAMS = (
+    "q", "region", "fund_universe", "fund_type", "strategy_label",
+    "investment_geography", "aum_min", "has_nav", "in_universe", "has_aum",
+    "domicile", "manager", "manager_id", "sort", "page", "page_size",
+    "max_expense_ratio", "min_return_1y", "min_return_10y", "elite_only",
+    "cursor", "manager_names", "sharpe_min", "sharpe_max",
+    "max_drawdown_min", "max_drawdown_max", "volatility_max",
+    "aum_max", "return_1y_max", "return_10y_min", "return_10y_max",
+)
+
+_MANAGERS_PARAMS = (
+    "q", "region", "fund_universe", "fund_type", "strategy_label",
+    "aum_min", "has_aum", "sort", "page", "page_size",
+)
+
+_FACETS_PARAMS = (
+    "q", "region", "fund_universe", "fund_type", "strategy_label",
+    "investment_geography", "aum_min", "has_nav", "has_aum",
+    "domicile", "manager",
+)
+
+
 def _normalize_to_fraction(value: float | Any | None, source: str) -> float | None:
     """Ensure percentage value is stored as pure decimal fraction (0.015 = 1.5%).
 
@@ -1936,6 +1985,7 @@ async def get_catalog(
     return_10y_min: float | None = Query(None, description="Min 10Y annualized return %"),
     return_10y_max: float | None = Query(None, description="Max 10Y annualized return %"),
     db: AsyncSession = Depends(get_db_with_rls),
+    _strict: None = _strict_query_params(*_CATALOG_PARAMS),
 ) -> UnifiedCatalogPage:
     parsed_manager_names = [n.strip() for n in manager_names.split(",") if n.strip()] if manager_names else None
     filters = CatalogFilters(
@@ -2152,6 +2202,7 @@ async def get_catalog_managers(
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=200),
     db: AsyncSession = Depends(get_db_with_rls),
+    _strict: None = _strict_query_params(*_MANAGERS_PARAMS),
 ) -> ManagerCatalogPage:
     """Group funds by manager_id, return aggregated AUM + fund types.
 
@@ -2246,6 +2297,7 @@ async def get_catalog_facets(
     domicile: str | None = Query(None),
     manager: str | None = Query(None),
     db: AsyncSession = Depends(get_db_with_rls),
+    _strict: None = _strict_query_params(*_FACETS_PARAMS),
 ) -> CatalogFacets:
     filters = CatalogFilters(
         q=q,

--- a/backend/app/domains/wealth/routes/universe.py
+++ b/backend/app/domains/wealth/routes/universe.py
@@ -401,7 +401,8 @@ async def approve_fund(
 
     svc = UniverseService()
 
-    def _approve() -> tuple[UniverseApprovalRead, str]:
+    def _approve() -> UniverseApprovalRead:
+        from app.core.db.models import AuditEvent
         from app.core.db.session import sync_session_factory
 
         with sync_session_factory() as sync_db, sync_db.begin():
@@ -452,20 +453,25 @@ async def approve_fund(
                     detail="Self-approval is not allowed",
                 )
 
-            return UniverseApprovalRead.model_validate(updated), old_decision
+            # Audit event in the SAME transaction as the mutation (C-11).
+            # If this fails, the mutation rolls back too.
+            sync_db.add(AuditEvent(
+                organization_id=uuid.UUID(org_id) if isinstance(org_id, str) else org_id,
+                actor_id=actor.actor_id,
+                actor_roles=[],
+                action="universe.approve",
+                entity_type="UniverseApproval",
+                entity_id=str(instrument_id),
+                before_state={"decision": old_decision},
+                after_state={"decision": body.decision, "rationale": body.rationale},
+                created_by=actor.actor_id,
+                updated_by=actor.actor_id,
+            ))
+            sync_db.flush()
 
-    approval_result, old_decision = await asyncio.to_thread(_approve)
-    await write_audit_event(
-        db,
-        actor_id=actor.actor_id,
-        action="universe.approve",
-        entity_type="UniverseApproval",
-        entity_id=str(instrument_id),
-        before={"decision": old_decision},
-        after={"decision": body.decision, "rationale": body.rationale},
-    )
-    await db.commit()
-    return approval_result
+            return UniverseApprovalRead.model_validate(updated)
+
+    return await asyncio.to_thread(_approve)
 
 
 @router.post(
@@ -499,7 +505,8 @@ async def reject_fund(
 
     svc = UniverseService()
 
-    def _reject() -> tuple[UniverseApprovalRead, str]:
+    def _reject() -> UniverseApprovalRead:
+        from app.core.db.models import AuditEvent
         from app.core.db.session import sync_session_factory
 
         with sync_session_factory() as sync_db, sync_db.begin():
@@ -543,20 +550,25 @@ async def reject_fund(
                     detail="Self-approval is not allowed",
                 )
 
-            return UniverseApprovalRead.model_validate(updated), old_decision
+            # Audit event in the SAME transaction as the mutation (C-11).
+            # If this fails, the mutation rolls back too.
+            sync_db.add(AuditEvent(
+                organization_id=uuid.UUID(org_id) if isinstance(org_id, str) else org_id,
+                actor_id=actor.actor_id,
+                actor_roles=[],
+                action="universe.reject",
+                entity_type="UniverseApproval",
+                entity_id=str(instrument_id),
+                before_state={"decision": old_decision},
+                after_state={"decision": "rejected", "rationale": body.rationale},
+                created_by=actor.actor_id,
+                updated_by=actor.actor_id,
+            ))
+            sync_db.flush()
 
-    rejection_result, old_decision = await asyncio.to_thread(_reject)
-    await write_audit_event(
-        db,
-        actor_id=actor.actor_id,
-        action="universe.reject",
-        entity_type="UniverseApproval",
-        entity_id=str(instrument_id),
-        before={"decision": old_decision},
-        after={"decision": "rejected", "rationale": body.rationale},
-    )
-    await db.commit()
-    return rejection_result
+            return UniverseApprovalRead.model_validate(updated)
+
+    return await asyncio.to_thread(_reject)
 
 
 @router.get(

--- a/backend/app/domains/wealth/workers/benchmark_ingest.py
+++ b/backend/app/domains/wealth/workers/benchmark_ingest.py
@@ -18,6 +18,11 @@ from sqlalchemy import func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.core.db.engine import async_session_factory as async_session
+from app.core.runtime.provider_gate import (
+    ExternalProviderGate,
+    GateConfig,
+    ProviderGateError,
+)
 from app.domains.wealth.models.benchmark_nav import BenchmarkNav
 from app.domains.wealth.models.block import AllocationBlock
 from app.services.providers.tiingo_instrument_provider import TiingoInstrumentProvider
@@ -27,9 +32,18 @@ logger = structlog.get_logger()
 # Deterministic lock ID — never use hash() (non-deterministic across processes)
 BENCHMARK_INGEST_LOCK_ID = 900_004
 
-MAX_RETRIES = 3
-BACKOFF_BASE = 1  # 1s, 4s, 16s
 UPSERT_CHUNK = 200  # Short transactions to prevent connection pool starvation
+
+# ExternalProviderGate — circuit breaker + hard timeout for Tiingo calls.
+# Mirrors esma_aum_sync.py pattern per Charter §3.
+_tiingo_gate: ExternalProviderGate[dict[str, pd.DataFrame] | None] = ExternalProviderGate(
+    GateConfig(
+        name="tiingo_benchmark",
+        timeout_s=60.0,
+        failure_threshold=3,
+        recovery_after_s=300.0,
+    ),
+)
 
 # Maximum NaN ratio before rejecting a ticker's data
 _MAX_NAN_RATIO = 0.05  # 5%
@@ -109,32 +123,31 @@ async def _do_ingest(db, lookback_days: int) -> dict[str, int | list[str]]:
         tickers=unique_tickers,
     )
 
-    # 3. Resolve period and fetch via Tiingo with retry
+    # 3. Resolve period and fetch via Tiingo (ExternalProviderGate)
     period = _resolve_period(lookback_days)
     hist: dict[str, pd.DataFrame] | None = None
 
     loop = asyncio.get_event_loop()
-    for attempt in range(MAX_RETRIES):
-        try:
-            hist = await loop.run_in_executor(
+    try:
+        async def _tiingo_coro() -> dict[str, pd.DataFrame] | None:
+            return await loop.run_in_executor(
                 _io_executor,
                 _fetch_via_tiingo,
                 unique_tickers,
                 period,
             )
-            break
-        except Exception as e:
-            wait = BACKOFF_BASE * (4 ** attempt)
-            logger.warning(
-                "Tiingo batch download failed, retrying",
-                attempt=attempt + 1,
-                wait=wait,
-                error=str(e),
-            )
-            if attempt == MAX_RETRIES - 1:
-                logger.error("Tiingo batch download exhausted retries")
-                return {"blocks_updated": 0, "rows_upserted": 0, "stale_blocks": [], "skipped_tickers": unique_tickers}
-            await asyncio.sleep(wait)
+
+        hist = await _tiingo_gate.call(
+            op_key=f"benchmark:{','.join(sorted(unique_tickers))}",
+            coro_factory=_tiingo_coro,
+        )
+    except ProviderGateError as e:
+        logger.error(
+            "Tiingo batch download failed (gate)",
+            error=str(e),
+            tickers=unique_tickers,
+        )
+        return {"blocks_updated": 0, "rows_upserted": 0, "stale_blocks": [], "skipped_tickers": unique_tickers}
 
     if hist is None or not hist:
         logger.error("No data returned from Tiingo batch download")

--- a/backend/app/domains/wealth/workers/strategy_reclassification.py
+++ b/backend/app/domains/wealth/workers/strategy_reclassification.py
@@ -442,13 +442,13 @@ async def _read_esma_funds(
         text(
             f"""
             SELECT
-                isin                 AS pk,
+                lei                  AS pk,
                 fund_name,
                 fund_type,
                 strategy_label       AS current_label
             FROM esma_funds
             WHERE is_institutional = true
-            ORDER BY isin
+            ORDER BY lei
             {limit_clause}
             """,
         ),

--- a/backend/tests/test_q102_c10_benchmark_gate.py
+++ b/backend/tests/test_q102_c10_benchmark_gate.py
@@ -1,0 +1,66 @@
+"""C-10: benchmark_ingest must use ExternalProviderGate, not manual retry.
+
+Tests that:
+- A Tiingo timeout returns a degraded marker (skipped_tickers) instead of raising.
+- The gate module-level instance exists and has correct config.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.runtime.provider_gate import ProviderGateError
+
+
+class TestBenchmarkIngestGate:
+    """Verify ExternalProviderGate is wired into benchmark_ingest."""
+
+    def test_gate_exists_with_correct_config(self):
+        from app.domains.wealth.workers.benchmark_ingest import _tiingo_gate
+
+        assert _tiingo_gate._cfg.name == "tiingo_benchmark"
+        assert _tiingo_gate._cfg.timeout_s == 60.0
+        assert _tiingo_gate._cfg.failure_threshold == 3
+        assert _tiingo_gate._cfg.recovery_after_s == 300.0
+
+    def test_manual_retry_constants_removed(self):
+        """MAX_RETRIES and BACKOFF_BASE should no longer exist."""
+        import app.domains.wealth.workers.benchmark_ingest as mod
+
+        assert not hasattr(mod, "MAX_RETRIES")
+        assert not hasattr(mod, "BACKOFF_BASE")
+
+    @pytest.mark.asyncio
+    async def test_tiingo_timeout_returns_degraded_not_raise(self):
+        """When the gate raises ProviderGateError (timeout/circuit open),
+        _do_ingest must return a degraded result with skipped_tickers,
+        NOT propagate the exception."""
+        from app.domains.wealth.workers.benchmark_ingest import _do_ingest
+
+        # Create mock blocks
+        block = MagicMock()
+        block.block_id = "us_equity"
+        block.benchmark_ticker = "SPY"
+        block.is_active = True
+
+        mock_db = AsyncMock()
+        blocks_result = MagicMock()
+        blocks_result.scalars.return_value.all.return_value = [block]
+        mock_db.execute.return_value = blocks_result
+
+        # Patch the gate to raise ProviderGateError (simulates timeout)
+        with patch(
+            "app.domains.wealth.workers.benchmark_ingest._tiingo_gate"
+        ) as mock_gate:
+            mock_gate.call = AsyncMock(
+                side_effect=ProviderGateError("provider 'tiingo_benchmark' timed out after 60.0s"),
+            )
+
+            result = await _do_ingest(mock_db, lookback_days=30)
+
+        # Must return degraded result, not raise
+        assert result["blocks_updated"] == 0
+        assert result["rows_upserted"] == 0
+        assert "SPY" in result["skipped_tickers"]

--- a/backend/tests/test_q102_c11_universe_audit_atomicity.py
+++ b/backend/tests/test_q102_c11_universe_audit_atomicity.py
@@ -1,0 +1,137 @@
+"""C-11: approve_fund / reject_fund must keep mutation + audit in one transaction.
+
+Tests that:
+- If the audit event write fails (flush raises), the approval mutation is
+  rolled back too (single transaction guarantee).
+- Both approve and reject routes use the same pattern.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestApproveRejectAuditAtomicity:
+    """Verify mutation + audit are in the same sync session transaction."""
+
+    @pytest.mark.asyncio
+    async def test_approve_rolls_back_on_audit_failure(self):
+        """When audit event flush raises, the entire transaction (including
+        the approval mutation) must roll back — no orphan state change."""
+        from app.domains.wealth.routes.universe import approve_fund
+
+        instrument_id = uuid.uuid4()
+        org_id = str(uuid.uuid4())
+        actor_id = "test-actor-123"
+
+        body = MagicMock()
+        body.decision = "approved"
+        body.rationale = "Looks good"
+
+        actor = MagicMock()
+        actor.actor_id = actor_id
+        actor.has_role = MagicMock(return_value=True)
+
+        db = MagicMock()  # async session (unused in new pattern)
+        user = MagicMock()
+
+        # Build a fake approval ORM object
+        fake_approval = MagicMock()
+        fake_approval.id = uuid.uuid4()
+        fake_approval.instrument_id = instrument_id
+        fake_approval.organization_id = org_id
+        fake_approval.is_current = True
+        fake_approval.decision = "pending"
+
+        fake_updated = MagicMock()
+        fake_updated.id = fake_approval.id
+        fake_updated.instrument_id = instrument_id
+        fake_updated.organization_id = org_id
+        fake_updated.decision = "approved"
+        fake_updated.rationale = "Looks good"
+        fake_updated.decided_by = actor_id
+        fake_updated.is_current = True
+        fake_updated.decided_at = None
+        fake_updated.submitted_by = "someone"
+        fake_updated.created_at = None
+        fake_updated.updated_at = None
+
+        flush_called = False
+        flush_error = RuntimeError("Simulated audit flush failure")
+
+        def _mock_flush():
+            nonlocal flush_called
+            flush_called = True
+            raise flush_error
+
+        with patch("app.core.db.session.sync_session_factory") as mock_factory, \
+             patch("vertical_engines.wealth.asset_universe.UniverseService") as MockSvc:
+
+            mock_sync_db = MagicMock()
+            mock_sync_db.expire_on_commit = False
+
+            # Make the context manager work
+            mock_ctx = MagicMock()
+            mock_ctx.__enter__ = MagicMock(return_value=mock_sync_db)
+            mock_ctx.__exit__ = MagicMock(return_value=False)
+            mock_factory.return_value = mock_ctx
+
+            # Mock begin() context manager
+            mock_begin = MagicMock()
+            mock_begin.__enter__ = MagicMock(return_value=None)
+            mock_begin.__exit__ = MagicMock(return_value=False)
+            mock_sync_db.begin.return_value = mock_begin
+
+            # Mock the SELECT query result
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = fake_approval
+            mock_sync_db.execute.return_value = mock_result
+
+            # Mock svc.approve_fund
+            mock_svc = MockSvc.return_value
+            mock_svc.approve_fund.return_value = fake_updated
+
+            # Make flush raise to simulate audit failure
+            mock_sync_db.flush.side_effect = flush_error
+
+            # The route should propagate the error (the context manager
+            # __exit__ sees the exception and rolls back the transaction)
+            with pytest.raises(RuntimeError, match="Simulated audit flush failure"):
+                await approve_fund(
+                    instrument_id=instrument_id,
+                    body=body,
+                    db=db,
+                    user=user,
+                    actor=actor,
+                    org_id=org_id,
+                )
+
+            # Verify that flush was called (audit event was attempted)
+            assert mock_sync_db.flush.called
+            # Verify the begin context's __exit__ was called (transaction cleanup)
+            assert mock_begin.__exit__.called
+
+    def test_approve_and_reject_both_use_sync_audit(self):
+        """Both approve_fund and reject_fund must create AuditEvent in the
+        sync session (not via async write_audit_event after to_thread)."""
+        import inspect
+
+        from app.domains.wealth.routes import universe
+
+        approve_src = inspect.getsource(universe.approve_fund)
+        reject_src = inspect.getsource(universe.reject_fund)
+
+        # The old pattern was: await write_audit_event(db, ...) after to_thread.
+        # The new pattern creates AuditEvent directly in the sync block.
+        for name, src in [("approve", approve_src), ("reject", reject_src)]:
+            # Must NOT have "await write_audit_event" after to_thread
+            # (The async write_audit_event should not be called for these routes)
+            assert "sync_db.add(AuditEvent(" in src, (
+                f"{name}_fund must create AuditEvent in the sync session"
+            )
+            assert "sync_db.flush()" in src, (
+                f"{name}_fund must flush the audit event in the sync session"
+            )

--- a/backend/tests/test_q102_c12_catalog_strict_params.py
+++ b/backend/tests/test_q102_c12_catalog_strict_params.py
@@ -1,0 +1,104 @@
+"""C-12: GET /catalog rejects unknown query params with 422.
+
+Tests that:
+- Unknown query params on /catalog, /catalog/managers, /catalog/facets
+  return HTTP 422 instead of being silently ignored.
+- Known params still pass validation.
+- Whitelist tuples match the route signatures.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.tenancy.middleware import get_db_with_rls
+
+
+def _make_test_app() -> FastAPI:
+    """Create a minimal app with just the screener router.
+
+    Overrides get_db_with_rls so auth/DB is not needed.
+    The _strict_query_params dependency runs before any DB query,
+    so we can test parameter validation in isolation.
+    """
+    from app.domains.wealth.routes.screener import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    # Override DB dependency — return a mock session
+    app.dependency_overrides[get_db_with_rls] = lambda: AsyncMock()
+
+    return app
+
+
+class TestCatalogStrictQueryParams:
+    """Verify _strict_query_params rejects unknown params."""
+
+    @pytest.mark.asyncio
+    async def test_catalog_unknown_param_returns_422(self):
+        app = _make_test_app()
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/screener/catalog?unknown_param=1")
+        assert resp.status_code == 422
+        assert "unknown_param" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_catalog_managers_unknown_param_returns_422(self):
+        app = _make_test_app()
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/screener/catalog/managers?bogus=true")
+        assert resp.status_code == 422
+        assert "bogus" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_catalog_facets_unknown_param_returns_422(self):
+        app = _make_test_app()
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/screener/catalog/facets?not_a_param=42")
+        assert resp.status_code == 422
+        assert "not_a_param" in resp.json()["detail"]
+
+    def test_param_whitelists_match_route_signatures(self):
+        """Sanity check: every param in the whitelist must exist as a
+        Query() parameter in the corresponding route function."""
+        import inspect
+
+        from app.domains.wealth.routes.screener import (
+            _CATALOG_PARAMS,
+            _FACETS_PARAMS,
+            _MANAGERS_PARAMS,
+            get_catalog,
+            get_catalog_facets,
+            get_catalog_managers,
+        )
+
+        for params, fn in [
+            (_CATALOG_PARAMS, get_catalog),
+            (_MANAGERS_PARAMS, get_catalog_managers),
+            (_FACETS_PARAMS, get_catalog_facets),
+        ]:
+            sig = inspect.signature(fn)
+            sig_params = {
+                name
+                for name, p in sig.parameters.items()
+                if not name.startswith("_") and name != "db"
+            }
+            whitelist = set(params)
+            missing = whitelist - sig_params
+            assert not missing, (
+                f"{fn.__name__}: whitelist has params not in signature: {missing}"
+            )

--- a/backend/tests/test_q102_c14_esma_lei_fix.py
+++ b/backend/tests/test_q102_c14_esma_lei_fix.py
@@ -1,0 +1,81 @@
+"""C-14: strategy_reclassification _read_esma_funds must use lei, not isin.
+
+Tests that:
+- The SQL in _read_esma_funds references esma_funds.lei (post-Q11B PK),
+  not the pre-Q11B isin column.
+- The reader yields _FundRow with source_pk from the lei column.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from app.domains.wealth.workers.strategy_reclassification import (
+    _read_esma_funds,
+)
+
+
+class TestEsmaFundsLeiReference:
+    """Verify _read_esma_funds references lei after Q11B migration."""
+
+    def test_sql_uses_lei_not_isin(self):
+        """The SQL text in _read_esma_funds must SELECT lei, not isin."""
+        source = inspect.getsource(_read_esma_funds)
+
+        # Must reference lei
+        assert "lei" in source, (
+            "_read_esma_funds must SELECT lei (post-Q11B PK)"
+        )
+
+        # Must NOT reference isin as a column (the old broken reference)
+        # We check for the specific SQL pattern "isin AS pk" or "ORDER BY isin"
+        assert "isin" not in source.lower(), (
+            "_read_esma_funds must not reference isin — "
+            "Q11B renamed it to legacy_isin_misnamed and changed PK to lei"
+        )
+
+    def test_reader_in_dispatch_table(self):
+        """_read_esma_funds must be wired in the source dispatch table."""
+        from app.domains.wealth.workers.strategy_reclassification import (
+            _reader_for_source,
+        )
+
+        reader = _reader_for_source("esma_funds")
+        assert reader is _read_esma_funds
+
+    @pytest.mark.asyncio
+    async def test_reader_yields_fund_row_with_lei_pk(self):
+        """When given a mock DB that returns a row, the reader must
+        populate source_pk from the 'pk' column (which is lei)."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        mock_db = AsyncMock()
+        # Simulate a single row returned by the SQL query
+        mock_mapping = {
+            "pk": "529900ABC123DEF456GH",  # LEI format (20 chars)
+            "fund_name": "Test UCITS Fund",
+            "fund_type": "UCITS",
+            "current_label": "Long/Short Equity",
+        }
+        mock_result = MagicMock()
+        mock_result.mappings.return_value.all.return_value = [mock_mapping]
+        mock_db.execute.return_value = mock_result
+
+        rows = []
+        async for row in _read_esma_funds(mock_db, limit=5):
+            rows.append(row)
+
+        assert len(rows) == 1
+        assert rows[0].source_table == "esma_funds"
+        assert rows[0].source_pk == "529900ABC123DEF456GH"
+        assert rows[0].fund_name == "Test UCITS Fund"
+        assert rows[0].fund_type == "UCITS"
+        assert rows[0].current_strategy_label == "Long/Short Equity"
+        assert rows[0].tiingo_description is None
+
+        # Verify the SQL sent to DB references lei
+        sql_arg = str(mock_db.execute.call_args[0][0])
+        assert "lei" in sql_arg.lower()
+        assert "isin" not in sql_arg.lower()


### PR DESCRIPTION
## Summary

Batched remediation for 4 accepted Wave 6 Session 09 Med-severity findings. Each fix is a separate commit within this PR.

- **C-10** — `benchmark_ingest` now uses `ExternalProviderGate` (circuit breaker + 60s hard timeout) instead of a manual retry loop with unbounded backoff. Mirrors the `esma_aum_sync.py` pattern per Charter §3. On gate error, returns degraded result (skipped_tickers) instead of raising.
- **C-11** — `approve_fund` / `reject_fund` no longer split mutation + audit across two transactions. AuditEvent is now created in the same sync session as the approval mutation via `sync_db.add(AuditEvent(...))` + `sync_db.flush()`. If audit write fails, the mutation rolls back atomically.
- **C-12** — `GET /catalog`, `/catalog/managers`, `/catalog/facets` now reject unknown query parameters with HTTP 422 via a `_strict_query_params` dependency. Each route has a declared whitelist tuple validated against the route signature in tests.
- **C-14** — `_read_esma_funds` in `strategy_reclassification` now references `esma_funds.lei` (post-Q11B PK) instead of the pre-Q11B `isin` column which was renamed to `legacy_isin_misnamed` in migration 0182.

## Test plan

- [x] C-10: `test_q102_c10_benchmark_gate.py` — gate config validation, manual retry constants removed, timeout returns degraded marker
- [x] C-11: `test_q102_c11_universe_audit_atomicity.py` — audit failure rolls back approval, both routes use sync AuditEvent pattern
- [x] C-12: `test_q102_c12_catalog_strict_params.py` — unknown params return 422 on all 3 routes, whitelist matches route signatures
- [x] C-14: `test_q102_c14_esma_lei_fix.py` — SQL uses lei not isin, reader yields correct FundRow, dispatch table wiring
- [x] All 20 existing `test_benchmark_ingest.py` tests still pass
- [x] All 48 existing `test_catalog.py` tests still pass
- [x] All 22 existing `test_apply_strategy_reclassification_cli.py` tests still pass
- [x] `ruff check` passes on all 4 modified source files

Generated with [Claude Code](https://claude.com/claude-code)