### PR TITLE
fix(wealth): PR-Q146 — cascade hygiene terminus

### DIFF
--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -531,6 +531,22 @@ async def apply_portfolio_transition(
                     status_code=status.HTTP_409_CONFLICT,
                     detail=f"Cannot activate: construction outcome '{ws}' requires resolution before activation.",
                 )
+            # PR-Q146 (C-07): mandate_infeasible requires a separate,
+            # structured acknowledgment — degraded_acknowledged alone is
+            # insufficient because it conflates technical degradation
+            # with mandate-level infeasibility.
+            if run.status == "mandate_infeasible":
+                if not metadata.get("mandate_infeasible_acknowledged"):
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=(
+                            "Portfolio's latest construction run is mandate_infeasible. "
+                            "Set metadata.mandate_infeasible_acknowledged=true "
+                            "(in addition to degraded_acknowledged) to proceed."
+                        ),
+                    )
+                metadata["mandate_infeasible_acknowledged_by"] = actor.actor_id
+
             if ws in degraded_signals and not metadata.get("degraded_acknowledged"):
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
@@ -2350,6 +2366,7 @@ async def _run_construction_async(
     # inner try never reaches compute_fund_level_inputs). Overwritten by the
     # successful path below.
     shrinkage_metrics: dict[str, Any] = {}
+    factor_conditioning_meta: dict[str, Any] | None = None  # PR-Q146 (C-09)
 
     # PR-A11 — cascade telemetry handle. Populated by the optimizer path
     # below; synthesized on the heuristic fallback branch so every result
@@ -2413,6 +2430,10 @@ async def _run_construction_async(
         # PR-A9 — surface the three-tier conditioning decision so the run
         # executor can persist + emit it on the SHRINKAGE SSE phase.
         shrinkage_metrics = dict(_fli.inputs_metadata.get("conditioning") or {})
+        # PR-Q146 (C-09): extract factor covariance eigenvalue conditioning
+        # metadata so the executor can persist it in statistical_inputs.
+        _fm_meta = _fli.inputs_metadata.get("factor_model") or {}
+        factor_conditioning_meta = _fm_meta.get("factor_conditioning")
 
         # Filter to funds with NAV data
         opt_fund_ids = [fid for fid in available_ids if fid in fund_blocks]
@@ -2786,6 +2807,9 @@ async def _run_construction_async(
     # ``FundLevelInputs.inputs_metadata.conditioning`` when the optimizer
     # reached the covariance stage; empty dict otherwise (caller checks).
     result["shrinkage"] = shrinkage_metrics
+    # PR-Q146 (C-09): eigenvalue regularization metadata from
+    # assemble_factor_covariance (persisted in statistical_inputs).
+    result["factor_conditioning"] = factor_conditioning_meta
 
     if composition.optimization:
         result["optimization"] = {

--- a/backend/app/domains/wealth/services/quant_queries.py
+++ b/backend/app/domains/wealth/services/quant_queries.py
@@ -44,6 +44,7 @@ from quant_engine.factor_model_pca import compute_residual_pca
 from quant_engine.factor_model_service import (
     assemble_factor_covariance,
     build_fundamental_factor_returns,
+    compute_factor_conditioning_meta,
     fit_fundamental_loadings,
 )
 
@@ -1539,6 +1540,11 @@ async def compute_fund_level_inputs(
                 annual_cov = assemble_factor_covariance(fit)
                 covariance_source = "factor_model"
 
+                # PR-Q146 (C-09): capture eigenvalue regularization metadata
+                # from the factor covariance assembly so it can be persisted
+                # in run.statistical_inputs.factor_conditioning.
+                _factor_conditioning = compute_factor_conditioning_meta(fit)
+
                 # A.2 — residual PCA diagnostic wired into metadata (was discarded)
                 pca_diag = compute_residual_pca(fit.residual_series)
 
@@ -1562,6 +1568,7 @@ async def compute_fund_level_inputs(
                     },
                     "kappa_factor_cov": kappa_factor_cov,
                     "shrinkage_lambda": fit.shrinkage_lambda,
+                    "factor_conditioning": _factor_conditioning,
                 }
                 ev = pca_diag.explained_variance_ratio
                 residual_pca_meta = {

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -2121,21 +2121,6 @@ async def _execute_inner(
     else:
         _cvar_enforcement = None  # early-exit paths (no cascade ran)
 
-    # PR-Q146 hotfix: compute NAV synthesis before validation so check #18
-    # sees the production executor summary instead of treating it as N/A.
-    nav_summary: dict[str, Any] | None = None
-    if not propose_mode and funds:
-        is_diagnostic = derived_run_status == "mandate_infeasible"
-        base_result["is_diagnostic"] = is_diagnostic
-        portfolio.fund_selection_schema = _jsonb_safe(base_result)
-
-        from app.domains.wealth.workers.portfolio_nav_synthesizer import (
-            synthesize_portfolio_nav,
-        )
-
-        nav_summary = await synthesize_portfolio_nav(db, portfolio, commit=False)
-        statistical_inputs_payload["portfolio_nav_synthesis"] = nav_summary
-
     validation_payload: dict[str, Any] = {
         "as_of_date": run.as_of_date.isoformat(),
         "profile": profile,
@@ -2166,10 +2151,6 @@ async def _execute_inner(
         as_of_date=run.as_of_date,
         effective_date=construction_effective_date,
     )
-    validation_result = validate_construction(
-        validation_payload, validation_db_context,
-    )
-    validation_jsonb = to_jsonb(validation_result)
 
     # ── 8. Narrative templater (pure Jinja2, no LLM) ──
     await _check_cancellation(job_id, "pre_narrative")
@@ -2208,7 +2189,6 @@ async def _execute_inner(
     run.factor_exposure = factor_exposure
     run.stress_results = stress_results
     run.advisor = advisor_result
-    run.validation = validation_jsonb
     run.narrative = narrative
     run.rationale_per_weight = {}
     run.weights_proposed = weights_proposed
@@ -2260,6 +2240,23 @@ async def _execute_inner(
                     actor_id=run.requested_by,
                     reason=f"Construction run {run.id}",
                 )
+
+        from app.domains.wealth.workers.portfolio_nav_synthesizer import (
+            synthesize_portfolio_nav,
+        )
+
+        nav_summary = await synthesize_portfolio_nav(db, portfolio, commit=False)
+        statistical_inputs_payload = {
+            **statistical_inputs_payload,
+            "portfolio_nav_synthesis": nav_summary,
+        }
+        validation_payload["statistical_inputs"] = statistical_inputs_payload
+        run.statistical_inputs = statistical_inputs_payload
+
+    validation_result = validate_construction(
+        validation_payload, validation_db_context,
+    )
+    run.validation = to_jsonb(validation_result)
 
     await db.flush()
 

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -10,7 +10,7 @@ Responsibilities
 4. Call ``_run_construction_async`` to get the optimizer output
 5. Run the 4 preset stress scenarios via ``PRESET_SCENARIOS`` — persist to ``portfolio_stress_results``
 6. Run the ``construction_advisor`` IF ``calibration.advisor_enabled`` (Task 3.3 fold-in)
-7. Run the 15-check ``validation_gate``
+7. Run the 18-check ``validation_gate``
 8. Render the deterministic Jinja2 narrative
 9. Update the run row with ``status='succeeded'|'failed'``, populate all
    enrichment columns, and compute ``wall_clock_ms``
@@ -647,14 +647,29 @@ def _build_cascade_telemetry(
     # optimal" from "Phase 3 min-CVaR fallback because CVaR target
     # infeasible" so the frontend can render the right operator_message
     # verbatim (smart-backend / dumb-frontend).
-    phase3_attempt = next(
-        (a for a in public_attempts if a["phase"] == "phase_3_min_cvar"),
-        None,
-    )
-    _cvar_within_limit = (
-        bool(phase3_attempt.get("cvar_within_limit"))
-        if phase3_attempt is not None else False
-    )
+    # PR-Q146 (C-08): derive _cvar_within_limit from the WINNER's attempt
+    # when the winner is Phase 1 or Phase 2, not from Phase 3. Phase 3's
+    # cvar_within_limit may be None (solver glitch) even when Phase 1
+    # solved optimally within limit — using Phase 3's flag would
+    # misclassify Phase 1 OPTIMAL as DEGRADED_OTHER.
+    if winning_phase in ("phase_1_ru_max_return", "phase_2_ru_robust"):
+        _winner_attempt = next(
+            (a for a in public_attempts if a["phase"] == winning_phase),
+            None,
+        )
+        _cvar_within_limit = (
+            bool(_winner_attempt.get("cvar_within_limit"))
+            if _winner_attempt is not None else False
+        )
+    else:
+        phase3_attempt = next(
+            (a for a in public_attempts if a["phase"] == "phase_3_min_cvar"),
+            None,
+        )
+        _cvar_within_limit = (
+            bool(phase3_attempt.get("cvar_within_limit"))
+            if phase3_attempt is not None else False
+        )
     winner_signal_enum = compute_winner_signal(
         winning_phase=winning_phase,
         cvar_within_limit=_cvar_within_limit,
@@ -1363,7 +1378,7 @@ async def execute_construction_run(
     3. Optimizer cascade via ``_run_construction_async``
     4. Stress suite (4 preset scenarios)
     5. Advisor fold-in (if ``calibration.advisor_enabled``)
-    6. 15-check validation gate
+    6. 18-check validation gate
     7. Jinja2 narrative templater
     8. Persistence of the ``portfolio_construction_runs`` row +
        ``portfolio_stress_results`` rows
@@ -1676,6 +1691,27 @@ async def execute_construction_run(
         run.status = "degraded"
     else:
         run.status = "succeeded"
+
+    # PR-Q146 (C-06): escalate to degraded if NAV synthesis returned
+    # no_fund_data on a portfolio that has instruments. This surfaces
+    # data-coverage gaps that would otherwise be silently stored.
+    nav_synthesis = (run.statistical_inputs or {}).get("portfolio_nav_synthesis")
+    if (
+        nav_synthesis is not None
+        and nav_synthesis.get("dates_computed") == 0
+        and nav_synthesis.get("status") == "no_fund_data"
+        and run.status == "succeeded"
+        and run.weights_proposed  # portfolio has > 0 instruments
+    ):
+        run.status = "degraded"
+        logger.warning(
+            "nav_synthesis_no_fund_data_degraded",
+            extra={
+                "run_id": str(run.id),
+                "nav_status": nav_synthesis.get("status"),
+            },
+        )
+
     run.completed_at = datetime.now(tz=timezone.utc)
     run.wall_clock_ms = int((time.perf_counter() - start_ts) * 1000)
 
@@ -2061,6 +2097,12 @@ async def _execute_inner(
         statistical_inputs_payload["kappa_final"] = shrinkage_block.get(
             "kappa_final",
         )
+    # PR-Q146 (C-09): persist factor covariance eigenvalue regularization
+    # metadata so post-hoc investigation doesn't require log search.
+    _fc_block = base_result.get("factor_conditioning") if isinstance(base_result, dict) else None
+    if isinstance(_fc_block, dict):
+        statistical_inputs_payload["factor_conditioning"] = _fc_block
+
     # PR-Q142 — derive cvar_enforcement from cascade_summary so the
     # validation gate check #17 (_check_cvar_enforcement) sees the flag.
     # The route path sets this on OptimizationMeta; the executor path must

--- a/backend/app/domains/wealth/workers/construction_run_executor.py
+++ b/backend/app/domains/wealth/workers/construction_run_executor.py
@@ -2121,6 +2121,21 @@ async def _execute_inner(
     else:
         _cvar_enforcement = None  # early-exit paths (no cascade ran)
 
+    # PR-Q146 hotfix: compute NAV synthesis before validation so check #18
+    # sees the production executor summary instead of treating it as N/A.
+    nav_summary: dict[str, Any] | None = None
+    if not propose_mode and funds:
+        is_diagnostic = derived_run_status == "mandate_infeasible"
+        base_result["is_diagnostic"] = is_diagnostic
+        portfolio.fund_selection_schema = _jsonb_safe(base_result)
+
+        from app.domains.wealth.workers.portfolio_nav_synthesizer import (
+            synthesize_portfolio_nav,
+        )
+
+        nav_summary = await synthesize_portfolio_nav(db, portfolio, commit=False)
+        statistical_inputs_payload["portfolio_nav_synthesis"] = nav_summary
+
     validation_payload: dict[str, Any] = {
         "as_of_date": run.as_of_date.isoformat(),
         "profile": profile,
@@ -2245,16 +2260,6 @@ async def _execute_inner(
                     actor_id=run.requested_by,
                     reason=f"Construction run {run.id}",
                 )
-
-        from app.domains.wealth.workers.portfolio_nav_synthesizer import (
-            synthesize_portfolio_nav,
-        )
-
-        nav_summary = await synthesize_portfolio_nav(db, portfolio, commit=False)
-        run.statistical_inputs = {
-            **(run.statistical_inputs or {}),
-            "portfolio_nav_synthesis": nav_summary,
-        }
 
     await db.flush()
 

--- a/backend/quant_engine/factor_model_service.py
+++ b/backend/quant_engine/factor_model_service.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -645,6 +646,45 @@ def assemble_factor_covariance(
         )
 
     return np.asarray(sigma, dtype=np.float64)
+
+
+def compute_factor_conditioning_meta(
+    fit: FundamentalFactorFit,
+    *,
+    kappa_target: float = 1e4,
+) -> dict[str, Any]:
+    """Return conditioning metadata for the factor covariance assembly.
+
+    PR-Q146 (C-09): mirrors the eigenvalue regularization logic in
+    ``assemble_factor_covariance`` but only computes the metadata dict
+    (no matrix reconstruction).  Called by the executor path to persist
+    conditioning diagnostics into ``run.statistical_inputs``.
+    """
+    B = fit.loadings
+    F = fit.factor_cov
+    D_diag = fit.residual_variance
+
+    sigma = (B @ F @ B.T) + np.diag(D_diag)
+    sigma = (sigma + sigma.T) / 2
+
+    eigvals = np.linalg.eigvalsh(sigma)
+    max_eigval = float(eigvals.max())
+    clamp_val = max(1e-10, max_eigval / kappa_target)
+
+    n_clamped = int((eigvals < clamp_val).sum())
+    kappa_before = max_eigval / max(float(eigvals.min()), 1e-16)
+    if n_clamped > 0:
+        clamped_eigvals = np.maximum(eigvals, clamp_val)
+        kappa_after = max_eigval / float(clamped_eigvals.min())
+    else:
+        kappa_after = kappa_before
+
+    return {
+        "kappa_before": round(kappa_before, 1),
+        "kappa_after": round(kappa_after, 1),
+        "eigenvalue_floor": float(clamp_val),
+        "n_clamped": n_clamped,
+    }
 
 
 def decompose_factors(

--- a/backend/tests/test_construct_end_to_end.py
+++ b/backend/tests/test_construct_end_to_end.py
@@ -289,11 +289,20 @@ async def _run_executor_with_mock(
     async def _mocked(*_args, **_kwargs):
         return mock_output
 
+    # PR-Q146 (C-06): mock NAV synthesis to return a healthy summary
+    # since the test DB has no seeded NAV data. Without this, the
+    # executor escalates to degraded because no_fund_data fires.
+    async def _mock_nav_synthesis(_db, _portfolio, *, commit=True):
+        return {"portfolio_id": str(portfolio_id), "status": "ok", "dates_computed": 100, "final_nav": 1050.0}
+
     # The executor imports _run_construction_async lazily from the
     # routes module; patch at that exact reference.
     with patch(
         "app.domains.wealth.routes.model_portfolios._run_construction_async",
         side_effect=_mocked,
+    ), patch(
+        "app.domains.wealth.workers.portfolio_nav_synthesizer.synthesize_portfolio_nav",
+        side_effect=_mock_nav_synthesis,
     ):
         async with async_session_factory() as session:
             # Set RLS context for the executor's writes.
@@ -373,11 +382,11 @@ async def test_construct_e2e_happy_path(seeded_portfolio):
     assert narrative["schema_version"] == 2
     assert len(narrative["technical"]["headline"]) > 0
 
-    # Validation section — aggregate + list of 17 checks
+    # Validation section — aggregate + list of 18 checks
     validation = json.loads(row["validation"])
     assert "passed" in validation
     assert "checks" in validation
-    assert validation["summary"]["total"] == 17
+    assert validation["summary"]["total"] == 18
 
     # Stress results — 4 preset scenarios were run
     stress_results = json.loads(row["stress_results"])

--- a/backend/tests/test_construct_end_to_end.py
+++ b/backend/tests/test_construct_end_to_end.py
@@ -275,6 +275,7 @@ async def _insert_calibration(
 async def _run_executor_with_mock(
     portfolio_id: uuid.UUID,
     mock_output: dict,
+    nav_summary: dict | None = None,
 ) -> dict:
     """Call ``execute_construction_run`` with a patched ``_run_construction_async``.
 
@@ -293,7 +294,12 @@ async def _run_executor_with_mock(
     # since the test DB has no seeded NAV data. Without this, the
     # executor escalates to degraded because no_fund_data fires.
     async def _mock_nav_synthesis(_db, _portfolio, *, commit=True):
-        return {"portfolio_id": str(portfolio_id), "status": "ok", "dates_computed": 100, "final_nav": 1050.0}
+        return nav_summary or {
+            "portfolio_id": str(portfolio_id),
+            "status": "ok",
+            "dates_computed": 100,
+            "final_nav": 1050.0,
+        }
 
     # The executor imports _run_construction_async lazily from the
     # routes module; patch at that exact reference.
@@ -340,6 +346,36 @@ async def _run_executor_with_mock(
     result = dict(row)
     result["_returned_status"] = status
     return result
+
+
+@pytest.mark.asyncio
+async def test_construct_e2e_nav_synthesis_warning_persisted(seeded_portfolio):
+    """Executor-provided NAV synthesis feeds validation check #18."""
+    await _insert_calibration(
+        seeded_portfolio, advisor_enabled=True, max_single_fund_weight=0.25,
+    )
+    row = await _run_executor_with_mock(
+        seeded_portfolio,
+        _HAPPY_OPTIMIZER_OUTPUT,
+        nav_summary={
+            "portfolio_id": str(seeded_portfolio),
+            "status": "no_fund_data",
+            "dates_computed": 0,
+        },
+    )
+
+    assert row["status"] == "degraded"
+
+    statistical_inputs = json.loads(row["statistical_inputs"])
+    assert statistical_inputs["portfolio_nav_synthesis"]["status"] == "no_fund_data"
+
+    validation = json.loads(row["validation"])
+    nav_check = next(
+        c for c in validation["checks"] if c["id"] == "nav_synthesis_check"
+    )
+    assert nav_check["passed"] is False
+    assert nav_check["severity"] == "warn"
+    assert nav_check["value"] == 0
 
 
 # ── Path 1: Happy path ───────────────────────────────────────────

--- a/backend/tests/test_taa_sprint3.py
+++ b/backend/tests/test_taa_sprint3.py
@@ -240,7 +240,7 @@ class TestValidationGateTaaBands:
     def test_check_16_registered_in_checks(self):
         check_ids = [cid for cid, _ in CHECKS]
         assert "taa_bands_within_ips" in check_ids
-        assert len(CHECKS) == 17
+        assert len(CHECKS) == 18
 
     def test_check_passes_when_bands_within_ips(self):
         payload = _base_payload()
@@ -310,11 +310,11 @@ class TestValidationGateTaaBands:
         assert taa_check.passed is True
 
     def test_check_16_does_not_block_other_checks(self):
-        """All 17 checks still run when TAA check is present."""
+        """All 18 checks still run when TAA check is present."""
         payload = _base_payload()
         db_ctx = ValidationDbContext(block_constraints=BLOCK_CONSTRAINTS)
         result = validate_construction(payload, db_ctx)
-        assert len(result.checks) == 17
+        assert len(result.checks) == 18
 
 
 # ===================================================================
@@ -434,7 +434,7 @@ class TestBackwardCompatibility:
         payload = _base_payload()
         del payload["calibration_snapshot"]["taa"]
         result = validate_construction(payload, ValidationDbContext())
-        assert len(result.checks) == 17
+        assert len(result.checks) == 18
 
     def test_empty_taa_provenance_is_safe(self):
         payload = _base_payload()

--- a/backend/tests/test_validation_gate.py
+++ b/backend/tests/test_validation_gate.py
@@ -1,16 +1,16 @@
-"""Unit tests for the 17-check construction validation gate.
+"""Unit tests for the 18-check construction validation gate.
 
 Phase 3 Task 3.1 of `docs/superpowers/plans/2026-04-08-portfolio-enterprise-workbench.md`.
 
 Covers:
-- Happy path: a well-formed payload passes all 17 checks.
+- Happy path: a well-formed payload passes all 18 checks.
 - Per-check failure: each block-severity check fails in isolation
   and the aggregate ``ValidationResult.passed`` flips to False.
 - Aggregation semantics: a payload that fails 3 blocks and 2 warns
   reports ``passed=False`` + ``len(blocks)==3`` + ``len(warnings)==2``.
 - Fail-soft guarantee: a check that raises is caught and converted
   to a warn-level failure without stranding activation.
-- No fail-fast: ALL 17 checks run even if the first one fails.
+- No fail-fast: ALL 18 checks run even if the first one fails.
 - JSONB serialization shape is stable.
 """
 
@@ -33,7 +33,7 @@ from vertical_engines.wealth.model_portfolio.validation_gate import (
 
 
 def _base_payload() -> dict[str, Any]:
-    """A known-good construction run payload that passes all 17 checks."""
+    """A known-good construction run payload that passes all 18 checks."""
     return {
         "as_of_date": "2026-04-08",
         "weights_proposed": {
@@ -115,18 +115,18 @@ def _base_db_context() -> ValidationDbContext:
 def test_happy_path_passes_all_15_checks():
     result = validate_construction(_base_payload(), _base_db_context())
     assert result.passed is True
-    assert len(result.checks) == 17
+    assert len(result.checks) == 18
     assert result.blocks == []
     failed_ids = [c.id for c in result.checks if not c.passed]
     assert failed_ids == [], (
-        f"happy path should pass all 17 checks; failed: {failed_ids}"
+        f"happy path should pass all 18 checks; failed: {failed_ids}"
     )
 
 
 def test_all_15_checks_run_even_with_empty_payload():
-    """No fail-fast: empty payload still runs all 17 checks."""
+    """No fail-fast: empty payload still runs all 18 checks."""
     result = validate_construction({}, ValidationDbContext())
-    assert len(result.checks) == 17
+    assert len(result.checks) == 18
     ids = [c.id for c in result.checks]
     # Order must match the CHECKS registry exactly
     expected_ids = [check_id for check_id, _ in CHECKS]
@@ -384,8 +384,8 @@ def test_no_fail_fast_all_15_checks_run():
     """Even a payload that fails the first check must run all 17."""
     payload = {}  # everything missing
     result = validate_construction(payload, ValidationDbContext())
-    assert len(result.checks) == 17, (
-        "no fail-fast: all 17 checks must always run"
+    assert len(result.checks) == 18, (
+        "no fail-fast: all 18 checks must always run"
     )
 
 
@@ -397,7 +397,7 @@ def test_check_that_raises_preserves_intended_severity():
     payload = _base_payload()
     payload["weights_proposed"] = None  # likely to raise in multiple checks
     result = validate_construction(payload, _base_db_context())
-    assert len(result.checks) == 17  # all 17 still run
+    assert len(result.checks) == 18  # all 17 still run
     # Raised checks preserve their intended severity from
     # _INTENDED_SEVERITY, not always "warn".
     for c in result.checks:
@@ -414,9 +414,9 @@ def test_to_jsonb_shape():
     # PR-Q140: severity_breakdown added to the top-level shape.
     assert set(j.keys()) == {"passed", "checks", "summary", "severity_breakdown"}
     assert j["passed"] is True
-    assert len(j["checks"]) == 17
-    assert j["summary"]["total"] == 17
-    assert j["summary"]["passed"] == 17
+    assert len(j["checks"]) == 18
+    assert j["summary"]["total"] == 18
+    assert j["summary"]["passed"] == 18
     assert j["summary"]["blocks_failed"] == 0
     assert j["summary"]["warnings_failed"] == 0
     # All checks pass → severity_breakdown is empty.
@@ -492,7 +492,7 @@ def test_warn_check_exception_stays_warn_severity():
 
 
 def test_intended_severity_registry_covers_all_checks():
-    """_INTENDED_SEVERITY must list all 17 checks from the CHECKS registry."""
+    """_INTENDED_SEVERITY must list all 18 checks from the CHECKS registry."""
     check_ids = {check_id for check_id, _ in CHECKS}
     registry_ids = set(_INTENDED_SEVERITY.keys())
     assert check_ids == registry_ids, (

--- a/backend/tests/wealth/test_load_universe_funds_prefilter.py
+++ b/backend/tests/wealth/test_load_universe_funds_prefilter.py
@@ -627,9 +627,15 @@ async def test_executor_marks_real_solver_runs_as_succeeded() -> None:
             )
             await db.flush()
 
+            async def _fake_nav(*a: Any, **kw: Any) -> dict[str, Any]:
+                return {"status": "ok", "dates_computed": 5, "funds_covered": 1}
+
             with mock_patch(
                 "app.domains.wealth.routes.model_portfolios._run_construction_async",
                 new=_fake,
+            ), mock_patch(
+                "app.domains.wealth.workers.portfolio_nav_synthesizer.synthesize_portfolio_nav",
+                new=_fake_nav,
             ):
                 run = await execute_construction_run(
                     db,

--- a/backend/tests/wealth/test_q146_cascade_hygiene.py
+++ b/backend/tests/wealth/test_q146_cascade_hygiene.py
@@ -1,0 +1,252 @@
+"""PR-Q146: cascade hygiene terminus — 4 Med/Low findings.
+
+C-06: NAV synthesizer no_fund_data → run.status degraded or validation warn.
+C-07: mandate_infeasible_acknowledged required for mandate_infeasible activation.
+C-08: Phase 1 winner with Phase 3 cvar_within_limit=None → OPTIMAL (not DEGRADED_OTHER).
+C-09: factor covariance conditioning metadata persisted in statistical_inputs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.domains.wealth.schemas.sanitized import WinnerSignal, compute_winner_signal
+
+# ── Test 1 (C-06): NAV no_fund_data → degraded or validation warn ──
+
+
+def test_nav_synthesis_no_fund_data_escalates_to_degraded() -> None:
+    """When NAV synthesis returns dates_computed=0 and status='no_fund_data'
+    on a portfolio with instruments, the outer executor status derivation
+    must escalate 'succeeded' to 'degraded'.
+
+    We exercise the inline logic that PR-Q146 added after the cascade-driven
+    status derivation in execute_construction_run.
+    """
+    # Simulate the status derivation logic from the executor.
+    # The cascade says "phase_1_succeeded" → run.status = "succeeded".
+    run_status = "succeeded"
+    weights_proposed = {"fund_a": 0.5, "fund_b": 0.5}
+    nav_synthesis = {
+        "portfolio_id": "abc",
+        "status": "no_fund_data",
+        "dates_computed": 0,
+    }
+
+    # PR-Q146 (C-06) escalation logic (mirrors executor inline code):
+    if (
+        nav_synthesis is not None
+        and nav_synthesis.get("dates_computed") == 0
+        and nav_synthesis.get("status") == "no_fund_data"
+        and run_status == "succeeded"
+        and weights_proposed
+    ):
+        run_status = "degraded"
+
+    assert run_status == "degraded"
+
+    # Also test that the validation gate check catches this.
+    from vertical_engines.wealth.model_portfolio.validation_gate import (
+        ValidationDbContext,
+        validate_construction,
+    )
+
+    payload = {
+        "weights_proposed": weights_proposed,
+        "statistical_inputs": {
+            "portfolio_nav_synthesis": nav_synthesis,
+        },
+        "calibration_snapshot": {},
+        "ex_ante_metrics": {},
+        "funds": [],
+        "stress_results": [],
+        "optimizer_trace": {},
+    }
+    result = validate_construction(payload, ValidationDbContext())
+    nav_check = next(
+        (c for c in result.checks if c.id == "nav_synthesis_check"), None,
+    )
+    assert nav_check is not None
+    assert nav_check.passed is False
+    assert nav_check.severity == "warn"
+    assert "no_fund_data" in (nav_check.explanation or "")
+
+
+# ── Test 2 (C-07): mandate_infeasible_acknowledged required ─────────
+
+
+def test_mandate_infeasible_requires_structured_ack() -> None:
+    """Activating a mandate_infeasible portfolio with only
+    degraded_acknowledged=True must be rejected (422).
+    With mandate_infeasible_acknowledged=True it must succeed."""
+    from unittest.mock import MagicMock
+
+    from fastapi import HTTPException
+
+    # Simulate the activation gate logic from the route.
+    run = MagicMock()
+    run.status = "mandate_infeasible"
+    run.cascade_telemetry = {
+        "winner_signal": "cvar_infeasible_min_var",
+        "cascade_summary": "phase_3_min_cvar_above_limit",
+    }
+
+    # Case 1: only degraded_acknowledged → 422
+    metadata_missing: dict = {"degraded_acknowledged": True}
+    with pytest.raises(HTTPException) as exc_info:
+        if run.status == "mandate_infeasible":
+            if not metadata_missing.get("mandate_infeasible_acknowledged"):
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "Portfolio's latest construction run is mandate_infeasible. "
+                        "Set metadata.mandate_infeasible_acknowledged=true "
+                        "(in addition to degraded_acknowledged) to proceed."
+                    ),
+                )
+    assert exc_info.value.status_code == 422
+    assert "mandate_infeasible_acknowledged" in exc_info.value.detail
+
+    # Case 2: both acknowledged → passes
+    metadata_ok: dict = {
+        "degraded_acknowledged": True,
+        "mandate_infeasible_acknowledged": True,
+    }
+    actor_id = "operator-1"
+    if run.status == "mandate_infeasible":
+        if not metadata_ok.get("mandate_infeasible_acknowledged"):
+            raise AssertionError("Should not reach here")
+        metadata_ok["mandate_infeasible_acknowledged_by"] = actor_id
+
+    assert metadata_ok["mandate_infeasible_acknowledged_by"] == "operator-1"
+
+
+# ── Test 3 (C-08): Phase 1 winner + Phase 3 None → OPTIMAL ─────────
+
+
+def test_phase1_winner_with_phase3_none_is_optimal() -> None:
+    """When Phase 1 wins optimally and Phase 3 has cvar_within_limit=None
+    (solver glitch), the winner signal must be OPTIMAL, not DEGRADED_OTHER.
+
+    This tests the fix in _build_cascade_telemetry where _cvar_within_limit
+    is now derived from the winner's attempt for Phase 1/2, not Phase 3.
+    """
+    from app.domains.wealth.workers.construction_run_executor import (
+        _build_cascade_telemetry,
+    )
+
+    cascade_block = {
+        "phase_attempts": [
+            {
+                "phase": "phase_1_ru_max_return",
+                "status": "succeeded",
+                "solver": "CLARABEL",
+                "objective_value": 0.1085,
+                "wall_ms": 287,
+                "infeasibility_reason": None,
+                "cvar_at_solution": 0.047,
+                "cvar_at_solution_cf": 0.053,
+                "cvar_limit_effective": 0.05,
+                "cvar_within_limit": True,  # Phase 1 knows it's within limit
+            },
+            {
+                "phase": "phase_2_ru_robust",
+                "status": "skipped",
+                "solver": None,
+                "objective_value": None,
+                "wall_ms": 0,
+                "infeasibility_reason": None,
+            },
+            {
+                "phase": "phase_3_min_cvar",
+                "status": "succeeded",
+                "solver": "CLARABEL",
+                "objective_value": 0.035,
+                "wall_ms": 90,
+                "infeasibility_reason": None,
+                "cvar_at_solution": 0.035,
+                "cvar_at_solution_cf": None,
+                "cvar_limit_effective": 0.05,
+                "cvar_within_limit": None,  # Solver glitch: None
+            },
+        ],
+        "winning_phase": "phase_1_ru_max_return",
+        "min_achievable_cvar": 0.035,
+    }
+
+    telemetry, run_status = _build_cascade_telemetry(
+        cascade_block=cascade_block,
+        optimizer_trace={"status": "optimal"},
+        cvar_limit=0.05,
+    )
+
+    assert run_status == "succeeded"
+    # The key assertion: winner_signal must be OPTIMAL despite Phase 3's
+    # cvar_within_limit being None.
+    assert telemetry["winner_signal"] == WinnerSignal.OPTIMAL.value
+
+    # Also verify compute_winner_signal directly with the corrected logic:
+    signal = compute_winner_signal(
+        winning_phase="phase_1_ru_max_return",
+        cvar_within_limit=True,  # From Phase 1's own attempt
+        cvar_limit=0.05,
+        min_achievable_cvar=0.035,
+    )
+    assert signal is WinnerSignal.OPTIMAL
+
+
+# ── Test 4 (C-09): conditioning meta persisted ──────────────────────
+
+
+def test_factor_conditioning_meta_persisted() -> None:
+    """assemble_factor_covariance with rank-deficient input must produce
+    conditioning_meta with n_clamped > 0, and the metadata must be
+    persistable in run.statistical_inputs.factor_conditioning."""
+    from quant_engine.factor_model_service import (
+        FundamentalFactorFit,
+        compute_factor_conditioning_meta,
+    )
+
+    # Build a rank-deficient factor model: 10 funds, 3 factors, but one
+    # factor is near-zero (degenerate).
+    rng = np.random.default_rng(42)
+    loadings = rng.standard_normal((10, 3)).astype(np.float64)
+    factor_cov = np.eye(3, dtype=np.float64)
+    # Make third factor near-zero → creates near-zero eigenvalues in Σ
+    factor_cov[2, 2] = 1e-14
+    # Residual variance near-zero for some funds → rank-deficient
+    residual_variance = np.full(10, 1e-12, dtype=np.float64)
+
+    fit = FundamentalFactorFit(
+        loadings=loadings,
+        factor_cov=factor_cov,
+        residual_variance=residual_variance,
+        factor_names=["f1", "f2", "f3"],
+        residual_series=np.zeros((100, 10), dtype=np.float64),
+        r_squared_per_fund=np.ones(10, dtype=np.float64),
+    )
+
+    meta = compute_factor_conditioning_meta(fit)
+
+    # Verify the metadata structure
+    assert "kappa_before" in meta
+    assert "kappa_after" in meta
+    assert "eigenvalue_floor" in meta
+    assert "n_clamped" in meta
+
+    # With the near-zero factor and residuals, eigenvalue clamping should
+    # trigger (n_clamped > 0).
+    assert meta["n_clamped"] > 0
+    assert meta["kappa_after"] <= meta["kappa_before"]
+    assert meta["eigenvalue_floor"] > 0
+
+    # Verify it's JSON-serializable (will be persisted in JSONB).
+    import json
+
+    json.dumps(meta)  # Should not raise
+
+    # Simulate persistence in statistical_inputs:
+    statistical_inputs: dict = {}
+    statistical_inputs["factor_conditioning"] = meta
+    assert statistical_inputs["factor_conditioning"]["n_clamped"] > 0

--- a/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
+++ b/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
@@ -1,8 +1,8 @@
-"""Validation gate with 17 checks for construction runs.
+"""Validation gate with 18 checks for construction runs.
 
 Phase 3 Task 3.1 of `docs/superpowers/plans/2026-04-08-portfolio-enterprise-workbench.md`.
 
-Runs 17 independent checks against a construction run payload.
+Runs 18 independent checks against a construction run payload.
 **No fail-fast** — every check is evaluated so the UI can render a
 complete health panel, not just the first failure. Aggregation is
 ``passed = not any(block failures)``.
@@ -32,9 +32,9 @@ Public surface
 - :class:`ValidationResult` — aggregate result
 - :class:`ValidationDbContext` — pre-fetched DB rows needed by the
   checks (keeps the gate synchronous and testable)
-- :func:`validate_construction` — run all 17 and aggregate
+- :func:`validate_construction` — run all 18 and aggregate
 
-The 17 checks
+The 18 checks
 -------------
 1. weights-sum-to-one
 2. no-stale-nav
@@ -90,13 +90,13 @@ class ValidationCheck:
 
 @dataclass(frozen=True, slots=True)
 class ValidationResult:
-    """Aggregate of the 17 checks."""
+    """Aggregate of the 18 checks."""
 
     passed: bool
     """True if no block-severity check failed."""
 
     checks: list[ValidationCheck]
-    """All 17 checks in stable order."""
+    """All 18 checks in stable order."""
 
     warnings: list[ValidationCheck] = field(default_factory=list)
     """Subset of ``checks`` where ``severity='warn'`` and ``passed=False``."""
@@ -884,6 +884,62 @@ def _check_cvar_enforcement(
     )
 
 
+# ── Check #18: NAV synthesis coverage (PR-Q146 C-06) ──────────────
+
+
+def _check_nav_synthesis(
+    run_payload: dict[str, Any],
+    _db: ValidationDbContext,
+) -> ValidationCheck:
+    """Check #18: NAV synthesis produced at least 1 date.
+
+    PR-Q146 (C-06): ``synthesize_portfolio_nav`` may return
+    ``status='no_fund_data'`` with ``dates_computed=0`` when none of the
+    instruments have price data.  Warn severity when the shortfall is
+    solo (no other failures); callers combine with the run-level
+    ``degraded`` escalation for compound failures.
+    """
+    nav_synthesis = (run_payload.get("statistical_inputs") or {}).get(
+        "portfolio_nav_synthesis",
+    )
+    if nav_synthesis is None:
+        return ValidationCheck(
+            id="nav_synthesis_check",
+            label="NAV synthesis coverage",
+            passed=True,
+            severity="warn",
+            value=None,
+            threshold=1,
+            explanation="NAV synthesis not applicable (propose mode or pre-construction).",
+        )
+    dates_computed = nav_synthesis.get("dates_computed", 0)
+    nav_status = nav_synthesis.get("status", "unknown")
+    has_instruments = bool(run_payload.get("weights_proposed"))
+    if dates_computed == 0 and nav_status == "no_fund_data" and has_instruments:
+        return ValidationCheck(
+            id="nav_synthesis_check",
+            label="NAV synthesis coverage",
+            passed=False,
+            severity="warn",
+            value=0,
+            threshold=1,
+            explanation=(
+                f"NAV synthesis returned 0 dates (status={nav_status}). "
+                "None of the portfolio instruments have price data in the "
+                "lookback window."
+            ),
+        )
+    return ValidationCheck(
+        id="nav_synthesis_check",
+        label="NAV synthesis coverage",
+        passed=True,
+        severity="warn",
+        value=dates_computed,
+        threshold=1,
+        explanation=f"NAV synthesis OK: {dates_computed} dates computed.",
+    )
+
+
 # ── Check registry — stable order for JSONB serialization ─────────
 
 
@@ -905,6 +961,7 @@ CHECKS: Final[list[tuple[str, Callable[[dict[str, Any], ValidationDbContext], Va
     ("factor_model_r_squared",          _check_factor_model_r_squared),
     ("taa_bands_within_ips",            _check_taa_bands_within_ips),
     ("cvar_enforcement",                _check_cvar_enforcement),
+    ("nav_synthesis_check",             _check_nav_synthesis),
 ]
 
 
@@ -934,6 +991,7 @@ _INTENDED_SEVERITY: Final[dict[str, Severity]] = {
     "factor_model_r_squared": "warn",
     "taa_bands_within_ips": "block",
     "cvar_enforcement": "block",
+    "nav_synthesis_check": "warn",
 }
 
 
@@ -941,7 +999,7 @@ def validate_construction(
     run_payload: dict[str, Any],
     db_context: ValidationDbContext | None = None,
 ) -> ValidationResult:
-    """Run all 17 checks against the construction run payload.
+    """Run all 18 checks against the construction run payload.
 
     **No fail-fast.** Every check is evaluated so the UI can show
     the full health panel. Aggregation rule:


### PR DESCRIPTION
## Summary

Terminus bundle for 4 Wave 6 cascade audit findings (Med/Low severity).

- **C-06 (Med)** NAV synthesizer `no_fund_data` now escalates `run.status` to `degraded` + validation gate check #18 (`nav_synthesis_check`, warn severity)
- **C-07 (Med)** Activation route requires `mandate_infeasible_acknowledged=true` (separate from `degraded_acknowledged`) for mandate_infeasible portfolios — returns 422 if missing
- **C-08 (Low)** `_build_cascade_telemetry` derives `_cvar_within_limit` from the WINNER's attempt for Phase 1/2 (not Phase 3) — prevents OPTIMAL misclassification as DEGRADED_OTHER on Phase 3 solver glitch
- **C-09 (Med)** `compute_factor_conditioning_meta()` added to `factor_model_service` — eigenvalue regularization metadata persisted in `run.statistical_inputs.factor_conditioning`

## Files changed

| File | Change |
|------|--------|
| `construction_run_executor.py` | C-06 degraded escalation, C-08 winner_signal derivation fix |
| `model_portfolios.py` (route) | C-07 mandate_infeasible_acknowledged gate, C-09 factor_conditioning plumbing |
| `validation_gate.py` | C-06 check #18 (nav_synthesis_check) |
| `factor_model_service.py` | C-09 compute_factor_conditioning_meta() |
| `quant_queries.py` | C-09 wiring conditioning meta into inputs_metadata |
| `model_portfolio.py` (schema) | No changes needed (metadata is dict) |
| `test_q146_cascade_hygiene.py` | 4 new tests |
| `test_construct_end_to_end.py` | Mock NAV synthesis for C-06 compatibility |
| `test_validation_gate.py` | 17→18 check count |
| `test_taa_sprint3.py` | 17→18 check count |

## Test plan

- [x] 4 new tests in `test_q146_cascade_hygiene.py` pass
- [x] 31 existing `test_validation_gate.py` tests pass (18 checks)
- [x] 37 existing `test_taa_sprint3.py` tests pass (18 checks)
- [x] 15 existing `test_construct_end_to_end.py` tests pass
- [x] 20 existing cascade tests pass
- [x] 18 existing factor model tests pass
- [x] `ruff check` clean
- [x] No new mypy errors (pre-existing only)
- [x] No frontend changes