### PR TITLE
fix(wealth): PR-Q110 — Wave 6 S10 C-01+C-02 — state machine validation gate bypass + missing constructed→approved edge (Crit)

### DIFF
--- a/backend/tests/test_portfolio_state_machine.py
+++ b/backend/tests/test_portfolio_state_machine.py
@@ -134,7 +134,8 @@ def test_constructed_actions_no_run_yet_hides_approve():
 
 
 def test_validated_actions():
-    actions = compute_allowed_actions("validated")
+    validation = ValidationStatus(has_run=True, passed=True)
+    actions = compute_allowed_actions("validated", validation=validation)
     assert ACTION_APPROVE in actions
     assert ACTION_REBUILD_DRAFT in actions
     assert ACTION_ACTIVATE not in actions  # only after approve
@@ -245,11 +246,61 @@ def test_validated_state_actions_under_self_approval_policy():
     accepts the call from a single-actor org and whether the audit row
     flags ``self_approved=true``. The state machine action computer
     should yield the same shape regardless of policy.allow_self_approval."""
-    actions_strict = compute_allowed_actions("validated", policy=ApprovalPolicy())
+    validation = ValidationStatus(has_run=True, passed=True)
+    actions_strict = compute_allowed_actions(
+        "validated", validation=validation, policy=ApprovalPolicy(),
+    )
     actions_relaxed = compute_allowed_actions(
-        "validated", policy=ApprovalPolicy(allow_self_approval=True),
+        "validated",
+        validation=validation,
+        policy=ApprovalPolicy(allow_self_approval=True),
     )
     assert set(actions_strict) == set(actions_relaxed)
+
+
+# ── PR-Q110: C-01 validation gate bypass + C-02 constructed→approved ──
+
+
+def test_approve_blocked_when_validation_failed():
+    """C-01: validated state with validation.passed=False must NOT expose
+    ACTION_APPROVE. Prevents approval bypass via the validated→approved path
+    when the validation gate has not actually passed."""
+    validation = ValidationStatus(has_run=True, passed=False)
+    actions = compute_allowed_actions("validated", validation=validation)
+    assert ACTION_APPROVE not in actions
+    # rebuild_draft should still be available
+    assert ACTION_REBUILD_DRAFT in actions
+
+
+def test_approve_allowed_when_validation_passed():
+    """C-01: validated state with validation.passed=True must expose
+    ACTION_APPROVE — the normal happy path."""
+    validation = ValidationStatus(has_run=True, passed=True)
+    actions = compute_allowed_actions("validated", validation=validation)
+    assert ACTION_APPROVE in actions
+    assert ACTION_REBUILD_DRAFT in actions
+
+
+def test_od5_override_constructed_to_approved():
+    """C-02: TRANSITIONS['constructed'] must include 'approved' so the
+    OD-5 override path (require_construction_for_approve=False) can
+    transition constructed→approved without raising InvalidStateTransition."""
+    assert "approved" in TRANSITIONS["constructed"]
+    # Also verify the action computer emits approve under OD-5 policy
+    validation = ValidationStatus(has_run=True, passed=False)
+    policy = ApprovalPolicy(require_construction_for_approve=False)
+    actions = compute_allowed_actions(
+        "constructed", validation=validation, policy=policy,
+    )
+    assert ACTION_APPROVE in actions
+
+
+def test_existing_constructed_to_validated_still_works():
+    """Regression: the existing constructed→validated edge must still be
+    present after adding the constructed→approved edge (C-02)."""
+    assert "validated" in TRANSITIONS["constructed"]
+    assert "rejected" in TRANSITIONS["constructed"]
+    assert "draft" in TRANSITIONS["constructed"]
 
 
 # NOTE: The DB-write path of the async ``transition()`` function is

--- a/backend/vertical_engines/wealth/model_portfolio/state_machine.py
+++ b/backend/vertical_engines/wealth/model_portfolio/state_machine.py
@@ -56,7 +56,7 @@ State = str  # 'draft' | 'constructed' | ... — runtime check via TRANSITIONS
 #: ``draft``).
 TRANSITIONS: Final[dict[State, set[State]]] = {
     "draft":       {"constructed", "archived"},
-    "constructed": {"validated", "rejected", "draft"},
+    "constructed": {"validated", "rejected", "draft", "approved"},
     "validated":   {"approved", "draft"},
     "approved":    {"live", "draft"},
     "live":        {"paused", "archived"},
@@ -184,9 +184,11 @@ def compute_allowed_actions(
         actions.append(ACTION_REBUILD_DRAFT)
 
     elif state == "validated":
-        # ``validated`` only exists if validation already passed; allow
-        # both approval paths (normal + self-approval flagged).
-        actions.append(ACTION_APPROVE)
+        # Gate on validation.passed — a portfolio may reach ``validated``
+        # with a failing gate (constructed→validated always allowed); the
+        # approve action must only appear when the gate actually passed.
+        if validation is not None and validation.passed:
+            actions.append(ACTION_APPROVE)
         actions.append(ACTION_REBUILD_DRAFT)
 
     elif state == "approved":


### PR DESCRIPTION
## Wave 6 Session 10 — C-01 + C-02 (Crit + Crit, bundled)

**Stage 2 jury verdict:** CONFIRMED Crit (both findings).

### C-01 — Validation gate bypass via validated→approved
`compute_allowed_actions` exposed `approve` from `validated` without rechecking \`ValidationStatus.passed\`. Approval bypass of hard validation = Always Crit per institutional convention.

- File: \`backend/vertical_engines/wealth/model_portfolio/state_machine.py:175-189\`
- Route consumer: \`backend/app/domains/wealth/routes/model_portfolios.py:403-405, 537-545\`

### C-02 — TRANSITIONS missing constructed→approved edge
Graph omitted \`approved\` from \`TRANSITIONS["constructed"]\`. \`ACTION_APPROVE\` was exposed when \`require_construction_for_approve\` is false, route mapped it to \`"approved"\`, and \`transition()\` rejected the missing edge with 409. Broke OD-5 override workflow.

- File: \`backend/vertical_engines/wealth/model_portfolio/state_machine.py:57-60\`

### Fix
- \`compute_allowed_actions\` now gates \`approve\` action on \`validation.passed\`
- \`"approved"\` added to \`TRANSITIONS["constructed"]\`
- 40/40 tests pass

### References
- Stage 2 jury: \`docs/audits/2026-04-29-wave6-session10-stage2-jury.md\` (C-01, C-02)
- Stage 3 prompt block: \`docs/prompts/2026-04-29-session-10-stage3-remediation-pr-prompts.md#Q110\`