### PR TITLE
fix(wealth): PR-Q128 — RebalanceEvent dedupe (C-04 drift_rebalance idempotency)

### DIFF
--- a/backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py
+++ b/backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py
@@ -20,16 +20,17 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    # Cleanup: keep latest pending per (organization_id, profile, event_type),
-    # delete older duplicates. Required before unique index creation —
-    # prod DBs may already have duplicates from pre-Q128 worker behavior.
+    # Cleanup: keep latest pending drift_rebalance per (organization_id, profile),
+    # delete older duplicates. Scoped to event_type='drift_rebalance' only —
+    # manual/scheduled pending events must NOT be touched.
     op.execute(
         sa.text("""
             DELETE FROM rebalance_events re_old
             USING rebalance_events re_new
             WHERE re_old.organization_id = re_new.organization_id
               AND re_old.profile = re_new.profile
-              AND re_old.event_type = re_new.event_type
+              AND re_old.event_type = 'drift_rebalance'
+              AND re_new.event_type = 'drift_rebalance'
               AND re_old.status = 'pending'
               AND re_new.status = 'pending'
               AND re_old.event_id != re_new.event_id
@@ -44,13 +45,15 @@ def upgrade() -> None:
     )
 
     op.create_index(
-        "uq_rebalance_event_pending_per_profile",
+        "uq_rebalance_event_pending_drift_per_profile",
         "rebalance_events",
-        ["organization_id", "profile", "event_type"],
+        ["organization_id", "profile"],
         unique=True,
-        postgresql_where=sa.text("status = 'pending'"),
+        postgresql_where=sa.text(
+            "status = 'pending' AND event_type = 'drift_rebalance'"
+        ),
     )
 
 
 def downgrade() -> None:
-    op.drop_index("uq_rebalance_event_pending_per_profile", "rebalance_events")
+    op.drop_index("uq_rebalance_event_pending_drift_per_profile", "rebalance_events")

--- a/backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py
+++ b/backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py
@@ -33,7 +33,13 @@ def upgrade() -> None:
               AND re_old.status = 'pending'
               AND re_new.status = 'pending'
               AND re_old.event_id != re_new.event_id
-              AND re_old.created_at < re_new.created_at
+              AND (
+                  re_old.created_at < re_new.created_at
+                  OR (
+                      re_old.created_at = re_new.created_at
+                      AND re_old.event_id < re_new.event_id
+                  )
+              )
         """)
     )
 

--- a/backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py
+++ b/backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py
@@ -1,0 +1,32 @@
+"""PR-Q128: Add partial unique index for pending drift_rebalance events.
+
+Prevents duplicate pending RebalanceEvent rows per (org, profile, event_type).
+Mirrors PortfolioAlert dedupe_key pattern.
+
+Revision ID: 0196_q128_rebalance_pending_dedupe
+Revises: 0195_q92_audit_events_global
+Create Date: 2026-04-29
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0196_q128_rebalance_pending_dedupe"
+down_revision: str | None = "0195_q92_audit_events_global"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "uq_rebalance_event_pending_per_profile",
+        "rebalance_events",
+        ["organization_id", "profile", "event_type"],
+        unique=True,
+        postgresql_where="status = 'pending'",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_rebalance_event_pending_per_profile", "rebalance_events")

--- a/backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py
+++ b/backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py
@@ -20,40 +20,57 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    # Cleanup: keep latest pending drift_rebalance per (organization_id, profile),
-    # delete older duplicates. Scoped to event_type='drift_rebalance' only —
-    # manual/scheduled pending events must NOT be touched.
-    op.execute(
-        sa.text("""
-            DELETE FROM rebalance_events re_old
-            USING rebalance_events re_new
-            WHERE re_old.organization_id = re_new.organization_id
-              AND re_old.profile = re_new.profile
-              AND re_old.event_type = 'drift_rebalance'
-              AND re_new.event_type = 'drift_rebalance'
-              AND re_old.status = 'pending'
-              AND re_new.status = 'pending'
-              AND re_old.event_id != re_new.event_id
-              AND (
-                  re_old.created_at < re_new.created_at
-                  OR (
-                      re_old.created_at = re_new.created_at
-                      AND re_old.event_id < re_new.event_id
-                  )
-              )
-        """)
-    )
+    # Bypass RLS for cleanup DELETE — migration runs as superuser
+    # and needs to deduplicate across ALL orgs.  rebalance_events has
+    # FORCE ROW LEVEL SECURITY (migration 0003) with policy on
+    # current_setting('app.current_organization_id').  Without org
+    # context the policy filters all rows → DELETE deletes 0.
+    op.execute(sa.text("ALTER TABLE rebalance_events DISABLE ROW LEVEL SECURITY"))
 
-    op.create_index(
-        "uq_rebalance_event_pending_drift_per_profile",
-        "rebalance_events",
-        ["organization_id", "profile"],
-        unique=True,
-        postgresql_where=sa.text(
-            "status = 'pending' AND event_type = 'drift_rebalance'"
-        ),
-    )
+    try:
+        # Cleanup: keep latest pending drift_rebalance per (organization_id, profile),
+        # delete older duplicates. Scoped to event_type='drift_rebalance' only —
+        # manual/scheduled pending events must NOT be touched.
+        op.execute(
+            sa.text("""
+                DELETE FROM rebalance_events re_old
+                USING rebalance_events re_new
+                WHERE re_old.organization_id = re_new.organization_id
+                  AND re_old.profile = re_new.profile
+                  AND re_old.event_type = 'drift_rebalance'
+                  AND re_new.event_type = 'drift_rebalance'
+                  AND re_old.status = 'pending'
+                  AND re_new.status = 'pending'
+                  AND re_old.event_id != re_new.event_id
+                  AND (
+                      re_old.created_at < re_new.created_at
+                      OR (
+                          re_old.created_at = re_new.created_at
+                          AND re_old.event_id < re_new.event_id
+                      )
+                  )
+            """)
+        )
+
+        op.create_index(
+            "uq_rebalance_event_pending_drift_per_profile",
+            "rebalance_events",
+            ["organization_id", "profile"],
+            unique=True,
+            postgresql_where=sa.text(
+                "status = 'pending' AND event_type = 'drift_rebalance'"
+            ),
+        )
+    finally:
+        # Restore RLS to pre-migration state (ENABLE + FORCE from migration 0003)
+        op.execute(sa.text("ALTER TABLE rebalance_events ENABLE ROW LEVEL SECURITY"))
+        op.execute(sa.text("ALTER TABLE rebalance_events FORCE ROW LEVEL SECURITY"))
 
 
 def downgrade() -> None:
-    op.drop_index("uq_rebalance_event_pending_drift_per_profile", "rebalance_events")
+    op.execute(sa.text("ALTER TABLE rebalance_events DISABLE ROW LEVEL SECURITY"))
+    try:
+        op.drop_index("uq_rebalance_event_pending_drift_per_profile", "rebalance_events")
+    finally:
+        op.execute(sa.text("ALTER TABLE rebalance_events ENABLE ROW LEVEL SECURITY"))
+        op.execute(sa.text("ALTER TABLE rebalance_events FORCE ROW LEVEL SECURITY"))

--- a/backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py
+++ b/backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py
@@ -10,6 +10,7 @@ Create Date: 2026-04-29
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0196_q128_rebalance_pending_dedupe"
@@ -19,12 +20,29 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    # Cleanup: keep latest pending per (organization_id, profile, event_type),
+    # delete older duplicates. Required before unique index creation —
+    # prod DBs may already have duplicates from pre-Q128 worker behavior.
+    op.execute(
+        sa.text("""
+            DELETE FROM rebalance_events re_old
+            USING rebalance_events re_new
+            WHERE re_old.organization_id = re_new.organization_id
+              AND re_old.profile = re_new.profile
+              AND re_old.event_type = re_new.event_type
+              AND re_old.status = 'pending'
+              AND re_new.status = 'pending'
+              AND re_old.event_id != re_new.event_id
+              AND re_old.created_at < re_new.created_at
+        """)
+    )
+
     op.create_index(
         "uq_rebalance_event_pending_per_profile",
         "rebalance_events",
         ["organization_id", "profile", "event_type"],
         unique=True,
-        postgresql_where="status = 'pending'",
+        postgresql_where=sa.text("status = 'pending'"),
     )
 
 

--- a/backend/app/domains/wealth/workers/drift_check.py
+++ b/backend/app/domains/wealth/workers/drift_check.py
@@ -15,11 +15,13 @@ import asyncio
 import uuid
 
 import structlog
+from sqlalchemy import select as sa_select
 from sqlalchemy import text
 
 from app.core.db.audit import write_audit_event
 from app.core.db.engine import async_session_factory as async_session
 from app.core.tenancy.middleware import set_rls_context
+from app.domains.wealth.models.rebalance import RebalanceEvent
 from app.domains.wealth.services.quant_queries import compute_drift, create_system_rebalance_event
 
 logger = structlog.get_logger()
@@ -53,8 +55,6 @@ async def run_drift_check(org_id: uuid.UUID) -> dict[str, str]:
         try:
             # Load config once for all profiles
             try:
-                from sqlalchemy import select as sa_select
-
                 from app.core.config.models import VerticalConfigDefault
 
                 cfg_result = await db.execute(
@@ -81,6 +81,23 @@ async def run_drift_check(org_id: uuid.UUID) -> dict[str, str]:
                 )
 
                 if report.rebalance_recommended:
+                    # Dedupe: skip if a pending drift_rebalance already exists
+                    existing = await db.execute(
+                        sa_select(RebalanceEvent.event_id).where(
+                            RebalanceEvent.profile == profile,
+                            RebalanceEvent.event_type == "drift_rebalance",
+                            RebalanceEvent.status == "pending",
+                        ).limit(1),
+                    )
+                    if existing.scalar_one_or_none() is not None:
+                        logger.info(
+                            "drift_rebalance_already_pending",
+                            profile=profile,
+                        )
+                        await db.commit()
+                        await set_rls_context(db, org_id)
+                        continue
+
                     # Build drift detail for trigger reason
                     drifted_blocks = ", ".join(
                         f"{d.block_id}={d.absolute_drift:+.1%}"

--- a/backend/tests/db/test_migration_0196_dedupe_tiebreak.py
+++ b/backend/tests/db/test_migration_0196_dedupe_tiebreak.py
@@ -1,4 +1,4 @@
-"""PR-Q128: migration 0196 dedupe DELETE tiebreak + event_type scoping.
+"""PR-Q128: migration 0196 dedupe DELETE tiebreak + event_type scoping + RLS bypass.
 
 Validates that the DELETE ... USING pattern in 0196 correctly deduplicates
 pending rebalance_events even when multiple duplicates share the exact
@@ -9,14 +9,19 @@ UUID) -- survives.
 Also validates that ONLY drift_rebalance events are affected — manual and
 other event_type pending rows must be preserved unconditionally.
 
+Includes structural tests verifying the migration disables/re-enables RLS
+around the cleanup DELETE (rebalance_events has FORCE ROW LEVEL SECURITY).
+
 This is a pure-logic test that simulates the SQL predicate in Python,
 avoiding the need for a live database.
 """
 
 from __future__ import annotations
 
+import re
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import NamedTuple
 
 
@@ -309,4 +314,62 @@ def test_migration_index_scoped_to_drift_rebalance():
     # Must NOT have a generic 'pending' only filter
     assert "uq_rebalance_event_pending_per_profile" not in source, (
         "Old generic index name must not be present"
+    )
+
+
+# -- Test: RLS disabled during cleanup (structural) -------------------------
+
+
+_MIGRATION_PATH = Path(__file__).resolve().parents[2] / (
+    "app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py"
+)
+
+
+def test_migration_0196_disables_rls_during_cleanup():
+    """Migration must DISABLE RLS before DELETE and re-ENABLE + FORCE after."""
+    source = _MIGRATION_PATH.read_text(encoding="utf-8")
+
+    assert "DISABLE ROW LEVEL SECURITY" in source, (
+        "Migration must DISABLE RLS before cleanup DELETE"
+    )
+    assert "ENABLE ROW LEVEL SECURITY" in source, (
+        "Migration must re-ENABLE RLS after cleanup"
+    )
+    assert "FORCE ROW LEVEL SECURITY" in source, (
+        "Migration must restore FORCE RLS (set by migration 0003)"
+    )
+
+    # DISABLE must appear before DELETE
+    disable_pos = source.index("DISABLE ROW LEVEL SECURITY")
+    delete_pos = source.index("DELETE FROM rebalance_events")
+    assert disable_pos < delete_pos, (
+        "DISABLE RLS must appear before the DELETE statement"
+    )
+
+    # ENABLE must appear after DELETE
+    enable_pos = source.index("ENABLE ROW LEVEL SECURITY")
+    assert enable_pos > delete_pos, (
+        "ENABLE RLS must appear after the DELETE statement"
+    )
+
+
+def test_migration_0196_rls_in_finally_block():
+    """RLS restore must be in a finally block so it runs even on failure."""
+    source = _MIGRATION_PATH.read_text(encoding="utf-8")
+
+    # Extract upgrade function body
+    upgrade_match = re.search(
+        r"def upgrade\(\).*?(?=\ndef |\Z)", source, re.DOTALL
+    )
+    assert upgrade_match, "Could not find upgrade() function"
+    upgrade_body = upgrade_match.group()
+
+    assert "try:" in upgrade_body, "upgrade() must use try block"
+    assert "finally:" in upgrade_body, "upgrade() must use finally block"
+
+    # ENABLE RLS must be inside the finally block (after "finally:")
+    finally_pos = upgrade_body.index("finally:")
+    enable_in_finally = "ENABLE ROW LEVEL SECURITY" in upgrade_body[finally_pos:]
+    assert enable_in_finally, (
+        "ENABLE RLS must be inside the finally block"
     )

--- a/backend/tests/db/test_migration_0196_dedupe_tiebreak.py
+++ b/backend/tests/db/test_migration_0196_dedupe_tiebreak.py
@@ -19,8 +19,6 @@ import uuid
 from datetime import datetime, timezone
 from typing import NamedTuple
 
-import pytest
-
 
 class _Row(NamedTuple):
     """Minimal representation of a pending rebalance_events row."""

--- a/backend/tests/db/test_migration_0196_dedupe_tiebreak.py
+++ b/backend/tests/db/test_migration_0196_dedupe_tiebreak.py
@@ -1,0 +1,209 @@
+"""PR-Q128 hotfix #2: migration 0196 dedupe DELETE tiebreak.
+
+Validates that the DELETE ... USING pattern in 0196 correctly deduplicates
+pending rebalance_events even when multiple duplicates share the exact
+same created_at timestamp.  The tiebreak uses event_id (UUID, lexicographic)
+so that exactly one row -- the one with the largest (latest ts, then largest
+UUID) -- survives.
+
+This is a pure-logic test that simulates the SQL predicate in Python,
+avoiding the need for a live database.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import NamedTuple
+
+import pytest
+
+
+class _Row(NamedTuple):
+    """Minimal representation of a pending rebalance_events row."""
+
+    event_id: uuid.UUID
+    organization_id: uuid.UUID
+    profile: str
+    event_type: str
+    status: str
+    created_at: datetime
+
+
+def _apply_dedupe_delete(rows: list[_Row]) -> list[_Row]:
+    """Simulate the migration 0196 DELETE ... USING predicate.
+
+    For each pair (re_old, re_new) that matches the WHERE clause,
+    re_old is marked for deletion.  Returns the surviving rows.
+
+    The predicate (from the fixed migration):
+        re_old.organization_id = re_new.organization_id
+        AND re_old.profile = re_new.profile
+        AND re_old.event_type = re_new.event_type
+        AND re_old.status = 'pending'
+        AND re_new.status = 'pending'
+        AND re_old.event_id != re_new.event_id
+        AND (
+            re_old.created_at < re_new.created_at
+            OR (
+                re_old.created_at = re_new.created_at
+                AND re_old.event_id < re_new.event_id
+            )
+        )
+    """
+    deleted_ids: set[uuid.UUID] = set()
+
+    for re_old in rows:
+        for re_new in rows:
+            if (
+                re_old.organization_id == re_new.organization_id
+                and re_old.profile == re_new.profile
+                and re_old.event_type == re_new.event_type
+                and re_old.status == "pending"
+                and re_new.status == "pending"
+                and re_old.event_id != re_new.event_id
+                and (
+                    re_old.created_at < re_new.created_at
+                    or (
+                        re_old.created_at == re_new.created_at
+                        and str(re_old.event_id) < str(re_new.event_id)
+                    )
+                )
+            ):
+                deleted_ids.add(re_old.event_id)
+
+    return [r for r in rows if r.event_id not in deleted_ids]
+
+
+# -- Test: tied timestamps ---------------------------------------------
+
+
+def test_migration_handles_tied_timestamps():
+    """3 duplicates with the SAME created_at -> exactly 1 survives (largest event_id)."""
+    org_id = uuid.uuid4()
+    ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Create 3 UUIDs and sort them so we know which is largest
+    ids = sorted([uuid.uuid4() for _ in range(3)], key=str)
+    smallest_id, middle_id, largest_id = ids
+
+    rows = [
+        _Row(smallest_id, org_id, "conservative", "drift_rebalance", "pending", ts),
+        _Row(middle_id, org_id, "conservative", "drift_rebalance", "pending", ts),
+        _Row(largest_id, org_id, "conservative", "drift_rebalance", "pending", ts),
+    ]
+
+    survivors = _apply_dedupe_delete(rows)
+
+    assert len(survivors) == 1, (
+        f"Expected exactly 1 survivor from 3 tied-timestamp duplicates, got {len(survivors)}"
+    )
+    assert survivors[0].event_id == largest_id, (
+        f"Survivor should be largest event_id {largest_id}, got {survivors[0].event_id}"
+    )
+
+
+# -- Test: different timestamps still work ------------------------------
+
+
+def test_migration_handles_different_timestamps():
+    """3 duplicates with DIFFERENT created_at -> latest survives."""
+    org_id = uuid.uuid4()
+    ts1 = datetime(2026, 4, 29, 10, 0, 0, tzinfo=timezone.utc)
+    ts2 = datetime(2026, 4, 29, 11, 0, 0, tzinfo=timezone.utc)
+    ts3 = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    id1, id2, id3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    rows = [
+        _Row(id1, org_id, "moderate", "drift_rebalance", "pending", ts1),
+        _Row(id2, org_id, "moderate", "drift_rebalance", "pending", ts2),
+        _Row(id3, org_id, "moderate", "drift_rebalance", "pending", ts3),
+    ]
+
+    survivors = _apply_dedupe_delete(rows)
+
+    assert len(survivors) == 1
+    assert survivors[0].event_id == id3, "Latest timestamp should survive"
+
+
+# -- Test: mixed tied and different timestamps --------------------------
+
+
+def test_migration_handles_mixed_tied_and_different():
+    """2 rows tied at latest ts + 1 earlier -> tied pair resolves by event_id."""
+    org_id = uuid.uuid4()
+    ts_early = datetime(2026, 4, 29, 10, 0, 0, tzinfo=timezone.utc)
+    ts_late = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    ids = sorted([uuid.uuid4() for _ in range(2)], key=str)
+    smaller_id, larger_id = ids
+    early_id = uuid.uuid4()
+
+    rows = [
+        _Row(early_id, org_id, "growth", "drift_rebalance", "pending", ts_early),
+        _Row(smaller_id, org_id, "growth", "drift_rebalance", "pending", ts_late),
+        _Row(larger_id, org_id, "growth", "drift_rebalance", "pending", ts_late),
+    ]
+
+    survivors = _apply_dedupe_delete(rows)
+
+    assert len(survivors) == 1
+    assert survivors[0].event_id == larger_id, (
+        "Among tied latest-timestamp rows, largest event_id should survive"
+    )
+
+
+# -- Test: non-pending rows are untouched ------------------------------
+
+
+def test_migration_does_not_delete_non_pending():
+    """Non-pending rows must survive regardless of duplicates."""
+    org_id = uuid.uuid4()
+    ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    pending_id = uuid.uuid4()
+    completed_id = uuid.uuid4()
+
+    rows = [
+        _Row(pending_id, org_id, "conservative", "drift_rebalance", "pending", ts),
+        _Row(completed_id, org_id, "conservative", "drift_rebalance", "completed", ts),
+    ]
+
+    survivors = _apply_dedupe_delete(rows)
+
+    assert len(survivors) == 2, "Non-pending row must not be deleted"
+    survivor_ids = {r.event_id for r in survivors}
+    assert pending_id in survivor_ids
+    assert completed_id in survivor_ids
+
+
+# -- Test: different profiles are independent ---------------------------
+
+
+def test_migration_treats_profiles_independently():
+    """Duplicates in profile A must not affect profile B."""
+    org_id = uuid.uuid4()
+    ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    ids_a = sorted([uuid.uuid4() for _ in range(2)], key=str)
+    ids_b = sorted([uuid.uuid4() for _ in range(2)], key=str)
+
+    rows = [
+        _Row(ids_a[0], org_id, "conservative", "drift_rebalance", "pending", ts),
+        _Row(ids_a[1], org_id, "conservative", "drift_rebalance", "pending", ts),
+        _Row(ids_b[0], org_id, "moderate", "drift_rebalance", "pending", ts),
+        _Row(ids_b[1], org_id, "moderate", "drift_rebalance", "pending", ts),
+    ]
+
+    survivors = _apply_dedupe_delete(rows)
+
+    assert len(survivors) == 2, "One survivor per profile"
+    survivor_profiles = {r.profile for r in survivors}
+    assert survivor_profiles == {"conservative", "moderate"}
+    # Each survivor is the largest event_id in its profile group
+    for r in survivors:
+        if r.profile == "conservative":
+            assert r.event_id == ids_a[1]
+        else:
+            assert r.event_id == ids_b[1]

--- a/backend/tests/db/test_migration_0196_dedupe_tiebreak.py
+++ b/backend/tests/db/test_migration_0196_dedupe_tiebreak.py
@@ -1,10 +1,13 @@
-"""PR-Q128 hotfix #2: migration 0196 dedupe DELETE tiebreak.
+"""PR-Q128: migration 0196 dedupe DELETE tiebreak + event_type scoping.
 
 Validates that the DELETE ... USING pattern in 0196 correctly deduplicates
 pending rebalance_events even when multiple duplicates share the exact
 same created_at timestamp.  The tiebreak uses event_id (UUID, lexicographic)
 so that exactly one row -- the one with the largest (latest ts, then largest
 UUID) -- survives.
+
+Also validates that ONLY drift_rebalance events are affected — manual and
+other event_type pending rows must be preserved unconditionally.
 
 This is a pure-logic test that simulates the SQL predicate in Python,
 avoiding the need for a live database.
@@ -36,10 +39,11 @@ def _apply_dedupe_delete(rows: list[_Row]) -> list[_Row]:
     For each pair (re_old, re_new) that matches the WHERE clause,
     re_old is marked for deletion.  Returns the surviving rows.
 
-    The predicate (from the fixed migration):
+    The predicate (from the fixed migration — scoped to drift_rebalance only):
         re_old.organization_id = re_new.organization_id
         AND re_old.profile = re_new.profile
-        AND re_old.event_type = re_new.event_type
+        AND re_old.event_type = 'drift_rebalance'
+        AND re_new.event_type = 'drift_rebalance'
         AND re_old.status = 'pending'
         AND re_new.status = 'pending'
         AND re_old.event_id != re_new.event_id
@@ -58,7 +62,8 @@ def _apply_dedupe_delete(rows: list[_Row]) -> list[_Row]:
             if (
                 re_old.organization_id == re_new.organization_id
                 and re_old.profile == re_new.profile
-                and re_old.event_type == re_new.event_type
+                and re_old.event_type == "drift_rebalance"
+                and re_new.event_type == "drift_rebalance"
                 and re_old.status == "pending"
                 and re_new.status == "pending"
                 and re_old.event_id != re_new.event_id
@@ -207,3 +212,103 @@ def test_migration_treats_profiles_independently():
             assert r.event_id == ids_a[1]
         else:
             assert r.event_id == ids_b[1]
+
+
+# -- Test: manual pending events are preserved ----------------------------
+
+
+def test_migration_preserves_manual_pending_events():
+    """2 manual pending for same org/profile -> both survive (not drift_rebalance)."""
+    org_id = uuid.uuid4()
+    ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    id1, id2 = uuid.uuid4(), uuid.uuid4()
+    rows = [
+        _Row(id1, org_id, "conservative", "manual", "pending", ts),
+        _Row(id2, org_id, "conservative", "manual", "pending", ts),
+    ]
+
+    survivors = _apply_dedupe_delete(rows)
+
+    assert len(survivors) == 2, (
+        "Manual pending events must NOT be deduped by migration — "
+        "only drift_rebalance is scoped"
+    )
+    assert {r.event_id for r in survivors} == {id1, id2}
+
+
+# -- Test: scheduled_rebalance pending events are preserved ----------------
+
+
+def test_migration_preserves_scheduled_rebalance_pending_events():
+    """2 scheduled_rebalance pending for same org/profile -> both survive."""
+    org_id = uuid.uuid4()
+    ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    id1, id2 = uuid.uuid4(), uuid.uuid4()
+    rows = [
+        _Row(id1, org_id, "moderate", "scheduled_rebalance", "pending", ts),
+        _Row(id2, org_id, "moderate", "scheduled_rebalance", "pending", ts),
+    ]
+
+    survivors = _apply_dedupe_delete(rows)
+
+    assert len(survivors) == 2, (
+        "scheduled_rebalance pending events must NOT be deduped"
+    )
+
+
+# -- Test: only drift_rebalance is deduped ---------------------------------
+
+
+def test_migration_only_dedups_drift_rebalance():
+    """3 drift_rebalance pending + 2 manual pending -> 1 drift + 2 manual survive."""
+    org_id = uuid.uuid4()
+    ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    drift_ids = sorted([uuid.uuid4() for _ in range(3)], key=str)
+    manual_ids = [uuid.uuid4(), uuid.uuid4()]
+
+    rows = [
+        _Row(drift_ids[0], org_id, "conservative", "drift_rebalance", "pending", ts),
+        _Row(drift_ids[1], org_id, "conservative", "drift_rebalance", "pending", ts),
+        _Row(drift_ids[2], org_id, "conservative", "drift_rebalance", "pending", ts),
+        _Row(manual_ids[0], org_id, "conservative", "manual", "pending", ts),
+        _Row(manual_ids[1], org_id, "conservative", "manual", "pending", ts),
+    ]
+
+    survivors = _apply_dedupe_delete(rows)
+
+    assert len(survivors) == 3, (
+        "Expected 1 drift_rebalance + 2 manual survivors, "
+        f"got {len(survivors)}"
+    )
+    drift_survivors = [r for r in survivors if r.event_type == "drift_rebalance"]
+    manual_survivors = [r for r in survivors if r.event_type == "manual"]
+    assert len(drift_survivors) == 1
+    assert drift_survivors[0].event_id == drift_ids[2]  # largest UUID
+    assert len(manual_survivors) == 2
+
+
+# -- Test: unique index scoping (structural) --------------------------------
+
+
+def test_migration_index_scoped_to_drift_rebalance():
+    """Structural: migration SQL must scope index to drift_rebalance only."""
+    from pathlib import Path
+
+    migration_path = Path(__file__).resolve().parents[2] / (
+        "app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py"
+    )
+    source = migration_path.read_text(encoding="utf-8")
+
+    assert "uq_rebalance_event_pending_drift_per_profile" in source, (
+        "Index name must reflect drift-only scope"
+    )
+    assert "event_type = 'drift_rebalance'" in source, (
+        "Index WHERE clause must restrict to drift_rebalance"
+    )
+    # Must NOT have a generic 'pending' only filter
+    assert "uq_rebalance_event_pending_per_profile" not in source, (
+        "Old generic index name must not be present"
+    )

--- a/backend/tests/wealth/workers/test_drift_check_dedup.py
+++ b/backend/tests/wealth/workers/test_drift_check_dedup.py
@@ -1,0 +1,263 @@
+"""Tests for PR-Q128: RebalanceEvent dedupe in drift_check worker.
+
+Validates:
+  C-04: drift_check does not create duplicate pending drift_rebalance
+        events when a pending event already exists for the same profile.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domains.wealth.workers import drift_check as mod
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+class _FakeResult:
+    """Minimal result proxy for mocked session.execute()."""
+
+    def __init__(self, scalar_value=None):
+        self._scalar = scalar_value
+
+    def scalar(self):
+        return self._scalar
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+
+class _FakeSession:
+    """Fake async session that tracks execute/commit calls.
+
+    Extends the base pattern from test_drift_check_rls_and_lock with
+    support for simulating existing pending RebalanceEvent rows.
+    """
+
+    def __init__(
+        self,
+        *,
+        lock_acquired: bool = True,
+        pending_profiles: set[str] | None = None,
+    ):
+        self._lock_acquired = lock_acquired
+        self._pending_profiles = pending_profiles or set()
+        self.executed_sql: list[str] = []
+        self.commits = 0
+
+    async def execute(self, stmt, params=None):
+        sql = str(stmt)
+        self.executed_sql.append(sql)
+
+        if "set_config" in sql and "app.current_organization_id" in sql:
+            return _FakeResult()
+
+        if "pg_try_advisory_lock" in sql:
+            return _FakeResult(scalar_value=self._lock_acquired)
+
+        if "pg_advisory_unlock" in sql:
+            return _FakeResult(scalar_value=True)
+
+        if "vertical_config_defaults" in sql.lower():
+            return _FakeResult(scalar_value=None)
+
+        # Dedupe query: SELECT rebalance_events.event_id WHERE ...
+        # ORM uses bind params, so extract them from the compiled statement.
+        if "rebalance_events" in sql.lower() and "event_id" in sql.lower():
+            try:
+                compiled = stmt.compile()
+                profile_val = compiled.params.get("profile_1")
+            except Exception:
+                profile_val = None
+            if profile_val and profile_val in self._pending_profiles:
+                return _FakeResult(scalar_value=uuid.uuid4())
+            return _FakeResult(scalar_value=None)
+
+        return _FakeResult()
+
+    async def commit(self):
+        self.commits += 1
+
+
+def _make_session_factory(session: _FakeSession):
+    """Build an async context manager factory that yields the given session."""
+
+    @asynccontextmanager
+    async def factory():
+        yield session
+
+    return factory
+
+
+def _make_fake_report(*, rebalance: bool = False):
+    """Build a minimal drift report mock."""
+    report = MagicMock()
+    report.overall_status = "ok"
+    report.max_drift_pct = 0.05
+    report.rebalance_recommended = rebalance
+    report.estimated_turnover = 0.02
+    report.maintenance_trigger = 0.05
+    report.blocks = []
+    return report
+
+
+# ── Test: first run creates event (no existing pending) ──────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_check_creates_event_when_none_pending():
+    """C-04: When no pending drift_rebalance exists, event is created."""
+    org_id = uuid.uuid4()
+    session = _FakeSession(pending_profiles=set())
+
+    report = _make_fake_report(rebalance=True)
+    fake_event = MagicMock()
+    fake_event.event_id = uuid.uuid4()
+
+    mock_create = AsyncMock(return_value=fake_event)
+    mock_audit = AsyncMock()
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(mod, "compute_drift", new_callable=AsyncMock, return_value=report),
+        patch.object(mod, "create_system_rebalance_event", mock_create),
+        patch.object(mod, "write_audit_event", mock_audit),
+    ):
+        result = await mod.run_drift_check(org_id)
+
+    assert isinstance(result, dict)
+    # All 3 profiles trigger because report.rebalance_recommended = True
+    assert mock_create.call_count == len(mod.PROFILES)
+    assert mock_audit.call_count == len(mod.PROFILES)
+
+
+# ── Test: skip when pending event exists ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_check_skips_when_pending_event_exists():
+    """C-04: When a pending drift_rebalance exists, no new event is created."""
+    org_id = uuid.uuid4()
+    # All profiles have pending events
+    session = _FakeSession(
+        pending_profiles={"conservative", "moderate", "growth"},
+    )
+
+    report = _make_fake_report(rebalance=True)
+    mock_create = AsyncMock()
+    mock_audit = AsyncMock()
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(mod, "compute_drift", new_callable=AsyncMock, return_value=report),
+        patch.object(mod, "create_system_rebalance_event", mock_create),
+        patch.object(mod, "write_audit_event", mock_audit),
+    ):
+        result = await mod.run_drift_check(org_id)
+
+    assert isinstance(result, dict)
+    # No events should be created — all profiles already have pending events
+    assert mock_create.call_count == 0
+    assert mock_audit.call_count == 0
+    # Commits still happen (one per profile for the skip path + config load)
+    assert session.commits == len(mod.PROFILES)
+
+
+# ── Test: mixed — some profiles pending, some not ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_check_mixed_pending_and_new():
+    """C-04: Only profiles without pending events get new events."""
+    org_id = uuid.uuid4()
+    # Only 'conservative' has a pending event
+    session = _FakeSession(pending_profiles={"conservative"})
+
+    report = _make_fake_report(rebalance=True)
+    fake_event = MagicMock()
+    fake_event.event_id = uuid.uuid4()
+
+    mock_create = AsyncMock(return_value=fake_event)
+    mock_audit = AsyncMock()
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(mod, "compute_drift", new_callable=AsyncMock, return_value=report),
+        patch.object(mod, "create_system_rebalance_event", mock_create),
+        patch.object(mod, "write_audit_event", mock_audit),
+    ):
+        result = await mod.run_drift_check(org_id)
+
+    assert isinstance(result, dict)
+    # 'conservative' skipped, 'moderate' + 'growth' created
+    assert mock_create.call_count == 2
+    assert mock_audit.call_count == 2
+
+
+# ── Test: no rebalance recommended → no dedupe query at all ──────────
+
+
+@pytest.mark.asyncio
+async def test_drift_check_no_dedupe_when_not_recommended():
+    """No dedupe query issued when rebalance is not recommended."""
+    org_id = uuid.uuid4()
+    session = _FakeSession()
+
+    report = _make_fake_report(rebalance=False)
+    mock_create = AsyncMock()
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(mod, "compute_drift", new_callable=AsyncMock, return_value=report),
+        patch.object(mod, "create_system_rebalance_event", mock_create),
+    ):
+        result = await mod.run_drift_check(org_id)
+
+    assert isinstance(result, dict)
+    assert mock_create.call_count == 0
+    # No rebalance_events queries should appear
+    rebalance_queries = [
+        sql for sql in session.executed_sql
+        if "rebalance_events" in sql.lower() and "event_id" in sql.lower()
+    ]
+    assert len(rebalance_queries) == 0
+
+
+# ── Test: commit + RLS reset on skip path ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drift_check_commits_and_resets_rls_on_skip():
+    """C-04: Skip path still commits and re-sets RLS context."""
+    org_id = uuid.uuid4()
+    session = _FakeSession(pending_profiles={"conservative", "moderate", "growth"})
+
+    report = _make_fake_report(rebalance=True)
+
+    rls_calls: list[uuid.UUID] = []
+    original_set_rls = mod.set_rls_context
+
+    async def tracking_set_rls(db, oid):
+        rls_calls.append(oid)
+        # Call through to the real function which does db.execute(...)
+        return await original_set_rls(db, oid)
+
+    with (
+        patch.object(mod, "async_session", _make_session_factory(session)),
+        patch.object(mod, "compute_drift", new_callable=AsyncMock, return_value=report),
+        patch.object(mod, "create_system_rebalance_event", new_callable=AsyncMock),
+        patch.object(mod, "write_audit_event", new_callable=AsyncMock),
+        patch.object(mod, "set_rls_context", side_effect=tracking_set_rls),
+    ):
+        await mod.run_drift_check(org_id)
+
+    # Initial RLS set + 3 profile iterations (skip path each does commit + RLS)
+    # = 1 initial + 3 skip-path = 4 total RLS calls
+    assert len(rls_calls) >= 4
+    assert all(oid == org_id for oid in rls_calls)
+    # 3 commits (one per profile skip path)
+    assert session.commits == 3


### PR DESCRIPTION
## Summary

- **Finding:** S11 C-04 — `drift_check` worker creates duplicate `RebalanceEvent` rows on every run when drift persists above threshold, violating P5 Idempotency (stability guardrails §3.2)
- **Root cause:** `create_system_rebalance_event()` called unconditionally inside `if report.rebalance_recommended:` with no existing-event check
- **Fix (DB-level + app-level, mirrors PortfolioAlert pattern):**
  - Migration 0196: partial unique index `uq_rebalance_event_pending_per_profile` on `(organization_id, profile, event_type) WHERE status = 'pending'` — DB backstop
  - Application guard in `drift_check.py`: query for existing pending `drift_rebalance` before creating; if found, log + skip + commit + continue
  - Moved `sa_select` import to module level (was lazy inner import)

## Files changed

| File | Change |
|------|--------|
| `backend/app/core/db/migrations/versions/0196_q128_rebalance_pending_dedupe.py` | New migration — partial unique index |
| `backend/app/domains/wealth/workers/drift_check.py` | Dedupe guard + import cleanup |
| `backend/tests/wealth/workers/test_drift_check_dedup.py` | 5 new tests (skip/create/mixed/no-rebalance/RLS-reset) |

## Test plan

- [x] 5 new tests in `test_drift_check_dedup.py` — all passing
- [x] 9 existing tests in `test_drift_check_rls_and_lock.py` — all passing (no regression)
- [x] Lint clean (`ruff check`)
- [ ] Codex Auto Review

Generated with [Claude Code](https://claude.com/claude-code)