### PR TITLE
fix(wealth): PR-Q145 — validation gate exposes CVaR infeasibility gap (C-02)

### DIFF
--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -2091,6 +2091,9 @@ async def _execute_inner(
         "statistical_inputs": statistical_inputs_payload,
         "factor_exposure": factor_exposure,
         "optimization": {"cvar_enforcement": _cvar_enforcement},
+        # PR-Q145 (C-02): pass min_achievable_cvar from cascade telemetry
+        # so validation gate can expose the infeasibility gap.
+        "min_achievable_cvar": (cascade_telemetry or {}).get("min_achievable_cvar"),
     }
     # PR-Q116 — populate ValidationDbContext from DB so that checks 7-10
     # (block min/max, banned instruments, approved universe) and check 16

--- a/backend/tests/test_validation_gate.py
+++ b/backend/tests/test_validation_gate.py
@@ -571,13 +571,14 @@ def test_cvar_check_with_infeasibility_gap_explains_actionably():
     must contain infeasibility language with the gap in bps and an
     actionable recommendation for the IC reviewer.
 
-    Scenario: cvar_95=-0.042, limit=-0.01, min_achievable=-0.042.
+    Scenario: cvar_95=-0.042, limit=-0.01, min_achievable=0.042 (positive
+    magnitude as emitted by optimizer cascade).
     Gap = |-0.042 - (-0.01)| = 0.032 = 320bps (>> 50bps threshold).
     """
     payload = _base_payload()
     payload["ex_ante_metrics"]["cvar_95"] = -0.042
     payload["calibration_snapshot"]["cvar_limit"] = 0.01
-    payload["min_achievable_cvar"] = -0.042
+    payload["min_achievable_cvar"] = 0.042
     result = validate_construction(payload, _base_db_context())
     cvar_check = next(c for c in result.checks if c.id == "cvar_within_limit")
     assert cvar_check.passed is False
@@ -608,13 +609,14 @@ def test_cvar_check_solver_imprecision_no_infeasibility_lang():
     infeasibility language — because this is solver imprecision, not
     a mandate mismatch.
 
-    Scenario: cvar=-0.0102, limit=-0.01, min_achievable=-0.0102.
+    Scenario: cvar=-0.0102, limit=-0.01, min_achievable=0.0102 (positive
+    magnitude as emitted by optimizer cascade).
     Gap = 0.0002 = 2bps (< 50bps threshold).
     """
     payload = _base_payload()
     payload["ex_ante_metrics"]["cvar_95"] = -0.0102
     payload["calibration_snapshot"]["cvar_limit"] = 0.01
-    payload["min_achievable_cvar"] = -0.0102
+    payload["min_achievable_cvar"] = 0.0102
     result = validate_construction(payload, _base_db_context())
     cvar_check = next(c for c in result.checks if c.id == "cvar_within_limit")
     assert cvar_check.passed is False

--- a/backend/tests/test_validation_gate.py
+++ b/backend/tests/test_validation_gate.py
@@ -561,3 +561,62 @@ def test_validation_passes_on_optimization_present_but_enforcement_none():
     result = validate_construction(payload, _base_db_context())
     cvar_enf = next(c for c in result.checks if c.id == "cvar_enforcement")
     assert cvar_enf.passed is True
+
+
+# ── CVaR infeasibility gap (PR-Q145, C-02) ────────────────────────
+
+
+def test_cvar_check_with_infeasibility_gap_explains_actionably():
+    """When min_achievable_cvar is far below the limit, the explanation
+    must contain infeasibility language with the gap in bps and an
+    actionable recommendation for the IC reviewer.
+
+    Scenario: cvar_95=-0.042, limit=-0.01, min_achievable=-0.042.
+    Gap = |-0.042 - (-0.01)| = 0.032 = 320bps (>> 50bps threshold).
+    """
+    payload = _base_payload()
+    payload["ex_ante_metrics"]["cvar_95"] = -0.042
+    payload["calibration_snapshot"]["cvar_limit"] = 0.01
+    payload["min_achievable_cvar"] = -0.042
+    result = validate_construction(payload, _base_db_context())
+    cvar_check = next(c for c in result.checks if c.id == "cvar_within_limit")
+    assert cvar_check.passed is False
+    assert cvar_check.severity == "block"
+    assert "infeasible" in cvar_check.explanation.lower()
+    assert "320bps" in cvar_check.explanation
+    assert "Mandate-level review" in cvar_check.explanation
+
+
+def test_cvar_check_without_min_achievable_falls_back():
+    """When min_achievable_cvar is None (older runs), the explanation
+    must use the generic Breach language, not infeasibility language."""
+    payload = _base_payload()
+    payload["ex_ante_metrics"]["cvar_95"] = -0.20
+    payload["calibration_snapshot"]["cvar_limit"] = 0.05
+    # No min_achievable_cvar key → None
+    payload.pop("min_achievable_cvar", None)
+    result = validate_construction(payload, _base_db_context())
+    cvar_check = next(c for c in result.checks if c.id == "cvar_within_limit")
+    assert cvar_check.passed is False
+    assert "Breach" in cvar_check.explanation
+    assert "infeasible" not in cvar_check.explanation.lower()
+
+
+def test_cvar_check_solver_imprecision_no_infeasibility_lang():
+    """When the gap between min_achievable_cvar and the limit is small
+    (< 50bps), the explanation must use generic Breach language — not
+    infeasibility language — because this is solver imprecision, not
+    a mandate mismatch.
+
+    Scenario: cvar=-0.0102, limit=-0.01, min_achievable=-0.0102.
+    Gap = 0.0002 = 2bps (< 50bps threshold).
+    """
+    payload = _base_payload()
+    payload["ex_ante_metrics"]["cvar_95"] = -0.0102
+    payload["calibration_snapshot"]["cvar_limit"] = 0.01
+    payload["min_achievable_cvar"] = -0.0102
+    result = validate_construction(payload, _base_db_context())
+    cvar_check = next(c for c in result.checks if c.id == "cvar_within_limit")
+    assert cvar_check.passed is False
+    assert "Breach" in cvar_check.explanation
+    assert "infeasible" not in cvar_check.explanation.lower()

--- a/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
+++ b/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
@@ -287,7 +287,7 @@ def _check_cvar_within_limit(
     # reviewers can distinguish solver imprecision from mandate infeasibility.
     # Threshold: gap >= 50bps → infeasibility language; < 50bps → generic Breach.
     min_achievable_cvar_f: float | None = (
-        float(min_achievable_cvar_raw) if min_achievable_cvar_raw is not None else None
+        -abs(float(min_achievable_cvar_raw)) if min_achievable_cvar_raw is not None else None
     )
     if (
         not passed

--- a/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
+++ b/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
@@ -152,6 +152,7 @@ _FACTOR_MODEL_MIN_R2: Final[float] = 0.30
 _STRESS_NAV_IMPACT_THRESHOLD: Final[float] = -0.40  # worse than -40% = block
 _BL_POSTERIOR_DEVIATION_MAX: Final[float] = 2.0  # sigma
 _BLOCK_WEIGHT_TOLERANCE: Final[float] = 1e-4
+_INFEASIBILITY_GAP_THRESHOLD: Final[float] = 0.005  # 50bps — below = solver imprecision
 
 
 # ── Individual check implementations ─────────────────────────────
@@ -246,6 +247,9 @@ def _check_cvar_within_limit(
     # PR-Q140 (C-11): propagate degraded_reason from cvar_service when
     # the CVaR computation fell back to NaN / insufficient observations.
     cvar_degraded_reason = metrics.get("cvar_degraded_reason")
+    # PR-Q145 (C-02): min_achievable_cvar from Phase 3 optimizer via
+    # cascade_telemetry → validation_payload.  None on legacy/older runs.
+    min_achievable_cvar_raw = run_payload.get("min_achievable_cvar")
     if cvar is None or limit is None:
         return ValidationCheck(
             id="cvar_within_limit",
@@ -277,6 +281,36 @@ def _check_cvar_within_limit(
             degraded_reason=cvar_degraded_reason,
         )
     passed = cvar_f >= limit_f  # less negative = within budget
+
+    # PR-Q145 (C-02): when CVaR check fails AND Phase 3 reported the
+    # minimum achievable CVaR, expose the infeasibility gap so IC
+    # reviewers can distinguish solver imprecision from mandate infeasibility.
+    # Threshold: gap >= 50bps → infeasibility language; < 50bps → generic Breach.
+    min_achievable_cvar_f: float | None = (
+        float(min_achievable_cvar_raw) if min_achievable_cvar_raw is not None else None
+    )
+    if (
+        not passed
+        and min_achievable_cvar_f is not None
+        and not math.isnan(min_achievable_cvar_f)
+        and min_achievable_cvar_f < limit_f  # more negative = worse loss floor
+        and abs(min_achievable_cvar_f - limit_f) >= _INFEASIBILITY_GAP_THRESHOLD
+    ):
+        # Express gap in basis points (positive = how far below the limit).
+        gap_bps = round(abs(min_achievable_cvar_f - limit_f) * 10_000)
+        explanation = (
+            f"CVaR target infeasible: minimum achievable CVaR for current "
+            f"universe is {min_achievable_cvar_f:.4%}. Configured limit is "
+            f"{limit_f:.4%}. Gap: {gap_bps}bps. Mandate-level review "
+            f"required: consider raising the CVaR target or expanding the "
+            f"universe with lower-tail-risk instruments."
+        )
+    else:
+        explanation = (
+            f"Ex-ante CVaR 95% is {cvar_f:.4%}; calibration limit is "
+            f"{limit_f:.4%}. {'OK' if passed else 'Breach'}."
+        )
+
     return ValidationCheck(
         id="cvar_within_limit",
         label="CVaR within calibration limit",
@@ -284,10 +318,7 @@ def _check_cvar_within_limit(
         passed=passed,
         value=round(cvar_f, 6),
         threshold=round(limit_f, 6),
-        explanation=(
-            f"Ex-ante CVaR 95% is {cvar_f:.4%}; calibration limit is "
-            f"{limit_f:.4%}. {'OK' if passed else 'Breach'}."
-        ),
+        explanation=explanation,
         degraded_reason=cvar_degraded_reason,
     )
 


### PR DESCRIPTION
## Summary

- **C-02 (High):** Validation gate CVaR check now distinguishes mandate infeasibility from solver imprecision.
- When gap >= 50bps: actionable explanation with minimum achievable CVaR, configured limit, gap in bps, and recommendation to raise target or expand universe.
- When gap < 50bps: generic "Breach" explanation (solver imprecision).
- When `min_achievable_cvar` is None (legacy runs): fallback to generic explanation.
- Pass/fail semantics unchanged — only explanation enhanced.

## Files changed

- `backend/vertical_engines/wealth/model_portfolio/validation_gate.py` — infeasibility gap explanation in `_check_cvar_within_limit`
- `backend/app/domains/wealth/workers/construction_run_executor.py` — passes `min_achievable_cvar` from cascade_telemetry to validation payload
- `backend/tests/test_validation_gate.py` — 3 new tests

## Test plan

- [x] `test_cvar_check_with_infeasibility_gap_explains_actionably` (320bps gap -> infeasibility language)
- [x] `test_cvar_check_without_min_achievable_falls_back` (None -> generic)
- [x] `test_cvar_check_solver_imprecision_no_infeasibility_lang` (2bps -> generic Breach)
- [x] 32 existing validation_gate tests pass
- [x] Lint clean

**Source:** Cascade robustness audit C-02 jury verdict
**Depends on:** Q140 (merged, soft dependency)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>