### PR TITLE
fix(wealth): PR-Q122 — Recovery: re-apply Q115 state_machine write_audit_event (Crit, regressed by Q111 rebase)

### DIFF
--- a/backend/tests/test_portfolio_state_machine.py
+++ b/backend/tests/test_portfolio_state_machine.py
@@ -23,8 +23,13 @@ infrastructure of the Phase 3 worker test without adding signal.
 
 from __future__ import annotations
 
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
+from app.domains.wealth.models.model_portfolio import PortfolioStateTransition
 from vertical_engines.wealth.model_portfolio.state_machine import (
     ACTION_ACTIVATE,
     ACTION_APPROVE,
@@ -41,6 +46,7 @@ from vertical_engines.wealth.model_portfolio.state_machine import (
     InvalidStateTransition,
     ValidationStatus,
     compute_allowed_actions,
+    transition,
 )
 
 # ── TRANSITIONS adjacency map sanity ───────────────────────────────
@@ -303,14 +309,86 @@ def test_existing_constructed_to_validated_still_works():
     assert "draft" in TRANSITIONS["constructed"]
 
 
-# NOTE: The DB-write path of the async ``transition()`` function is
-# exercised end-to-end in Phase 3 Task 3.4 (the
-# ``construction_run_executor`` worker test) using the project's real
-# Postgres test DB. A SQLite-based unit test was attempted here but
-# the project policy (per ``backend/tests/conftest.py``) is "Tests run
-# against real PostgreSQL — asyncpg requires PG", and ``aiosqlite`` is
-# intentionally not in the dev dependency set. The state machine
-# logic above (TRANSITIONS adjacency, ``compute_allowed_actions``,
-# ``InvalidStateTransition``, ``ApprovalPolicy``) is fully covered by
-# the pure-Python tests; the DB plumbing is exercised by the worker
-# test in Phase 3.
+# ── PR-Q115: write_audit_event on transition ──────────────────────
+
+
+def _mock_db_for_transition(portfolio_id, org_id, from_state="draft"):
+    """Build a mocked AsyncSession sufficient for ``transition()``."""
+    mock_portfolio = MagicMock()
+    mock_portfolio.id = portfolio_id
+    mock_portfolio.state = from_state
+    mock_portfolio.organization_id = org_id
+    mock_portfolio.state_changed_at = datetime(2026, 4, 29, tzinfo=timezone.utc)
+
+    db = AsyncMock()
+    select_result = MagicMock()
+    select_result.scalar_one_or_none.return_value = mock_portfolio
+    update_result = MagicMock()
+    db.execute = AsyncMock(side_effect=[select_result, update_result])
+    db.add = MagicMock()  # Session.add is synchronous
+    return db, mock_portfolio
+
+
+@pytest.mark.asyncio
+async def test_transition_writes_audit_event():
+    """PR-Q115: transition() must call write_audit_event with correct kwargs."""
+    pid = uuid.uuid4()
+    org_id = uuid.uuid4()
+    db, _ = _mock_db_for_transition(pid, org_id, from_state="draft")
+
+    with patch(
+        "vertical_engines.wealth.model_portfolio.state_machine.write_audit_event",
+        new_callable=AsyncMock,
+    ) as mock_audit:
+        await transition(
+            db,
+            portfolio_id=pid,
+            to_state="constructed",
+            actor_id="actor_1",
+            reason="test reason",
+        )
+
+        mock_audit.assert_called_once()
+        kwargs = mock_audit.call_args.kwargs
+        assert kwargs["action"] == "model_portfolio.state_transition"
+        assert kwargs["entity_type"] == "ModelPortfolio"
+        assert kwargs["entity_id"] == str(pid)
+        assert kwargs["allow_global"] is False
+        assert kwargs["before"] == {"state": "draft"}
+        assert kwargs["after"]["state"] == "constructed"
+        assert kwargs["after"]["actor_id"] == "actor_1"
+        assert kwargs["after"]["reason"] == "test reason"
+
+
+@pytest.mark.asyncio
+async def test_transition_writes_both_domain_and_audit_rows():
+    """PR-Q115: Both PortfolioStateTransition AND audit_events row are created."""
+    pid = uuid.uuid4()
+    org_id = uuid.uuid4()
+    db, _ = _mock_db_for_transition(pid, org_id, from_state="draft")
+
+    added_objects: list = []
+    db.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+
+    with patch(
+        "vertical_engines.wealth.model_portfolio.state_machine.write_audit_event",
+        new_callable=AsyncMock,
+    ) as mock_audit:
+        await transition(
+            db,
+            portfolio_id=pid,
+            to_state="constructed",
+            actor_id="actor_1",
+        )
+
+        # Domain-specific row: PortfolioStateTransition was db.add()-ed
+        transition_rows = [
+            obj for obj in added_objects
+            if isinstance(obj, PortfolioStateTransition)
+        ]
+        assert len(transition_rows) == 1
+        assert transition_rows[0].from_state == "draft"
+        assert transition_rows[0].to_state == "constructed"
+
+        # Unified audit: write_audit_event also called
+        mock_audit.assert_called_once()

--- a/backend/vertical_engines/wealth/model_portfolio/state_machine.py
+++ b/backend/vertical_engines/wealth/model_portfolio/state_machine.py
@@ -37,6 +37,7 @@ import structlog
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.db.audit import write_audit_event
 from app.domains.wealth.models.model_portfolio import (
     ModelPortfolio,
     PortfolioStateTransition,
@@ -341,6 +342,24 @@ async def transition(
     await db.flush()
     await db.refresh(transition_row)
     await db.refresh(portfolio)
+
+    # PR-Q115: emit unified audit event (Session 10 I-Audit-Tenant-1).
+    # The PortfolioStateTransition row is domain-specific; the audit_events
+    # row feeds the unified tenant-scoped audit feed.
+    await write_audit_event(
+        db,
+        action="model_portfolio.state_transition",
+        entity_type="ModelPortfolio",
+        entity_id=str(portfolio_id),
+        actor_id=actor_id,
+        before={"state": from_state},
+        after={
+            "state": to_state,
+            "actor_id": actor_id,
+            "reason": reason,
+        },
+        allow_global=False,
+    )
 
     logger.info(
         "portfolio_state_transition",


### PR DESCRIPTION
## Wave 6 Session 10 — C-11 RECOVERY (Crit)

**Original PR:** [#416](https://github.com/Andreicr1/netz-analysis-engine/pull/416) (Q115, merged 2026-04-29 04:21 UTC, commit \`e564cedf\`)
**Regression vector:** Q111 \`gh pr merge --rebase --admin\` at 14:16:19 UTC silently reverted Q115's changes to \`state_machine.py\` and \`test_portfolio_state_machine.py\`.

### Diagnosis

Q111-Q114 worktree branches were created from \`5c7290a9\` (pre-Q115 main) before Q115 was direct-pushed to main as \`e564cedf\`. When Q111 was admin-rebase-merged onto post-Q115 main:
- Expected: rebase replays Q111's CVaR-only diff onto \`e564cedf\`, preserving Q115's \`state_machine.py\` blob \`6e3e8be3\`.
- Actual: rebase produced commit \`e0f91096\` whose tree contains \`state_machine.py\` at blob \`0aec9df1\` (pre-Q115). Q115's import + \`write_audit_event\` call silently dropped.

Q110 (#417) compounded: it modified the already-regressed pre-Q115 file, encoding the regression into its own merged commit.

### Pre-merge state of main

| Crit finding | Status before Q122 |
|---|---|
| C-01 + C-02 (Q110) | Fix present |
| C-03 (Q111) | Fix present |
| C-05 (Q112) | Fix present |
| C-06 (Q113) | Fix present |
| C-11 (Q115) | **REGRESSED — \`I-Audit-Tenant-1\` Q92 invariant violated again** |

### Fix

Cherry-pick of \`e564cedf\` onto current main with conflict resolution in \`test_portfolio_state_machine.py\` (Q110 + Q115 test blocks were both appended after the same anchor; resolution = keep both).

### Verification

- \`backend/tests/test_portfolio_state_machine.py\`: **42/42 passing** (Q110's 4 tests + Q115's 2 tests + 36 pre-existing)
- \`grep write_audit_event backend/vertical_engines/wealth/model_portfolio/state_machine.py\` → import (line 40) + call (line 349)
- \`TRANSITIONS["constructed"]\` (line 60): includes \`"approved"\` (Q110 C-02 fix preserved)
- \`compute_allowed_actions\` (line 188): gates ACTION_APPROVE on \`validation.passed\` (Q110 C-01 fix preserved)

### Anti-pattern reference

This is a NEW variant of the obsolete-base PR pattern documented in \`feedback_obsolete_pr_branch_pattern.md\` — specifically: branches based on a commit BEFORE a parallel direct-push, when admin-rebase-merged, can silently revert the direct-pushed work even when there is no line-level overlap. Recommended remediation: prefer \`git pull --rebase\` on the branch before \`gh pr merge\`, OR avoid direct push to main (always go via PR).

Memory will be updated with this sub-pattern after this PR lands.

### References

- Original Q115 finding: \`docs/audits/2026-04-29-wave6-session10-stage2-jury.md\` (C-11)
- Stage 3 prompt: \`docs/prompts/2026-04-29-session-10-stage3-remediation-pr-prompts.md#Q115\`