### PR TITLE
chore(wealth): PR-Q103 — sweep org_id: str annotation lies (Low cleanup)

### DIFF
--- a/backend/app/domains/wealth/routes/analytics.py
+++ b/backend/app/domains/wealth/routes/analytics.py
@@ -136,7 +136,7 @@ async def create_backtest(
     body: BacktestRequest,
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> BacktestRunRead:
     _validate_profile(body.profile)
 

--- a/backend/app/domains/wealth/routes/content.py
+++ b/backend/app/domains/wealth/routes/content.py
@@ -78,7 +78,7 @@ async def trigger_outlook(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> ContentSummary:
     """Trigger async Investment Outlook generation."""
     _require_feature()
@@ -128,7 +128,7 @@ async def trigger_flash_report(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> ContentSummary:
     """Trigger async Flash Report generation."""
     _require_feature()
@@ -180,7 +180,7 @@ async def trigger_spotlight(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> ContentSummary:
     """Trigger async Manager Spotlight generation."""
     _require_feature()
@@ -349,7 +349,7 @@ async def stream_content_generation(
     job_id: str,
     request: Request,
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ):
     """SSE stream for content generation progress."""
     _require_feature()

--- a/backend/app/domains/wealth/routes/dd_reports.py
+++ b/backend/app/domains/wealth/routes/dd_reports.py
@@ -250,7 +250,7 @@ async def trigger_dd_report(
     body: DDReportCreate | None = None,
     db: AsyncSession = Depends(get_db_with_rls),
     actor: Actor = Depends(require_role(Role.INVESTMENT_TEAM)),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> DDReportSummary:
     """Trigger async DD Report generation.
 
@@ -441,7 +441,7 @@ async def regenerate_dd_report(
     body: DDReportRegenerate | None = None,
     db: AsyncSession = Depends(get_db_with_rls),
     actor: Actor = Depends(require_role(Role.INVESTMENT_TEAM)),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> DDReportSummary:
     """Force regeneration of specific chapters or entire report."""
     result = await db.execute(
@@ -728,7 +728,7 @@ async def stream_dd_report(
     report_id: uuid.UUID,
     request: Request,
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> Any:
     """SSE stream providing real-time DD Report generation progress.
 

--- a/backend/app/domains/wealth/routes/fact_sheets.py
+++ b/backend/app/domains/wealth/routes/fact_sheets.py
@@ -61,7 +61,7 @@ async def generate_fact_sheet(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> dict[str, Any]:
     """Trigger on-demand fact-sheet generation.
 
@@ -127,9 +127,9 @@ async def generate_fact_sheet(
 
                 fact_job_id = f"fs-{portfolio_id}-{uuid.uuid4().hex[:8]}"
                 async with async_session_factory() as record_db:
-                    await set_rls_context(record_db, uuid.UUID(str(org_id)))
+                    await set_rls_context(record_db, org_id)
                     report_record = WealthGeneratedReport(
-                        organization_id=uuid.UUID(str(org_id)),
+                        organization_id=org_id,
                         portfolio_id=portfolio_id,
                         report_type="fact_sheet",
                         job_id=fact_job_id,
@@ -156,7 +156,7 @@ async def list_fact_sheets(
     portfolio_id: uuid.UUID,
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> dict[str, Any]:
     """List available fact-sheet PDFs for a portfolio."""
     _require_feature()
@@ -203,7 +203,7 @@ async def download_dd_report_pdf(
     language: Literal["pt", "en"] = Query(default="pt", description="PDF language"),
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> Response:
     """Generate and download a DD Report as PDF."""
     from sqlalchemy.orm import selectinload
@@ -308,7 +308,7 @@ async def download_dd_report_pdf(
 async def download_fact_sheet(
     fact_sheet_path: str,
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> Response:
     """Download a fact-sheet PDF by storage path."""
     _require_feature()

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -100,7 +100,7 @@ logger = structlog.get_logger()
 
 
 async def _resolve_approval_policy(
-    db: AsyncSession, org_id: str | uuid.UUID,
+    db: AsyncSession, org_id: uuid.UUID,
 ) -> ApprovalPolicy:
     """Resolve the org's approval policy from ConfigService.
 
@@ -111,7 +111,7 @@ async def _resolve_approval_policy(
     try:
         result = await ConfigService(db).get(
             "wealth", "approval_policy",
-            org_id=uuid.UUID(str(org_id)) if not isinstance(org_id, uuid.UUID) else org_id,
+            org_id=org_id,
         )
         cfg = result.value or {}
         return ApprovalPolicy(
@@ -200,7 +200,7 @@ async def create_model_portfolio(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> ModelPortfolioRead:
     """Create a new model portfolio (Phase 5 Task 5.1).
 
@@ -218,8 +218,6 @@ async def create_model_portfolio(
     (the source must belong to the same org — RLS guarantees that).
     """
     _require_ic_role(actor)
-
-    org_uuid = uuid.UUID(str(org_id))
 
     # Optional clone source — fetch first so a 404 happens before any
     # writes hit the DB.
@@ -243,7 +241,7 @@ async def create_model_portfolio(
         source_calibration = src_cal.scalar_one_or_none()
 
     portfolio = ModelPortfolio(
-        organization_id=org_uuid,
+        organization_id=org_id,
         profile=body.profile,
         display_name=body.display_name,
         description=body.description,
@@ -272,7 +270,7 @@ async def create_model_portfolio(
         default_cvar_limit_for_profile,
     )
     calibration = PortfolioCalibration(
-        organization_id=org_uuid,
+        organization_id=org_id,
         portfolio_id=portfolio.id,
         updated_by=actor.actor_id,
         cvar_limit=default_cvar_limit_for_profile(portfolio.profile),
@@ -320,7 +318,7 @@ async def create_model_portfolio(
 async def list_model_portfolios(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> list[ModelPortfolioRead]:
     """List all model portfolios for the organization.
 
@@ -425,7 +423,7 @@ async def apply_portfolio_transition(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> ModelPortfolioRead:
     """Single dispatcher for all state-machine actions (DL3).
 
@@ -584,7 +582,7 @@ async def construct_portfolio(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> ConstructRunAccepted:
     """Kick off an enriched construction run via the Job-or-Stream pattern.
 
@@ -707,7 +705,7 @@ _ADVANCED_FIELDS: tuple[str, ...] = (
 async def _ensure_calibration(
     db: AsyncSession,
     portfolio_id: uuid.UUID,
-    organization_id: uuid.UUID | str,
+    organization_id: uuid.UUID,
     profile: str | None = None,
 ) -> PortfolioCalibration:
     """Fetch-or-create the ``portfolio_calibration`` row for a portfolio.
@@ -733,16 +731,11 @@ async def _ensure_calibration(
     if row is not None:
         return row
 
-    org_uuid = (
-        organization_id
-        if isinstance(organization_id, uuid.UUID)
-        else uuid.UUID(str(organization_id))
-    )
     from app.domains.wealth.models.model_portfolio import (
         default_cvar_limit_for_profile,
     )
     row = PortfolioCalibration(
-        organization_id=org_uuid,
+        organization_id=organization_id,
         portfolio_id=portfolio_id,
         cvar_limit=default_cvar_limit_for_profile(profile),
     )
@@ -761,7 +754,7 @@ async def get_portfolio_calibration(
     portfolio_id: uuid.UUID,
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> PortfolioCalibrationRead:
     """Read the Builder CalibrationPanel state for a portfolio.
 
@@ -794,7 +787,7 @@ async def update_portfolio_calibration(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> PortfolioCalibrationRead:
     """Persist the Builder CalibrationPanel Apply action.
 
@@ -1212,7 +1205,7 @@ async def get_construction_advice(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> ConstructionAdviceRead:
     """Analyze block coverage gaps and recommend candidate funds.
 
@@ -3457,7 +3450,7 @@ async def list_portfolio_reports(
     limit: int = Query(default=50, ge=1, le=200),
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> dict[str, Any]:
     """Unified report history for a portfolio.
 
@@ -3519,7 +3512,7 @@ async def generate_portfolio_report(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> dict[str, Any]:
     """Unified report generation trigger.
 
@@ -3594,7 +3587,7 @@ async def stream_report_progress(
     job_id: str,
     request: Request,
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> Any:
     """Subscribe to SSE events for a report generation job."""
     from app.core.jobs.sse import create_job_stream
@@ -4860,7 +4853,7 @@ async def propose_allocation(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> JobCreatedResponse:
     """Kick off a propose-mode construction run.
 
@@ -4931,7 +4924,7 @@ async def latest_proposal(
     profile: str,
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> LatestProposalResponse:
     """Return the latest ``run_mode='propose'`` run for the profile.
 
@@ -5056,7 +5049,7 @@ async def approve_proposal(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> ApprovalResponse:
     """Approve a propose run for the given profile.
 
@@ -5137,7 +5130,6 @@ async def approve_proposal(
     raw_proposed_bands = telemetry.get("proposed_bands") or []
     proposal_metrics = telemetry.get("proposal_metrics") or {}
     approver = actor.actor_id
-    org_uuid = uuid.UUID(str(org_id))
     now_ts = await db.scalar(_sa_text("SELECT now()"))
 
     # Update strategic_allocation only when the run carries band data
@@ -5177,7 +5169,7 @@ async def approve_proposal(
                 "run_id": run_id,
                 "ts": now_ts,
                 "approver": approver[:100],
-                "org": org_uuid,
+                "org": org_id,
                 "profile": profile_lc,
                 "block_id": bid,
             },
@@ -5196,7 +5188,7 @@ async def approve_proposal(
                AND superseded_at IS NULL
             """
         ),
-        {"ts": now_ts, "org": org_uuid, "profile": profile_lc},
+        {"ts": now_ts, "org": org_id, "profile": profile_lc},
     )
 
     approval_id = uuid.uuid4()
@@ -5216,7 +5208,7 @@ async def approve_proposal(
         {
             "id": approval_id,
             "run_id": run_id,
-            "org": org_uuid,
+            "org": org_id,
             "profile": profile_lc,
             "approver": approver,
             "ts": now_ts,
@@ -5263,7 +5255,7 @@ async def approve_proposal(
     return ApprovalResponse(
         approval_id=approval_id,
         run_id=run_id,
-        organization_id=org_uuid,
+        organization_id=org_id,
         profile=profile_lc,
         approved_at=now_ts,
         approved_by=approver,
@@ -5289,7 +5281,7 @@ async def set_override(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> StrategicAllocationRow:
     """Set or clear override_min/override_max on one block.
 
@@ -5348,7 +5340,7 @@ async def set_override(
             "omin": body.override_min,
             "omax": body.override_max,
             "rationale": body.rationale,
-            "org": uuid.UUID(str(org_id)),
+            "org": org_id,
             "profile": profile_lc,
             "block_id": body.block_id,
         },
@@ -5410,7 +5402,7 @@ async def get_strategic_allocation(
     profile: str,
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> StrategicAllocationResponse:
     """Return every canonical ``strategic_allocation`` row for the profile.
 
@@ -5441,8 +5433,6 @@ async def get_strategic_allocation(
             ),
         )
 
-    org_uuid = uuid.UUID(str(org_id))
-
     rows_stmt = _sa_text(
         """
         SELECT block_id, target_weight, drift_min, drift_max,
@@ -5455,7 +5445,7 @@ async def get_strategic_allocation(
     )
     result = await db.execute(
         rows_stmt,
-        {"org": org_uuid, "profile": profile_lc},
+        {"org": org_id, "profile": profile_lc},
     )
     by_block: dict[str, dict[str, Any]] = {
         str(r["block_id"]): dict(r) for r in result.mappings().all()
@@ -5552,7 +5542,7 @@ async def get_strategic_allocation(
         cvar_limit = float(cvar_raw)
 
     return StrategicAllocationResponse(
-        organization_id=org_uuid,
+        organization_id=org_id,
         profile=profile_lc,
         cvar_limit=cvar_limit,
         has_active_approval=has_active_approval,
@@ -5573,7 +5563,7 @@ async def get_approval_history(
     profile: str,
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
     limit: int = Query(10, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ) -> ApprovalHistoryResponse:
@@ -5596,8 +5586,6 @@ async def get_approval_history(
             ),
         )
 
-    org_uuid = uuid.UUID(str(org_id))
-
     total_stmt = _sa_text(
         """
         SELECT COUNT(*) AS n
@@ -5607,7 +5595,7 @@ async def get_approval_history(
         """
     )
     total = int(
-        (await db.execute(total_stmt, {"org": org_uuid, "profile": profile_lc}))
+        (await db.execute(total_stmt, {"org": org_id, "profile": profile_lc}))
         .scalar_one()
     )
 
@@ -5626,7 +5614,7 @@ async def get_approval_history(
     result = await db.execute(
         rows_stmt,
         {
-            "org": org_uuid,
+            "org": org_id,
             "profile": profile_lc,
             "limit": limit,
             "offset": offset,
@@ -5659,7 +5647,7 @@ async def get_approval_history(
     ]
 
     return ApprovalHistoryResponse(
-        organization_id=org_uuid,
+        organization_id=org_id,
         profile=profile_lc,
         total=total,
         entries=entries,

--- a/backend/app/domains/wealth/routes/monitoring.py
+++ b/backend/app/domains/wealth/routes/monitoring.py
@@ -32,7 +32,7 @@ router = APIRouter(prefix="/monitoring", tags=["monitoring"])
 )
 async def get_monitoring_alerts(
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> AlertBatchRead:
     """Return monitoring alerts for the current organization.
 

--- a/backend/app/domains/wealth/routes/portfolio_views.py
+++ b/backend/app/domains/wealth/routes/portfolio_views.py
@@ -67,7 +67,7 @@ async def create_view(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> PortfolioViewRead:
     _require_ic_role(actor)
     await _get_portfolio_or_404(db, portfolio_id)

--- a/backend/app/domains/wealth/routes/rebalancing.py
+++ b/backend/app/domains/wealth/routes/rebalancing.py
@@ -59,7 +59,7 @@ async def apply_rebalance_proposal(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> PortfolioSnapshotRead:
     """Apply a pending rebalance proposal.
 

--- a/backend/app/domains/wealth/routes/research.py
+++ b/backend/app/domains/wealth/routes/research.py
@@ -255,8 +255,7 @@ async def _load_style_bias_payload(
     )
 
 
-def _latest_risk_row_stmt(org_id: uuid.UUID | str | None):
-    org_uuid = org_id if isinstance(org_id, uuid.UUID) else uuid.UUID(str(org_id))
+def _latest_risk_row_stmt(org_id: uuid.UUID):
     base = (
         select(
             FundRiskMetrics.instrument_id,
@@ -268,7 +267,7 @@ def _latest_risk_row_stmt(org_id: uuid.UUID | str | None):
             func.row_number().over(
                 partition_by=FundRiskMetrics.instrument_id,
                 order_by=(
-                    case((FundRiskMetrics.organization_id == org_uuid, 0), else_=1),
+                    case((FundRiskMetrics.organization_id == org_id, 0), else_=1),
                     FundRiskMetrics.calc_date.desc(),
                 ),
             ).label("rn"),
@@ -276,7 +275,7 @@ def _latest_risk_row_stmt(org_id: uuid.UUID | str | None):
         .where(
             or_(
                 FundRiskMetrics.organization_id.is_(None),
-                FundRiskMetrics.organization_id == org_uuid,
+                FundRiskMetrics.organization_id == org_id,
             ),
         )
     )
@@ -331,7 +330,7 @@ async def get_research_scatter(
     limit: int = Query(default=80, ge=2, le=200),
     approved_only: bool = Query(default=True),
     db: AsyncSession = Depends(get_db_with_rls),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
     user: CurrentUser = Depends(get_current_user),
 ) -> ResearchScatterResponse:
     risk_sq = _latest_risk_row_stmt(org_id).subquery()

--- a/backend/app/domains/wealth/routes/screener.py
+++ b/backend/app/domains/wealth/routes/screener.py
@@ -2865,7 +2865,7 @@ async def fast_track_approval(
     body: FastTrackRequest,
     db: AsyncSession = Depends(get_db_with_rls),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> FastTrackResult:
     """Approve liquid/regulated instruments directly to the universe.
 

--- a/backend/app/domains/wealth/routes/search.py
+++ b/backend/app/domains/wealth/routes/search.py
@@ -182,7 +182,7 @@ async def global_search(
     categories: str = Query("funds,managers,documents", description="Comma-separated categories"),
     db: AsyncSession = Depends(get_db_with_rls),
     _user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> GlobalSearchResponse:
     """Fan-out search across funds, managers, and documents."""
     cats = {c.strip() for c in categories.split(",") if c.strip() in VALID_CATEGORIES}

--- a/backend/app/domains/wealth/routes/universe.py
+++ b/backend/app/domains/wealth/routes/universe.py
@@ -152,7 +152,7 @@ async def list_universe(
     ),
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> list[UniverseAssetRead]:
     """List all approved and active funds in the investment universe.
 
@@ -322,7 +322,7 @@ async def list_universe(
 async def list_pending_approvals(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> list[UniverseApprovalRead]:
     """List all pending approval requests for the organization.
 
@@ -387,7 +387,7 @@ async def approve_fund(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> UniverseApprovalRead:
     """Approve or watchlist a fund for the investment universe.
 
@@ -479,7 +479,7 @@ async def reject_fund(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
-    org_id: str = Depends(get_org_id),
+    org_id: uuid.UUID = Depends(get_org_id),
 ) -> UniverseApprovalRead:
     """Reject a fund from the investment universe.
 

--- a/backend/tests/static/test_no_org_id_str_annotation.py
+++ b/backend/tests/static/test_no_org_id_str_annotation.py
@@ -1,0 +1,41 @@
+import ast
+from pathlib import Path
+
+
+def _has_depends_get_org_id(default_node: ast.AST | None) -> bool:
+    """Return True if the default is ``Depends(get_org_id)``."""
+    if default_node is None:
+        return False
+    if not isinstance(default_node, ast.Call):
+        return False
+    func = default_node.func
+    if isinstance(func, ast.Name) and func.id == "Depends":
+        if default_node.args and isinstance(default_node.args[0], ast.Name):
+            return default_node.args[0].id == "get_org_id"
+    return False
+
+
+def test_no_org_id_str_lying_annotation():
+    """Static check: no route handler annotates ``org_id: str = Depends(get_org_id)``."""
+    offenders: list[str] = []
+    for path in Path("backend/app/domains").rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            all_args = node.args.args + node.args.kwonlyargs
+            defaults_offset = len(node.args.args) - len(node.args.defaults)
+            all_defaults: list[ast.AST | None] = (
+                [None] * defaults_offset + list(node.args.defaults)
+                + list(node.args.kw_defaults)
+            )
+            for arg, default in zip(all_args, all_defaults, strict=False):
+                if arg.arg != "org_id":
+                    continue
+                if not _has_depends_get_org_id(default):
+                    continue
+                if arg.annotation:
+                    ann = ast.unparse(arg.annotation)
+                    if ann == "str":
+                        offenders.append(f"{path}:{arg.lineno}")
+    assert not offenders, f"org_id: str = Depends(get_org_id) annotation lies remain: {offenders}"


### PR DESCRIPTION
## Wave 6 Session 09 — Finding C-15 (Low, CONFIRMED)

**Jury verdict (GPT-5.5, 2026-04-28):**
> \`get_org_id\` returns \`uuid.UUID | None\` at \`middleware.py:38-40\`, while \`rg\` finds many route parameters annotated \`org_id: str = Depends(get_org_id)\` across many \`model_portfolios.py\` sites and other files. **Most of these pass the value through or stringify defensively, so this is not the same as C-03's current crash sites. Per institutional convention, an annotation lie without current runtime impact is a footgun, and Low matches the Stage 1 rating.**

## Severity rationale

§3.3 institutional convention — annotation lie without current runtime impact is a footgun. PR-Q96 already fixed the 5 crash sites; this PR cleans up the remaining 30+ footgun sites before they trip a future maintainer.

## Implementation

- Bulk annotation rename: \`org_id: str = Depends(get_org_id)\` → \`org_id: uuid.UUID = Depends(get_org_id)\`
- Where bodies had defensive \`uuid.UUID(str(org_id))\` casts, simplified to direct usage
- Static AST test added to prevent regression

## Stage 4 reminder

Codex Auto Review will trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)