### PR TITLE
fix(wealth): PR-Q111 — Wave 6 S10 C-03 — CVaR improvement sign flip in construction advisor (Crit)

### DIFF
--- a/backend/tests/test_construction_advisor.py
+++ b/backend/tests/test_construction_advisor.py
@@ -343,6 +343,53 @@ class TestProjectCvarForCandidates:
         assert result[0].projected_cvar_95 is not None
         assert result[0].cvar_improvement != 0.0
 
+    def test_cvar_improvement_sign(self):
+        """PR-Q111: positive improvement when CVaR improves (less negative)."""
+        rng = np.random.default_rng(99)
+        port_ret = rng.normal(0.0003, 0.015, size=(252, 2))
+        current_weights = np.array([0.5, 0.5])
+
+        c1 = CandidateFund(
+            block_id="fi_us_aggregate",
+            instrument_id="fund-sign-test",
+            name="Bond Fund Sign",
+            ticker="BST",
+            strategy_label="Fixed Income",
+            volatility_1y=0.04,
+            correlation_with_portfolio=-0.1,
+            overlap_pct=0.0,
+            projected_cvar_95=None,
+            cvar_improvement=0.0,
+            in_universe=False,
+            external_id="CIK-SIGN",
+        )
+
+        # Low-vol bond returns — should reduce portfolio CVaR
+        cand_returns = {"fund-sign-test": rng.normal(0.0001, 0.003, size=252)}
+
+        # Use a known current_cvar = -0.08 (8% loss).
+        # Adding a low-vol bond should produce projected > -0.08 (less negative).
+        result = project_cvar_for_candidates(
+            [c1], port_ret, cand_returns, current_weights,
+            {"fi_us_aggregate": 0.30},
+            current_cvar=-0.08,
+        )
+
+        assert len(result) == 1
+        proj = result[0].projected_cvar_95
+        assert proj is not None
+
+        # projected is less negative than current → improvement must be positive
+        if proj > -0.08:
+            assert result[0].cvar_improvement > 0, (
+                f"CVaR improved ({proj:.4f} > -0.08) but cvar_improvement "
+                f"is {result[0].cvar_improvement} (should be positive)"
+            )
+
+        # Verify the formula directly: (projected - current) / abs(current)
+        expected = round((proj - (-0.08)) / abs(-0.08), 4)
+        assert result[0].cvar_improvement == expected
+
 
 # ---------------------------------------------------------------------------
 # 5. Minimum Viable Set

--- a/backend/vertical_engines/wealth/model_portfolio/construction_advisor.py
+++ b/backend/vertical_engines/wealth/model_portfolio/construction_advisor.py
@@ -402,7 +402,7 @@ def project_cvar_for_candidates(
 
         if projected is not None and abs(current_cvar) > 1e-8:
             # improvement: how much of the gap did we close? (positive = better)
-            improvement = round((current_cvar - projected) / abs(current_cvar), 4)
+            improvement = round((projected - current_cvar) / abs(current_cvar), 4)
 
         result.append(
             replace(

--- a/backend/vertical_engines/wealth/model_portfolio/models.py
+++ b/backend/vertical_engines/wealth/model_portfolio/models.py
@@ -171,7 +171,7 @@ class CandidateFund:
     correlation_with_portfolio: float
     overlap_pct: float
     projected_cvar_95: float | None
-    cvar_improvement: float  # (current - projected) / abs(current)
+    cvar_improvement: float  # (projected - current) / abs(current); positive = better
     in_universe: bool
     external_id: str
     has_holdings_data: bool = True


### PR DESCRIPTION
## Wave 6 Session 10 — C-03 (Crit)

**Stage 2 jury verdict:** CONFIRMED Crit.

### Mechanism
\`project_cvar_historical\` returns negative CVaR values under the codebase's negative-loss convention. Candidate improvement was computed as \`(current_cvar - projected) / abs(current_cvar)\`, so improving from \`-0.08\` to \`-0.06\` produced a NEGATIVE score, while worsening to \`-0.10\` produced a POSITIVE score. Candidates were sorted descending → **advisor was recommending the WORST funds**.

Math sign error inverting recommendations = Always Crit per institutional convention.

- File: \`backend/vertical_engines/wealth/model_portfolio/construction_advisor.py:403-405\`
- Sort site: \`construction_advisor.py:415-416\`

### Fix
Reversed subtraction to \`(projected - current_cvar)\` so positive score = improvement under the negative-loss convention.

- 37/37 tests pass

### References
- Stage 2 jury: \`docs/audits/2026-04-29-wave6-session10-stage2-jury.md\` (C-03)
- Stage 3 prompt block: \`docs/prompts/2026-04-29-session-10-stage3-remediation-pr-prompts.md#Q111\`