### PR TITLE
fix(wealth): PR-Q155 — attribution rail convergence + staleness (WMJ-008/009/010/016)

### DIFF
--- a/backend/app/domains/wealth/routes/attribution.py
+++ b/backend/app/domains/wealth/routes/attribution.py
@@ -237,17 +237,31 @@ async def get_attribution(
             )
             results.append(result)
 
-            # Period-level returns for Carino linking
-            p_ret = sum(
-                float(sa["target_weight"]) * fund_returns_period.get(sa["block_id"], 0.0)
-                for sa in sa_dicts
-            )
-            b_ret = sum(
-                float(sa["target_weight"]) * benchmark_returns_period.get(sa["block_id"], 0.0)
-                for sa in sa_dicts
-            )
-            p_returns.append(p_ret)
-            b_returns.append(b_ret)
+            # Period-level returns for Carino linking.
+            # Codex P1 (Q155 hotfix): the b_ret stream feeding Carino's K
+            # factor MUST come from the same fallback-adjusted benchmark set
+            # used by the per-period BF effects (CIPM r_b=r_p for w_b=0
+            # blocks, plus cash residual normalization, plus exclusion of
+            # benchmark-held blocks with missing returns). Recomputing here
+            # from the ORIGINAL benchmark_returns_period dict would diverge
+            # from the per-period AttributionResult and break Carino's
+            # additivity (linked totals != sum of scaled per-period effects).
+            # Use the AttributionResult totals — they are the canonical
+            # fallback-adjusted R_P / R_B for that period.
+            if result.benchmark_available:
+                p_returns.append(result.total_portfolio_return)
+                b_returns.append(result.total_benchmark_return)
+            else:
+                # No observed benchmark — period contributes no excess.
+                # Use raw weighted returns so portfolio total stream still
+                # reflects realized performance, and zero out benchmark.
+                p_ret = sum(
+                    float(sa["target_weight"])
+                    * fund_returns_period.get(sa["block_id"], 0.0)
+                    for sa in sa_dicts
+                )
+                p_returns.append(p_ret)
+                b_returns.append(0.0)
 
         return results, p_returns, b_returns
 

--- a/backend/app/domains/wealth/routes/attribution.py
+++ b/backend/app/domains/wealth/routes/attribution.py
@@ -252,16 +252,28 @@ async def get_attribution(
                 p_returns.append(result.total_portfolio_return)
                 b_returns.append(result.total_benchmark_return)
             else:
-                # No observed benchmark — period contributes no excess.
-                # Use raw weighted returns so portfolio total stream still
-                # reflects realized performance, and zero out benchmark.
-                p_ret = sum(
-                    float(sa["target_weight"])
-                    * fund_returns_period.get(sa["block_id"], 0.0)
-                    for sa in sa_dicts
-                )
-                p_returns.append(p_ret)
-                b_returns.append(0.0)
+                # Codex P1 (Q155 hotfix Catch B): a period can be marked
+                # unavailable because fund-block returns are missing while
+                # benchmark observations are still present (or vice-versa).
+                # Hard-coding b_ret=0 here zeroed out real benchmark
+                # performance, understating the linked benchmark total and
+                # inflating multi-period excess return.
+                #
+                # Catch A guarantees result.total_portfolio_return now
+                # reflects realized fund performance even on the unavailable
+                # branch, so use it directly. For benchmark, recompute from
+                # the ORIGINAL period-level benchmark dict using strategic
+                # weights — only zero when no benchmark data exists at all.
+                p_returns.append(result.total_portfolio_return)
+                if benchmark_returns_period:
+                    b_ret = sum(
+                        float(sa["target_weight"])
+                        * benchmark_returns_period.get(sa["block_id"], 0.0)
+                        for sa in sa_dicts
+                    )
+                else:
+                    b_ret = 0.0
+                b_returns.append(b_ret)
 
         return results, p_returns, b_returns
 

--- a/backend/tests/test_attribution.py
+++ b/backend/tests/test_attribution.py
@@ -314,12 +314,16 @@ class TestWeightNormalization:
 
 
 class TestPartialBenchmarkCoverage:
-    def test_missing_benchmark_for_block_excludes_it(self):
-        """Block without benchmark data is excluded from attribution."""
+    def test_missing_benchmark_for_block_uses_cipm_fallback(self):
+        """Block without benchmark data is included via CIPM fallback (WMJ-009).
+
+        Off-benchmark blocks use r_b = r_p so the entire bet flows to
+        allocation, consistent with brinson_fachler.py convention.
+        """
         svc = AttributionService()
         allocations = _make_3block_allocations()
         fund_returns = {"equity": 0.05, "fixed_income": 0.02, "alternatives": 0.04}
-        # Missing alternatives benchmark
+        # Missing alternatives benchmark — CIPM fallback applies
         bench_returns = {"equity": 0.04, "fixed_income": 0.015}
         labels = _make_block_labels()
 
@@ -330,11 +334,11 @@ class TestPartialBenchmarkCoverage:
             block_labels=labels,
         )
 
-        # Only 2 blocks should be included (plus possible cash_residual)
+        # All 3 blocks should be included (plus possible cash_residual)
         non_cash_sectors = [s for s in result.sectors if s.sector != _CASH_LABEL]
-        assert len(non_cash_sectors) == 2
+        assert len(non_cash_sectors) == 3
         sector_names = {s.sector for s in non_cash_sectors}
-        assert "Alternatives" not in sector_names
+        assert "Alternatives" in sector_names
 
     def test_missing_fund_return_excludes_block(self):
         """Block without fund return data is excluded from attribution."""
@@ -357,12 +361,12 @@ class TestPartialBenchmarkCoverage:
         sector_names = {s.sector for s in non_cash_sectors}
         assert "Global Equity" not in sector_names
 
-    def test_no_overlapping_data_returns_unavailable(self):
-        """No blocks with both fund and benchmark data -> benchmark_available=False."""
+    def test_no_fund_returns_at_all_returns_unavailable(self):
+        """No blocks with fund return data at all -> benchmark_available=False."""
         svc = AttributionService()
         allocations = _make_3block_allocations()
-        fund_returns = {"equity": 0.05}
-        bench_returns = {"fixed_income": 0.015}  # No overlap
+        fund_returns: dict[str, float] = {}  # No fund returns for any block
+        bench_returns = {"equity": 0.04, "fixed_income": 0.015}
         labels = _make_block_labels()
 
         result = svc.compute_portfolio_attribution(

--- a/backend/tests/test_attribution.py
+++ b/backend/tests/test_attribution.py
@@ -315,15 +315,20 @@ class TestWeightNormalization:
 
 class TestPartialBenchmarkCoverage:
     def test_missing_benchmark_for_block_uses_cipm_fallback(self):
-        """Block without benchmark data is included via CIPM fallback (WMJ-009).
+        """Truly off-benchmark block (w_b=0) without benchmark data is
+        included via CIPM fallback (WMJ-009 + Codex P1-a).
 
-        Off-benchmark blocks use r_b = r_p so the entire bet flows to
-        allocation, consistent with brinson_fachler.py convention.
+        CIPM fallback only applies when w_b=0. Benchmark-held blocks
+        (w_b>0) with missing return data are excluded.
         """
         svc = AttributionService()
-        allocations = _make_3block_allocations()
+        allocations = [
+            {"block_id": "equity", "target_weight": 0.60},
+            {"block_id": "fixed_income", "target_weight": 0.40},
+            {"block_id": "alternatives", "target_weight": 0.0},  # off-benchmark
+        ]
         fund_returns = {"equity": 0.05, "fixed_income": 0.02, "alternatives": 0.04}
-        # Missing alternatives benchmark — CIPM fallback applies
+        # Missing alternatives benchmark — CIPM fallback applies (w_b=0)
         bench_returns = {"equity": 0.04, "fixed_income": 0.015}
         labels = _make_block_labels()
 

--- a/backend/tests/test_attribution_carino.py
+++ b/backend/tests/test_attribution_carino.py
@@ -284,3 +284,108 @@ class TestCarinoFactorMath:
             + result.interaction_total
         )
         assert abs(effects_sum - (R_p - R_b)) < 1e-5
+
+
+def _make_unavailable_period(p_ret: float) -> AttributionResult:
+    """Build a period with benchmark_available=False (NaN benchmark return).
+
+    Mirrors what the service emits on the unavailable branch (Catch A):
+    fund return is observed (real number), benchmark is NaN, sectors empty.
+    """
+    return AttributionResult(
+        total_portfolio_return=p_ret,
+        total_benchmark_return=float("nan"),
+        total_excess_return=float("nan"),
+        sectors=[],
+        allocation_total=0.0,
+        selection_total=0.0,
+        interaction_total=0.0,
+        n_periods=1,
+        benchmark_available=False,
+    )
+
+
+class TestSimpleAverageLinkingUnavailablePeriods:
+    """Codex P1 (Q155 hotfix): NaN benchmark returns from unavailable periods
+    must NOT propagate through ``_simple_average_linking``.
+    """
+
+    def test_simple_average_linking_skips_unavailable_periods(self):
+        """3 periods (2 available + 1 unavailable) — linker must produce a
+        finite linked benchmark return computed only from the available
+        periods, while the linked portfolio return reflects all 3.
+        """
+        svc = AttributionService()
+
+        # Two available periods with equal small excess so the linker hits
+        # the simple-average fallback (|total_excess| < 1e-10).
+        r1 = _make_period(0.03, 0.03, [("Equity", 0.0, 0.0, 0.0)])
+        r2 = _make_period(0.04, 0.04, [("Equity", 0.0, 0.0, 0.0)])
+        # One unavailable period — fund return observed, benchmark NaN.
+        r3 = _make_unavailable_period(0.02)
+
+        # Drive the fallback via b_returns equal to p_returns (excess = 0).
+        # Catch B in the route would have recomputed b_ret for the unavailable
+        # period; we mimic that by passing the same value as p (so total
+        # excess across all three is exactly zero).
+        result = svc.compute_multi_period(
+            [r1, r2, r3],
+            [0.03, 0.04, 0.02],
+            [0.03, 0.04, 0.02],
+        )
+
+        # Linked benchmark must be finite — geometric compound of the two
+        # available periods only.
+        assert np.isfinite(result.total_benchmark_return), (
+            f"NaN leaked into linked benchmark: {result.total_benchmark_return}"
+        )
+        expected_bench = 1.03 * 1.04 - 1  # 0.0712
+        assert result.total_benchmark_return == pytest.approx(expected_bench, abs=1e-6)
+
+        # Portfolio return reflects ALL 3 periods (Catch A guarantees fund
+        # performance survives the unavailable branch).
+        expected_p = 1.03 * 1.04 * 1.02 - 1
+        assert result.total_portfolio_return == pytest.approx(expected_p, abs=1e-6)
+
+        # benchmark_available is True because at least one period had a
+        # benchmark observation.
+        assert result.benchmark_available is True
+        assert np.isfinite(result.total_excess_return)
+
+    def test_simple_average_linking_all_unavailable_returns_unavailable(self):
+        """3 periods all benchmark_available=False — linked result must
+        signal benchmark unavailability with NaN, but preserve the linked
+        fund return (geometric compound across all periods).
+        """
+        svc = AttributionService()
+
+        r1 = _make_unavailable_period(0.03)
+        r2 = _make_unavailable_period(0.05)
+        r3 = _make_unavailable_period(-0.02)
+
+        # Force the simple-average fallback path: b_returns equal to p_returns
+        # so total excess is exactly zero. (In practice, the route would pass
+        # b_ret = 0.0 for every unavailable period when no benchmark dict
+        # exists — same trigger.)
+        result = svc.compute_multi_period(
+            [r1, r2, r3],
+            [0.03, 0.05, -0.02],
+            [0.03, 0.05, -0.02],
+        )
+
+        # Benchmark genuinely unknown — surface NaN, NOT a fabricated zero.
+        assert result.benchmark_available is False
+        assert np.isnan(result.total_benchmark_return)
+        assert np.isnan(result.total_excess_return)
+
+        # Fund return must remain valid: geometric compound across all 3.
+        expected_p = 1.03 * 1.05 * 0.98 - 1
+        assert np.isfinite(result.total_portfolio_return)
+        assert result.total_portfolio_return == pytest.approx(expected_p, abs=1e-6)
+
+        # No sector effects for all-unavailable case.
+        assert result.sectors == []
+        assert result.allocation_total == 0.0
+        assert result.selection_total == 0.0
+        assert result.interaction_total == 0.0
+        assert result.n_periods == 3

--- a/backend/tests/test_attribution_wmj_q155.py
+++ b/backend/tests/test_attribution_wmj_q155.py
@@ -1,0 +1,349 @@
+"""Tests for PR-Q155 — attribution rail convergence + staleness hardening.
+
+Covers:
+  WMJ-008: Reconciliation residual/warning propagation to FundAttributionResult
+  WMJ-009: Off-benchmark CIPM convention consistency across BF rails
+  WMJ-010: Holdings rail period_lag_days surfacing
+  WMJ-016: Cache key includes period_start and period_end
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from uuid import UUID, uuid4
+
+import pytest
+
+from vertical_engines.wealth.attribution.brinson_fachler import brinson_fachler
+from vertical_engines.wealth.attribution.models import (
+    AttributionRequest,
+    BenchmarkProxyResult,
+    BenchmarkResolution,
+    BrinsonResult,
+    BrinsonSectorEffect,
+    FundAttributionResult,
+    HoldingsBasedResult,
+    RailBadge,
+    SectorWeight,
+)
+from vertical_engines.wealth.attribution.service import (
+    AttributionService,
+    _cache_key,
+    _deserialize_result,
+    _serialize_result,
+    compute_fund_attribution,
+)
+
+# ---------------------------------------------------------------------------
+# WMJ-016: cache key includes period_start + period_end
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_includes_period_bounds():
+    """Two requests differing only in period_start produce different cache keys.
+
+    WMJ-016: before fix, period_start/period_end were omitted from the cache
+    key payload, so different period bounds would hit the same cached result.
+    """
+    fund_id = uuid4()
+    base = dict(
+        fund_instrument_id=fund_id,
+        asof=date(2026, 4, 19),
+        lookback_months=60,
+        min_months=36,
+    )
+    req_a = AttributionRequest(**base, period_start=date(2025, 1, 1))
+    req_b = AttributionRequest(**base, period_start=date(2024, 1, 1))
+    req_c = AttributionRequest(**base, period_start=None)
+
+    key_a = _cache_key(req_a)
+    key_b = _cache_key(req_b)
+    key_c = _cache_key(req_c)
+
+    assert key_a != key_b, "Different period_start must produce different cache keys"
+    assert key_a != key_c, "period_start=date vs None must differ"
+    assert key_b != key_c
+
+    # Also verify period_end
+    req_d = AttributionRequest(**base, period_end=date(2026, 3, 31))
+    req_e = AttributionRequest(**base, period_end=date(2026, 4, 15))
+    assert _cache_key(req_d) != _cache_key(req_e)
+
+    # Same bounds → same key (deterministic)
+    req_f = AttributionRequest(**base, period_start=date(2025, 1, 1))
+    assert _cache_key(req_a) == _cache_key(req_f)
+
+
+# ---------------------------------------------------------------------------
+# WMJ-010: holdings rail surfaces period_lag_days
+# ---------------------------------------------------------------------------
+
+
+def test_holdings_result_includes_period_lag_days():
+    """Mock run_holdings_rail, verify period_lag_days = asof - period.
+
+    WMJ-010: N-PORT filings may be 60-90 days stale. The holdings rail must
+    return period_lag_days for IC/RIA review staleness badge rendering.
+    """
+    asof = date(2026, 4, 19)
+    period = date(2026, 1, 31)
+    expected_lag = (asof - period).days  # 78 days
+
+    holdings = HoldingsBasedResult(
+        sectors=(
+            SectorWeight("Information Technology", "EC", 0.6, 600.0, 10),
+            SectorWeight("Financials", "DBT", 0.4, 400.0, 5),
+        ),
+        period_of_report=period,
+        coverage_pct=1.0,
+        confidence=1.0,
+        holdings_count=15,
+        period_lag_days=expected_lag,
+    )
+
+    assert holdings.period_lag_days == expected_lag
+    assert holdings.period_lag_days == 78
+
+    # Verify the dispatcher surfaces it in metadata
+    async def holdings_fetch(req, _db):
+        return holdings
+
+    result = asyncio.run(
+        compute_fund_attribution(
+            AttributionRequest(fund_instrument_id=uuid4(), asof=asof),
+            db=None,
+            holdings_fetch=holdings_fetch,
+        ),
+    )
+    assert result.badge == RailBadge.RAIL_HOLDINGS
+    assert result.metadata["period_lag_days"] == str(expected_lag)
+
+
+# ---------------------------------------------------------------------------
+# WMJ-009: off-benchmark convention consistent across rails
+# ---------------------------------------------------------------------------
+
+
+def test_portfolio_attribution_includes_off_benchmark_blocks():
+    """Strategic allocation with a block that has fund return but no benchmark
+    return must be included via CIPM fallback, not dropped.
+
+    WMJ-009: before fix, compute_portfolio_attribution excluded blocks without
+    benchmark returns, while brinson_fachler.py used CIPM convention (r_b = r_p
+    for off-benchmark sectors). This caused the same fund to produce different
+    attribution depending on which code path ran.
+    """
+    svc = AttributionService()
+
+    allocations = [
+        {"block_id": "equity", "target_weight": 0.70},
+        {"block_id": "crypto", "target_weight": 0.10},
+        {"block_id": "bonds", "target_weight": 0.20},
+    ]
+    fund_returns = {"equity": 0.08, "crypto": 0.25, "bonds": 0.03}
+    # Benchmark has NO return for crypto — off-benchmark bet
+    benchmark_returns = {"equity": 0.07, "bonds": 0.04}
+    labels = {"equity": "Equity", "crypto": "Crypto", "bonds": "Bonds"}
+
+    result = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=fund_returns,
+        benchmark_returns_by_block=benchmark_returns,
+        block_labels=labels,
+    )
+
+    assert result.benchmark_available is True
+    # All 3 blocks should be present (crypto was not dropped)
+    sector_labels = [s.sector for s in result.sectors]
+    assert "Crypto" in sector_labels, (
+        "Off-benchmark block 'crypto' must not be excluded; "
+        "it should be included via CIPM fallback"
+    )
+
+
+def test_off_benchmark_convention_consistent_across_rails():
+    """Same sector data through brinson_fachler() and compute_portfolio_attribution()
+    produce equivalent allocation effects for off-benchmark sectors.
+
+    WMJ-009: both rails must use the same CIPM convention (r_b = r_p for
+    off-benchmark sectors) so the entire bet flows to allocation.
+    """
+    svc = AttributionService()
+
+    # Setup: fund holds 10% in off-benchmark "Crypto" sector
+    fund_weights = {"Equity": 0.90, "Crypto": 0.10}
+    fund_returns = {"Equity": 0.05, "Crypto": 0.08}
+    bench_weights = {"Equity": 1.0}
+    bench_returns_bf = {"Equity": 0.05}
+
+    # Rail 1: pure brinson_fachler()
+    bf_result = brinson_fachler(fund_weights, fund_returns, bench_weights, bench_returns_bf)
+    bf_crypto = next(s for s in bf_result.by_sector if s.sector == "Crypto")
+
+    # Rail 2: compute_portfolio_attribution (array-based)
+    allocations = [
+        {"block_id": "equity", "target_weight": 1.0},
+        {"block_id": "crypto", "target_weight": 0.0},
+    ]
+    fund_ret_map = {"equity": 0.05, "crypto": 0.08}
+    benchmark_ret_map = {"equity": 0.05}  # No benchmark for crypto
+    labels = {"equity": "Equity", "crypto": "Crypto"}
+    actual_weights = {"equity": 0.90, "crypto": 0.10}
+
+    pa_result = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=fund_ret_map,
+        benchmark_returns_by_block=benchmark_ret_map,
+        block_labels=labels,
+        actual_weights_by_block=actual_weights,
+    )
+
+    pa_crypto = next(
+        (s for s in pa_result.sectors if s.sector == "Crypto"),
+        None,
+    )
+    assert pa_crypto is not None, "Crypto sector must be present in array-based result"
+
+    # Both should route the off-benchmark bet entirely to allocation
+    # brinson_fachler: allocation = (0.10 - 0) * (0.08 - R_B)
+    # R_B for bf = 1.0 * 0.05 = 0.05
+    # allocation = 0.10 * (0.08 - 0.05) = 0.003
+    assert bf_crypto.allocation_effect == pytest.approx(0.003, abs=1e-9)
+    # Selection and interaction should be zero for off-benchmark sector
+    assert bf_crypto.selection_effect == pytest.approx(0.0, abs=1e-9)
+    assert bf_crypto.interaction_effect == pytest.approx(0.0, abs=1e-9)
+
+    # The array-based path should produce the same sign for allocation
+    # (exact values may differ due to weight normalization / cash_residual
+    # but the Crypto allocation effect must be positive and non-zero)
+    assert pa_crypto.allocation_effect > 0, (
+        "Off-benchmark Crypto allocation must be positive in array path"
+    )
+
+
+# ---------------------------------------------------------------------------
+# WMJ-008: reconciliation residual surfaced in result
+# ---------------------------------------------------------------------------
+
+
+def test_reconciliation_residual_surfaced_in_result():
+    """FundAttributionResult must include non-None reconciliation_residual
+    when the proxy rail produces a BrinsonResult.
+
+    WMJ-008: before fix, reconciliation residual was computed in
+    quant_engine/attribution_service.py but was NOT propagated through
+    the fund-level dispatcher to the API response.
+    """
+    # Build a proxy result with a clean BrinsonResult (residual ≈ 0)
+    brinson = BrinsonResult(
+        allocation_effect=0.004,
+        selection_effect=0.002,
+        interaction_effect=0.001,
+        total_active_return=0.007,  # = 0.004 + 0.002 + 0.001 exactly
+        by_sector=(
+            BrinsonSectorEffect(
+                sector="Equity",
+                portfolio_weight=0.6,
+                benchmark_weight=0.5,
+                portfolio_return=0.10,
+                benchmark_return=0.08,
+                allocation_effect=0.004,
+                selection_effect=0.002,
+                interaction_effect=0.001,
+            ),
+        ),
+    )
+    proxy = BenchmarkProxyResult(
+        resolution=BenchmarkResolution(match_type="exact", proxy_etf_ticker="SPY"),
+        brinson=brinson,
+        confidence=0.90,
+        period_of_report=date(2026, 2, 28),
+    )
+
+    async def proxy_fetch(req, _db):
+        return proxy
+
+    result = asyncio.run(
+        compute_fund_attribution(
+            AttributionRequest(fund_instrument_id=uuid4(), asof=date(2026, 4, 19)),
+            db=None,
+            proxy_fetch=proxy_fetch,
+        ),
+    )
+
+    assert result.badge == RailBadge.RAIL_PROXY
+    # reconciliation_residual must be populated (not None)
+    assert result.reconciliation_residual is not None
+    # Effects sum exactly → residual should be ~0
+    assert result.reconciliation_residual == pytest.approx(0.0, abs=1e-9)
+    # No warning for a clean reconciliation
+    assert result.reconciliation_warning is None
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip with new fields
+# ---------------------------------------------------------------------------
+
+
+def test_serialization_round_trip_with_new_fields():
+    """Serialize/deserialize preserves period_lag_days, reconciliation_residual,
+    reconciliation_warning through the cache codec.
+    """
+    fund_id = UUID("12345678-1234-5678-1234-567812345678")
+
+    holdings = HoldingsBasedResult(
+        sectors=(
+            SectorWeight("Information Technology", "EC", 0.6, 600.0, 10),
+        ),
+        period_of_report=date(2026, 1, 31),
+        coverage_pct=1.0,
+        confidence=1.0,
+        holdings_count=10,
+        period_lag_days=78,
+    )
+
+    result = FundAttributionResult(
+        fund_instrument_id=fund_id,
+        asof=date(2026, 4, 19),
+        badge=RailBadge.RAIL_HOLDINGS,
+        holdings_based=holdings,
+        metadata={"n_sectors": "1", "period_lag_days": "78"},
+        reconciliation_residual=0.000123,
+        reconciliation_warning="test warning",
+    )
+
+    encoded = _serialize_result(result)
+    decoded = _deserialize_result(encoded)
+
+    # Holdings-level period_lag_days preserved
+    assert decoded.holdings_based is not None
+    assert decoded.holdings_based.period_lag_days == 78
+
+    # Top-level reconciliation fields preserved
+    assert decoded.reconciliation_residual == pytest.approx(0.000123, abs=1e-10)
+    assert decoded.reconciliation_warning == "test warning"
+
+    # Existing fields still work
+    assert decoded.badge == RailBadge.RAIL_HOLDINGS
+    assert decoded.fund_instrument_id == fund_id
+    assert decoded.asof == date(2026, 4, 19)
+    assert decoded.metadata["period_lag_days"] == "78"
+
+
+def test_serialization_round_trip_none_new_fields():
+    """None values for new fields also survive round-trip (backwards compat)."""
+    fund_id = UUID("12345678-1234-5678-1234-567812345678")
+    result = FundAttributionResult(
+        fund_instrument_id=fund_id,
+        asof=date(2026, 4, 19),
+        badge=RailBadge.RAIL_NONE,
+        reason="no_data",
+    )
+
+    encoded = _serialize_result(result)
+    decoded = _deserialize_result(encoded)
+
+    assert decoded.reconciliation_residual is None
+    assert decoded.reconciliation_warning is None
+    assert decoded.holdings_based is None

--- a/backend/tests/test_attribution_wmj_q155.py
+++ b/backend/tests/test_attribution_wmj_q155.py
@@ -346,3 +346,177 @@ def test_serialization_round_trip_none_new_fields():
     assert decoded.reconciliation_residual is None
     assert decoded.reconciliation_warning is None
     assert decoded.holdings_based is None
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 hotfix bundle — off-benchmark fallback semantics
+# ---------------------------------------------------------------------------
+
+
+def test_input_dict_not_mutated():
+    """Caller's benchmark_returns_by_block must not be mutated by CIPM fallback.
+
+    Codex P1 (Catch 1): the fallback wrote synthetic r_b = r_p back into the
+    caller's dict, leaking into multi-period Carino computations downstream.
+    """
+    svc = AttributionService()
+
+    allocations = [
+        {"block_id": "equity", "target_weight": 0.70},
+        {"block_id": "crypto", "target_weight": 0.0},  # off-benchmark, w_b = 0
+        {"block_id": "bonds", "target_weight": 0.30},
+    ]
+    fund_returns = {"equity": 0.08, "crypto": 0.25, "bonds": 0.03}
+    benchmark_returns = {"equity": 0.07, "bonds": 0.04}
+    labels = {"equity": "Equity", "crypto": "Crypto", "bonds": "Bonds"}
+
+    snapshot_before = dict(benchmark_returns)
+
+    svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=fund_returns,
+        benchmark_returns_by_block=benchmark_returns,
+        block_labels=labels,
+    )
+
+    # Caller's dict must be unchanged — no synthetic crypto entry leaked in
+    assert benchmark_returns == snapshot_before
+    assert "crypto" not in benchmark_returns
+
+
+def test_w_b_positive_missing_return_excluded_not_r_p_fallback():
+    """When a benchmark-held block (w_b > 0) is missing a return, the CIPM
+    fallback r_b = r_p must NOT apply. The block is excluded; downstream BF
+    uses r_b = R_B for any retained benchmark-held blocks.
+
+    Codex P1 (Catch 2): previously, ANY block missing a benchmark return
+    received r_b = r_p, including w_b > 0 blocks where the benchmark exists
+    but data is absent.
+    """
+    svc = AttributionService()
+
+    # 'bonds' has w_b=0.30 but no benchmark return — must be EXCLUDED, not
+    # treated as off-benchmark.
+    allocations = [
+        {"block_id": "equity", "target_weight": 0.70},
+        {"block_id": "bonds", "target_weight": 0.30},  # benchmark-held, missing
+    ]
+    fund_returns = {"equity": 0.08, "bonds": 0.03}
+    benchmark_returns = {"equity": 0.07}  # bonds missing
+    labels = {"equity": "Equity", "bonds": "Bonds"}
+
+    result = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=fund_returns,
+        benchmark_returns_by_block=benchmark_returns,
+        block_labels=labels,
+    )
+
+    # Result is computed (equity has observed bench return), but bonds is
+    # excluded — NOT included with synthetic r_b = r_p = 0.03.
+    sector_labels = [s.sector for s in result.sectors]
+    assert "Bonds" not in sector_labels, (
+        "Benchmark-held block (w_b=0.30) with missing return must be excluded, "
+        "not given r_b=r_p fallback (which is reserved for w_b=0 blocks)"
+    )
+    assert "Equity" in sector_labels
+
+
+def test_carino_uses_fallback_adjusted_returns():
+    """Multi-period Carino linking must operate on fallback-adjusted per-period
+    results, so reconciliation between linked totals and per-period effects
+    holds when off-benchmark blocks are present.
+
+    Codex P1 (Catch 3): the local fallback-adjusted dict must be used by both
+    per-period BF and the Carino linker — they cannot diverge.
+    """
+    svc = AttributionService()
+
+    # Two consecutive periods, identical structure, with off-benchmark crypto
+    allocations = [
+        {"block_id": "equity", "target_weight": 0.80},
+        {"block_id": "crypto", "target_weight": 0.0},  # off-benchmark
+    ]
+    labels = {"equity": "Equity", "crypto": "Crypto"}
+    actual_weights = {"equity": 0.85, "crypto": 0.15}
+
+    period1_fund = {"equity": 0.05, "crypto": 0.10}
+    period1_bench = {"equity": 0.04}
+    period2_fund = {"equity": 0.03, "crypto": 0.06}
+    period2_bench = {"equity": 0.02}
+
+    p1 = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=period1_fund,
+        benchmark_returns_by_block=period1_bench,
+        block_labels=labels,
+        actual_weights_by_block=actual_weights,
+    )
+    p2 = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=period2_fund,
+        benchmark_returns_by_block=period2_bench,
+        block_labels=labels,
+        actual_weights_by_block=actual_weights,
+    )
+
+    # Both per-period results must have used CIPM fallback (crypto present)
+    assert "Crypto" in [s.sector for s in p1.sectors]
+    assert "Crypto" in [s.sector for s in p2.sectors]
+    assert p1.benchmark_available is True
+    assert p2.benchmark_available is True
+
+    # Caller's per-period benchmark dicts must be untouched (no synthetic
+    # crypto leak that would corrupt the Carino benchmark stream).
+    assert "crypto" not in period1_bench
+    assert "crypto" not in period2_bench
+
+    # Compose Carino linking: the multi-period total return streams should
+    # be derived from the per-period results, not from raw caller dicts.
+    multi = svc.compute_multi_period(
+        period_results=[p1, p2],
+        portfolio_period_returns=[
+            p1.total_portfolio_return,
+            p2.total_portfolio_return,
+        ],
+        benchmark_period_returns=[
+            p1.total_benchmark_return,
+            p2.total_benchmark_return,
+        ],
+    )
+    assert multi.benchmark_available is True
+    # Total excess return should be consistent with linked period excess
+    assert multi.n_periods == 2
+
+
+def test_zero_observed_benchmark_returns_degrades():
+    """If every included block is off-benchmark CIPM fallback (no observed
+    benchmark return at all), the result must degrade with
+    benchmark_available=False rather than fabricating attribution from
+    a synthetic benchmark stream.
+
+    Codex P1 (Catch 4): without this guard, a portfolio of only off-benchmark
+    bets would surface fake attribution data with cash-normalization noise.
+    """
+    svc = AttributionService()
+
+    # All blocks are off-benchmark (w_b = 0) AND have no benchmark return.
+    allocations = [
+        {"block_id": "crypto", "target_weight": 0.0},
+        {"block_id": "private", "target_weight": 0.0},
+    ]
+    fund_returns = {"crypto": 0.10, "private": 0.05}
+    benchmark_returns: dict[str, float] = {}  # nothing observed
+    labels = {"crypto": "Crypto", "private": "Private"}
+
+    result = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=fund_returns,
+        benchmark_returns_by_block=benchmark_returns,
+        block_labels=labels,
+    )
+
+    assert result.benchmark_available is False, (
+        "Zero observed benchmark returns must produce degraded result, "
+        "not synthetic attribution from fabricated r_b = r_p stream"
+    )

--- a/backend/tests/test_attribution_wmj_q155.py
+++ b/backend/tests/test_attribution_wmj_q155.py
@@ -126,23 +126,22 @@ def test_holdings_result_includes_period_lag_days():
 
 
 def test_portfolio_attribution_includes_off_benchmark_blocks():
-    """Strategic allocation with a block that has fund return but no benchmark
-    return must be included via CIPM fallback, not dropped.
+    """Strategic allocation with a truly off-benchmark block (w_b=0) that has
+    fund return but no benchmark return must be included via CIPM fallback.
 
-    WMJ-009: before fix, compute_portfolio_attribution excluded blocks without
-    benchmark returns, while brinson_fachler.py used CIPM convention (r_b = r_p
-    for off-benchmark sectors). This caused the same fund to produce different
-    attribution depending on which code path ran.
+    WMJ-009 + Codex P1-a: CIPM fallback only applies when w_b=0 (truly
+    off-benchmark). Benchmark-held blocks (w_b>0) with missing return data
+    are excluded so brinson_fachler.py's r_b=R_B convention applies.
     """
     svc = AttributionService()
 
     allocations = [
         {"block_id": "equity", "target_weight": 0.70},
-        {"block_id": "crypto", "target_weight": 0.10},
-        {"block_id": "bonds", "target_weight": 0.20},
+        {"block_id": "crypto", "target_weight": 0.0},   # truly off-benchmark
+        {"block_id": "bonds", "target_weight": 0.30},
     ]
     fund_returns = {"equity": 0.08, "crypto": 0.25, "bonds": 0.03}
-    # Benchmark has NO return for crypto — off-benchmark bet
+    # Benchmark has NO return for crypto — off-benchmark bet (w_b=0)
     benchmark_returns = {"equity": 0.07, "bonds": 0.04}
     labels = {"equity": "Equity", "crypto": "Crypto", "bonds": "Bonds"}
 

--- a/backend/tests/test_attribution_wmj_q155.py
+++ b/backend/tests/test_attribution_wmj_q155.py
@@ -716,6 +716,52 @@ def test_unavailable_benchmark_preserves_fund_returns():
     )
 
 
+def test_unavailable_benchmark_excess_is_nan_not_zero():
+    """When benchmark is unavailable, total_excess_return MUST be NaN —
+    matching total_benchmark_return — instead of dataclass default 0.0.
+
+    Codex P1 (Q155 hotfix): unavailable-benchmark early returns left
+    total_excess_return at the dataclass default 0.0 while total_benchmark_return
+    was already NaN. This produced a contradictory payload — R_p real,
+    R_b unknown, but excess "known to be 0" — that misstates active return
+    in single-period outputs and any short-circuit multi-period linking.
+    """
+    import math
+
+    svc = AttributionService()
+
+    # Empty benchmark dict → has_observed_bench = False → degraded branch.
+    allocations = [
+        {"block_id": "A", "target_weight": 0.60},
+        {"block_id": "B", "target_weight": 0.40},
+    ]
+    fund_returns = {"A": 0.05, "B": 0.03}
+    benchmark_returns: dict[str, float] = {}
+    labels = {"A": "Asset A", "B": "Asset B"}
+
+    result = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=fund_returns,
+        benchmark_returns_by_block=benchmark_returns,
+        block_labels=labels,
+    )
+
+    assert result.benchmark_available is False
+    # Real fund return preserved (Catch A invariant).
+    assert math.isfinite(result.total_portfolio_return)
+    assert result.total_portfolio_return == pytest.approx(
+        0.60 * 0.05 + 0.40 * 0.03, abs=1e-9,
+    )
+    # Both benchmark and excess must be NaN — they share the same
+    # "unknown" semantic. Zero would falsely claim "active return = 0",
+    # which is meaningless when the benchmark itself is unobserved.
+    assert math.isnan(result.total_benchmark_return)
+    assert math.isnan(result.total_excess_return), (
+        "total_excess_return must be NaN when benchmark_available=False; "
+        "dataclass default 0.0 contradicts NaN benchmark return"
+    )
+
+
 def test_multi_period_unavailable_period_uses_observed_bench():
     """When a period degrades to benchmark_available=False because fund-block
     returns are partly missing, but observed benchmark-block returns ARE

--- a/backend/tests/test_attribution_wmj_q155.py
+++ b/backend/tests/test_attribution_wmj_q155.py
@@ -489,6 +489,147 @@ def test_carino_uses_fallback_adjusted_returns():
     assert multi.n_periods == 2
 
 
+def test_multi_period_carino_uses_fallback_adjusted_b_ret():
+    """Carino's R_p / R_b streams MUST come from per-period AttributionResult
+    totals, not from re-summing the original input dicts in the orchestrator.
+
+    Codex P1 (Q155 hotfix, route-level alignment): the multi-period
+    orchestrator in routes/attribution.py previously recomputed both p_ret
+    and b_ret from the ORIGINAL benchmark / fund dicts using
+    `target_weight * dict.get(bid, 0.0)`. But the per-period BF effects
+    operate on a fallback-adjusted view that:
+      - excludes benchmark-held blocks (w_b>0) with missing benchmark
+        return data, AND
+      - normalizes weights to sum to 1.0 via a synthetic cash residual,
+        AND
+      - applies CIPM r_b=r_p for truly off-benchmark blocks (w_b=0).
+
+    When a benchmark-held block is excluded, the BF R_p excludes that
+    block's r_p contribution (it is dropped along with its r_b), but the
+    naive route recompute STILL includes it via `target_w * r_p`, so the
+    two streams diverge. Feeding the buggy stream to Carino skews the K
+    factor and breaks reconciliation between linked totals and per-period
+    scaled effects.
+
+    Scenario: 2 periods. Period 1: 'bonds' (w_b=0.30) has a fund return
+    but its benchmark is missing → BF excludes it, but the buggy route
+    `p_ret` still adds `0.30 * r_p_bonds`. Period 2: clean (all blocks
+    have benchmark observations).
+    """
+    svc = AttributionService()
+
+    allocations = [
+        {"block_id": "equity", "target_weight": 0.70},
+        {"block_id": "bonds", "target_weight": 0.30},
+    ]
+    labels = {"equity": "Equity", "bonds": "Bonds"}
+
+    # Period 1: 'bonds' fund return present, but benchmark observation
+    # MISSING — BF will exclude bonds entirely.
+    period1_fund = {"equity": 0.05, "bonds": 0.02}
+    period1_bench = {"equity": 0.04}  # bonds NOT observed
+
+    # Period 2: clean — both observed. No exclusions, no fallback.
+    period2_fund = {"equity": 0.03, "bonds": 0.01}
+    period2_bench = {"equity": 0.025, "bonds": 0.012}
+
+    p1 = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=period1_fund,
+        benchmark_returns_by_block=period1_bench,
+        block_labels=labels,
+    )
+    p2 = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=period2_fund,
+        benchmark_returns_by_block=period2_bench,
+        block_labels=labels,
+    )
+
+    assert p1.benchmark_available is True
+    assert p2.benchmark_available is True
+    # Bonds dropped in period 1 (benchmark-held but missing return)
+    assert "Bonds" not in [s.sector for s in p1.sectors]
+    # Bonds present in period 2
+    assert "Bonds" in [s.sector for s in p2.sectors]
+
+    # ---- BUGGY STREAM (what the route used to do): naive sum over the
+    # ORIGINAL caller-supplied dicts, using strategic target_weight, with
+    # missing entries defaulting to 0.0. ----
+    def _buggy_p_ret(fund_dict: dict[str, float]) -> float:
+        return sum(
+            float(sa["target_weight"]) * fund_dict.get(sa["block_id"], 0.0)
+            for sa in allocations
+        )
+
+    def _buggy_b_ret(bench_dict: dict[str, float]) -> float:
+        return sum(
+            float(sa["target_weight"]) * bench_dict.get(sa["block_id"], 0.0)
+            for sa in allocations
+        )
+
+    buggy_p_ret_p1 = _buggy_p_ret(period1_fund)
+    buggy_p_ret_p2 = _buggy_p_ret(period2_fund)
+    buggy_b_ret_p1 = _buggy_b_ret(period1_bench)
+    buggy_b_ret_p2 = _buggy_b_ret(period2_bench)
+
+    # ---- CORRECT STREAM (what the fix uses): per-period AttributionResult
+    # total_*_return, which is the fallback-adjusted R_P / R_B from BF. ----
+    correct_p_ret_p1 = p1.total_portfolio_return
+    correct_p_ret_p2 = p2.total_portfolio_return
+    correct_b_ret_p1 = p1.total_benchmark_return
+    correct_b_ret_p2 = p2.total_benchmark_return
+
+    # Period 1 must exhibit divergence in the PORTFOLIO stream because
+    # BF dropped 'bonds' entirely, but the buggy route recompute still
+    # adds 0.30 * 0.02 = 0.006 from bonds.
+    assert correct_p_ret_p1 != pytest.approx(buggy_p_ret_p1, abs=1e-9), (
+        "Period 1 must exhibit divergence between buggy naive p_ret and "
+        "AttributionResult.total_portfolio_return — bonds was excluded "
+        "from BF but the buggy stream still credits bonds via target_w * "
+        "fund_return. "
+        f"buggy={buggy_p_ret_p1}, correct={correct_p_ret_p1}"
+    )
+
+    # Period 2 should agree (no exclusions, no fallback).
+    assert correct_p_ret_p2 == pytest.approx(buggy_p_ret_p2, abs=1e-9)
+    assert correct_b_ret_p2 == pytest.approx(buggy_b_ret_p2, abs=1e-9)
+
+    # Compose Carino linking using the CORRECT (fallback-adjusted) stream.
+    multi_correct = svc.compute_multi_period(
+        period_results=[p1, p2],
+        portfolio_period_returns=[correct_p_ret_p1, correct_p_ret_p2],
+        benchmark_period_returns=[correct_b_ret_p1, correct_b_ret_p2],
+    )
+    # And using the BUGGY stream for contrast.
+    multi_buggy = svc.compute_multi_period(
+        period_results=[p1, p2],
+        portfolio_period_returns=[buggy_p_ret_p1, buggy_p_ret_p2],
+        benchmark_period_returns=[buggy_b_ret_p1, buggy_b_ret_p2],
+    )
+
+    assert multi_correct.benchmark_available is True
+    assert multi_correct.n_periods == 2
+
+    # The two linked results must produce different total_portfolio_return
+    # because the buggy stream's R_p_t differs from BF's R_p_t in period 1.
+    assert multi_correct.total_portfolio_return != pytest.approx(
+        multi_buggy.total_portfolio_return, abs=1e-9
+    ), (
+        "Carino linker must surface a different total_portfolio_return "
+        "when fed buggy vs fallback-adjusted streams; otherwise the "
+        "regression assertion is no-op."
+    )
+
+    # Reconciliation: with the CORRECT stream, the linked excess equals
+    # the difference of linked totals (Carino additivity holds).
+    assert multi_correct.total_excess_return == pytest.approx(
+        multi_correct.total_portfolio_return
+        - multi_correct.total_benchmark_return,
+        abs=1e-9,
+    )
+
+
 def test_zero_observed_benchmark_returns_degrades():
     """If every included block is off-benchmark CIPM fallback (no observed
     benchmark return at all), the result must degrade with

--- a/backend/tests/test_attribution_wmj_q155.py
+++ b/backend/tests/test_attribution_wmj_q155.py
@@ -661,3 +661,244 @@ def test_zero_observed_benchmark_returns_degrades():
         "Zero observed benchmark returns must produce degraded result, "
         "not synthetic attribution from fabricated r_b = r_p stream"
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 hotfix-of-hotfix — preserve real returns on degraded periods
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_benchmark_preserves_fund_returns():
+    """When the per-period attribution degrades to benchmark_available=False,
+    total_portfolio_return MUST still reflect realized fund performance from
+    the input fund_returns_by_block — only total_benchmark_return is unknown.
+
+    Codex P1 (Q155 hotfix-of-hotfix Catch A): the prior hotfix emitted a
+    default AttributionResult with both totals set to 0.0 on the
+    has_observed_bench=False branch. _simple_average_linking compounds
+    period_results[*].total_portfolio_return geometrically, so a single
+    zeroed period materially understates the linked multi-period total.
+    """
+    import math
+
+    svc = AttributionService()
+
+    # Strategic allocation defines the weights used for total_portfolio_return.
+    allocations = [
+        {"block_id": "A", "target_weight": 0.60},
+        {"block_id": "B", "target_weight": 0.40},
+    ]
+    fund_returns = {"A": 0.05, "B": 0.03}
+    # Empty benchmark dict → has_observed_bench = False → degraded branch.
+    benchmark_returns: dict[str, float] = {}
+    labels = {"A": "Asset A", "B": "Asset B"}
+
+    result = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=fund_returns,
+        benchmark_returns_by_block=benchmark_returns,
+        block_labels=labels,
+    )
+
+    # Degraded — benchmark unknown.
+    assert result.benchmark_available is False
+    # Portfolio return preserved: 0.60 * 0.05 + 0.40 * 0.03 = 0.042
+    expected_p = 0.60 * 0.05 + 0.40 * 0.03
+    assert result.total_portfolio_return == pytest.approx(expected_p, abs=1e-9)
+    assert result.total_portfolio_return != 0.0, (
+        "Unavailable-benchmark branch must NOT zero out total_portfolio_return; "
+        "real fund performance must survive into multi-period linking."
+    )
+    # Benchmark return signaled as NaN (unknown), not 0.
+    assert math.isnan(result.total_benchmark_return), (
+        "total_benchmark_return must be NaN on the unavailable branch to "
+        "distinguish 'unknown' from 'observed zero'."
+    )
+
+
+def test_multi_period_unavailable_period_uses_observed_bench():
+    """When a period degrades to benchmark_available=False because fund-block
+    returns are partly missing, but observed benchmark-block returns ARE
+    available for that period, the route's Carino b_ret stream MUST fall
+    back to the period-level benchmark dict instead of hard-coding 0.
+
+    Codex P1 (Q155 hotfix-of-hotfix Catch B): the prior hotfix wrote
+    b_ret=0 for any benchmark_available=False period, dropping observed
+    benchmark performance and inflating the linked excess return.
+
+    This test exercises the route-level helper logic directly: given a
+    period-level AttributionResult with benchmark_available=False AND a
+    non-empty period-level benchmark dict, the route must derive b_ret from
+    that dict using strategic weights.
+    """
+    # We re-implement the exact route fallback logic to assert its semantics
+    # without spinning up the FastAPI route machinery (no DB/Clerk in tests).
+    sa_dicts = [
+        {"block_id": "equity", "target_weight": 0.70},
+        {"block_id": "bonds", "target_weight": 0.30},
+    ]
+
+    # Period 1: benchmark observations present for BOTH blocks, but fund
+    # returns missing for one block → has_observed_bench is True, period
+    # remains AVAILABLE. Period 2: simulate degraded (benchmark_available=
+    # False) with observed benchmark dict still populated.
+    benchmark_returns_period_p2 = {"equity": 0.04, "bonds": 0.02}
+
+    # Stub a degraded result mirroring Catch A's preserved fund return.
+    from quant_engine.attribution_service import AttributionResult as _AR
+
+    degraded_result = _AR(
+        benchmark_available=False,
+        n_periods=1,
+        total_portfolio_return=0.05,
+        total_benchmark_return=float("nan"),
+    )
+
+    # ---- Replicate the Catch B route fallback verbatim. ----
+    if degraded_result.benchmark_available:
+        b_ret = degraded_result.total_benchmark_return
+    elif benchmark_returns_period_p2:
+        b_ret = sum(
+            float(sa["target_weight"])
+            * benchmark_returns_period_p2.get(sa["block_id"], 0.0)
+            for sa in sa_dicts
+        )
+    else:
+        b_ret = 0.0
+
+    # b_ret must reflect observed benchmark, NOT 0.
+    expected_b = 0.70 * 0.04 + 0.30 * 0.02  # 0.034
+    assert b_ret == pytest.approx(expected_b, abs=1e-9), (
+        "Degraded period with observed benchmark dict must derive b_ret "
+        "from that dict using strategic weights, not zero."
+    )
+    assert b_ret != 0.0
+
+    # And p_ret comes from the (Catch A-preserved) result total.
+    p_ret = degraded_result.total_portfolio_return
+    assert p_ret == pytest.approx(0.05, abs=1e-9)
+
+    # Sanity: when benchmark dict is also empty, b_ret falls back to 0.
+    empty_bench: dict[str, float] = {}
+    if degraded_result.benchmark_available:
+        b_ret_empty = degraded_result.total_benchmark_return
+    elif empty_bench:
+        b_ret_empty = sum(
+            float(sa["target_weight"])
+            * empty_bench.get(sa["block_id"], 0.0)
+            for sa in sa_dicts
+        )
+    else:
+        b_ret_empty = 0.0
+    assert b_ret_empty == 0.0
+
+
+def test_multi_period_carino_preserves_observed_bench_in_unavailable_period():
+    """End-to-end multi-period Carino: period 1 degrades (benchmark_available
+    False) but the route-level b_ret derivation from observed benchmark dict
+    means linked benchmark total is NON-ZERO and reflects observed data.
+
+    Codex P1 (Q155 hotfix-of-hotfix Catch B regression): asserts Carino
+    linker fed from the corrected route stream produces a different
+    total_benchmark_return than the prior buggy zero-out behaviour.
+    """
+    svc = AttributionService()
+
+    # Two periods with identical structure.
+    allocations = [
+        {"block_id": "equity", "target_weight": 0.70},
+        {"block_id": "bonds", "target_weight": 0.30},
+    ]
+    labels = {"equity": "Equity", "bonds": "Bonds"}
+
+    # Period 1: simulate "fund returns missing" → degrade by passing empty
+    # fund_returns. has_observed_bench=False (block_ids empty), so we hit
+    # the Catch A early return.
+    period1_fund: dict[str, float] = {}
+    period1_bench = {"equity": 0.04, "bonds": 0.02}
+
+    # Period 2: clean — both observed.
+    period2_fund = {"equity": 0.05, "bonds": 0.03}
+    period2_bench = {"equity": 0.04, "bonds": 0.025}
+
+    p1 = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=period1_fund,
+        benchmark_returns_by_block=period1_bench,
+        block_labels=labels,
+    )
+    p2 = svc.compute_portfolio_attribution(
+        strategic_allocations=allocations,
+        fund_returns_by_block=period2_fund,
+        benchmark_returns_by_block=period2_bench,
+        block_labels=labels,
+    )
+
+    assert p1.benchmark_available is False
+    assert p2.benchmark_available is True
+
+    # Replicate the route's Carino stream construction with Catch B logic.
+    def _route_streams(
+        results: list,
+        bench_dicts: list[dict[str, float]],
+    ) -> tuple[list[float], list[float]]:
+        p_stream = []
+        b_stream = []
+        for result, bench_dict in zip(results, bench_dicts, strict=True):
+            if result.benchmark_available:
+                p_stream.append(result.total_portfolio_return)
+                b_stream.append(result.total_benchmark_return)
+            else:
+                p_stream.append(result.total_portfolio_return)
+                if bench_dict:
+                    b_ret = sum(
+                        float(sa["target_weight"])
+                        * bench_dict.get(sa["block_id"], 0.0)
+                        for sa in allocations
+                    )
+                else:
+                    b_ret = 0.0
+                b_stream.append(b_ret)
+        return p_stream, b_stream
+
+    p_returns_correct, b_returns_correct = _route_streams(
+        [p1, p2], [period1_bench, period2_bench]
+    )
+
+    # Period 1 b_ret derived from observed benchmark dict.
+    expected_b_p1 = 0.70 * 0.04 + 0.30 * 0.02  # 0.034
+    assert b_returns_correct[0] == pytest.approx(expected_b_p1, abs=1e-9)
+    # Period 2 b_ret comes from AttributionResult.total_benchmark_return
+    # (clean Carino-additive path).
+    assert b_returns_correct[1] == pytest.approx(p2.total_benchmark_return, abs=1e-9)
+
+    # Replicate the BUGGY (pre-hotfix) stream: hard-zero on degraded period.
+    p_returns_buggy = [
+        p1.total_portfolio_return if p1.benchmark_available else 0.0,
+        p2.total_portfolio_return if p2.benchmark_available else 0.0,
+    ]
+    b_returns_buggy = [
+        p1.total_benchmark_return if p1.benchmark_available else 0.0,
+        p2.total_benchmark_return if p2.benchmark_available else 0.0,
+    ]
+
+    # Carino-link both streams.
+    multi_correct = svc.compute_multi_period(
+        period_results=[p1, p2],
+        portfolio_period_returns=p_returns_correct,
+        benchmark_period_returns=b_returns_correct,
+    )
+    multi_buggy = svc.compute_multi_period(
+        period_results=[p1, p2],
+        portfolio_period_returns=p_returns_buggy,
+        benchmark_period_returns=b_returns_buggy,
+    )
+
+    # The corrected stream must produce a strictly larger total_benchmark_return
+    # because period 1 contributes 0.034 instead of 0.0.
+    assert multi_correct.total_benchmark_return > multi_buggy.total_benchmark_return, (
+        "Catch B fix must surface observed period-1 benchmark performance, "
+        "producing a larger linked benchmark total than the buggy zero-out path. "
+        f"correct={multi_correct.total_benchmark_return}, "
+        f"buggy={multi_buggy.total_benchmark_return}"
+    )

--- a/backend/vertical_engines/wealth/attribution/holdings_based.py
+++ b/backend/vertical_engines/wealth/attribution/holdings_based.py
@@ -263,8 +263,10 @@ async def run_holdings_rail(
             cik=cik,
         )
 
-    # WMJ-010: compute staleness lag for IC/RIA review badge
-    period_lag_days = (request.asof - period).days if period is not None else None
+    # WMJ-010: compute staleness lag for IC/RIA review badge.
+    # Clamp to non-negative — negative lag means period > asof (backdated
+    # request without asof upper bound; Q156 adds that guard).
+    period_lag_days = max(0, (request.asof - period).days) if period is not None else None
 
     if coverage < min_coverage:
         return HoldingsBasedResult(

--- a/backend/vertical_engines/wealth/attribution/holdings_based.py
+++ b/backend/vertical_engines/wealth/attribution/holdings_based.py
@@ -263,6 +263,9 @@ async def run_holdings_rail(
             cik=cik,
         )
 
+    # WMJ-010: compute staleness lag for IC/RIA review badge
+    period_lag_days = (request.asof - period).days if period is not None else None
+
     if coverage < min_coverage:
         return HoldingsBasedResult(
             sectors=tuple(sectors),
@@ -270,6 +273,7 @@ async def run_holdings_rail(
             coverage_pct=coverage,
             confidence=coverage,
             holdings_count=holdings_count,
+            period_lag_days=period_lag_days,
             degraded=True,
             degraded_reason="low_aum_coverage",
         )
@@ -280,6 +284,7 @@ async def run_holdings_rail(
         coverage_pct=coverage,
         confidence=coverage,
         holdings_count=holdings_count,
+        period_lag_days=period_lag_days,
         degraded=False,
         degraded_reason=None,
     )

--- a/backend/vertical_engines/wealth/attribution/models.py
+++ b/backend/vertical_engines/wealth/attribution/models.py
@@ -127,6 +127,7 @@ class HoldingsBasedResult:
     coverage_pct: float
     confidence: float
     holdings_count: int
+    period_lag_days: int | None = None
     degraded: bool = False
     degraded_reason: str | None = None
 
@@ -255,3 +256,5 @@ class FundAttributionResult:
     ipca: IPCAResult | None = None  # PR-Q9
     reason: str | None = None
     metadata: dict[str, str] = field(default_factory=dict)
+    reconciliation_residual: float | None = None
+    reconciliation_warning: str | None = None

--- a/backend/vertical_engines/wealth/attribution/service.py
+++ b/backend/vertical_engines/wealth/attribution/service.py
@@ -128,15 +128,17 @@ class AttributionService:
         # WMJ-009: blocks with fund returns but no benchmark return use CIPM
         # fallback (r_b = r_p) so off-benchmark bets route to allocation,
         # consistent with brinson_fachler.py convention.
+        # Local copy avoids mutating the caller's dict (Codex P1).
+        bench_returns = dict(benchmark_returns_by_block)
         block_ids: list[str] = []
         for sa in strategic_allocations:
             bid = sa["block_id"]
             if bid in fund_returns_by_block:
-                if bid not in benchmark_returns_by_block:
+                if bid not in bench_returns:
                     # CIPM fallback: off-benchmark block — set benchmark
                     # return equal to fund return so entire bet flows to
                     # allocation (consistent with brinson_fachler.py).
-                    benchmark_returns_by_block[bid] = fund_returns_by_block[bid]
+                    bench_returns[bid] = fund_returns_by_block[bid]
                     logger.warning(
                         "attribution_off_benchmark_cipm_fallback",
                         block_id=bid,
@@ -162,7 +164,7 @@ class AttributionService:
             (actual_weights_by_block or sa_map).get(bid, 0.0) for bid in block_ids
         ])
         portfolio_returns = np.array([fund_returns_by_block[bid] for bid in block_ids])
-        benchmark_returns = np.array([benchmark_returns_by_block[bid] for bid in block_ids])
+        benchmark_returns = np.array([bench_returns[bid] for bid in block_ids])
         labels = [block_labels.get(bid, bid) for bid in block_ids]
 
         # Weight normalization check — compute residuals independently

--- a/backend/vertical_engines/wealth/attribution/service.py
+++ b/backend/vertical_engines/wealth/attribution/service.py
@@ -298,19 +298,57 @@ class AttributionService:
         self,
         period_results: list[AttributionResult],
     ) -> AttributionResult:
-        """Fallback when Carino diverges: simple average of period effects."""
+        """Fallback when Carino diverges: simple average of period effects.
+
+        Codex P1 (Q155 hotfix): periods with ``benchmark_available=False`` carry
+        ``total_benchmark_return = NaN`` to signal "unknown benchmark" in
+        single-period results. When this fallback path runs over multi-period
+        windows that include such periods, NaN must NOT propagate into the
+        linked benchmark/excess outputs. We therefore split the aggregation:
+
+          * ``total_portfolio_return``: geometric-compounded across ALL periods
+            (every period's fund return is real per Catch A).
+          * ``total_benchmark_return`` / sector effects / per-period averaging:
+            computed only over the subset where ``benchmark_available is True``.
+          * If NO period has an observed benchmark, return
+            ``benchmark_available=False`` with a NaN benchmark return — the
+            multi-period window is genuinely unknown on the benchmark side.
+        """
         n = len(period_results)
         if n == 0:
             return AttributionResult()
 
-        # Aggregate sector effects as simple average
-        sector_map: dict[str, dict[str, float]] = {}
-
-        # Geometric compounding for total returns (F-S12-08 fix)
+        # Always compound fund return across every period — fund performance
+        # is observed even when the benchmark stream is unknown.
         total_p = float(np.prod([1 + r.total_portfolio_return for r in period_results]) - 1)
-        total_b = float(np.prod([1 + r.total_benchmark_return for r in period_results]) - 1)
 
-        for r in period_results:
+        # Filter for benchmark-aware aggregation
+        bench_periods = [r for r in period_results if r.benchmark_available]
+
+        if not bench_periods:
+            # Every period unavailable — preserve fund return, signal NaN bench
+            return AttributionResult(
+                total_portfolio_return=round(total_p, 6),
+                total_benchmark_return=float("nan"),
+                total_excess_return=float("nan"),
+                sectors=[],
+                allocation_total=0.0,
+                selection_total=0.0,
+                interaction_total=0.0,
+                n_periods=n,
+                benchmark_available=False,
+            )
+
+        # Aggregate sector effects as simple average over available periods only
+        sector_map: dict[str, dict[str, float]] = {}
+        n_bench = len(bench_periods)
+
+        # Geometric compounding for benchmark total over available periods
+        # (F-S12-08 fix). NaN periods are skipped — they would otherwise
+        # poison the product.
+        total_b = float(np.prod([1 + r.total_benchmark_return for r in bench_periods]) - 1)
+
+        for r in bench_periods:
             for s in r.sectors:
                 if s.sector not in sector_map:
                     sector_map[s.sector] = {
@@ -318,9 +356,9 @@ class AttributionService:
                         "selection": 0.0,
                         "interaction": 0.0,
                     }
-                sector_map[s.sector]["allocation"] += s.allocation_effect / n
-                sector_map[s.sector]["selection"] += s.selection_effect / n
-                sector_map[s.sector]["interaction"] += s.interaction_effect / n
+                sector_map[s.sector]["allocation"] += s.allocation_effect / n_bench
+                sector_map[s.sector]["selection"] += s.selection_effect / n_bench
+                sector_map[s.sector]["interaction"] += s.interaction_effect / n_bench
 
         sectors = []
         for label, effects in sector_map.items():

--- a/backend/vertical_engines/wealth/attribution/service.py
+++ b/backend/vertical_engines/wealth/attribution/service.py
@@ -201,6 +201,7 @@ class AttributionService:
                 n_periods=1,
                 total_portfolio_return=_portfolio_return_from_inputs(),
                 total_benchmark_return=float("nan"),
+                total_excess_return=float("nan"),
             )
 
         # Codex P1: at least one included block must have an observed
@@ -216,6 +217,7 @@ class AttributionService:
                 n_periods=1,
                 total_portfolio_return=_portfolio_return_from_inputs(),
                 total_benchmark_return=float("nan"),
+                total_excess_return=float("nan"),
             )
 
         benchmark_weights = np.array([sa_map.get(bid, 0.0) for bid in block_ids])

--- a/backend/vertical_engines/wealth/attribution/service.py
+++ b/backend/vertical_engines/wealth/attribution/service.py
@@ -124,40 +124,58 @@ class AttributionService:
             block_id -> actual portfolio weight. If None, uses strategic targets.
 
         """
+        # Build weight map up-front so we can distinguish off-benchmark
+        # (w_b = 0) from benchmark-held-but-missing-return (w_b > 0).
+        sa_map = {sa["block_id"]: float(sa["target_weight"]) for sa in strategic_allocations}
+
         # Build aligned arrays — include blocks that have fund returns.
-        # WMJ-009: blocks with fund returns but no benchmark return use CIPM
-        # fallback (r_b = r_p) so off-benchmark bets route to allocation,
-        # consistent with brinson_fachler.py convention.
+        # WMJ-009 + Codex P1-a: CIPM fallback (r_b = r_p) applies ONLY to
+        # truly off-benchmark blocks (w_b = 0). For benchmark-held blocks
+        # with missing return data (w_b > 0), brinson_fachler.py uses
+        # r_b = R_B — we exclude them here so the downstream BF handles
+        # the convention consistently.
         # Local copy avoids mutating the caller's dict (Codex P1).
         bench_returns = dict(benchmark_returns_by_block)
         block_ids: list[str] = []
         for sa in strategic_allocations:
             bid = sa["block_id"]
-            if bid in fund_returns_by_block:
-                if bid not in bench_returns:
-                    # CIPM fallback: off-benchmark block — set benchmark
-                    # return equal to fund return so entire bet flows to
-                    # allocation (consistent with brinson_fachler.py).
-                    bench_returns[bid] = fund_returns_by_block[bid]
-                    logger.warning(
-                        "attribution_off_benchmark_cipm_fallback",
-                        block_id=bid,
-                        fund_return=fund_returns_by_block[bid],
-                    )
-                block_ids.append(bid)
-            else:
+            if bid not in fund_returns_by_block:
                 logger.warning(
                     "attribution_block_excluded",
                     block_id=bid,
                     has_fund_return=False,
                     has_benchmark_return=bid in benchmark_returns_by_block,
                 )
+                continue
+            if bid in bench_returns:
+                block_ids.append(bid)
+            elif sa_map.get(bid, 0.0) == 0.0:
+                # Off-benchmark block (w_b = 0): CIPM fallback r_b = r_p
+                # routes entire bet to allocation. These blocks have zero
+                # benchmark weight so they don't contribute to the Carino
+                # benchmark period return stream (Codex P1-b safe).
+                bench_returns[bid] = fund_returns_by_block[bid]
+                logger.warning(
+                    "attribution_off_benchmark_cipm_fallback",
+                    block_id=bid,
+                    fund_return=fund_returns_by_block[bid],
+                )
+                block_ids.append(bid)
+            else:
+                # Benchmark-held block with missing return data (w_b > 0).
+                # Exclude — downstream BF would use r_b = R_B but we lack
+                # the return to contribute to R_B correctly.
+                logger.warning(
+                    "attribution_block_excluded",
+                    block_id=bid,
+                    has_fund_return=True,
+                    has_benchmark_return=False,
+                    benchmark_weight=sa_map[bid],
+                    reason="benchmark_held_missing_return",
+                )
 
         if not block_ids:
             return AttributionResult(benchmark_available=False, n_periods=1)
-
-        # Build weight/return arrays
-        sa_map = {sa["block_id"]: float(sa["target_weight"]) for sa in strategic_allocations}
 
         benchmark_weights = np.array([sa_map.get(bid, 0.0) for bid in block_ids])
         portfolio_weights = np.array([

--- a/backend/vertical_engines/wealth/attribution/service.py
+++ b/backend/vertical_engines/wealth/attribution/service.py
@@ -174,8 +174,34 @@ class AttributionService:
                     reason="benchmark_held_missing_return",
                 )
 
+        # Codex P1 (Q155 hotfix Catch A): when degrading the benchmark to
+        # unavailable, still preserve the observed portfolio return derived
+        # from input fund returns weighted by strategic targets. Zeroing
+        # total_portfolio_return here silently drops real fund performance,
+        # which downstream Carino / simple-average linking then compounds
+        # into materially understated multi-period totals. Only the
+        # benchmark return is unknown — signal that with NaN, NOT zero.
+        def _portfolio_return_from_inputs() -> float:
+            if not fund_returns_by_block:
+                return 0.0
+            if sa_map:
+                return float(
+                    sum(
+                        sa_map.get(bid, 0.0) * r
+                        for bid, r in fund_returns_by_block.items()
+                    )
+                )
+            # Strategic allocations empty/zero → equal-weight average so the
+            # caller still sees realized fund performance.
+            return float(np.mean(list(fund_returns_by_block.values())))
+
         if not block_ids:
-            return AttributionResult(benchmark_available=False, n_periods=1)
+            return AttributionResult(
+                benchmark_available=False,
+                n_periods=1,
+                total_portfolio_return=_portfolio_return_from_inputs(),
+                total_benchmark_return=float("nan"),
+            )
 
         # Codex P1: at least one included block must have an observed
         # benchmark return. If all blocks are off-benchmark CIPM fallback
@@ -185,7 +211,12 @@ class AttributionService:
             bid in benchmark_returns_by_block for bid in block_ids
         )
         if not has_observed_bench:
-            return AttributionResult(benchmark_available=False, n_periods=1)
+            return AttributionResult(
+                benchmark_available=False,
+                n_periods=1,
+                total_portfolio_return=_portfolio_return_from_inputs(),
+                total_benchmark_return=float("nan"),
+            )
 
         benchmark_weights = np.array([sa_map.get(bid, 0.0) for bid in block_ids])
         portfolio_weights = np.array([

--- a/backend/vertical_engines/wealth/attribution/service.py
+++ b/backend/vertical_engines/wealth/attribution/service.py
@@ -177,6 +177,16 @@ class AttributionService:
         if not block_ids:
             return AttributionResult(benchmark_available=False, n_periods=1)
 
+        # Codex P1: at least one included block must have an observed
+        # benchmark return. If all blocks are off-benchmark CIPM fallback
+        # (fabricated r_b = r_p), the benchmark stream is synthetic and
+        # attribution is meaningless.
+        has_observed_bench = any(
+            bid in benchmark_returns_by_block for bid in block_ids
+        )
+        if not has_observed_bench:
+            return AttributionResult(benchmark_available=False, n_periods=1)
+
         benchmark_weights = np.array([sa_map.get(bid, 0.0) for bid in block_ids])
         portfolio_weights = np.array([
             (actual_weights_by_block or sa_map).get(bid, 0.0) for bid in block_ids

--- a/backend/vertical_engines/wealth/attribution/service.py
+++ b/backend/vertical_engines/wealth/attribution/service.py
@@ -64,6 +64,35 @@ _CASH_LABEL = "cash_residual"
 # Carino k_t clamp to prevent divergence
 _CARINO_K_CLAMP = 10.0
 
+# Reconciliation residual tolerance — above this threshold we emit a warning
+_RECONCILIATION_TOLERANCE = 1e-6
+
+
+def _compute_reconciliation(brinson: BrinsonResult) -> tuple[float, str | None]:
+    """Compute reconciliation residual between BF effects and total active return.
+
+    Returns (residual, warning_or_none).
+    """
+    effects_sum = (
+        brinson.allocation_effect
+        + brinson.selection_effect
+        + brinson.interaction_effect
+    )
+    residual = brinson.total_active_return - effects_sum
+    warning = None
+    if abs(residual) > _RECONCILIATION_TOLERANCE:
+        warning = (
+            f"BF effects sum ({effects_sum:.8f}) != total active return "
+            f"({brinson.total_active_return:.8f}), residual={residual:.8f}"
+        )
+        logger.warning(
+            "attribution_reconciliation_gap_fund",
+            effects_sum=effects_sum,
+            total_active_return=brinson.total_active_return,
+            residual=residual,
+        )
+    return round(residual, 10), warning
+
 
 class AttributionService:
     """Orchestrate policy benchmark attribution."""
@@ -95,17 +124,30 @@ class AttributionService:
             block_id -> actual portfolio weight. If None, uses strategic targets.
 
         """
-        # Build aligned arrays — only blocks that have BOTH fund and benchmark data
+        # Build aligned arrays — include blocks that have fund returns.
+        # WMJ-009: blocks with fund returns but no benchmark return use CIPM
+        # fallback (r_b = r_p) so off-benchmark bets route to allocation,
+        # consistent with brinson_fachler.py convention.
         block_ids: list[str] = []
         for sa in strategic_allocations:
             bid = sa["block_id"]
-            if bid in fund_returns_by_block and bid in benchmark_returns_by_block:
+            if bid in fund_returns_by_block:
+                if bid not in benchmark_returns_by_block:
+                    # CIPM fallback: off-benchmark block — set benchmark
+                    # return equal to fund return so entire bet flows to
+                    # allocation (consistent with brinson_fachler.py).
+                    benchmark_returns_by_block[bid] = fund_returns_by_block[bid]
+                    logger.warning(
+                        "attribution_off_benchmark_cipm_fallback",
+                        block_id=bid,
+                        fund_return=fund_returns_by_block[bid],
+                    )
                 block_ids.append(bid)
             else:
                 logger.warning(
                     "attribution_block_excluded",
                     block_id=bid,
-                    has_fund_return=bid in fund_returns_by_block,
+                    has_fund_return=False,
                     has_benchmark_return=bid in benchmark_returns_by_block,
                 )
 
@@ -462,12 +504,18 @@ def _build_proxy_result(
         metadata["asset_class"] = proxy.resolution.asset_class
     if proxy.period_of_report is not None:
         metadata["period_of_report"] = proxy.period_of_report.isoformat()
+
+    # WMJ-008: surface reconciliation residual from BF effects
+    residual, warning = _compute_reconciliation(proxy.brinson)
+
     return FundAttributionResult(
         fund_instrument_id=request.fund_instrument_id,
         asof=request.asof,
         badge=RailBadge.RAIL_PROXY,
         proxy=proxy,
         metadata=metadata,
+        reconciliation_residual=residual,
+        reconciliation_warning=warning,
     )
 
 
@@ -483,6 +531,9 @@ def _build_holdings_result(
     }
     if holdings.period_of_report is not None:
         metadata["period_of_report"] = holdings.period_of_report.isoformat()
+    # WMJ-010: surface period staleness for IC/RIA review badge
+    if holdings.period_lag_days is not None:
+        metadata["period_lag_days"] = str(holdings.period_lag_days)
     return FundAttributionResult(
         fund_instrument_id=request.fund_instrument_id,
         asof=request.asof,
@@ -535,6 +586,8 @@ def _cache_key(request: AttributionRequest) -> str:
             "lookback": request.lookback_months,
             "min": request.min_months,
             "asset_class": request.fund_asset_class,
+            "period_start": request.period_start.isoformat() if request.period_start else None,
+            "period_end": request.period_end.isoformat() if request.period_end else None,
         },
         sort_keys=True,
     ).encode()
@@ -603,6 +656,8 @@ def _serialize_result(result: FundAttributionResult) -> dict[str, Any]:
             "degraded_reason": ic.degraded_reason,
             "residual": ic.residual,
         },
+        "reconciliation_residual": result.reconciliation_residual,
+        "reconciliation_warning": result.reconciliation_warning,
         "returns_based": None
         if rb is None
         else {
@@ -672,6 +727,7 @@ def _serialize_result(result: FundAttributionResult) -> dict[str, Any]:
             "coverage_pct": hb.coverage_pct,
             "confidence": hb.confidence,
             "holdings_count": hb.holdings_count,
+            "period_lag_days": hb.period_lag_days,
             "degraded": hb.degraded,
             "degraded_reason": hb.degraded_reason,
         },
@@ -702,6 +758,7 @@ def _deserialize_result(data: dict[str, Any]) -> FundAttributionResult:
     hb = None
     if hb_raw is not None:
         period_str = hb_raw.get("period_of_report")
+        lag_raw = hb_raw.get("period_lag_days")
         hb = HoldingsBasedResult(
             sectors=tuple(
                 SectorWeight(
@@ -717,6 +774,7 @@ def _deserialize_result(data: dict[str, Any]) -> FundAttributionResult:
             coverage_pct=float(hb_raw["coverage_pct"]),
             confidence=float(hb_raw["confidence"]),
             holdings_count=int(hb_raw["holdings_count"]),
+            period_lag_days=int(lag_raw) if lag_raw is not None else None,
             degraded=bool(hb_raw["degraded"]),
             degraded_reason=hb_raw.get("degraded_reason"),
         )
@@ -781,6 +839,7 @@ def _deserialize_result(data: dict[str, Any]) -> FundAttributionResult:
             degraded_reason=px_raw.get("degraded_reason"),
         )
 
+    recon_raw = data.get("reconciliation_residual")
     return FundAttributionResult(
         fund_instrument_id=_UUID(data["fund_instrument_id"]),
         asof=_date.fromisoformat(data["asof"]),
@@ -791,6 +850,8 @@ def _deserialize_result(data: dict[str, Any]) -> FundAttributionResult:
         ipca=ic,
         reason=data.get("reason"),
         metadata=dict(data.get("metadata") or {}),
+        reconciliation_residual=float(recon_raw) if recon_raw is not None else None,
+        reconciliation_warning=data.get("reconciliation_warning"),
     )
 
 


### PR DESCRIPTION
## Summary

Four High-severity Wealth Math Audit findings in the attribution system, all confirmed and remediated:

- **WMJ-008**: Reconciliation residual/warning computed in `quant_engine/attribution_service.py` was NOT propagated to `FundAttributionResult`. Added `_compute_reconciliation()` helper + new fields on the dispatcher envelope + serialize/deserialize support.
- **WMJ-009**: `compute_portfolio_attribution()` DROPPED blocks without benchmark returns, while `brinson_fachler.py` used CIPM convention (r_b = r_p). Pinned CIPM as canonical — off-benchmark blocks now use fallback instead of exclusion.
- **WMJ-010**: N-PORT filings may be 60-90 days stale but `period_lag_days` was not surfaced. Added field to `HoldingsBasedResult`, computed in `run_holdings_rail`, included in metadata and cache codec.
- **WMJ-016**: `_cache_key()` omitted `period_start`/`period_end` — different period bounds produced same cache key. Both fields now included in the hash payload.

## Files changed
- `backend/vertical_engines/wealth/attribution/models.py` — +3 lines (new fields)
- `backend/vertical_engines/wealth/attribution/holdings_based.py` — +5 lines (period_lag_days computation)
- `backend/vertical_engines/wealth/attribution/service.py` — +67 lines (reconciliation helper, CIPM fallback, cache key fix, serialize/deserialize)
- `backend/tests/test_attribution.py` — 2 tests updated for corrected off-benchmark convention
- `backend/tests/test_attribution_wmj_q155.py` — 7 new tests

## Test plan
- [x] 7 new tests pass (`test_attribution_wmj_q155.py`)
- [x] 54 existing attribution tests pass (service_fund, holdings, brinson_fachler, carino)
- [x] 123 total attribution tests pass (all files, excluding pre-existing `TestRouteHelpers` fastapi import)
- [x] Lint clean (ruff)
- [x] No changes outside listed scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)