### PR TITLE
fix(quant): PR-Q124 — eigenvalue regularization in factor model covariance assembly

### DIFF
--- a/backend/quant_engine/factor_model_service.py
+++ b/backend/quant_engine/factor_model_service.py
@@ -599,13 +599,25 @@ def fit_fundamental_loadings(
     )
 
 
-def assemble_factor_covariance(fit: FundamentalFactorFit) -> npt.NDArray[np.float64]:
-    """Returns Σ = B · F · B' + diag(D) with PSD enforcement.
+def assemble_factor_covariance(
+    fit: FundamentalFactorFit,
+    *,
+    kappa_target: float = 1e4,
+) -> npt.NDArray[np.float64]:
+    """Returns Σ = B · F · B' + diag(D) with PSD + conditioning enforcement.
 
     Accepts only ``FundamentalFactorFit`` — never ``PCADiagnostic`` (the
     residual diagnostic lives in ``factor_model_pca`` and has no bearing
     on covariance assembly). Enforced at the type level; see
     ``tests/quant_engine/test_assemble_factor_covariance_types.py``.
+
+    PR-Q124: eigenvalue floor is now ``max_eigval / kappa_target`` so the
+    assembled matrix stays within the recoverable conditioning band.  The
+    previous floor (``1e-8 * trace / N``) was orders of magnitude too small
+    for N >> K factor models (159 funds, 8 factors) where many eigenvalues
+    derive solely from residual variance — pathological κ > 1e6 made the
+    optimizer cascade unreachable even when the underlying estimates were
+    reasonable (κ ~48 K on an adjacent run).
     """
     B = fit.loadings
     F = fit.factor_cov
@@ -614,14 +626,23 @@ def assemble_factor_covariance(fit: FundamentalFactorFit) -> npt.NDArray[np.floa
     sigma = (B @ F @ B.T) + np.diag(D_diag)
     sigma = (sigma + sigma.T) / 2
 
-    N = sigma.shape[0]
-    trace_sig = np.trace(sigma)
-    clamp_val = max(1e-10, 1e-8 * trace_sig / N)
-
     eigvals, eigvecs = np.linalg.eigh(sigma)
+    max_eigval = float(eigvals.max())
+    clamp_val = max(1e-10, max_eigval / kappa_target)
+
     if eigvals.min() < clamp_val:
+        kappa_before = max_eigval / max(float(eigvals.min()), 1e-16)
         eigvals = np.maximum(eigvals, clamp_val)
         sigma = eigvecs @ np.diag(eigvals) @ eigvecs.T
+        kappa_after = max_eigval / float(eigvals.min())
+        logger.info(
+            "factor_covariance_eigenvalue_regularized",
+            n_funds=sigma.shape[0],
+            kappa_before=round(kappa_before, 1),
+            kappa_after=round(kappa_after, 1),
+            kappa_target=kappa_target,
+            eigenvalue_floor=float(clamp_val),
+        )
 
     return np.asarray(sigma, dtype=np.float64)
 


### PR DESCRIPTION
## Summary

- **Root cause:** `assemble_factor_covariance()` eigenvalue floor (`1e-8 * trace/N ≈ 2e-10`) was orders of magnitude too small for N >> K factor models (159 funds, 8 factors). When fund residual variances are small, κ(Σ) exceeds the 1e6 pathological threshold, blocking the optimizer cascade entirely.
- **Fix:** Eigenvalue floor is now `max_eigval / kappa_target` (default 1e4) — proportional to the maximum eigenvalue, not the trace average. This keeps the assembled matrix in the recoverable "warn, proceed" conditioning band.
- **Observability:** Logs `factor_covariance_eigenvalue_regularized` with before/after kappa when regularization activates.

## Evidence

| Portfolio | Before (κ=7.67M) | After (κ=10K) |
|---|---|---|
| Balanced Income | degraded, sharpe=0.0 | **succeeded**, sharpe=1.26, return=13.3% |
| Dynamic Growth | degraded, sharpe=0.0 | **succeeded**, sharpe=1.47, return=17.1% |
| Conservative | degraded, sharpe=0.0 | degraded/cvar_infeasible_min_var (correct — CVaR limit too tight) |

## Files changed

- `backend/quant_engine/factor_model_service.py` — `assemble_factor_covariance()`: replace trace-proportional eigenvalue floor with max-eigenvalue-proportional floor

## Test plan

- [x] `test_assemble_factor_covariance_types` — 3 passed
- [x] `test_construction_integration` — 4 passed
- [x] `test_optimizer_correctness` — 17 passed
- [x] All quant_engine tests — 769 passed (1 pre-existing failure in pareto test)
- [x] Live validation: triggered construction for all 3 model portfolios on local DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)