### PR TITLE
fix(wealth): PR-Q143 — advice cache org-scoped key (C-12)

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -1258,9 +1258,10 @@ async def get_construction_advice(
 
     profile = portfolio.profile
 
-    # 2. Redis cache check
-    cache_key = _hash_advice_input(str(portfolio_id), str(portfolio.updated_at))
-    cached = await _get_cached_advice(cache_key)
+    # 2. Redis cache check (org-scoped — C-12 defense-in-depth)
+    org_id_str = str(org_id)
+    cache_key = _hash_advice_input(org_id_str, str(portfolio_id), str(portfolio.updated_at))
+    cached = await _get_cached_advice(org_id_str, cache_key)
     if cached is not None:
         logger.info("construction_advice_cache_hit", cache_key=cache_key)
         return ConstructionAdviceRead(**cached)
@@ -1366,7 +1367,7 @@ async def get_construction_advice(
 
     # 10. Serialize and cache
     result_dict = asdict(advice)
-    await _set_cached_advice(cache_key, result_dict)
+    await _set_cached_advice(org_id_str, cache_key, result_dict)
 
     logger.info(
         "construction_advice_computed",
@@ -1803,20 +1804,15 @@ async def activate_portfolio(
 # ── Advice cache helpers ──────────────────────────────────────────────────
 
 
-def _hash_advice_input(portfolio_id: str, updated_at: str) -> str:
-    """Deterministic hash for advice cache key."""
+def _hash_advice_input(organization_id: str, portfolio_id: str, updated_at: str) -> str:
+    """Deterministic hash for advice cache key (org-scoped, defense-in-depth)."""
     import hashlib
-    import json
 
-    payload = json.dumps({
-        "portfolio_id": portfolio_id,
-        "updated_at": updated_at,
-        "date": date.today().isoformat(),
-    }, sort_keys=True).encode()
-    return hashlib.sha256(payload).hexdigest()[:24]
+    payload = f"{organization_id}|{portfolio_id}|{updated_at}|{date.today().isoformat()}"
+    return hashlib.sha256(payload.encode()).hexdigest()[:24]
 
 
-async def _get_cached_advice(cache_key: str) -> dict | None:
+async def _get_cached_advice(org_id: str, cache_key: str) -> dict | None:
     """Check Redis for cached advice result (fail-open)."""
     try:
         import redis.asyncio as aioredis
@@ -1825,7 +1821,7 @@ async def _get_cached_advice(cache_key: str) -> dict | None:
 
         r = aioredis.Redis(connection_pool=get_redis_pool())
         try:
-            cached = await r.get(f"advice:cache:{cache_key}")
+            cached = await r.get(f"advice:cache:{org_id}:{cache_key}")
             if cached:
                 import json
 
@@ -1833,11 +1829,11 @@ async def _get_cached_advice(cache_key: str) -> dict | None:
         finally:
             await r.aclose()
     except Exception:
-        logger.debug("advice_cache_miss", cache_key=cache_key)
+        logger.debug("advice_cache_miss", org_id=org_id, cache_key=cache_key)
     return None
 
 
-async def _set_cached_advice(cache_key: str, result: dict, ttl: int = 600) -> None:
+async def _set_cached_advice(org_id: str, cache_key: str, result: dict, ttl: int = 600) -> None:
     """Cache advice result in Redis (10min TTL, fail-open)."""
     try:
         import json
@@ -1849,14 +1845,14 @@ async def _set_cached_advice(cache_key: str, result: dict, ttl: int = 600) -> No
         r = aioredis.Redis(connection_pool=get_redis_pool())
         try:
             await r.set(
-                f"advice:cache:{cache_key}",
+                f"advice:cache:{org_id}:{cache_key}",
                 json.dumps(result, default=str),
                 ex=ttl,
             )
         finally:
             await r.aclose()
     except Exception:
-        logger.debug("advice_cache_set_failed", cache_key=cache_key)
+        logger.debug("advice_cache_set_failed", org_id=org_id, cache_key=cache_key)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/backend/tests/test_advice_cache_org_scoped.py
+++ b/backend/tests/test_advice_cache_org_scoped.py
@@ -1,0 +1,144 @@
+"""Tests for advice cache org-scoped key — PR-Q143 (C-12 cross-tenant defense).
+
+Validates that:
+1. _hash_advice_input includes organization_id in the hash.
+2. Redis key prefix includes org_id for human-readable inspection.
+3. Same portfolio + different org yields different cache key (isolation).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domains.wealth.routes.model_portfolios import (
+    _get_cached_advice,
+    _hash_advice_input,
+    _set_cached_advice,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Hash includes organization_id
+# ---------------------------------------------------------------------------
+
+
+class TestHashIncludesOrganizationId:
+    def test_same_portfolio_different_org_yields_different_hash(self):
+        """Same portfolio_id + updated_at but different org_id -> different cache key."""
+        h1 = _hash_advice_input("org-aaa", "port-123", "2026-01-01T00:00:00")
+        h2 = _hash_advice_input("org-bbb", "port-123", "2026-01-01T00:00:00")
+        assert h1 != h2
+
+    def test_same_org_same_inputs_same_hash(self):
+        """Identical inputs should produce identical hash (deterministic)."""
+        h1 = _hash_advice_input("org-aaa", "port-123", "2026-01-01T00:00:00")
+        h2 = _hash_advice_input("org-aaa", "port-123", "2026-01-01T00:00:00")
+        assert h1 == h2
+
+    def test_hash_length(self):
+        h = _hash_advice_input("org-x", "port-y", "ts")
+        assert len(h) == 24
+
+    def test_hash_matches_expected_payload(self):
+        """Hash is SHA-256 of 'org|portfolio|updated_at|date'."""
+        org = "org-unit-test"
+        pid = "port-42"
+        ts = "2026-04-29T12:00:00"
+        today = date.today().isoformat()
+        payload = f"{org}|{pid}|{ts}|{today}"
+        expected = hashlib.sha256(payload.encode()).hexdigest()[:24]
+        assert _hash_advice_input(org, pid, ts) == expected
+
+
+# ---------------------------------------------------------------------------
+# 2. Redis key prefix includes org_id
+# ---------------------------------------------------------------------------
+
+
+class TestRedisKeyPrefixIncludesOrgId:
+    @pytest.mark.asyncio
+    async def test_get_uses_org_scoped_key(self):
+        """_get_cached_advice reads from 'advice:cache:{org_id}:{cache_key}'."""
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=json.dumps({"a": 1}).encode())
+        mock_redis.aclose = AsyncMock()
+
+        with patch(
+            "app.core.jobs.tracker.get_redis_pool",
+            return_value=MagicMock(),
+        ), patch(
+            "redis.asyncio.Redis",
+            return_value=mock_redis,
+        ):
+            result = await _get_cached_advice("org-abc", "hashval123")
+
+        mock_redis.get.assert_awaited_once_with("advice:cache:org-abc:hashval123")
+        assert result == {"a": 1}
+
+    @pytest.mark.asyncio
+    async def test_set_uses_org_scoped_key(self):
+        """_set_cached_advice writes to 'advice:cache:{org_id}:{cache_key}'."""
+        mock_redis = AsyncMock()
+        mock_redis.set = AsyncMock()
+        mock_redis.aclose = AsyncMock()
+
+        with patch(
+            "app.core.jobs.tracker.get_redis_pool",
+            return_value=MagicMock(),
+        ), patch(
+            "redis.asyncio.Redis",
+            return_value=mock_redis,
+        ):
+            await _set_cached_advice("org-xyz", "hashval456", {"b": 2}, ttl=120)
+
+        mock_redis.set.assert_awaited_once()
+        call_args = mock_redis.set.call_args
+        assert call_args[0][0] == "advice:cache:org-xyz:hashval456"
+        assert call_args[1]["ex"] == 120
+
+
+# ---------------------------------------------------------------------------
+# 3. Cache isolated across orgs
+# ---------------------------------------------------------------------------
+
+
+class TestCacheIsolatedAcrossOrgs:
+    @pytest.mark.asyncio
+    async def test_cache_miss_for_different_org(self):
+        """Write advice for org A, read with org B context -> cache miss."""
+        store: dict[str, bytes] = {}
+
+        async def mock_get(key: str) -> bytes | None:
+            return store.get(key)
+
+        async def mock_set(key: str, value: str | bytes, *, ex: int = 0) -> None:
+            store[key] = value if isinstance(value, bytes) else value.encode()
+
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(side_effect=mock_get)
+        mock_redis.set = AsyncMock(side_effect=mock_set)
+        mock_redis.aclose = AsyncMock()
+
+        with patch(
+            "app.core.jobs.tracker.get_redis_pool",
+            return_value=MagicMock(),
+        ), patch(
+            "redis.asyncio.Redis",
+            return_value=mock_redis,
+        ):
+            # Same portfolio hash, but org A writes
+            cache_key = "shared-hash-value"
+            await _set_cached_advice("org-A", cache_key, {"advice": "for A"})
+
+            # org A reads -> hit
+            hit = await _get_cached_advice("org-A", cache_key)
+            assert hit is not None
+            assert hit["advice"] == "for A"
+
+            # org B reads same cache_key -> miss (different prefix)
+            miss = await _get_cached_advice("org-B", cache_key)
+            assert miss is None


### PR DESCRIPTION
## Summary

- **C-12 cross-tenant cache leak fix**: `_hash_advice_input` now includes `organization_id` in the SHA-256 payload (first positional arg), ensuring different orgs produce different cache hashes even for identical portfolio_id + updated_at
- Redis key prefix changed from `advice:cache:{hash}` to `advice:cache:{org_id}:{hash}` for human-readable inspection and defense-in-depth tenant isolation
- All 3 helper functions (`_hash_advice_input`, `_get_cached_advice`, `_set_cached_advice`) and the route caller updated consistently
- structlog debug messages now include `org_id` for observability

## Survey of other wealth domain Redis cache keys

| Key pattern | Verdict |
|---|---|
| `advice:cache:` | **Fixed in this PR** — now `advice:cache:{org_id}:{hash}` |
| `analytics:cache:` | OK — operates on org-scoped RLS data (block_ids from org's allocation) |
| `macro_raw:` | OK — global tables, no RLS, comment-documented |
| `job:{id}:pdf_key` | OK — job_id is UUID, inherently unique |

## Cache invalidation

Existing entries auto-invalidate (different key shape). Advice cache TTL is 10min — no manual flush needed.

## Test plan

- [x] `test_same_portfolio_different_org_yields_different_hash` — same portfolio_id + updated_at, different org_id -> different hashes
- [x] `test_same_org_same_inputs_same_hash` — determinism check
- [x] `test_hash_length` — 24-char truncated SHA-256
- [x] `test_hash_matches_expected_payload` — payload format verification
- [x] `test_get_uses_org_scoped_key` — Redis GET uses `advice:cache:{org_id}:{hash}` key
- [x] `test_set_uses_org_scoped_key` — Redis SET uses `advice:cache:{org_id}:{hash}` key
- [x] `test_cache_miss_for_different_org` — write for org A, read with org B -> cache miss
- [x] All 7 new tests pass, 5718 existing tests pass (2 pre-existing failures unrelated)
- [x] Lint clean, architecture 31/31 contracts kept

Generated with [Claude Code](https://claude.com/claude-code)