### PR TITLE
fix(wealth): PR-Q149 — IPCA factor contribution period bounds (F-S12-05)

### DIFF
--- a/backend/tests/vertical_engines/wealth/test_attribution_ipca_rail_unit.py
+++ b/backend/tests/vertical_engines/wealth/test_attribution_ipca_rail_unit.py
@@ -351,3 +351,304 @@ async def test_symmetric_option_a_fallback(failure_scenario):
 
     assert result is sentinel, f"Expected Option A fallback for {failure_scenario}, got {result}"
     mock_opt_a.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests 9-11: IPCA period bounds (PR-Q149 / F-S12-05)
+# ---------------------------------------------------------------------------
+
+def test_resolve_period_bounds_explicit():
+    """9a. Explicit period_start/end passes through unchanged."""
+    from vertical_engines.wealth.attribution.ipca_rail import _resolve_period_bounds
+
+    req = _make_request(period_start=date(2025, 6, 1), period_end=date(2026, 4, 19))
+    start, end, defaulted = _resolve_period_bounds(req)
+    assert start == date(2025, 6, 1)
+    assert end == date(2026, 4, 19)
+    assert defaulted is False
+
+
+def test_resolve_period_bounds_defaults_to_lookback():
+    """9b. None period_start defaults to asof - lookback_months."""
+    from vertical_engines.wealth.attribution.ipca_rail import _resolve_period_bounds
+
+    req = _make_request(period_start=None, period_end=None, lookback_months=12)
+    start, end, defaulted = _resolve_period_bounds(req)
+    # lookback_months=12 → ~365 days
+    assert start < req.asof
+    delta_days = (req.asof - start).days
+    # 12 * 30.4375 = 365.25 → int = 365
+    assert 360 <= delta_days <= 370
+    assert end == req.asof
+    assert defaulted is True
+
+
+@pytest.mark.asyncio
+async def test_ipca_period_bounded():
+    """10. Two requests with different period bounds produce different contributions.
+
+    When period bounds are respected, factor_returns_contribution reflects
+    only the factor returns in the specified period — not the full history.
+    Two non-overlapping periods must yield different contribution vectors.
+    """
+    # Build a fit with 60 months of factor returns. First 30 months have
+    # positive factor returns, last 30 have negative. If period bounds
+    # are respected, period=[0..30] gives positive mean, period=[30..60]
+    # gives negative mean.
+    K = 3
+    rng = np.random.default_rng(149)
+    factor_returns = np.zeros((K, 60))
+    factor_returns[:, :30] = np.abs(rng.standard_normal((K, 30))) + 0.01
+    factor_returns[:, 30:] = -np.abs(rng.standard_normal((K, 30))) - 0.01
+
+    dates = pd.date_range("2021-01-31", periods=60, freq="ME")
+
+    fit = IPCAFit(
+        gamma=np.eye(6, K, dtype=np.float64),
+        factor_returns=factor_returns,
+        K=K,
+        intercept=False,
+        r_squared=0.5,
+        oos_r_squared=0.03,
+        converged=True,
+        n_iterations=50,
+        dates=dates,
+    )
+
+    fund_id = uuid4()
+
+    # Period A: first 30 months (positive factor returns)
+    req_a = AttributionRequest(
+        fund_instrument_id=fund_id,
+        asof=date(2023, 6, 30),
+        fund_asset_class="Equity",
+        period_start=date(2021, 1, 1),
+        period_end=date(2023, 6, 30),
+    )
+
+    # Period B: last 30 months (negative factor returns)
+    req_b = AttributionRequest(
+        fund_instrument_id=fund_id,
+        asof=date(2026, 1, 31),
+        fund_asset_class="Equity",
+        period_start=date(2023, 7, 1),
+        period_end=date(2026, 1, 31),
+    )
+
+    ref_date = date(2026, 3, 31)
+    cs_rows = [
+        _CSRow(instrument_id=fund_id, size=1.0, value=1.0, momentum=1.0,
+               quality=1.0, investment=1.0, profitability=1.0),
+    ]
+    h_rows = [_HRow(pct_of_nav=10.0, instrument_id=fund_id)]
+
+    async def _run_with_request(req):
+        call_count = 0
+
+        async def mock_execute(stmt, params=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _FakeResult([_RefRow(ref_period=ref_date)])
+            elif call_count == 2:
+                return _FakeResult(cs_rows)
+            elif call_count == 3:
+                return _FakeResult(h_rows)
+            return _FakeResult([])
+
+        db = AsyncMock()
+        db.execute = mock_execute
+
+        with patch("vertical_engines.wealth.attribution.ipca_rail.load_latest_ipca_fit", return_value=fit), \
+             patch("vertical_engines.wealth.attribution.ipca_rail.resolve_cik",
+                   new=AsyncMock(return_value=_mock_cik("0001234567"))), \
+             patch("vertical_engines.wealth.attribution.ipca_rail.latest_period_for_cik",
+                   return_value=date(2026, 3, 31)), \
+             patch("vertical_engines.wealth.attribution.ipca_rail._estimate_alpha_fixed_beta",
+                   new=AsyncMock(return_value=0.0)):
+            return await run_ipca_rail(req, db)
+
+    result_a = await _run_with_request(req_a)
+    result_b = await _run_with_request(req_b)
+
+    assert result_a is not None, "Period A returned None"
+    assert result_b is not None, "Period B returned None"
+    # Contributions must differ — period A positive, period B negative
+    for i in range(K):
+        assert result_a.factor_returns_contribution[i] != result_b.factor_returns_contribution[i], (
+            f"Factor {i} contribution identical for different periods — bounds not respected"
+        )
+
+
+@pytest.mark.asyncio
+async def test_ipca_default_period_uses_lookback():
+    """11. Request with None period bounds defaults to asof - lookback_months.
+
+    Build a fit spanning 120 months. Request with asof near the end and
+    lookback_months=12 should use only the last ~12 months for f_t_mean,
+    not all 120. Verify by comparing against explicit period bounds matching
+    the same lookback window.
+    """
+    from datetime import timedelta
+
+    K = 3
+    rng = np.random.default_rng(1149)
+    dates = pd.date_range("2016-01-31", periods=120, freq="ME")
+    factor_returns = rng.standard_normal((K, 120))
+    # Make the first 108 months have very different mean from the last 12
+    factor_returns[:, :108] = factor_returns[:, :108] + 5.0
+
+    fit = IPCAFit(
+        gamma=np.eye(6, K, dtype=np.float64),
+        factor_returns=factor_returns,
+        K=K,
+        intercept=False,
+        r_squared=0.5,
+        oos_r_squared=0.03,
+        converged=True,
+        n_iterations=50,
+        dates=dates,
+    )
+
+    fund_id = uuid4()
+    asof = date(2025, 12, 31)
+
+    # Request with None period bounds + lookback_months=12
+    req_default = AttributionRequest(
+        fund_instrument_id=fund_id,
+        asof=asof,
+        fund_asset_class="Equity",
+        lookback_months=12,
+        period_start=None,
+        period_end=None,
+    )
+
+    # Request with explicit period matching the lookback
+    inferred_start = asof - timedelta(days=int(30.4375 * 12))
+    req_explicit = AttributionRequest(
+        fund_instrument_id=fund_id,
+        asof=asof,
+        fund_asset_class="Equity",
+        lookback_months=12,
+        period_start=inferred_start,
+        period_end=asof,
+    )
+
+    ref_date = date(2026, 3, 31)
+    cs_rows = [
+        _CSRow(instrument_id=fund_id, size=1.0, value=1.0, momentum=1.0,
+               quality=1.0, investment=1.0, profitability=1.0),
+    ]
+    h_rows = [_HRow(pct_of_nav=10.0, instrument_id=fund_id)]
+
+    async def _run_with_request(req):
+        call_count = 0
+
+        async def mock_execute(stmt, params=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _FakeResult([_RefRow(ref_period=ref_date)])
+            elif call_count == 2:
+                return _FakeResult(cs_rows)
+            elif call_count == 3:
+                return _FakeResult(h_rows)
+            return _FakeResult([])
+
+        db = AsyncMock()
+        db.execute = mock_execute
+
+        with patch("vertical_engines.wealth.attribution.ipca_rail.load_latest_ipca_fit", return_value=fit), \
+             patch("vertical_engines.wealth.attribution.ipca_rail.resolve_cik",
+                   new=AsyncMock(return_value=_mock_cik("0001234567"))), \
+             patch("vertical_engines.wealth.attribution.ipca_rail.latest_period_for_cik",
+                   return_value=date(2026, 3, 31)), \
+             patch("vertical_engines.wealth.attribution.ipca_rail._estimate_alpha_fixed_beta",
+                   new=AsyncMock(return_value=0.0)):
+            return await run_ipca_rail(req, db)
+
+    result_default = await _run_with_request(req_default)
+    result_explicit = await _run_with_request(req_explicit)
+
+    assert result_default is not None, "Default period returned None"
+    assert result_explicit is not None, "Explicit period returned None"
+    # Both should produce identical contributions (same bounds)
+    for i in range(K):
+        assert abs(result_default.factor_returns_contribution[i] -
+                   result_explicit.factor_returns_contribution[i]) < 1e-12, (
+            f"Factor {i} contribution differs between default and explicit lookback bounds"
+        )
+
+
+@pytest.mark.asyncio
+async def test_ipca_no_lookback_degrades_gracefully():
+    """12. Edge case where lookback produces no factor data — degraded, not crash.
+
+    When factor_returns_for_period returns an empty array (no factor data
+    in the lookback window), the rail should return zero contributions,
+    not raise an exception.
+    """
+    K = 3
+    # Factor returns only cover 2020; asof is 2026 with lookback=12 months
+    dates = pd.date_range("2020-01-31", periods=12, freq="ME")
+    rng = np.random.default_rng(2149)
+    factor_returns = rng.standard_normal((K, 12))
+
+    fit = IPCAFit(
+        gamma=np.eye(6, K, dtype=np.float64),
+        factor_returns=factor_returns,
+        K=K,
+        intercept=False,
+        r_squared=0.5,
+        oos_r_squared=0.03,
+        converged=True,
+        n_iterations=50,
+        dates=dates,
+    )
+
+    fund_id = uuid4()
+    req = AttributionRequest(
+        fund_instrument_id=fund_id,
+        asof=date(2026, 4, 19),
+        fund_asset_class="Equity",
+        lookback_months=12,
+    )
+
+    ref_date = date(2026, 3, 31)
+    cs_rows = [
+        _CSRow(instrument_id=fund_id, size=1.0, value=1.0, momentum=1.0,
+               quality=1.0, investment=1.0, profitability=1.0),
+    ]
+    h_rows = [_HRow(pct_of_nav=10.0, instrument_id=fund_id)]
+
+    call_count = 0
+
+    async def mock_execute(stmt, params=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeResult([_RefRow(ref_period=ref_date)])
+        elif call_count == 2:
+            return _FakeResult(cs_rows)
+        elif call_count == 3:
+            return _FakeResult(h_rows)
+        return _FakeResult([])
+
+    db = AsyncMock()
+    db.execute = mock_execute
+
+    with patch("vertical_engines.wealth.attribution.ipca_rail.load_latest_ipca_fit", return_value=fit), \
+         patch("vertical_engines.wealth.attribution.ipca_rail.resolve_cik",
+               new=AsyncMock(return_value=_mock_cik("0001234567"))), \
+         patch("vertical_engines.wealth.attribution.ipca_rail.latest_period_for_cik",
+               return_value=date(2026, 3, 31)), \
+         patch("vertical_engines.wealth.attribution.ipca_rail._estimate_alpha_fixed_beta",
+               new=AsyncMock(return_value=0.0)):
+        result = await run_ipca_rail(req, db)
+
+    assert result is not None, "Rail crashed instead of degrading gracefully"
+    # All contributions should be zero (no factor data in lookback window)
+    for i in range(K):
+        assert result.factor_returns_contribution[i] == 0.0, (
+            f"Factor {i} contribution should be 0.0 when no data in lookback period"
+        )

--- a/backend/tests/vertical_engines/wealth/test_attribution_ipca_rail_unit.py
+++ b/backend/tests/vertical_engines/wealth/test_attribution_ipca_rail_unit.py
@@ -383,6 +383,29 @@ def test_resolve_period_bounds_defaults_to_lookback():
     assert defaulted is True
 
 
+def test_resolve_period_bounds_anchors_to_period_end():
+    """9c. When period_end is explicit but period_start is None, lookback
+    anchors to period_end — not asof — preventing inverted windows on
+    backdated analyses (P1 badge fix)."""
+    from vertical_engines.wealth.attribution.ipca_rail import _resolve_period_bounds
+
+    # Backdated: period_end is 1 year before asof
+    req = _make_request(
+        asof=date(2026, 4, 19),
+        period_start=None,
+        period_end=date(2025, 4, 19),
+        lookback_months=6,
+    )
+    start, end, defaulted = _resolve_period_bounds(req)
+    assert end == date(2025, 4, 19)
+    assert defaulted is True
+    # start must be ~6 months before period_end, not before asof
+    assert start < end, "inverted window: start >= end"
+    delta_days = (end - start).days
+    # 6 * 30.4375 ≈ 182
+    assert 178 <= delta_days <= 188
+
+
 @pytest.mark.asyncio
 async def test_ipca_period_bounded():
     """10. Two requests with different period bounds produce different contributions.

--- a/backend/vertical_engines/wealth/attribution/ipca_rail.py
+++ b/backend/vertical_engines/wealth/attribution/ipca_rail.py
@@ -1,7 +1,7 @@
 """IPCA attribution rail."""
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import date, timedelta
 from typing import Any
 
 import numpy as np
@@ -70,11 +70,29 @@ async def load_latest_ipca_fit(
     )
 
 
+def _resolve_period_bounds(
+    request: AttributionRequest,
+) -> tuple[date, date, bool]:
+    """Derive period_start/end from request, defaulting to lookback window.
+
+    Returns (period_start, period_end, defaulted) where ``defaulted`` is True
+    when the caller did not supply explicit bounds and we fell back to
+    ``asof - lookback_months``.  This prevents full-history averaging that
+    introduces look-ahead / survivorship bias in DD reports (F-S12-05).
+    """
+    period_end = request.period_end if request.period_end is not None else request.asof
+    if request.period_start is not None:
+        return request.period_start, period_end, False
+    # Mirror the returns-rail pattern: 30.4375 days/month
+    inferred_start = request.asof - timedelta(days=int(30.4375 * request.lookback_months))
+    return inferred_start, period_end, True
+
+
 async def run_ipca_rail(request: AttributionRequest, db: AsyncSession) -> IPCAResult | None:
     """Execute IPCA attribution rail (Option B: Instrumented)."""
     if not request.fund_asset_class:
         return None
-        
+
     fit = await load_latest_ipca_fit(db, request.fund_asset_class)
     # IPCA validity gate. KP-S 2019 reports realistic out-of-sample R² in
     # the 0.02-0.05 band on equity panels — accept any positive signal.
@@ -207,16 +225,27 @@ async def run_ipca_rail(request: AttributionRequest, db: AsyncSession) -> IPCARe
     # Implied beta = Gamma' * z_fund
     beta = fit.gamma.T @ z_fund
     
-    # Calculate returns contribution
-    factor_returns_period = fit.factor_returns_for_period(request.period_start, request.period_end)
-    f_t_mean = factor_returns_period.mean(axis=1) if factor_returns_period.size > 0 else np.zeros(fit.K)
+    # Calculate returns contribution — always period-bounded (F-S12-05)
+    period_start, period_end, period_defaulted = _resolve_period_bounds(request)
+    factor_returns_period = fit.factor_returns_for_period(period_start, period_end)
+
+    if factor_returns_period.size == 0:
+        logger.warning(
+            "ipca_factor_returns_empty_for_period",
+            period_start=str(period_start),
+            period_end=str(period_end),
+            defaulted=period_defaulted,
+        )
+        f_t_mean = np.zeros(fit.K)
+    else:
+        f_t_mean = factor_returns_period.mean(axis=1)
     contribution_per_factor = beta * f_t_mean
-    
+
     # Estimate alpha using fixed beta
     alpha = await _estimate_alpha_fixed_beta(request, db, fit, beta)
-    
+
     factor_names = ["Size", "Value", "Momentum", "Quality", "Investment", "Profitability"]
-    
+
     return IPCAResult(
         factor_names=factor_names[:fit.K],
         factor_exposures=beta.tolist(),
@@ -299,7 +328,7 @@ async def _run_ipca_rail_option_a(request: AttributionRequest, db: AsyncSession,
     rows = res.all()
     if len(rows) < 12:  # require at least 12 months for regression
         return None
-        
+
     fund_returns_df = pd.DataFrame(
         [(r.month, float(r.nav_eom)) for r in rows],
         columns=["month", "nav"]
@@ -325,11 +354,19 @@ async def _run_ipca_rail_option_a(request: AttributionRequest, db: AsyncSession,
     if len(aligned) < 12:
         return None
 
+    # --- Period-bound the aligned data (F-S12-05) ---
+    # Regression uses all aligned history for beta estimation (more data =
+    # better regression), but factor contribution (f_t_mean) must be
+    # computed only over the analysis period to avoid look-ahead bias.
+    period_start, period_end, period_defaulted = _resolve_period_bounds(request)
+    p_start = pd.Period(period_start, freq="M")
+    p_end = pd.Period(period_end, freq="M")
+
     # Time-series regression: r_fund_t = α + β' f_t + ε_t
     y = aligned["return"].values
     X = aligned[[f"factor_{i}" for i in range(fit.K)]].values
     X_sm = sm.add_constant(X)
-    
+
     try:
         model = sm.OLS(y, X_sm).fit()
         alpha = float(model.params[0])
@@ -338,11 +375,25 @@ async def _run_ipca_rail_option_a(request: AttributionRequest, db: AsyncSession,
         logger.warning("ipca_regression_failed", error=str(e))
         return None
 
-    f_t_mean = X.mean(axis=0)
+    # Factor contribution uses period-bounded subset only
+    period_mask = (aligned.index >= p_start) & (aligned.index <= p_end)
+    aligned_period = aligned[period_mask]
+
+    if len(aligned_period) == 0:
+        logger.warning(
+            "ipca_option_a_no_data_in_period",
+            period_start=str(period_start),
+            period_end=str(period_end),
+            defaulted=period_defaulted,
+        )
+        f_t_mean = np.zeros(fit.K)
+    else:
+        X_period = aligned_period[[f"factor_{i}" for i in range(fit.K)]].values
+        f_t_mean = X_period.mean(axis=0)
     contribution_per_factor = beta * f_t_mean
 
     factor_names = ["Size", "Value", "Momentum", "Quality", "Investment", "Profitability"]
-    
+
     return IPCAResult(
         factor_names=factor_names[:fit.K],
         factor_exposures=beta.tolist(),

--- a/backend/vertical_engines/wealth/attribution/ipca_rail.py
+++ b/backend/vertical_engines/wealth/attribution/ipca_rail.py
@@ -83,8 +83,10 @@ def _resolve_period_bounds(
     period_end = request.period_end if request.period_end is not None else request.asof
     if request.period_start is not None:
         return request.period_start, period_end, False
-    # Mirror the returns-rail pattern: 30.4375 days/month
-    inferred_start = request.asof - timedelta(days=int(30.4375 * request.lookback_months))
+    # Mirror the returns-rail pattern: 30.4375 days/month.
+    # Anchor to period_end (not asof) so backdated analyses don't produce
+    # inverted windows when period_end < asof.
+    inferred_start = period_end - timedelta(days=int(30.4375 * request.lookback_months))
     return inferred_start, period_end, True
 
 


### PR DESCRIPTION
## Summary

- **F-S12-05 (Crit):** When `period_start`/`period_end` are None, `factor_returns_for_period` returned ALL historical factor returns — look-ahead bias in DD reports.
- Fix: `_resolve_period_bounds()` defaults `period_start` to `asof - lookback_months`, `period_end` to `asof`. Graceful degradation when period yields empty factor data.
- Both instrumented path and time-series regression fallback respect period bounds.

## Test plan

- [x] `test_ipca_period_bounded` — different periods produce different contributions
- [x] `test_ipca_default_period_uses_lookback` — None bounds match explicit lookback bounds
- [x] `test_ipca_no_lookback_degrades_gracefully` — empty period → zero contributions, no crash
- [x] All 15 IPCA unit tests pass, 80 IPCA-related tests pass
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)