### PR TITLE
fix(wealth): PR-Q161 — docs + Sterling + cash residual + test tautologies

### DIFF
--- a/backend/quant_engine/return_statistics_service.py
+++ b/backend/quant_engine/return_statistics_service.py
@@ -180,7 +180,18 @@ def _compute_semi_deviation(returns: np.ndarray) -> float | None:
 def _compute_sterling_ratio(
     daily_returns: np.ndarray,
 ) -> float | None:
-    """Sterling ratio = ann_return / abs(avg_yearly_max_dd - 10%).
+    """Sterling ratio = ann_return / abs(avg_yearly_max_dd − 10%).
+
+    Convention (WMJ-022 pinned):
+        denominator = |avg_max_dd − 0.10|
+
+    ``avg_max_dd`` is negative (drawdowns), so the subtraction *increases*
+    the denominator: e.g. avg_max_dd = −0.20 → |−0.20 − 0.10| = 0.30.
+    This matches the "original Sterling" convention (Kestner 1996) where
+    10% is an *additive* cushion that penalises funds with small
+    drawdowns less harshly.  The alternative "|DD| − 10%" convention
+    (sometimes called "modified Sterling") was considered but not adopted
+    — it produces negative denominators for low-DD funds.
 
     Uses 3-year equivalent: average of annual max drawdowns.
     Falls back to single max DD if < 3 years of data.

--- a/backend/tests/quant_engine/test_factor_model_ipca_correctness.py
+++ b/backend/tests/quant_engine/test_factor_model_ipca_correctness.py
@@ -68,11 +68,12 @@ class TestBugI2WalkForwardBoundary:
         """T=72 exactly → at least one fold runs (not empty range)."""
         ret, chars = _synthetic_panel(T=72, N=30, K=2, L=6, seed=7)
         fit = fit_universe(ret, chars, max_k=3)
-        # If the loop ran, oos_r_squared should not be the unvalidated default
-        assert fit.oos_r_squared != 0.0 or fit.degraded is False or fit.degraded is True
-        # Key: it should NOT fall into the short-panel path (degraded for insufficient_dates)
-        if fit.degraded:
-            assert "insufficient_dates" not in (fit.degraded_reason or "")
+        # WMJ-030 (TEMP-A7-18): replaced tautological assertion
+        # (``degraded is False or degraded is True`` is always True).
+        # T=72 must not hit the short-panel guard — verify positively.
+        assert "insufficient_dates" not in (fit.degraded_reason or ""), (
+            "T=72 must not hit short-panel guard"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_attribution.py
+++ b/backend/tests/test_attribution.py
@@ -461,10 +461,10 @@ class TestMultiPeriodCarino:
         np.testing.assert_almost_equal(result.total_portfolio_return, expected_p, decimal=5)
         np.testing.assert_almost_equal(result.total_benchmark_return, expected_b, decimal=5)
 
-        # Effects should approximately sum to excess return
-        # Carino linking with synthetic per-period effects may not be exact
+        # WMJ-030 (TEMP-A7-02): tightened from decimal=3 to decimal=5 to
+        # match test_attribution_carino.py tolerance (< 1e-5) post-PR-Q148.
         effects_sum = result.allocation_total + result.selection_total + result.interaction_total
-        np.testing.assert_almost_equal(effects_sum, result.total_excess_return, decimal=3)
+        np.testing.assert_almost_equal(effects_sum, result.total_excess_return, decimal=5)
 
     def test_three_period_additivity(self):
         """Three periods: effects sum = excess return when per-period effects sum to excess."""
@@ -534,12 +534,8 @@ class TestCarinoEdgeCases:
 
     def test_opposing_excesses_fallback_to_average(self):
         """Opposing excesses (+5%/-5%) -> total excess ~0 -> simple average fallback."""
-        r1 = self._make_period_result(0.10, 0.05)  # +5% excess
-        r2 = self._make_period_result(0.00, 0.05)  # -5% excess
-
-        # Compound: P = 1.10 * 1.00 - 1 = 0.10, B = 1.05 * 1.05 - 1 = 0.1025
-        # Total excess = 0.10 - 0.1025 = -0.0025 (not exactly zero)
-        # Let's use exact opposing values
+        # WMJ-030 (TEMP-A7-19): removed dead code — prior r1/r2 assignments
+        # were immediately overwritten.
         r1 = self._make_period_result(0.05, 0.00)  # +5% excess
         r2 = self._make_period_result(0.00, 0.05)  # -5% excess
         # Compound: P = 1.05 * 1.00 - 1 = 0.05, B = 1.00 * 1.05 - 1 = 0.05

--- a/backend/tests/test_attribution_carino.py
+++ b/backend/tests/test_attribution_carino.py
@@ -389,3 +389,56 @@ class TestSimpleAverageLinkingUnavailablePeriods:
         assert result.selection_total == 0.0
         assert result.interaction_total == 0.0
         assert result.n_periods == 3
+
+
+# ── WMJ-030 (TEMP-A1-12): Carino L'Hôpital branch ───────────────────
+
+
+class TestCarinoLHopitalBranch:
+    """Exercise the ``abs(diff) < 1e-10`` branch in ``_carino_factor``
+    where r_p == r_b and the scale factor reduces to 1/(1+r_p)."""
+
+    def test_identical_returns_exercises_lhopital(self):
+        """Every period has excess = 0 → forces L'Hôpital in _carino_factor."""
+        p_rets = [0.05, 0.03]
+        b_rets = [0.05, 0.03]  # identical → excess = 0 every period
+
+        periods = [
+            _make_period(p, b, [("All", 0.0, 0.0, 0.0)])
+            for p, b in zip(p_rets, b_rets, strict=False)
+        ]
+
+        result = compute_multi_period_attribution(periods, p_rets, b_rets)
+
+        assert np.isfinite(result.allocation_total)
+        assert np.isfinite(result.selection_total)
+        assert np.isfinite(result.interaction_total)
+
+        # Total excess must be zero (same returns)
+        R_p = float(np.prod([1 + r for r in p_rets]) - 1)
+        R_b = float(np.prod([1 + r for r in b_rets]) - 1)
+        assert abs(R_p - R_b) < 1e-10
+
+    def test_near_zero_excess_per_period_reconciles(self):
+        """Tiny per-period excess that rounds to ~0 → L'Hôpital path."""
+        eps = 1e-12
+        p_rets = [0.02 + eps, 0.04 + eps, -0.01 + eps]
+        b_rets = [0.02, 0.04, -0.01]
+
+        periods = []
+        for p, b in zip(p_rets, b_rets, strict=False):
+            excess = p - b
+            periods.append(
+                _make_period(p, b, [("All", excess * 0.5, excess * 0.3, excess * 0.2)]),
+            )
+
+        result = compute_multi_period_attribution(periods, p_rets, b_rets)
+
+        effects_sum = (
+            result.allocation_total
+            + result.selection_total
+            + result.interaction_total
+        )
+        R_p = float(np.prod([1 + r for r in p_rets]) - 1)
+        R_b = float(np.prod([1 + r for r in b_rets]) - 1)
+        assert abs(effects_sum - (R_p - R_b)) < 1e-5

--- a/backend/tests/test_return_statistics_service.py
+++ b/backend/tests/test_return_statistics_service.py
@@ -329,5 +329,57 @@ def test_sterling_yearly_chunk_captures_initial_drawdown():
     chunk1 = np.concatenate([np.full(5, -0.01), np.full(247, 0.0001)])
     daily = np.concatenate([chunk1, chunk1, chunk1])
     result = compute_return_statistics(daily)
-    if result.sterling_ratio is not None:
-        assert result.sterling_ratio is not None
+    # WMJ-030: replaced tautological assertion (was `if x is not None: assert x is not None`).
+    # This fund has 5 consecutive -1% losses per year → net negative return → negative Sterling.
+    assert result.sterling_ratio is not None
+    assert np.isfinite(result.sterling_ratio)
+
+
+# ── WMJ-022: Sterling convention — denominator = |avg_max_dd − 0.10| ──
+
+
+def test_sterling_convention_denominator_documented():
+    """Pin the Sterling denominator convention: abs(avg_max_dd − 0.10).
+
+    With avg_max_dd = −0.20 (negative drawdown):
+        denominator = |−0.20 − 0.10| = 0.30  ("|DD| + 10%" style)
+
+    This is the "original Sterling" convention (Kestner 1996), NOT
+    the "modified Sterling" where denominator = |DD| − 10%.
+    """
+    # Build a 3-year (756-day) series with known max drawdowns per year.
+    # Each year: 5 days of sharp loss producing ~-20% DD, then flat recovery.
+    year_days = 252
+    loss_days = 5
+    # daily loss to compound to -20%: (1+r)^5 = 0.80 → r = 0.80^(1/5) - 1
+    daily_loss = 0.80 ** (1.0 / loss_days) - 1  # ≈ -0.0437
+
+    def _make_year() -> np.ndarray:
+        days = np.zeros(year_days)
+        days[:loss_days] = daily_loss  # sharp loss → ~-20% DD
+        # remaining days: zero return (no recovery)
+        return days
+
+    daily = np.concatenate([_make_year(), _make_year(), _make_year()])
+    sterling = _compute_sterling_ratio(daily)
+    assert sterling is not None
+
+    # Manually compute what the formula should produce:
+    n = len(daily)
+    cum_return = float(np.prod(1.0 + daily))
+    ann_return = cum_return ** (252.0 / n) - 1
+
+    # Each yearly chunk has max DD ≈ -0.20 (from the 5 loss days).
+    # avg_max_dd ≈ -0.20
+    # Our denominator: |(-0.20) - 0.10| = 0.30
+    # Alternative "modified" denominator: |(-0.20)| - 0.10 = 0.10
+    # Verify our convention produces Sterling = ann_return / ~0.30
+    expected_sterling_original = ann_return / 0.30  # ≈ negative/0.30
+    expected_sterling_modified = ann_return / 0.10  # ≈ negative/0.10
+
+    # The actual Sterling should be close to the "original" convention value,
+    # NOT the "modified" value (which is 3× larger in magnitude).
+    assert abs(sterling - expected_sterling_original) < abs(sterling - expected_sterling_modified), (
+        f"Sterling {sterling:.4f} is closer to modified ({expected_sterling_modified:.4f}) "
+        f"than original ({expected_sterling_original:.4f}) — wrong convention"
+    )

--- a/backend/tests/test_return_statistics_service.py
+++ b/backend/tests/test_return_statistics_service.py
@@ -364,22 +364,27 @@ def test_sterling_convention_denominator_documented():
     sterling = _compute_sterling_ratio(daily)
     assert sterling is not None
 
-    # Manually compute what the formula should produce:
+    # Replicate the formula exactly to compute the expected value.
+    from quant_engine.drawdown_service import compute_drawdown_series as _dd
+
     n = len(daily)
     cum_return = float(np.prod(1.0 + daily))
     ann_return = cum_return ** (252.0 / n) - 1
 
-    # Each yearly chunk has max DD ≈ -0.20 (from the 5 loss days).
-    # avg_max_dd ≈ -0.20
-    # Our denominator: |(-0.20) - 0.10| = 0.30
-    # Alternative "modified" denominator: |(-0.20)| - 0.10 = 0.10
-    # Verify our convention produces Sterling = ann_return / ~0.30
-    expected_sterling_original = ann_return / 0.30  # ≈ negative/0.30
-    expected_sterling_modified = ann_return / 0.10  # ≈ negative/0.10
+    n_years = n // 252
+    trimmed = daily[-n_years * 252 :]
+    yearly_max_dds = []
+    for i in range(n_years):
+        chunk = trimmed[i * 252 : (i + 1) * 252]
+        navs = np.concatenate([[1.0], np.cumprod(1 + chunk)])
+        yearly_max_dds.append(float(np.min(_dd(navs))))
 
-    # The actual Sterling should be close to the "original" convention value,
-    # NOT the "modified" value (which is 3× larger in magnitude).
-    assert abs(sterling - expected_sterling_original) < abs(sterling - expected_sterling_modified), (
-        f"Sterling {sterling:.4f} is closer to modified ({expected_sterling_modified:.4f}) "
-        f"than original ({expected_sterling_original:.4f}) — wrong convention"
+    avg_max_dd = float(np.mean(yearly_max_dds))
+    # Pinned convention: denominator = |avg_max_dd − 0.10|
+    denominator = abs(avg_max_dd - 0.10)
+    expected_sterling = ann_return / denominator
+
+    assert sterling == pytest.approx(expected_sterling, abs=1e-8), (
+        f"Sterling {sterling} != expected {expected_sterling} "
+        f"(avg_max_dd={avg_max_dd:.6f}, denominator={denominator:.6f})"
     )

--- a/backend/tests/test_validation_gate.py
+++ b/backend/tests/test_validation_gate.py
@@ -314,6 +314,30 @@ def test_stale_nav_passes_when_all_recent():
     assert nav_check.passed
 
 
+# ── WMJ-019: fail-closed when as_of_date missing ─────────────────
+
+
+def test_stale_nav_fails_closed_when_as_of_date_missing():
+    """Missing as_of_date must fail-closed (block), not skip with passed=True."""
+    payload = _base_payload()
+    del payload["as_of_date"]
+    result = validate_construction(payload, _base_db_context())
+    nav_check = next(c for c in result.checks if c.id == "no_stale_nav")
+    assert nav_check.passed is False
+    assert nav_check.severity == "block"
+    assert "missing" in nav_check.explanation.lower()
+
+
+def test_stale_nav_fails_closed_empty_as_of_date():
+    """Empty string as_of_date must also fail-closed."""
+    payload = _base_payload()
+    payload["as_of_date"] = ""
+    result = validate_construction(payload, _base_db_context())
+    nav_check = next(c for c in result.checks if c.id == "no_stale_nav")
+    assert nav_check.passed is False
+    assert nav_check.severity == "block"
+
+
 # ── Warn-severity cases ──────────────────────────────────────────
 
 

--- a/backend/vertical_engines/wealth/attribution/service.py
+++ b/backend/vertical_engines/wealth/attribution/service.py
@@ -240,6 +240,12 @@ class AttributionService:
         if needs_cash:
             benchmark_weights = np.append(benchmark_weights, 1.0 - bw_sum)
             portfolio_weights = np.append(portfolio_weights, 1.0 - pw_sum)
+            # WMJ-024: Cash residual return convention — r_cash = 0.0.
+            # The residual sleeve absorbs weight-sum gaps (weights < 1.0)
+            # and is assumed to earn zero return.  This is standard BF
+            # practice: cash is the "numeraire" with no excess contribution.
+            # If IC policy requires SOFR/overnight attribution for cash,
+            # replace 0.0 with the period overnight rate.
             portfolio_returns = np.append(portfolio_returns, 0.0)
             benchmark_returns = np.append(benchmark_returns, 0.0)
             labels.append(_CASH_LABEL)

--- a/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
+++ b/backend/vertical_engines/wealth/model_portfolio/validation_gate.py
@@ -190,14 +190,17 @@ def _check_no_stale_nav(
     as_of_date_raw = run_payload.get("as_of_date")
 
     if not as_of_date_raw:
+        # WMJ-019: fail-closed — missing as_of_date must block, not skip.
+        # Production caller (construction_run_executor) always provides it,
+        # so this is defense-in-depth against future callers or payload bugs.
         return ValidationCheck(
             id="no_stale_nav",
             label="NAV data is fresh",
             severity="block",
-            passed=True,
-            value=0,
+            passed=False,
+            value=None,
             threshold=db.nav_staleness_threshold_days,
-            explanation="as_of_date missing from payload; staleness check skipped.",
+            explanation="as_of_date missing from payload; staleness check cannot run.",
         )
 
     as_of = (

--- a/docs/reference/wealth-math-conventions.md
+++ b/docs/reference/wealth-math-conventions.md
@@ -1,0 +1,54 @@
+# Wealth Math Conventions
+
+Pinned conventions for institutional wealth analytics.
+Audit reference: `docs/audits/2026-04-30-wealth-math-audit-meta-jury-gpt55.md`.
+
+---
+
+## Sterling Ratio Denominator (WMJ-022)
+
+**Convention adopted:** Original Sterling (Kestner 1996).
+
+```
+Sterling = ann_return / |avg_max_dd − 0.10|
+```
+
+`avg_max_dd` is **negative** (drawdowns are negative by sign convention in this codebase). The subtraction of 0.10 therefore *increases* the denominator magnitude:
+
+| avg_max_dd | denominator | interpretation |
+|------------|-------------|----------------|
+| −0.05      | \|−0.05 − 0.10\| = 0.15 | low-DD fund, cushioned |
+| −0.20      | \|−0.20 − 0.10\| = 0.30 | moderate DD |
+| −0.40      | \|−0.40 − 0.10\| = 0.50 | high DD |
+
+The alternative "modified Sterling" convention (`|DD| − 10%`, i.e. `abs(avg_max_dd) − 0.10`) was **not adopted** because it produces negative or near-zero denominators for low-drawdown funds (e.g. money market, short-duration bond), making the ratio undefined or explosive.
+
+**Implementation:** `backend/quant_engine/return_statistics_service.py` → `_compute_sterling_ratio()`.
+
+**Annualization:** Geometric (cumulative return raised to 252/n power), matching the F08 convention for all return annualization in the engine.
+
+---
+
+## Cash Residual Return Convention (WMJ-024)
+
+**Convention adopted:** `r_cash = 0.0` (zero return).
+
+When portfolio or benchmark weights do not sum to 1.0, the attribution service injects a `cash_residual` sleeve to absorb the gap. Both the portfolio and benchmark cash sleeves are assigned **zero return**.
+
+This is standard Brinson-Fachler practice: cash is the numeraire with no excess contribution. The allocation effect of the cash sleeve captures whether the portfolio is over- or under-invested relative to the benchmark.
+
+If IC policy requires overnight/SOFR attribution for the cash sleeve, `0.0` should be replaced with the period overnight rate at the injection site.
+
+**Implementation:** `backend/vertical_engines/wealth/attribution/service.py` → `_CASH_LABEL = "cash_residual"`, lines 243–244.
+
+---
+
+## Drawdown Sign Convention
+
+Drawdowns are **negative** throughout the codebase (`compute_drawdown_series` returns values ≤ 0). `max_drawdown` is the most negative value in the series (i.e. `np.min(dd_series)`).
+
+This convention is consistent across:
+- `quant_engine/drawdown_service.py`
+- `quant_engine/return_statistics_service.py` (Sterling, Calmar)
+- `quant_engine/cvar_service.py`
+- `vertical_engines/wealth/model_portfolio/validation_gate.py`


### PR DESCRIPTION
## Summary

Sprint 3 P2 terminus — documentation, convention pinning, and test tautology cleanup from the wealth math audit (WMJ-019, WMJ-022, WMJ-024, WMJ-030).

### WMJ-019: Validation gate fail-closed
- `_check_no_stale_nav` now returns `passed=False` (block) when `as_of_date` is missing from payload
- Was `passed=True` (skip) — defense-in-depth per Stage 3 "NOT EXPECTED" verdict

### WMJ-022: Sterling ratio convention pinned
- Docstring updated: `abs(avg_max_dd − 0.10)` = "original Sterling" (Kestner 1996)
- Reference doc created: `docs/reference/wealth-math-conventions.md`
- Convention test added verifying denominator matches original (not modified) Sterling

### WMJ-024: Cash residual r=0 convention documented
- Inline comment in attribution service explains `r_cash = 0.0` convention
- Documented in reference doc

### WMJ-030: Test tautology cleanup (Cluster C-12)
- **TEMP-A7-18**: Replaced always-true assertion (`degraded is False or degraded is True`)
- **TEMP-A7-02**: Tightened Carino tolerance from `decimal=3` to `decimal=5` (matches `test_attribution_carino.py`)
- **TEMP-A7-19**: Removed dead code (r1/r2 immediately overwritten)
- **TEMP-A1-12**: Added Carino L'Hôpital branch test (exercises `abs(diff) < 1e-10` path)
- Fixed tautological Sterling chunk test (`if x is not None: assert x is not None`)

## Files changed (9)
- `backend/vertical_engines/wealth/model_portfolio/validation_gate.py` — fail-closed
- `backend/quant_engine/return_statistics_service.py` — Sterling docstring
- `backend/vertical_engines/wealth/attribution/service.py` — cash convention comment
- `backend/tests/test_validation_gate.py` — +2 tests
- `backend/tests/test_return_statistics_service.py` — +1 test, 1 fix
- `backend/tests/test_attribution_carino.py` — +2 tests (L'Hôpital)
- `backend/tests/test_attribution.py` — 2 fixes (tolerance, dead code)
- `backend/tests/quant_engine/test_factor_model_ipca_correctness.py` — 1 fix (truthiness)
- `docs/reference/wealth-math-conventions.md` — new convention reference

## Test plan
- [x] `test_validation_gate.py` — 33 passed (2 new: missing as_of_date fail-closed)
- [x] `test_return_statistics_service.py` — 33 passed (1 new: Sterling convention)
- [x] `test_attribution_carino.py` — 12 passed (2 new: L'Hôpital branch)
- [x] `test_attribution.py` — 27 passed (2 tightened)
- [x] `test_factor_model_ipca_correctness.py` — 12 passed (1 fixed truthiness)
- [x] Lint clean (`ruff check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)