### PR TITLE
fix(credit): unblock svelte-check on deal detail page (rejection_code/notes)

### DIFF
--- a/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/[dealId]/+page.server.ts
+++ b/frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/[dealId]/+page.server.ts
@@ -18,7 +18,13 @@ export const load: PageServerLoad = async ({ params, parent }) => {
 
 	if (deal.status === "rejected") {
 		return {
-			deal: {},
+			// Empty fallback intentionally typed as Record<string, unknown>
+			// (not literal {}) so consumers can safely access optional
+			// deal fields without forming a Record<string, unknown> | {}
+			// union — the latter rejects arbitrary property access on the
+			// {} branch and surfaces as "Property X does not exist" in
+			// svelte-check.
+			deal: {} as Record<string, unknown>,
 			stageTimeline: null,
 			icMemo: null,
 			votingStatus: null,


### PR DESCRIPTION
## Summary

CI job 73891099552 surfaced 3 svelte-check errors on \`frontends/credit/src/routes/(team)/funds/[fundId]/pipeline/[dealId]/+page.svelte\`:

\`\`\`
Property 'rejection_code' does not exist on type 'Record<string, unknown> | {}'.
Property 'rejection_notes' does not exist on type 'Record<string, unknown> | {}'.
\`\`\`

Root cause: the load function returned a literal \`{}\` on the rejected branch and \`Record<string, unknown>\` on the success branch. The inferred \`data.deal\` type was the union — and the \`{}\` arm rejects arbitrary property access.

Fix is a one-line cast: \`{} as Record<string, unknown>\` on the fallback. Both branches now expose the same type. All template accesses (\`description\`, \`created_at\`, \`asset_id\`, \`name\`, \`stage\`, plus \`rejection_*\`) now type-check uniformly as \`unknown\`, which Svelte renders fine and which existing \`as DealStage\` casts at call sites already account for.

No behavioural change. No source rename. Comment block on the fallback documents WHY the cast is required so the next refactor doesn't innocently revert to \`{}\`.

## Verification

\`pnpm exec svelte-check\` on \`frontends/credit\`:
- Before: 5 errors (3 in deal page + 2 pre-existing in \`+layout.svelte\`)
- After: 2 errors (only the pre-existing \`data.fund possibly null\` ones — untouched by this PR)

## Test plan

- [x] svelte-check on credit frontend confirms the 3 errors are gone
- [ ] CI re-run on a branch that touched credit will be green for this file
- [ ] Visual smoke: deal detail page renders correctly for rejected deals (fallback path) and active deals (happy path)

## Context

The credit type-check step in \`.github/workflows/ci.yml\` is still non-blocking per issue #277. This PR doesn't change that gate; it just removes one specific blocker that was making job logs noisy and at risk of masking real regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)