### PR TITLE
fix(wealth): PR-Q106 — Codex P1+P2 — Q94 reactivation correctness (sec_registered prefilter + test assertion)

### DIFF
--- a/backend/app/domains/wealth/workers/universe_sync.py
+++ b/backend/app/domains/wealth/workers/universe_sync.py
@@ -343,9 +343,11 @@ async def _sync_sec_registered(db: AsyncSession) -> dict[str, Any]:
             )
         FROM sec_registered_funds rf
         WHERE rf.ticker IS NOT NULL
-          AND NOT EXISTS (
-              SELECT 1 FROM instruments_universe iu WHERE iu.ticker = rf.ticker
-          )
+        -- Q106: NOT EXISTS prefilter removed. The minimal ON CONFLICT clause
+        -- (only is_active + updated_at) cannot overwrite Phase 2's name/attributes,
+        -- so the prefilter that was preventing the conflict path from firing is
+        -- redundant and broke Q94's reactivation invariant. See Wave 6 S09 C-01
+        -- + Codex review on PR-Q94 commit.
         ON CONFLICT (ticker) DO UPDATE SET
             is_active = true,
             updated_at = now()

--- a/backend/tests/wealth/workers/test_universe_sync_reactivation.py
+++ b/backend/tests/wealth/workers/test_universe_sync_reactivation.py
@@ -50,6 +50,21 @@ def _extract_on_conflict_sql(sqls: list[str]) -> str | None:
     return None
 
 
+def _extract_on_conflict_clause(sqls: list[str]) -> str | None:
+    """Return the substring from ON CONFLICT to end of statement.
+
+    Q106: tighter than _extract_on_conflict_sql which returns the full
+    statement (where is_active appears in INSERT column list, giving
+    false positives in the test).
+    """
+    for sql in sqls:
+        upper = sql.upper()
+        idx = upper.find("ON CONFLICT")
+        if idx >= 0:
+            return sql[idx:]
+    return None
+
+
 # ── Phase 1: SEC ETFs ─────────────────────────────────────────────────
 
 
@@ -59,11 +74,14 @@ async def test_sec_etf_reactivation_sets_is_active():
     db = _CapturingSession()
     await mod._sync_sec_etfs(db)  # type: ignore[arg-type]
 
-    sql = _extract_on_conflict_sql(db.executed_sql)
-    assert sql is not None, "Expected ON CONFLICT SQL from _sync_sec_etfs"
-    assert "is_active" in sql.lower(), (
-        "_sync_sec_etfs ON CONFLICT must set is_active"
-    )
+    clause = _extract_on_conflict_clause(db.executed_sql)
+    assert clause is not None, "Expected ON CONFLICT clause from _sync_sec_etfs"
+    clause_lower = clause.lower()
+    assert "is_active" in clause_lower, "ON CONFLICT clause must reference is_active"
+    assert (
+        "is_active = excluded.is_active" in clause_lower
+        or "is_active = true" in clause_lower
+    ), f"_sync_sec_etfs ON CONFLICT must reactivate. Clause was:\n{clause}"
 
 
 # ── Phase 2: SEC MF Series ───────────────────────────────────────────
@@ -75,11 +93,14 @@ async def test_sec_mf_series_reactivation_sets_is_active():
     db = _CapturingSession()
     await mod._sync_sec_mf_series(db)  # type: ignore[arg-type]
 
-    sql = _extract_on_conflict_sql(db.executed_sql)
-    assert sql is not None, "Expected ON CONFLICT SQL from _sync_sec_mf_series"
-    assert "is_active" in sql.lower(), (
-        "_sync_sec_mf_series ON CONFLICT must set is_active"
-    )
+    clause = _extract_on_conflict_clause(db.executed_sql)
+    assert clause is not None, "Expected ON CONFLICT clause from _sync_sec_mf_series"
+    clause_lower = clause.lower()
+    assert "is_active" in clause_lower, "ON CONFLICT clause must reference is_active"
+    assert (
+        "is_active = excluded.is_active" in clause_lower
+        or "is_active = true" in clause_lower
+    ), f"_sync_sec_mf_series ON CONFLICT must reactivate. Clause was:\n{clause}"
 
 
 # ── Phase 3: SEC Registered Funds ────────────────────────────────────
@@ -95,15 +116,18 @@ async def test_sec_registered_reactivation_sets_is_active():
     db = _CapturingSession()
     await mod._sync_sec_registered(db)  # type: ignore[arg-type]
 
-    sql = _extract_on_conflict_sql(db.executed_sql)
-    assert sql is not None, "Expected ON CONFLICT SQL from _sync_sec_registered"
+    clause = _extract_on_conflict_clause(db.executed_sql)
+    assert clause is not None, "Expected ON CONFLICT clause from _sync_sec_registered"
     # Must no longer use DO NOTHING
-    assert "DO NOTHING" not in sql.upper(), (
+    assert "DO NOTHING" not in clause.upper(), (
         "_sync_sec_registered must not use DO NOTHING (blocks reactivation)"
     )
-    assert "is_active" in sql.lower(), (
-        "_sync_sec_registered ON CONFLICT must set is_active"
-    )
+    clause_lower = clause.lower()
+    assert "is_active" in clause_lower, "ON CONFLICT clause must reference is_active"
+    assert (
+        "is_active = excluded.is_active" in clause_lower
+        or "is_active = true" in clause_lower
+    ), f"_sync_sec_registered ON CONFLICT must reactivate. Clause was:\n{clause}"
 
 
 # ── Phase 3b: SEC BDCs ───────────────────────────────────────────────
@@ -115,11 +139,14 @@ async def test_sec_bdcs_reactivation_sets_is_active():
     db = _CapturingSession()
     await mod._sync_sec_bdcs(db)  # type: ignore[arg-type]
 
-    sql = _extract_on_conflict_sql(db.executed_sql)
-    assert sql is not None, "Expected ON CONFLICT SQL from _sync_sec_bdcs"
-    assert "is_active" in sql.lower(), (
-        "_sync_sec_bdcs ON CONFLICT must set is_active"
-    )
+    clause = _extract_on_conflict_clause(db.executed_sql)
+    assert clause is not None, "Expected ON CONFLICT clause from _sync_sec_bdcs"
+    clause_lower = clause.lower()
+    assert "is_active" in clause_lower, "ON CONFLICT clause must reference is_active"
+    assert (
+        "is_active = excluded.is_active" in clause_lower
+        or "is_active = true" in clause_lower
+    ), f"_sync_sec_bdcs ON CONFLICT must reactivate. Clause was:\n{clause}"
 
 
 # ── Phase 4: ESMA UCITS ──────────────────────────────────────────────
@@ -131,11 +158,14 @@ async def test_esma_funds_reactivation_sets_is_active():
     db = _CapturingSession()
     await mod._sync_esma_funds(db)  # type: ignore[arg-type]
 
-    sql = _extract_on_conflict_sql(db.executed_sql)
-    assert sql is not None, "Expected ON CONFLICT SQL from _sync_esma_funds"
-    assert "is_active" in sql.lower(), (
-        "_sync_esma_funds ON CONFLICT must set is_active"
-    )
+    clause = _extract_on_conflict_clause(db.executed_sql)
+    assert clause is not None, "Expected ON CONFLICT clause from _sync_esma_funds"
+    clause_lower = clause.lower()
+    assert "is_active" in clause_lower, "ON CONFLICT clause must reference is_active"
+    assert (
+        "is_active = excluded.is_active" in clause_lower
+        or "is_active = true" in clause_lower
+    ), f"_sync_esma_funds ON CONFLICT must reactivate. Clause was:\n{clause}"
 
 
 # ── Phase 5: SEC MMFs ────────────────────────────────────────────────
@@ -147,8 +177,33 @@ async def test_sec_mmfs_reactivation_sets_is_active():
     db = _CapturingSession()
     await mod._sync_sec_mmfs(db)  # type: ignore[arg-type]
 
-    sql = _extract_on_conflict_sql(db.executed_sql)
-    assert sql is not None, "Expected ON CONFLICT SQL from _sync_sec_mmfs"
-    assert "is_active" in sql.lower(), (
-        "_sync_sec_mmfs ON CONFLICT must set is_active"
+    clause = _extract_on_conflict_clause(db.executed_sql)
+    assert clause is not None, "Expected ON CONFLICT clause from _sync_sec_mmfs"
+    clause_lower = clause.lower()
+    assert "is_active" in clause_lower, "ON CONFLICT clause must reference is_active"
+    assert (
+        "is_active = excluded.is_active" in clause_lower
+        or "is_active = true" in clause_lower
+    ), f"_sync_sec_mmfs ON CONFLICT must reactivate. Clause was:\n{clause}"
+
+
+# ── Q106: NOT EXISTS prefilter guard ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sec_registered_no_not_exists_prefilter():
+    """Q106: _sync_sec_registered must NOT prefilter on NOT EXISTS — that
+    blocked the reactivation path the Q94 fix was meant to enable."""
+    db = _CapturingSession()
+    await mod._sync_sec_registered(db)  # type: ignore[arg-type]
+
+    matched = [s for s in db.executed_sql if "FROM sec_registered_funds" in s]
+    assert matched, "Expected _sync_sec_registered to issue an INSERT against sec_registered_funds"
+    sql = matched[0]
+    # Strip SQL comments (-- ...) before checking, so the Q106 explanatory
+    # comment ("NOT EXISTS prefilter removed") doesn't trigger a false positive.
+    import re
+    sql_no_comments = re.sub(r"--[^\n]*", "", sql)
+    assert "NOT EXISTS" not in sql_no_comments.upper(), (
+        "_sync_sec_registered must not prefilter via NOT EXISTS — it blocks reactivation"
     )


### PR DESCRIPTION
## Codex Auto Review on Q94 commit (Wave 6 S09 C-01) — 2 catches

### P1 — \`_sync_sec_registered\` NOT EXISTS prefilter blocked reactivation
Q94's \`ON CONFLICT DO UPDATE SET is_active = true\` was DEAD CODE for deactivated rows because the WHERE clause's \`NOT EXISTS\` filter excluded any ticker already in \`instruments_universe\`. Reactivation invariant broken for SEC registered direct-ticker funds.

**Fix:** remove the prefilter. The minimal ON CONFLICT clause (only is_active + updated_at) cannot overwrite Phase 2's name/attributes, so the prefilter is redundant.

### P2 — regression test asserted \`is_active\` in whole SQL
The Q94 tests asserted \`"is_active" in sql.lower()\` against the whole INSERT statement (where \`is_active\` appears in the column list and SELECT side). Test would pass even if ON CONFLICT clause stopped setting is_active.

**Fix:** new helper \`_extract_on_conflict_clause\` extracts ON CONFLICT body only; tests assert reactivation pattern in that scope.

## Tests

- 7/7 reactivation tests pass with stricter assertion
- New test (no NOT EXISTS prefilter) verifies the fix
- \`make lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)