### PR TITLE
chore(wealth): PR-Q121 — Wave 6 S10 batch (RNG seed dispersion + CVaR sqrt heuristic)

### DIFF
--- a/backend/tests/test_construction_advisor.py
+++ b/backend/tests/test_construction_advisor.py
@@ -309,6 +309,54 @@ class TestProjectCvarHistorical:
         assert result < 0  # CVaR is always negative (loss)
         assert result > -2.0  # sanity: not more than -200%
 
+    def test_cvar_uses_rolling_when_sufficient_data(self):
+        """C-14: rolling 252-day path for >= 252 days; sqrt fallback for < 252."""
+        rng = np.random.default_rng(77)
+
+        # --- Rolling path: 500 days of data (>= 252) ---
+        # Use realistic equity-like volatility so the 5% tail is negative
+        port_ret_long = rng.normal(0.0003, 0.015, size=(500, 2))
+        cand_ret_long = rng.normal(0.0001, 0.008, size=500)
+        weights = np.array([0.5, 0.5])
+
+        result_rolling = project_cvar_historical(
+            port_ret_long, cand_ret_long, weights, 0.10,
+        )
+        assert result_rolling is not None
+        assert result_rolling < 0  # loss convention
+
+        # Manually compute the rolling path to verify
+        combined = np.column_stack([port_ret_long, cand_ret_long])
+        new_w = np.append(weights * 0.9, 0.10)
+        port_daily = combined @ new_w
+        annual_rets = np.convolve(port_daily, np.ones(252), mode="valid")
+        sorted_annual = np.sort(annual_rets)
+        cutoff = max(int(len(sorted_annual) * 0.05), 1)
+        expected_cvar = float(round(np.mean(sorted_annual[:cutoff]), 6))
+        assert result_rolling == pytest.approx(expected_cvar, abs=1e-6)
+
+        # --- Sqrt fallback path: 150 days of data (< 252 but >= 126 MIN) ---
+        port_ret_short = rng.normal(0.0003, 0.015, size=(150, 2))
+        cand_ret_short = rng.normal(0.0001, 0.008, size=150)
+
+        result_sqrt = project_cvar_historical(
+            port_ret_short, cand_ret_short, weights, 0.10,
+        )
+        assert result_sqrt is not None
+        assert result_sqrt < 0  # loss convention
+
+        # Manually compute the sqrt fallback to verify
+        combined_s = np.column_stack([port_ret_short, cand_ret_short])
+        port_daily_s = combined_s @ new_w
+        sorted_s = np.sort(port_daily_s)
+        cutoff_s = max(int(len(sorted_s) * 0.05), 1)
+        daily_cvar = float(-np.mean(sorted_s[:cutoff_s]))
+        expected_sqrt = float(round(-daily_cvar * np.sqrt(252), 6))
+        assert result_sqrt == pytest.approx(expected_sqrt, abs=1e-6)
+
+        # The two results should differ — rolling != sqrt scaling
+        assert result_rolling != pytest.approx(result_sqrt, abs=0.001)
+
 
 class TestProjectCvarForCandidates:
     def test_fills_projection_fields(self):
@@ -580,7 +628,7 @@ class TestBuildAdvice:
         assert result.current_cvar_95 == -0.10
         assert result.cvar_limit == -0.06
         assert result.cvar_gap == pytest.approx(-0.04)
-        assert result.projected_cvar_is_heuristic is True
+        assert result.projected_cvar_is_heuristic is False  # 252 days → rolling path
 
         # Coverage should detect gaps
         assert result.coverage.total_blocks == 4
@@ -786,7 +834,7 @@ class TestEndToEndAdvisorFlow:
         assert advice.coverage.total_blocks == 5
         assert len(advice.coverage.block_gaps) >= 3  # fi, alt, cash gaps
         assert len(advice.candidates) > 0
-        assert advice.projected_cvar_is_heuristic is True
+        assert advice.projected_cvar_is_heuristic is False  # 252 days → rolling path
 
         # All candidates should have projected CVaR
         projected_candidates = [c for c in advice.candidates if c.projected_cvar_95 is not None]

--- a/backend/tests/test_stress_parametric.py
+++ b/backend/tests/test_stress_parametric.py
@@ -6,7 +6,9 @@ from quant_engine.cvar_service import compute_cvar_from_returns
 from vertical_engines.wealth.model_portfolio.stress_scenarios import (
     PRESET_SCENARIOS,
     StressScenarioResult,
+    apply_idiosyncratic_dispersion,
     run_stress_scenario,
+    run_stress_scenario_fund_level,
 )
 
 
@@ -99,3 +101,68 @@ class TestRunStressScenario:
         assert result.cvar_stressed is not None
         # Stressed CVaR should be materially worse (at least 10% more negative)
         assert result.cvar_stressed < base_cvar * 1.10
+
+
+class TestIdiosyncraticDispersion:
+    """C-13: per-fund RNG seed produces distinct shocks per fund."""
+
+    def test_dispersion_produces_different_shocks_per_fund(self):
+        """Same base seed + different fund_ids must yield distinct residuals."""
+        import hashlib
+
+        base_seed = 42
+        block_shock = -0.38
+        fund_vol = 0.15
+
+        shocks: dict[str, float] = {}
+        for fid in ["fund_a", "fund_b", "fund_c"]:
+            fund_hash = int(hashlib.md5(fid.encode()).hexdigest()[:8], 16)
+            fund_seed = (base_seed + fund_hash) & 0xFFFFFFFF
+            shocks[fid] = apply_idiosyncratic_dispersion(
+                block_shock=block_shock,
+                fund_volatility=fund_vol,
+                seed=fund_seed,
+            )
+
+        assert len(set(shocks.values())) == 3, (
+            f"Expected 3 distinct shocks but got {shocks}"
+        )
+
+    def test_fund_level_scenario_produces_distinct_per_fund_shocks(self):
+        """run_stress_scenario_fund_level must not produce identical impacts."""
+        fund_ids = ["fund_a", "fund_b", "fund_c"]
+        fund_weights = {fid: 1.0 / 3 for fid in fund_ids}
+        fund_blocks = {fid: "na_equity_large" for fid in fund_ids}
+        fund_vols = {fid: 0.15 for fid in fund_ids}
+        shocks = {"na_equity_large": -0.38}
+
+        result = run_stress_scenario_fund_level(
+            fund_weights=fund_weights,
+            fund_blocks=fund_blocks,
+            fund_volatilities=fund_vols,
+            shocks=shocks,
+            seed=42,
+        )
+
+        # NAV impact must differ from naive (all-identical) calculation
+        naive_impact = sum(w * (-0.38) for w in fund_weights.values())
+        assert result.nav_impact_pct != round(naive_impact, 6), (
+            "Fund-level shocks should differ from block-level due to dispersion"
+        )
+
+    def test_dispersion_deterministic_for_same_fund(self):
+        """Same fund_id + same base seed must produce identical results."""
+        import hashlib
+
+        base_seed = 99
+        fund_id = "fund_x"
+        fund_hash = int(hashlib.md5(fund_id.encode()).hexdigest()[:8], 16)
+        fund_seed = (base_seed + fund_hash) & 0xFFFFFFFF
+
+        s1 = apply_idiosyncratic_dispersion(
+            block_shock=-0.20, fund_volatility=0.12, seed=fund_seed,
+        )
+        s2 = apply_idiosyncratic_dispersion(
+            block_shock=-0.20, fund_volatility=0.12, seed=fund_seed,
+        )
+        assert s1 == s2

--- a/backend/vertical_engines/wealth/model_portfolio/construction_advisor.py
+++ b/backend/vertical_engines/wealth/model_portfolio/construction_advisor.py
@@ -343,15 +343,21 @@ def project_cvar_historical(
     # Portfolio daily returns with new weights
     port_daily = combined @ new_weights  # (T,)
 
-    # Historical CVaR
-    sorted_ret = np.sort(port_daily)
-    cutoff = max(int(len(sorted_ret) * alpha), 1)
-    daily_cvar = float(-np.mean(sorted_ret[:cutoff]))
-
-    # Annualize (sqrt(252) for volatility-based scaling)
-    annual_cvar = daily_cvar * np.sqrt(252)
-
-    return float(round(-annual_cvar, 6))  # negative = loss convention
+    # Historical CVaR — annualization strategy depends on data length
+    if len(port_daily) >= 252:
+        # Rolling 252-day cumulative returns for proper annual CVaR
+        annual_returns = np.convolve(port_daily, np.ones(252), mode="valid")
+        sorted_annual = np.sort(annual_returns)
+        cutoff = max(int(len(sorted_annual) * alpha), 1)
+        annual_cvar = float(-np.mean(sorted_annual[:cutoff]))
+        return float(round(-annual_cvar, 6))  # negative = loss convention
+    else:
+        # Fallback: sqrt(252) heuristic for short histories
+        sorted_ret = np.sort(port_daily)
+        cutoff = max(int(len(sorted_ret) * alpha), 1)
+        daily_cvar = float(-np.mean(sorted_ret[:cutoff]))
+        annual_cvar = daily_cvar * np.sqrt(252)
+        return float(round(-annual_cvar, 6))  # negative = loss convention
 
 
 def project_cvar_for_candidates(
@@ -775,6 +781,15 @@ def build_advice(
         # Only keep profiles where the current portfolio would pass
         alt_profiles = [a for a in alt_profiles if a.current_cvar_would_pass]
 
+    # Determine if rolling CVaR path was used (not heuristic) for any candidate.
+    # Rolling path requires min(portfolio_days, candidate_days) >= 252.
+    n_port_days = portfolio_daily_returns.shape[0]
+    min_cand_days = min(
+        (len(v) for v in candidate_returns.values()),
+        default=0,
+    )
+    cvar_is_heuristic = min(n_port_days, min_cand_days) < 252
+
     return ConstructionAdvice(
         portfolio_id=portfolio_id,
         profile=profile,
@@ -785,5 +800,5 @@ def build_advice(
         candidates=ranked,
         minimum_viable_set=mvs,
         alternative_profiles=alt_profiles,
-        projected_cvar_is_heuristic=True,
+        projected_cvar_is_heuristic=cvar_is_heuristic,
     )

--- a/backend/vertical_engines/wealth/model_portfolio/stress_scenarios.py
+++ b/backend/vertical_engines/wealth/model_portfolio/stress_scenarios.py
@@ -10,6 +10,7 @@ block-level weights for instant NAV impact and stressed CVaR estimation.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from datetime import date
 
@@ -224,11 +225,16 @@ def run_stress_scenario_fund_level(
         if block_id is None:
             continue
         block_shock = shocks.get(block_id, 0.0)
+        # C-13: derive per-fund seed so each fund gets a distinct residual
+        fund_seed: int | None = None
+        if seed is not None:
+            fund_hash = int(hashlib.md5(fund_id.encode()).hexdigest()[:8], 16)
+            fund_seed = (seed + fund_hash) & 0xFFFFFFFF
         fund_shock = apply_idiosyncratic_dispersion(
             block_shock=block_shock,
             fund_volatility=fund_volatilities.get(fund_id),
             fund_beta=fund_betas.get(fund_id),
-            seed=seed,
+            seed=fund_seed,
         )
         impact = weight * fund_shock
         block_impacts[block_id] = round(block_impacts.get(block_id, 0.0) + impact, 6)


### PR DESCRIPTION
## Summary

Batched remediation for two small Wave 6 Session 10 findings (Med + Low severity).

### C-13 — Per-fund RNG seed for idiosyncratic dispersion (Med)
- **File:** `stress_scenarios.py`
- **Problem:** `run_stress_scenario_fund_level` passed the same `seed` (e.g., 42) to `apply_idiosyncratic_dispersion` for every fund → identical residuals across all funds, defeating the purpose of idiosyncratic dispersion
- **Fix:** Derive per-fund seed via `(seed + int(hashlib.md5(fund_id.encode()).hexdigest()[:8], 16)) & 0xFFFFFFFF` — deterministic but distinct per fund
- **Tests:** 3 new tests (distinct shocks per fund, end-to-end via `run_stress_scenario_fund_level`, determinism for same fund)

### C-14 — Rolling CVaR annualization replaces sqrt(252) heuristic (Low)
- **File:** `construction_advisor.py`
- **Problem:** `project_cvar_historical` multiplied daily CVaR by `sqrt(252)` — appropriate for volatility scaling, not CVaR. Produces misleading annualized values
- **Fix:** When ≥252 days available, compute annual CVaR from rolling 252-day cumulative returns (proper tail estimation). Retain sqrt(252) fallback for short histories with `projected_cvar_is_heuristic=True` flag
- **Tests:** 1 new test verifying both paths (rolling for sufficient data, sqrt fallback for short series)

**Source:** Wave 6 Session 10 Stage 2 jury verdict
**Batch rationale:** Small scope, P2/P3 cleanup wave — each commit is standalone-revertable

## Test plan
- [x] 49/49 tests pass (stress_scenarios + construction_advisor suites)
- [x] Lint clean (ruff)
- [x] Each fix in separate commit — independently revertable

🤖 Generated with [Claude Code](https://claude.com/claude-code)