### PR TITLE
fix(terminal): PR-UX-2 — /portfolio/builder resolves profile from portfolio_id

### DIFF
--- a/frontends/terminal/src/routes/portfolio/builder/+page.server.ts
+++ b/frontends/terminal/src/routes/portfolio/builder/+page.server.ts
@@ -29,6 +29,7 @@ import type { PageServerLoad } from "./$types";
 import {
 	DEFAULT_PROFILE,
 	buildBuilderRedirect,
+	extractCanonicalPortfolioId,
 } from "@investintell/ii-terminal-core/utils/builder-redirect";
 
 const FETCH_TIMEOUT_MS = 4000;
@@ -57,10 +58,10 @@ async function fetchPortfolioProfile(
 export const load: PageServerLoad = async ({ url, parent }) => {
 	const { token } = await parent();
 
-	// Extract portfolio_id (or legacy id) without consuming the iterator
-	// — buildBuilderRedirect re-walks the params for normalization.
-	const portfolioId =
-		url.searchParams.get("portfolio_id") ?? url.searchParams.get("id");
+	// Resolve the canonical id via the same helper buildBuilderRedirect
+	// uses to emit it — guaranteeing lookup and redirect agree even if
+	// the URL contains both ?portfolio_id= and ?id=, or repeated keys.
+	const portfolioId = extractCanonicalPortfolioId(url.searchParams);
 
 	let resolvedProfile: string | null = null;
 	if (portfolioId && token) {

--- a/frontends/terminal/src/routes/portfolio/builder/+page.server.ts
+++ b/frontends/terminal/src/routes/portfolio/builder/+page.server.ts
@@ -37,6 +37,11 @@ const FETCH_TIMEOUT_MS = 4000;
 /**
  * Lookup a portfolio's profile by id. Returns ``null`` on any failure
  * — caller falls back to ``DEFAULT_PROFILE``.
+ *
+ * ``portfolioId`` MUST already be a UUID validated by
+ * ``extractCanonicalPortfolioId``; ``encodeURIComponent`` is applied
+ * here as defense in depth so any future caller that bypasses the
+ * helper still cannot inject path separators into the API path.
  */
 async function fetchPortfolioProfile(
 	token: string,
@@ -45,7 +50,7 @@ async function fetchPortfolioProfile(
 	try {
 		const api = createServerApiClient(token);
 		const portfolio = await api.get<ModelPortfolio>(
-			`/model-portfolios/${portfolioId}`,
+			`/model-portfolios/${encodeURIComponent(portfolioId)}`,
 			undefined,
 			{ signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
 		);

--- a/frontends/terminal/src/routes/portfolio/builder/+page.server.ts
+++ b/frontends/terminal/src/routes/portfolio/builder/+page.server.ts
@@ -27,7 +27,6 @@ import { createServerApiClient } from "@investintell/ii-terminal-core/api/client
 import type { ModelPortfolio } from "@investintell/ii-terminal-core/types/model-portfolio";
 import type { PageServerLoad } from "./$types";
 import {
-	DEFAULT_PROFILE,
 	buildBuilderRedirect,
 	extractCanonicalPortfolioId,
 } from "@investintell/ii-terminal-core/utils/builder-redirect";
@@ -77,6 +76,10 @@ export const load: PageServerLoad = async ({ url, parent }) => {
 	throw redirect(307, dest);
 };
 
-// Re-export so deep-link debugging tools can introspect the fallback
-// profile without re-importing the helper module directly.
-export { DEFAULT_PROFILE };
+// NOTE: DEFAULT_PROFILE is intentionally NOT re-exported here.
+// SvelteKit +page.server.ts modules accept only a fixed export
+// surface (load, prerender, csr, ssr, trailingSlash, config, entries,
+// actions). Arbitrary re-exports are rejected by the SvelteKit build
+// step. Consumers needing the fallback profile constant must import
+// it directly from
+// "@investintell/ii-terminal-core/utils/builder-redirect".

--- a/frontends/terminal/src/routes/portfolio/builder/+page.server.ts
+++ b/frontends/terminal/src/routes/portfolio/builder/+page.server.ts
@@ -14,29 +14,63 @@
  *   - ``?tab=portfolio`` → forced on the destination so users land
  *     on the builder surface, not the strategic governance tab.
  *
- * Profile resolution from ``?id=``: not performed here. Looking up
- * the portfolio's profile would require an extra authenticated round
- * trip on every redirect, and the new workspace does not yet surface
- * a per-portfolio profile filter. Redirecting to /allocation/moderate
- * is acceptable — users can switch profiles via the ProfileStrip on
- * arrival. Documented in the X3.1 PR body.
+ * PR-UX-2: profile resolution from ``?portfolio_id=<uuid>`` (or the
+ * legacy ``?id=<uuid>``). When a portfolio_id is present, fetch
+ * ``/model-portfolios/{id}`` to resolve the portfolio's profile and
+ * redirect into ``/allocation/{profile}`` instead of always landing
+ * on /allocation/moderate. Falls back to ``/allocation/moderate`` if
+ * the lookup fails (no token, fetch error, missing/invalid profile)
+ * — graceful degrade so a transient API blip never blocks the route.
  */
 import { redirect } from "@sveltejs/kit";
+import { createServerApiClient } from "@investintell/ii-terminal-core/api/client";
+import type { ModelPortfolio } from "@investintell/ii-terminal-core/types/model-portfolio";
 import type { PageServerLoad } from "./$types";
+import {
+	DEFAULT_PROFILE,
+	buildBuilderRedirect,
+} from "@investintell/ii-terminal-core/utils/builder-redirect";
 
-export const load: PageServerLoad = async ({ url }) => {
-	const dest = new URL("/allocation/moderate", url.origin);
-	dest.searchParams.set("tab", "portfolio");
+const FETCH_TIMEOUT_MS = 4000;
 
-	for (const [key, value] of url.searchParams) {
-		if (key === "id") {
-			// Legacy name on wealth call sites — normalize to portfolio_id
-			// so the new workspace's PortfolioTabContent picks it up.
-			dest.searchParams.set("portfolio_id", value);
-			continue;
-		}
-		dest.searchParams.set(key, value);
+/**
+ * Lookup a portfolio's profile by id. Returns ``null`` on any failure
+ * — caller falls back to ``DEFAULT_PROFILE``.
+ */
+async function fetchPortfolioProfile(
+	token: string,
+	portfolioId: string,
+): Promise<string | null> {
+	try {
+		const api = createServerApiClient(token);
+		const portfolio = await api.get<ModelPortfolio>(
+			`/model-portfolios/${portfolioId}`,
+			undefined,
+			{ signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+		);
+		return portfolio?.profile ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export const load: PageServerLoad = async ({ url, parent }) => {
+	const { token } = await parent();
+
+	// Extract portfolio_id (or legacy id) without consuming the iterator
+	// — buildBuilderRedirect re-walks the params for normalization.
+	const portfolioId =
+		url.searchParams.get("portfolio_id") ?? url.searchParams.get("id");
+
+	let resolvedProfile: string | null = null;
+	if (portfolioId && token) {
+		resolvedProfile = await fetchPortfolioProfile(token, portfolioId);
 	}
 
-	throw redirect(307, dest.pathname + dest.search);
+	const dest = buildBuilderRedirect(url.searchParams, resolvedProfile);
+	throw redirect(307, dest);
 };
+
+// Re-export so deep-link debugging tools can introspect the fallback
+// profile without re-importing the helper module directly.
+export { DEFAULT_PROFILE };

--- a/packages/ii-terminal-core/package.json
+++ b/packages/ii-terminal-core/package.json
@@ -64,7 +64,9 @@
   "scripts": {
     "build": "svelte-package -i ./src/lib -o ./dist",
     "prepublishOnly": "pnpm build",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "peerDependencies": {
     "@investintell/ui": "workspace:*",

--- a/packages/ii-terminal-core/src/lib/utils/builder-redirect.test.ts
+++ b/packages/ii-terminal-core/src/lib/utils/builder-redirect.test.ts
@@ -7,8 +7,12 @@ import {
 	DEFAULT_PROFILE,
 	buildBuilderRedirect,
 	extractCanonicalPortfolioId,
+	isValidPortfolioId,
 	normalizeProfile,
 } from "./builder-redirect.js";
+
+const UUID_A = "11111111-2222-3333-4444-555555555555";
+const UUID_B = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 
 describe("normalizeProfile", () => {
 	test("returns canonical profile when valid", () => {
@@ -70,12 +74,12 @@ describe("buildBuilderRedirect", () => {
 
 	test("preserves arbitrary query params untouched", () => {
 		const params = new URLSearchParams(
-			"portfolio_id=p1&alloc=growth&foo=bar",
+			`portfolio_id=${UUID_A}&alloc=growth&foo=bar`,
 		);
 		const dest = buildBuilderRedirect(params, "growth");
 		expect(dest).toContain("alloc=growth");
 		expect(dest).toContain("foo=bar");
-		expect(dest).toContain("portfolio_id=p1");
+		expect(dest).toContain(`portfolio_id=${UUID_A}`);
 		expect(dest).toContain("tab=portfolio");
 	});
 
@@ -102,35 +106,35 @@ describe("buildBuilderRedirect", () => {
 	// /allocation/{profile} route for the wrong portfolio.
 
 	test("URL with both portfolio_id then id keeps portfolio_id as canonical (id-after-portfolio_id ordering)", () => {
-		const params = new URLSearchParams("portfolio_id=BBBB&id=AAAA");
+		const params = new URLSearchParams(`portfolio_id=${UUID_B}&id=${UUID_A}`);
 		const dest = buildBuilderRedirect(params, "growth");
 		const query = new URLSearchParams(dest.split("?")[1] ?? "");
-		expect(query.getAll("portfolio_id")).toEqual(["BBBB"]);
+		expect(query.getAll("portfolio_id")).toEqual([UUID_B]);
 		expect(query.has("id")).toBe(false);
 	});
 
 	test("URL with id then portfolio_id keeps portfolio_id as canonical (portfolio_id-after-id ordering)", () => {
-		const params = new URLSearchParams("id=AAAA&portfolio_id=BBBB");
+		const params = new URLSearchParams(`id=${UUID_A}&portfolio_id=${UUID_B}`);
 		const dest = buildBuilderRedirect(params, "growth");
 		const query = new URLSearchParams(dest.split("?")[1] ?? "");
-		expect(query.getAll("portfolio_id")).toEqual(["BBBB"]);
+		expect(query.getAll("portfolio_id")).toEqual([UUID_B]);
 		expect(query.has("id")).toBe(false);
 	});
 
 	test("repeated portfolio_id collapses to the first value (matches URLSearchParams.get precedence)", () => {
 		const params = new URLSearchParams(
-			"portfolio_id=AAAA&portfolio_id=BBBB",
+			`portfolio_id=${UUID_A}&portfolio_id=${UUID_B}`,
 		);
 		const dest = buildBuilderRedirect(params, "growth");
 		const query = new URLSearchParams(dest.split("?")[1] ?? "");
-		expect(query.getAll("portfolio_id")).toEqual(["AAAA"]);
+		expect(query.getAll("portfolio_id")).toEqual([UUID_A]);
 	});
 
 	test("repeated legacy id collapses to the first value", () => {
-		const params = new URLSearchParams("id=AAAA&id=BBBB");
+		const params = new URLSearchParams(`id=${UUID_A}&id=${UUID_B}`);
 		const dest = buildBuilderRedirect(params, "growth");
 		const query = new URLSearchParams(dest.split("?")[1] ?? "");
-		expect(query.getAll("portfolio_id")).toEqual(["AAAA"]);
+		expect(query.getAll("portfolio_id")).toEqual([UUID_A]);
 		expect(query.has("id")).toBe(false);
 	});
 
@@ -142,26 +146,128 @@ describe("buildBuilderRedirect", () => {
 		expect(query.has("id")).toBe(false);
 		expect(query.get("foo")).toBe("bar");
 	});
+
+	// ── Security: non-UUID ids must NOT reach the redirect ────────
+	// Codex P2: a crafted ?portfolio_id=../foo could otherwise land
+	// in /allocation/{profile}?portfolio_id=../foo and propagate to
+	// any consumer that interpolates it into a path. UUID validation
+	// is the single source of truth in extractCanonicalPortfolioId.
+
+	test("non-UUID portfolio_id is silently dropped from destination", () => {
+		const params = new URLSearchParams("portfolio_id=../../etc/passwd");
+		const dest = buildBuilderRedirect(params, null);
+		const query = new URLSearchParams(dest.split("?")[1] ?? "");
+		expect(query.has("portfolio_id")).toBe(false);
+		expect(query.has("id")).toBe(false);
+	});
+
+	test("non-UUID legacy id is silently dropped from destination", () => {
+		const params = new URLSearchParams("id=foo/bar");
+		const dest = buildBuilderRedirect(params, null);
+		const query = new URLSearchParams(dest.split("?")[1] ?? "");
+		expect(query.has("portfolio_id")).toBe(false);
+		expect(query.has("id")).toBe(false);
+	});
+
+	test("URL-encoded path-traversal payload is rejected as non-UUID", () => {
+		const params = new URLSearchParams("portfolio_id=%2e%2e%2ffoo");
+		const dest = buildBuilderRedirect(params, null);
+		const query = new URLSearchParams(dest.split("?")[1] ?? "");
+		expect(query.has("portfolio_id")).toBe(false);
+	});
+
+	test("when portfolio_id is non-UUID but id is a valid UUID, id wins via fallback", () => {
+		// Documents the precedence: non-UUID portfolio_id is treated as
+		// missing for canonicalization, so the legacy id (if a valid
+		// UUID) is used as the fallback. Mirrors extractCanonicalPortfolioId.
+		const params = new URLSearchParams(`portfolio_id=garbage&id=${UUID_A}`);
+		const dest = buildBuilderRedirect(params, "growth");
+		const query = new URLSearchParams(dest.split("?")[1] ?? "");
+		expect(query.getAll("portfolio_id")).toEqual([UUID_A]);
+		expect(query.has("id")).toBe(false);
+	});
+});
+
+describe("isValidPortfolioId", () => {
+	test("accepts canonical lowercase v4 UUIDs", () => {
+		expect(isValidPortfolioId(UUID_A)).toBe(true);
+		expect(isValidPortfolioId(UUID_B)).toBe(true);
+	});
+
+	test("accepts mixed-case UUIDs (RFC 4122 is case-insensitive)", () => {
+		expect(
+			isValidPortfolioId("11111111-2222-3333-4444-AaBbCcDdEeFf"),
+		).toBe(true);
+	});
+
+	test("rejects non-UUID strings", () => {
+		expect(isValidPortfolioId("garbage")).toBe(false);
+		expect(isValidPortfolioId("p1")).toBe(false);
+		expect(isValidPortfolioId("anything")).toBe(false);
+		expect(isValidPortfolioId("")).toBe(false);
+	});
+
+	test("rejects path-traversal payloads", () => {
+		expect(isValidPortfolioId("..")).toBe(false);
+		expect(isValidPortfolioId("../../etc/passwd")).toBe(false);
+		expect(isValidPortfolioId("foo/bar")).toBe(false);
+		expect(isValidPortfolioId("%2e%2e%2ffoo")).toBe(false);
+	});
+
+	test("rejects UUID with extra path segment appended", () => {
+		expect(isValidPortfolioId(`${UUID_A}/extra`)).toBe(false);
+		expect(isValidPortfolioId(`${UUID_A}?injected=1`)).toBe(false);
+	});
+
+	test("rejects null / undefined", () => {
+		expect(isValidPortfolioId(null)).toBe(false);
+		expect(isValidPortfolioId(undefined)).toBe(false);
+	});
 });
 
 describe("extractCanonicalPortfolioId", () => {
-	test("prefers portfolio_id over id", () => {
-		const params = new URLSearchParams("id=AAAA&portfolio_id=BBBB");
-		expect(extractCanonicalPortfolioId(params)).toBe("BBBB");
+	test("prefers portfolio_id over id when both are valid UUIDs", () => {
+		const params = new URLSearchParams(`id=${UUID_A}&portfolio_id=${UUID_B}`);
+		expect(extractCanonicalPortfolioId(params)).toBe(UUID_B);
 	});
 
 	test("falls back to legacy id when portfolio_id absent", () => {
-		const params = new URLSearchParams("id=AAAA");
-		expect(extractCanonicalPortfolioId(params)).toBe("AAAA");
+		const params = new URLSearchParams(`id=${UUID_A}`);
+		expect(extractCanonicalPortfolioId(params)).toBe(UUID_A);
 	});
 
 	test("returns first value when key is repeated", () => {
-		const params = new URLSearchParams("portfolio_id=AAAA&portfolio_id=BBBB");
-		expect(extractCanonicalPortfolioId(params)).toBe("AAAA");
+		const params = new URLSearchParams(
+			`portfolio_id=${UUID_A}&portfolio_id=${UUID_B}`,
+		);
+		expect(extractCanonicalPortfolioId(params)).toBe(UUID_A);
 	});
 
 	test("returns null when neither key is present", () => {
 		const params = new URLSearchParams("foo=bar");
+		expect(extractCanonicalPortfolioId(params)).toBeNull();
+	});
+
+	test("returns null for non-UUID portfolio_id with no fallback id", () => {
+		const params = new URLSearchParams("portfolio_id=garbage");
+		expect(extractCanonicalPortfolioId(params)).toBeNull();
+	});
+
+	test("returns null for non-UUID legacy id", () => {
+		const params = new URLSearchParams("id=garbage");
+		expect(extractCanonicalPortfolioId(params)).toBeNull();
+	});
+
+	test("falls through invalid portfolio_id to a valid legacy id", () => {
+		// Conservative-but-permissive precedence: a malformed canonical
+		// key shouldn't shadow a usable legacy fallback. Both must be
+		// invalid for the helper to give up.
+		const params = new URLSearchParams(`portfolio_id=garbage&id=${UUID_A}`);
+		expect(extractCanonicalPortfolioId(params)).toBe(UUID_A);
+	});
+
+	test("rejects path-traversal portfolio_id even when no fallback id present", () => {
+		const params = new URLSearchParams("portfolio_id=../../etc/passwd");
 		expect(extractCanonicalPortfolioId(params)).toBeNull();
 	});
 });

--- a/packages/ii-terminal-core/src/lib/utils/builder-redirect.test.ts
+++ b/packages/ii-terminal-core/src/lib/utils/builder-redirect.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the /portfolio/builder → /allocation/{profile}
+ * redirect resolver (PR-UX-2).
+ */
+import { describe, expect, test } from "vitest";
+import {
+	DEFAULT_PROFILE,
+	buildBuilderRedirect,
+	normalizeProfile,
+} from "./builder-redirect.js";
+
+describe("normalizeProfile", () => {
+	test("returns canonical profile when valid", () => {
+		expect(normalizeProfile("growth")).toBe("growth");
+		expect(normalizeProfile("conservative")).toBe("conservative");
+		expect(normalizeProfile("moderate")).toBe("moderate");
+	});
+
+	test("is case-insensitive", () => {
+		expect(normalizeProfile("Growth")).toBe("growth");
+		expect(normalizeProfile("MODERATE")).toBe("moderate");
+	});
+
+	test("returns null for unknown / empty / nullish", () => {
+		expect(normalizeProfile("aggressive")).toBeNull();
+		expect(normalizeProfile("")).toBeNull();
+		expect(normalizeProfile(null)).toBeNull();
+		expect(normalizeProfile(undefined)).toBeNull();
+	});
+});
+
+describe("buildBuilderRedirect", () => {
+	test("deep-link with growth portfolio resolves to /allocation/growth", () => {
+		const params = new URLSearchParams(
+			"portfolio_id=11111111-2222-3333-4444-555555555555",
+		);
+		const dest = buildBuilderRedirect(params, "growth");
+		expect(dest.startsWith("/allocation/growth?")).toBe(true);
+		expect(dest).toContain("portfolio_id=11111111-2222-3333-4444-555555555555");
+		expect(dest).toContain("tab=portfolio");
+	});
+
+	test("legacy ?id= is rewritten as portfolio_id and preserved", () => {
+		const params = new URLSearchParams(
+			"id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		);
+		const dest = buildBuilderRedirect(params, "conservative");
+		expect(dest.startsWith("/allocation/conservative?")).toBe(true);
+		expect(dest).toContain("portfolio_id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+		// Legacy ?id= param must be dropped (rewritten as portfolio_id).
+		// Using URLSearchParams to avoid substring matching on
+		// ``portfolio_id`` (which contains ``id=``).
+		const query = new URLSearchParams(dest.split("?")[1] ?? "");
+		expect(query.has("id")).toBe(false);
+	});
+
+	test("falls back to DEFAULT_PROFILE when resolved profile is null", () => {
+		const params = new URLSearchParams("portfolio_id=anything");
+		const dest = buildBuilderRedirect(params, null);
+		expect(dest.startsWith(`/allocation/${DEFAULT_PROFILE}?`)).toBe(true);
+		expect(DEFAULT_PROFILE).toBe("moderate");
+	});
+
+	test("falls back to DEFAULT_PROFILE for invalid resolved profile", () => {
+		const params = new URLSearchParams("portfolio_id=anything");
+		const dest = buildBuilderRedirect(params, "balanced");
+		expect(dest.startsWith(`/allocation/${DEFAULT_PROFILE}?`)).toBe(true);
+	});
+
+	test("preserves arbitrary query params untouched", () => {
+		const params = new URLSearchParams(
+			"portfolio_id=p1&alloc=growth&foo=bar",
+		);
+		const dest = buildBuilderRedirect(params, "growth");
+		expect(dest).toContain("alloc=growth");
+		expect(dest).toContain("foo=bar");
+		expect(dest).toContain("portfolio_id=p1");
+		expect(dest).toContain("tab=portfolio");
+	});
+
+	test("forces tab=portfolio even when source omits it", () => {
+		const params = new URLSearchParams("");
+		const dest = buildBuilderRedirect(params, null);
+		expect(dest).toBe(`/allocation/${DEFAULT_PROFILE}?tab=portfolio`);
+	});
+
+	test("source ?tab= is honored (last-write-wins on URLSearchParams.set)", () => {
+		// If a caller explicitly passes tab=stress, we still rewrite to
+		// portfolio because tab=portfolio is set first then the source
+		// overwrites — guard test to lock current behavior.
+		const params = new URLSearchParams("tab=stress");
+		const dest = buildBuilderRedirect(params, null);
+		// Source-provided tab wins because it iterates after the seed.
+		expect(dest).toContain("tab=stress");
+	});
+});

--- a/packages/ii-terminal-core/src/lib/utils/builder-redirect.test.ts
+++ b/packages/ii-terminal-core/src/lib/utils/builder-redirect.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "vitest";
 import {
 	DEFAULT_PROFILE,
 	buildBuilderRedirect,
+	extractCanonicalPortfolioId,
 	normalizeProfile,
 } from "./builder-redirect.js";
 
@@ -92,5 +93,75 @@ describe("buildBuilderRedirect", () => {
 		const dest = buildBuilderRedirect(params, null);
 		// Source-provided tab wins because it iterates after the seed.
 		expect(dest).toContain("tab=stress");
+	});
+
+	// ── Regression: lookup ↔ emit must agree on canonical id ──────
+	// Codex P2: previously the loader read get("portfolio_id") ?? get("id")
+	// while the builder iterated source params with set() last-write-wins,
+	// so URLs combining both keys (or repeating one) could land on the
+	// /allocation/{profile} route for the wrong portfolio.
+
+	test("URL with both portfolio_id then id keeps portfolio_id as canonical (id-after-portfolio_id ordering)", () => {
+		const params = new URLSearchParams("portfolio_id=BBBB&id=AAAA");
+		const dest = buildBuilderRedirect(params, "growth");
+		const query = new URLSearchParams(dest.split("?")[1] ?? "");
+		expect(query.getAll("portfolio_id")).toEqual(["BBBB"]);
+		expect(query.has("id")).toBe(false);
+	});
+
+	test("URL with id then portfolio_id keeps portfolio_id as canonical (portfolio_id-after-id ordering)", () => {
+		const params = new URLSearchParams("id=AAAA&portfolio_id=BBBB");
+		const dest = buildBuilderRedirect(params, "growth");
+		const query = new URLSearchParams(dest.split("?")[1] ?? "");
+		expect(query.getAll("portfolio_id")).toEqual(["BBBB"]);
+		expect(query.has("id")).toBe(false);
+	});
+
+	test("repeated portfolio_id collapses to the first value (matches URLSearchParams.get precedence)", () => {
+		const params = new URLSearchParams(
+			"portfolio_id=AAAA&portfolio_id=BBBB",
+		);
+		const dest = buildBuilderRedirect(params, "growth");
+		const query = new URLSearchParams(dest.split("?")[1] ?? "");
+		expect(query.getAll("portfolio_id")).toEqual(["AAAA"]);
+	});
+
+	test("repeated legacy id collapses to the first value", () => {
+		const params = new URLSearchParams("id=AAAA&id=BBBB");
+		const dest = buildBuilderRedirect(params, "growth");
+		const query = new URLSearchParams(dest.split("?")[1] ?? "");
+		expect(query.getAll("portfolio_id")).toEqual(["AAAA"]);
+		expect(query.has("id")).toBe(false);
+	});
+
+	test("no id keys present omits portfolio_id from destination", () => {
+		const params = new URLSearchParams("foo=bar");
+		const dest = buildBuilderRedirect(params, null);
+		const query = new URLSearchParams(dest.split("?")[1] ?? "");
+		expect(query.has("portfolio_id")).toBe(false);
+		expect(query.has("id")).toBe(false);
+		expect(query.get("foo")).toBe("bar");
+	});
+});
+
+describe("extractCanonicalPortfolioId", () => {
+	test("prefers portfolio_id over id", () => {
+		const params = new URLSearchParams("id=AAAA&portfolio_id=BBBB");
+		expect(extractCanonicalPortfolioId(params)).toBe("BBBB");
+	});
+
+	test("falls back to legacy id when portfolio_id absent", () => {
+		const params = new URLSearchParams("id=AAAA");
+		expect(extractCanonicalPortfolioId(params)).toBe("AAAA");
+	});
+
+	test("returns first value when key is repeated", () => {
+		const params = new URLSearchParams("portfolio_id=AAAA&portfolio_id=BBBB");
+		expect(extractCanonicalPortfolioId(params)).toBe("AAAA");
+	});
+
+	test("returns null when neither key is present", () => {
+		const params = new URLSearchParams("foo=bar");
+		expect(extractCanonicalPortfolioId(params)).toBeNull();
 	});
 });

--- a/packages/ii-terminal-core/src/lib/utils/builder-redirect.ts
+++ b/packages/ii-terminal-core/src/lib/utils/builder-redirect.ts
@@ -30,23 +30,56 @@ export function normalizeProfile(
 }
 
 /**
+ * RFC 4122 UUID (v1–v5, any version digit, any variant). The
+ * /model-portfolios endpoint always issues UUIDs as ids, so anything
+ * that isn't a UUID is either malformed or a path-traversal attempt
+ * (e.g. ``..``, ``foo/bar``, ``%2e%2e``) and must NOT be interpolated
+ * into the API path or echoed into the redirect destination.
+ */
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidPortfolioId(
+	raw: string | null | undefined,
+): raw is string {
+	return typeof raw === "string" && UUID_RE.test(raw);
+}
+
+/**
  * Extract the canonical portfolio_id from a URLSearchParams, applying
  * the precedence rule shared by lookup and redirect emit:
  *
- *   1. First value of ``portfolio_id`` if present.
- *   2. Else first value of ``id`` (legacy wealth callers).
+ *   1. First value of ``portfolio_id`` if present AND a valid UUID.
+ *   2. Else first value of ``id`` (legacy wealth callers) if a valid
+ *      UUID.
  *   3. Else ``null``.
  *
- * Centralizing this avoids the regression where the loader fetches
- * the profile for one id while the redirect carries another (e.g.
- * URL contains both ``?portfolio_id=B&id=A`` or repeated keys, which
- * would have been resolved differently by ``URLSearchParams.get``
- * vs. last-write-wins iteration in ``buildBuilderRedirect``).
+ * Centralizing this avoids two regressions:
+ *   - Loader and redirect drifting on which id is canonical when both
+ *     keys are present or repeated (P2 hotfix #1).
+ *   - Crafted ids containing path separators (``..``, ``/``, encoded
+ *     equivalents) reaching ``/model-portfolios/${id}`` and triggering
+ *     authenticated GETs against unrelated backend routes (P2 hotfix
+ *     #2). UUID validation here means both the lookup and the
+ *     redirect emit ignore non-UUID values entirely.
  */
 export function extractCanonicalPortfolioId(
 	source: URLSearchParams,
 ): string | null {
-	return source.get("portfolio_id") ?? source.get("id");
+	// Try each candidate key in precedence order and return the first
+	// VALID UUID. We deliberately fall through on a present-but-invalid
+	// portfolio_id so that a malformed canonical key doesn't shadow a
+	// usable legacy id — e.g. ``?portfolio_id=garbage&id=<uuid>`` still
+	// resolves to <uuid> instead of dropping both. Any non-UUID input is
+	// rejected entirely, so this fallback can never widen the
+	// path-traversal attack surface.
+	for (const candidate of [
+		source.get("portfolio_id"),
+		source.get("id"),
+	]) {
+		if (isValidPortfolioId(candidate)) return candidate;
+	}
+	return null;
 }
 
 /**

--- a/packages/ii-terminal-core/src/lib/utils/builder-redirect.ts
+++ b/packages/ii-terminal-core/src/lib/utils/builder-redirect.ts
@@ -30,11 +30,37 @@ export function normalizeProfile(
 }
 
 /**
+ * Extract the canonical portfolio_id from a URLSearchParams, applying
+ * the precedence rule shared by lookup and redirect emit:
+ *
+ *   1. First value of ``portfolio_id`` if present.
+ *   2. Else first value of ``id`` (legacy wealth callers).
+ *   3. Else ``null``.
+ *
+ * Centralizing this avoids the regression where the loader fetches
+ * the profile for one id while the redirect carries another (e.g.
+ * URL contains both ``?portfolio_id=B&id=A`` or repeated keys, which
+ * would have been resolved differently by ``URLSearchParams.get``
+ * vs. last-write-wins iteration in ``buildBuilderRedirect``).
+ */
+export function extractCanonicalPortfolioId(
+	source: URLSearchParams,
+): string | null {
+	return source.get("portfolio_id") ?? source.get("id");
+}
+
+/**
  * Build the destination URL string for the /portfolio/builder
  * redirect.
  *
  * Rules:
- *   - ``id`` is rewritten to ``portfolio_id`` (legacy wealth callers).
+ *   - ``portfolio_id`` is emitted exactly once, from the canonical
+ *     value chosen by ``extractCanonicalPortfolioId`` — guaranteeing
+ *     the redirect carries the same id the loader used for the
+ *     profile lookup, regardless of source key order or duplicates.
+ *   - Legacy ``id`` is dropped from the output (its value already
+ *     contributes to the canonical id when no ``portfolio_id`` is
+ *     present).
  *   - All other query params pass through untouched.
  *   - ``tab=portfolio`` is forced on the destination.
  *   - Destination profile is the resolved profile if valid, else
@@ -48,11 +74,15 @@ export function buildBuilderRedirect(
 	destParams.set("tab", "portfolio");
 
 	for (const [key, value] of source) {
-		if (key === "id") {
-			destParams.set("portfolio_id", value);
-			continue;
-		}
+		// Strip both id keys — the canonical portfolio_id is emitted
+		// once, after the iteration, from the precedence helper.
+		if (key === "id" || key === "portfolio_id") continue;
 		destParams.set(key, value);
+	}
+
+	const canonicalPortfolioId = extractCanonicalPortfolioId(source);
+	if (canonicalPortfolioId) {
+		destParams.set("portfolio_id", canonicalPortfolioId);
 	}
 
 	const profile = normalizeProfile(resolvedProfile) ?? DEFAULT_PROFILE;

--- a/packages/ii-terminal-core/src/lib/utils/builder-redirect.ts
+++ b/packages/ii-terminal-core/src/lib/utils/builder-redirect.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure helpers for the /portfolio/builder → /allocation/{profile}
+ * redirect (PR-UX-2).
+ *
+ * Lives in ii-terminal-core (instead of co-located with the route)
+ * so the redirect contract is unit testable via the package's vitest
+ * harness, without requiring a vitest runner in frontends/terminal.
+ */
+import {
+	ALLOCATION_PROFILES,
+	type AllocationProfile,
+} from "../types/allocation-page.js";
+
+export const DEFAULT_PROFILE: AllocationProfile = "moderate";
+
+export function isAllocationProfile(raw: string): raw is AllocationProfile {
+	return (ALLOCATION_PROFILES as readonly string[]).includes(raw);
+}
+
+/**
+ * Normalize an unknown profile string (case-insensitive) into the
+ * canonical AllocationProfile or ``null`` if it isn't one we serve.
+ */
+export function normalizeProfile(
+	raw: string | null | undefined,
+): AllocationProfile | null {
+	if (!raw) return null;
+	const lower = raw.toLowerCase();
+	return isAllocationProfile(lower) ? lower : null;
+}
+
+/**
+ * Build the destination URL string for the /portfolio/builder
+ * redirect.
+ *
+ * Rules:
+ *   - ``id`` is rewritten to ``portfolio_id`` (legacy wealth callers).
+ *   - All other query params pass through untouched.
+ *   - ``tab=portfolio`` is forced on the destination.
+ *   - Destination profile is the resolved profile if valid, else
+ *     ``DEFAULT_PROFILE`` (graceful degrade).
+ */
+export function buildBuilderRedirect(
+	source: URLSearchParams,
+	resolvedProfile: string | null,
+): string {
+	const destParams = new URLSearchParams();
+	destParams.set("tab", "portfolio");
+
+	for (const [key, value] of source) {
+		if (key === "id") {
+			destParams.set("portfolio_id", value);
+			continue;
+		}
+		destParams.set(key, value);
+	}
+
+	const profile = normalizeProfile(resolvedProfile) ?? DEFAULT_PROFILE;
+	return `/allocation/${profile}?${destParams.toString()}`;
+}

--- a/packages/ii-terminal-core/vitest.config.ts
+++ b/packages/ii-terminal-core/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Pure-JS/TS unit test runner for ii-terminal-core helpers.
+ *
+ * Svelte component tests under ``src/lib/components/**`` require the
+ * Svelte vite plugin and a browser-like environment (jsdom + Svelte 5
+ * runes harness). Until that toolchain lands, exclude them so the
+ * helper tests (utils/, formatters/) can run on their own.
+ */
+export default defineConfig({
+	test: {
+		include: ["src/lib/**/*.test.ts"],
+		exclude: [
+			"node_modules/**",
+			"dist/**",
+			".svelte-kit/**",
+			"src/lib/components/**",
+		],
+	},
+});

--- a/packages/investintell-ui/src/lib/utils/api-client.ts
+++ b/packages/investintell-ui/src/lib/utils/api-client.ts
@@ -171,15 +171,27 @@ export class NetzApiClient {
 		const url = buildUrl(this.baseUrl, path, params);
 		const headers = await this.headers();
 		const signal = options?.signal ?? AbortSignal.timeout(this.timeoutMs);
-		// GET is idempotent — retry once on timeout/network error
+		// GET is idempotent — retry once on timeout/network error,
+		// BUT only when we own the timeout. If the caller supplied a
+		// signal (manual abort or AbortSignal.timeout), that signal IS
+		// the deadline contract — retrying past it would silently
+		// extend the caller's hard cap (e.g. a 4s cap becoming
+		// 4s + this.timeoutMs ≈ 19s on TimeoutError).
 		try {
 			const res = await fetch(url, { headers, signal });
 			return handleResponse<T>(res);
 		} catch (err) {
-			// Don't retry if caller aborted
-			if (options?.signal && err instanceof DOMException && err.name === "AbortError") throw err;
+			// Caller-supplied signal is authoritative — never retry past
+			// its deadline, regardless of whether it tripped via abort()
+			// (AbortError) or AbortSignal.timeout (TimeoutError).
+			if (
+				options?.signal
+				&& err instanceof DOMException
+				&& (err.name === "AbortError" || err.name === "TimeoutError")
+			) throw err;
+
+			// Default-timeout path only: GET is idempotent, retry once.
 			if (err instanceof DOMException && err.name === "TimeoutError") {
-				// Retry once
 				const res = await fetch(url, { headers, signal: AbortSignal.timeout(this.timeoutMs) });
 				return handleResponse<T>(res);
 			}

--- a/packages/ui/src/lib/utils/__tests__/api-client.test.ts
+++ b/packages/ui/src/lib/utils/__tests__/api-client.test.ts
@@ -25,7 +25,10 @@ function jsonResponse(status: number, body: unknown = {}): Response {
 }
 
 beforeEach(() => {
-	vi.clearAllMocks();
+	// resetAllMocks clears both call history AND queued return values
+	// (clearAllMocks only clears history, leaking unused .mockXxxValueOnce
+	// queue entries into the next test).
+	vi.resetAllMocks();
 	resetRedirectGate();
 	setAuthRedirectHandler(null as unknown as () => void);
 	setConflictHandler(null as unknown as (msg: string) => void);
@@ -159,6 +162,61 @@ describe("409 conflict handling", () => {
 				"Resource was modified by another user",
 			);
 		}
+	});
+});
+
+describe("GET timeout / retry semantics", () => {
+	function timeoutError(): DOMException {
+		return new DOMException("The operation was aborted due to timeout", "TimeoutError");
+	}
+
+	function abortError(): DOMException {
+		return new DOMException("The user aborted a request.", "AbortError");
+	}
+
+	it("retries once on TimeoutError when no caller signal is supplied", async () => {
+		mockFetch.mockRejectedValueOnce(timeoutError());
+		mockFetch.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+		const client = createServerApiClient("http://api.test", "tok");
+		const result = await client.get<{ ok: boolean }>("/slow");
+
+		expect(result).toEqual({ ok: true });
+		expect(mockFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("does NOT retry on TimeoutError when caller supplied a signal (caller deadline is authoritative)", async () => {
+		// Codex P2 hotfix: a caller-supplied AbortSignal.timeout(4000)
+		// must give a hard 4s cap. The previous retry path silently
+		// extended that to 4s + this.timeoutMs (≈ 19s) on TimeoutError.
+		mockFetch.mockRejectedValueOnce(timeoutError());
+		mockFetch.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+
+		const client = createServerApiClient("http://api.test", "tok");
+		const ctrl = new AbortController();
+		await expect(
+			client.get<{ ok: boolean }>("/slow", undefined, { signal: ctrl.signal }),
+		).rejects.toThrow(DOMException);
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT retry on AbortError when caller supplied a signal", async () => {
+		mockFetch.mockRejectedValueOnce(abortError());
+
+		const client = createServerApiClient("http://api.test", "tok");
+		const ctrl = new AbortController();
+		await expect(
+			client.get("/x", undefined, { signal: ctrl.signal }),
+		).rejects.toThrow(DOMException);
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT retry on non-timeout errors regardless of caller signal", async () => {
+		mockFetch.mockRejectedValueOnce(new TypeError("network down"));
+
+		const client = createServerApiClient("http://api.test", "tok");
+		await expect(client.get("/x")).rejects.toThrow(TypeError);
+		expect(mockFetch).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/ui/src/lib/utils/api-client.ts
+++ b/packages/ui/src/lib/utils/api-client.ts
@@ -171,15 +171,27 @@ export class NetzApiClient {
 		const url = buildUrl(this.baseUrl, path, params);
 		const headers = await this.headers();
 		const signal = options?.signal ?? AbortSignal.timeout(this.timeoutMs);
-		// GET is idempotent — retry once on timeout/network error
+		// GET is idempotent — retry once on timeout/network error,
+		// BUT only when we own the timeout. If the caller supplied a
+		// signal (manual abort or AbortSignal.timeout), that signal IS
+		// the deadline contract — retrying past it would silently
+		// extend the caller's hard cap (e.g. a 4s cap becoming
+		// 4s + this.timeoutMs ≈ 19s on TimeoutError).
 		try {
 			const res = await fetch(url, { headers, signal });
 			return handleResponse<T>(res);
 		} catch (err) {
-			// Don't retry if caller aborted
-			if (options?.signal && err instanceof DOMException && err.name === "AbortError") throw err;
+			// Caller-supplied signal is authoritative — never retry past
+			// its deadline, regardless of whether it tripped via abort()
+			// (AbortError) or AbortSignal.timeout (TimeoutError).
+			if (
+				options?.signal
+				&& err instanceof DOMException
+				&& (err.name === "AbortError" || err.name === "TimeoutError")
+			) throw err;
+
+			// Default-timeout path only: GET is idempotent, retry once.
 			if (err instanceof DOMException && err.name === "TimeoutError") {
-				// Retry once
 				const res = await fetch(url, { headers, signal: AbortSignal.timeout(this.timeoutMs) });
 				return handleResponse<T>(res);
 			}


### PR DESCRIPTION
## Summary

- `/portfolio/builder` was hardcoded to redirect to `/allocation/moderate`, ignoring the portfolio's actual profile when a deep link supplied `?portfolio_id=` (or legacy `?id=`). Conservative and growth deep links landed on the moderate strategic tab and required a manual `ProfileStrip` switch.
- The loader now fetches `/model-portfolios/{id}` via `createServerApiClient` (same pattern as `allocation/[profile]/+page.server.ts`), reads the `profile` field, and redirects to `/allocation/{profile}` with the original query params and `tab=portfolio` preserved. Lookup failures (no token, fetch error, unknown profile) fall back to `/allocation/moderate` so a transient API blip never blocks the redirect.
- Resolution logic extracted into `@investintell/ii-terminal-core/utils/builder-redirect` so the redirect contract is unit testable without a SvelteKit SSR harness; wires up vitest in `ii-terminal-core` (devDep already present) and adds 10 unit tests.

Refs: `docs/plans/2026-04-30-builder-workspace-redesign-final.md` §2.9, §6.2.2, §9 PR-UX-2.

## Test plan

- [x] `pnpm --filter @investintell/ii-terminal-core test` — 10 new + 9 pre-existing tests pass (19/19).
- [x] `pnpm --filter ii-terminal check` — 0 errors, 1 pre-existing a11y warning unchanged.
- [x] Unit coverage for: deep-link with growth/conservative profile, legacy `?id=` rewrite, null/invalid-profile fallback to `moderate`, query passthrough (`alloc=`, `foo=bar`), forced `tab=portfolio`.
- [ ] Manual smoke (recommended in QA): visit `/portfolio/builder?portfolio_id=<growth-id>` → expect `/allocation/growth?tab=portfolio&portfolio_id=<id>`; visit with bogus id → expect `/allocation/moderate?...` (fallback path).

---

## Stability Guardrails Checklist

> Charter: `docs/reference/stability-guardrails.md`.

### Backend

- N/A — no backend changes (frontend-only PR).

### Frontend

- [x] New `+page.server.ts` load fetches pass an explicit `AbortSignal.timeout(...)` — `FETCH_TIMEOUT_MS = 4000` for the new model-portfolio lookup.
- [x] Detail-page load contract (`RouteData<T>`) — **N/A**, this route is a 307 redirect (no rendered page). Failure mode is graceful fallback to `/allocation/moderate`, not a `throw error()`.
- [x] Numeric/date/currency formatting — N/A, no rendering.
- N/A — no new event sources, no mutating client calls, no async callbacks.

### Tests & verification

- [x] New unit tests added in `packages/ii-terminal-core/src/lib/utils/builder-redirect.test.ts` (10 tests).
- [x] Verified with `pnpm test` in the touched package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)