### PR TITLE
fix(wealth): PR-Q112 — Wave 6 S10 C-05 — stressed CVaR shift /T dilution fix (Crit)

### DIFF
--- a/backend/tests/test_stress_parametric.py
+++ b/backend/tests/test_stress_parametric.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+from quant_engine.cvar_service import compute_cvar_from_returns
 from vertical_engines.wealth.model_portfolio.stress_scenarios import (
     PRESET_SCENARIOS,
     StressScenarioResult,
@@ -76,3 +77,25 @@ class TestRunStressScenario:
         assert result.nav_impact_pct == 0.0
         assert result.worst_block is None
         assert result.best_block is None
+
+    def test_stressed_cvar_materially_different_from_unstressed(self):
+        """PR-Q112 (S10 C-05): stressed CVaR must reflect the scenario shock.
+
+        The old implementation divided nav_impact by T, diluting a -38%
+        GFC shock to ~-0.15%/day across 252 observations — producing
+        stressed CVaR indistinguishable from unstressed.  The fix appends
+        the shock as a single extreme observation so it properly impacts
+        the CVaR_95 tail.
+        """
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.0004, 0.01, 252)
+        base_cvar, _ = compute_cvar_from_returns(returns, confidence=0.95)
+
+        # 100% equity portfolio hit by GFC -38% shock
+        result = run_stress_scenario(
+            {"equity": 1.0}, {"equity": -0.38}, returns, "gfc"
+        )
+
+        assert result.cvar_stressed is not None
+        # Stressed CVaR should be materially worse (at least 10% more negative)
+        assert result.cvar_stressed < base_cvar * 1.10

--- a/backend/vertical_engines/wealth/model_portfolio/stress_scenarios.py
+++ b/backend/vertical_engines/wealth/model_portfolio/stress_scenarios.py
@@ -244,7 +244,11 @@ def run_stress_scenario_fund_level(
     if historical_returns is not None and len(historical_returns) >= 30:
         from quant_engine.cvar_service import compute_cvar_from_returns
 
-        shifted = historical_returns + nav_impact / len(historical_returns)
+        # PR-Q112 (S10 C-05): append shock as a single extreme observation
+        # instead of spreading nav_impact/T across all returns (which
+        # dilutes a -38% GFC shock to -0.15%/day, rendering CVaR useless).
+        shock_obs = np.array([nav_impact])
+        shifted = np.concatenate([historical_returns, shock_obs])
         cvar_stressed, _ = compute_cvar_from_returns(shifted, confidence=0.95)
         cvar_stressed = round(cvar_stressed, 6)
 
@@ -299,13 +303,16 @@ def run_stress_scenario(
         worst_block = min(block_impacts, key=block_impacts.get)  # type: ignore[arg-type]
         best_block = max(block_impacts, key=block_impacts.get)  # type: ignore[arg-type]
 
-    # Stressed CVaR: shift historical returns by nav_impact and recompute
+    # Stressed CVaR: append scenario shock as extreme observation and recompute
     cvar_stressed = None
     if historical_returns is not None and len(historical_returns) >= 30:
         from quant_engine.cvar_service import compute_cvar_from_returns
 
-        # Apply shock as a one-time shift to the return distribution
-        shifted = historical_returns + nav_impact / len(historical_returns)
+        # PR-Q112 (S10 C-05): append shock as a single extreme observation
+        # instead of spreading nav_impact/T across all returns (which
+        # dilutes a -38% GFC shock to -0.15%/day, rendering CVaR useless).
+        shock_obs = np.array([nav_impact])
+        shifted = np.concatenate([historical_returns, shock_obs])
         cvar_stressed, _ = compute_cvar_from_returns(shifted, confidence=0.95)
         cvar_stressed = round(cvar_stressed, 6)
 


### PR DESCRIPTION
## Wave 6 Session 10 — C-05 (Crit)

**Stage 2 jury verdict:** CONFIRMED Crit.

### Mechanism
Fund-level and block-level stress CVaR shifted daily history by \`nav_impact / len(historical_returns)\`. Since preset scenario shocks are total-return shocks (per inline doc at \`stress_scenarios.py:126-128\`), dividing by arbitrary history length **diluted GFC-scale losses into negligible daily mean shifts** — magnitude wrong by >10× for normal daily histories.

Feeds IC-facing stress output → Always Crit per institutional convention.

- Fund-level site: \`backend/vertical_engines/wealth/model_portfolio/stress_scenarios.py:243-249\`
- Block-level site: \`stress_scenarios.py:302-310\`

### Fix
Both sites: replaced uniform per-day shift with \`np.concatenate([returns, [nav_impact]])\` — appends scenario shock as a single observation rather than diluting it across the history window.

- 72/72 stress tests pass

### References
- Stage 2 jury: \`docs/audits/2026-04-29-wave6-session10-stage2-jury.md\` (C-05)
- Stage 3 prompt block: \`docs/prompts/2026-04-29-session-10-stage3-remediation-pr-prompts.md#Q112\`