### PR TITLE
feat(wealth): PR-BE-7 — consolidate legacy 'aggressive' profile into 'growth'

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/codebase_structure.md
+++ b/.serena/memories/codebase_structure.md
@@ -1,0 +1,29 @@
+# Codebase Structure
+
+Root layout:
+- `backend/`: Python backend packages and tests.
+- `backend/app/`: FastAPI application. `app/main.py` creates the FastAPI app and registers `/api/v1` routers.
+- `backend/app/core/`: auth/tenancy/RLS, DB engine and migrations, config, runtime guardrail primitives, jobs, middleware.
+- `backend/app/domains/`: API/domain layers. `wealth/` has models, queries, routes, schemas, services, utils, workers. `credit/` has actions, ai, dashboard, dataroom, deals, documents, global_agent, modules, portfolio, reporting.
+- `backend/app/services/`: shared app services such as storage client.
+- `backend/ai_engine/`: vertical-agnostic ingestion/classification/extraction/validation/prompt/LLM/knowledge pipeline.
+- `backend/quant_engine/`: quantitative services: CVaR/tail VaR, optimizer, risk budgeting, Black-Litterman, factor models/PCA/IPCA, GARCH, scoring, regime, rebalance, macro/FRED/Treasury/OFR, fixed income analytics, drawdown/return stats, correlation, stress, momentum.
+- `backend/vertical_engines/credit/`: credit vertical packages such as critic, deal_conversion, deep_review, domain_ai, edgar, kyc, market_data, memo, pipeline, portfolio, quant, retrieval, sponsor, underwriting. Package convention: `models.py`, `service.py`, helpers; `service.py` is entry point.
+- `backend/vertical_engines/wealth/`: wealth vertical packages such as asset_universe, attribution, correlation, critic, dd_report, fact_sheet, fee_drag, long_form_report, mandate_fit, model_portfolio, monitoring, monthly_report, peer_group, rebalancing, screener, watchlist, plus standalone engines.
+- `backend/app/core/db/migrations/versions/`: Alembic migrations. Latest files observed include `0199_q165_consolidate_aggressive_into_growth.py`; docs may mention older heads, so verify with Alembic/files before relying on a documented head.
+- `frontends/credit/`: SvelteKit app `netz-credit-intelligence`.
+- `frontends/wealth/`: SvelteKit app `netz-wealth-os`.
+- `frontends/terminal/`: SvelteKit app `ii-terminal`.
+- `packages/ui/`: shared Credit/Netz design system package `@netz/ui`.
+- `packages/investintell-ui/`: Wealth/InvestIntell design system package `@investintell/ui`.
+- `packages/ii-terminal-core/`: terminal shared core package.
+- `packages/eslint-plugin-netz-runtime/`: custom ESLint/runtime linting package.
+- `profiles/` and `calibration/`: YAML seed configuration only.
+- `docs/`: plans, audits, prompts, diagnostics, references. Relevant reference docs include `docs/reference/frontend-architecture-reference.md`, `docs/reference/wealth-math-conventions.md`, and `docs/reference/stability-guardrails.md`.
+- `scripts/`: root scripts including token drift sentinel.
+- `infra/`, `.github/`, `e2e/`, `tests/`: infrastructure, CI, E2E and auxiliary tests.
+
+Frontend workspace:
+- `pnpm-workspace.yaml` includes `packages/*` and `frontends/*`.
+- Turborepo `build` and `check` are topological; `dev` is persistent and uncached.
+- Credit uses `@netz/ui`; Wealth and Terminal use `@investintell/ui` and terminal core. Frontends share via design system packages and backend API, not direct cross-imports.

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,21 @@
+# Netz Analysis Engine - Project Overview
+
+Netz Analysis Engine is a unified multi-tenant institutional investment analysis engine for asset/wealth management and private credit workflows. The project should be approached as a high-end asset/wealth management engineering system: correctness, auditability, tenant isolation, deterministic analytics, and operational safety matter.
+
+Product scope is analytical only: credit deals/portfolio/documents/reporting/dashboard/global agent and wealth analytics/portfolio construction/screener/research. Operational modules such as cash management, signatures, counterparties, bank reconciliation, and tenant/user CRUD are intentionally out of scope and should not be reintroduced.
+
+Primary stack:
+- Python 3.12 backend with FastAPI, async SQLAlchemy/asyncpg, Pydantic v2, Alembic, structlog, Redis, SSE via `sse-starlette`.
+- PostgreSQL 16 + TimescaleDB + pgvector; local dev via docker-compose, production via Timescale Cloud. Redis local via Docker, production via Upstash.
+- Quant stack includes pandas, scipy, cvxpy, statsmodels, arch, aeon, IPCA, lmoments3, matplotlib, reportlab.
+- AI/data pipeline stack includes OpenAI, Jinja2 prompts, pgvector, DuckDB/Parquet, SEC EDGAR providers, local fallback providers.
+- Frontend monorepo uses pnpm 10.28.1, Turborepo v2, SvelteKit 2/Svelte 5/Vite 6/TypeScript/Tailwind 4, Playwright, Vitest, ESLint.
+
+Important concepts:
+- Auth is Clerk JWT v2. `organization_id` comes from `o.id`; dev bypass uses `X-DEV-ACTOR` / dev token. Tenant/user management is handled in Clerk Dashboard, not custom UI.
+- Runtime config comes from DB via ConfigService. `profiles/` and `calibration/` YAML are seed data only, not runtime config sources.
+- External time-series and SEC/market data are DB-first: workers ingest into TimescaleDB/global tables; user-facing routes and vertical engines should read DB-only methods, not call external APIs in hot paths.
+- Data lake writes go through StorageClient abstraction. Local dev defaults to `.data/lake/`; production target is Cloudflare R2. ADLS is deprecated and kept only for compatibility/rollback.
+- Prompts are Netz IP and must not be exposed via client-facing API responses.
+
+Repository state at onboarding: worktree had pre-existing modifications/untracked docs and `.serena/`; do not revert unrelated user changes.

--- a/.serena/memories/style_and_conventions.md
+++ b/.serena/memories/style_and_conventions.md
@@ -1,0 +1,48 @@
+# Style and Conventions
+
+General engineering stance:
+- Treat this as an institutional asset/wealth management system: deterministic math, auditability, tenant isolation, performance envelopes, and operational safety are first-class requirements.
+- Prefer existing repo patterns and domain boundaries over new abstractions.
+- Do not revert unrelated user changes in the worktree.
+
+Python/backend style:
+- Python target is 3.12; line length is 100. Ruff selects E/F/I/B/SIM, with several migration-era ignores in `pyproject.toml`.
+- Mypy is strict for backend app code. Use type hints consistently.
+- FastAPI route handlers should be `async def`, use `AsyncSession` from `get_db_with_rls`, declare `response_model=`, and return Pydantic objects via `model_validate()` rather than raw inline dict serialization.
+- SQLAlchemy relationships should use `lazy="raise"`; load explicitly with `selectinload()`/`joinedload()`.
+- Use `expire_on_commit=False`; avoid implicit async ORM I/O.
+- RLS context must use `SET LOCAL`, not `SET`. RLS policies should use `(SELECT current_setting(...))` to avoid per-row performance cliffs.
+- Avoid module-level asyncio primitives (`Semaphore`, `Lock`, `Event`); create lazily in async context.
+- Extract scalar values/frozen dataclasses before crossing async/thread boundaries with ORM data.
+- Advisory lock keys must be deterministic (e.g. `zlib.crc32`), never Python `hash()`.
+
+Architecture/import rules:
+- `vertical_engines.credit` and `vertical_engines.wealth` must remain independent.
+- In vertical engine packages, `service.py` is the entry point. Models/helpers must not import from `service.py`; `service.py` imports helpers.
+- Quant services should stay vertical-agnostic and should not import `app.domains.wealth`.
+- Credit business logic in `vertical_engines/credit/` should not be rewritten casually; only narrow session injection is called out as allowed in docs.
+
+Data/config/storage rules:
+- Use `ConfigService.get(vertical, config_type, org_id)` for runtime config. YAML in `profiles/` and `calibration/` is seed-only.
+- Use `StorageClient` abstraction; do not call R2/ADLS SDKs directly from business code.
+- Storage path construction must go through `storage_routing.py` helpers such as `bronze_document_path()`, `silver_chunks_path()`, `silver_metadata_path()`, `gold_memo_path()`.
+- Storage write is source of truth and should happen before pgvector upsert. pgvector is a derived index that can be rebuilt from silver Parquet.
+- Silver Parquet must include `embedding_model` and `embedding_dim`.
+- Tenant-scoped vector/DuckDB queries must filter by `organization_id`; global wealth vector data has `organization_id IS NULL` and should be handled intentionally.
+- Global tables such as `instruments_universe`, `nav_timeseries`, `fund_risk_metrics`, SEC tables, macro/benchmark data have no RLS and no tenant ownership. Org scoping for instruments is via `instruments_org`.
+
+External data and workers:
+- User-facing routes and vertical engines read from DB. Do not call external APIs such as FRED, Treasury, OFR, Yahoo/Tiingo, SEC EDGAR in request hot paths.
+- SEC provider services expose DB-only and fetch methods; routes/DD reports must use DB-only reads and leave fetch/discovery calls to ingestion workers.
+
+Frontend style:
+- SvelteKit/Svelte 5 + TypeScript. Use existing design systems and tokens.
+- Wealth/Terminal use `@investintell/ui` (`--ii-*`, dark-first, Urbanist/Geist). Credit uses `@netz/ui` (`--netz-*`, light-first, IBM Plex).
+- Frontends never cross-import each other. Wealth should not directly import `@netz/ui` components unless using the documented compatibility bridge; Credit should not import `@investintell/ui`.
+- Number/date/currency formatting in frontend code must use exported formatters from the design system (`formatNumber`, `formatCurrency`, `formatPercent`, `formatDate`, etc.). Avoid `.toFixed()`, `.toLocaleString()`, and direct `new Intl.*` in app code.
+- For routes/detail pages with failure states, prefer RouteData load contracts and boundary/error components per stability guardrails.
+
+Wealth math conventions:
+- Drawdowns are negative throughout the codebase; max drawdown is the most negative point.
+- Sterling ratio uses original Kestner convention: `ann_return / |avg_max_dd - 0.10|` with negative drawdowns.
+- Attribution cash residual uses `r_cash = 0.0` unless an IC policy explicitly introduces overnight/SOFR attribution.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,46 @@
+# Suggested Commands
+
+Environment setup on Windows:
+- `.\dev.ps1` - setup helper. Activates `.venv`, loads `.env.dev`, and moves into `backend/`.
+- `.\dev.ps1 -Install` - reinstall Python deps as editable package with `[dev,ai,quant,edgar]`.
+- `.\dev.ps1 -Reset` - recreate the venv.
+
+Backend development:
+- `make serve` - run FastAPI dev server on `127.0.0.1:8000`.
+- `make test` - run backend pytest suite under `backend/tests`.
+- `make test ARGS="-k pattern"` - run a targeted backend test subset.
+- `make lint` - Ruff check on backend.
+- `make typecheck` - mypy on `backend/app/`.
+- `make architecture` - import-linter contracts.
+- `make coverage-runtime` - runtime guardrails coverage gate.
+- `make check` - full gate: lint, architecture, typecheck, token sync, test.
+
+Database/local services:
+- `make up` - start local PostgreSQL 16 + TimescaleDB + pgvector and Redis via docker-compose.
+- `make down` - stop local docker-compose stack.
+- `make migrate` - Alembic upgrade head.
+- `make migration MSG="description"` - generate Alembic revision.
+- Local DB defaults: PostgreSQL on `localhost:5434`, DB `netz_engine`, user `netz`, password `password`; Redis on `localhost:6379`.
+
+Workers:
+- Generic CLI: `cd backend && python -m app.workers.cli <worker_name>`.
+- Registered worker names include `universe_sync`, `universe_auto_import`, `tiingo_enrichment`, `macro_ingestion`, `benchmark_ingest`, `treasury_ingestion`, `ofr_ingestion`, `bis_ingestion`, `imf_ingestion`, `nport_ingestion`, `nport_fund_discovery`, `esma_aum_sync`, `esma_ingestion`, `sec_refresh`, `sec_13f_ingestion`, `sec_adv_ingestion`, `brochure_download`, `brochure_extract`, `wealth_embedding`, `regime_fit`, `fast_track_eviction`, `instrument_ingestion`, `drift_check`, `risk_calc`, `portfolio_eval`, `portfolio_nav_synthesizer`, `screening_batch`, `watchlist_batch`, `alert_sweeper`.
+- SEC seed shortcuts: `python -m data_providers.sec.seed.populate_seed --recent-only`, `--only-ticker-map`, or `--resume`.
+
+Frontend/monorepo:
+- `pnpm install` - install JS deps if needed.
+- `pnpm run dev` or `make dev-all` - run Turborepo dev tasks.
+- `make dev-credit`, `make dev-wealth`, `make dev-terminal` - run individual SvelteKit apps.
+- `make build-all` - topological build of frontend packages/apps.
+- `make check-all` - frontend lint + check via Turbo.
+- `make lint-frontend` - ESLint all frontend packages.
+- `make check-terminal`, `make lint-terminal`, `make build-terminal` - terminal-specific gates.
+- `make types` - generate TS API types from running backend OpenAPI schema.
+- `pnpm test:e2e`, `pnpm test:e2e:credit`, `pnpm test:e2e:wealth`, `pnpm test:e2e:ui` - Playwright scripts.
+
+Windows utility commands:
+- `Get-ChildItem -Force` - list files including hidden.
+- `rg "pattern" path` and `rg --files` - preferred search/file listing.
+- `Get-Content path -TotalCount N` - read first N lines.
+- `Get-Content path | Select-Object -Skip S -First N` - read a slice.
+- `git status --short`, `git diff -- path`, `git diff --stat` - inspect changes without modifying worktree.

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -1,0 +1,30 @@
+# Task Completion Checklist
+
+Before claiming a backend change is complete:
+- Run the narrowest relevant pytest target first, e.g. `make test ARGS="-k pattern"` or `cd backend && python -m pytest path/to/test.py`.
+- Run `make lint` for Python lint changes.
+- Run `make typecheck` when touching typed backend/domain/service code.
+- Run `make architecture` when touching imports, vertical engines, quant_engine dependencies, or package boundaries.
+- Run `make check` for broad backend changes or before handoff when feasible.
+- If a change touches migrations/schema, verify `make migrate` against local DB when feasible and inspect Alembic revision dependencies/head state.
+- If a change touches runtime guardrails, run `make coverage-runtime` or relevant runtime tests.
+
+Before claiming a frontend change is complete:
+- Run package-specific checks when scoped: `make check-terminal`, `make lint-terminal`, or `pnpm --filter <package> check` / `lint` / `test`.
+- For shared UI packages, run package build/check/tests as relevant (`pnpm --filter @investintell/ui build`, `check`, `test`; similarly for `@netz/ui`).
+- For broad frontend changes, run `make check-all` and/or `make build-all` when feasible.
+- For route/UI behavior changes, verify in a browser or Playwright when practical. Root Playwright scripts include `pnpm test:e2e`, `pnpm test:e2e:credit`, `pnpm test:e2e:wealth`.
+- If generated API types are needed, run backend then `make types`.
+
+Data/domain safety checklist:
+- Confirm tenant-scoped reads filter by organization and use RLS/session helpers.
+- Confirm global market/SEC/instrument tables are not incorrectly filtered by tenant.
+- Confirm user-facing code does not call external data providers directly in hot paths.
+- Confirm runtime config uses ConfigService, not YAML seed files.
+- Confirm storage writes use StorageClient and path helpers.
+- Confirm prompts or proprietary prompt content are not exposed to clients.
+
+Git/worktree hygiene:
+- Inspect `git status --short` and relevant diffs before final summary.
+- Do not revert unrelated dirty worktree changes.
+- Mention tests/checks actually run. If not run, state that clearly and why.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,119 @@
+# the name by which the project can be referenced within Serena
+project_name: "netz-analysis-engine"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  ansible             bash                clojure             cpp
+#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
+#   elixir              elm                 erlang              fortran             fsharp
+#   go                  groovy              haskell             haxe                hlsl
+#   java                json                julia               kotlin              lean4
+#   lua                 luau                markdown            matlab              msl
+#   nix                 ocaml               pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         python_ty
+#   r                   rego                ruby                ruby_solargraph     rust
+#   scala               solidity            swift               systemverilog       terraform
+#   toml                typescript          typescript_vts      vue                 yaml
+#   zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- python
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/backend/app/core/db/migrations/versions/0199_q165_consolidate_aggressive_into_growth.py
+++ b/backend/app/core/db/migrations/versions/0199_q165_consolidate_aggressive_into_growth.py
@@ -166,8 +166,7 @@ def upgrade() -> None:
     # (UNIQUE on ``portfolio_id`` alone), so the legacy ``aggressive``
     # value is a free-form artefact. Plain UPDATE is collision-free.
     op.execute(
-        "UPDATE portfolio_calibration SET mandate = 'growth' "
-        "WHERE mandate = 'aggressive'",
+        "UPDATE portfolio_calibration SET mandate = 'growth' WHERE mandate = 'aggressive'",
     )
 
 

--- a/backend/app/core/db/migrations/versions/0199_q165_consolidate_aggressive_into_growth.py
+++ b/backend/app/core/db/migrations/versions/0199_q165_consolidate_aggressive_into_growth.py
@@ -30,7 +30,111 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # ── Profile namespace (full sweep) ─────────────────────────────
+    # ── Phase 1 — pre-UPDATE collision dedup (Codex P2/P3 catches) ──
+    # Five public-schema tables enforce uniqueness on a key tuple that
+    # includes ``profile``. On environments with both ``aggressive``
+    # AND ``growth`` rows for the same logical key, the blanket UPDATE
+    # in phase 2 would raise a unique-violation and abort the whole
+    # migration. Strategy: ``aggressive`` is a development artefact
+    # per the F1 audit narrative (2026-04-30); on a true collision we
+    # delete the ``aggressive`` row and keep ``growth`` as canonical.
+    # Each DELETE is scoped to the same partial-index predicate as
+    # the unique constraint it shadows, so non-colliding rows survive
+    # and get rewritten in phase 2.
+    #
+    # Conflict surfaces:
+    #   model_portfolios     | uq_model_portfolios_org_profile_active
+    #                          (organization_id, profile)
+    #                          WHERE status IN ('draft','backtesting','live')
+    #   portfolio_snapshots  | uq_portfolio_snapshots_org_profile_date
+    #                          (organization_id, profile, snapshot_date)
+    #   rebalance_events     | uq_rebalance_event_pending_drift_per_profile
+    #                          (organization_id, profile)
+    #                          WHERE status='pending'
+    #                            AND event_type='drift_rebalance'
+    #   taa_regime_state     | uq_taa_regime_state_org_profile_date
+    #                          (organization_id, profile, as_of_date)
+    #   tactical_positions   | uq_tactical_one_active_per_block
+    #                          (organization_id, profile, block_id)
+    #                          WHERE valid_to IS NULL
+
+    # model_portfolios — collide on (org, status_active)
+    op.execute(
+        """
+        DELETE FROM model_portfolios mp_a
+        WHERE mp_a.profile = 'aggressive'
+          AND mp_a.status IN ('draft', 'backtesting', 'live')
+          AND EXISTS (
+              SELECT 1 FROM model_portfolios mp_g
+              WHERE mp_g.organization_id = mp_a.organization_id
+                AND mp_g.profile = 'growth'
+                AND mp_g.status IN ('draft', 'backtesting', 'live')
+          )
+        """,
+    )
+
+    # portfolio_snapshots — collide on (org, snapshot_date)
+    op.execute(
+        """
+        DELETE FROM portfolio_snapshots ps_a
+        WHERE ps_a.profile = 'aggressive'
+          AND EXISTS (
+              SELECT 1 FROM portfolio_snapshots ps_g
+              WHERE ps_g.organization_id = ps_a.organization_id
+                AND ps_g.profile = 'growth'
+                AND ps_g.snapshot_date = ps_a.snapshot_date
+          )
+        """,
+    )
+
+    # rebalance_events — collide on (org) within pending drift partial index
+    op.execute(
+        """
+        DELETE FROM rebalance_events re_a
+        WHERE re_a.profile = 'aggressive'
+          AND re_a.status = 'pending'
+          AND re_a.event_type = 'drift_rebalance'
+          AND EXISTS (
+              SELECT 1 FROM rebalance_events re_g
+              WHERE re_g.organization_id = re_a.organization_id
+                AND re_g.profile = 'growth'
+                AND re_g.status = 'pending'
+                AND re_g.event_type = 'drift_rebalance'
+          )
+        """,
+    )
+
+    # taa_regime_state — collide on (org, as_of_date)
+    op.execute(
+        """
+        DELETE FROM taa_regime_state ts_a
+        WHERE ts_a.profile = 'aggressive'
+          AND EXISTS (
+              SELECT 1 FROM taa_regime_state ts_g
+              WHERE ts_g.organization_id = ts_a.organization_id
+                AND ts_g.profile = 'growth'
+                AND ts_g.as_of_date = ts_a.as_of_date
+          )
+        """,
+    )
+
+    # tactical_positions — collide on (org, block_id) within active partial index
+    op.execute(
+        """
+        DELETE FROM tactical_positions tp_a
+        WHERE tp_a.profile = 'aggressive'
+          AND tp_a.valid_to IS NULL
+          AND EXISTS (
+              SELECT 1 FROM tactical_positions tp_g
+              WHERE tp_g.organization_id = tp_a.organization_id
+                AND tp_g.profile = 'growth'
+                AND tp_g.block_id = tp_a.block_id
+                AND tp_g.valid_to IS NULL
+          )
+        """,
+    )
+
+    # ── Phase 2 — full sweep of profile-column tables ──────────────
     # Every public-schema table with a ``profile`` column must be
     # rewritten in lockstep with the route-layer alias normaliser —
     # otherwise queries canonicalised to ``growth`` would silently
@@ -56,10 +160,11 @@ def upgrade() -> None:
             f"WHERE profile = 'aggressive'",
         )
 
-    # ── Mandate namespace ──────────────────────────────────────────
+    # ── Phase 3 — mandate namespace ────────────────────────────────
     # ``portfolio_calibration.mandate`` is a ``String(64)`` column with
-    # no DB-level CHECK constraint, so the legacy ``aggressive`` value
-    # is a free-form artefact. Same hygienic UPDATE pattern.
+    # no DB-level CHECK constraint and no profile-based uniqueness
+    # (UNIQUE on ``portfolio_id`` alone), so the legacy ``aggressive``
+    # value is a free-form artefact. Plain UPDATE is collision-free.
     op.execute(
         "UPDATE portfolio_calibration SET mandate = 'growth' "
         "WHERE mandate = 'aggressive'",

--- a/backend/app/core/db/migrations/versions/0199_q165_consolidate_aggressive_into_growth.py
+++ b/backend/app/core/db/migrations/versions/0199_q165_consolidate_aggressive_into_growth.py
@@ -30,22 +30,31 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # ── Profile namespace ──────────────────────────────────────────
-    # Three tables carry a ``profile`` column whose canonical enum was
-    # ``conservative`` / ``moderate`` / ``growth`` / ``aggressive``.
-    # PR-BE-7 collapses ``aggressive`` into ``growth``.
-    op.execute(
-        "UPDATE model_portfolios SET profile = 'growth' "
-        "WHERE profile = 'aggressive'",
+    # ── Profile namespace (full sweep) ─────────────────────────────
+    # Every public-schema table with a ``profile`` column must be
+    # rewritten in lockstep with the route-layer alias normaliser —
+    # otherwise queries canonicalised to ``growth`` would silently
+    # miss legacy ``aggressive`` rows during the 180-day compatibility
+    # window, producing a data-visibility regression (Codex P2 catch
+    # on PR #463). Audit source:
+    #   SELECT table_name FROM information_schema.columns
+    #   WHERE table_schema='public' AND column_name='profile';
+    _PROFILE_TABLES = (
+        "model_portfolios",
+        "strategic_allocation",
+        "allocation_approvals",
+        "allocation_template_audit",
+        "backtest_runs",
+        "portfolio_snapshots",
+        "rebalance_events",
+        "taa_regime_state",
+        "tactical_positions",
     )
-    op.execute(
-        "UPDATE strategic_allocation SET profile = 'growth' "
-        "WHERE profile = 'aggressive'",
-    )
-    op.execute(
-        "UPDATE allocation_approvals SET profile = 'growth' "
-        "WHERE profile = 'aggressive'",
-    )
+    for table in _PROFILE_TABLES:
+        op.execute(
+            f"UPDATE {table} SET profile = 'growth' "
+            f"WHERE profile = 'aggressive'",
+        )
 
     # ── Mandate namespace ──────────────────────────────────────────
     # ``portfolio_calibration.mandate`` is a ``String(64)`` column with

--- a/backend/app/core/db/migrations/versions/0199_q165_consolidate_aggressive_into_growth.py
+++ b/backend/app/core/db/migrations/versions/0199_q165_consolidate_aggressive_into_growth.py
@@ -134,8 +134,8 @@ def upgrade() -> None:
         """,
     )
 
-    # ── Phase 2 — full sweep of profile-column tables ──────────────
-    # Every public-schema table with a ``profile`` column must be
+    # ── Phase 2 — full sweep of stored profile slugs ───────────────
+    # Every public-schema table with a stored profile slug must be
     # rewritten in lockstep with the route-layer alias normaliser —
     # otherwise queries canonicalised to ``growth`` would silently
     # miss legacy ``aggressive`` rows during the 180-day compatibility
@@ -143,6 +143,8 @@ def upgrade() -> None:
     # on PR #463). Audit source:
     #   SELECT table_name FROM information_schema.columns
     #   WHERE table_schema='public' AND column_name='profile';
+    #   SELECT table_name FROM information_schema.columns
+    #   WHERE table_schema='public' AND column_name='portfolio_profile';
     _PROFILE_TABLES = (
         "model_portfolios",
         "strategic_allocation",
@@ -159,6 +161,18 @@ def upgrade() -> None:
             f"UPDATE {table} SET profile = 'growth' "
             f"WHERE profile = 'aggressive'",
         )
+
+    # Blended benchmarks use ``portfolio_profile`` instead of ``profile``.
+    # Keep stored data aligned with ``routes/blended_benchmark.py`` where
+    # legacy URL params are canonicalised through ``_validate_profile`` before
+    # querying by ``portfolio_profile``.
+    op.execute(
+        """
+        UPDATE blended_benchmarks
+        SET portfolio_profile = 'growth'
+        WHERE portfolio_profile = 'aggressive'
+        """,
+    )
 
     # ── Phase 3 — mandate namespace ────────────────────────────────
     # ``portfolio_calibration.mandate`` is a ``String(64)`` column with

--- a/backend/app/core/db/migrations/versions/0199_q165_consolidate_aggressive_into_growth.py
+++ b/backend/app/core/db/migrations/versions/0199_q165_consolidate_aggressive_into_growth.py
@@ -1,0 +1,68 @@
+"""PR-BE-7 — consolidate legacy ``aggressive`` profile/mandate into ``growth``.
+
+Defensive backfill across every wealth surface that historically carried
+the ``aggressive`` slug. Per the F1 audit (2026-04-30), the local docker
+DB and the Timescale Cloud target both have **zero** rows referencing
+the legacy slug — ``aggressive`` was a development artefact, not a
+canonical product profile, and never made it into a tenant snapshot.
+The migration runs anyway as a one-time hygiene sweep so any developer
+fixture or stale environment is brought into line with the
+post-PR-BE-7 enum (``conservative`` / ``moderate`` / ``growth``).
+
+The application-layer alias normaliser (introduced alongside this
+migration) keeps URL- and mandate-level callers backward compatible
+through 2026-10-30 (180 days post-merge); the DB layer is the
+authoritative truth source from this revision onward.
+
+Revision ID: 0199_q165_consolidate_aggressive_into_growth
+Revises: 0198_q159_rebuild_mv_nport_sector_attribution
+Create Date: 2026-04-30
+"""
+from __future__ import annotations
+
+from alembic import op
+
+# Revision identifiers, used by Alembic.
+revision = "0199_q165_consolidate_aggressive_into_growth"
+down_revision = "0198_q159_rebuild_mv_nport_sector_attribution"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── Profile namespace ──────────────────────────────────────────
+    # Three tables carry a ``profile`` column whose canonical enum was
+    # ``conservative`` / ``moderate`` / ``growth`` / ``aggressive``.
+    # PR-BE-7 collapses ``aggressive`` into ``growth``.
+    op.execute(
+        "UPDATE model_portfolios SET profile = 'growth' "
+        "WHERE profile = 'aggressive'",
+    )
+    op.execute(
+        "UPDATE strategic_allocation SET profile = 'growth' "
+        "WHERE profile = 'aggressive'",
+    )
+    op.execute(
+        "UPDATE allocation_approvals SET profile = 'growth' "
+        "WHERE profile = 'aggressive'",
+    )
+
+    # ── Mandate namespace ──────────────────────────────────────────
+    # ``portfolio_calibration.mandate`` is a ``String(64)`` column with
+    # no DB-level CHECK constraint, so the legacy ``aggressive`` value
+    # is a free-form artefact. Same hygienic UPDATE pattern.
+    op.execute(
+        "UPDATE portfolio_calibration SET mandate = 'growth' "
+        "WHERE mandate = 'aggressive'",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "PR-BE-7 consolidates the legacy 'aggressive' profile/mandate "
+        "into 'growth'. The original distinction was a development "
+        "artefact, not a canonical product setting, so a reversible "
+        "downgrade would have to invent which rows were originally "
+        "'aggressive' vs which were 'growth'. Restore from a "
+        "pre-migration backup if you genuinely need the legacy split.",
+    )

--- a/backend/app/domains/wealth/models/model_portfolio.py
+++ b/backend/app/domains/wealth/models/model_portfolio.py
@@ -16,11 +16,14 @@ import uuid
 from datetime import date, datetime
 from decimal import Decimal
 
+import structlog
 from sqlalchemy import Boolean, Date, DateTime, Integer, Numeric, String, Text, Uuid, func
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.db.base import Base, OrganizationScopedMixin
+
+logger = structlog.get_logger()
 
 
 class ModelPortfolio(OrganizationScopedMixin, Base):
@@ -75,8 +78,15 @@ _CVAR_DEFAULT_BY_PROFILE: dict[str, Decimal] = {
     "conservative": Decimal("0.0500"),  # PR-A18: was 0.0250 (A12.2)
     "moderate": Decimal("0.0750"),      # PR-A18: was 0.0500
     "growth": Decimal("0.1000"),        # PR-A18: was 0.0800
-    "aggressive": Decimal("0.1250"),    # PR-A18: was 0.1000
 }
+
+# PR-BE-7 (2026-04-30) — `aggressive` was a development artefact and not
+# a canonical product profile. Legacy callers may still pass it; we
+# normalise to `growth` (the canonical Dynamic Growth profile) and emit
+# a structured deprecation log so the sunset dashboard can track residual
+# usage. Sunset target: 2026-10-30 (180 days post-merge).
+_LEGACY_PROFILE_ALIASES: dict[str, str] = {"aggressive": "growth"}
+_LEGACY_PROFILE_SUNSET_DATE = "2026-10-30"
 
 
 def default_cvar_limit_for_profile(profile: str | None) -> Decimal:
@@ -85,11 +95,22 @@ def default_cvar_limit_for_profile(profile: str | None) -> Decimal:
     Falls back to ``Decimal("0.0750")`` (moderate, PR-A18) for None /
     unknown values so code paths without a resolved profile (legacy
     fixtures, future profiles not yet calibrated) get a safe value
-    rather than KeyError. Lookup is case-insensitive.
+    rather than KeyError. Lookup is case-insensitive. ``aggressive``
+    is normalised to ``growth`` (PR-BE-7) with a deprecation log.
     """
     if profile is None:
         return Decimal("0.0750")
-    return _CVAR_DEFAULT_BY_PROFILE.get(profile.lower(), Decimal("0.0750"))
+    received = profile.lower()
+    canonical = _LEGACY_PROFILE_ALIASES.get(received, received)
+    if canonical != received:
+        logger.info(
+            "legacy_profile_alias_used",
+            received=profile,
+            canonical=canonical,
+            sunset_at=_LEGACY_PROFILE_SUNSET_DATE,
+            source="default_cvar_limit_for_profile",
+        )
+    return _CVAR_DEFAULT_BY_PROFILE.get(canonical, Decimal("0.0750"))
 
 
 class PortfolioCalibration(OrganizationScopedMixin, Base):

--- a/backend/app/domains/wealth/routes/_profile_normalizer.py
+++ b/backend/app/domains/wealth/routes/_profile_normalizer.py
@@ -1,0 +1,74 @@
+"""PR-BE-7 — backward-compat URL alias normaliser for profile path params.
+
+Maps the legacy ``aggressive`` profile slug to the canonical ``growth``
+slug with a structured deprecation log so the sunset dashboard can
+track residual usage. ``aggressive`` was a development artefact and is
+not a canonical product profile; ``growth`` is the institutional
+"Dynamic Growth" profile (display label resolved by
+``profile_display_label`` / ``profileDisplayLabel``).
+
+Sunset target: 2026-10-30 (180 days post-merge).
+
+Usage in route handlers
+-----------------------
+    from app.domains.wealth.routes._profile_normalizer import (
+        normalize_profile_param,
+    )
+
+    @router.get("/{profile}/strategic")
+    async def get_strategic(profile: str, ...):
+        profile = normalize_profile_param(profile)
+        ...
+
+Unknown profiles raise ``HTTPException(400)`` with the list of valid
+slugs in ``detail`` so a misconfigured client gets actionable feedback
+instead of a downstream "no rows found" 404. Tenant-scoped custom
+profiles are out of scope here (Q6 / v2 / post-GA) and will land via a
+ConfigService-backed registry rather than by widening this hardcoded
+allowlist.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import HTTPException
+
+logger = structlog.get_logger()
+
+_LEGACY_PROFILE_ALIASES: dict[str, str] = {"aggressive": "growth"}
+_VALID_PROFILES: frozenset[str] = frozenset({"conservative", "moderate", "growth"})
+_SUNSET_DATE = "2026-10-30"
+
+
+def normalize_profile_param(profile: str) -> str:
+    """Resolve a path-param profile slug, accepting one legacy alias.
+
+    Returns the canonical lowercase slug. Emits ``legacy_profile_url_alias``
+    when the legacy ``aggressive`` slug is received. Raises 400 for any
+    other unknown slug — never silently passes through to downstream
+    queries that would 404 with a confusing "no allocation found"
+    message.
+    """
+    lc = profile.strip().lower()
+    if lc in _LEGACY_PROFILE_ALIASES:
+        canonical = _LEGACY_PROFILE_ALIASES[lc]
+        logger.info(
+            "legacy_profile_url_alias",
+            received=profile,
+            canonical=canonical,
+            sunset_at=_SUNSET_DATE,
+        )
+        return canonical
+    if lc not in _VALID_PROFILES:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_profile",
+                "message": f"Profile '{profile}' is not recognized.",
+                "valid_profiles": sorted(_VALID_PROFILES),
+            },
+        )
+    return lc
+
+
+__all__ = ["normalize_profile_param"]

--- a/backend/app/domains/wealth/routes/allocation.py
+++ b/backend/app/domains/wealth/routes/allocation.py
@@ -52,7 +52,7 @@ async def get_strategic(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[StrategicAllocationRead]:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     today = date.today()
     stmt = (
         select(StrategicAllocation)
@@ -80,7 +80,7 @@ async def update_strategic(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(require_ic_member),
 ) -> list[StrategicAllocationRead]:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     today = date.today()
 
     # Expire current allocations
@@ -133,7 +133,7 @@ async def get_tactical(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[TacticalPositionRead]:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     today = date.today()
     stmt = (
         select(TacticalPosition)
@@ -160,7 +160,7 @@ async def update_tactical(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(require_ic_member),
 ) -> list[TacticalPositionRead]:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     today = date.today()
 
     # Expire current positions
@@ -206,7 +206,7 @@ async def get_effective(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[EffectiveAllocationRead]:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     today = date.today()
 
     # Get strategic allocations
@@ -281,7 +281,7 @@ async def simulate_allocation(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> SimulationResult:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
 
     # --- validate weights sum ≈ 1.0 ---
     weights_sum = sum(body.weights.values())
@@ -540,7 +540,7 @@ async def get_regime_bands(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> RegimeBandsRead:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
 
     # Fetch latest taa_regime_state row
     stmt = (
@@ -615,7 +615,7 @@ async def get_taa_history(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> TaaHistoryRead:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
 
     # Total count
     count_stmt = (
@@ -653,7 +653,7 @@ async def get_effective_with_regime(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[EffectiveAllocationWithRegimeRead]:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     today = date.today()
 
     # Get strategic allocations

--- a/backend/app/domains/wealth/routes/analytics.py
+++ b/backend/app/domains/wealth/routes/analytics.py
@@ -138,7 +138,7 @@ async def create_backtest(
     user: CurrentUser = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_org_id),
 ) -> BacktestRunRead:
-    _validate_profile(body.profile)
+    body.profile = _validate_profile(body.profile)
 
     # If cv=True in params, run walk-forward backtest synchronously (on-demand analytics)
     cv_metrics = None
@@ -236,7 +236,7 @@ async def optimize(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> OptimizeResult:
-    _validate_profile(body.profile)
+    body.profile = _validate_profile(body.profile)
 
     # Get strategic allocation blocks for this profile
     today = date.today()
@@ -336,7 +336,7 @@ async def optimize_pareto(
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
 ) -> ParetoOptimizeResult:
-    _validate_profile(body.profile)
+    body.profile = _validate_profile(body.profile)
 
     today = date.today()
     alloc_stmt = (
@@ -669,7 +669,7 @@ async def get_risk_budget(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> RiskBudgetResponse:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
 
     allocations, block_ids, block_names, weights = await _resolve_profile_weights(db, profile)
 
@@ -736,7 +736,7 @@ async def get_factor_analysis(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> FactorAnalysisResponse:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
 
     _, block_ids, _, weights = await _resolve_profile_weights(db, profile)
 

--- a/backend/app/domains/wealth/routes/attribution.py
+++ b/backend/app/domains/wealth/routes/attribution.py
@@ -25,6 +25,7 @@ from app.domains.wealth.models.block import AllocationBlock
 from app.domains.wealth.models.instrument_org import InstrumentOrg
 from app.domains.wealth.models.model_portfolio import ModelPortfolio
 from app.domains.wealth.models.nav import NavTimeseries
+from app.domains.wealth.routes.common import validate_profile as _validate_profile
 from app.domains.wealth.schemas.attribution import AttributionRead, SectorAttributionRead
 
 logger = structlog.get_logger()
@@ -71,6 +72,7 @@ async def get_attribution(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> AttributionRead:
+    profile = _validate_profile(profile)
     effective_end = end_date or date.today()
     effective_start = start_date or _add_months(effective_end, -12)
 

--- a/backend/app/domains/wealth/routes/blended_benchmark.py
+++ b/backend/app/domains/wealth/routes/blended_benchmark.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security.clerk_auth import CurrentUser, get_current_user, require_ic_member
 from app.core.tenancy.middleware import get_db_with_rls
+from app.domains.wealth.routes.common import validate_profile as _validate_profile
 from app.domains.wealth.schemas.blended_benchmark import (
     BlendedBenchmarkCreate,
     BlendedBenchmarkNAV,
@@ -46,6 +47,7 @@ async def get_benchmark(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> BlendedBenchmarkRead | None:
+    profile = _validate_profile(profile)
     return await svc.get_active_benchmark(db, profile)
 
 
@@ -61,6 +63,7 @@ async def create_benchmark(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(require_ic_member),
 ) -> BlendedBenchmarkRead:
+    profile = _validate_profile(profile)
     return await svc.create_blended_benchmark(db, profile, body)
 
 

--- a/backend/app/domains/wealth/routes/common.py
+++ b/backend/app/domains/wealth/routes/common.py
@@ -4,13 +4,24 @@ from __future__ import annotations
 
 import asyncio
 
+import structlog
 from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domains.wealth.models.portfolio import PortfolioSnapshot
 
+logger = structlog.get_logger()
+
 VALID_PROFILES = {"conservative", "moderate", "growth"}
+
+# PR-BE-7 — backward-compat URL alias for the legacy ``aggressive``
+# profile. Sunset 2026-10-30 (180d post-merge). Centralised here so
+# every route that calls ``validate_profile`` inherits the alias
+# automatically — see ``_profile_normalizer.py`` for the shared
+# rationale.
+_LEGACY_PROFILE_ALIASES: dict[str, str] = {"aggressive": "growth"}
+_LEGACY_PROFILE_SUNSET_DATE = "2026-10-30"
 
 # ---------------------------------------------------------------------------
 #  Content generation backpressure
@@ -50,13 +61,30 @@ async def require_content_slot() -> None:
 
 
 def validate_profile(profile: str) -> str:
-    """Validate that profile is one of the allowed values."""
-    if profile not in VALID_PROFILES:
+    """Validate that profile is one of the allowed values.
+
+    Returns the canonical (lowercased, alias-resolved) slug — callers
+    must use the return value, not the original argument, when joining
+    against ``profile`` columns. The legacy ``aggressive`` slug is
+    rewritten to ``growth`` (PR-BE-7) with a structured deprecation
+    log so the sunset dashboard can track residual usage.
+    """
+    lc = profile.strip().lower()
+    if lc in _LEGACY_PROFILE_ALIASES:
+        canonical = _LEGACY_PROFILE_ALIASES[lc]
+        logger.info(
+            "legacy_profile_url_alias",
+            received=profile,
+            canonical=canonical,
+            sunset_at=_LEGACY_PROFILE_SUNSET_DATE,
+        )
+        return canonical
+    if lc not in VALID_PROFILES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid profile. Must be one of: {', '.join(sorted(VALID_PROFILES))}",
         )
-    return profile
+    return lc
 
 
 async def get_latest_snapshot(

--- a/backend/app/domains/wealth/routes/correlation_regime.py
+++ b/backend/app/domains/wealth/routes/correlation_regime.py
@@ -20,6 +20,7 @@ from app.core.tenancy.middleware import get_db_with_rls
 from app.domains.wealth.models.instrument import Instrument
 from app.domains.wealth.models.model_portfolio import ModelPortfolio
 from app.domains.wealth.models.nav import NavTimeseries
+from app.domains.wealth.routes.common import validate_profile as _validate_profile
 from app.domains.wealth.schemas.correlation_regime import (
     ConcentrationRead,
     CorrelationRegimeRead,
@@ -44,6 +45,7 @@ async def get_correlation_regime(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> CorrelationRegimeRead:
+    profile = _validate_profile(profile)
     # 1. Load live model portfolio
     mp_stmt = select(ModelPortfolio).where(
         ModelPortfolio.profile == profile,
@@ -220,6 +222,7 @@ async def get_pair_correlation(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> PairCorrelationTimeseriesRead:
+    profile = _validate_profile(profile)
     # Load instrument names
     inst_stmt = select(Instrument.instrument_id, Instrument.name).where(
         Instrument.instrument_id.in_([inst_a, inst_b]),

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -4886,8 +4886,32 @@ async def _set_cached_mc(cache_key: str, result: dict, ttl: int = 3600) -> None:
 
 
 _PROPOSE_VALID_PROFILES: frozenset[str] = frozenset(
-    {"conservative", "moderate", "growth", "aggressive"},
+    {"conservative", "moderate", "growth"},
 )
+
+# PR-BE-7 — backward-compat alias for the legacy ``aggressive`` slug on
+# propose-mode endpoints. Sunset 2026-10-30 (180d post-merge). Mirrored
+# from ``app.domains.wealth.routes.common._LEGACY_PROFILE_ALIASES`` so
+# the propose endpoints (which validate against their own
+# ``_PROPOSE_VALID_PROFILES`` frozenset rather than the shared
+# ``validate_profile`` helper) inherit the same normalisation surface.
+_PROPOSE_LEGACY_ALIASES: dict[str, str] = {"aggressive": "growth"}
+
+
+def _normalize_propose_profile(profile: str) -> str:
+    """Normalise a propose-mode profile slug, accepting the legacy alias."""
+    lc = profile.strip().lower()
+    if lc in _PROPOSE_LEGACY_ALIASES:
+        canonical = _PROPOSE_LEGACY_ALIASES[lc]
+        logger.info(
+            "legacy_profile_url_alias",
+            received=profile,
+            canonical=canonical,
+            sunset_at="2026-10-30",
+            scope="propose_mode",
+        )
+        return canonical
+    return lc
 
 
 async def _resolve_propose_target_portfolio(
@@ -4961,7 +4985,7 @@ async def propose_allocation(
 
     _require_ic_role(actor)
 
-    profile_lc = profile.strip().lower()
+    profile_lc = _normalize_propose_profile(profile)
     if profile_lc not in _PROPOSE_VALID_PROFILES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -5016,7 +5040,7 @@ async def latest_proposal(
     pair. ``proposed_bands`` carries one entry per canonical block
     (excluded blocks emit ``target_weight = 0`` with rationale).
     """
-    profile_lc = profile.strip().lower()
+    profile_lc = _normalize_propose_profile(profile)
     if profile_lc not in _PROPOSE_VALID_PROFILES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -5149,7 +5173,7 @@ async def approve_proposal(
 
     _require_ic_role(actor)
 
-    profile_lc = profile.strip().lower()
+    profile_lc = _normalize_propose_profile(profile)
     if profile_lc not in _PROPOSE_VALID_PROFILES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -5380,7 +5404,7 @@ async def set_override(
 
     _require_ic_role(actor)
 
-    profile_lc = profile.strip().lower()
+    profile_lc = _normalize_propose_profile(profile)
     if profile_lc not in _PROPOSE_VALID_PROFILES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -5507,7 +5531,7 @@ async def get_strategic_allocation(
         humanize_block,
     )
 
-    profile_lc = profile.strip().lower()
+    profile_lc = _normalize_propose_profile(profile)
     if profile_lc not in _PROPOSE_VALID_PROFILES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -5660,7 +5684,7 @@ async def get_approval_history(
     """
     from sqlalchemy import text as _sa_text
 
-    profile_lc = profile.strip().lower()
+    profile_lc = _normalize_propose_profile(profile)
     if profile_lc not in _PROPOSE_VALID_PROFILES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/domains/wealth/routes/portfolios/__init__.py
+++ b/backend/app/domains/wealth/routes/portfolios/__init__.py
@@ -65,7 +65,7 @@ async def get_portfolio(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> PortfolioSummary:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     snap = await get_latest_snapshot(db, profile)
     return _snapshot_to_summary(profile, snap)
 
@@ -81,7 +81,7 @@ async def get_snapshot(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> PortfolioSnapshotRead | None:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     snap = await get_latest_snapshot(db, profile)
     if snap is None:
         return None
@@ -105,7 +105,7 @@ async def get_history(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[PortfolioSnapshotRead]:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     stmt = select(PortfolioSnapshot).where(PortfolioSnapshot.profile == profile)
     if from_date is not None:
         stmt = stmt.where(PortfolioSnapshot.snapshot_date >= from_date)
@@ -135,7 +135,7 @@ async def trigger_rebalance(
     user: CurrentUser = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_org_id),
 ) -> RebalanceEventRead:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     snap = await get_latest_snapshot(db, profile)
 
     event = RebalanceEvent(
@@ -169,7 +169,7 @@ async def list_rebalance_events(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[RebalanceEventRead]:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     stmt = select(RebalanceEvent).where(RebalanceEvent.profile == profile)
     if event_status is not None:
         stmt = stmt.where(RebalanceEvent.status == event_status)
@@ -190,7 +190,7 @@ async def get_rebalance_event(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> RebalanceEventRead:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     stmt = select(RebalanceEvent).where(
         RebalanceEvent.event_id == event_id,
         RebalanceEvent.profile == profile,
@@ -217,7 +217,7 @@ async def approve_rebalance(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(require_ic_member()),
 ) -> RebalanceEventRead:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     # SELECT FOR UPDATE to prevent concurrent approval race condition
     stmt = (
         select(RebalanceEvent)
@@ -269,7 +269,7 @@ async def execute_rebalance(
     3. Transition event to 'executed'
     4. Publish SSE alert
     """
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
 
     from quant_engine.rebalance_service import validate_status_transition
 

--- a/backend/app/domains/wealth/routes/risk.py
+++ b/backend/app/domains/wealth/routes/risk.py
@@ -195,7 +195,7 @@ async def get_cvar(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> CVaRStatus:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
     snap = await get_latest_snapshot(db, profile)
     cvar = _snap_to_cvar(profile, snap)
 
@@ -248,7 +248,7 @@ async def get_cvar_history(
     db: AsyncSession = Depends(get_db_with_rls),
     user: CurrentUser = Depends(get_current_user),
 ) -> list[CVaRPoint]:
-    _validate_profile(profile)
+    profile = _validate_profile(profile)
 
     today = date.today()
     # Default: last 6 months if no from_date — avoids full hypertable scan

--- a/backend/app/domains/wealth/schemas/preview.py
+++ b/backend/app/domains/wealth/schemas/preview.py
@@ -13,7 +13,15 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+import structlog
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+logger = structlog.get_logger()
+
+# PR-BE-7 — sunset 2026-10-30 (180d post-merge). Legacy ``aggressive``
+# clients are rewritten to ``growth`` BEFORE Literal validation so the
+# request body alias contract holds end-to-end (Codex P1 catch on #463).
+_LEGACY_MANDATE_ALIASES: dict[str, str] = {"aggressive": "growth"}
 
 
 class PreviewCvarRequest(BaseModel):
@@ -29,6 +37,22 @@ class PreviewCvarRequest(BaseModel):
 
     cvar_limit: float = Field(..., ge=0.0005, le=0.20)
     mandate: Literal["conservative", "moderate", "growth"] | None = None
+
+    @field_validator("mandate", mode="before")
+    @classmethod
+    def _rewrite_legacy_mandate(cls, value: object) -> object:
+        if isinstance(value, str):
+            lc = value.strip().lower()
+            canonical = _LEGACY_MANDATE_ALIASES.get(lc)
+            if canonical is not None:
+                logger.info(
+                    "legacy_mandate_payload_alias",
+                    received=value,
+                    canonical=canonical,
+                    sunset_at="2026-10-30",
+                )
+                return canonical
+        return value
 
 
 class AchievableReturnBandDTO(BaseModel):

--- a/backend/app/domains/wealth/schemas/preview.py
+++ b/backend/app/domains/wealth/schemas/preview.py
@@ -28,7 +28,7 @@ class PreviewCvarRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     cvar_limit: float = Field(..., ge=0.0005, le=0.20)
-    mandate: Literal["conservative", "moderate", "growth", "aggressive"] | None = None
+    mandate: Literal["conservative", "moderate", "growth"] | None = None
 
 
 class AchievableReturnBandDTO(BaseModel):

--- a/backend/app/domains/wealth/schemas/sanitized.py
+++ b/backend/app/domains/wealth/schemas/sanitized.py
@@ -263,6 +263,46 @@ METRIC_LABELS: dict[str, str] = {
     "dtw_drift": "Strategy Deviation Score",
 }
 
+# PR-BE-7 — Profile display labels.
+#
+# Slugs (``conservative`` / ``moderate`` / ``growth``) are stable in
+# code, URL, and DB; product copy ("Dynamic Growth" for ``growth``) is
+# resolved here so backend-driven copy stays consistent with the
+# frontend ``profileDisplayLabel`` helper. ``aggressive`` is rewritten
+# to ``growth`` (sunset 2026-10-30) — see PR-BE-7.
+_PROFILE_DISPLAY_FULL: dict[str, str] = {
+    "conservative": "Conservative",
+    "moderate": "Moderate",
+    "growth": "Dynamic Growth",
+}
+_PROFILE_DISPLAY_DENSE: dict[str, str] = {
+    "conservative": "Conservative",
+    "moderate": "Moderate",
+    "growth": "Dynamic",
+}
+_PROFILE_LEGACY_ALIASES: dict[str, str] = {"aggressive": "growth"}
+
+
+def profile_display_label(
+    profile: str,
+    context: Literal["dense", "full"] = "full",
+) -> str:
+    """Return the user-facing label for a profile slug.
+
+    ``context="dense"`` renders the short form ("Dynamic"), used in
+    chips, badges, and tight headers. ``context="full"`` renders the
+    institutional name ("Dynamic Growth") used in copy that has room
+    for the marketing label. Unknown slugs (e.g. tenant-scoped custom
+    profiles introduced via ConfigService in v2) fall through to a
+    title-cased version of the raw slug — never silently dropped.
+    """
+    canonical = _PROFILE_LEGACY_ALIASES.get(profile.lower(), profile.lower())
+    table = _PROFILE_DISPLAY_DENSE if context == "dense" else _PROFILE_DISPLAY_FULL
+    if canonical in table:
+        return table[canonical]
+    return profile[:1].upper() + profile[1:] if profile else profile
+
+
 # Backend emits SCREAMING_SNAKE enums; the institutional reading is
 # the three-state Expansion / Cautious / Stress phrasing.
 REGIME_LABELS: dict[str, str] = {

--- a/backend/quant_engine/mandate_risk_aversion.py
+++ b/backend/quant_engine/mandate_risk_aversion.py
@@ -50,14 +50,35 @@ RA_MAX = 10.0                # upper bound — beyond this, optimizer scaling fa
 # Pre-compiled normaliser: collapse runs of whitespace + dashes into one underscore.
 _KEY_NORMALISER = re.compile(r"[\s\-]+")
 
+# PR-BE-7 — backward-compat alias for the legacy ``aggressive`` mandate.
+# The dict ``_MANDATE_RISK_AVERSION`` keeps the key so any direct lookups
+# elsewhere keep working, but normalised input is rewritten to ``growth``
+# with a deprecation log. Sunset 2026-10-30 (180d post-merge). Atomic
+# (compound) keys like ``moderate_aggressive`` are NOT touched — those
+# are independent ladder rungs, not the legacy artefact.
+_MANDATE_ALIASES: dict[str, str] = {"aggressive": "growth"}
+_MANDATE_SUNSET_DATE = "2026-10-30"
+
 
 def _normalise_mandate(mandate: str) -> str:
     """Normalise a free-text mandate label to the canonical dict key.
 
     Collapses runs of whitespace and dashes (e.g., '  ', '--', ' - ')
-    into single underscores. Idempotent.
+    into single underscores. Idempotent. The legacy ``aggressive``
+    mandate is rewritten to ``growth`` (PR-BE-7) with a structured
+    deprecation log.
     """
-    return _KEY_NORMALISER.sub("_", mandate.strip().lower())
+    key = _KEY_NORMALISER.sub("_", mandate.strip().lower())
+    if key in _MANDATE_ALIASES:
+        canonical = _MANDATE_ALIASES[key]
+        logger.info(
+            "legacy_mandate_alias_used",
+            received=key,
+            canonical=canonical,
+            sunset_at=_MANDATE_SUNSET_DATE,
+        )
+        return canonical
+    return key
 
 
 def resolve_risk_aversion(

--- a/backend/tests/db/test_migration_0199_q165.py
+++ b/backend/tests/db/test_migration_0199_q165.py
@@ -71,6 +71,32 @@ def test_upgrade_rewrites_mandate_in_portfolio_calibration() -> None:
     )
 
 
+# ── Phase 1 — pre-UPDATE dedup (Codex P3 catch on PR #463) ───────────
+# Five tables enforce uniqueness on a key tuple that includes ``profile``;
+# the migration must DELETE colliding aggressive rows BEFORE the UPDATE
+# loop so a legacy environment with both ``growth`` and ``aggressive``
+# rows for the same logical key does not abort with unique-violation.
+
+@pytest.mark.parametrize("table,join_predicate", [
+    ("model_portfolios", "mp_g.organization_id = mp_a.organization_id"),
+    ("portfolio_snapshots", "ps_g.snapshot_date = ps_a.snapshot_date"),
+    ("rebalance_events", "re_g.event_type = 'drift_rebalance'"),
+    ("taa_regime_state", "ts_g.as_of_date = ts_a.as_of_date"),
+    ("tactical_positions", "tp_g.block_id = tp_a.block_id"),
+])
+def test_upgrade_dedups_before_rewriting(table: str, join_predicate: str) -> None:
+    src = _MIGRATION_PATH.read_text(encoding="utf-8")
+    assert f"DELETE FROM {table}" in src, (
+        f"upgrade must DELETE colliding aggressive rows from {table} "
+        "BEFORE the UPDATE loop (unique-key collision risk)."
+    )
+    assert join_predicate in src, (
+        f"DELETE on {table} must scope by the partial-index key "
+        f"({join_predicate!r}) so non-colliding aggressive rows survive "
+        "to be rewritten in phase 2."
+    )
+
+
 def test_downgrade_explicitly_rejects_reversal() -> None:
     src = _MIGRATION_PATH.read_text(encoding="utf-8")
     assert "raise NotImplementedError" in src

--- a/backend/tests/db/test_migration_0199_q165.py
+++ b/backend/tests/db/test_migration_0199_q165.py
@@ -41,16 +41,34 @@ def test_revision_chain_anchored_at_0198_head() -> None:
     ), "PR-BE-7 must rebase on the current alembic head (0198_q159)."
 
 
-@pytest.mark.parametrize("table,column", [
-    ("model_portfolios", "profile"),
-    ("strategic_allocation", "profile"),
-    ("allocation_approvals", "profile"),
-    ("portfolio_calibration", "mandate"),
+# Profile-column tables are rewritten via a loop over ``_PROFILE_TABLES``;
+# the test asserts each table name is present in the tuple literal.
+@pytest.mark.parametrize("table", [
+    "model_portfolios",
+    "strategic_allocation",
+    "allocation_approvals",
+    "allocation_template_audit",
+    "backtest_runs",
+    "portfolio_snapshots",
+    "rebalance_events",
+    "taa_regime_state",
+    "tactical_positions",
 ])
-def test_upgrade_targets_each_known_table(table: str, column: str) -> None:
+def test_upgrade_covers_each_profile_column_table(table: str) -> None:
     src = _MIGRATION_PATH.read_text(encoding="utf-8")
-    expected = f"UPDATE {table} SET {column} = 'growth'"
-    assert expected in src, f"upgrade missing rewrite for {table}.{column}"
+    assert f'"{table}",' in src, (
+        f"upgrade _PROFILE_TABLES must include {table!r} — Codex P2 "
+        "catch on PR #463 required full sweep of profile-column tables "
+        "to honour the 180-day alias compat contract."
+    )
+
+
+def test_upgrade_rewrites_mandate_in_portfolio_calibration() -> None:
+    src = _MIGRATION_PATH.read_text(encoding="utf-8")
+    assert (
+        "UPDATE portfolio_calibration SET mandate = 'growth' "
+        "WHERE mandate = 'aggressive'" in src
+    )
 
 
 def test_downgrade_explicitly_rejects_reversal() -> None:

--- a/backend/tests/db/test_migration_0199_q165.py
+++ b/backend/tests/db/test_migration_0199_q165.py
@@ -1,0 +1,61 @@
+"""PR-BE-7 — migration 0199 consolidates legacy ``aggressive`` into ``growth``.
+
+The migration is purely a defensive backfill (every wealth row in the
+local docker DB and Timescale Cloud target is already on the canonical
+3-profile enum per the F1 audit, 2026-04-30). These tests assert:
+
+  * The migration revision chain points at the prior head.
+  * The upgrade SQL targets the four expected tables.
+  * The downgrade explicitly rejects reversal.
+
+Live-DB invariants (no row carries ``aggressive`` after upgrade) are
+covered by the broader integration suite — kept out of this file so it
+can run in fast CI without the docker compose stack.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "app"
+    / "core"
+    / "db"
+    / "migrations"
+    / "versions"
+    / "0199_q165_consolidate_aggressive_into_growth.py"
+)
+
+
+def test_migration_file_exists() -> None:
+    assert _MIGRATION_PATH.is_file(), f"missing migration: {_MIGRATION_PATH}"
+
+
+def test_revision_chain_anchored_at_0198_head() -> None:
+    src = _MIGRATION_PATH.read_text(encoding="utf-8")
+    assert 'revision = "0199_q165_consolidate_aggressive_into_growth"' in src
+    assert (
+        'down_revision = "0198_q159_rebuild_mv_nport_sector_attribution"' in src
+    ), "PR-BE-7 must rebase on the current alembic head (0198_q159)."
+
+
+@pytest.mark.parametrize("table,column", [
+    ("model_portfolios", "profile"),
+    ("strategic_allocation", "profile"),
+    ("allocation_approvals", "profile"),
+    ("portfolio_calibration", "mandate"),
+])
+def test_upgrade_targets_each_known_table(table: str, column: str) -> None:
+    src = _MIGRATION_PATH.read_text(encoding="utf-8")
+    expected = f"UPDATE {table} SET {column} = 'growth'"
+    assert expected in src, f"upgrade missing rewrite for {table}.{column}"
+
+
+def test_downgrade_explicitly_rejects_reversal() -> None:
+    src = _MIGRATION_PATH.read_text(encoding="utf-8")
+    assert "raise NotImplementedError" in src
+    assert "consolidates" in src.lower(), (
+        "downgrade docstring must explain why the rollback is unsupported"
+    )

--- a/backend/tests/quant_engine/test_block_coverage_service.py
+++ b/backend/tests/quant_engine/test_block_coverage_service.py
@@ -141,7 +141,7 @@ async def test_uncovered_block_with_no_catalog_candidates() -> None:
         catalog_tickers={},
     )
 
-    report = await validate_block_coverage(session, org_id, "aggressive")
+    report = await validate_block_coverage(session, org_id, "growth")
     assert report.is_sufficient is False
     assert len(report.gaps) == 1
     gap = report.gaps[0]

--- a/backend/tests/test_attribution.py
+++ b/backend/tests/test_attribution.py
@@ -94,7 +94,7 @@ class TestModels:
             benchmark_approach="policy",
         )
         with pytest.raises(AttributeError):
-            par.profile = "aggressive"  # type: ignore[misc]
+            par.profile = "growth"  # type: ignore[misc]
 
     def test_portfolio_attribution_result_uses_tuple(self):
         par = PortfolioAttributionResult(
@@ -670,7 +670,7 @@ class TestAttributionSchemas:
         from app.domains.wealth.schemas.attribution import AttributionRead
 
         schema = AttributionRead(
-            profile="aggressive",
+            profile="growth",
             start_date=date(2025, 6, 1),
             end_date=date(2025, 12, 1),
             granularity="quarterly",

--- a/backend/tests/wealth/test_cvar_profile_defaults.py
+++ b/backend/tests/wealth/test_cvar_profile_defaults.py
@@ -18,8 +18,13 @@ def test_growth_default() -> None:
     assert default_cvar_limit_for_profile("growth") == Decimal("0.1000")
 
 
-def test_aggressive_default() -> None:
-    assert default_cvar_limit_for_profile("aggressive") == Decimal("0.1250")
+def test_aggressive_alias_resolves_to_growth() -> None:
+    """PR-BE-7 — legacy ``aggressive`` slug normalises to ``growth`` (0.1000).
+
+    The previous A12.2 mapping (0.1250) was specific to the aggressive
+    profile that the engine has consolidated into Dynamic Growth.
+    """
+    assert default_cvar_limit_for_profile("aggressive") == Decimal("0.1000")
 
 
 def test_unknown_profile_falls_back_to_moderate() -> None:

--- a/backend/tests/wealth/test_factor_analysis_degraded.py
+++ b/backend/tests/wealth/test_factor_analysis_degraded.py
@@ -64,8 +64,12 @@ async def test_factor_analysis_returns_200_when_nav_data_insufficient() -> None:
         "app.domains.wealth.routes.analytics._resolve_profile_weights",
         return_value=(None, ["na_equity_large"], None, [1.0]),
     ), patch(
+        # PR-BE-7: ``_validate_profile`` returns the canonical slug now
+        # (with legacy ``aggressive`` rewritten to ``growth``). The mock
+        # must echo the canonical value back so callers downstream of
+        # the validator receive the same string the test passed in.
         "app.domains.wealth.routes.analytics._validate_profile",
-        return_value=None,
+        return_value="growth",
     ):
         db = AsyncMock()
 

--- a/backend/tests/wealth/test_profile_alias_normalizer.py
+++ b/backend/tests/wealth/test_profile_alias_normalizer.py
@@ -98,3 +98,45 @@ def test_validate_profile_unknown_slug_rejected() -> None:
     with pytest.raises(HTTPException) as exc:
         validate_profile("speculative")
     assert exc.value.status_code == 400
+
+
+# ── Pydantic payload alias (Codex P1 catch on PR #463) ───────────────
+
+
+def test_preview_cvar_request_aggressive_payload_rewritten_to_growth() -> None:
+    """Legacy ``mandate: 'aggressive'`` payload is rewritten before Literal validation.
+
+    Older clients still POSTing ``aggressive`` to /portfolios/{id}/preview-cvar
+    must succeed (with structured deprecation log) instead of failing 400 at
+    Pydantic validation. Sunset 2026-10-30.
+    """
+    from app.domains.wealth.schemas.preview import PreviewCvarRequest
+
+    req = PreviewCvarRequest.model_validate({"cvar_limit": 0.10, "mandate": "aggressive"})
+    assert req.mandate == "growth"
+
+
+def test_preview_cvar_request_aggressive_uppercase_payload_rewritten() -> None:
+    """Case-insensitive payload normalisation."""
+    from app.domains.wealth.schemas.preview import PreviewCvarRequest
+
+    req = PreviewCvarRequest.model_validate({"cvar_limit": 0.10, "mandate": "AGGRESSIVE"})
+    assert req.mandate == "growth"
+
+
+@pytest.mark.parametrize("mandate", ["conservative", "moderate", "growth", None])
+def test_preview_cvar_request_canonical_mandate_passthrough(mandate: str | None) -> None:
+    from app.domains.wealth.schemas.preview import PreviewCvarRequest
+
+    req = PreviewCvarRequest.model_validate({"cvar_limit": 0.10, "mandate": mandate})
+    assert req.mandate == mandate
+
+
+def test_preview_cvar_request_truly_invalid_mandate_still_rejected() -> None:
+    """Non-alias unknown mandates still raise validation error."""
+    from pydantic import ValidationError
+
+    from app.domains.wealth.schemas.preview import PreviewCvarRequest
+
+    with pytest.raises(ValidationError):
+        PreviewCvarRequest.model_validate({"cvar_limit": 0.10, "mandate": "speculative"})

--- a/backend/tests/wealth/test_profile_alias_normalizer.py
+++ b/backend/tests/wealth/test_profile_alias_normalizer.py
@@ -1,0 +1,100 @@
+"""PR-BE-7 — backward-compat alias normalisation for legacy ``aggressive``.
+
+Covers four surfaces:
+  * ``default_cvar_limit_for_profile`` (model layer)
+  * ``_PROPOSE_VALID_PROFILES`` (propose-mode endpoint allowlist)
+  * ``normalize_profile_param`` (URL path-param normaliser module)
+  * ``validate_profile`` (shared route helper, post-PR-BE-7)
+
+Sunset target for the alias: 2026-10-30 (180 days post-merge).
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from fastapi import HTTPException
+
+from app.domains.wealth.models.model_portfolio import default_cvar_limit_for_profile
+from app.domains.wealth.routes._profile_normalizer import normalize_profile_param
+from app.domains.wealth.routes.common import validate_profile
+from app.domains.wealth.routes.model_portfolios import _PROPOSE_VALID_PROFILES
+
+# ── Model-layer alias ────────────────────────────────────────────────
+
+
+def test_growth_default_cvar_unchanged() -> None:
+    """Status-quo regression — growth keeps the 0.1000 CVaR default."""
+    assert default_cvar_limit_for_profile("growth") == Decimal("0.1000")
+
+
+def test_aggressive_alias_returns_growth_default() -> None:
+    """Legacy ``aggressive`` resolves to the growth default (0.1000)."""
+    assert default_cvar_limit_for_profile("aggressive") == Decimal("0.1000")
+
+
+def test_aggressive_uppercase_alias_resolves_to_growth() -> None:
+    """Case-insensitive normalisation also rewrites the alias."""
+    assert default_cvar_limit_for_profile("AGGRESSIVE") == Decimal("0.1000")
+
+
+# ── Propose-mode allowlist ───────────────────────────────────────────
+
+
+def test_propose_valid_profiles_excludes_aggressive() -> None:
+    """``_PROPOSE_VALID_PROFILES`` no longer carries the legacy slug."""
+    assert "growth" in _PROPOSE_VALID_PROFILES
+    assert "conservative" in _PROPOSE_VALID_PROFILES
+    assert "moderate" in _PROPOSE_VALID_PROFILES
+    assert "aggressive" not in _PROPOSE_VALID_PROFILES
+
+
+# ── URL alias normaliser ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("conservative", "conservative"),
+    ("moderate", "moderate"),
+    ("growth", "growth"),
+    ("Conservative", "conservative"),
+    ("GROWTH", "growth"),
+])
+def test_normalize_profile_param_canonical_passthrough(raw: str, expected: str) -> None:
+    assert normalize_profile_param(raw) == expected
+
+
+def test_normalize_profile_param_aggressive_alias_resolves_to_growth() -> None:
+    """Legacy URL ``/allocation/aggressive/strategic`` resolves to growth."""
+    assert normalize_profile_param("aggressive") == "growth"
+    assert normalize_profile_param("Aggressive") == "growth"
+    assert normalize_profile_param(" AGGRESSIVE ") == "growth"
+
+
+def test_normalize_profile_param_invalid_profile_rejected() -> None:
+    """Unknown slugs raise 400 with the list of valid profiles."""
+    with pytest.raises(HTTPException) as exc:
+        normalize_profile_param("dynamic")
+    assert exc.value.status_code == 400
+    detail = exc.value.detail
+    assert isinstance(detail, dict)
+    assert detail["error"] == "invalid_profile"
+    assert sorted(detail["valid_profiles"]) == ["conservative", "growth", "moderate"]
+
+
+# ── Shared validate_profile (existing helper) ────────────────────────
+
+
+def test_validate_profile_aggressive_alias_resolves_to_growth() -> None:
+    """The shared validator rewrites legacy ``aggressive`` to ``growth``."""
+    assert validate_profile("aggressive") == "growth"
+
+
+@pytest.mark.parametrize("slug", ["conservative", "moderate", "growth"])
+def test_validate_profile_canonical_passthrough(slug: str) -> None:
+    assert validate_profile(slug) == slug
+
+
+def test_validate_profile_unknown_slug_rejected() -> None:
+    with pytest.raises(HTTPException) as exc:
+        validate_profile("speculative")
+    assert exc.value.status_code == 400

--- a/frontends/wealth/src/lib/components/portfolio/CalibrationPanel.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/CalibrationPanel.svelte
@@ -96,7 +96,7 @@
 		{ value: "conservative", label: "Conservative" },
 		{ value: "moderate", label: "Moderate" },
 		{ value: "balanced", label: "Balanced" },
-		{ value: "aggressive", label: "Aggressive" },
+		{ value: "growth", label: "Dynamic Growth" },
 	] as const;
 
 	const REGIME_OPTIONS = [

--- a/frontends/wealth/src/lib/components/portfolio/NewPortfolioDialog.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/NewPortfolioDialog.svelte
@@ -43,7 +43,7 @@
 
 	// ── Form state ───────────────────────────────────────────────
 	let name = $state("");
-	let mandate = $state<"conservative" | "moderate" | "balanced" | "aggressive">("moderate");
+	let mandate = $state<"conservative" | "moderate" | "balanced" | "growth">("moderate");
 	let description = $state("");
 	let copyFrom = $state<string>(""); // empty string means "no clone"
 
@@ -54,7 +54,7 @@
 		{ value: "conservative", label: "Conservative" },
 		{ value: "moderate", label: "Moderate" },
 		{ value: "balanced", label: "Balanced" },
-		{ value: "aggressive", label: "Aggressive" },
+		{ value: "growth", label: "Dynamic Growth" },
 	];
 
 	const copyFromOptions = $derived.by(() => {

--- a/frontends/wealth/src/lib/i18n/quant-labels.ts
+++ b/frontends/wealth/src/lib/i18n/quant-labels.ts
@@ -152,3 +152,10 @@ export function regimeLabel(raw: string | null | undefined): string {
  * used in chart titles and section headings.
  */
 export const MARKET_REGIME_HEADER = "Market Regime: Expansion / Cautious / Stress";
+
+// PR-BE-7 — Profile display label, owned by terminal-core. Re-exported
+// here so wealth call sites can keep importing from
+// ``$wealth/i18n/quant-labels`` without taking a hard dependency on the
+// terminal-core path. Canonisation lives in terminal-core; this is a
+// pass-through.
+export { profileDisplayLabel } from "@investintell/ii-terminal-core/i18n/quant-labels";

--- a/frontends/wealth/src/lib/types/portfolio-calibration.ts
+++ b/frontends/wealth/src/lib/types/portfolio-calibration.ts
@@ -14,7 +14,16 @@
  * from ``JARGON_TRANSLATION`` when that table lands.
  */
 
-export type CalibrationMandate = "conservative" | "moderate" | "aggressive" | "balanced";
+/**
+ * Calibration mandate slugs.
+ *
+ * PR-BE-7 (2026-04-30) — ``aggressive`` was a development artefact and
+ * is no longer a canonical product mandate. ``growth`` (display label
+ * "Dynamic Growth", resolved via ``profileDisplayLabel``) replaces it.
+ * The legacy slug is normalised to ``growth`` in profile-defaults
+ * helpers and on the backend through 2026-10-30 (180-day sunset).
+ */
+export type CalibrationMandate = "conservative" | "moderate" | "balanced" | "growth";
 
 export type CalibrationRegimeOverride =
 	| "auto"

--- a/frontends/wealth/src/lib/util/profile-defaults.ts
+++ b/frontends/wealth/src/lib/util/profile-defaults.ts
@@ -5,29 +5,47 @@
  * expose these via an admin config endpoint so the frontend stops
  * duplicating the mapping.
  *
+ * PR-BE-7 (2026-04-30) — ``aggressive`` was a development artefact and
+ * is no longer a canonical profile. The slug is rewritten to ``growth``
+ * with a console warning so any residual caller is visible during the
+ * 180-day sunset window (target 2026-10-30).
+ *
  * Unknown / null profile → 0.075 (moderate), matching the backend fallback.
  */
 export function defaultCvarForProfile(profile: string | null | undefined): number {
-	switch ((profile ?? "").toLowerCase()) {
+	const raw = (profile ?? "").toLowerCase();
+	const canonical = raw === "aggressive" ? "growth" : raw;
+	if (raw === "aggressive") {
+		console.warn(
+			"[PR-BE-7] Legacy 'aggressive' profile received in defaultCvarForProfile; " +
+				"normalised to 'growth'. Sunset 2026-10-30.",
+		);
+	}
+	switch (canonical) {
 		case "conservative":
 			return 0.05; // PR-A18: was 0.025
 		case "moderate":
 			return 0.075; // PR-A18: was 0.05
 		case "growth":
-			return 0.1; // PR-A18: was 0.08
-		case "aggressive":
-			return 0.125; // PR-A18: was 0.1
+			return 0.1; // PR-A18: was 0.08 (Dynamic Growth)
 		default:
 			return 0.075; // moderate fallback (PR-A18)
 	}
 }
 
-/** Human label for the profile, used in UI copy. */
+/**
+ * Human label for the profile, used in UI copy.
+ *
+ * Prefer ``profileDisplayLabel`` from ``$lib/i18n/quant-labels`` when
+ * the call site needs context-sensitive ("Dynamic" vs "Dynamic Growth")
+ * phrasing — this helper is retained for legacy call sites that pass a
+ * raw string straight into a chart title or table cell.
+ */
 export function profileLabel(profile: string | null | undefined): string {
-	const p = (profile ?? "").toLowerCase();
-	if (p === "conservative") return "Conservative";
-	if (p === "moderate") return "Moderate";
-	if (p === "growth") return "Growth";
-	if (p === "aggressive") return "Aggressive";
+	const raw = (profile ?? "").toLowerCase();
+	const canonical = raw === "aggressive" ? "growth" : raw;
+	if (canonical === "conservative") return "Conservative";
+	if (canonical === "moderate") return "Moderate";
+	if (canonical === "growth") return "Dynamic Growth";
 	return profile ?? "Moderate";
 }

--- a/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationPanel.svelte
@@ -96,7 +96,7 @@
 		{ value: "conservative", label: "Conservative" },
 		{ value: "moderate", label: "Moderate" },
 		{ value: "balanced", label: "Balanced" },
-		{ value: "aggressive", label: "Aggressive" },
+		{ value: "growth", label: "Dynamic Growth" },
 	] as const;
 
 	const REGIME_OPTIONS = [

--- a/packages/ii-terminal-core/src/lib/i18n/quant-labels.test.ts
+++ b/packages/ii-terminal-core/src/lib/i18n/quant-labels.test.ts
@@ -1,0 +1,50 @@
+/**
+ * PR-BE-7 — profileDisplayLabel canonical helper.
+ *
+ * Verifies the slug → product copy mapping, the legacy ``aggressive``
+ * alias rewrite, and the unknown-slug fallback.
+ */
+import { describe, expect, test } from "vitest";
+import { profileDisplayLabel } from "./quant-labels";
+
+describe("profileDisplayLabel", () => {
+	test("growth dense → Dynamic", () => {
+		expect(profileDisplayLabel("growth", "dense")).toBe("Dynamic");
+	});
+
+	test("growth full → Dynamic Growth", () => {
+		expect(profileDisplayLabel("growth", "full")).toBe("Dynamic Growth");
+	});
+
+	test("growth defaults to full when context omitted", () => {
+		expect(profileDisplayLabel("growth")).toBe("Dynamic Growth");
+	});
+
+	test("aggressive dense alias → Dynamic", () => {
+		expect(profileDisplayLabel("aggressive", "dense")).toBe("Dynamic");
+	});
+
+	test("aggressive full alias → Dynamic Growth", () => {
+		expect(profileDisplayLabel("aggressive", "full")).toBe("Dynamic Growth");
+	});
+
+	test("conservative dense + full identical", () => {
+		expect(profileDisplayLabel("conservative", "dense")).toBe("Conservative");
+		expect(profileDisplayLabel("conservative", "full")).toBe("Conservative");
+	});
+
+	test("moderate dense + full identical", () => {
+		expect(profileDisplayLabel("moderate", "dense")).toBe("Moderate");
+		expect(profileDisplayLabel("moderate", "full")).toBe("Moderate");
+	});
+
+	test("unknown profile falls through to title-case", () => {
+		// Forward-compat fallback for tenant-scoped custom profiles
+		// (Q6 v2 / post-GA — custom profiles via ConfigService).
+		expect(profileDisplayLabel("speculative", "full")).toBe("Speculative");
+	});
+
+	test("uppercase canonical slug normalises to canonical label", () => {
+		expect(profileDisplayLabel("GROWTH", "dense")).toBe("Dynamic");
+	});
+});

--- a/packages/ii-terminal-core/src/lib/i18n/quant-labels.ts
+++ b/packages/ii-terminal-core/src/lib/i18n/quant-labels.ts
@@ -152,3 +152,49 @@ export function regimeLabel(raw: string | null | undefined): string {
  * used in chart titles and section headings.
  */
 export const MARKET_REGIME_HEADER = "Market Regime: Expansion / Cautious / Stress";
+
+// ── PR-BE-7 — Profile display labels ─────────────────────────────────
+//
+// Slugs (``conservative`` / ``moderate`` / ``growth``) are stable in
+// code, URL, and DB. Product copy ("Dynamic Growth" for ``growth``)
+// flows through this helper so the marketing label stays decoupled
+// from the persisted slug. ``aggressive`` is rewritten to ``growth``
+// (sunset 2026-10-30, 180 days post-merge) — see PR-BE-7.
+//
+// Mirror of the Pydantic helper
+// ``app.domains.wealth.schemas.sanitized.profile_display_label``.
+
+type ProfileSlug = "conservative" | "moderate" | "growth";
+type DisplayContext = "dense" | "full";
+
+const PROFILE_DISPLAY: Readonly<Record<ProfileSlug, Record<DisplayContext, string>>> = {
+	conservative: { dense: "Conservative", full: "Conservative" },
+	moderate: { dense: "Moderate", full: "Moderate" },
+	growth: { dense: "Dynamic", full: "Dynamic Growth" },
+};
+
+/**
+ * Resolve a profile slug to its institutional display label.
+ *
+ * ``context="dense"`` yields the short form ("Dynamic"), used in
+ * chips, badges, and tight chart legends. ``context="full"`` yields
+ * the marketing name ("Dynamic Growth"), used in copy that has room
+ * for the longer phrasing. ``conservative`` and ``moderate`` are
+ * identical across contexts.
+ *
+ * Unknown slugs (e.g. tenant-scoped custom profiles introduced via
+ * ConfigService in v2 / post-GA) fall through to a title-cased
+ * version of the raw slug — never silently dropped.
+ */
+export function profileDisplayLabel(
+	profile: string,
+	context: DisplayContext = "full",
+): string {
+	const lc = profile.toLowerCase();
+	const canonical = lc === "aggressive" ? "growth" : lc;
+	if (canonical in PROFILE_DISPLAY) {
+		return PROFILE_DISPLAY[canonical as ProfileSlug][context];
+	}
+	if (!profile) return profile;
+	return profile.charAt(0).toUpperCase() + profile.slice(1);
+}

--- a/packages/ii-terminal-core/src/lib/types/portfolio-calibration.ts
+++ b/packages/ii-terminal-core/src/lib/types/portfolio-calibration.ts
@@ -14,7 +14,16 @@
  * from ``JARGON_TRANSLATION`` when that table lands.
  */
 
-export type CalibrationMandate = "conservative" | "moderate" | "aggressive" | "balanced";
+/**
+ * Calibration mandate slugs.
+ *
+ * PR-BE-7 (2026-04-30) — ``aggressive`` was a development artefact and
+ * is no longer a canonical product mandate. ``growth`` (display label
+ * "Dynamic Growth", resolved via ``profileDisplayLabel``) replaces it.
+ * The legacy slug is normalised to ``growth`` in profile-defaults
+ * helpers and on the backend through 2026-10-30 (180-day sunset).
+ */
+export type CalibrationMandate = "conservative" | "moderate" | "balanced" | "growth";
 
 export type CalibrationRegimeOverride =
 	| "auto"

--- a/packages/ii-terminal-core/src/lib/utils/profile-defaults.ts
+++ b/packages/ii-terminal-core/src/lib/utils/profile-defaults.ts
@@ -5,29 +5,47 @@
  * expose these via an admin config endpoint so the frontend stops
  * duplicating the mapping.
  *
+ * PR-BE-7 (2026-04-30) — ``aggressive`` was a development artefact and
+ * is no longer a canonical profile. The slug is rewritten to ``growth``
+ * with a console warning so any residual caller is visible during the
+ * 180-day sunset window (target 2026-10-30).
+ *
  * Unknown / null profile → 0.075 (moderate), matching the backend fallback.
  */
 export function defaultCvarForProfile(profile: string | null | undefined): number {
-	switch ((profile ?? "").toLowerCase()) {
+	const raw = (profile ?? "").toLowerCase();
+	const canonical = raw === "aggressive" ? "growth" : raw;
+	if (raw === "aggressive") {
+		console.warn(
+			"[PR-BE-7] Legacy 'aggressive' profile received in defaultCvarForProfile; " +
+				"normalised to 'growth'. Sunset 2026-10-30.",
+		);
+	}
+	switch (canonical) {
 		case "conservative":
 			return 0.05; // PR-A18: was 0.025
 		case "moderate":
 			return 0.075; // PR-A18: was 0.05
 		case "growth":
-			return 0.1; // PR-A18: was 0.08
-		case "aggressive":
-			return 0.125; // PR-A18: was 0.1
+			return 0.1; // PR-A18: was 0.08 (Dynamic Growth)
 		default:
 			return 0.075; // moderate fallback (PR-A18)
 	}
 }
 
-/** Human label for the profile, used in UI copy. */
+/**
+ * Human label for the profile, used in UI copy.
+ *
+ * Prefer ``profileDisplayLabel`` from ``$lib/i18n/quant-labels`` when
+ * the call site needs context-sensitive ("Dynamic" vs "Dynamic Growth")
+ * phrasing — this helper is retained for legacy call sites that pass a
+ * raw string straight into a chart title or table cell.
+ */
 export function profileLabel(profile: string | null | undefined): string {
-	const p = (profile ?? "").toLowerCase();
-	if (p === "conservative") return "Conservative";
-	if (p === "moderate") return "Moderate";
-	if (p === "growth") return "Growth";
-	if (p === "aggressive") return "Aggressive";
+	const raw = (profile ?? "").toLowerCase();
+	const canonical = raw === "aggressive" ? "growth" : raw;
+	if (canonical === "conservative") return "Conservative";
+	if (canonical === "moderate") return "Moderate";
+	if (canonical === "growth") return "Dynamic Growth";
 	return profile ?? "Moderate";
 }


### PR DESCRIPTION
## Summary

Consolidates the development-artefact `aggressive` profile/mandate into the canonical `growth` ("Dynamic Growth") profile across the entire wealth surface. Slugs (`conservative` / `moderate` / `growth`) stay stable in code, URL, and DB; "Dynamic Growth" is product copy resolved via the new `profileDisplayLabel` helper, **not** a 4th enum value.

Foundational PR for the Builder workspace redesign (`docs/plans/2026-04-30-builder-workspace-redesign-final.md` §9 PR-BE-7). Lands before PR-BE-2/BE-4/BE-6.

## What changed

**Backend (5 files + 1 new helper module + 1 migration):**
- `_PROPOSE_VALID_PROFILES` minus `aggressive`; 6 callsite updates
- `_CVAR_DEFAULT_BY_PROFILE` minus `aggressive` (was 0.1250 — dev artefact); growth unchanged at 0.1000
- New `_profile_normalizer.py` module + centralised alias resolution in `routes/common.validate_profile`
- `mandate_risk_aversion._normalise_mandate('aggressive')` → `'growth'` with structlog event (compound `moderate_aggressive` preserved)
- `schemas/sanitized.py` extended with `profile_display_label(slug, "dense"|"full")`
- Alembic migration `0199_q165_consolidate_aggressive_into_growth` — defensive backfill (zero rows in production per F1 audit)

**Frontend (10 files: terminal-core canonical + wealth dual + tests):**
- `CalibrationMandate` type swap (`aggressive` → `growth`)
- New canonical `profileDisplayLabel` in `packages/ii-terminal-core/src/lib/i18n/quant-labels.ts`; wealth re-exports
- `CalibrationPanel` + `NewPortfolioDialog` mandate option swap
- Backward-compat: `profileLabel` and `defaultCvarForProfile` rewrite legacy `aggressive` → `growth` with `console.warn`

**Tests (16 new + 4 fixture renames + 1 mock fix):**
- `test_profile_alias_normalizer.py`, `test_migration_0199_q165.py`, `quant-labels.test.ts`
- Fixture renames in `test_attribution`, `test_block_coverage_service`, `test_cvar_profile_defaults`
- `test_factor_analysis_degraded` mock fix (validator return value became load-bearing)

## Backward compat — sunset 2026-10-30 (180d)

- URL alias: `GET /allocation/aggressive/*` → `growth` with `legacy_profile_url_alias` event
- Mandate alias: `_normalise_mandate('aggressive')` → `growth` with `legacy_mandate_alias_used` event
- Model alias: `default_cvar_limit_for_profile('aggressive')` → 0.1000 with `legacy_profile_alias_used` event

Three structlog events feed the sunset dashboard for cleanup tracking.

## Out of scope (per brief)

- ❌ No new `dynamic` enum value (Dynamic Growth is product copy, not a 4th slug)
- ❌ `moderate_aggressive` ladder rung untouched (compound, internal)
- ❌ `mandate_fit/risk_bucket` (asset-class domain) untouched
- ❌ Historical migrations 0143/0145 not edited
- ❌ Wealth ↔ terminal-core canonisation deferred to PR-UX-4
- ❌ Tenant-scoped custom profiles (Q6 §11) deferred to v2 / post-GA

## Stability Guardrails

- **P5 Idempotent** — migration `UPDATE ... WHERE = 'aggressive'`; re-run is no-op
- **P4 Lifecycle** — alias normalisers are pure functions; no module-level state
- **Audit trail** — three structured deprecation events for ETL/dashboard
- **Forward compat** — display label fallback to title-case supports Q6 v2 custom profiles without code changes

## Test plan

- [x] `ruff check` — pass (1 import sort auto-fix)
- [x] `pytest tests/wealth/ tests/quant_engine/ tests/test_attribution.py tests/db/test_migration_0199_q165.py` — **1250/1252 pass**; 2 pre-existing fails unrelated to this PR (`test_optimizer_missing_expected_returns` PR-Q41 follow-up, `test_macro_ingestion_smoke` worker fixture teardown)
- [x] `pytest -k "profile or aggressive or growth or mandate"` — **201/201 pass** (incl. 16 new alias tests)
- [x] `vitest packages/ii-terminal-core/src/lib/i18n/quant-labels.test.ts` — **9/9 pass**
- [x] `pnpm svelte-check` (wealth + terminal) — **0 errors**
- [x] `alembic upgrade head` — applied cleanly; head now `0199_q165_consolidate_aggressive_into_growth`
- [x] `mypy` on new module — clean
- [ ] Codex Auto Review wait window completed
- [ ] Manual review of migration UPDATE statements + alias normaliser callsites

## Migration

- Revision: `0199_q165_consolidate_aggressive_into_growth`
- Down-revision: `0198_q159_rebuild_mv_nport_sector_attribution`
- Downgrade explicitly raises `NotImplementedError` (consolidation not semantically reversible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)