### PR TITLE
fix(wealth): PR-Q124 — Wave 6 S11 strategy_drift_scanner bundle (C-01 baseline overlap + C-09 flat baseline + C-12 hysteresis) (Crit)

### DIFF
--- a/backend/app/domains/wealth/routes/strategy_drift.py
+++ b/backend/app/domains/wealth/routes/strategy_drift.py
@@ -169,6 +169,22 @@ async def _do_drift_scan(
         if key not in metrics_by_instrument:
             metrics_by_instrument[key] = []
 
+    # 2b. Load previous statuses for hysteresis (C-12)
+    prev_status_stmt = (
+        select(
+            StrategyDriftAlert.instrument_id,
+            StrategyDriftAlert.status,
+        )
+        .where(
+            StrategyDriftAlert.instrument_id.in_(instrument_ids),
+            StrategyDriftAlert.is_current == True,  # noqa: E712
+        )
+    )
+    prev_result = await db.execute(prev_status_stmt)
+    previous_statuses: dict[str, str] = {
+        str(row.instrument_id): row.status for row in prev_result.all()
+    }
+
     # 3. Run scan in thread
     from vertical_engines.wealth.monitoring.strategy_drift_scanner import scan_all_strategy_drift
 
@@ -176,6 +192,8 @@ async def _do_drift_scan(
         scan_all_strategy_drift,
         metrics_by_instrument,
         instrument_names,
+        None,  # config — use defaults
+        previous_statuses=previous_statuses,
     )
 
     # 4. Persist results — mark previous alerts as not current, insert new
@@ -458,6 +476,18 @@ async def get_instrument_drift(
     # Extract to plain dicts for thread-safe processing
     metrics_dicts = [_metrics_row_to_dict(r) for r in metrics_rows]
 
+    # Load previous status for hysteresis (C-12)
+    prev_stmt = (
+        select(StrategyDriftAlert.status)
+        .where(
+            StrategyDriftAlert.instrument_id == instrument_id,
+            StrategyDriftAlert.is_current == True,  # noqa: E712
+        )
+        .limit(1)
+    )
+    prev_result = await db.execute(prev_stmt)
+    prev_status = prev_result.scalar()
+
     from vertical_engines.wealth.monitoring.strategy_drift_scanner import scan_strategy_drift
 
     drift_result = await asyncio.to_thread(
@@ -466,6 +496,7 @@ async def get_instrument_drift(
         str(instrument_id),
         inst_name,
         {"recent_window_days": recent_days, "baseline_window_days": baseline_days},
+        previous_status=prev_status,
     )
 
     return StrategyDriftRead(

--- a/backend/tests/test_strategy_drift.py
+++ b/backend/tests/test_strategy_drift.py
@@ -391,3 +391,282 @@ class TestConstants:
 
     def test_epsilon_is_small(self):
         assert _EPSILON == 1e-10
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  PR-Q124: C-01 — Baseline excludes recent window
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestBaselineExcludesRecentWindow:
+    """C-01: When recent ⊂ baseline, z-score is biased toward zero.
+
+    Fix: baseline_rows = metrics_history[-baseline_count:-recent_count]
+    so μ_baseline and σ_baseline are computed from non-overlapping data.
+    """
+
+    def test_baseline_excludes_recent_window(self):
+        """270 stable + 90 shifted → z ≈ 3.0, is_anomalous=True.
+
+        Before fix: z ≈ 1.73 (recent absorbed into baseline → bias toward 0).
+        After fix: z ≈ 3.0 (clean baseline, shifted recent → correct detection).
+        """
+        np.random.seed(42)
+
+        # 270 stable baseline points (volatility centered at 0.15)
+        stable_rows = []
+        for i in range(270):
+            stable_rows.append(
+                _make_metrics_row(
+                    f"d{i:03d}",
+                    volatility_1y=0.15,
+                    max_drawdown_1y=-0.08,
+                    sharpe_1y=1.2,
+                    sortino_1y=1.5,
+                    alpha_1y=0.02,
+                    beta_1y=0.95,
+                    tracking_error_1y=0.03,
+                ),
+            )
+
+        # Add small noise to get nonzero sigma
+        for i in range(270):
+            stable_rows[i]["volatility_1y"] = 0.15 + np.random.normal(0, 0.002)
+
+        # 90 shifted recent points (volatility shifted to 0.15 + 3σ ≈ 0.156)
+        sigma_approx = 0.002  # std of baseline
+        shift = 3.0 * sigma_approx  # 3σ shift
+        shifted_rows = []
+        for i in range(90):
+            shifted_rows.append(
+                _make_metrics_row(
+                    f"r{i:03d}",
+                    volatility_1y=0.15 + shift,
+                    max_drawdown_1y=-0.08,
+                    sharpe_1y=1.2,
+                    sortino_1y=1.5,
+                    alpha_1y=0.02,
+                    beta_1y=0.95,
+                    tracking_error_1y=0.03,
+                ),
+            )
+
+        history = stable_rows + shifted_rows  # 360 total
+
+        result = scan_strategy_drift(
+            history,
+            "inst_c01",
+            "C01 Test Fund",
+            config={
+                "recent_window_days": 90,
+                "baseline_window_days": 360,
+            },
+        )
+
+        # Find the volatility metric
+        vol_metric = next(
+            m for m in result.metrics if m.metric_name == "volatility_1y"
+        )
+
+        # z should be approximately 3.0 (shifted by 3σ of baseline)
+        assert abs(vol_metric.z_score) > 2.0, (
+            f"Expected z > 2.0 but got {vol_metric.z_score}. "
+            f"Baseline likely still contains recent window (C-01 not fixed)."
+        )
+        assert vol_metric.is_anomalous is True
+        assert result.status == "drift_detected"
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  PR-Q124: C-09 — Flat baseline breakout detection
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestFlatBaselineBreakout:
+    """C-09: sigma_baseline < ε → unconditional is_anomalous=False was wrong.
+
+    Fix: fall back to absolute-distance check when sigma is degenerate.
+    """
+
+    def test_flat_baseline_breakout_detected(self):
+        """Baseline all 0.0, recent all 5.0 → is_anomalous=True.
+
+        Before fix: unconditionally False (flat baseline guard).
+        After fix: abs_diff = 5.0 > tol (0.001) → True.
+        """
+        baseline = [
+            _make_metrics_row(f"d{i:03d}", tracking_error_1y=0.0)
+            for i in range(270)
+        ]
+        recent = [
+            _make_metrics_row(f"r{i:03d}", tracking_error_1y=5.0)
+            for i in range(90)
+        ]
+        history = baseline + recent
+
+        result = scan_strategy_drift(
+            history,
+            "inst_c09",
+            "C09 Flat Baseline Fund",
+            config={
+                "recent_window_days": 90,
+                "baseline_window_days": 360,
+            },
+        )
+
+        te_metric = next(
+            m for m in result.metrics if m.metric_name == "tracking_error_1y"
+        )
+        assert te_metric.z_score == 0.0  # sentinel for degenerate sigma
+        assert te_metric.is_anomalous is True, (
+            "Expected breakout from flat baseline to be detected (C-09 not fixed)."
+        )
+        assert result.status == "drift_detected"
+
+    def test_flat_baseline_within_tol_not_anomalous(self):
+        """Baseline all 0.0, recent all 0.0005 (< 0.001 tol) → is_anomalous=False.
+
+        Small perturbation within tolerance should not trigger.
+        """
+        baseline = [
+            _make_metrics_row(f"d{i:03d}", tracking_error_1y=0.0)
+            for i in range(270)
+        ]
+        recent = [
+            _make_metrics_row(f"r{i:03d}", tracking_error_1y=0.0005)
+            for i in range(90)
+        ]
+        history = baseline + recent
+
+        result = scan_strategy_drift(
+            history,
+            "inst_c09b",
+            "C09 Within-Tol Fund",
+            config={
+                "recent_window_days": 90,
+                "baseline_window_days": 360,
+            },
+        )
+
+        te_metric = next(
+            m for m in result.metrics if m.metric_name == "tracking_error_1y"
+        )
+        assert te_metric.z_score == 0.0
+        assert te_metric.is_anomalous is False
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  PR-Q124: C-12 — Hysteresis open/close band
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestHysteresisOpenCloseBand:
+    """C-12: Without hysteresis, z oscillating at 1.95/2.05 flaps daily.
+
+    Fix: open threshold (2.0) to enter drift_detected, close threshold
+    (1.5) to return to stable.
+    """
+
+    def _make_z_controlled_history(
+        self, target_z: float, baseline_std: float = 0.01,
+    ) -> list[dict]:
+        """Build 360-row history where volatility_1y z-score ≈ target_z.
+
+        270 baseline rows at mean=0.15 with given std.
+        90 recent rows at mean = 0.15 + target_z * baseline_std.
+        """
+        np.random.seed(0)
+        baseline_mean = 0.15
+        recent_mean = baseline_mean + target_z * baseline_std
+
+        rows: list[dict] = []
+        for i in range(270):
+            rows.append(
+                _make_metrics_row(
+                    f"d{i:03d}",
+                    volatility_1y=baseline_mean + np.random.normal(0, baseline_std),
+                ),
+            )
+        for i in range(90):
+            rows.append(
+                _make_metrics_row(f"r{i:03d}", volatility_1y=recent_mean),
+            )
+        return rows
+
+    def test_hysteresis_open_close_band(self):
+        """Verify hysteresis band behavior.
+
+        - previous_status="drift_detected", z≈1.6 → is_anomalous=True
+          (still above close=1.5)
+        - previous_status="stable", z≈1.6 → is_anomalous=False
+          (below open=2.0)
+        """
+        # z≈1.6: above close (1.5) but below open (2.0)
+        history = self._make_z_controlled_history(1.6)
+
+        # Case 1: previously drift_detected → use close_threshold=1.5 → 1.6>1.5 → anomalous
+        result_drift = scan_strategy_drift(
+            history,
+            "inst_hyst",
+            "Hysteresis Fund",
+            config={
+                "recent_window_days": 90,
+                "baseline_window_days": 360,
+                "z_threshold": 2.0,
+                "z_close_threshold": 1.5,
+            },
+            previous_status="drift_detected",
+        )
+        vol_drift = next(
+            m for m in result_drift.metrics if m.metric_name == "volatility_1y"
+        )
+        assert vol_drift.is_anomalous is True, (
+            f"Expected z≈1.6 > close_threshold=1.5 with previous=drift_detected, "
+            f"but is_anomalous={vol_drift.is_anomalous} (z={vol_drift.z_score})"
+        )
+
+        # Case 2: previously stable → use open_threshold=2.0 → 1.6<2.0 → not anomalous
+        result_stable = scan_strategy_drift(
+            history,
+            "inst_hyst",
+            "Hysteresis Fund",
+            config={
+                "recent_window_days": 90,
+                "baseline_window_days": 360,
+                "z_threshold": 2.0,
+                "z_close_threshold": 1.5,
+            },
+            previous_status="stable",
+        )
+        vol_stable = next(
+            m for m in result_stable.metrics if m.metric_name == "volatility_1y"
+        )
+        assert vol_stable.is_anomalous is False, (
+            f"Expected z≈1.6 < open_threshold=2.0 with previous=stable, "
+            f"but is_anomalous={vol_stable.is_anomalous} (z={vol_stable.z_score})"
+        )
+
+    def test_hysteresis_config_validation(self):
+        """Inverted band (close >= open) → ValueError."""
+        with pytest.raises(ValueError, match="z_close_threshold"):
+            scan_strategy_drift(
+                [_make_metrics_row(f"d{i}") for i in range(100)],
+                "inst_val",
+                "Validation Fund",
+                config={
+                    "z_threshold": 1.5,
+                    "z_close_threshold": 2.0,  # inverted!
+                },
+            )
+
+        # Equal values should also fail
+        with pytest.raises(ValueError, match="z_close_threshold"):
+            scan_strategy_drift(
+                [_make_metrics_row(f"d{i}") for i in range(100)],
+                "inst_val",
+                "Validation Fund",
+                config={
+                    "z_threshold": 2.0,
+                    "z_close_threshold": 2.0,  # equal!
+                },
+            )

--- a/backend/vertical_engines/wealth/monitoring/strategy_drift_scanner.py
+++ b/backend/vertical_engines/wealth/monitoring/strategy_drift_scanner.py
@@ -1,24 +1,52 @@
 """Strategy drift scanner — detects fund behavior changes via z-score.
 
-Compares recent metric distribution (90d of calc_dates) against baseline (360d).
+Compares recent metric distribution (90d of calc_dates) against a
+**non-overlapping** baseline (preceding 270d when recent=90, baseline=360).
 Designed to run in asyncio.to_thread(). Pure sync, no DB, no I/O.
 
 Formula:
     z = (μ_recent - μ_baseline) / σ_baseline
 
 Alert when |z| > threshold (strict greater-than: z=2.0 exactly is NOT anomalous).
+
+Hysteresis (C-12):
+    Once drift_detected, the close threshold (default 1.5) applies — a fund must
+    fall below z_close_threshold to return to stable. Prevents daily flapping
+    when z oscillates near the open threshold.
+
+Flat-baseline guard (C-09):
+    When σ_baseline < ε (constant metric), an absolute-distance check replaces
+    the z-score. Breakouts from flat baselines (e.g., index fund TE → active TE)
+    are detected via ``flat_baseline_abs_tol`` (default 0.001 = 10bps).
+
 Severity:
     - "severe" if anomalous_count >= 3 of 7 metrics (~43%)
     - "moderate" if >= 1
     - "none" if 0
 
 NOTE: If METRICS_TO_CHECK is reduced below 3, "severe" becomes unreachable.
+
+Config keys
+-----------
+recent_window_days : int (default 90)
+baseline_window_days : int (default 360)
+z_threshold : float (default 2.0)
+    Open threshold — z must exceed this to trigger drift_detected from stable.
+z_close_threshold : float (default 1.5)
+    Close threshold — z must fall below this to return to stable from
+    drift_detected. Must be < z_threshold; validated at config resolution.
+min_baseline_points : int (default 20)
+    Minimum data points in baseline after excluding recent window.
+    If the non-overlapping baseline has fewer rows, returns insufficient_data.
+min_recent_points : int (default 5)
+flat_baseline_abs_tol : float (default 0.001 = 10bps)
+    Absolute tolerance for breakout detection when σ_baseline is degenerate.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import structlog
@@ -49,21 +77,40 @@ _EPSILON = 1e-10
 _DEFAULT_RECENT_WINDOW_DAYS = 90
 _DEFAULT_BASELINE_WINDOW_DAYS = 360
 _DEFAULT_Z_THRESHOLD = 2.0
+_DEFAULT_Z_CLOSE_THRESHOLD = 1.5
 _DEFAULT_MIN_BASELINE_POINTS = 20
 _DEFAULT_MIN_RECENT_POINTS = 5
+_DEFAULT_FLAT_BASELINE_ABS_TOL = 0.001  # 10bps
 
 
 def _resolve_config(config: dict[str, Any] | None) -> dict[str, Any]:
-    """Merge config with defaults."""
+    """Merge config with defaults and validate constraints.
+
+    Raises
+    ------
+    ValueError
+        If z_close_threshold >= z_threshold (inverted hysteresis band).
+    """
     defaults = {
         "recent_window_days": _DEFAULT_RECENT_WINDOW_DAYS,
         "baseline_window_days": _DEFAULT_BASELINE_WINDOW_DAYS,
         "z_threshold": _DEFAULT_Z_THRESHOLD,
+        "z_close_threshold": _DEFAULT_Z_CLOSE_THRESHOLD,
         "min_baseline_points": _DEFAULT_MIN_BASELINE_POINTS,
         "min_recent_points": _DEFAULT_MIN_RECENT_POINTS,
+        "flat_baseline_abs_tol": _DEFAULT_FLAT_BASELINE_ABS_TOL,
     }
     if config:
         defaults.update(config)
+
+    # Validate hysteresis band: close must be strictly less than open
+    if defaults["z_close_threshold"] >= defaults["z_threshold"]:
+        raise ValueError(
+            f"z_close_threshold ({defaults['z_close_threshold']}) must be "
+            f"< z_threshold ({defaults['z_threshold']}). "
+            f"Inverted hysteresis band disables drift persistence."
+        )
+
     return defaults
 
 
@@ -72,6 +119,8 @@ def scan_strategy_drift(
     instrument_id: str,
     instrument_name: str,
     config: dict[str, Any] | None = None,
+    *,
+    previous_status: Literal["stable", "drift_detected"] | None = None,
 ) -> StrategyDriftResult:
     """Detect behavior change for a single instrument.
 
@@ -86,7 +135,13 @@ def scan_strategy_drift(
         Display name for alerting.
     config : dict | None
         Overrides for thresholds. Keys: recent_window_days, baseline_window_days,
-        z_threshold, min_baseline_points, min_recent_points.
+        z_threshold, z_close_threshold, min_baseline_points, min_recent_points,
+        flat_baseline_abs_tol.
+    previous_status : "stable" | "drift_detected" | None
+        Previous scan status for this instrument (keyword-only). When
+        ``"drift_detected"``, the close threshold (z_close_threshold) is used
+        instead of the open threshold — providing hysteresis to prevent
+        alert flapping.
 
     Returns
     -------
@@ -109,14 +164,21 @@ def scan_strategy_drift(
             detected_at=now_dt,
         )
 
-    # Split into recent and baseline windows by calc_date count
-    # metrics_history is sorted by calc_date ascending
+    # Split into recent and baseline windows by calc_date count.
+    # C-01 fix: baseline EXCLUDES recent window to prevent mu_baseline
+    # from absorbing the recent shift and biasing z toward zero.
     total_points = len(metrics_history)
     recent_count = min(cfg["recent_window_days"], total_points)
     baseline_count = min(cfg["baseline_window_days"], total_points)
 
     recent_rows = metrics_history[-recent_count:]
-    baseline_rows = metrics_history[-baseline_count:]
+    # Non-overlapping baseline: everything in the baseline window BEFORE the recent window.
+    # baseline_rows = metrics_history[-baseline_count : -recent_count]
+    # Edge case: if baseline_count <= recent_count, this slice is empty → insufficient_data.
+    if baseline_count > recent_count:
+        baseline_rows = metrics_history[-baseline_count:-recent_count]
+    else:
+        baseline_rows = []
 
     # Check minimum sample sizes
     if len(baseline_rows) < cfg["min_baseline_points"]:
@@ -143,9 +205,17 @@ def scan_strategy_drift(
             detected_at=now_dt,
         )
 
+    # C-12: Hysteresis — select threshold based on previous status
+    open_threshold = cfg["z_threshold"]
+    close_threshold = cfg["z_close_threshold"]
+    threshold_to_apply = (
+        close_threshold if previous_status == "drift_detected" else open_threshold
+    )
+
     # Compute z-scores per metric
     metric_drifts: list[MetricDrift] = []
     anomalous_count = 0
+    flat_baseline_tol = cfg["flat_baseline_abs_tol"]
 
     for metric_name in METRICS_TO_CHECK:
         # Extract values, skip None/NaN
@@ -170,23 +240,32 @@ def scan_strategy_drift(
         sigma_baseline = float(np.std(baseline_vals, ddof=1)) if len(baseline_vals) > 1 else 0.0
         mu_recent = float(np.mean(recent_vals))
 
-        # Guard: σ near zero → metric is constant, skip
+        # C-09: Flat-baseline guard — σ near zero means metric was constant.
+        # Instead of unconditionally marking is_anomalous=False, check
+        # absolute distance to detect breakouts from flat baselines
+        # (e.g., passive index fund tracking error jumping from 0 to 5%).
         if sigma_baseline < _EPSILON:
+            abs_diff = abs(mu_recent - mu_baseline)
+            is_anomalous = abs_diff > flat_baseline_tol
+
+            if is_anomalous:
+                anomalous_count += 1
+
             metric_drifts.append(
                 MetricDrift(
                     metric_name=metric_name,
                     recent_mean=round(mu_recent, 6),
                     baseline_mean=round(mu_baseline, 6),
                     baseline_std=0.0,
-                    z_score=0.0,
-                    is_anomalous=False,
+                    z_score=0.0,  # sentinel — σ was degenerate
+                    is_anomalous=is_anomalous,
                 ),
             )
             continue
 
         z = (mu_recent - mu_baseline) / sigma_baseline
-        # Strict greater-than: z=2.0 exactly is NOT anomalous
-        is_anomalous = abs(z) > cfg["z_threshold"]
+        # Strict greater-than with hysteresis-aware threshold
+        is_anomalous = abs(z) > threshold_to_apply
 
         if is_anomalous:
             anomalous_count += 1
@@ -228,6 +307,8 @@ def scan_all_strategy_drift(
     all_instruments_metrics: dict[str, list[dict[str, Any]]],
     instrument_names: dict[str, str],
     config: dict[str, Any] | None = None,
+    *,
+    previous_statuses: dict[str, str] | None = None,
 ) -> StrategyDriftScanResult:
     """Scan all instruments for strategy drift.
 
@@ -239,6 +320,9 @@ def scan_all_strategy_drift(
         instrument_id → display name.
     config : dict | None
         Overrides for thresholds.
+    previous_statuses : dict | None
+        instrument_id → previous status ("stable" | "drift_detected").
+        Used for hysteresis. When None, all instruments use open threshold.
 
     Returns
     -------
@@ -251,10 +335,18 @@ def scan_all_strategy_drift(
     all_results: list[StrategyDriftResult] = []
     stable_count = 0
     insufficient_count = 0
+    prev_map = previous_statuses or {}
 
     for instrument_id, metrics_history in all_instruments_metrics.items():
         name = instrument_names.get(instrument_id, instrument_id)
-        result = scan_strategy_drift(metrics_history, instrument_id, name, config)
+        prev_status = prev_map.get(instrument_id)
+        result = scan_strategy_drift(
+            metrics_history,
+            instrument_id,
+            name,
+            config,
+            previous_status=prev_status,
+        )
         all_results.append(result)
 
         if result.status == "drift_detected":


### PR DESCRIPTION
## Summary

Bundles three Wave 6 Session 11 findings that suppress drift detection from different angles within `strategy_drift_scanner.py`. All three must land together — any single fix alone leaves the other two suppression mechanisms active.

### C-01 (Crit) — Recent window ⊂ baseline → z-score bias toward zero

**Jury verdict:** `baseline_rows = metrics_history[-baseline_count:]` includes the recent window, so μ_baseline absorbs recent shifts and σ_baseline is inflated by bimodal distribution. A 60bps volatility shift produces z=1.73 instead of z=3.0 — missed below the 2.0 threshold.

**Fix:** `baseline_rows = metrics_history[-baseline_count:-recent_count]` — non-overlapping slices. If the resulting baseline has fewer than `min_baseline_points` (default 20), returns `insufficient_data`.

### C-09 (Crit) — Flat baseline guard unconditionally suppresses breakouts

**Jury verdict:** `if sigma_baseline < EPSILON: is_anomalous=False` regardless of |μ_recent - μ_baseline|. For passive index funds (tracking error ≈ 0 baseline), a real breakout (peg break to 5% TE) is silently masked.

**Fix:** When σ is degenerate, fall back to absolute-distance check: `is_anomalous = abs(mu_recent - mu_baseline) > flat_baseline_abs_tol`. New config key `flat_baseline_abs_tol` (default 0.001 = 10bps).

### C-12 (High) — No hysteresis → alert flapping

**Jury verdict:** `is_anomalous = abs(z) > threshold` with no previous-status input. Z-score oscillating between 1.95 and 2.05 flaps status daily. Alert fatigue.

**Fix:** Open/close hysteresis band. New config key `z_close_threshold` (default 1.5, must be < `z_threshold`). When `previous_status="drift_detected"`, close threshold applies; otherwise open threshold. Config validation rejects inverted bands with explicit `ValueError`.

Route callers (`trigger_drift_scan`, `get_instrument_drift`) updated to load `previous_status` from `strategy_drift_alerts.status WHERE is_current=True`.

## Changed files

- `backend/vertical_engines/wealth/monitoring/strategy_drift_scanner.py` — all three fixes
- `backend/app/domains/wealth/routes/strategy_drift.py` — previous_status injection for hysteresis
- `backend/tests/test_strategy_drift.py` — 5 new tests

## Test plan

- [x] `test_baseline_excludes_recent_window` — 270 stable + 90 shifted → z ≈ 3.0, is_anomalous=True
- [x] `test_flat_baseline_breakout_detected` — baseline all 0.0 + recent all 5.0 → is_anomalous=True
- [x] `test_flat_baseline_within_tol_not_anomalous` — baseline all 0.0 + recent all 0.0005 → is_anomalous=False
- [x] `test_hysteresis_open_close_band` — previous=drift_detected, z=1.6 → True; previous=stable, z=1.6 → False
- [x] `test_hysteresis_config_validation` — inverted band → ValueError
- [x] All 19 existing strategy_drift tests pass unchanged
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)