### PR TITLE
docs(env): PR-Q138 — IMF_API_KEY placeholder in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ MISTRAL_API_KEY=
 FRED_API_KEY=
 DC_API_KEY=
 OPENFIGI_API_KEY=
+IMF_API_KEY=    # IMF Data SDMX API key (https://data.imf.org/en/apis)
 
 # ── SEC EDGAR Bulk ────────────────────────────────────────────────
 # local path to SEC Company Facts bulk JSON; dev-only until follow-up PR wires HTTP delta ingestion.


### PR DESCRIPTION
## Standalone env placeholder for IMF SDMX 2.1 migration prep

Adds \`IMF_API_KEY=\` placeholder to \`.env.example\` documenting the env var that the upcoming Q139 IMF provider migration will require.

### Context

Current IMF provider (\`backend/data_providers/imf/service.py\`) uses public DataMapper API (\`imf.org/external/datamapper/api/v1\`) — no auth. Public service degraded today for ~2h, causing recurring CI flake on \`tests/test_data_providers_e2e.py::TestImfE2E\` across multiple Sprint 2 P1 PRs.

Andrei provisioned an Azure-fronted IMF Data SDMX 2.1 API key. Standalone placeholder commit decouples the env var documentation from the provider migration work (Q139).

### Validation

Key tested via \`GET https://api.imf.org/external/sdmx/2.1/dataflow/IMF.RES\` with header \`Ocp-Apim-Subscription-Key\` — 200 OK. Returned full IMF.RES dataflow catalog (WEO 9.0.0, WEO_2025_OCT_VINTAGE, PCPS, CTOT, MPFT, etc.). Indicators we use (\`NGDP_RPCH\`, \`PCPIPCH\`, \`GGXCNL_NGDP\`, \`GGXWDG_NGDP\`) confirmed available in WEO dataflow.

### Scope

- \`.env.example\` placeholder (1 line)
- No provider code change
- No CI gate change (IMF E2E flake mitigation deferred to Q139)

### Follow-ups (NOT in this PR)

- **Q139**: IMF provider migration DataMapper → SDMX 2.1 (uses key, retry/backoff, replaces \`fetch_country_indicator\` shape)
- **Test infra decision**: post-Q139, decide whether to keep \`TestImfE2E\` in CI gate (with auth) OR move to nightly-only