### PR TITLE
chore(gitignore): explicit package build output patterns (PR-OPS-1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ node_modules/
 **/*.js.map
 **/*.css.map
 
+# Package build outputs (svelte-package + tsc) — never commit generated bundles
+packages/*/dist/
+packages/*/.svelte-kit/__package__/
+
 # Lock files (tracked by pnpm — not source code)
 pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary

- Adds explicit gitignore patterns `packages/*/dist/` and `packages/*/.svelte-kit/__package__/` under a labelled comment header, declaring intent to keep generated svelte-package + tsc bundle output untracked per builder workspace redesign §5.4 D2 / §9 PR-OPS-1.
- These patterns are subsumed by existing `**/dist/` and `.svelte-kit/` rules but are stated explicitly so future contributors do not need to reason about glob precedence when a new package is added under `packages/`.
- No source changes. No `git rm --cached` was needed: `git ls-files | grep -E '^packages/[^/]+/(dist|\.svelte-kit/__package__)/'` returned 0 at branch creation, confirming nothing under those patterns was ever tracked.

## Test plan

- [x] `git diff origin/main -- .gitignore` shows exactly 4 added lines (one comment, one blank, two patterns) — no other diff in `.gitignore`.
- [x] `git show --stat HEAD` shows `.gitignore | 4 ++++` and nothing else — single-file commit.
- [x] `git ls-files | grep -E '^packages/[^/]+/(dist|\.svelte-kit/__package__)/' | wc -l` → 0 (no tracked files affected; gitignore-only change).
- [ ] CI green on push.

---

## Stability Guardrails Checklist

> Charter: `docs/reference/stability-guardrails.md`. Pure config / non-functional change — no hot-path code touched.

### Backend

- N/A — gitignore-only change, no backend code touched.

### Frontend

- N/A — gitignore-only change, no frontend code touched.

### Tests & verification

- [x] `make check` not required — `.gitignore` is not under lint/typecheck/architecture coverage.
- [x] No suppressions added.
- N/A — no e2e surface touched.

### Observability

- N/A — no runtime code paths touched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)