### PR TITLE
fix(terminal-core): PR-UX-1 — ProposeButton terminal tokens

### DIFF
--- a/packages/ii-terminal-core/src/lib/components/allocation/ProposeButton.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/ProposeButton.svelte
@@ -190,7 +190,7 @@
 
 	<button
 		type="button"
-		class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
+		class="propose-cta"
 		onclick={() => void propose()}
 		disabled={running}
 	>
@@ -214,3 +214,37 @@
 		<p class="mt-2 text-xs text-destructive">{errorMsg}</p>
 	{/if}
 </section>
+
+<style>
+	/* Propose CTA — terminal token styling.
+	   Mirrors `.pp-create-btn` in PortfolioPicker.svelte (truth source):
+	   transparent background, status-success border + text, mono caps,
+	   hover tint via color-mix. Replaces Tailwind `bg-primary` utilities
+	   to keep the allocation surface aligned with terminal tokens. */
+	.propose-cta {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-2) var(--terminal-space-4);
+		background: transparent;
+		border: 1px solid var(--terminal-status-success);
+		color: var(--terminal-status-success);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+	.propose-cta:hover:not(:disabled) {
+		background: color-mix(in srgb, var(--terminal-status-success) 10%, transparent);
+	}
+	.propose-cta:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+	.propose-cta:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>


### PR DESCRIPTION
## Summary

- Replaces Tailwind utility classes (`bg-primary`, `text-primary-foreground`, `hover:bg-primary/90`, `inline-flex`, `rounded-md`, `disabled:opacity-50`, `text-sm`, `px-4 py-2`, `gap-2`, `items-center`) on the Propose Allocation CTA in `ProposeButton.svelte` with a scoped `.propose-cta` class using `var(--terminal-*)` design tokens.
- Mirrors the styling of `.pp-create-btn` in `packages/ii-terminal-core/src/lib/components/portfolio/PortfolioPicker.svelte:197-215` (truth source for terminal CTA tokens): transparent background, `--terminal-status-success` border + text, `--terminal-font-mono` caps, hover tint via `color-mix`, focus ring via `--terminal-border-focus`.
- Visual fix only — `onclick` handler, propose flow, SSE stream parsing, and `CascadeTimeline` integration are unchanged.

## CSS diff snippet

**Before** (template):
```svelte
<button
  type="button"
  class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm hover:bg-primary/90 disabled:opacity-50"
  onclick={() => void propose()}
  disabled={running}
>
```

**After** (template):
```svelte
<button
  type="button"
  class="propose-cta"
  onclick={() => void propose()}
  disabled={running}
>
```

**New `<style>` block** (mirrors `.pp-create-btn`):
```css
.propose-cta {
  display: inline-flex;
  align-items: center;
  gap: var(--terminal-space-2);
  padding: var(--terminal-space-2) var(--terminal-space-4);
  background: transparent;
  border: 1px solid var(--terminal-status-success);
  color: var(--terminal-status-success);
  font-family: var(--terminal-font-mono);
  font-size: var(--terminal-text-11);
  font-weight: 600;
  letter-spacing: var(--terminal-tracking-caps);
  text-transform: uppercase;
  cursor: pointer;
}
.propose-cta:hover:not(:disabled) {
  background: color-mix(in srgb, var(--terminal-status-success) 10%, transparent);
}
.propose-cta:focus-visible {
  outline: var(--terminal-border-focus);
  outline-offset: 2px;
}
.propose-cta:disabled {
  opacity: 0.5;
  cursor: not-allowed;
}
```

## Token mapping (Tailwind → terminal token)

| Tailwind utility removed | Terminal token replacement |
|---|---|
| `inline-flex items-center` | `display: inline-flex; align-items: center;` |
| `gap-2` | `gap: var(--terminal-space-2)` |
| `px-4 py-2` | `padding: var(--terminal-space-2) var(--terminal-space-4)` |
| `rounded-md` | (removed — terminal CTAs use sharp corners per `.pp-create-btn`) |
| `bg-primary` | `background: transparent` (matches `.pp-create-btn`) |
| `text-primary-foreground` | `color: var(--terminal-status-success)` |
| `text-sm` | `font-size: var(--terminal-text-11)` + `font-family: var(--terminal-font-mono)` |
| `hover:bg-primary/90` | `color-mix(in srgb, var(--terminal-status-success) 10%, transparent)` on hover |
| `disabled:opacity-50` | `opacity: 0.5; cursor: not-allowed;` on `:disabled` |
| (none — added) | `border: 1px solid var(--terminal-status-success)` (matches `.pp-create-btn`) |
| (none — added) | `text-transform: uppercase` + `letter-spacing: var(--terminal-tracking-caps)` (matches `.pp-create-btn`) |
| (none — added) | `:focus-visible` outline via `--terminal-border-focus` |

## Verification

- Grep confirms no Tailwind utility classes survive on the Propose CTA button (`bg-primary`, `text-primary-foreground`, `hover:bg-` no longer match this element). The remaining `bg-primary/10 text-primary` on line 179 is on the icon container `<span>` next to the section heading — explicitly out of scope per the PR-UX-1 spec ("CTA button styling only").
- `onclick={() => void propose()}` and `disabled={running}` bindings unchanged.
- All four states styled: idle, hover, focus-visible, disabled.

## Screenshots

Screenshots not captured — agent execution environment cannot reliably bring up `make dev-credit` / `make dev-wealth` interactively to take browser captures of the allocation page in the time budget. The CSS diff above + the `.pp-create-btn` truth source in `PortfolioPicker.svelte` are sufficient for visual review. Reviewer can sanity check by loading `/allocation/[profile]` in either terminal frontend after merge.

## Refs

- `docs/plans/2026-04-30-builder-workspace-redesign-final.md` §2.4 (diagnostic), §6.2.2 (row ProposeButton refactor), §7.4 (CTA token spec), §9 (PR-UX-1).
- Truth source: `packages/ii-terminal-core/src/lib/components/portfolio/PortfolioPicker.svelte:197-215` (`.pp-create-btn`).

## Test plan

- [ ] Pull branch, run `make dev-credit` (or wealth terminal — `ii-terminal-core` is consumed by both), navigate to `/allocation/[profile]`, confirm "Propose Allocation" CTA renders with terminal mono caps + green outline + transparent fill.
- [ ] Hover the CTA — confirm subtle green tint appears (color-mix 10%).
- [ ] Focus the CTA via Tab — confirm focus outline matches other terminal CTAs (`--terminal-border-focus`).
- [ ] Click Propose — confirm SSE stream still drives `CascadeTimeline` and proposal completes (logic unchanged).
- [ ] During `running=true`, confirm CTA shows `Loader2` spinner + "Proposing…" text and is visually disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)