### PR TITLE
fix(wealth): PR-Q140 — cascade status taxonomy (mandate_infeasible)

### DIFF
--- a/backend/app/core/db/migrations/versions/0197_q140_cascade_status_mandate_infeasible.py
+++ b/backend/app/core/db/migrations/versions/0197_q140_cascade_status_mandate_infeasible.py
@@ -1,0 +1,80 @@
+"""PR-Q140: extend status CHECK with 'mandate_infeasible'.
+
+Cascade status taxonomy refinement (C-01): separates mandate
+infeasibility (Phase 3 CVaR limit unreachable, engine working correctly)
+from technical degradation (covariance failure, heuristic fallback).
+
+DROP + ADD inside a single DDL transaction (no table rewrite). Existing
+rows remain valid under the new constraint.
+
+Revision ID: 0197_q140_cascade_status_mandate_infeasible
+Revises: 0196_q128_rebalance_pending_dedupe
+Create Date: 2026-04-29
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0197_q140_cascade_status_mandate_infeasible"
+down_revision: str | None = "0196_q128_rebalance_pending_dedupe"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        DROP CONSTRAINT portfolio_construction_runs_status_check
+        """,
+    )
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        ADD CONSTRAINT portfolio_construction_runs_status_check
+        CHECK (status = ANY (ARRAY[
+            'running'::text,
+            'succeeded'::text,
+            'failed'::text,
+            'superseded'::text,
+            'cancelled'::text,
+            'degraded'::text,
+            'mandate_infeasible'::text
+        ]))
+        """,
+    )
+
+
+def downgrade() -> None:
+    # Roll any 'mandate_infeasible' rows back to 'degraded' before
+    # tightening — preserves the pre-Q140 semantics where both
+    # infeasibility and technical degradation mapped to 'degraded'.
+    op.execute(
+        """
+        UPDATE portfolio_construction_runs
+        SET status = 'degraded'
+        WHERE status = 'mandate_infeasible'
+        """,
+    )
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        DROP CONSTRAINT portfolio_construction_runs_status_check
+        """,
+    )
+    op.execute(
+        """
+        ALTER TABLE portfolio_construction_runs
+        ADD CONSTRAINT portfolio_construction_runs_status_check
+        CHECK (status = ANY (ARRAY[
+            'running'::text,
+            'succeeded'::text,
+            'failed'::text,
+            'superseded'::text,
+            'cancelled'::text,
+            'degraded'::text
+        ]))
+        """,
+    )

--- a/backend/app/domains/wealth/models/model_portfolio.py
+++ b/backend/app/domains/wealth/models/model_portfolio.py
@@ -197,8 +197,9 @@ class PortfolioConstructionRun(OrganizationScopedMixin, Base):
     exposure, advisor advice, validation gate result, narrative output,
     and per-instrument rationale (DL4).
 
-    Status enum mirrors the CHECK constraint in migration 0099:
-    ``running`` → ``succeeded`` | ``failed`` | ``superseded``.
+    Status enum mirrors the CHECK constraint (migrations 0099 / 0141 / 0197):
+    ``running`` → ``succeeded`` | ``mandate_infeasible`` | ``degraded`` |
+    ``failed`` | ``superseded`` | ``cancelled``.
 
     The ``calibration_id`` FK is added in migration 0105 once
     ``portfolio_calibration`` exists. Until then, callers may write

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -131,22 +131,30 @@ async def _latest_validation_status(
     """Project the most recent construction run's validation gate.
 
     Returns ``has_run=False`` if no runs exist for the portfolio.
-    Reads only the ``validation`` JSONB column to keep the projection
-    cheap — Phase 3 Task 3.1 fills it; until then it's ``{}`` and we
-    treat that as "not yet validated".
+    Reads the ``validation`` JSONB column + ``status`` to keep the
+    projection cheap — Phase 3 Task 3.1 fills validation; until then
+    it's ``{}`` and we treat that as "not yet validated".
+
+    PR-Q140: also reads ``status`` to propagate ``mandate_infeasible``
+    to the state machine (C-01 taxonomy split).
     """
     row = await db.execute(
-        select(PortfolioConstructionRun.validation)
+        select(
+            PortfolioConstructionRun.validation,
+            PortfolioConstructionRun.status,
+        )
         .where(PortfolioConstructionRun.portfolio_id == portfolio_id)
         .order_by(PortfolioConstructionRun.requested_at.desc())
         .limit(1),
     )
-    validation = row.scalar_one_or_none()
-    if validation is None:
+    result = row.one_or_none()
+    if result is None:
         return ValidationStatus(has_run=False, passed=False)
+    validation, run_status = result
     return ValidationStatus(
         has_run=True,
-        passed=bool(validation.get("passed", False)),
+        passed=bool((validation or {}).get("passed", False)),
+        run_status=run_status,
     )
 
 
@@ -672,7 +680,7 @@ async def construct_portfolio(
     return ConstructRunAccepted(
         run_id=run.id,
         portfolio_id=portfolio_id,
-        status=run.status,  # running | succeeded | failed
+        status=run.status,  # running | succeeded | mandate_infeasible | degraded | failed
         job_id=job_id,
         stream_url=f"/api/v1/jobs/{job_id}/stream",
         run_url=f"/api/v1/model-portfolios/{portfolio_id}/runs/{run.id}",

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -438,14 +438,15 @@ _PHASE_PUBLIC_KEY: dict[str, str] = {
 # - Phase 1/2 win → succeeded
 # - Phase 3 winner WITHIN cvar_limit → succeeded (rare — Phase 1 usually
 #   wins whenever the universe supports it)
-# - Phase 3 winner ABOVE cvar_limit → degraded (universe floor binds)
+# - Phase 3 winner ABOVE cvar_limit → mandate_infeasible (PR-Q140: universe
+#   floor binds — engine working correctly, configured limit unreachable)
 # - Upstream heuristic (compute_fund_level_inputs failed before cascade) → degraded
 # - Constraint polytope empty (block bands sum > 1) → failed
 _STATUS_BY_SUMMARY: dict[str, str] = {
     "phase_1_succeeded": "succeeded",
     "phase_2_robust_succeeded": "succeeded",
     "phase_3_min_cvar_within_limit": "succeeded",
-    "phase_3_min_cvar_above_limit": "degraded",
+    "phase_3_min_cvar_above_limit": "mandate_infeasible",
     "upstream_heuristic": "degraded",
     "constraint_polytope_empty": "failed",
 }
@@ -483,7 +484,7 @@ def _build_cascade_telemetry(
     -------
     (telemetry_dict, run_status)
         ``telemetry_dict`` matches the shape in PR-A11 Section A.2.
-        ``run_status`` is one of ``succeeded|degraded|failed``.
+        ``run_status`` is one of ``succeeded|mandate_infeasible|degraded|failed``.
     """
     block = cascade_block or {}
     raw_attempts: list[dict[str, Any]] = list(block.get("phase_attempts") or [])
@@ -1646,18 +1647,19 @@ async def execute_construction_run(
         )
         return run
 
-    # PR-A12 cascade summary enum drives run.status. Post-A12 there is no
-    # cvar-blind fallback that produced weights — Phase 3 always runs
-    # CVaR-aware, so ``phase_3_min_cvar_above_limit`` and ``upstream_heuristic``
-    # are the only ``degraded`` outcomes; ``constraint_polytope_empty`` is the
-    # only remaining terminal failure. The legacy solver-string check stays
+    # PR-A12 / PR-Q140 cascade summary enum drives run.status.
+    # Post-A12 there is no cvar-blind fallback that produced weights —
+    # Phase 3 always runs CVaR-aware, so ``phase_3_min_cvar_above_limit``
+    # yields ``mandate_infeasible`` (PR-Q140: engine working, configured
+    # limit unreachable), ``upstream_heuristic`` yields ``degraded``
+    # (technical fallback), ``constraint_polytope_empty`` is the only
+    # remaining terminal failure. The legacy solver-string check stays
     # as a defensive fallback for empty cascade_telemetry (pre-A11 mocks).
     telemetry_summary = (run.cascade_telemetry or {}).get("cascade_summary")
     solver = (run.optimizer_trace or {}).get("solver")
-    if telemetry_summary in (
-        "phase_3_min_cvar_above_limit",
-        "upstream_heuristic",
-    ):
+    if telemetry_summary == "phase_3_min_cvar_above_limit":
+        run.status = "mandate_infeasible"
+    elif telemetry_summary == "upstream_heuristic":
         run.status = "degraded"
     elif telemetry_summary == "constraint_polytope_empty":
         run.status = "failed"

--- a/backend/tests/test_validation_gate.py
+++ b/backend/tests/test_validation_gate.py
@@ -410,20 +410,21 @@ def test_check_that_raises_preserves_intended_severity():
 def test_to_jsonb_shape():
     result = validate_construction(_base_payload(), _base_db_context())
     j = to_jsonb(result)
-    assert set(j.keys()) == {"passed", "checks", "summary"}
+    # PR-Q140: severity_breakdown added to the top-level shape.
+    assert set(j.keys()) == {"passed", "checks", "summary", "severity_breakdown"}
     assert j["passed"] is True
     assert len(j["checks"]) == 16
     assert j["summary"]["total"] == 16
     assert j["summary"]["passed"] == 16
     assert j["summary"]["blocks_failed"] == 0
     assert j["summary"]["warnings_failed"] == 0
+    # All checks pass → severity_breakdown is empty.
+    assert j["severity_breakdown"] == {}
 
-    # Every check has the expected keys
+    # Every check has the expected keys (degraded_reason is omitted when None).
     for c in j["checks"]:
-        assert set(c.keys()) == {
-            "id", "label", "severity", "passed",
-            "value", "threshold", "explanation",
-        }
+        assert {"id", "label", "severity", "passed",
+                "value", "threshold", "explanation"}.issubset(set(c.keys()))
 
 
 def test_to_jsonb_preserves_check_order():

--- a/backend/tests/wealth/test_cascade_status_taxonomy.py
+++ b/backend/tests/wealth/test_cascade_status_taxonomy.py
@@ -1,0 +1,299 @@
+"""PR-Q140 — cascade status taxonomy tests.
+
+Covers the 5 acceptance criteria:
+
+1. Phase 3 above limit → run.status = "mandate_infeasible"
+2. Upstream heuristic → run.status = "degraded"
+3. Phase 1 optimal → run.status = "succeeded"
+4. CVaR degraded_reason propagates to ValidationStatus
+5. State machine blocks approval on mandate_infeasible
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.domains.wealth.workers.construction_run_executor import (
+    _build_cascade_telemetry,
+)
+from vertical_engines.wealth.model_portfolio.state_machine import (
+    ACTION_APPROVE,
+    ACTION_REBUILD_DRAFT,
+    ACTION_REJECT,
+    ACTION_VALIDATE,
+    ApprovalPolicy,
+    ValidationStatus,
+    compute_allowed_actions,
+)
+from vertical_engines.wealth.model_portfolio.validation_gate import (
+    ValidationDbContext,
+    validate_construction,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+def _phase_3_above_limit_block() -> dict[str, Any]:
+    """Canonical Conservative-like block: Phase 1 infeasible, Phase 3 above limit."""
+    return {
+        "phase_attempts": [
+            {
+                "phase": "phase_1_ru_max_return", "status": "infeasible",
+                "solver": None, "objective_value": None, "wall_ms": 312,
+                "infeasibility_reason": "PRIMAL_INFEASIBLE",
+                "cvar_at_solution": None, "cvar_at_solution_cf": None,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": None,
+            },
+            {
+                "phase": "phase_2_ru_robust", "status": "skipped", "solver": None,
+                "objective_value": None, "wall_ms": 0,
+                "infeasibility_reason": None,
+            },
+            {
+                "phase": "phase_3_min_cvar", "status": "succeeded",
+                "solver": "CLARABEL", "objective_value": 0.0635,
+                "wall_ms": 89, "infeasibility_reason": None,
+                "cvar_at_solution": 0.0635, "cvar_at_solution_cf": 0.071,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": False,
+            },
+        ],
+        "winning_phase": "phase_3_min_cvar",
+        "min_achievable_cvar": 0.0635,
+        "achievable_return_band": {
+            "lower": 0.0998, "upper": 0.0998,
+            "lower_at_cvar": 0.0635, "upper_at_cvar": 0.0635,
+        },
+    }
+
+
+def _phase_1_winner_block() -> dict[str, Any]:
+    """Phase 1 succeeds — golden path."""
+    return {
+        "phase_attempts": [
+            {
+                "phase": "phase_1_ru_max_return", "status": "succeeded",
+                "solver": "CLARABEL", "objective_value": 0.1085, "wall_ms": 287,
+                "infeasibility_reason": None,
+                "cvar_at_solution": 0.047, "cvar_at_solution_cf": 0.053,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": True,
+            },
+            {
+                "phase": "phase_2_ru_robust", "status": "skipped", "solver": None,
+                "objective_value": None, "wall_ms": 0,
+                "infeasibility_reason": None,
+            },
+            {
+                "phase": "phase_3_min_cvar", "status": "succeeded",
+                "solver": "CLARABEL", "objective_value": 0.0352, "wall_ms": 91,
+                "infeasibility_reason": None,
+                "cvar_at_solution": 0.0352, "cvar_at_solution_cf": 0.040,
+                "cvar_limit_effective": 0.05, "cvar_within_limit": True,
+            },
+        ],
+        "winning_phase": "phase_1_ru_max_return",
+        "min_achievable_cvar": 0.0352,
+        "achievable_return_band": {
+            "lower": 0.0975, "upper": 0.1085,
+            "lower_at_cvar": 0.0352, "upper_at_cvar": 0.047,
+        },
+    }
+
+
+def _base_payload() -> dict[str, Any]:
+    """A known-good construction run payload that passes all 16 checks."""
+    return {
+        "as_of_date": "2026-04-29",
+        "weights_proposed": {
+            "11111111-1111-1111-1111-111111111111": 0.20,
+            "22222222-2222-2222-2222-222222222222": 0.20,
+            "33333333-3333-3333-3333-333333333333": 0.20,
+            "44444444-4444-4444-4444-444444444444": 0.20,
+            "55555555-5555-5555-5555-555555555555": 0.20,
+        },
+        "calibration_snapshot": {
+            "cvar_limit": 0.05,
+            "max_single_fund_weight": 0.25,
+            "turnover_cap": 0.30,
+            "bl_enabled": False,
+            "garch_enabled": False,
+        },
+        "ex_ante_metrics": {
+            "cvar_95": -0.04,
+            "expected_return": 0.08,
+            "turnover": 0.10,
+        },
+        "funds": [
+            {"instrument_id": "11111111-1111-1111-1111-111111111111",
+             "block_id": "na_equity_large", "weight": 0.20},
+            {"instrument_id": "22222222-2222-2222-2222-222222222222",
+             "block_id": "na_equity_large", "weight": 0.20},
+            {"instrument_id": "33333333-3333-3333-3333-333333333333",
+             "block_id": "fi_treasury", "weight": 0.20},
+            {"instrument_id": "44444444-4444-4444-4444-444444444444",
+             "block_id": "fi_treasury", "weight": 0.20},
+            {"instrument_id": "55555555-5555-5555-5555-555555555555",
+             "block_id": "intl_equity_dm", "weight": 0.20},
+        ],
+        "stress_results": [
+            {"scenario": "gfc_2008", "nav_impact_pct": -0.15},
+            {"scenario": "covid_2020", "nav_impact_pct": -0.10},
+        ],
+        "optimizer_trace": {},
+        "statistical_inputs": {},
+        "factor_exposure": {"average_r_squared": 0.65},
+    }
+
+
+def _base_db_context() -> ValidationDbContext:
+    ids = frozenset({
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+        "33333333-3333-3333-3333-333333333333",
+        "44444444-4444-4444-4444-444444444444",
+        "55555555-5555-5555-5555-555555555555",
+    })
+    return ValidationDbContext(
+        approved_instrument_ids=ids,
+        block_constraints={
+            "na_equity_large": (0.0, 0.50),
+            "fi_treasury": (0.0, 0.50),
+            "intl_equity_dm": (0.0, 0.50),
+        },
+        nav_latest_date={
+            "11111111-1111-1111-1111-111111111111": "2026-04-28",
+            "22222222-2222-2222-2222-222222222222": "2026-04-28",
+            "33333333-3333-3333-3333-333333333333": "2026-04-28",
+            "44444444-4444-4444-4444-444444444444": "2026-04-28",
+            "55555555-5555-5555-5555-555555555555": "2026-04-28",
+        },
+    )
+
+
+# ── Test 1: Phase 3 above limit → mandate_infeasible ────────────
+
+
+def test_phase_3_above_limit_yields_mandate_infeasible() -> None:
+    """C-01: Phase 3 winner with cvar_above_limit must produce
+    run.status = 'mandate_infeasible', not 'degraded'."""
+    telemetry, status = _build_cascade_telemetry(
+        cascade_block=_phase_3_above_limit_block(),
+        optimizer_trace={"status": "degraded"},
+        cvar_limit=0.05,
+    )
+    assert status == "mandate_infeasible"
+    assert telemetry["cascade_summary"] == "phase_3_min_cvar_above_limit"
+    # Operator signal still present for frontend rendering.
+    sig = telemetry["operator_signal"]
+    assert sig is not None
+    assert sig["kind"] == "cvar_limit_below_universe_floor"
+
+
+# ── Test 2: Upstream heuristic → degraded ────────────────────────
+
+
+def test_upstream_heuristic_yields_degraded() -> None:
+    """C-01: Covariance fallback / technical degradation must stay 'degraded'."""
+    cascade_block: dict[str, Any] = {
+        "phase_attempts": [],
+        "winning_phase": "upstream_heuristic",
+    }
+    telemetry, status = _build_cascade_telemetry(
+        cascade_block=cascade_block,
+        optimizer_trace={"status": "fallback:insufficient_fund_data"},
+        cvar_limit=0.05,
+    )
+    assert status == "degraded"
+    assert telemetry["cascade_summary"] == "upstream_heuristic"
+    sig = telemetry["operator_signal"]
+    assert sig is not None
+    assert sig["kind"] == "upstream_data_missing"
+
+
+# ── Test 3: Phase 1 optimal → succeeded ─────────────────────────
+
+
+def test_phase_1_optimal_yields_succeeded() -> None:
+    """Golden path: Phase 1 wins → run.status = 'succeeded'."""
+    telemetry, status = _build_cascade_telemetry(
+        cascade_block=_phase_1_winner_block(),
+        optimizer_trace={"status": "optimal"},
+        cvar_limit=0.05,
+    )
+    assert status == "succeeded"
+    assert telemetry["cascade_summary"] == "phase_1_succeeded"
+    assert telemetry["operator_signal"] is None
+
+
+# ── Test 4: CVaR degraded_reason propagates to validation ────────
+
+
+def test_cvar_service_degraded_reason_propagates_to_validation() -> None:
+    """C-11: NaN CVaR with degraded_reason from cvar_service must appear
+    on the ValidationCheck and in the ValidationResult's severity_breakdown."""
+    payload = _base_payload()
+    # Simulate NaN CVaR from cvar_service with degraded_reason.
+    payload["ex_ante_metrics"]["cvar_95"] = float("nan")
+    payload["ex_ante_metrics"]["cvar_degraded_reason"] = "insufficient_obs_12"
+
+    result = validate_construction(payload, db_context=_base_db_context())
+
+    # Find the CVaR check.
+    cvar_check = next(c for c in result.checks if c.id == "cvar_within_limit")
+    assert not cvar_check.passed
+    assert cvar_check.degraded_reason == "insufficient_obs_12"
+    assert "NaN" in cvar_check.explanation
+
+    # severity_breakdown must include the CVaR check under "block".
+    assert "block" in result.severity_breakdown
+    assert "cvar_within_limit" in result.severity_breakdown["block"]
+
+
+# ── Test 5: State machine blocks approval on mandate_infeasible ──
+
+
+def test_state_machine_blocks_approval_on_mandate_infeasible() -> None:
+    """C-01: Portfolio with run.status = 'mandate_infeasible' must NOT
+    have the approve action, regardless of validation.passed."""
+    # Even with validation.passed=True (all 16 gate checks passed),
+    # mandate_infeasible should block approval.
+    validation = ValidationStatus(
+        has_run=True,
+        passed=True,
+        run_status="mandate_infeasible",
+    )
+    actions = compute_allowed_actions("constructed", validation=validation)
+    assert ACTION_APPROVE not in actions
+    # validate, reject, rebuild_draft should still be available.
+    assert ACTION_VALIDATE in actions
+    assert ACTION_REJECT in actions
+    assert ACTION_REBUILD_DRAFT in actions
+
+    # Also verify soft-block policy cannot override mandate_infeasible.
+    policy = ApprovalPolicy(require_construction_for_approve=False)
+    actions_soft = compute_allowed_actions(
+        "constructed", validation=validation, policy=policy,
+    )
+    assert ACTION_APPROVE not in actions_soft
+
+
+# ── Bonus: ensure existing 'degraded' run_status does NOT block ──
+
+
+def test_state_machine_allows_approval_on_degraded_run_status() -> None:
+    """Backward compat: a technically degraded run with passing validation
+    should still allow approval (existing behavior preserved)."""
+    validation = ValidationStatus(
+        has_run=True,
+        passed=True,
+        run_status="degraded",
+    )
+    actions = compute_allowed_actions("constructed", validation=validation)
+    assert ACTION_APPROVE in actions
+
+
+def test_state_machine_allows_approval_on_none_run_status() -> None:
+    """Backward compat: legacy ValidationStatus without run_status
+    (defaulting to None) should behave identically to pre-Q140."""
+    validation = ValidationStatus(has_run=True, passed=True)
+    actions = compute_allowed_actions("constructed", validation=validation)
+    assert ACTION_APPROVE in actions

--- a/backend/tests/wealth/test_construction_run_executor_cascade.py
+++ b/backend/tests/wealth/test_construction_run_executor_cascade.py
@@ -56,13 +56,14 @@ def _phase_3_above_limit_block() -> dict:
     }
 
 
-def test_phase_3_above_limit_yields_degraded_and_floor_signal() -> None:
+def test_phase_3_above_limit_yields_mandate_infeasible_and_floor_signal() -> None:
     telemetry, status = _build_cascade_telemetry(
         cascade_block=_phase_3_above_limit_block(),
         optimizer_trace={"status": "degraded"},
         cvar_limit=0.05,
     )
-    assert status == "degraded"
+    # PR-Q140: mandate infeasibility is distinct from technical degradation.
+    assert status == "mandate_infeasible"
     assert telemetry["cascade_summary"] == "phase_3_min_cvar_above_limit"
     assert telemetry["min_achievable_cvar"] == 0.0635
     band = telemetry["achievable_return_band"]

--- a/backend/tests/wealth/test_universe_coverage_gate.py
+++ b/backend/tests/wealth/test_universe_coverage_gate.py
@@ -168,7 +168,8 @@ def test_secondary_coexists_with_primary_below_floor() -> None:
         optimizer_trace={"status": "degraded"},
         cvar_limit=0.05,
     )
-    assert status == "degraded"
+    # PR-Q140: phase_3_min_cvar_above_limit → mandate_infeasible (was degraded).
+    assert status == "mandate_infeasible"
     sig = telemetry["operator_signal"]
     assert sig["kind"] == "cvar_limit_below_universe_floor"
     assert sig["secondary"] is not None

--- a/backend/vertical_engines/wealth/model_portfolio/state_machine.py
+++ b/backend/vertical_engines/wealth/model_portfolio/state_machine.py
@@ -100,9 +100,9 @@ class ValidationStatus:
     """Minimal projection of a construction run's validation result.
 
     Used by ``compute_allowed_actions`` to decide whether ``approve`` is
-    a valid action when the portfolio is in ``constructed`` state. Only
-    the two booleans matter — the full ``ValidationResult`` lives in the
-    construction run record (Phase 3 Task 3.1).
+    a valid action when the portfolio is in ``constructed`` state. The
+    full ``ValidationResult`` lives in the construction run record
+    (Phase 3 Task 3.1).
     """
 
     has_run: bool
@@ -111,6 +111,12 @@ class ValidationStatus:
     passed: bool
     """True if the most recent construction run's validation gate passed
     with zero block-severity failures."""
+
+    run_status: str | None = None
+    """PR-Q140 (C-01): construction run terminal status. When
+    ``mandate_infeasible``, the approve action is blocked regardless of
+    ``passed`` — the universe cannot satisfy the configured CVaR limit,
+    so progressing to approval is semantically invalid."""
 
 
 @dataclass(frozen=True)
@@ -176,11 +182,20 @@ def compute_allowed_actions(
     elif state == "constructed":
         # ``validate`` is always available — it just re-runs the gate.
         actions.append(ACTION_VALIDATE)
-        # Soft-block per OD-5: keep ``approve`` visible even if validation
-        # is failing — the route captures the override rationale.
-        if validation is not None and validation.has_run:
-            if validation.passed or not policy.require_construction_for_approve:
-                actions.append(ACTION_APPROVE)
+        # PR-Q140 (C-01): mandate_infeasible blocks approval unconditionally.
+        # The universe cannot satisfy the configured CVaR limit — progressing
+        # to approval is semantically invalid; operator must expand universe
+        # or relax the limit first.
+        _mandate_infeasible = (
+            validation is not None
+            and validation.run_status == "mandate_infeasible"
+        )
+        if not _mandate_infeasible:
+            # Soft-block per OD-5: keep ``approve`` visible even if validation
+            # is failing — the route captures the override rationale.
+            if validation is not None and validation.has_run:
+                if validation.passed or not policy.require_construction_for_approve:
+                    actions.append(ACTION_APPROVE)
         actions.append(ACTION_REJECT)
         actions.append(ACTION_REBUILD_DRAFT)
 

--- a/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
+++ b/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
@@ -81,6 +81,10 @@ class ValidationCheck:
     value: float | int | None
     threshold: float | int | None
     explanation: str
+    degraded_reason: str | None = None
+    """PR-Q140 (C-11): propagated from cvar_service when CVaR computation
+    fell back to NaN/insufficient-obs. Enables operator-facing diagnostics
+    without collapsing severity into a single boolean."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -98,6 +102,11 @@ class ValidationResult:
 
     blocks: list[ValidationCheck] = field(default_factory=list)
     """Subset of ``checks`` where ``severity='block'`` and ``passed=False``."""
+
+    severity_breakdown: dict[str, list[str]] = field(default_factory=dict)
+    """PR-Q140 (C-11): mapping severity → list of failed check IDs.
+    Cascade-aware consumers (state_machine) use this instead of the
+    single ``passed`` boolean to distinguish degraded from blocking."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -233,6 +242,9 @@ def _check_cvar_within_limit(
     cvar = metrics.get("cvar_95")
     calibration = run_payload.get("calibration_snapshot") or {}
     limit = calibration.get("cvar_limit")
+    # PR-Q140 (C-11): propagate degraded_reason from cvar_service when
+    # the CVaR computation fell back to NaN / insufficient observations.
+    cvar_degraded_reason = metrics.get("cvar_degraded_reason")
     if cvar is None or limit is None:
         return ValidationCheck(
             id="cvar_within_limit",
@@ -242,11 +254,27 @@ def _check_cvar_within_limit(
             value=cvar,
             threshold=limit,
             explanation="Missing cvar_95 or cvar_limit in payload.",
+            degraded_reason=cvar_degraded_reason,
         )
     # CVaR convention in this codebase: negative = loss.
     # Limit e.g. -0.05 means 5% loss budget.
     cvar_f = float(cvar)
     limit_f = -abs(float(limit))
+    # PR-Q140 (C-11): NaN cvar from insufficient obs → fail with reason.
+    if math.isnan(cvar_f):
+        return ValidationCheck(
+            id="cvar_within_limit",
+            label="CVaR within calibration limit",
+            severity="block",
+            passed=False,
+            value=None,
+            threshold=round(limit_f, 6),
+            explanation=(
+                f"CVaR 95% is NaN (degraded: {cvar_degraded_reason or 'unknown'}); "
+                f"calibration limit is {limit_f:.4%}."
+            ),
+            degraded_reason=cvar_degraded_reason,
+        )
     passed = cvar_f >= limit_f  # less negative = within budget
     return ValidationCheck(
         id="cvar_within_limit",
@@ -259,6 +287,7 @@ def _check_cvar_within_limit(
             f"Ex-ante CVaR 95% is {cvar_f:.4%}; calibration limit is "
             f"{limit_f:.4%}. {'OK' if passed else 'Breach'}."
         ),
+        degraded_reason=cvar_degraded_reason,
     )
 
 
@@ -851,11 +880,20 @@ def validate_construction(
     blocks = [c for c in checks if c.severity == "block" and not c.passed]
     warnings = [c for c in checks if c.severity == "warn" and not c.passed]
 
+    # PR-Q140 (C-11): severity_breakdown — mapping severity → list of
+    # failed check IDs, so cascade-aware consumers (state_machine) can
+    # distinguish degraded from blocking without collapsing to a single bool.
+    severity_breakdown: dict[str, list[str]] = {}
+    for c in checks:
+        if not c.passed:
+            severity_breakdown.setdefault(c.severity, []).append(c.id)
+
     return ValidationResult(
         passed=len(blocks) == 0,
         checks=checks,
         warnings=warnings,
         blocks=blocks,
+        severity_breakdown=severity_breakdown,
     )
 
 
@@ -877,6 +915,8 @@ def to_jsonb(result: ValidationResult) -> dict[str, Any]:
                 "value": c.value,
                 "threshold": c.threshold,
                 "explanation": c.explanation,
+                # PR-Q140 (C-11): propagate degraded_reason when present.
+                **({"degraded_reason": c.degraded_reason} if c.degraded_reason else {}),
             }
             for c in result.checks
         ],
@@ -886,4 +926,6 @@ def to_jsonb(result: ValidationResult) -> dict[str, Any]:
             "blocks_failed": len(result.blocks),
             "warnings_failed": len(result.warnings),
         },
+        # PR-Q140 (C-11): severity → failed check IDs for cascade-aware consumers.
+        "severity_breakdown": result.severity_breakdown,
     }


### PR DESCRIPTION
## Summary

Bundles two cascade robustness findings (C-01 + C-11) that share the same architectural target: unify status semantics across cvar_service, cascade output, validation gate, and lifecycle state machine.

- **C-01**: `_STATUS_BY_SUMMARY` now maps `phase_3_min_cvar_above_limit` to `mandate_infeasible` (was `degraded`). Mandate infeasibility (engine working correctly, configured CVaR limit unreachable by the universe) is semantically distinct from technical degradation (covariance failure, heuristic fallback). Downstream consumers can now distinguish the two.
- **C-11**: `ValidationCheck` gains optional `degraded_reason` field, propagated from `cvar_service` when CVaR falls back to NaN/insufficient observations. `ValidationResult` gains `severity_breakdown` (severity -> failed check IDs) so cascade-aware consumers avoid collapsing to a single boolean. `ValidationStatus` gains `run_status` field; `compute_allowed_actions` blocks approval unconditionally when `run_status == "mandate_infeasible"`.
- **Migration 0197**: Extends CHECK constraint on `portfolio_construction_runs.status` with `mandate_infeasible`.
- **Backward compat**: Existing callers reading `run.status == "degraded"` continue to work for genuine technical degradation. `ValidationStatus(run_status=None)` (legacy path) behaves identically to pre-Q140.

## Files changed (10)

| File | Change |
|------|--------|
| `migrations/0197_q140_cascade_status_mandate_infeasible.py` | New migration: add `mandate_infeasible` to CHECK |
| `construction_run_executor.py` | `_STATUS_BY_SUMMARY` + final status assignment |
| `model_portfolio.py` (ORM) | Docstring update |
| `model_portfolios.py` (routes) | `_latest_validation_status` now reads `run.status` |
| `validation_gate.py` | `degraded_reason` on check, `severity_breakdown` on result, NaN CVaR handling |
| `state_machine.py` | `ValidationStatus.run_status`, mandate_infeasible blocks approve |
| `test_cascade_status_taxonomy.py` | 7 new tests (5 required + 2 backward compat) |
| `test_construction_run_executor_cascade.py` | Updated assertion: degraded -> mandate_infeasible |
| `test_universe_coverage_gate.py` | Updated assertion: degraded -> mandate_infeasible |
| `test_validation_gate.py` | Updated JSONB shape assertion for severity_breakdown |

## Test plan

- [x] 5 required acceptance tests pass
- [x] 2 additional backward-compat tests pass
- [x] All existing executor, validation gate, and state machine tests pass (130 tests)
- [x] Lint clean (`make lint`)
- [x] Architecture check clean (`make architecture`)
- [x] Pre-existing mypy errors only (no new type errors)
- [ ] Migration 0197 runs on local Docker DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)