### PR TITLE
fix(wealth): PR-Q117 — Wave 6 S10 C-09 — fail-closed block-severity checks (High)

### DIFF
--- a/backend/tests/test_validation_gate.py
+++ b/backend/tests/test_validation_gate.py
@@ -21,6 +21,7 @@ from typing import Any
 import pytest
 
 from vertical_engines.wealth.model_portfolio.validation_gate import (
+    _INTENDED_SEVERITY,
     CHECKS,
     ValidationDbContext,
     ValidationResult,
@@ -387,22 +388,20 @@ def test_no_fail_fast_all_15_checks_run():
     )
 
 
-# ── Resilience: a raising check becomes a warn ───────────────────
+# ── Resilience: a raising check preserves intended severity ───────
 
 
-def test_check_that_raises_is_caught_as_warn():
-    """A bug in one check cannot strand activation."""
-    # Inject an instrument with a non-string key to force a TypeError
-    # path in one of the checks.
+def test_check_that_raises_preserves_intended_severity():
+    """A check that raises preserves its intended severity (fail-closed)."""
     payload = _base_payload()
     payload["weights_proposed"] = None  # likely to raise in multiple checks
     result = validate_construction(payload, _base_db_context())
-    assert len(result.checks) == 16  # all 15 still run
-    # None of the raised ones are block severity (they were caught
-    # and converted to warn).
+    assert len(result.checks) == 16  # all 16 still run
+    # Raised checks preserve their intended severity from
+    # _INTENDED_SEVERITY, not always "warn".
     for c in result.checks:
         if not c.passed and c.explanation.startswith("Check raised:"):
-            assert c.severity == "warn"
+            assert c.severity == _INTENDED_SEVERITY.get(c.id, "block")
 
 
 # ── JSONB serialization ──────────────────────────────────────────
@@ -446,3 +445,55 @@ def test_validation_result_is_frozen_dataclass():
     # Frozen dataclass — mutation must raise FrozenInstanceError
     with pytest.raises(dataclasses.FrozenInstanceError):
         result.passed = False  # type: ignore[misc]
+
+
+# ── Fail-closed severity preservation (PR-Q117, C-09) ────────────
+
+
+def test_block_check_exception_stays_block_severity():
+    """A block-severity check that raises must stay block, not demote to warn.
+
+    Wave 6 S10 C-09: the old code silently demoted all exceptions to
+    severity='warn', allowing block checks on malformed input to pass
+    the gate. With _INTENDED_SEVERITY, the exception handler preserves
+    the check's canonical severity. Default for unknown IDs is 'block'
+    (fail-closed).
+    """
+    payload = {"weights_proposed": {"a": "not_a_number"}}
+    result = validate_construction(payload, ValidationDbContext())
+    wst = next(c for c in result.checks if c.id == "weights_sum_to_one")
+    assert wst.severity == "block"
+    assert not wst.passed
+    assert not result.passed  # block failure must prevent activation
+
+
+def test_warn_check_exception_stays_warn_severity():
+    """A warn-severity check that raises must stay warn, not escalate to block.
+
+    Counterpart to the block test: when a warn-severity check (e.g.
+    stress_within_tolerance) raises, the gate must not accidentally
+    escalate it to block. The aggregate result should still pass.
+    """
+    payload = _base_payload()
+    # Force stress_within_tolerance to raise by injecting a non-numeric
+    # nav_impact_pct that will fail float() conversion.
+    payload["stress_results"] = [
+        {"scenario": "evil", "nav_impact_pct": "not_a_number"},
+    ]
+    result = validate_construction(payload, _base_db_context())
+    stress = next(c for c in result.checks if c.id == "stress_within_tolerance")
+    assert stress.severity == "warn"
+    assert not stress.passed
+    assert stress.explanation.startswith("Check raised:")
+    # A warn-only failure must NOT block the aggregate result
+    assert result.passed is True
+
+
+def test_intended_severity_registry_covers_all_checks():
+    """_INTENDED_SEVERITY must list all 16 checks from the CHECKS registry."""
+    check_ids = {check_id for check_id, _ in CHECKS}
+    registry_ids = set(_INTENDED_SEVERITY.keys())
+    assert check_ids == registry_ids, (
+        f"Missing from _INTENDED_SEVERITY: {check_ids - registry_ids}; "
+        f"Extra in _INTENDED_SEVERITY: {registry_ids - check_ids}"
+    )

--- a/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
+++ b/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
@@ -17,6 +17,15 @@ Severity taxonomy
 - ``warn`` — a warning that does not block activation but is
   surfaced in the narrative and the Builder's CalibrationPanel.
 
+Exception handling — fail-closed (§3.2)
+---------------------------------------
+When a check function raises an unhandled exception, the gate
+preserves the check's **intended severity** from ``_INTENDED_SEVERITY``
+rather than demoting it to ``warn``. Unknown check IDs default to
+``block`` (fail-closed). This ensures that block-severity checks
+on malformed input remain blocking — a bug in a check function
+cannot silently bypass the gate.
+
 Public surface
 --------------
 - :class:`ValidationCheck` — frozen dataclass, one per check
@@ -767,6 +776,34 @@ CHECKS: Final[list[tuple[str, Callable[[dict[str, Any], ValidationDbContext], Va
 ]
 
 
+# ── Intended severity per check (fail-closed default) ─────────────
+#
+# When a check function raises, this registry determines the severity
+# of the resulting ValidationCheck. Unknown check IDs default to
+# "block" (fail-closed, §3.2). This prevents a TypeError or missing
+# key from silently demoting a block-severity check to warn.
+
+
+_INTENDED_SEVERITY: Final[dict[str, Severity]] = {
+    "weights_sum_to_one": "block",
+    "no_stale_nav": "block",
+    "cvar_within_limit": "block",
+    "turnover_within_cap": "warn",
+    "min_diversification_count": "block",
+    "max_single_fund_weight": "block",
+    "all_block_min_weights_satisfied": "block",
+    "all_block_max_weights_satisfied": "block",
+    "no_banned_instruments": "block",
+    "all_instruments_approved": "block",
+    "stress_within_tolerance": "warn",
+    "no_unrealistic_expected_return": "warn",
+    "bl_views_consistent_with_prior": "warn",
+    "garch_convergence_rate": "warn",
+    "factor_model_r_squared": "warn",
+    "taa_bands_within_ips": "block",
+}
+
+
 def validate_construction(
     run_payload: dict[str, Any],
     db_context: ValidationDbContext | None = None,
@@ -798,12 +835,12 @@ def validate_construction(
         try:
             result = check_fn(run_payload, db_context)
         except Exception as exc:  # noqa: BLE001
-            # A check that raises is a warn-level failure — never a
-            # block — so a bug in one check can't strand activation.
+            # Preserve the check's intended severity from the registry.
+            # Unknown check IDs default to "block" (fail-closed, §3.2).
             result = ValidationCheck(
                 id=_check_id,
                 label=_check_id.replace("_", " ").capitalize(),
-                severity="warn",
+                severity=_INTENDED_SEVERITY.get(_check_id, "block"),
                 passed=False,
                 value=None,
                 threshold=None,


### PR DESCRIPTION
## Summary

- **Wave 6 S10 C-09 (High):** `validate_construction()` exception handler silently demoted ALL check exceptions to `severity="warn"`, regardless of the check's intended severity. Block-severity checks (`weights_sum_to_one`, `cvar_within_limit`, `no_stale_nav`, etc.) on malformed input became non-blocking warnings, bypassing the gate.
- Added `_INTENDED_SEVERITY` registry mapping all 16 checks to their canonical severity. Exception handler now reads from this registry instead of hardcoding `"warn"`. Unknown check IDs default to `"block"` (fail-closed, institutional convention §3.2).
- Updated docstring to document fail-closed exception handling semantics.

## Files changed

- `backend/vertical_engines/wealth/model_portfolio/validation_gate.py` — `_INTENDED_SEVERITY` registry + exception handler fix + docstring update
- `backend/tests/test_validation_gate.py` — 1 test updated + 3 new tests

## Test plan

- [x] `test_block_check_exception_stays_block_severity` — malformed payload causes block-severity check to raise; confirms severity stays `"block"` and `result.passed` is `False`
- [x] `test_warn_check_exception_stays_warn_severity` — malformed payload causes warn-severity check to raise; confirms severity stays `"warn"` and `result.passed` is `True`
- [x] `test_intended_severity_registry_covers_all_checks` — structural test ensuring `_INTENDED_SEVERITY` lists exactly the same 16 check IDs as `CHECKS`
- [x] `test_check_that_raises_preserves_intended_severity` — updated from old test to verify severity matches `_INTENDED_SEVERITY` instead of always `"warn"`
- [x] All 21 validation_gate tests pass
- [x] Full `pytest -k validation` suite: 224 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)