### PR TITLE
fix(wealth): PR-Q118 — executor bypasses state_machine.transition() (High)

### DIFF
--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -2094,9 +2094,17 @@ async def _execute_inner(
         portfolio.fund_selection_schema = _jsonb_safe(base_result)
         portfolio.status = "backtesting"
         if portfolio.state in {"draft", "rejected"}:
-            portfolio.state = "constructed"
-            portfolio.state_changed_by = run.requested_by
-            portfolio.state_changed_at = datetime.now(tz=timezone.utc)
+            from vertical_engines.wealth.model_portfolio.state_machine import (
+                transition as sm_transition,
+            )
+
+            await sm_transition(
+                db,
+                portfolio_id=portfolio.id,
+                to_state="constructed",
+                actor_id=run.requested_by,
+                reason=f"Construction run {run.id}",
+            )
 
         from app.domains.wealth.workers.portfolio_nav_synthesizer import (
             synthesize_portfolio_nav,

--- a/backend/tests/test_portfolio_state_machine.py
+++ b/backend/tests/test_portfolio_state_machine.py
@@ -392,3 +392,80 @@ async def test_transition_writes_both_domain_and_audit_rows():
 
         # Unified audit: write_audit_event also called
         mock_audit.assert_called_once()
+
+
+# ── PR-Q118: executor uses transition() → audit row + event ──────
+
+
+def test_rejected_to_constructed_is_valid_edge():
+    """PR-Q118: TRANSITIONS must allow rejected→constructed so the executor
+    can re-construct a rejected portfolio via state_machine.transition()."""
+    assert "constructed" in TRANSITIONS["rejected"]
+
+
+@pytest.mark.asyncio
+async def test_construction_creates_transition_audit_row():
+    """PR-Q118: When the executor path triggers draft→constructed via
+    transition(), a PortfolioStateTransition row is created with correct
+    from_state/to_state."""
+    pid = uuid.uuid4()
+    org_id = uuid.uuid4()
+    db, _ = _mock_db_for_transition(pid, org_id, from_state="draft")
+
+    added_objects: list = []
+    db.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+
+    with patch(
+        "vertical_engines.wealth.model_portfolio.state_machine.write_audit_event",
+        new_callable=AsyncMock,
+    ):
+        await transition(
+            db,
+            portfolio_id=pid,
+            to_state="constructed",
+            actor_id="executor_actor",
+            reason="Construction run abc-123",
+        )
+
+    transition_rows = [
+        obj for obj in added_objects
+        if isinstance(obj, PortfolioStateTransition)
+    ]
+    assert len(transition_rows) == 1
+    assert transition_rows[0].from_state == "draft"
+    assert transition_rows[0].to_state == "constructed"
+    assert transition_rows[0].actor_id == "executor_actor"
+    assert transition_rows[0].reason == "Construction run abc-123"
+
+
+@pytest.mark.asyncio
+async def test_construction_creates_audit_event_row():
+    """PR-Q118: After Q115, executor→transition()→write_audit_event.
+    Verify the unified audit_events entry is emitted with the correct
+    model_portfolio.state_transition action for both draft and rejected
+    source states."""
+    for from_state in ("draft", "rejected"):
+        pid = uuid.uuid4()
+        org_id = uuid.uuid4()
+        db, _ = _mock_db_for_transition(pid, org_id, from_state=from_state)
+
+        with patch(
+            "vertical_engines.wealth.model_portfolio.state_machine.write_audit_event",
+            new_callable=AsyncMock,
+        ) as mock_audit:
+            await transition(
+                db,
+                portfolio_id=pid,
+                to_state="constructed",
+                actor_id="executor_actor",
+                reason=f"Construction run from {from_state}",
+            )
+
+            mock_audit.assert_called_once()
+            kwargs = mock_audit.call_args.kwargs
+            assert kwargs["action"] == "model_portfolio.state_transition"
+            assert kwargs["entity_type"] == "ModelPortfolio"
+            assert kwargs["entity_id"] == str(pid)
+            assert kwargs["allow_global"] is False
+            assert kwargs["before"] == {"state": from_state}
+            assert kwargs["after"]["state"] == "constructed"

--- a/backend/vertical_engines/wealth/model_portfolio/state_machine.py
+++ b/backend/vertical_engines/wealth/model_portfolio/state_machine.py
@@ -63,7 +63,7 @@ TRANSITIONS: Final[dict[State, set[State]]] = {
     "live":        {"paused", "archived"},
     "paused":      {"live", "archived"},
     "archived":    set(),
-    "rejected":    {"draft", "archived"},
+    "rejected":    {"draft", "constructed", "archived"},
 }
 
 


### PR DESCRIPTION
## Summary

- **Wave 6 Session 10 C-10** — construction executor directly mutated `portfolio.state`, `state_changed_by`, and `state_changed_at`, bypassing `state_machine.transition()` which provides row-locking, graph edge validation, `PortfolioStateTransition` audit row, and `write_audit_event` (PR-Q115)
- Replaced the 3-line direct mutation with an `await sm_transition()` call inside the existing `portfolio.state in {"draft", "rejected"}` guard
- Added `rejected -> constructed` edge to `TRANSITIONS` map — the executor already supported re-construction from rejected state, but the state machine graph didn't include this edge
- Depends on PR-Q115 (commit `586e0037`, already merged)

## Changes

| File | Change |
|------|--------|
| `construction_run_executor.py` | Replace direct `portfolio.state = "constructed"` with `sm_transition()` call |
| `state_machine.py` | Add `"constructed"` to `TRANSITIONS["rejected"]` edges |
| `test_portfolio_state_machine.py` | 3 new tests: edge validity, transition audit row, audit event row |

## Test plan

- [x] `test_rejected_to_constructed_is_valid_edge` — confirms graph edge exists
- [x] `test_construction_creates_transition_audit_row` — verifies `PortfolioStateTransition` row with correct `from_state`/`to_state`/`actor_id`/`reason`
- [x] `test_construction_creates_audit_event_row` — verifies `write_audit_event` is called with correct kwargs for both `draft` and `rejected` source states
- [x] All 93 construction-related tests pass
- [x] All 45 state machine tests pass
- [x] Lint clean

Generated with [Claude Code](https://claude.com/claude-code)