### PR TITLE
PR-Q116: Populate ValidationDbContext from DB; fix block bounds parity

### DIFF
--- a/backend/app/domains/wealth/queries/validation_context.py
+++ b/backend/app/domains/wealth/queries/validation_context.py
@@ -101,10 +101,21 @@ async def build_validation_db_context(
     #    PR-Q116 hotfix: previous COALESCE chain fell back to
     #    target_weight * 0.5/1.5 which was tighter than propose-mode's
     #    default [0, 1], causing false block failures.
+    #    PR-Q116 hotfix #3 — Codex P1: filter to the active allocation
+    #    version exactly like ``_run_construction_async`` does (see
+    #    ``routes/model_portfolios.py``):
+    #      ``effective_from <= today`` AND
+    #      ``effective_to IS NULL OR effective_to > today``,
+    #    then collapse duplicates to the latest ``effective_from`` per block.
+    #    Without this filter, historical/future rows can overwrite the
+    #    active one in undefined DB order, making validation enforce
+    #    different bounds than the optimizer used.
+    today = date.today()
     block_rows = await db.execute(
         text(
             """
-            SELECT sa.block_id,
+            SELECT DISTINCT ON (sa.block_id)
+                   sa.block_id,
                    sa.override_min,
                    sa.override_max,
                    sa.drift_min,
@@ -114,9 +125,12 @@ async def build_validation_db_context(
               FROM strategic_allocation sa
              WHERE sa.organization_id = :org
                AND sa.profile = :profile
+               AND sa.effective_from <= :today
+               AND (sa.effective_to IS NULL OR sa.effective_to > :today)
+             ORDER BY sa.block_id, sa.effective_from DESC
             """
         ),
-        {"org": org_str, "profile": profile},
+        {"org": org_str, "profile": profile, "today": today},
     )
     block_constraints: dict[str, tuple[float, float]] = {}
     strategic_targets: dict[str, float] = {}

--- a/backend/app/domains/wealth/queries/validation_context.py
+++ b/backend/app/domains/wealth/queries/validation_context.py
@@ -148,20 +148,31 @@ async def build_validation_db_context(
         )
         strategic_targets[str(block_id)] = float(target_w or 0.0)
 
-    # 4. NAV latest dates for staleness check (only for instruments in the run)
+    # 4. NAV latest dates for staleness check (only for instruments in the run).
+    #    PR-Q116 hotfix #5 — Codex P2: bound to ``as_of_date`` when supplied,
+    #    so backdated runs are evaluated against the run date and not against
+    #    forward-looking NAVs ingested afterwards (which would let
+    #    ``no_stale_nav`` pass on data the optimizer never saw).
     nav_latest_date: dict[str, str] = {}
     if instrument_ids:
+        nav_params: dict[str, object] = {
+            "ids": [uuid.UUID(iid) for iid in instrument_ids],
+        }
+        as_of_clause = ""
+        if as_of_date is not None:
+            as_of_clause = " AND nav_date <= :as_of"
+            nav_params["as_of"] = as_of_date
         nav_rows = await db.execute(
             text(
-                """
+                f"""
                 SELECT CAST(instrument_id AS TEXT),
                        CAST(MAX(nav_date) AS TEXT) AS latest_date
                   FROM nav_timeseries
-                 WHERE instrument_id = ANY(:ids)
+                 WHERE instrument_id = ANY(:ids){as_of_clause}
                  GROUP BY instrument_id
                 """
             ),
-            {"ids": [uuid.UUID(iid) for iid in instrument_ids]},
+            nav_params,
         )
         for iid, latest in nav_rows.all():
             if latest is not None:

--- a/backend/app/domains/wealth/queries/validation_context.py
+++ b/backend/app/domains/wealth/queries/validation_context.py
@@ -1,0 +1,145 @@
+"""Pre-fetch DB state for the construction validation gate.
+
+PR-Q116 — Wave 6 S10 C-04.  The ``ValidationDbContext`` was previously
+instantiated empty, which disabled 5 of the 16 hard checks (banned
+instruments, approved universe, block min/max, TAA/IPS bands).
+
+This module provides ``build_validation_db_context()`` which loads all
+five fields from the org's DB state so the gate can actually enforce them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from vertical_engines.wealth.model_portfolio.validation_gate import (
+    ValidationDbContext,
+)
+
+
+async def build_validation_db_context(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID | str,
+    profile: str,
+    instrument_ids: list[str],
+    as_of_date: date | None = None,
+    nav_staleness_threshold_days: int = 10,
+) -> ValidationDbContext:
+    """Build a fully-populated ``ValidationDbContext`` from the DB.
+
+    Parameters
+    ----------
+    db
+        RLS-aware async session (organization context already set).
+    organization_id
+        Current org UUID.
+    profile
+        Portfolio profile (e.g. ``"conservative"``).
+    instrument_ids
+        List of instrument UUID strings from the optimizer output
+        (the keys of ``weights_proposed``).
+    as_of_date
+        Construction run as-of date; used for staleness check.
+    nav_staleness_threshold_days
+        Days before a NAV observation is considered stale.
+
+    Returns
+    -------
+    ValidationDbContext
+        Frozen dataclass ready for ``validate_construction()``.
+    """
+    org_str = str(organization_id)
+
+    # Run all independent queries in parallel via gather-like pattern.
+    # Since we're on a single session, we run them sequentially but
+    # each is a lightweight indexed lookup.
+
+    # 1. Banned instruments: instruments_org with approval_status = 'rejected'
+    banned_rows = await db.execute(
+        text(
+            """
+            SELECT CAST(instrument_id AS TEXT)
+              FROM instruments_org
+             WHERE organization_id = :org
+               AND approval_status = 'rejected'
+            """
+        ),
+        {"org": org_str},
+    )
+    banned_instrument_ids = frozenset(row[0] for row in banned_rows.all())
+
+    # 2. Approved instruments: instruments_org with approval_status = 'approved'
+    approved_rows = await db.execute(
+        text(
+            """
+            SELECT CAST(instrument_id AS TEXT)
+              FROM instruments_org
+             WHERE organization_id = :org
+               AND approval_status = 'approved'
+            """
+        ),
+        {"org": org_str},
+    )
+    approved_instrument_ids = frozenset(row[0] for row in approved_rows.all())
+
+    # 3. Block constraints: strategic_allocation (min/max from drift bands,
+    #    falling back to override bounds, then to ±5pp default around target).
+    #    The optimizer-facing bounds were dropped in PR-A26.2 so we derive
+    #    from the approved drift bands which the realize-mode loader uses.
+    block_rows = await db.execute(
+        text(
+            """
+            SELECT sa.block_id,
+                   COALESCE(sa.drift_min, sa.override_min, sa.target_weight * 0.5) AS min_w,
+                   COALESCE(sa.drift_max, sa.override_max,
+                            LEAST(sa.target_weight * 1.5, 1.0)) AS max_w,
+                   COALESCE(sa.target_weight, 0.0) AS target_w
+              FROM strategic_allocation sa
+             WHERE sa.organization_id = :org
+               AND sa.profile = :profile
+               AND COALESCE(sa.excluded_from_portfolio, false) = false
+            """
+        ),
+        {"org": org_str, "profile": profile},
+    )
+    block_constraints: dict[str, tuple[float, float]] = {}
+    strategic_targets: dict[str, float] = {}
+    for block_id, min_w, max_w, target_w in block_rows.all():
+        block_constraints[str(block_id)] = (
+            float(min_w or 0.0),
+            float(max_w or 1.0),
+        )
+        strategic_targets[str(block_id)] = float(target_w or 0.0)
+
+    # 4. NAV latest dates for staleness check (only for instruments in the run)
+    nav_latest_date: dict[str, str] = {}
+    if instrument_ids:
+        nav_rows = await db.execute(
+            text(
+                """
+                SELECT CAST(instrument_id AS TEXT),
+                       CAST(MAX(nav_date) AS TEXT) AS latest_date
+                  FROM nav_timeseries
+                 WHERE instrument_id = ANY(:ids)
+                 GROUP BY instrument_id
+                """
+            ),
+            {"ids": [uuid.UUID(iid) for iid in instrument_ids]},
+        )
+        for iid, latest in nav_rows.all():
+            if latest is not None:
+                nav_latest_date[str(iid)] = str(latest)
+
+    return ValidationDbContext(
+        banned_instrument_ids=banned_instrument_ids,
+        approved_instrument_ids=approved_instrument_ids,
+        strategic_targets=strategic_targets,
+        block_constraints=block_constraints,
+        nav_latest_date=nav_latest_date,
+        nav_staleness_threshold_days=nav_staleness_threshold_days,
+    )

--- a/backend/app/domains/wealth/queries/validation_context.py
+++ b/backend/app/domains/wealth/queries/validation_context.py
@@ -16,6 +16,7 @@ from datetime import date
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from vertical_engines.wealth.model_portfolio.block_bounds import resolve_block_bounds
 from vertical_engines.wealth.model_portfolio.validation_gate import (
     ValidationDbContext,
 )
@@ -87,32 +88,33 @@ async def build_validation_db_context(
     )
     approved_instrument_ids = frozenset(row[0] for row in approved_rows.all())
 
-    # 3. Block constraints: strategic_allocation (min/max from drift bands,
-    #    falling back to override bounds, then to ±5pp default around target).
-    #    The optimizer-facing bounds were dropped in PR-A26.2 so we derive
-    #    from the approved drift bands which the realize-mode loader uses.
+    # 3. Block constraints: strategic_allocation — resolve bounds via the
+    #    shared helper that _build_propose_block_constraints also uses.
+    #    PR-Q116 hotfix: previous COALESCE chain fell back to
+    #    target_weight * 0.5/1.5 which was tighter than propose-mode's
+    #    default [0, 1], causing false block failures.
     block_rows = await db.execute(
         text(
             """
             SELECT sa.block_id,
-                   COALESCE(sa.drift_min, sa.override_min, sa.target_weight * 0.5) AS min_w,
-                   COALESCE(sa.drift_max, sa.override_max,
-                            LEAST(sa.target_weight * 1.5, 1.0)) AS max_w,
+                   sa.override_min,
+                   sa.override_max,
+                   COALESCE(sa.excluded_from_portfolio, false) AS excluded,
                    COALESCE(sa.target_weight, 0.0) AS target_w
               FROM strategic_allocation sa
              WHERE sa.organization_id = :org
                AND sa.profile = :profile
-               AND COALESCE(sa.excluded_from_portfolio, false) = false
             """
         ),
         {"org": org_str, "profile": profile},
     )
     block_constraints: dict[str, tuple[float, float]] = {}
     strategic_targets: dict[str, float] = {}
-    for block_id, min_w, max_w, target_w in block_rows.all():
-        block_constraints[str(block_id)] = (
-            float(min_w or 0.0),
-            float(max_w or 1.0),
+    for block_id, override_min, override_max, excluded, target_w in block_rows.all():
+        block_constraints[str(block_id)] = resolve_block_bounds(
+            override_min=float(override_min) if override_min is not None else None,
+            override_max=float(override_max) if override_max is not None else None,
+            excluded_from_portfolio=bool(excluded),
         )
         strategic_targets[str(block_id)] = float(target_w or 0.0)
 

--- a/backend/app/domains/wealth/queries/validation_context.py
+++ b/backend/app/domains/wealth/queries/validation_context.py
@@ -37,6 +37,7 @@ async def build_validation_db_context(
     instrument_ids: list[str],
     mode: ModeType = "propose",
     as_of_date: date | None = None,
+    effective_date: date | None = None,
     nav_staleness_threshold_days: int = 10,
 ) -> ValidationDbContext:
     """Build a fully-populated ``ValidationDbContext`` from the DB.
@@ -53,7 +54,13 @@ async def build_validation_db_context(
         List of instrument UUID strings from the optimizer output
         (the keys of ``weights_proposed``).
     as_of_date
-        Construction run as-of date; used for staleness check.
+        Construction run as-of date; used for the NAV staleness check.
+    effective_date
+        Allocation-window pin shared with the optimizer (the same value
+        ``_run_construction_async`` used for ``effective_from <= today``).
+        Defaults to ``date.today()`` when omitted, but callers in the
+        executor MUST forward the optimizer's pinned date so a run that
+        crosses midnight does not see two different allocation versions.
     nav_staleness_threshold_days
         Days before a NAV observation is considered stale.
 
@@ -110,7 +117,10 @@ async def build_validation_db_context(
     #    Without this filter, historical/future rows can overwrite the
     #    active one in undefined DB order, making validation enforce
     #    different bounds than the optimizer used.
-    today = date.today()
+    #    PR-Q116 hotfix #6 — Codex P2: prefer the caller-supplied
+    #    ``effective_date`` so optimizer and validation share a single
+    #    allocation snapshot even when the run straddles midnight.
+    today = effective_date or date.today()
     block_rows = await db.execute(
         text(
             """

--- a/backend/app/domains/wealth/queries/validation_context.py
+++ b/backend/app/domains/wealth/queries/validation_context.py
@@ -6,6 +6,10 @@ instruments, approved universe, block min/max, TAA/IPS bands).
 
 This module provides ``build_validation_db_context()`` which loads all
 five fields from the org's DB state so the gate can actually enforce them.
+
+PR-Q116 hotfix #2 — Codex P1: realize-mode bounds parity.  The ``mode``
+parameter selects the same bounds hierarchy the optimizer used, so
+validation and optimizer always agree on block limits.
 """
 
 from __future__ import annotations
@@ -16,7 +20,10 @@ from datetime import date
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from vertical_engines.wealth.model_portfolio.block_bounds import resolve_block_bounds
+from vertical_engines.wealth.model_portfolio.block_bounds import (
+    ModeType,
+    resolve_block_bounds,
+)
 from vertical_engines.wealth.model_portfolio.validation_gate import (
     ValidationDbContext,
 )
@@ -28,6 +35,7 @@ async def build_validation_db_context(
     organization_id: uuid.UUID | str,
     profile: str,
     instrument_ids: list[str],
+    mode: ModeType = "propose",
     as_of_date: date | None = None,
     nav_staleness_threshold_days: int = 10,
 ) -> ValidationDbContext:
@@ -99,6 +107,8 @@ async def build_validation_db_context(
             SELECT sa.block_id,
                    sa.override_min,
                    sa.override_max,
+                   sa.drift_min,
+                   sa.drift_max,
                    COALESCE(sa.excluded_from_portfolio, false) AS excluded,
                    COALESCE(sa.target_weight, 0.0) AS target_w
               FROM strategic_allocation sa
@@ -110,11 +120,17 @@ async def build_validation_db_context(
     )
     block_constraints: dict[str, tuple[float, float]] = {}
     strategic_targets: dict[str, float] = {}
-    for block_id, override_min, override_max, excluded, target_w in block_rows.all():
+    for (
+        block_id, override_min, override_max,
+        drift_min_val, drift_max_val, excluded, target_w,
+    ) in block_rows.all():
         block_constraints[str(block_id)] = resolve_block_bounds(
             override_min=float(override_min) if override_min is not None else None,
             override_max=float(override_max) if override_max is not None else None,
+            drift_min=float(drift_min_val) if drift_min_val is not None else None,
+            drift_max=float(drift_max_val) if drift_max_val is not None else None,
             excluded_from_portfolio=bool(excluded),
+            mode=mode,
         )
         strategic_targets[str(block_id)] = float(target_w or 0.0)
 

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -80,6 +80,7 @@ from app.domains.wealth.schemas.portfolio import (
     PositionDetail,
 )
 from app.shared.enums import Role
+from vertical_engines.wealth.model_portfolio.block_bounds import resolve_block_bounds
 from vertical_engines.wealth.model_portfolio.state_machine import (
     ACTION_ACTIVATE,
     ACTION_APPROVE,
@@ -1924,18 +1925,14 @@ def _build_propose_block_constraints(
 
     constraints: list[Any] = []
     for bid in canonical_block_ids:
-        if bid in excluded_block_ids:
-            constraints.append(
-                block_constraint_cls(block_id=bid, min_weight=0.0, max_weight=0.0),
-            )
-            continue
         omin, omax = overrides_by_block.get(bid, (None, None))
+        min_w, max_w = resolve_block_bounds(
+            override_min=omin,
+            override_max=omax,
+            excluded_from_portfolio=bid in excluded_block_ids,
+        )
         constraints.append(
-            block_constraint_cls(
-                block_id=bid,
-                min_weight=omin if omin is not None else 0.0,
-                max_weight=omax if omax is not None else 1.0,
-            ),
+            block_constraint_cls(block_id=bid, min_weight=min_w, max_weight=max_w),
         )
     return constraints, sorted(overrides_by_block.keys())
 

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -1944,6 +1944,7 @@ async def _run_construction_async(
     portfolio_id: uuid.UUID | None = None,
     cvar_limit_override: float | None = None,
     propose_mode: bool = False,
+    effective_date: date | None = None,
 ) -> dict[str, Any]:
     """Run optimizer-driven portfolio construction (fully async).
 
@@ -2056,7 +2057,10 @@ async def _run_construction_async(
     universe_funds = [f for f in universe_funds if f["instrument_id"] in _kept_strs]
 
     # ── 3. Query strategic allocation for this profile ──
-    today = date.today()
+    # PR-Q116 hotfix #6 — accept ``effective_date`` from the caller so the
+    # validation gate can pin the same allocation snapshot the optimizer
+    # used (avoids midnight-cross drift between phases).
+    today = effective_date or date.today()
     alloc_stmt = (
         select(StrategicAllocation)
         .where(

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -73,6 +73,9 @@ from app.domains.wealth.models.model_portfolio import (
     PortfolioConstructionRun,
     PortfolioStressResult,
 )
+from app.domains.wealth.queries.validation_context import (
+    build_validation_db_context,
+)
 from app.domains.wealth.schemas.sanitized import (
     WinnerSignal,
     build_operator_message,
@@ -98,7 +101,6 @@ from vertical_engines.wealth.model_portfolio.stress_scenarios import (
     run_stress_scenario,
 )
 from vertical_engines.wealth.model_portfolio.validation_gate import (
-    ValidationDbContext,
     to_jsonb,
     validate_construction,
 )
@@ -2034,8 +2036,18 @@ async def _execute_inner(
         "statistical_inputs": statistical_inputs_payload,
         "factor_exposure": factor_exposure,
     }
+    # PR-Q116 — populate ValidationDbContext from DB so that checks 7-10
+    # (block min/max, banned instruments, approved universe) and check 16
+    # (TAA/IPS bands) see real org data instead of empty defaults.
+    validation_db_context = await build_validation_db_context(
+        db,
+        organization_id=organization_id,
+        profile=profile,
+        instrument_ids=list(weights_proposed.keys()),
+        as_of_date=run.as_of_date,
+    )
     validation_result = validate_construction(
-        validation_payload, ValidationDbContext(),
+        validation_payload, validation_db_context,
     )
     validation_jsonb = to_jsonb(validation_result)
 

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -1794,9 +1794,17 @@ async def _execute_inner(
     )
 
     # ── 4. Optimizer cascade ──
+    # PR-Q116 hotfix #6 — pin a single allocation-window date for the
+    # whole run. Without this, a run that crosses midnight could see one
+    # ``date.today()`` in the optimizer and a different one in
+    # ``build_validation_db_context`` below, producing false block/TAA
+    # failures when the active strategic_allocation row changes between
+    # phases.
+    construction_effective_date = date.today()
     base_result = await _run_construction_async(
         db, profile, str(organization_id), portfolio_id=portfolio_id,
         propose_mode=propose_mode,
+        effective_date=construction_effective_date,
     )
 
     # PR-A8 — Layer 3 dedup telemetry. Surfaced as a sanitized SSE event
@@ -2048,6 +2056,7 @@ async def _execute_inner(
         instrument_ids=list(weights_proposed.keys()),
         mode="propose" if propose_mode else "realize",
         as_of_date=run.as_of_date,
+        effective_date=construction_effective_date,
     )
     validation_result = validate_construction(
         validation_payload, validation_db_context,

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -2039,11 +2039,14 @@ async def _execute_inner(
     # PR-Q116 — populate ValidationDbContext from DB so that checks 7-10
     # (block min/max, banned instruments, approved universe) and check 16
     # (TAA/IPS bands) see real org data instead of empty defaults.
+    # PR-Q116 hotfix #2 — mode-aware: realize uses drift bands as fallback,
+    # propose uses [0, 1].  Must match what the optimizer actually used.
     validation_db_context = await build_validation_db_context(
         db,
         organization_id=organization_id,
         profile=profile,
         instrument_ids=list(weights_proposed.keys()),
+        mode="propose" if propose_mode else "realize",
         as_of_date=run.as_of_date,
     )
     validation_result = validate_construction(

--- a/backend/tests/test_validation_db_context.py
+++ b/backend/tests/test_validation_db_context.py
@@ -218,11 +218,11 @@ class TestBuildValidationDbContext:
                     (iid,) for iid in _INSTRUMENT_IDS[:4]
                 ]
             elif call_count == 3:
-                # Block constraints query — 5 columns:
-                # (block_id, override_min, override_max, excluded, target_w)
+                # Block constraints query — 7 columns:
+                # (block_id, override_min, override_max, drift_min, drift_max, excluded, target_w)
                 result.all.return_value = [
-                    ("na_equity_large", 0.30, 0.70, False, 0.50),
-                    ("fi_treasury", 0.20, 0.40, False, 0.30),
+                    ("na_equity_large", 0.30, 0.70, None, None, False, 0.50),
+                    ("fi_treasury", 0.20, 0.40, None, None, False, 0.30),
                 ]
             elif call_count == 4:
                 # NAV latest dates query

--- a/backend/tests/test_validation_db_context.py
+++ b/backend/tests/test_validation_db_context.py
@@ -218,10 +218,11 @@ class TestBuildValidationDbContext:
                     (iid,) for iid in _INSTRUMENT_IDS[:4]
                 ]
             elif call_count == 3:
-                # Block constraints query
+                # Block constraints query — 5 columns:
+                # (block_id, override_min, override_max, excluded, target_w)
                 result.all.return_value = [
-                    ("na_equity_large", 0.30, 0.70, 0.50),
-                    ("fi_treasury", 0.20, 0.40, 0.30),
+                    ("na_equity_large", 0.30, 0.70, False, 0.50),
+                    ("fi_treasury", 0.20, 0.40, False, 0.30),
                 ]
             elif call_count == 4:
                 # NAV latest dates query

--- a/backend/tests/test_validation_db_context.py
+++ b/backend/tests/test_validation_db_context.py
@@ -1,0 +1,285 @@
+"""Tests for PR-Q116 — ValidationDbContext population from DB.
+
+Verifies that:
+1. ``build_validation_db_context`` returns a fully-populated context.
+2. The validation gate correctly uses the populated context to detect
+   banned instruments (check 9) and approved universe (check 10).
+3. Block constraints from strategic_allocation are passed through.
+4. An empty context (pre-Q116 behavior) lets banned instruments pass
+   undetected, confirming the defect existed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vertical_engines.wealth.model_portfolio.validation_gate import (
+    ValidationDbContext,
+    validate_construction,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+_INSTRUMENT_IDS = [
+    "11111111-1111-1111-1111-111111111111",
+    "22222222-2222-2222-2222-222222222222",
+    "33333333-3333-3333-3333-333333333333",
+    "44444444-4444-4444-4444-444444444444",
+    "55555555-5555-5555-5555-555555555555",
+]
+
+
+def _base_payload() -> dict[str, Any]:
+    return {
+        "as_of_date": "2026-04-08",
+        "weights_proposed": {iid: 0.20 for iid in _INSTRUMENT_IDS},
+        "calibration_snapshot": {
+            "cvar_limit": 0.05,
+            "max_single_fund_weight": 0.25,
+            "turnover_cap": 0.30,
+            "bl_enabled": False,
+            "garch_enabled": False,
+        },
+        "ex_ante_metrics": {
+            "cvar_95": -0.04,
+            "expected_return": 0.08,
+            "turnover": 0.10,
+        },
+        "funds": [
+            {"instrument_id": iid, "block_id": "na_equity_large", "weight": 0.20}
+            for iid in _INSTRUMENT_IDS
+        ],
+        "stress_results": [
+            {"scenario": "gfc_2008", "nav_impact_pct": -0.15},
+        ],
+        "optimizer_trace": {},
+        "statistical_inputs": {},
+        "factor_exposure": {"average_r_squared": 0.65},
+    }
+
+
+def _populated_context(
+    *,
+    banned: frozenset[str] | None = None,
+    approved: frozenset[str] | None = None,
+) -> ValidationDbContext:
+    """Build a context that mirrors what build_validation_db_context returns."""
+    return ValidationDbContext(
+        banned_instrument_ids=banned or frozenset(),
+        approved_instrument_ids=approved or frozenset(_INSTRUMENT_IDS),
+        strategic_targets={"na_equity_large": 1.0},
+        block_constraints={"na_equity_large": (0.0, 1.0)},
+        nav_latest_date={iid: "2026-04-07" for iid in _INSTRUMENT_IDS},
+        nav_staleness_threshold_days=10,
+    )
+
+
+# ── Defect confirmation: empty context misses banned instruments ──
+
+
+class TestEmptyContextDefect:
+    """Confirms the pre-Q116 defect: empty context lets banned pass."""
+
+    def test_empty_context_banned_check_passes_vacuously(self):
+        """With empty banned set, check 9 always passes even if there
+        SHOULD be banned instruments — the gate can't discriminate."""
+        payload = _base_payload()
+        empty_ctx = ValidationDbContext()
+        result = validate_construction(payload, empty_ctx)
+        check_9 = [c for c in result.checks if c.id == "no_banned_instruments"]
+        assert len(check_9) == 1
+        # Pre-Q116: always passes because banned set is empty
+        assert check_9[0].passed is True
+
+    def test_empty_context_approved_check_downgrades_to_warn(self):
+        """With empty approved set, check 10 downgrades to warn-level
+        pass with 'check skipped' explanation."""
+        payload = _base_payload()
+        empty_ctx = ValidationDbContext()
+        result = validate_construction(payload, empty_ctx)
+        check_10 = [c for c in result.checks if c.id == "all_instruments_approved"]
+        assert len(check_10) == 1
+        assert check_10[0].severity == "warn"
+        assert check_10[0].passed is True
+        assert "skipped" in check_10[0].explanation.lower()
+
+    def test_empty_context_block_max_passes_vacuously(self):
+        """With empty block_constraints, check 8 always passes."""
+        payload = _base_payload()
+        empty_ctx = ValidationDbContext()
+        result = validate_construction(payload, empty_ctx)
+        check_8 = [c for c in result.checks
+                    if c.id == "all_block_max_weights_satisfied"]
+        assert len(check_8) == 1
+        assert check_8[0].passed is True
+
+
+# ── Populated context: gate now enforces checks ──
+
+
+class TestPopulatedContextEnforcement:
+    """Verifies that a properly populated context makes the gate enforce."""
+
+    def test_banned_instrument_detected_with_populated_context(self):
+        """Check 9 (no_banned_instruments) FAILS when a weighted
+        instrument is in the banned set — the core fix of PR-Q116."""
+        payload = _base_payload()
+        ctx = _populated_context(
+            banned=frozenset({_INSTRUMENT_IDS[0]}),
+        )
+        result = validate_construction(payload, ctx)
+        check_9 = [c for c in result.checks if c.id == "no_banned_instruments"]
+        assert len(check_9) == 1
+        assert check_9[0].passed is False
+        assert check_9[0].severity == "block"
+        assert result.passed is False
+
+    def test_approved_universe_enforced_with_populated_context(self):
+        """Check 10 (all_instruments_approved) FAILS when an instrument
+        is not in the approved set."""
+        payload = _base_payload()
+        # Approve only 4 of 5 instruments
+        ctx = _populated_context(
+            approved=frozenset(_INSTRUMENT_IDS[:4]),
+        )
+        result = validate_construction(payload, ctx)
+        check_10 = [c for c in result.checks
+                     if c.id == "all_instruments_approved"]
+        assert len(check_10) == 1
+        assert check_10[0].passed is False
+        assert check_10[0].severity == "block"
+
+    def test_block_max_weight_enforced_with_populated_context(self):
+        """Check 8 (block_max) FAILS when a block exceeds the max
+        from block_constraints."""
+        payload = _base_payload()
+        # All 5 instruments in one block = 100% weight,
+        # but max is 60%
+        ctx = _populated_context()
+        ctx = ValidationDbContext(
+            banned_instrument_ids=ctx.banned_instrument_ids,
+            approved_instrument_ids=ctx.approved_instrument_ids,
+            strategic_targets={"na_equity_large": 0.50},
+            block_constraints={"na_equity_large": (0.30, 0.60)},
+            nav_latest_date=ctx.nav_latest_date,
+        )
+        result = validate_construction(payload, ctx)
+        check_8 = [c for c in result.checks
+                    if c.id == "all_block_max_weights_satisfied"]
+        assert len(check_8) == 1
+        assert check_8[0].passed is False
+        assert check_8[0].severity == "block"
+
+    def test_all_checks_pass_with_correct_populated_context(self):
+        """A fully-correct context + payload passes all checks."""
+        payload = _base_payload()
+        ctx = _populated_context()
+        result = validate_construction(payload, ctx)
+        assert result.passed is True
+        block_failures = [c for c in result.checks
+                          if c.severity == "block" and not c.passed]
+        assert len(block_failures) == 0
+
+
+# ── build_validation_db_context unit test (mocked DB) ──
+
+
+class TestBuildValidationDbContext:
+    """Test the query helper with a mocked AsyncSession."""
+
+    @pytest.mark.asyncio
+    async def test_builds_context_with_all_fields(self):
+        """Verify the returned context has all 5 fields populated."""
+        from app.domains.wealth.queries.validation_context import (
+            build_validation_db_context,
+        )
+
+        # Mock DB session that returns canned rows for each query
+        db = AsyncMock()
+
+        # Track call count to return different results per query
+        call_count = 0
+
+        async def _mock_execute(stmt, params=None):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                # Banned instruments query
+                result.all.return_value = [
+                    (_INSTRUMENT_IDS[4],),
+                ]
+            elif call_count == 2:
+                # Approved instruments query
+                result.all.return_value = [
+                    (iid,) for iid in _INSTRUMENT_IDS[:4]
+                ]
+            elif call_count == 3:
+                # Block constraints query
+                result.all.return_value = [
+                    ("na_equity_large", 0.30, 0.70, 0.50),
+                    ("fi_treasury", 0.20, 0.40, 0.30),
+                ]
+            elif call_count == 4:
+                # NAV latest dates query
+                result.all.return_value = [
+                    (iid, "2026-04-07") for iid in _INSTRUMENT_IDS
+                ]
+            else:
+                result.all.return_value = []
+            return result
+
+        db.execute = _mock_execute
+
+        import uuid as _uuid
+
+        ctx = await build_validation_db_context(
+            db,
+            organization_id=_uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            profile="conservative",
+            instrument_ids=_INSTRUMENT_IDS,
+        )
+
+        assert isinstance(ctx, ValidationDbContext)
+        assert _INSTRUMENT_IDS[4] in ctx.banned_instrument_ids
+        assert len(ctx.approved_instrument_ids) == 4
+        assert "na_equity_large" in ctx.block_constraints
+        assert ctx.block_constraints["na_equity_large"] == (0.30, 0.70)
+        assert "fi_treasury" in ctx.block_constraints
+        assert len(ctx.nav_latest_date) == 5
+        assert ctx.strategic_targets["na_equity_large"] == 0.50
+        assert ctx.nav_staleness_threshold_days == 10
+
+    @pytest.mark.asyncio
+    async def test_empty_db_returns_empty_context(self):
+        """When the org has no data, context fields are empty but valid."""
+        from app.domains.wealth.queries.validation_context import (
+            build_validation_db_context,
+        )
+
+        db = AsyncMock()
+
+        async def _mock_execute(stmt, params=None):
+            result = MagicMock()
+            result.all.return_value = []
+            return result
+
+        db.execute = _mock_execute
+
+        import uuid as _uuid
+
+        ctx = await build_validation_db_context(
+            db,
+            organization_id=_uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            profile="conservative",
+            instrument_ids=[],
+        )
+
+        assert isinstance(ctx, ValidationDbContext)
+        assert len(ctx.banned_instrument_ids) == 0
+        assert len(ctx.approved_instrument_ids) == 0
+        assert len(ctx.block_constraints) == 0
+        assert len(ctx.nav_latest_date) == 0

--- a/backend/tests/wealth/test_validation_db_context.py
+++ b/backend/tests/wealth/test_validation_db_context.py
@@ -162,14 +162,35 @@ class TestRealizeModeBlockBounds:
         )
         assert result == (0.0, 1.0)
 
-    def test_override_wins_in_both_modes(self) -> None:
-        """Overrides set + drift set → overrides take priority in both."""
-        for mode_fn in (_propose_bounds_for, _realize_bounds_for):
-            result = mode_fn(
-                override_min=0.15, override_max=0.35,
-                drift_min=0.10, drift_max=0.50,
-            )
-            assert result == (0.15, 0.35), f"{mode_fn.__name__} returned {result}"
+    def test_override_wins_in_propose_only(self) -> None:
+        """Overrides take priority in propose mode; in realize mode they are
+        ignored (the realize optimizer builds constraints from drift bands
+        only — see ``_run_construction_async`` in routes/model_portfolios.py).
+        Validation must mirror that to avoid enforcing stricter bounds than
+        the optimizer actually used (Codex P1 false block pass/fail)."""
+        propose = _propose_bounds_for(
+            override_min=0.15, override_max=0.35,
+            drift_min=0.10, drift_max=0.50,
+        )
+        assert propose == (0.15, 0.35)
+
+        realize = _realize_bounds_for(
+            override_min=0.15, override_max=0.35,
+            drift_min=0.10, drift_max=0.50,
+        )
+        assert realize == (0.10, 0.50), (
+            f"realize must ignore overrides and use drift bands, got {realize}"
+        )
+
+    def test_realize_ignores_overrides_when_drift_null(self) -> None:
+        """Realize must ignore overrides even when drift bands are NULL —
+        it falls back to (0, 1) just like the optimizer's missing-drift path
+        (``alloc_dicts`` defaults `min_weight=0.0`, `max_weight=1.0`)."""
+        result = _realize_bounds_for(
+            override_min=0.15, override_max=0.35,
+            drift_min=None, drift_max=None,
+        )
+        assert result == (0.0, 1.0)
 
     def test_excluded_wins_over_drift_in_realize(self) -> None:
         """Excluded blocks are (0, 0) even with drift bounds."""

--- a/backend/tests/wealth/test_validation_db_context.py
+++ b/backend/tests/wealth/test_validation_db_context.py
@@ -1,12 +1,21 @@
-"""Tests for block-bounds parity between validation and propose-mode.
+"""Tests for block-bounds parity between validation and propose/realize modes.
 
 PR-Q116 hotfix — Codex P1: validation fallback bounds must match
 ``_build_propose_block_constraints`` exactly.
+
+PR-Q116 hotfix #2 — Codex P1: realize-mode bounds parity.  Mode-aware
+resolver uses drift bands as fallback in realize mode.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 from vertical_engines.wealth.model_portfolio.block_bounds import resolve_block_bounds
+from vertical_engines.wealth.model_portfolio.validation_gate import (
+    ValidationDbContext,
+    validate_construction,
+)
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -15,35 +24,79 @@ def _propose_bounds_for(
     *,
     override_min: float | None = None,
     override_max: float | None = None,
+    drift_min: float | None = None,
+    drift_max: float | None = None,
     excluded: bool = False,
 ) -> tuple[float, float]:
     """Simulate what _build_propose_block_constraints produces for one block."""
     return resolve_block_bounds(
         override_min=override_min,
         override_max=override_max,
+        drift_min=drift_min,
+        drift_max=drift_max,
         excluded_from_portfolio=excluded,
+        mode="propose",
     )
 
 
-def _validation_bounds_for(
+def _realize_bounds_for(
     *,
     override_min: float | None = None,
     override_max: float | None = None,
+    drift_min: float | None = None,
+    drift_max: float | None = None,
     excluded: bool = False,
 ) -> tuple[float, float]:
-    """Simulate what build_validation_db_context produces for one block.
-
-    Both code paths now call resolve_block_bounds — this test asserts
-    they stay identical.
-    """
+    """Simulate what build_validation_db_context produces in realize mode."""
     return resolve_block_bounds(
         override_min=float(override_min) if override_min is not None else None,
         override_max=float(override_max) if override_max is not None else None,
+        drift_min=float(drift_min) if drift_min is not None else None,
+        drift_max=float(drift_max) if drift_max is not None else None,
         excluded_from_portfolio=bool(excluded),
+        mode="realize",
     )
 
 
-# ── Tests ────────────────────────────────────────────────────────────
+_INSTRUMENT_IDS = [
+    "11111111-1111-1111-1111-111111111111",
+    "22222222-2222-2222-2222-222222222222",
+    "33333333-3333-3333-3333-333333333333",
+    "44444444-4444-4444-4444-444444444444",
+    "55555555-5555-5555-5555-555555555555",
+]
+
+
+def _base_payload() -> dict[str, Any]:
+    return {
+        "as_of_date": "2026-04-08",
+        "weights_proposed": {iid: 0.20 for iid in _INSTRUMENT_IDS},
+        "calibration_snapshot": {
+            "cvar_limit": 0.05,
+            "max_single_fund_weight": 0.25,
+            "turnover_cap": 0.30,
+            "bl_enabled": False,
+            "garch_enabled": False,
+        },
+        "ex_ante_metrics": {
+            "cvar_95": -0.04,
+            "expected_return": 0.08,
+            "turnover": 0.10,
+        },
+        "funds": [
+            {"instrument_id": iid, "block_id": "na_equity_large", "weight": 0.20}
+            for iid in _INSTRUMENT_IDS
+        ],
+        "stress_results": [
+            {"scenario": "gfc_2008", "nav_impact_pct": -0.15},
+        ],
+        "optimizer_trace": {},
+        "statistical_inputs": {},
+        "factor_exposure": {"average_r_squared": 0.65},
+    }
+
+
+# ── Tests: propose-mode (original hotfix #1 parity) ─────────────────
 
 
 class TestValidationBoundsMatchProposeMode:
@@ -53,36 +106,128 @@ class TestValidationBoundsMatchProposeMode:
     def test_validation_bounds_match_propose_mode_when_overrides_null(self) -> None:
         """Core P1 regression: NULL overrides → [0.0, 1.0], not target*0.5/1.5."""
         propose = _propose_bounds_for(override_min=None, override_max=None)
-        validation = _validation_bounds_for(override_min=None, override_max=None)
         assert propose == (0.0, 1.0), f"propose-mode should default to [0, 1], got {propose}"
-        assert validation == propose, (
-            f"validation bounds {validation} != propose bounds {propose}"
-        )
 
     def test_validation_bounds_use_override_min_max_when_present(self) -> None:
         """When operator sets override bounds, both consumers use them."""
         propose = _propose_bounds_for(override_min=0.1, override_max=0.3)
-        validation = _validation_bounds_for(override_min=0.1, override_max=0.3)
         assert propose == (0.1, 0.3)
-        assert validation == propose
 
     def test_validation_bounds_excluded_block(self) -> None:
         """Excluded blocks collapse to [0, 0] in both paths."""
         propose = _propose_bounds_for(excluded=True, override_min=0.2, override_max=0.5)
-        validation = _validation_bounds_for(excluded=True, override_min=0.2, override_max=0.5)
         assert propose == (0.0, 0.0)
-        assert validation == propose
 
     def test_partial_override_min_only(self) -> None:
         """Only override_min set — max defaults to 1.0."""
         propose = _propose_bounds_for(override_min=0.05, override_max=None)
-        validation = _validation_bounds_for(override_min=0.05, override_max=None)
         assert propose == (0.05, 1.0)
-        assert validation == propose
 
     def test_partial_override_max_only(self) -> None:
         """Only override_max set — min defaults to 0.0."""
         propose = _propose_bounds_for(override_min=None, override_max=0.4)
-        validation = _validation_bounds_for(override_min=None, override_max=0.4)
         assert propose == (0.0, 0.4)
-        assert validation == propose
+
+    def test_propose_mode_ignores_drift_bands(self) -> None:
+        """Propose-mode ignores drift_min/drift_max even when set."""
+        result = _propose_bounds_for(
+            override_min=None, override_max=None,
+            drift_min=0.10, drift_max=0.30,
+        )
+        assert result == (0.0, 1.0), (
+            f"propose-mode should ignore drift bands, got {result}"
+        )
+
+
+# ── Tests: realize-mode (hotfix #2) ──────────────────────────────────
+
+
+class TestRealizeModeBlockBounds:
+    """PR-Q116 hotfix #2: realize-mode validation uses drift bands."""
+
+    def test_realize_mode_uses_drift_bounds_when_overrides_null(self) -> None:
+        """Core hotfix #2: drift_min=0.10, drift_max=0.30, overrides NULL →
+        realize mode returns (0.10, 0.30)."""
+        result = _realize_bounds_for(
+            override_min=None, override_max=None,
+            drift_min=0.10, drift_max=0.30,
+        )
+        assert result == (0.10, 0.30)
+
+    def test_realize_mode_falls_back_to_zero_one_when_drift_null(self) -> None:
+        """Overrides NULL, drift NULL, realize → (0, 1)."""
+        result = _realize_bounds_for(
+            override_min=None, override_max=None,
+            drift_min=None, drift_max=None,
+        )
+        assert result == (0.0, 1.0)
+
+    def test_override_wins_in_both_modes(self) -> None:
+        """Overrides set + drift set → overrides take priority in both."""
+        for mode_fn in (_propose_bounds_for, _realize_bounds_for):
+            result = mode_fn(
+                override_min=0.15, override_max=0.35,
+                drift_min=0.10, drift_max=0.50,
+            )
+            assert result == (0.15, 0.35), f"{mode_fn.__name__} returned {result}"
+
+    def test_excluded_wins_over_drift_in_realize(self) -> None:
+        """Excluded blocks are (0, 0) even with drift bounds."""
+        result = _realize_bounds_for(
+            excluded=True,
+            drift_min=0.10, drift_max=0.30,
+        )
+        assert result == (0.0, 0.0)
+
+    def test_partial_drift_ignored(self) -> None:
+        """Only one of drift_min/drift_max set → falls back to (0, 1)."""
+        result1 = _realize_bounds_for(drift_min=0.10, drift_max=None)
+        assert result1 == (0.0, 1.0)
+        result2 = _realize_bounds_for(drift_min=None, drift_max=0.30)
+        assert result2 == (0.0, 1.0)
+
+
+# ── Integration: realize-mode validation catches drift violation ──────
+
+
+class TestRealizeModeValidationIntegration:
+    """End-to-end: realize-mode validation with drift bounds detects violations."""
+
+    def test_realize_mode_validation_catches_drift_violation(self) -> None:
+        """A portfolio at 100% in one block violates drift_max=0.30."""
+        payload = _base_payload()
+        ctx = ValidationDbContext(
+            banned_instrument_ids=frozenset(),
+            approved_instrument_ids=frozenset(_INSTRUMENT_IDS),
+            strategic_targets={"na_equity_large": 0.20},
+            block_constraints={"na_equity_large": (0.10, 0.30)},  # drift bounds
+            nav_latest_date={iid: "2026-04-07" for iid in _INSTRUMENT_IDS},
+            nav_staleness_threshold_days=10,
+        )
+        result = validate_construction(payload, ctx)
+        check_8 = [c for c in result.checks
+                    if c.id == "all_block_max_weights_satisfied"]
+        assert len(check_8) == 1
+        assert check_8[0].passed is False, (
+            "Block at 100% should violate drift_max=0.30"
+        )
+
+    def test_realize_mode_passes_within_drift_bounds(self) -> None:
+        """A portfolio within drift bounds passes."""
+        payload = _base_payload()
+        # All 5 funds at 20% = 100% in one block, drift allows [0, 1]
+        ctx = ValidationDbContext(
+            banned_instrument_ids=frozenset(),
+            approved_instrument_ids=frozenset(_INSTRUMENT_IDS),
+            strategic_targets={"na_equity_large": 1.0},
+            block_constraints={"na_equity_large": (0.0, 1.0)},
+            nav_latest_date={iid: "2026-04-07" for iid in _INSTRUMENT_IDS},
+            nav_staleness_threshold_days=10,
+        )
+        result = validate_construction(payload, ctx)
+        check_7 = [c for c in result.checks
+                    if c.id == "all_block_min_weights_satisfied"]
+        check_8 = [c for c in result.checks
+                    if c.id == "all_block_max_weights_satisfied"]
+        assert check_7[0].passed is True
+        assert check_8[0].passed is True

--- a/backend/tests/wealth/test_validation_db_context.py
+++ b/backend/tests/wealth/test_validation_db_context.py
@@ -1,0 +1,88 @@
+"""Tests for block-bounds parity between validation and propose-mode.
+
+PR-Q116 hotfix — Codex P1: validation fallback bounds must match
+``_build_propose_block_constraints`` exactly.
+"""
+
+from __future__ import annotations
+
+from vertical_engines.wealth.model_portfolio.block_bounds import resolve_block_bounds
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _propose_bounds_for(
+    *,
+    override_min: float | None = None,
+    override_max: float | None = None,
+    excluded: bool = False,
+) -> tuple[float, float]:
+    """Simulate what _build_propose_block_constraints produces for one block."""
+    return resolve_block_bounds(
+        override_min=override_min,
+        override_max=override_max,
+        excluded_from_portfolio=excluded,
+    )
+
+
+def _validation_bounds_for(
+    *,
+    override_min: float | None = None,
+    override_max: float | None = None,
+    excluded: bool = False,
+) -> tuple[float, float]:
+    """Simulate what build_validation_db_context produces for one block.
+
+    Both code paths now call resolve_block_bounds — this test asserts
+    they stay identical.
+    """
+    return resolve_block_bounds(
+        override_min=float(override_min) if override_min is not None else None,
+        override_max=float(override_max) if override_max is not None else None,
+        excluded_from_portfolio=bool(excluded),
+    )
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestValidationBoundsMatchProposeMode:
+    """PR-Q116: when override_*/drift_* are NULL, validation must use
+    exactly the bounds that _build_propose_block_constraints produces."""
+
+    def test_validation_bounds_match_propose_mode_when_overrides_null(self) -> None:
+        """Core P1 regression: NULL overrides → [0.0, 1.0], not target*0.5/1.5."""
+        propose = _propose_bounds_for(override_min=None, override_max=None)
+        validation = _validation_bounds_for(override_min=None, override_max=None)
+        assert propose == (0.0, 1.0), f"propose-mode should default to [0, 1], got {propose}"
+        assert validation == propose, (
+            f"validation bounds {validation} != propose bounds {propose}"
+        )
+
+    def test_validation_bounds_use_override_min_max_when_present(self) -> None:
+        """When operator sets override bounds, both consumers use them."""
+        propose = _propose_bounds_for(override_min=0.1, override_max=0.3)
+        validation = _validation_bounds_for(override_min=0.1, override_max=0.3)
+        assert propose == (0.1, 0.3)
+        assert validation == propose
+
+    def test_validation_bounds_excluded_block(self) -> None:
+        """Excluded blocks collapse to [0, 0] in both paths."""
+        propose = _propose_bounds_for(excluded=True, override_min=0.2, override_max=0.5)
+        validation = _validation_bounds_for(excluded=True, override_min=0.2, override_max=0.5)
+        assert propose == (0.0, 0.0)
+        assert validation == propose
+
+    def test_partial_override_min_only(self) -> None:
+        """Only override_min set — max defaults to 1.0."""
+        propose = _propose_bounds_for(override_min=0.05, override_max=None)
+        validation = _validation_bounds_for(override_min=0.05, override_max=None)
+        assert propose == (0.05, 1.0)
+        assert validation == propose
+
+    def test_partial_override_max_only(self) -> None:
+        """Only override_max set — min defaults to 0.0."""
+        propose = _propose_bounds_for(override_min=None, override_max=0.4)
+        validation = _validation_bounds_for(override_min=None, override_max=0.4)
+        assert propose == (0.0, 0.4)
+        assert validation == propose

--- a/backend/tests/wealth/test_validation_db_context.py
+++ b/backend/tests/wealth/test_validation_db_context.py
@@ -200,12 +200,15 @@ class TestRealizeModeBlockBounds:
         )
         assert result == (0.0, 0.0)
 
-    def test_partial_drift_ignored(self) -> None:
-        """Only one of drift_min/drift_max set → falls back to (0, 1)."""
+    def test_partial_drift_filled_side_by_side(self) -> None:
+        """One-sided drift bounds are filled side-by-side, mirroring the
+        realize optimizer's ``alloc_dicts`` build (drift_min OR 0.0,
+        drift_max OR 1.0). Anything else would make validation enforce
+        different bounds than the optimizer (Codex P1 false pass/fail)."""
         result1 = _realize_bounds_for(drift_min=0.10, drift_max=None)
-        assert result1 == (0.0, 1.0)
+        assert result1 == (0.10, 1.0)
         result2 = _realize_bounds_for(drift_min=None, drift_max=0.30)
-        assert result2 == (0.0, 1.0)
+        assert result2 == (0.0, 0.30)
 
 
 # ── Integration: realize-mode validation catches drift violation ──────

--- a/backend/vertical_engines/wealth/model_portfolio/block_bounds.py
+++ b/backend/vertical_engines/wealth/model_portfolio/block_bounds.py
@@ -27,13 +27,13 @@ def resolve_block_bounds(
     """Resolve effective bounds for a single allocation block.
 
     Modes:
-    - ``"propose"``: optimizer uses ``[0, 1]`` when overrides NULL
-      (no drift dependency).
+    - ``"propose"``: optimizer uses overrides when present, else ``[0, 1]``;
+      drift bands are not consulted.
       Hierarchy: excluded → (0,0) | override present → use them | else (0, 1)
-    - ``"realize"``: optimizer uses drift bands when overrides NULL
-      (``resolve_effective_bands``).
-      Hierarchy: excluded → (0,0) | override present → use them
-                | drift present → use them | else (0, 1)
+    - ``"realize"``: optimizer (``resolve_effective_bands``) builds constraints
+      from drift bands only — overrides are NOT applied. The resolver mirrors
+      that exactly: overrides are ignored.
+      Hierarchy: excluded → (0,0) | drift present → use them | else (0, 1)
 
     Validation MUST call this with the SAME mode as the optimizer used,
     or risk false pass/fail (Codex Wave 6 S10 P1 lesson).
@@ -46,6 +46,15 @@ def resolve_block_bounds(
     if excluded_from_portfolio:
         return (0.0, 0.0)
 
+    if mode == "realize":
+        # Realize optimizer uses drift bands only; overrides are not applied
+        # by ``_run_construction_async`` (see ``alloc_dicts`` build there).
+        # Validation must mirror that or it enforces stricter limits than
+        # the optimizer actually used (Codex P1 — false block failures/passes).
+        if drift_min is not None and drift_max is not None:
+            return (float(drift_min), float(drift_max))
+        return (0.0, 1.0)
+
     if override_min is not None and override_max is not None:
         return (float(override_min), float(override_max))
 
@@ -55,8 +64,5 @@ def resolve_block_bounds(
             float(override_min) if override_min is not None else 0.0,
             float(override_max) if override_max is not None else 1.0,
         )
-
-    if mode == "realize" and drift_min is not None and drift_max is not None:
-        return (float(drift_min), float(drift_max))
 
     return (0.0, 1.0)

--- a/backend/vertical_engines/wealth/model_portfolio/block_bounds.py
+++ b/backend/vertical_engines/wealth/model_portfolio/block_bounds.py
@@ -48,12 +48,17 @@ def resolve_block_bounds(
 
     if mode == "realize":
         # Realize optimizer uses drift bands only; overrides are not applied
-        # by ``_run_construction_async`` (see ``alloc_dicts`` build there).
-        # Validation must mirror that or it enforces stricter limits than
-        # the optimizer actually used (Codex P1 — false block failures/passes).
-        if drift_min is not None and drift_max is not None:
-            return (float(drift_min), float(drift_max))
-        return (0.0, 1.0)
+        # by ``_run_construction_async`` (see ``alloc_dicts`` build there,
+        # which fills each side independently:
+        # ``min_weight = drift_min if not None else 0.0``,
+        # ``max_weight = drift_max if not None else 1.0``).
+        # Validation must mirror that side-by-side fill or it enforces
+        # different limits than the optimizer (Codex P1 — false block
+        # failures/passes when only one drift side is populated).
+        return (
+            float(drift_min) if drift_min is not None else 0.0,
+            float(drift_max) if drift_max is not None else 1.0,
+        )
 
     if override_min is not None and override_max is not None:
         return (float(override_min), float(override_max))

--- a/backend/vertical_engines/wealth/model_portfolio/block_bounds.py
+++ b/backend/vertical_engines/wealth/model_portfolio/block_bounds.py
@@ -1,0 +1,36 @@
+"""Shared block-bounds resolution for propose-mode construction.
+
+Single source of truth consumed by both the optimizer constraint builder
+(``_build_propose_block_constraints``) and the validation gate context loader
+(``build_validation_db_context``).
+
+PR-Q116 hotfix — Codex P1: align fallback bounds with propose-mode.
+"""
+
+from __future__ import annotations
+
+
+def resolve_block_bounds(
+    *,
+    override_min: float | None,
+    override_max: float | None,
+    excluded_from_portfolio: bool = False,
+) -> tuple[float, float]:
+    """Resolve effective bounds for a single allocation block.
+
+    Priority:
+    1. ``excluded_from_portfolio`` → ``(0.0, 0.0)``
+    2. ``override_min`` / ``override_max`` when set by operator
+    3. Default ``(0.0, 1.0)`` — full-range freedom in propose-mode
+
+    Returns
+    -------
+    tuple[float, float]
+        ``(min_weight, max_weight)``
+    """
+    if excluded_from_portfolio:
+        return (0.0, 0.0)
+    return (
+        float(override_min) if override_min is not None else 0.0,
+        float(override_max) if override_max is not None else 1.0,
+    )

--- a/backend/vertical_engines/wealth/model_portfolio/block_bounds.py
+++ b/backend/vertical_engines/wealth/model_portfolio/block_bounds.py
@@ -1,13 +1,18 @@
-"""Shared block-bounds resolution for propose-mode construction.
+"""Shared block-bounds resolution for construction modes.
 
 Single source of truth consumed by both the optimizer constraint builder
 (``_build_propose_block_constraints``) and the validation gate context loader
 (``build_validation_db_context``).
 
 PR-Q116 hotfix — Codex P1: align fallback bounds with propose-mode.
+PR-Q116 hotfix #2 — Codex P1: realize-mode bounds parity (mode-aware).
 """
 
 from __future__ import annotations
+
+from typing import Literal
+
+ModeType = Literal["propose", "realize"]
 
 
 def resolve_block_bounds(
@@ -15,13 +20,23 @@ def resolve_block_bounds(
     override_min: float | None,
     override_max: float | None,
     excluded_from_portfolio: bool = False,
+    drift_min: float | None = None,
+    drift_max: float | None = None,
+    mode: ModeType = "propose",
 ) -> tuple[float, float]:
     """Resolve effective bounds for a single allocation block.
 
-    Priority:
-    1. ``excluded_from_portfolio`` → ``(0.0, 0.0)``
-    2. ``override_min`` / ``override_max`` when set by operator
-    3. Default ``(0.0, 1.0)`` — full-range freedom in propose-mode
+    Modes:
+    - ``"propose"``: optimizer uses ``[0, 1]`` when overrides NULL
+      (no drift dependency).
+      Hierarchy: excluded → (0,0) | override present → use them | else (0, 1)
+    - ``"realize"``: optimizer uses drift bands when overrides NULL
+      (``resolve_effective_bands``).
+      Hierarchy: excluded → (0,0) | override present → use them
+                | drift present → use them | else (0, 1)
+
+    Validation MUST call this with the SAME mode as the optimizer used,
+    or risk false pass/fail (Codex Wave 6 S10 P1 lesson).
 
     Returns
     -------
@@ -30,7 +45,18 @@ def resolve_block_bounds(
     """
     if excluded_from_portfolio:
         return (0.0, 0.0)
-    return (
-        float(override_min) if override_min is not None else 0.0,
-        float(override_max) if override_max is not None else 1.0,
-    )
+
+    if override_min is not None and override_max is not None:
+        return (float(override_min), float(override_max))
+
+    # Partial overrides: fill the missing side with its default
+    if override_min is not None or override_max is not None:
+        return (
+            float(override_min) if override_min is not None else 0.0,
+            float(override_max) if override_max is not None else 1.0,
+        )
+
+    if mode == "realize" and drift_min is not None and drift_max is not None:
+        return (float(drift_min), float(drift_max))
+
+    return (0.0, 1.0)


### PR DESCRIPTION
## Summary

- **Implement `build_validation_db_context()`** to load banned/approved instruments, block constraints, and NAV staleness data from the database instead of using empty defaults. This re-enables checks 7–10 (block min/max, banned instruments, approved universe) in the validation gate.
- **Extract shared block-bounds resolution** into `resolve_block_bounds()` to ensure validation and optimizer use identical constraint logic. Fixes Codex P1 regression where validation fell back to `target_weight * 0.5/1.5` instead of propose-mode's `[0, 1]`.
- **Add mode-aware bounds resolution** (propose vs. realize) so validation mirrors the optimizer's actual constraint hierarchy: propose uses overrides or `[0, 1]`; realize uses drift bands or `[0, 1]`.
- **Integrate context builder** into `construction_run_executor.py` and refactor `_build_propose_block_constraints()` to use the shared resolver.

## Test plan

- [x] Added 286-line test suite (`test_validation_db_context.py`) covering:
  - Empty context defect confirmation (banned/approved checks skip vacuously)
  - Populated context enforcement (checks 8–10 now fail on violations)
  - `build_validation_db_context()` with mocked DB (all 5 fields populated correctly)
  - Empty DB returns valid empty context
- [x] Added 254-line test suite (`test_validation_db_context.py` in wealth/) covering:
  - Propose-mode bounds parity (overrides or `[0, 1]`, ignores drift)
  - Realize-mode bounds parity (drift bands or `[0, 1]`, ignores overrides)
  - Integration: realize-mode validation catches drift violations
- [x] Existing validation gate tests continue to pass with populated context

---

## Stability Guardrails Checklist

### Backend

- [x] No new WebSocket handlers.
- [x] No new external HTTP calls.
- [x] No new LLM calls.
- [x] `build_validation_db_context()` is async but called from `_execute_inner()` which is already async; no new blocking paths.
- [x] No new mutating endpoints.
- [x] No new persistent bridges.
- [x] No new in-process or cross-process dedupe.
- [x] No advisory locks.
- [x] `_execute_inner()` already has authz checks before calling the new context builder.

### Frontend

- N/A — no frontend changes.

### Tests & verification

- [x] Regression tests added for the block-bounds parity defect (Codex P1).
- [x] Unit tests verify empty context behavior (pre-Q116 defect) and populated context enforcement.
- [x] `make check` passes (new modules follow existing style).

### Observability

- N/A — no new background jobs or provider gates.

https://claude.ai/code/session_01GRgvXTU51as74ckMB2etiJ