### PR TITLE
fix(wealth): PR-Q113 — Wave 6 S10 C-06 — historical stress missing fund history coverage gate (Crit)

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -3221,6 +3221,8 @@ def _run_stress(
                 "end_date": str(s.end_date),
                 "portfolio_return": s.portfolio_return,
                 "max_drawdown": s.max_drawdown,
+                "degraded": s.degraded,
+                "degraded_reason": s.degraded_reason,
             }
             for s in result.scenarios
         ],

--- a/backend/tests/test_model_portfolio.py
+++ b/backend/tests/test_model_portfolio.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import uuid
+from datetime import date as d
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -13,6 +17,7 @@ from vertical_engines.wealth.model_portfolio.models import (
     LiveNAV,
     OptimizationMeta,
     PortfolioComposition,
+    ScenarioResult,
     StressResult,
 )
 from vertical_engines.wealth.model_portfolio.portfolio_builder import (
@@ -598,6 +603,138 @@ class TestPortfolioMetricsF01:
         assert result.max_drawdown <= -0.099, (
             f"max_drawdown should reflect the day-1 10% loss, got {result.max_drawdown}"
         )
+
+
+class TestHistoricalStressCoverage:
+    """PR-Q113: Historical stress must detect missing fund history (C-06)."""
+
+    def test_historical_stress_handles_missing_funds(self):
+        """Portfolio with 100% in fund incepted 2015; replay 2008 GFC scenario.
+
+        The fund has zero rows for 2008 dates, so coverage is 0%.
+        The scenario should be marked degraded=True with max_drawdown=None.
+        """
+        from vertical_engines.wealth.model_portfolio.track_record import compute_stress
+
+        young_fund_id = uuid.uuid4()
+
+        # Build mock DB: fund only has NAV from 2015 onward.
+        # GFC scenario runs 2007-10-01 to 2009-03-31 — fund has ZERO rows there.
+        # COVID scenario runs 2020-02-15 to 2020-04-30 — fund HAS rows.
+        covid_start = d(2020, 2, 15)
+        covid_end = d(2020, 4, 30)
+        covid_dates = []
+        current = covid_start
+        while current <= covid_end:
+            if current.weekday() < 5:  # weekdays only
+                covid_dates.append(current)
+            current += timedelta(days=1)
+
+        mock_rows = [
+            SimpleNamespace(
+                instrument_id=young_fund_id,
+                nav_date=dt,
+                return_1d=-0.01,  # -1% per day
+            )
+            for dt in covid_dates
+        ]
+
+        mock_result = MagicMock()
+        mock_result.__iter__ = lambda self: iter(mock_rows)
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value = mock_result
+
+        result = compute_stress(
+            mock_db,
+            fund_ids=[young_fund_id],
+            weights=[1.0],
+        )
+
+        # GFC scenario: fund has no data → should be degraded
+        gfc = next((s for s in result.scenarios if s.name == "2008_gfc"), None)
+        assert gfc is not None, "GFC scenario should still appear in results"
+        assert gfc.degraded is True, "GFC should be degraded — fund has no 2008 data"
+        assert gfc.max_drawdown is None, "Degraded scenario should not report drawdown"
+        assert gfc.portfolio_return is None, "Degraded scenario should not report return"
+        assert gfc.degraded_reason is not None
+
+        # COVID scenario: fund has full data → should NOT be degraded
+        covid = next((s for s in result.scenarios if s.name == "2020_covid"), None)
+        assert covid is not None, "COVID scenario should be present"
+        assert covid.degraded is False
+        assert covid.max_drawdown is not None
+        assert covid.portfolio_return is not None
+
+    def test_full_coverage_stress_not_degraded(self):
+        """A fund with data spanning all scenarios should produce no degraded results."""
+        from vertical_engines.wealth.model_portfolio.stress_scenarios import SCENARIOS
+        from vertical_engines.wealth.model_portfolio.track_record import compute_stress
+
+        fund_id = uuid.uuid4()
+
+        # Generate rows for ALL scenario windows
+        earliest = min(s.start_date for s in SCENARIOS)
+        latest = max(s.end_date for s in SCENARIOS)
+
+        all_dates = []
+        current = earliest
+        while current <= latest:
+            if current.weekday() < 5:
+                all_dates.append(current)
+            current += timedelta(days=1)
+
+        mock_rows = [
+            SimpleNamespace(
+                instrument_id=fund_id,
+                nav_date=dt,
+                return_1d=0.001,  # +0.1% per day
+            )
+            for dt in all_dates
+        ]
+
+        mock_result = MagicMock()
+        mock_result.__iter__ = lambda self: iter(mock_rows)
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value = mock_result
+
+        result = compute_stress(
+            mock_db,
+            fund_ids=[fund_id],
+            weights=[1.0],
+        )
+
+        assert len(result.scenarios) == len(SCENARIOS)
+        for s in result.scenarios:
+            assert s.degraded is False, f"Scenario {s.name} should not be degraded"
+            assert s.portfolio_return is not None
+            assert s.max_drawdown is not None
+
+    def test_scenario_result_degraded_defaults(self):
+        """ScenarioResult backwards compatibility — degraded defaults to False."""
+        # Old-style creation (no degraded args) — should default gracefully
+        sr = ScenarioResult(
+            name="test",
+            start_date=d(2020, 1, 1),
+            end_date=d(2020, 12, 31),
+            portfolio_return=-0.10,
+            max_drawdown=-0.15,
+        )
+        assert sr.degraded is False
+        assert sr.degraded_reason is None
+
+        # Degraded creation
+        sr_deg = ScenarioResult(
+            name="test_deg",
+            start_date=d(2020, 1, 1),
+            end_date=d(2020, 12, 31),
+            degraded=True,
+            degraded_reason="Low coverage",
+        )
+        assert sr_deg.degraded is True
+        assert sr_deg.portfolio_return is None
+        assert sr_deg.max_drawdown is None
 
 
 class TestQuantAnalyzerRewired:

--- a/backend/vertical_engines/wealth/fact_sheet/fact_sheet_engine.py
+++ b/backend/vertical_engines/wealth/fact_sheet/fact_sheet_engine.py
@@ -395,6 +395,8 @@ class FactSheetEngine:
                     end_date=s.end_date,
                     portfolio_return=s.portfolio_return,
                     max_drawdown=s.max_drawdown,
+                    degraded=s.degraded,
+                    degraded_reason=s.degraded_reason,
                 )
                 for s in result.scenarios
             ]

--- a/backend/vertical_engines/wealth/fact_sheet/models.py
+++ b/backend/vertical_engines/wealth/fact_sheet/models.py
@@ -71,8 +71,10 @@ class StressRow:
     name: str
     start_date: date
     end_date: date
-    portfolio_return: float
-    max_drawdown: float
+    portfolio_return: float | None = None
+    max_drawdown: float | None = None
+    degraded: bool = False
+    degraded_reason: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/vertical_engines/wealth/model_portfolio/models.py
+++ b/backend/vertical_engines/wealth/model_portfolio/models.py
@@ -90,9 +90,11 @@ class ScenarioResult:
     name: str
     start_date: date
     end_date: date
-    portfolio_return: float
-    max_drawdown: float
+    portfolio_return: float | None = None
+    max_drawdown: float | None = None
     recovery_days: int | None = None
+    degraded: bool = False
+    degraded_reason: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/vertical_engines/wealth/model_portfolio/track_record.py
+++ b/backend/vertical_engines/wealth/model_portfolio/track_record.py
@@ -31,6 +31,11 @@ logger = structlog.get_logger()
 # Minimum trading days for a fund to be included in backtest
 MIN_HISTORY_DAYS = 252
 
+# Minimum portfolio weight coverage for a stress scenario day to be valid.
+# If the sum of weights for funds with actual return data on a given day
+# falls below this threshold, the scenario is marked as degraded.
+COVERAGE_THRESHOLD = 0.80
+
 
 def compute_backtest(
     db: Session,
@@ -216,16 +221,59 @@ def compute_stress(
                 scenario=scenario.name,
                 available_days=len(scenario_dates),
             )
+            scenario_results.append(
+                ScenarioResult(
+                    name=scenario.name,
+                    start_date=scenario.start_date,
+                    end_date=scenario.end_date,
+                    degraded=True,
+                    degraded_reason=(
+                        f"Insufficient data: {len(scenario_dates)} trading days "
+                        f"available (minimum 5)"
+                    ),
+                ),
+            )
             continue
 
-        # Compute weighted portfolio returns for the scenario window
+        # Compute weighted portfolio returns for the scenario window,
+        # tracking per-day coverage (sum of weights with actual data).
         portfolio_returns = []
+        scenario_degraded = False
+        degraded_reason: str | None = None
         for d in scenario_dates:
             day_return = 0.0
+            day_coverage = 0.0
             for fid, w in zip(fund_ids, weights, strict=False):
-                r = returns_lookup.get((fid, d), 0.0)
-                day_return += w * r
+                r = returns_lookup.get((fid, d))
+                if r is not None:
+                    day_return += w * r
+                    day_coverage += w
+            if day_coverage < COVERAGE_THRESHOLD:
+                scenario_degraded = True
+                degraded_reason = (
+                    f"Coverage {day_coverage:.0%} < {COVERAGE_THRESHOLD:.0%} on {d}"
+                )
+                logger.warning(
+                    "stress_coverage_below_threshold",
+                    scenario=scenario.name,
+                    date=str(d),
+                    coverage=round(day_coverage, 4),
+                    threshold=COVERAGE_THRESHOLD,
+                )
+                break
             portfolio_returns.append(day_return)
+
+        if scenario_degraded:
+            scenario_results.append(
+                ScenarioResult(
+                    name=scenario.name,
+                    start_date=scenario.start_date,
+                    end_date=scenario.end_date,
+                    degraded=True,
+                    degraded_reason=degraded_reason,
+                ),
+            )
+            continue
 
         pr = np.array(portfolio_returns)
         cum = np.cumprod(1.0 + pr)


### PR DESCRIPTION
## Wave 6 Session 10 — C-06 (Crit)

**Stage 2 jury verdict:** CONFIRMED Crit.

### Mechanism
\`compute_stress\` used \`returns_lookup.get((fid, d), 0.0)\` for missing NAV observations during scenario replay. **No per-day coverage threshold, degraded flag, or proxy fallback** before portfolio returns were accumulated → young funds became stress-immune cash.

Missing data treated as zero in stress scenarios = Always Crit per institutional convention.

- File: \`backend/vertical_engines/wealth/model_portfolio/track_record.py:198-230\`

### Fix
- 80% per-day coverage threshold gate
- \`degraded\` flag added to \`ScenarioResult\` model
- Coverage propagation through 6 files (model + consumers: routes, fact_sheet, fact_sheet engine)
- 83/83 tests pass

### References
- Stage 2 jury: \`docs/audits/2026-04-29-wave6-session10-stage2-jury.md\` (C-06)
- Stage 3 prompt block: \`docs/prompts/2026-04-29-session-10-stage3-remediation-pr-prompts.md#Q113\`