### PR TITLE
chore(wealth): PR-Q108 — Codex P2 — annotation guard test path resolution

### DIFF
--- a/backend/tests/static/test_no_org_id_str_annotation.py
+++ b/backend/tests/static/test_no_org_id_str_annotation.py
@@ -1,6 +1,15 @@
 import ast
 from pathlib import Path
 
+# Resolve repo-root from this test file's location:
+# backend/tests/static/test_no_org_id_str_annotation.py
+#   parent[0] = backend/tests/static
+#   parent[1] = backend/tests
+#   parent[2] = backend
+#   parent[3] = repo root
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_DOMAINS_ROOT = _REPO_ROOT / "backend" / "app" / "domains"
+
 
 def _has_depends_get_org_id(default_node: ast.AST | None) -> bool:
     """Return True if the default is ``Depends(get_org_id)``."""
@@ -16,9 +25,16 @@ def _has_depends_get_org_id(default_node: ast.AST | None) -> bool:
 
 
 def test_no_org_id_str_lying_annotation():
-    """Static check: no route handler annotates ``org_id: str = Depends(get_org_id)``."""
+    """Static check: no route handler annotates ``org_id: str = Depends(get_org_id)``.
+
+    Q108: path resolution anchored to __file__ so the guard works
+    regardless of pytest cwd (repo root vs backend/).
+    """
+    assert _DOMAINS_ROOT.is_dir(), (
+        f"_DOMAINS_ROOT must resolve to an existing directory. Got: {_DOMAINS_ROOT}"
+    )
     offenders: list[str] = []
-    for path in Path("backend/app/domains").rglob("*.py"):
+    for path in _DOMAINS_ROOT.rglob("*.py"):
         tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -39,3 +55,17 @@ def test_no_org_id_str_lying_annotation():
                     if ann == "str":
                         offenders.append(f"{path}:{arg.lineno}")
     assert not offenders, f"org_id: str = Depends(get_org_id) annotation lies remain: {offenders}"
+
+
+def test_guard_path_resolves_to_real_directory():
+    """Q108 invariant: _DOMAINS_ROOT must resolve to an existing dir
+    independent of cwd. Catches the original bug where the guard scanned
+    a non-existent path and passed vacuously."""
+    assert _DOMAINS_ROOT.is_dir(), (
+        f"_DOMAINS_ROOT must resolve regardless of cwd. Got: {_DOMAINS_ROOT}"
+    )
+    py_files = list(_DOMAINS_ROOT.rglob("*.py"))
+    assert len(py_files) > 50, (
+        f"Expected >50 Python files under app/domains, got {len(py_files)}. "
+        "Path resolution likely broken."
+    )


### PR DESCRIPTION
## Codex Auto Review on PR-Q103 (Wave 6 S09 C-15) — 1 P2 catch

Q103's static guard test scanned \`Path("backend/app/domains")\` — a relative path that only resolves from repo root. CI runs pytest with \`cwd=backend\`, so the path never existed and the test passed silently regardless of whether new offenders were introduced. Guard ineffective.

## Fix

Anchor path via \`Path(__file__).resolve().parents[3] / "backend" / "app" / "domains"\`. Add \`assert _DOMAINS_ROOT.is_dir()\` to fail loudly if the directory layout ever changes.

## Tests

- 2/2 tests pass: meta-test confirms path resolves to real directory; existing guard runs identically from both repo-root and cwd=backend
- \`make lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)