### PR TITLE
fix(wealth): PR-Q109 — Codex P1 — regime_fit advisory lock requires pinned connection

### DIFF
--- a/backend/app/domains/wealth/workers/regime_fit.py
+++ b/backend/app/domains/wealth/workers/regime_fit.py
@@ -32,9 +32,9 @@ from typing import Any, cast
 import numpy as np
 import structlog
 from sqlalchemy import CursorResult, select, text, update
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
 
-from app.core.db.engine import async_session_factory as async_session
+from app.core.db.engine import engine
 from app.domains.wealth.models.macro import MacroData
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 
@@ -68,7 +68,7 @@ async def _fetch_vix_series(db: AsyncSession, lookback_days: int = PREFERRED_VIX
 
 
 async def _fetch_vix_series_with_dates(
-    db: AsyncSession, lookback_days: int = PREFERRED_VIX_LOOKBACK,
+    conn: AsyncConnection, lookback_days: int = PREFERRED_VIX_LOOKBACK,
 ) -> list[tuple[date, float]]:
     """Fetch VIX daily observations with dates from macro_data, ascending."""
     start_date = date.today() - timedelta(days=lookback_days)
@@ -80,7 +80,7 @@ async def _fetch_vix_series_with_dates(
         )
         .order_by(MacroData.obs_date)
     )
-    result = await db.execute(stmt)
+    result = await conn.execute(stmt)
     return [(row[0], float(row[1])) for row in result.all()]
 
 
@@ -183,7 +183,7 @@ def _classify_regime_from_probs(
 
 
 async def _persist_regime_history(
-    db: AsyncSession,
+    conn: AsyncConnection,
     dates: list[date],
     p_low_vol_series: list[float],
     p_high_vol_series: list[float],
@@ -232,15 +232,15 @@ async def _persist_regime_history(
                 vix_value = EXCLUDED.vix_value,
                 computed_at = EXCLUDED.computed_at
         """  # noqa: S608
-        await db.execute(text(sql), params)
+        await conn.execute(text(sql), params)
         upserted += batch_end - batch_start
 
-    await db.commit()
+    await conn.commit()
     return upserted
 
 
 async def _update_snapshots_with_regime_probs(
-    db: AsyncSession,
+    conn: AsyncConnection,
     p_high_vol_current: float,
 ) -> int:
     """Update today's portfolio snapshots with regime_probs for all profiles.
@@ -259,19 +259,17 @@ async def _update_snapshots_with_regime_probs(
         .where(PortfolioSnapshot.snapshot_date == today)
         .values(regime_probs=regime_probs_value)
     )
-    result = cast(CursorResult[Any], await db.execute(stmt))
-    await db.commit()
+    result = cast(CursorResult[Any], await conn.execute(stmt))
+    await conn.commit()
     return result.rowcount
 
 
-async def _do_regime_fit(db: AsyncSession) -> dict[str, Any]:
-    """Core regime fitting logic — uses lock-owning session for all I/O.
-
-    Phase commits are explicit so the session is never idle in an open
-    transaction across CPU-bound work or external waits.
+async def _do_regime_fit(conn: AsyncConnection) -> dict[str, Any]:
+    """Core regime fitting logic — bound to a pinned connection so the
+    advisory lock held on ``conn`` survives across phase commits.
     """
-    vix_with_dates = await _fetch_vix_series_with_dates(db)
-    await db.commit()  # phase 1 done; session is idle but NOT in transaction
+    vix_with_dates = await _fetch_vix_series_with_dates(conn)
+    await conn.commit()  # phase 1 done; connection stays pinned
 
     n_obs = len(vix_with_dates)
     if n_obs < MIN_VIX_OBS:
@@ -286,7 +284,7 @@ async def _do_regime_fit(db: AsyncSession) -> dict[str, Any]:
     vix_values = [v for _, v in vix_with_dates]
 
     logger.info("VIX history fetched", n_obs=n_obs)
-    high_vol_probs = _fit_markov_regime(vix_values)  # CPU only; session not in tx
+    high_vol_probs = _fit_markov_regime(vix_values)  # CPU only; connection not in tx
 
     if high_vol_probs is None:
         return {"status": "skipped", "reason": "fitting_failed"}
@@ -300,14 +298,14 @@ async def _do_regime_fit(db: AsyncSession) -> dict[str, Any]:
     vix_or_none: list[float | None] = list(vix_values)
 
     n_persisted = await _persist_regime_history(
-        db, dates_list, p_low_vol_series, p_high_vol_series, vix_or_none,
+        conn, dates_list, p_low_vol_series, p_high_vol_series, vix_or_none,
     )
-    await db.commit()  # phase 3 done
+    await conn.commit()  # phase 3 done
     logger.info("Regime history persisted", rows_upserted=n_persisted)
 
     # Update today's portfolio snapshots with current regime probs
-    n_updated = await _update_snapshots_with_regime_probs(db, p_high)
-    await db.commit()  # phase 4 done
+    n_updated = await _update_snapshots_with_regime_probs(conn, p_high)
+    await conn.commit()  # phase 4 done
 
     logger.info("Regime probs written to snapshots", snapshots_updated=n_updated)
     return {
@@ -320,28 +318,38 @@ async def _do_regime_fit(db: AsyncSession) -> dict[str, Any]:
 
 
 async def run_regime_fit() -> dict[str, Any]:
-    """Fit Markov regime model on VIX, persist full series, enrich snapshots."""
+    """Fit Markov regime model on VIX, persist full series, enrich snapshots.
+
+    Uses ``engine.connect()`` to pin a single connection for the entire
+    lock lifetime.  PostgreSQL advisory locks are bound to connections,
+    not to SQLAlchemy sessions — ``commit()`` on an ``AsyncSession`` can
+    return the connection to the pool, silently losing the lock.  A
+    pinned ``AsyncConnection`` keeps the same connection across phase
+    commits, ensuring the lock is held until explicitly released.
+    """
     logger.info("Starting Markov regime fitting")
 
-    async with async_session() as db:
-        # Advisory lock — skip if already running (non-blocking)
-        lock_result = await db.execute(
+    async with engine.connect() as conn:
+        # Advisory lock — skip if already running (non-blocking).
+        # Connection is pinned for the lifetime of this ``async with`` —
+        # commits within do not return it to the pool.
+        lock_result = await conn.execute(
             text(f"SELECT pg_try_advisory_lock({LOCK_ID})"),
         )
         lock_acquired = bool(lock_result.scalar())
-        await db.commit()  # close implicit tx; advisory lock survives commits
+        await conn.commit()  # close implicit tx; advisory lock survives (pinned conn)
 
         if not lock_acquired:
             logger.warning("Regime fit already running — skipping")
             return {"status": "skipped", "reason": "lock_held"}
 
         try:
-            return await _do_regime_fit(db)
+            return await _do_regime_fit(conn)
         finally:
-            await db.execute(
+            await conn.execute(
                 text(f"SELECT pg_advisory_unlock({LOCK_ID})"),
             )
-            await db.commit()
+            await conn.commit()
 
 
 if __name__ == "__main__":

--- a/backend/scripts/backfill_regime_history.py
+++ b/backend/scripts/backfill_regime_history.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db.engine import async_session_factory as async_session
+from app.core.db.engine import engine
 from app.domains.wealth.models.macro import MacroData
 from app.domains.wealth.workers.regime_fit import (
     MIN_VIX_OBS,
@@ -70,9 +71,9 @@ async def main() -> None:
 
     logger.info("HMM fit complete, persisting regime history", n_obs=n_obs)
 
-    async with async_session() as db:
+    async with engine.connect() as conn:
         n_persisted = await _persist_regime_history(
-            db, dates_list, p_low_vol_series, p_high_vol_series, vix_or_none,
+            conn, dates_list, p_low_vol_series, p_high_vol_series, vix_or_none,
         )
 
     # Log regime distribution

--- a/backend/tests/wealth/workers/test_regime_fit_lock.py
+++ b/backend/tests/wealth/workers/test_regime_fit_lock.py
@@ -1,9 +1,10 @@
-"""Tests for regime_fit advisory lock acquire/release (PR-Q99).
+"""Tests for regime_fit advisory lock acquire/release (PR-Q99, Q109).
 
 Validates:
   C-04: LOCK_ID 900_026 is acquired before run_regime_fit body executes
   C-04: Lock is released in finally (even on exception or cancellation)
   C-04: Concurrent invocation returns {"status": "skipped", "reason": "lock_held"}
+  Q109: Advisory lock acquired and released on the SAME pinned connection
 """
 
 from __future__ import annotations
@@ -21,7 +22,7 @@ from app.domains.wealth.workers import regime_fit as mod
 
 
 class _FakeResult:
-    """Minimal result proxy for mocked session.execute()."""
+    """Minimal result proxy for mocked connection.execute()."""
 
     def __init__(self, scalar_value=None):
         self._scalar = scalar_value
@@ -30,8 +31,8 @@ class _FakeResult:
         return self._scalar
 
 
-class _FakeSession:
-    """Fake async session that tracks execute calls for lock assertions."""
+class _FakeConnection:
+    """Fake async connection that tracks execute calls for lock assertions."""
 
     def __init__(self, *, lock_acquired: bool = True):
         self._lock_acquired = lock_acquired
@@ -53,14 +54,17 @@ class _FakeSession:
         pass
 
 
-def _make_session_factory(session: _FakeSession):
-    """Build an async context manager factory that yields the given session."""
+class _FakeEngine:
+    """Fake engine whose connect() returns a fake connection context manager."""
+
+    def __init__(self, conn: _FakeConnection):
+        self._conn = conn
+        self.connect_call_count = 0
 
     @asynccontextmanager
-    async def factory():
-        yield session
-
-    return factory
+    async def connect(self):
+        self.connect_call_count += 1
+        yield self._conn
 
 
 # Sample VIX data — 300 points (> MIN_VIX_OBS=252) for tests that need fitting
@@ -75,16 +79,17 @@ _SAMPLE_VIX_DATES = [
 @pytest.mark.asyncio
 async def test_regime_fit_skips_when_lock_held():
     """Lock not acquired -> returns {"status": "skipped", "reason": "lock_held"}."""
-    session = _FakeSession(lock_acquired=False)
+    conn = _FakeConnection(lock_acquired=False)
+    fake_engine = _FakeEngine(conn)
 
-    with patch.object(mod, "async_session", _make_session_factory(session)):
+    with patch.object(mod, "engine", fake_engine):
         result = await mod.run_regime_fit()
 
     assert result == {"status": "skipped", "reason": "lock_held"}
 
     # Lock was attempted but not acquired — no unlock should be called
-    lock_sqls = [sql for sql in session.executed_sql if "pg_try_advisory_lock" in sql]
-    unlock_sqls = [sql for sql in session.executed_sql if "pg_advisory_unlock" in sql]
+    lock_sqls = [sql for sql in conn.executed_sql if "pg_try_advisory_lock" in sql]
+    unlock_sqls = [sql for sql in conn.executed_sql if "pg_advisory_unlock" in sql]
     assert len(lock_sqls) == 1, "Lock must be attempted once"
     assert len(unlock_sqls) == 0, "Lock was never acquired — unlock must not be called"
 
@@ -95,10 +100,11 @@ async def test_regime_fit_skips_when_lock_held():
 @pytest.mark.asyncio
 async def test_regime_fit_releases_lock_on_exception():
     """Advisory lock is released even when _fetch_vix_series_with_dates raises."""
-    session = _FakeSession(lock_acquired=True)
+    conn = _FakeConnection(lock_acquired=True)
+    fake_engine = _FakeEngine(conn)
 
     with (
-        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(mod, "engine", fake_engine),
         patch.object(
             mod,
             "_fetch_vix_series_with_dates",
@@ -110,8 +116,8 @@ async def test_regime_fit_releases_lock_on_exception():
             await mod.run_regime_fit()
 
     # Even after exception, lock must have been released
-    lock_sqls = [sql for sql in session.executed_sql if "pg_try_advisory_lock" in sql]
-    unlock_sqls = [sql for sql in session.executed_sql if "pg_advisory_unlock" in sql]
+    lock_sqls = [sql for sql in conn.executed_sql if "pg_try_advisory_lock" in sql]
+    unlock_sqls = [sql for sql in conn.executed_sql if "pg_advisory_unlock" in sql]
     assert len(lock_sqls) == 1, "Lock must be acquired once"
     assert len(unlock_sqls) == 1, "Lock must be released even on exception"
 
@@ -122,10 +128,11 @@ async def test_regime_fit_releases_lock_on_exception():
 @pytest.mark.asyncio
 async def test_regime_fit_releases_lock_on_cancellation():
     """Advisory lock is released on asyncio.CancelledError (BaseException)."""
-    session = _FakeSession(lock_acquired=True)
+    conn = _FakeConnection(lock_acquired=True)
+    fake_engine = _FakeEngine(conn)
 
     with (
-        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(mod, "engine", fake_engine),
         patch.object(
             mod,
             "_fetch_vix_series_with_dates",
@@ -137,7 +144,7 @@ async def test_regime_fit_releases_lock_on_cancellation():
             await mod.run_regime_fit()
 
     # CancelledError is a BaseException — try/finally must still release lock
-    unlock_sqls = [sql for sql in session.executed_sql if "pg_advisory_unlock" in sql]
+    unlock_sqls = [sql for sql in conn.executed_sql if "pg_advisory_unlock" in sql]
     assert len(unlock_sqls) == 1, "Lock must be released even on CancelledError"
 
 
@@ -147,10 +154,11 @@ async def test_regime_fit_releases_lock_on_cancellation():
 @pytest.mark.asyncio
 async def test_regime_fit_acquires_and_releases_lock_on_success():
     """Normal run: lock acquired, body runs, lock released."""
-    session = _FakeSession(lock_acquired=True)
+    conn = _FakeConnection(lock_acquired=True)
+    fake_engine = _FakeEngine(conn)
 
     with (
-        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(mod, "engine", fake_engine),
         patch.object(
             mod,
             "_fetch_vix_series_with_dates",
@@ -179,14 +187,14 @@ async def test_regime_fit_acquires_and_releases_lock_on_success():
 
     assert result["status"] == "completed"
 
-    lock_sqls = [sql for sql in session.executed_sql if "pg_try_advisory_lock" in sql]
-    unlock_sqls = [sql for sql in session.executed_sql if "pg_advisory_unlock" in sql]
+    lock_sqls = [sql for sql in conn.executed_sql if "pg_try_advisory_lock" in sql]
+    unlock_sqls = [sql for sql in conn.executed_sql if "pg_advisory_unlock" in sql]
     assert len(lock_sqls) == 1, "Lock must be acquired once"
     assert len(unlock_sqls) == 1, "Lock must be released once"
 
     # Unlock must come after lock
-    lock_idx = next(i for i, sql in enumerate(session.executed_sql) if "pg_try_advisory_lock" in sql)
-    unlock_idx = next(i for i, sql in enumerate(session.executed_sql) if "pg_advisory_unlock" in sql)
+    lock_idx = next(i for i, sql in enumerate(conn.executed_sql) if "pg_try_advisory_lock" in sql)
+    unlock_idx = next(i for i, sql in enumerate(conn.executed_sql) if "pg_advisory_unlock" in sql)
     assert unlock_idx > lock_idx, "Unlock must come after lock acquisition"
 
 
@@ -196,39 +204,79 @@ async def test_regime_fit_acquires_and_releases_lock_on_success():
 @pytest.mark.asyncio
 async def test_regime_fit_uses_correct_lock_id():
     """Lock SQL must contain LOCK_ID = 900026."""
-    session = _FakeSession(lock_acquired=False)
+    conn = _FakeConnection(lock_acquired=False)
+    fake_engine = _FakeEngine(conn)
 
-    with patch.object(mod, "async_session", _make_session_factory(session)):
+    with patch.object(mod, "engine", fake_engine):
         await mod.run_regime_fit()
 
-    lock_sqls = [sql for sql in session.executed_sql if "pg_try_advisory_lock" in sql]
+    lock_sqls = [sql for sql in conn.executed_sql if "pg_try_advisory_lock" in sql]
     assert len(lock_sqls) == 1
     assert "900026" in lock_sqls[0], f"Lock SQL must use LOCK_ID 900026, got: {lock_sqls[0]}"
 
 
-# ── Test: Q104 invariant — single session for all I/O ──────────────────
+# ── Test: Q109 — pinned connection invariant ───────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_regime_fit_uses_lock_owning_session_for_all_io():
-    """Q104 invariant: all phases of regime fit must use the lock-owning
-    session, not child sessions. This prevents idle-in-transaction timeout
-    from killing the lock-holder mid-job and silently releasing the lock.
-
-    Verified by wrapping async_session() and asserting it's called exactly once.
+async def test_regime_fit_lock_held_on_pinned_connection():
+    """Q109: advisory lock acquired and released on the SAME pinned
+    connection via engine.connect(). Verifies that exactly one connection
+    is opened and both lock/unlock happen on it.
     """
-    session = _FakeSession(lock_acquired=True)
-    base_factory = _make_session_factory(session)
-
-    call_count = 0
-
-    def counting_factory(*args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        return base_factory(*args, **kwargs)
+    conn = _FakeConnection(lock_acquired=True)
+    fake_engine = _FakeEngine(conn)
 
     with (
-        patch.object(mod, "async_session", side_effect=counting_factory),
+        patch.object(mod, "engine", fake_engine),
+        patch.object(
+            mod,
+            "_fetch_vix_series_with_dates",
+            new_callable=AsyncMock,
+            return_value=_SAMPLE_VIX_DATES,
+        ),
+        patch.object(mod, "_fit_markov_regime", return_value=[0.3] * 300),
+        patch.object(
+            mod,
+            "_persist_regime_history",
+            new_callable=AsyncMock,
+            return_value=300,
+        ),
+        patch.object(
+            mod,
+            "_update_snapshots_with_regime_probs",
+            new_callable=AsyncMock,
+            return_value=5,
+        ),
+    ):
+        result = await mod.run_regime_fit()
+
+    assert result["status"] == "completed"
+    assert fake_engine.connect_call_count == 1, (
+        "Must use exactly one pinned connection for the entire lock lifetime"
+    )
+
+    # Both lock and unlock happened on the same connection object
+    lock_sqls = [sql for sql in conn.executed_sql if "pg_try_advisory_lock" in sql]
+    unlock_sqls = [sql for sql in conn.executed_sql if "pg_advisory_unlock" in sql]
+    assert len(lock_sqls) == 1, "Lock must be acquired once on pinned connection"
+    assert len(unlock_sqls) == 1, "Lock must be released once on pinned connection"
+
+
+# ── Test: Q109 — all phases use the pinned connection ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_regime_fit_uses_pinned_connection_for_all_phases():
+    """Q109: all phases of regime fit must use the pinned connection,
+    not child sessions. The connection passed to _do_regime_fit is the
+    same one that holds the advisory lock.
+    """
+    conn = _FakeConnection(lock_acquired=True)
+    fake_engine = _FakeEngine(conn)
+
+    with (
+        patch.object(mod, "engine", fake_engine),
         patch.object(
             mod,
             "_fetch_vix_series_with_dates",
@@ -240,7 +288,8 @@ async def test_regime_fit_uses_lock_owning_session_for_all_io():
 
     assert result["status"] == "skipped"
     assert result["reason"] == "insufficient_vix_history"
-    assert call_count == 1, (
-        f"Expected exactly 1 async_session() open (lock-owning session). "
-        f"Got {call_count}. _do_regime_fit must use the passed db, not open new sessions."
+    assert fake_engine.connect_call_count == 1, (
+        f"Expected exactly 1 engine.connect() call (pinned connection). "
+        f"Got {fake_engine.connect_call_count}. "
+        f"_do_regime_fit must use the passed conn, not open new ones."
     )


### PR DESCRIPTION
## Codex Auto Review on PR-Q104 #408 (merged) — 1 P1 catch

Q104 introduced `await db.commit()` between phases on the lock-holding
`AsyncSession`, assuming the advisory lock would persist because it's
session-scoped in PostgreSQL. SQLAlchemy `AsyncSession.commit()` can
return the underlying connection to the pool, however — and PostgreSQL
advisory locks are bound to **connections**, not to AsyncSession.
Subsequent queries can run on a different connection where the lock is
not held; the critical section is no longer protected and a concurrent
worker can acquire the lock on yet another connection.

## Fix

Switch from `AsyncSession` to a pinned `AsyncConnection` via
`engine.connect()` for the lock-holding scope. The `async with` block
guarantees the same connection across phase commits. `_do_regime_fit`
and helpers now take `AsyncConnection` (Path A — raw SQL only, no ORM
identity map needed).

## Changes

- `run_regime_fit()` → `engine.connect()` instead of `async_session()`
- `_do_regime_fit(conn: AsyncConnection)` — pinned connection parameter
- `_fetch_vix_series_with_dates`, `_persist_regime_history`, `_update_snapshots_with_regime_probs` → `AsyncConnection` parameter
- Backfill script updated for consistency

## Test plan

- [x] Existing Q99/Q104 lock tests updated and passing (5/5)
- [x] New `test_regime_fit_lock_held_on_pinned_connection` — asserts exactly 1 `engine.connect()` call
- [x] New `test_regime_fit_uses_pinned_connection_for_all_phases` — asserts no child sessions
- [x] `ruff check` clean

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>