### PR TITLE
fix(wealth): PR-Q105 — Codex P1+P2 — Q91 migration downgrade path defects

### DIFF
--- a/backend/app/core/db/migrations/versions/0194_q91_ucits_data_gate.py
+++ b/backend/app/core/db/migrations/versions/0194_q91_ucits_data_gate.py
@@ -345,7 +345,9 @@ ORDER BY external_id, aum_usd DESC NULLS LAST;
 """
 
 
-# Down: restore 0183 view (legacy_isin_misnamed-based UCITS branch).
+# Down: restore full 0183 view (all 6 branches, pre-Q91 UCITS shape).
+# Q105 fix — Codex P1: original _MV_SQL_DOWN only had the UCITS branch,
+# which would silently strip 5 of 6 universe branches on rollback.
 _MV_SQL_DOWN = """
 CREATE MATERIALIZED VIEW mv_unified_funds AS
 SELECT DISTINCT ON (external_id) * FROM (
@@ -382,12 +384,180 @@ SELECT DISTINCT ON (external_id) * FROM (
             UNION SELECT DISTINCT COALESCE(strategy_label, fund_name) FROM esma_funds
         ) t
     )
+    -- Branch 1: registered_us
+    SELECT
+        'registered_us'::text as universe,
+        COALESCE(fc.class_id, fc.series_id, rf.cik)::text as external_id,
+        COALESCE(fc.series_name, rf.fund_name)::text as name,
+        COALESCE(fc.ticker, rf.ticker)::text as ticker,
+        rf.isin::text as isin,
+        'US'::text as region,
+        rf.fund_type::text as fund_type,
+        rf.strategy_label::text as strategy_label,
+        COALESCE(NULLIF(rf.total_assets, 0), fc.net_assets, rf.monthly_avg_net_assets)::numeric as aum_usd,
+        rf.currency::text as currency,
+        rf.domicile::text as domicile,
+        COALESCE(m.firm_name, rf.fund_name)::text as manager_name,
+        CASE WHEN m.crd_number IS NOT NULL THEN m.crd_number ELSE NULL END::text as manager_id,
+        rf.inception_date as inception_date,
+        rf.total_shareholder_accounts as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        fc.series_id as series_id,
+        fc.series_name as series_name,
+        fc.class_id as class_id,
+        fc.class_name as class_name,
+        (rf.last_nport_date IS NOT NULL) as has_holdings,
+        (COALESCE(fc.ticker, rf.ticker) IS NOT NULL) as has_nav,
+        EXISTS (
+            SELECT 1 FROM sec_13f_holdings h
+            JOIN sec_managers sm ON sm.cik = h.cik
+            WHERE sm.crd_number = rf.crd_number
+            AND h.report_date >= CURRENT_DATE - INTERVAL '180 days'
+        ) as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(rf.strategy_label, rf.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        ps.expense_ratio_pct,
+        ps.avg_annual_return_1y,
+        ps.avg_annual_return_10y,
+        rf.is_index,
+        rf.is_target_date,
+        rf.is_fund_of_fund,
+        rf.is_institutional
+    FROM sec_registered_funds rf
+    LEFT JOIN sec_fund_classes fc ON rf.cik = fc.cik
+    LEFT JOIN sec_managers m ON rf.crd_number = m.crd_number AND m.crd_number NOT LIKE 'cik_%%'
+    LEFT JOIN sec_fund_prospectus_stats ps ON fc.series_id = ps.series_id AND fc.class_id = ps.class_id
+    WHERE TRUE
+    AND NOT EXISTS (SELECT 1 FROM sec_etfs e WHERE e.series_id = COALESCE(fc.series_id, rf.series_id))
+    AND NOT EXISTS (SELECT 1 FROM sec_bdcs b WHERE b.series_id = COALESCE(fc.series_id, rf.series_id))
+    AND NOT EXISTS (SELECT 1 FROM sec_money_market_funds mmf WHERE mmf.series_id = COALESCE(fc.series_id, rf.series_id))
+
+    UNION ALL
+    -- Branch 2: ETFs
+    SELECT
+        'registered_us'::text as universe,
+        e.series_id::text as external_id,
+        e.fund_name::text as name,
+        e.ticker::text as ticker,
+        e.isin::text as isin,
+        'US'::text as region,
+        'etf'::text as fund_type,
+        e.strategy_label::text as strategy_label,
+        e.monthly_avg_net_assets as aum_usd,
+        e.currency::text as currency,
+        e.domicile::text as domicile,
+        NULL::text as manager_name,
+        NULL::text as manager_id,
+        e.inception_date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        TRUE as has_holdings,
+        (e.ticker IS NOT NULL) as has_nav,
+        FALSE as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(e.strategy_label, e.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        ps.expense_ratio_pct,
+        ps.avg_annual_return_1y,
+        ps.avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        e.is_institutional
+    FROM sec_etfs e
+    LEFT JOIN sec_fund_prospectus_stats ps ON e.series_id = ps.series_id
+
+    UNION ALL
+    -- Branch 3: BDCs
+    SELECT
+        'registered_us'::text as universe,
+        b.series_id::text as external_id,
+        b.fund_name::text as name,
+        b.ticker::text as ticker,
+        b.isin::text as isin,
+        'US'::text as region,
+        'bdc'::text as fund_type,
+        b.strategy_label::text as strategy_label,
+        b.monthly_avg_net_assets as aum_usd,
+        b.currency::text as currency,
+        b.domicile::text as domicile,
+        NULL::text as manager_name,
+        NULL::text as manager_id,
+        b.inception_date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        TRUE as has_holdings,
+        (b.ticker IS NOT NULL) as has_nav,
+        FALSE as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(b.strategy_label, b.fund_name) LIMIT 1) as investment_geography,
+        NULL::integer as vintage_year,
+        ps.expense_ratio_pct,
+        ps.avg_annual_return_1y,
+        ps.avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        b.is_institutional
+    FROM sec_bdcs b
+    LEFT JOIN sec_fund_prospectus_stats ps ON b.series_id = ps.series_id
+
+    UNION ALL
+    -- Branch 4: private_us
+    SELECT
+        'private_us'::text as universe,
+        mf.id::text as external_id,
+        mf.fund_name::text as name,
+        NULL::text as ticker,
+        NULL::text as isin,
+        'US'::text as region,
+        mf.fund_type::text as fund_type,
+        mf.strategy_label::text as strategy_label,
+        mf.gross_asset_value::numeric as aum_usd,
+        'USD'::text as currency,
+        'US'::text as domicile,
+        sm.firm_name::text as manager_name,
+        sm.crd_number::text as manager_id,
+        NULL::date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        mf.investor_count as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        FALSE as has_holdings,
+        FALSE as has_nav,
+        EXISTS (
+            SELECT 1 FROM sec_13f_holdings h
+            WHERE h.cik = sm.cik
+            AND h.report_date >= CURRENT_DATE - INTERVAL '180 days'
+        ) as has_13f_overlay,
+        (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(mf.strategy_label, mf.fund_name) LIMIT 1) as investment_geography,
+        mf.vintage_year as vintage_year,
+        NULL::numeric as expense_ratio_pct,
+        NULL::numeric as avg_annual_return_1y,
+        NULL::numeric as avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        mf.is_fund_of_funds as is_fund_of_fund,
+        mf.is_institutional
+    FROM sec_manager_funds mf
+    JOIN sec_managers sm ON mf.crd_number = sm.crd_number
+
+    UNION ALL
+    -- Branch 5: ucits_eu (pre-Q91 shape from 0183)
     SELECT
         'ucits_eu'::text as universe,
-        ef.legacy_isin_misnamed::text as external_id,
-        ef.fund_name::text as name,
+        COALESCE(es.isin, ef.lei)::text as external_id,
+        COALESCE(NULLIF(es.full_name, ''), ef.fund_name)::text as name,
         ef.yahoo_ticker::text as ticker,
-        ef.legacy_isin_misnamed::text as isin,
+        es.isin::text as isin,
         'EU'::text as region,
         ef.fund_type::text as fund_type,
         ef.strategy_label::text as strategy_label,
@@ -404,7 +574,7 @@ SELECT DISTINCT ON (external_id) * FROM (
         NULL::text as class_id,
         NULL::text as class_name,
         FALSE as has_holdings,
-        TRUE as has_nav,
+        (ef.yahoo_ticker IS NOT NULL) as has_nav,
         FALSE as has_13f_overlay,
         (SELECT gl.investment_geography FROM geo_logic gl WHERE gl.text_val = COALESCE(ef.strategy_label, ef.fund_name) LIMIT 1) as investment_geography,
         NULL::integer as vintage_year,
@@ -416,8 +586,46 @@ SELECT DISTINCT ON (external_id) * FROM (
         NULL::boolean as is_fund_of_fund,
         ef.is_institutional
     FROM esma_funds ef
-    JOIN esma_managers em ON ef.esma_manager_id = em.esma_id
+    LEFT JOIN esma_securities es ON es.fund_lei = ef.lei AND es.is_active
+    LEFT JOIN esma_managers em ON em.esma_id = ef.esma_manager_id
     WHERE ef.yahoo_ticker IS NOT NULL AND ef.yahoo_ticker != ''
+
+    UNION ALL
+    -- Branch 6: money_market
+    SELECT
+        'registered_us'::text as universe,
+        mmf.series_id::text as external_id,
+        mmf.fund_name::text as name,
+        NULL::text as ticker,
+        NULL::text as isin,
+        'US'::text as region,
+        'money_market'::text as fund_type,
+        mmf.strategy_label::text as strategy_label,
+        mmf.net_assets::numeric as aum_usd,
+        mmf.currency::text as currency,
+        mmf.domicile::text as domicile,
+        mmf.investment_adviser::text as manager_name,
+        NULL::text as manager_id,
+        NULL::date as inception_date,
+        NULL::integer as total_shareholder_accounts,
+        NULL::integer as investor_count,
+        NULL::text as series_id,
+        NULL::text as series_name,
+        NULL::text as class_id,
+        NULL::text as class_name,
+        FALSE as has_holdings,
+        FALSE as has_nav,
+        FALSE as has_13f_overlay,
+        'US'::text as investment_geography,
+        NULL::integer as vintage_year,
+        NULL::numeric as expense_ratio_pct,
+        NULL::numeric as avg_annual_return_1y,
+        NULL::numeric as avg_annual_return_10y,
+        NULL::boolean as is_index,
+        NULL::boolean as is_target_date,
+        NULL::boolean as is_fund_of_fund,
+        mmf.is_institutional
+    FROM sec_money_market_funds mmf
 ) combined
 ORDER BY external_id, aum_usd DESC NULLS LAST;
 """
@@ -455,8 +663,13 @@ WHERE ef.yahoo_ticker = iu.ticker
 _BRIDGE_DOWN = """
 UPDATE instruments_universe iu
 SET attributes = iu.attributes - 'fund_lei'
-WHERE iu.attributes->>'fund_subtype' = 'ucits'
-  AND iu.attributes ? 'fund_lei';
+FROM esma_funds ef
+WHERE ef.yahoo_ticker = iu.ticker
+  AND ef.yahoo_ticker IS NOT NULL
+  AND ef.yahoo_ticker <> ''
+  AND iu.attributes->>'fund_subtype' = 'ucits'
+  AND iu.attributes ? 'fund_lei'
+  AND iu.attributes->>'fund_lei' = ef.lei;
 """
 
 

--- a/backend/tests/db/test_migration_0194_q91.py
+++ b/backend/tests/db/test_migration_0194_q91.py
@@ -150,8 +150,23 @@ async def test_ucits_with_nav_are_active():
 # Q105 — Codex P1+P2 catches on Q91 downgrade path
 # ---------------------------------------------------------------------------
 
-_MIGRATION_PATH = Path(
-    "backend/app/core/db/migrations/versions/0194_q91_ucits_data_gate.py"
+# Q105/Codex P1 fix: anchor path via __file__ so the test runs in both
+# repo-root and cwd=backend execution contexts (CI uses cwd=backend per
+# .github/workflows/ci.yml + Makefile). Original hard-coded
+# "backend/app/core/db/migrations/..." resolved to "backend/backend/..."
+# under cwd=backend and produced FileNotFoundError before any assertion.
+# Path layout: backend/tests/db/test_migration_0194_q91.py
+#   parents[0] = backend/tests/db
+#   parents[1] = backend/tests
+#   parents[2] = backend
+#   parents[3] = repo root
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MIGRATION_PATH = (
+    _REPO_ROOT / "backend" / "app" / "core" / "db" / "migrations" / "versions"
+    / "0194_q91_ucits_data_gate.py"
+)
+assert _MIGRATION_PATH.is_file(), (
+    f"_MIGRATION_PATH must resolve regardless of cwd. Got: {_MIGRATION_PATH}"
 )
 
 

--- a/backend/tests/db/test_migration_0194_q91.py
+++ b/backend/tests/db/test_migration_0194_q91.py
@@ -6,6 +6,8 @@ ESMA↔instruments_universe bridge. Read-only assertions on the live DB.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import asyncpg
 import pytest
 
@@ -141,4 +143,56 @@ async def test_ucits_with_nav_are_active():
     assert violators == 0, (
         f"{violators} UCITS instruments have NAV data but are is_active=false — "
         "universe_sync._deactivate_no_nav race not yet patched (Q92 follow-up)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Q105 — Codex P1+P2 catches on Q91 downgrade path
+# ---------------------------------------------------------------------------
+
+_MIGRATION_PATH = Path(
+    "backend/app/core/db/migrations/versions/0194_q91_ucits_data_gate.py"
+)
+
+
+def test_q105_mv_sql_down_contains_all_6_branches():
+    """Q105 invariant: _MV_SQL_DOWN must recreate all 6 universe branches
+    (registered_us, ETFs, BDCs, private_us, ucits_eu, money_market).
+    Codex P1 catch — original _MV_SQL_DOWN only had the UCITS branch."""
+    text = _MIGRATION_PATH.read_text()
+    down_idx = text.index("_MV_SQL_DOWN")
+    # Find the closing triple-quote to delimit the SQL block
+    block_start = text.index('"""', down_idx)
+    block_end = text.index('"""', block_start + 3)
+    down_block = text[block_start:block_end]
+
+    assert "sec_registered_funds rf" in down_block, "Branch 1 (registered_us) missing"
+    assert "sec_etfs e" in down_block, "Branch 2 (ETFs) missing"
+    assert "sec_bdcs b" in down_block, "Branch 3 (BDCs) missing"
+    assert "sec_manager_funds mf" in down_block, "Branch 4 (private_us) missing"
+    assert "esma_funds ef" in down_block, "Branch 5 (ucits_eu) missing"
+    assert "sec_money_market_funds mmf" in down_block, "Branch 6 (money_market) missing"
+
+    # Verify it uses the 0183 UCITS shape (LEFT JOIN esma_securities, not INNER JOIN instruments_universe)
+    assert "LEFT JOIN esma_securities es" in down_block, (
+        "UCITS branch should use LEFT JOIN esma_securities (0183 shape)"
+    )
+    assert "COALESCE(es.isin, ef.lei)" in down_block, (
+        "UCITS branch should use COALESCE(es.isin, ef.lei) for external_id (0183 shape)"
+    )
+
+
+def test_q105_bridge_down_constrains_to_q91_added_rows():
+    """Q105 invariant: _BRIDGE_DOWN must restrict removal to rows Q91
+    plausibly added (JOIN esma_funds + match fund_lei = ef.lei).
+    Codex P2 catch — original removed fund_lei from ALL UCITS rows."""
+    text = _MIGRATION_PATH.read_text()
+    bridge_down_idx = text.index("_BRIDGE_DOWN")
+    bridge_down_block = text[bridge_down_idx:bridge_down_idx + 2000]
+
+    assert "FROM esma_funds ef" in bridge_down_block, (
+        "_BRIDGE_DOWN must JOIN esma_funds to restrict rollback scope"
+    )
+    assert "iu.attributes->>'fund_lei' = ef.lei" in bridge_down_block, (
+        "_BRIDGE_DOWN must verify fund_lei matches the value Q91 would have set"
     )


### PR DESCRIPTION
## Codex Auto Review on PR-Q91 (#391, merged) — 2 catches

### P1 — `_MV_SQL_DOWN` only recreates UCITS branch
Rollback would silently strip 5 of 6 branches from `mv_unified_funds`
(registered_us mutual funds, ETFs, BDCs, private_us, money_market).
Fix: restore full pre-Q91 view shape (matches 0183 predecessor).

### P2 — `_BRIDGE_DOWN` over-strips fund_lei from rows Q91 didn't add
`_BRIDGE_UP` only populates fund_lei where NULL/empty. `_BRIDGE_DOWN`
removed it from any UCITS row that has it, regardless of origin.
Fix: JOIN esma_funds + match fund_lei = ef.lei, ensuring rollback only
touches rows whose current fund_lei value Q91 would have produced.

## Changes
- `0194_q91_ucits_data_gate.py` — `_MV_SQL_DOWN` replaced with full 6-branch 0183 view; `_BRIDGE_DOWN` restricted to JOIN-matched rows
- `test_migration_0194_q91.py` — 2 new static tests (`test_q105_mv_sql_down_contains_all_6_branches`, `test_q105_bridge_down_constrains_to_q91_added_rows`)

## Out of scope
No new migration. In-place patch on 0194 because `upgrade()` already
ran in production; only `downgrade()` behavior changes.

## Test plan
- [x] All 7 tests pass (5 existing + 2 new Q105)
- [x] Lint clean (ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)