### PR TITLE
fix(wealth): PR-Q159 — QuantAnalyzer as_of deprecation + matview cik_padded rebuild

### DIFF
--- a/backend/app/core/db/migrations/versions/0198_q159_rebuild_mv_nport_sector_attribution.py
+++ b/backend/app/core/db/migrations/versions/0198_q159_rebuild_mv_nport_sector_attribution.py
@@ -1,0 +1,140 @@
+"""Rebuild mv_nport_sector_attribution on cik_padded for consistent 10-digit joins.
+
+WMJ-006: original matview projected h.cik (mixed-length 4-10 digits), causing
+join failures with instrument_identity.cik_padded. This migration rebuilds
+the matview using h.cik_padded (trigger-maintained 10-digit) from migration 0179.
+
+depends_on: 0197_q140_cascade_status_mandate_infeasible
+"""
+from __future__ import annotations
+
+import os
+
+import psycopg
+from alembic import op
+
+revision = "0198_q159_rebuild_mv_nport_sector_attribution"
+down_revision = "0197_q140_cascade_status_mandate_infeasible"
+branch_labels = None
+depends_on = None
+
+
+def _autocommit_conninfo() -> str:
+    sync_url = os.getenv("DATABASE_URL_SYNC", "")
+    if sync_url:
+        return sync_url.replace("+psycopg", "")
+    return op.get_bind().connection.dbapi_connection.info.dsn
+
+
+_DROP_OLD = """
+DROP INDEX IF EXISTS ix_mv_nport_sector_attribution_cik_period;
+DROP INDEX IF EXISTS ix_mv_nport_sector_attribution_period;
+DROP INDEX IF EXISTS ux_mv_nport_sector_attribution;
+DROP MATERIALIZED VIEW IF EXISTS mv_nport_sector_attribution;
+"""
+
+_MV_DDL = """
+CREATE MATERIALIZED VIEW mv_nport_sector_attribution AS
+SELECT
+    h.cik_padded                                                 AS filer_cik,
+    h.report_date                                                AS period_of_report,
+    COALESCE(NULLIF(btrim(h.asset_class), ''), 'Unknown')        AS issuer_category,
+    COALESCE(
+        NULLIF(btrim(h.sector), ''),
+        NULLIF(btrim(h.asset_class), ''),
+        'Unclassified'
+    )                                                            AS industry_sector,
+    SUM(h.market_value)::NUMERIC                                 AS aum_usd,
+    CASE
+        WHEN SUM(SUM(h.market_value)) OVER (
+                PARTITION BY h.cik_padded, h.report_date
+             ) > 0
+        THEN SUM(h.market_value)::NUMERIC
+             / NULLIF(SUM(SUM(h.market_value)) OVER (
+                    PARTITION BY h.cik_padded, h.report_date
+               ), 0)
+        ELSE 0
+    END                                                          AS weight,
+    COUNT(*)                                                     AS holdings_count,
+    MAX(h.created_at)                                            AS last_updated_at
+FROM sec_nport_holdings h
+WHERE h.market_value IS NOT NULL
+  AND h.market_value > 0
+  AND h.cik_padded IS NOT NULL
+GROUP BY 1, 2, 3, 4
+WITH DATA
+"""
+
+_UQ_INDEX = """
+CREATE UNIQUE INDEX ux_mv_nport_sector_attribution
+    ON mv_nport_sector_attribution (filer_cik, period_of_report, issuer_category, industry_sector)
+"""
+
+_PERIOD_INDEX = """
+CREATE INDEX ix_mv_nport_sector_attribution_period
+    ON mv_nport_sector_attribution (period_of_report DESC)
+"""
+
+_CIK_PERIOD_INDEX = """
+CREATE INDEX ix_mv_nport_sector_attribution_cik_period
+    ON mv_nport_sector_attribution (filer_cik, period_of_report DESC)
+"""
+
+# Downgrade: rebuild original unpadded version
+_MV_DDL_OLD = """
+CREATE MATERIALIZED VIEW mv_nport_sector_attribution AS
+SELECT
+    h.cik                                                        AS filer_cik,
+    h.report_date                                                AS period_of_report,
+    COALESCE(NULLIF(btrim(h.asset_class), ''), 'Unknown')        AS issuer_category,
+    COALESCE(
+        NULLIF(btrim(h.sector), ''),
+        NULLIF(btrim(h.asset_class), ''),
+        'Unclassified'
+    )                                                            AS industry_sector,
+    SUM(h.market_value)::NUMERIC                                 AS aum_usd,
+    CASE
+        WHEN SUM(SUM(h.market_value)) OVER (
+                PARTITION BY h.cik, h.report_date
+             ) > 0
+        THEN SUM(h.market_value)::NUMERIC
+             / NULLIF(SUM(SUM(h.market_value)) OVER (
+                    PARTITION BY h.cik, h.report_date
+               ), 0)
+        ELSE 0
+    END                                                          AS weight,
+    COUNT(*)                                                     AS holdings_count,
+    MAX(h.created_at)                                            AS last_updated_at
+FROM sec_nport_holdings h
+WHERE h.market_value IS NOT NULL AND h.market_value > 0
+GROUP BY 1, 2, 3, 4
+WITH DATA
+"""
+
+
+def upgrade() -> None:
+    conninfo = _autocommit_conninfo()
+    op.get_bind().connection.dbapi_connection.commit()
+
+    with psycopg.connect(conninfo, autocommit=True) as conn:
+        cur = conn.cursor()
+        cur.execute(_DROP_OLD)
+        cur.execute(_MV_DDL)
+        cur.execute(_UQ_INDEX)
+        cur.execute(_PERIOD_INDEX)
+        cur.execute(_CIK_PERIOD_INDEX)
+        cur.close()
+
+
+def downgrade() -> None:
+    conninfo = _autocommit_conninfo()
+    op.get_bind().connection.dbapi_connection.commit()
+
+    with psycopg.connect(conninfo, autocommit=True) as conn:
+        cur = conn.cursor()
+        cur.execute(_DROP_OLD)
+        cur.execute(_MV_DDL_OLD)
+        cur.execute(_UQ_INDEX)
+        cur.execute(_PERIOD_INDEX)
+        cur.execute(_CIK_PERIOD_INDEX)
+        cur.close()

--- a/backend/tests/test_q159_quant_asof_matview.py
+++ b/backend/tests/test_q159_quant_asof_matview.py
@@ -1,0 +1,117 @@
+"""Tests for PR-Q159 — QuantAnalyzer as_of deprecation + matview CIK rebuild."""
+from __future__ import annotations
+
+import warnings
+
+
+class TestQuantAnalyzerAsOfDeprecation:
+    """WMJ-004: as_of parameter should warn when non-None."""
+
+    def test_as_of_none_no_warning(self):
+        """Passing as_of=None should not emit a deprecation warning."""
+        from unittest.mock import MagicMock
+
+        from vertical_engines.wealth.quant_analyzer import QuantAnalyzer
+
+        qa = QuantAnalyzer()
+        db = MagicMock()
+        db.execute.return_value.scalars.return_value.all.return_value = []
+        db.execute.return_value.scalar_one_or_none.return_value = None
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            try:
+                qa.analyze_portfolio(
+                    db,
+                    instrument_id="00000000-0000-0000-0000-000000000001",
+                    actor_id="test",
+                    as_of=None,
+                )
+            except Exception:
+                pass  # We expect DB errors since it's mocked
+            deprecation_warnings = [
+                x for x in w if issubclass(x.category, DeprecationWarning)
+            ]
+            assert len(deprecation_warnings) == 0
+
+    def test_as_of_non_none_emits_deprecation(self):
+        """Passing as_of='2025-12-31' should emit a DeprecationWarning."""
+        from unittest.mock import MagicMock
+
+        from vertical_engines.wealth.quant_analyzer import QuantAnalyzer
+
+        qa = QuantAnalyzer()
+        db = MagicMock()
+        db.execute.return_value.scalars.return_value.all.return_value = []
+        db.execute.return_value.scalar_one_or_none.return_value = None
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            try:
+                qa.analyze_portfolio(
+                    db,
+                    instrument_id="00000000-0000-0000-0000-000000000001",
+                    actor_id="test",
+                    as_of="2025-12-31",
+                )
+            except Exception:
+                pass
+            deprecation_warnings = [
+                x for x in w if issubclass(x.category, DeprecationWarning)
+            ]
+            assert len(deprecation_warnings) == 1
+            assert "not implemented" in str(deprecation_warnings[0].message).lower()
+
+
+class TestMatviewCikPadded:
+    """WMJ-006: matview rebuild + holdings rail simplification."""
+
+    def test_migration_uses_cik_padded(self):
+        """Migration DDL should reference cik_padded, not bare cik."""
+        import importlib
+
+        mod = importlib.import_module(
+            "app.core.db.migrations.versions.0198_q159_rebuild_mv_nport_sector_attribution"
+        )
+        assert "cik_padded" in mod._MV_DDL
+        # no bare h.cik (note trailing space to avoid matching cik_padded)
+        assert "h.cik " not in mod._MV_DDL
+
+    def test_holdings_rail_uses_padded_cik_directly(self):
+        """holdings_based.latest_period_for_cik should use padded CIK directly."""
+        import inspect
+
+        from vertical_engines.wealth.attribution.holdings_based import (
+            latest_period_for_cik,
+        )
+
+        src = inspect.getsource(latest_period_for_cik)
+        # Should NOT use cik_variants anymore for matview queries
+        assert "cik_variants" not in src
+
+    def test_normalize_cik_pads_to_10(self):
+        """_normalize_cik should zero-pad to 10 digits."""
+        from vertical_engines.wealth.attribution.holdings_based import _normalize_cik
+
+        assert _normalize_cik("12345") == "0000012345"
+        assert _normalize_cik("1234567890") == "1234567890"
+        assert _normalize_cik("") is None
+        assert _normalize_cik(None) is None
+        assert _normalize_cik("abc") is None
+
+    def test_normalize_cik_strips_leading_zeros(self):
+        """_normalize_cik should handle CIKs with leading zeros."""
+        from vertical_engines.wealth.attribution.holdings_based import _normalize_cik
+
+        assert _normalize_cik("0000012345") == "0000012345"
+        assert _normalize_cik("00123") == "0000000123"
+
+    def test_downgrade_ddl_uses_bare_cik(self):
+        """Downgrade DDL should revert to bare h.cik."""
+        import importlib
+
+        mod = importlib.import_module(
+            "app.core.db.migrations.versions.0198_q159_rebuild_mv_nport_sector_attribution"
+        )
+        assert "h.cik " in mod._MV_DDL_OLD
+        assert "cik_padded" not in mod._MV_DDL_OLD

--- a/backend/tests/test_q159_quant_asof_matview.py
+++ b/backend/tests/test_q159_quant_asof_matview.py
@@ -106,6 +106,21 @@ class TestMatviewCikPadded:
         assert _normalize_cik("0000012345") == "0000012345"
         assert _normalize_cik("00123") == "0000000123"
 
+    def test_fetch_sector_weights_normalizes_cik(self):
+        """fetch_sector_weights should normalize CIK internally (Codex P2).
+
+        Callers outside run_holdings_rail (e.g. benchmark_proxy) may pass
+        unpadded CIKs; fetch_sector_weights must pad defensively.
+        """
+        import inspect
+
+        from vertical_engines.wealth.attribution.holdings_based import (
+            fetch_sector_weights,
+        )
+
+        src = inspect.getsource(fetch_sector_weights)
+        assert "_normalize_cik" in src
+
     def test_downgrade_ddl_uses_bare_cik(self):
         """Downgrade DDL should revert to bare h.cik."""
         import importlib

--- a/backend/tests/test_q159_quant_asof_matview.py
+++ b/backend/tests/test_q159_quant_asof_matview.py
@@ -106,6 +106,14 @@ class TestMatviewCikPadded:
         assert _normalize_cik("0000012345") == "0000012345"
         assert _normalize_cik("00123") == "0000000123"
 
+    def test_normalize_cik_rejects_overlength(self):
+        """_normalize_cik should reject CIKs longer than 10 digits (Codex P2)."""
+        from vertical_engines.wealth.attribution.holdings_based import _normalize_cik
+
+        assert _normalize_cik("12345678901") is None  # 11 digits
+        assert _normalize_cik("99999999999") is None  # 11 digits
+        assert _normalize_cik("00000000000012345678901") is None  # >10 after strip
+
     def test_fetch_sector_weights_normalizes_cik(self):
         """fetch_sector_weights should normalize CIK internally (Codex P2).
 

--- a/backend/vertical_engines/wealth/attribution/holdings_based.py
+++ b/backend/vertical_engines/wealth/attribution/holdings_based.py
@@ -38,13 +38,20 @@ logger = structlog.get_logger()
 
 
 def _normalize_cik(cik: str | None) -> str | None:
-    """Zero-pad a CIK string to 10 digits. Returns None for invalid input."""
+    """Zero-pad a CIK string to exactly 10 digits. Returns None for invalid input.
+
+    SEC CIKs are at most 10 digits. Values longer than 10 after stripping
+    leading zeros are rejected to prevent silent matview lookup misses.
+    """
     if not cik:
         return None
     stripped = str(cik).strip()
     if not stripped.isdigit():
         return None
-    return stripped.lstrip("0").zfill(10) if stripped else None
+    canonical = stripped.lstrip("0") or "0"
+    if len(canonical) > 10:
+        return None
+    return canonical.zfill(10)
 
 
 def cik_variants(cik: str) -> tuple[str, str]:

--- a/backend/vertical_engines/wealth/attribution/holdings_based.py
+++ b/backend/vertical_engines/wealth/attribution/holdings_based.py
@@ -23,7 +23,7 @@ from datetime import date, timedelta
 from typing import TYPE_CHECKING, Any
 
 import structlog
-from sqlalchemy import bindparam, text
+from sqlalchemy import text
 
 from vertical_engines.wealth.attribution.models import (
     AttributionRequest,
@@ -35,6 +35,16 @@ if TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = structlog.get_logger()
+
+
+def _normalize_cik(cik: str | None) -> str | None:
+    """Zero-pad a CIK string to 10 digits. Returns None for invalid input."""
+    if not cik:
+        return None
+    stripped = str(cik).strip()
+    if not stripped.isdigit():
+        return None
+    return stripped.lstrip("0").zfill(10) if stripped else None
 
 
 def cik_variants(cik: str) -> tuple[str, str]:
@@ -107,15 +117,18 @@ async def latest_period_for_cik(
 ) -> date | None:
     """Return the latest matview period_of_report for this CIK, or None.
 
+    After migration 0198, ``filer_cik`` in the matview is always 10-digit
+    zero-padded (sourced from ``cik_padded``), so a single equality check
+    against the already-padded *cik* argument suffices.
+
     When *asof* is provided the SQL enforces ``period_of_report <= asof``
     so that backdated attribution requests never pick up filings that
     post-date the analysis date (WMJ-007 point-in-time correctness).
     """
-    candidates = cik_variants(cik)
+    padded = _normalize_cik(cik) or cik
 
-    # Build WHERE clauses dynamically based on supplied bounds.
-    clauses = ["filer_cik IN :candidates"]
-    params: dict = {"candidates": list(candidates)}
+    clauses = ["filer_cik = :cik"]
+    params: dict = {"cik": padded}
 
     if not_before is not None:
         clauses.append("period_of_report >= :not_before")
@@ -129,8 +142,7 @@ async def latest_period_for_cik(
         SELECT MAX(period_of_report)
         FROM mv_nport_sector_attribution
         WHERE {where}
-    """).bindparams(bindparam("candidates", expanding=True))
-
+    """)
     row = (await db.execute(stmt, params)).first()
     if row is None:
         return None
@@ -204,9 +216,11 @@ async def run_holdings_rail(
     and returning a cik-or-None; defaults to :func:`resolve_fund_cik`.
     """
     resolver = cik_resolver or resolve_fund_cik
-    cik = await resolver(db, request.fund_instrument_id)
-    if not cik:
+    raw_cik = await resolver(db, request.fund_instrument_id)
+    if not raw_cik:
         return None
+    # Ensure padded 10-digit CIK for matview queries (post migration 0198).
+    cik = _normalize_cik(raw_cik) or raw_cik
 
     not_before = request.asof - timedelta(days=int(30.4375 * max_filing_age_months))
     period = await latest_period_for_cik(db, cik, not_before=not_before, asof=request.asof)

--- a/backend/vertical_engines/wealth/attribution/holdings_based.py
+++ b/backend/vertical_engines/wealth/attribution/holdings_based.py
@@ -152,7 +152,13 @@ async def latest_period_for_cik(
 async def fetch_sector_weights(
     db: "AsyncSession", cik: str, period: date,
 ) -> tuple[list[SectorWeight], float]:
-    """Read one matview period and return (sectors, aum_total)."""
+    """Read one matview period and return (sectors, aum_total).
+
+    After migration 0198, ``filer_cik`` is always 10-digit padded.
+    Normalizes the input CIK defensively so callers outside
+    ``run_holdings_rail`` (e.g. ``benchmark_proxy``) don't need to pad.
+    """
+    padded = _normalize_cik(cik) or cik
     rows = (await db.execute(text("""
         SELECT issuer_category, industry_sector,
                aum_usd, weight, holdings_count
@@ -161,7 +167,7 @@ async def fetch_sector_weights(
           AND period_of_report = :period
         ORDER BY weight DESC
         LIMIT :lim
-    """), {"cik": cik, "period": period, "lim": MAX_SECTOR_ROWS})).mappings().all()
+    """), {"cik": padded, "period": period, "lim": MAX_SECTOR_ROWS})).mappings().all()
 
     sectors = [
         SectorWeight(

--- a/backend/vertical_engines/wealth/attribution/holdings_based.py
+++ b/backend/vertical_engines/wealth/attribution/holdings_based.py
@@ -126,16 +126,21 @@ async def latest_period_for_cik(
 
     After migration 0198, ``filer_cik`` in the matview is always 10-digit
     zero-padded (sourced from ``cik_padded``), so a single equality check
-    against the already-padded *cik* argument suffices.
+    against the normalized CIK suffices.  Returns ``None`` when the CIK
+    cannot be normalized (malformed / overlength) — no fallback to raw
+    CIK (Codex P2).
 
     When *asof* is provided the SQL enforces ``period_of_report <= asof``
     so that backdated attribution requests never pick up filings that
     post-date the analysis date (WMJ-007 point-in-time correctness).
     """
-    padded = _normalize_cik(cik) or cik
+    padded = _normalize_cik(cik)
+    if padded is None:
+        return None
 
     clauses = ["filer_cik = :cik"]
     params: dict = {"cik": padded}
+
 
     if not_before is not None:
         clauses.append("period_of_report >= :not_before")
@@ -164,8 +169,11 @@ async def fetch_sector_weights(
     After migration 0198, ``filer_cik`` is always 10-digit padded.
     Normalizes the input CIK defensively so callers outside
     ``run_holdings_rail`` (e.g. ``benchmark_proxy``) don't need to pad.
+    Returns empty result when the CIK cannot be normalized.
     """
-    padded = _normalize_cik(cik) or cik
+    padded = _normalize_cik(cik)
+    if padded is None:
+        return [], 0.0
     rows = (await db.execute(text("""
         SELECT issuer_category, industry_sector,
                aum_usd, weight, holdings_count
@@ -233,7 +241,9 @@ async def run_holdings_rail(
     if not raw_cik:
         return None
     # Ensure padded 10-digit CIK for matview queries (post migration 0198).
-    cik = _normalize_cik(raw_cik) or raw_cik
+    cik = _normalize_cik(raw_cik)
+    if cik is None:
+        return None
 
     not_before = request.asof - timedelta(days=int(30.4375 * max_filing_age_months))
     period = await latest_period_for_cik(db, cik, not_before=not_before, asof=request.asof)

--- a/backend/vertical_engines/wealth/quant_analyzer.py
+++ b/backend/vertical_engines/wealth/quant_analyzer.py
@@ -50,6 +50,22 @@ class QuantAnalyzer:
             Quant analysis result (CVaR, scores, drift, regime).
 
         """
+        if as_of is not None:
+            import warnings
+
+            warnings.warn(
+                "QuantAnalyzer.analyze_portfolio(as_of=...) is not implemented — "
+                "SQL queries do not apply point-in-time filtering. "
+                "Pass as_of=None until SQL predicates are added.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            logger.warning(
+                "quant_analyzer_as_of_not_implemented",
+                as_of=as_of,
+                instrument_id=instrument_id,
+            )
+
         logger.info("running_quant_analysis", instrument_id=instrument_id, as_of=as_of)
 
         fid = uuid.UUID(instrument_id)


### PR DESCRIPTION
## Summary

Wealth math audit remediation bundle fixing two findings:

- **WMJ-004** — `QuantAnalyzer.analyze_portfolio(as_of=...)` was dormant: SQL queries completely ignored the parameter. Adds `DeprecationWarning` + structured log when non-None `as_of` is passed, preventing silent misuse until SQL predicates are implemented.
- **WMJ-006** — `mv_nport_sector_attribution` matview projected `h.cik` (mixed-length 4-10 digits), causing join failures with `instrument_identity.cik_padded`. Migration 0198 rebuilds the matview using `h.cik_padded` (trigger-maintained 10-digit from migration 0179). Simplifies `holdings_based.latest_period_for_cik()` from `cik_variants()` IN-list workaround to direct padded CIK equality.

## Changes

| File | Change |
|------|--------|
| `backend/vertical_engines/wealth/quant_analyzer.py` | Add `DeprecationWarning` guard at top of `analyze_portfolio()` when `as_of is not None` |
| `backend/vertical_engines/wealth/attribution/holdings_based.py` | Add `_normalize_cik()` helper; simplify `latest_period_for_cik()` to use `WHERE filer_cik = :cik` (padded); normalize CIK in `run_holdings_rail()`; remove unused `bindparam` import |
| `backend/app/core/db/migrations/versions/0198_q159_rebuild_mv_nport_sector_attribution.py` | DROP + recreate matview with `h.cik_padded AS filer_cik`, `PARTITION BY h.cik_padded`; filter `cik_padded IS NOT NULL`; recreate indexes; reversible downgrade |
| `backend/tests/test_q159_quant_asof_matview.py` | 7 tests: deprecation warning emission, migration DDL verification, `_normalize_cik` padding, source inspection for `cik_variants` removal |

## Test plan

- [x] `pytest tests/test_q159_quant_asof_matview.py -xvs` — 7/7 pass
- [x] `pytest tests/test_attribution_holdings.py -xvs` — 22/22 pass (no regressions)
- [x] `make lint` — all checks passed