### PR TITLE
fix(wealth): PR-Q119 — NAV staleness threshold enforcement (High)

### DIFF
--- a/backend/tests/test_validation_gate.py
+++ b/backend/tests/test_validation_gate.py
@@ -268,6 +268,50 @@ def test_block_max_weight_violation():
     assert failed[0].passed is False
 
 
+# ── NAV staleness threshold enforcement (PR-Q119) ────────────────
+
+
+def test_stale_nav_detects_old_dates():
+    """Fund with NAV 39 days old (> 10d threshold) is flagged stale."""
+    payload = _base_payload()
+    payload["as_of_date"] = "2026-04-09"
+    payload["weights_proposed"] = {
+        "fund_a": 0.50,
+        "fund_b": 0.50,
+    }
+    db = ValidationDbContext(
+        nav_latest_date={
+            "fund_a": "2026-03-01",  # 39 days old → stale
+            "fund_b": "2026-04-07",  # 2 days old → ok
+        },
+        nav_staleness_threshold_days=10,
+    )
+    result = validate_construction(payload, db)
+    nav_check = next(c for c in result.checks if c.id == "no_stale_nav")
+    assert not nav_check.passed
+    assert nav_check.value == 1
+
+
+def test_stale_nav_passes_when_all_recent():
+    """All NAV dates within the threshold window pass the check."""
+    payload = _base_payload()
+    payload["as_of_date"] = "2026-04-09"
+    payload["weights_proposed"] = {
+        "fund_a": 0.50,
+        "fund_b": 0.50,
+    }
+    db = ValidationDbContext(
+        nav_latest_date={
+            "fund_a": "2026-04-07",
+            "fund_b": "2026-04-08",
+        },
+        nav_staleness_threshold_days=10,
+    )
+    result = validate_construction(payload, db)
+    nav_check = next(c for c in result.checks if c.id == "no_stale_nav")
+    assert nav_check.passed
+
+
 # ── Warn-severity cases ──────────────────────────────────────────
 
 

--- a/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
+++ b/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import date, timedelta
 from typing import Any, Final, Literal
 
 Severity = Literal["block", "warn"]
@@ -166,13 +167,38 @@ def _check_no_stale_nav(
 ) -> ValidationCheck:
     weights = run_payload.get("weights_proposed") or {}
     instrument_ids = [str(iid) for iid in weights]
-    as_of_date = run_payload.get("as_of_date")
+    as_of_date_raw = run_payload.get("as_of_date")
+
+    if not as_of_date_raw:
+        return ValidationCheck(
+            id="no_stale_nav",
+            label="NAV data is fresh",
+            severity="block",
+            passed=True,
+            value=0,
+            threshold=db.nav_staleness_threshold_days,
+            explanation="as_of_date missing from payload; staleness check skipped.",
+        )
+
+    as_of = (
+        date.fromisoformat(as_of_date_raw)
+        if isinstance(as_of_date_raw, str)
+        else as_of_date_raw
+    )
+    cutoff = as_of - timedelta(days=db.nav_staleness_threshold_days)
+
     stale_count = 0
-    if as_of_date:
-        for iid in instrument_ids:
-            latest = db.nav_latest_date.get(iid)
-            if latest is None:
-                stale_count += 1
+    for iid in instrument_ids:
+        latest = db.nav_latest_date.get(iid)
+        if latest is None:
+            stale_count += 1
+            continue
+        latest_date = (
+            date.fromisoformat(latest) if isinstance(latest, str) else latest
+        )
+        if latest_date < cutoff:
+            stale_count += 1
+
     passed = stale_count == 0
     return ValidationCheck(
         id="no_stale_nav",
@@ -180,10 +206,12 @@ def _check_no_stale_nav(
         severity="block",
         passed=passed,
         value=stale_count,
-        threshold=0,
+        threshold=db.nav_staleness_threshold_days,
         explanation=(
-            f"{stale_count} instrument(s) have NAV data older than "
-            f"{db.nav_staleness_threshold_days} days or missing entirely."
+            f"{stale_count} instrument(s) with NAV older than "
+            f"{db.nav_staleness_threshold_days}d as of {as_of}"
+            if not passed
+            else "All NAV data within staleness threshold."
         ),
     )
 


### PR DESCRIPTION
## Summary

- **Finding:** Wave 6 S10 C-12 -- _check_no_stale_nav in validation_gate.py verified NAV presence only. nav_staleness_threshold_days (default 10) was defined on ValidationDbContext but never compared against as_of_date. A fund with 30-day-old NAV passed the check.
- **Fix:** Compare each instrument latest_date against as_of_date - timedelta(days=threshold_days). Handles both str and date instances. Graceful degradation when as_of_date is absent (check passes with skip explanation).
- **Severity:** High (institutional convention 3.2 -- data quality gate ineffective)

## Changes

- backend/vertical_engines/wealth/model_portfolio/validation_gate.py -- rewrote _check_no_stale_nav to enforce date arithmetic against threshold; added date/timedelta imports; threshold value now surfaced in ValidationCheck.threshold field
- backend/tests/test_validation_gate.py -- 2 new tests: test_stale_nav_detects_old_dates (39d > 10d -> stale), test_stale_nav_passes_when_all_recent (within window -> pass)

## Test plan

- [x] test_stale_nav_detects_old_dates -- fund_a 39 days old flagged, fund_b 2 days old passes, value == 1
- [x] test_stale_nav_passes_when_all_recent -- both funds within 10d window, check passes
- [x] All 20 existing test_validation_gate.py tests pass (including happy path)
- [x] Full validation test suite: 223 passed
- [x] Lint clean (ruff check)