### PR TITLE
fix(wealth): PR-Q151 — defensive fallback cluster

### DIFF
--- a/backend/app/domains/wealth/schemas/correlation_regime.py
+++ b/backend/app/domains/wealth/schemas/correlation_regime.py
@@ -49,6 +49,8 @@ class CorrelationRegimeRead(BaseModel):
     baseline_average_correlation: float
     regime_shift_detected: bool
     computed_at: datetime
+    degraded: bool = False
+    degraded_reason: str | None = None
 
 
 class PairCorrelationTimeseriesRead(BaseModel):

--- a/backend/quant_engine/active_share_service.py
+++ b/backend/quant_engine/active_share_service.py
@@ -24,6 +24,8 @@ class ActiveShareResult:
     n_portfolio_positions: int = 0
     n_benchmark_positions: int = 0
     n_common_positions: int = 0
+    degraded: bool = False
+    degraded_reason: str | None = None
 
 
 def compute_active_share(
@@ -43,13 +45,34 @@ def compute_active_share(
         Annualized excess return for efficiency calculation.
 
     """
-    if not portfolio_weights or not benchmark_weights:
+    if not portfolio_weights and not benchmark_weights:
+        return ActiveShareResult(
+            active_share=100.0,
+            overlap=0.0,
+            n_portfolio_positions=0,
+            n_benchmark_positions=0,
+            n_common_positions=0,
+            degraded=True,
+            degraded_reason="no_positions",
+        )
+    if not benchmark_weights:
         return ActiveShareResult(
             active_share=100.0,
             overlap=0.0,
             n_portfolio_positions=len(portfolio_weights),
+            n_benchmark_positions=0,
+            n_common_positions=0,
+            degraded=True,
+            degraded_reason="no_benchmark",
+        )
+    if not portfolio_weights:
+        return ActiveShareResult(
+            active_share=100.0,
+            overlap=0.0,
+            n_portfolio_positions=0,
             n_benchmark_positions=len(benchmark_weights),
             n_common_positions=0,
+            degraded=False,
         )
 
     # Union of all position identifiers

--- a/backend/tests/test_active_share_service.py
+++ b/backend/tests/test_active_share_service.py
@@ -122,6 +122,8 @@ class TestEdgeCases:
         assert result.active_share == 100.0
         assert result.n_portfolio_positions == 0
         assert result.n_common_positions == 0
+        # Empty portfolio with non-empty benchmark is well-defined (100% AS)
+        assert result.degraded is False
 
     def test_empty_benchmark(self):
         result = compute_active_share(
@@ -160,3 +162,47 @@ class TestEdgeCases:
         )
         with pytest.raises(AttributeError):
             result.active_share = 0.0  # type: ignore[misc]
+
+
+# ── Degraded flag (F-S12-06) ────────────────────────────────────────
+
+
+class TestDegradedFlag:
+    def test_active_share_empty_benchmark_degraded(self):
+        """Empty benchmark → degraded=True, reason='no_benchmark'."""
+        result = compute_active_share(
+            portfolio_weights={"A": 0.5, "B": 0.5},
+            benchmark_weights={},
+        )
+        assert result.degraded is True
+        assert result.degraded_reason == "no_benchmark"
+        assert result.active_share == 100.0
+
+    def test_active_share_both_empty_degraded(self):
+        """Both empty → degraded=True, reason='no_positions'."""
+        result = compute_active_share(
+            portfolio_weights={},
+            benchmark_weights={},
+        )
+        assert result.degraded is True
+        assert result.degraded_reason == "no_positions"
+        assert result.active_share == 100.0
+
+    def test_active_share_portfolio_empty_not_degraded(self):
+        """Empty portfolio + non-empty benchmark → degraded=False (well-defined)."""
+        result = compute_active_share(
+            portfolio_weights={},
+            benchmark_weights={"A": 1.0},
+        )
+        assert result.degraded is False
+        assert result.degraded_reason is None
+        assert result.active_share == 100.0
+
+    def test_normal_computation_not_degraded(self):
+        """Normal computation → degraded=False."""
+        result = compute_active_share(
+            portfolio_weights={"A": 0.5, "B": 0.5},
+            benchmark_weights={"A": 0.4, "B": 0.6},
+        )
+        assert result.degraded is False
+        assert result.degraded_reason is None

--- a/backend/tests/test_correlation.py
+++ b/backend/tests/test_correlation.py
@@ -342,3 +342,42 @@ class TestCorrelationModels:
             mp_threshold=1.2, n_signal_eigenvalues=1,
         )
         assert ca.concentration_status == "moderate_concentration"
+
+
+# ── Degraded flag (F-S12-11) ────────────────────────────────────────
+
+
+class TestCorrelationInsufficientDataDegraded:
+    def test_correlation_insufficient_data_degraded(self):
+        """Insufficient data → degraded=True, concentration_status='unknown'."""
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0, 0.01, (30, 3))
+        svc = CorrelationService(config={"min_observations": 45})
+        result = svc.analyze_portfolio_correlation(
+            instrument_ids=("id-a", "id-b", "id-c"),
+            instrument_names=("Fund A", "Fund B", "Fund C"),
+            returns_matrix=returns,
+            profile="moderate",
+        )
+        assert result.degraded is True
+        assert result.degraded_reason == "insufficient_data"
+        assert result.concentration.concentration_status == "unknown"
+        assert result.concentration.absorption_status == "unknown"
+        assert result.concentration.diversification_ratio == 0.0
+
+    def test_sufficient_data_not_degraded(self):
+        """Sufficient data → degraded=False."""
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0, 0.01, (100, 3))
+        svc = CorrelationService(config={
+            "apply_denoising": False, "apply_shrinkage": False,
+            "min_observations": 10, "window_days": 100,
+        })
+        result = svc.analyze_portfolio_correlation(
+            instrument_ids=("id-a", "id-b", "id-c"),
+            instrument_names=("Fund A", "Fund B", "Fund C"),
+            returns_matrix=returns,
+            profile="moderate",
+        )
+        assert result.degraded is False
+        assert result.degraded_reason is None

--- a/backend/tests/vertical_engines/wealth/test_attribution_ipca_rail_unit.py
+++ b/backend/tests/vertical_engines/wealth/test_attribution_ipca_rail_unit.py
@@ -47,16 +47,22 @@ def _make_request(**overrides) -> AttributionRequest:
 
 
 def _make_fit(oos_r_squared: float = 0.03, K: int = 6) -> IPCAFit:
+    # 30 monthly periods from 2024-01 to 2026-06, covering the default
+    # request window (2026-01 → 2026-04) so factor_returns_for_period
+    # returns non-empty.  Prior to F-S12-08 the rail silently returned
+    # zeros on empty periods; now it returns None, so test fixtures
+    # must have factor data spanning the analysis window.
+    n_periods = 30
     return IPCAFit(
         gamma=np.eye(K, dtype=np.float64),
-        factor_returns=np.random.default_rng(42).standard_normal((K, 20)),
+        factor_returns=np.random.default_rng(42).standard_normal((K, n_periods)),
         K=K,
         intercept=False,
         r_squared=0.5,
         oos_r_squared=oos_r_squared,
         converged=True,
         n_iterations=50,
-        dates=pd.date_range("2024-01-31", periods=20, freq="ME"),
+        dates=pd.date_range("2024-01-31", periods=n_periods, freq="ME"),
     )
 
 
@@ -271,20 +277,22 @@ async def test_option_a_date_alignment():
 
     req = _make_request()
     fit = _make_fit(K=4)
-    # Override dates to end-of-month (like real IPCA fits)
+    # Override dates to end-of-month covering the request period (2026-01..2026-04).
+    # 30 periods from 2024-01 → 2026-06 so factor_returns_for_period is non-empty.
     fit = IPCAFit(
         gamma=fit.gamma[:, :4],  # 6×4
-        factor_returns=np.random.default_rng(99).standard_normal((4, 24)),
+        factor_returns=np.random.default_rng(99).standard_normal((4, 30)),
         K=4,
         intercept=False,
         r_squared=0.5,
         oos_r_squared=0.03,
         converged=True,
         n_iterations=50,
-        dates=pd.date_range("2024-01-31", periods=24, freq="ME"),
+        dates=pd.date_range("2024-01-31", periods=30, freq="ME"),
     )
 
-    # Simulate nav rows with first-of-month dates (as produced by date_trunc)
+    # Simulate nav rows with first-of-month dates (as produced by date_trunc).
+    # Must span through 2026 so aligned_period has data in 2026-01..2026-04.
     _NavRow = namedtuple("_NavRow", ["month", "nav_eom"])
     nav_rows = [
         _NavRow(month=date(2023, m, 1), nav_eom=100.0 + m)
@@ -292,6 +300,12 @@ async def test_option_a_date_alignment():
     ] + [
         _NavRow(month=date(2024, m, 1), nav_eom=112.0 + m * 0.5)
         for m in range(1, 13)
+    ] + [
+        _NavRow(month=date(2025, m, 1), nav_eom=118.0 + m * 0.3)
+        for m in range(1, 13)
+    ] + [
+        _NavRow(month=date(2026, m, 1), nav_eom=121.6 + m * 0.2)
+        for m in range(1, 5)
     ]
 
     async def mock_execute(stmt, params=None):
@@ -604,12 +618,12 @@ async def test_ipca_default_period_uses_lookback():
 
 
 @pytest.mark.asyncio
-async def test_ipca_no_lookback_degrades_gracefully():
-    """12. Edge case where lookback produces no factor data — degraded, not crash.
+async def test_ipca_empty_period_returns_none():
+    """12. Empty factor period → None (dispatcher falls through to next rail).
 
     When factor_returns_for_period returns an empty array (no factor data
-    in the lookback window), the rail should return zero contributions,
-    not raise an exception.
+    in the lookback window), the rail must return None instead of emitting
+    zero contributions with positive confidence (F-S12-08).
     """
     K = 3
     # Factor returns only cover 2020; asof is 2026 with lookback=12 months
@@ -669,9 +683,6 @@ async def test_ipca_no_lookback_degrades_gracefully():
                new=AsyncMock(return_value=0.0)):
         result = await run_ipca_rail(req, db)
 
-    assert result is not None, "Rail crashed instead of degrading gracefully"
-    # All contributions should be zero (no factor data in lookback window)
-    for i in range(K):
-        assert result.factor_returns_contribution[i] == 0.0, (
-            f"Factor {i} contribution should be 0.0 when no data in lookback period"
-        )
+    assert result is None, (
+        "Rail should return None on empty factor period so dispatcher falls through"
+    )

--- a/backend/vertical_engines/wealth/attribution/ipca_rail.py
+++ b/backend/vertical_engines/wealth/attribution/ipca_rail.py
@@ -238,9 +238,8 @@ async def run_ipca_rail(request: AttributionRequest, db: AsyncSession) -> IPCARe
             period_end=str(period_end),
             defaulted=period_defaulted,
         )
-        f_t_mean = np.zeros(fit.K)
-    else:
-        f_t_mean = factor_returns_period.mean(axis=1)
+        return None
+    f_t_mean = factor_returns_period.mean(axis=1)
     contribution_per_factor = beta * f_t_mean
 
     # Estimate alpha using fixed beta
@@ -388,10 +387,9 @@ async def _run_ipca_rail_option_a(request: AttributionRequest, db: AsyncSession,
             period_end=str(period_end),
             defaulted=period_defaulted,
         )
-        f_t_mean = np.zeros(fit.K)
-    else:
-        X_period = aligned_period[[f"factor_{i}" for i in range(fit.K)]].values
-        f_t_mean = X_period.mean(axis=0)
+        return None
+    X_period = aligned_period[[f"factor_{i}" for i in range(fit.K)]].values
+    f_t_mean = X_period.mean(axis=0)
     contribution_per_factor = beta * f_t_mean
 
     factor_names = ["Size", "Value", "Momentum", "Quality", "Investment", "Profitability"]

--- a/backend/vertical_engines/wealth/correlation/models.py
+++ b/backend/vertical_engines/wealth/correlation/models.py
@@ -54,3 +54,5 @@ class PortfolioCorrelationResult:
     baseline_average_correlation: float
     regime_shift_detected: bool
     computed_at: datetime
+    degraded: bool = False
+    degraded_reason: str | None = None

--- a/backend/vertical_engines/wealth/correlation/service.py
+++ b/backend/vertical_engines/wealth/correlation/service.py
@@ -66,15 +66,17 @@ class CorrelationService:
                 contagion_pairs=(),
                 concentration=ConcentrationAnalysis(
                     eigenvalues=(), explained_variance_ratios=(),
-                    first_eigenvalue_ratio=0.0, concentration_status="diversified",
-                    diversification_ratio=1.0, dr_alert=False,
-                    absorption_ratio=0.0, absorption_status="normal",
+                    first_eigenvalue_ratio=0.0, concentration_status="unknown",
+                    diversification_ratio=0.0, dr_alert=False,
+                    absorption_ratio=0.0, absorption_status="unknown",
                     mp_threshold=0.0, n_signal_eigenvalues=0,
                 ),
                 average_correlation=0.0,
                 baseline_average_correlation=0.0,
                 regime_shift_detected=False,
                 computed_at=datetime.now(UTC),
+                degraded=True,
+                degraded_reason="insufficient_data",
             )
 
         # Map pair indices to instrument identifiers


### PR DESCRIPTION
## Summary

- **F-S12-06 (High):** Active share returns `degraded=True` with `degraded_reason="no_benchmark"` or `"no_positions"` on empty inputs, instead of silently reporting 100.0 (indistinguishable from truly fully-active fund). Empty portfolio with non-empty benchmark remains `degraded=False` (well-defined: 100% AS is correct).
- **F-S12-08 (High):** IPCA rail returns `None` on empty factor period so the dispatcher falls through to the next attribution rail, instead of emitting zero contributions with positive confidence (`fit.oos_r_squared`). Both Option B and Option A paths fixed.
- **F-S12-11 (High):** Correlation service returns `concentration_status="unknown"`, `absorption_status="unknown"`, `diversification_ratio=0.0`, and `degraded=True` on insufficient data, instead of optimistic defaults (`"diversified"`, `"normal"`, `1.0`).

## Changes

| File | Change |
|------|--------|
| `backend/quant_engine/active_share_service.py` | Add `degraded`/`degraded_reason` fields; split empty-input handler into 3 branches |
| `backend/vertical_engines/wealth/attribution/ipca_rail.py` | Return `None` instead of `np.zeros(fit.K)` on empty factor period (both paths) |
| `backend/vertical_engines/wealth/correlation/models.py` | Add `degraded`/`degraded_reason` fields to `PortfolioCorrelationResult` |
| `backend/vertical_engines/wealth/correlation/service.py` | Set `"unknown"` status + `degraded=True` on insufficient data |
| `backend/app/domains/wealth/schemas/correlation_regime.py` | Add `degraded`/`degraded_reason` to Pydantic `CorrelationRegimeRead` |
| `backend/tests/test_active_share_service.py` | 4 new tests (3 degraded branches + normal not degraded) |
| `backend/tests/test_correlation.py` | 2 new tests (insufficient data degraded + sufficient not degraded) |
| `backend/tests/vertical_engines/wealth/test_attribution_ipca_rail_unit.py` | Updated empty-period test to assert `None`; fixed test fixtures to cover request period |

## Test plan

- [x] `test_active_share_empty_benchmark_degraded` — portfolio with empty benchmark
- [x] `test_active_share_both_empty_degraded` — both empty
- [x] `test_active_share_portfolio_empty_not_degraded` — empty portfolio is well-defined
- [x] `test_ipca_empty_period_returns_none` — empty factor period returns None
- [x] `test_correlation_insufficient_data_degraded` — insufficient data returns unknown status
- [x] All 62 tests in the 3 affected test files pass
- [x] Lint clean

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>