### PR TITLE
feat(wealth): PR-UX-5 — sanitization parity (canonize quant-labels + CI gate)

### DIFF
--- a/backend/tests/wealth/test_sanitization_parity.py
+++ b/backend/tests/wealth/test_sanitization_parity.py
@@ -1,0 +1,318 @@
+"""Sanitization parity test — backend ↔ frontend i18n drift gate.
+
+Enforces that every metric / regime / scenario key emitted by the
+backend (``backend/app/domains/wealth/schemas/sanitized.py``) is
+representable on the frontend
+(``packages/ii-terminal-core/src/lib/i18n/quant-labels.ts``).
+
+The frontend dictionary is the *single* canonical TypeScript source
+(the wealth-side ``frontends/wealth/src/lib/i18n/quant-labels.ts`` is a
+re-export shim — see PR-UX-5). Backend keys ⊆ frontend keys means
+nothing the backend can emit will reach the UI as untranslated jargon.
+
+The test parses the TypeScript source with simple regexes — there is
+no Node runtime in CI for this test. Anything that defeats those
+regexes (e.g. computed keys, dynamic ``Object.keys`` of an external
+import) will surface as a parity failure, which is the correct
+behaviour: the test should fail loudly when the introspection contract
+breaks, not silently pass.
+
+Spec: ``docs/plans/2026-04-30-builder-workspace-redesign-final.md`` §8.
+
+PR-UX-5 — sanitization parity (canonize quant-labels + CI gate).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.domains.wealth.schemas.sanitized import (
+    EVENT_TYPE_LABELS,
+    METRIC_LABELS,
+    REGIME_LABELS,
+)
+
+# ── §8 canonical fixture ─────────────────────────────────────────────
+#
+# The plan §8 mappings table. Hardcoded here on purpose — markdown
+# parsing is brittle and §8 is a stable institutional contract. If the
+# doc table changes, update this fixture in the same PR.
+#
+# Each entry is the raw key that crosses the wire; both backend and
+# frontend MUST be able to translate it.
+
+DOC_SECTION_8_METRIC_KEYS: tuple[str, ...] = (
+    # CVaR / Expected Shortfall family
+    "cvar_95",
+    "expected_shortfall",
+    "cvar_95_1m",
+    "cvar_95_3m",
+    "cvar_95_6m",
+    "cvar_95_12m",
+    "cvar_95_conditional",
+    # Regime
+    "regime",
+    "market_regime",
+    # Volatility models
+    "garch_volatility",
+    "ewma_volatility",
+    "volatility_garch",
+    # Macro composite
+    "cfnai",
+    "macro_score",
+    # Drawdown
+    "max_drawdown",
+    "drawdown",
+    "max_drawdown_1y",
+    "max_drawdown_3y",
+    # Strategy drift
+    "dtw_drift_score",
+)
+
+DOC_SECTION_8_REGIME_KEYS: tuple[str, ...] = (
+    "RISK_ON",
+    "RISK_OFF",
+    "NEUTRAL",
+    "CRISIS",
+    "EXPANSION",
+    "CAUTIOUS",
+    "STRESS",
+)
+
+DOC_SECTION_8_SCENARIO_KEYS: tuple[str, ...] = (
+    "gfc_2008",
+    "covid_2020",
+    "taper_2013",
+    "rate_shock_200bps",
+)
+
+# ── Frontend file location ───────────────────────────────────────────
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FRONTEND_QUANT_LABELS = (
+    REPO_ROOT
+    / "packages"
+    / "ii-terminal-core"
+    / "src"
+    / "lib"
+    / "i18n"
+    / "quant-labels.ts"
+)
+WEALTH_QUANT_LABELS_SHIM = (
+    REPO_ROOT
+    / "frontends"
+    / "wealth"
+    / "src"
+    / "lib"
+    / "i18n"
+    / "quant-labels.ts"
+)
+
+
+def _read_frontend_source() -> str:
+    if not FRONTEND_QUANT_LABELS.exists():
+        pytest.fail(
+            f"Canonical frontend dictionary missing: {FRONTEND_QUANT_LABELS}"
+        )
+    return FRONTEND_QUANT_LABELS.read_text(encoding="utf-8")
+
+
+def _parse_metric_label_keys(source: str) -> set[str]:
+    """Extract canonical METRIC_LABELS keys.
+
+    Matches the body of the ``METRIC_LABELS`` const declaration and
+    pulls out the bare-identifier or quoted keys on each line.
+    """
+    block_match = re.search(
+        r"const\s+METRIC_LABELS\s*:[^=]*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.DOTALL,
+    )
+    if not block_match:
+        pytest.fail(
+            "Could not locate METRIC_LABELS const in canonical frontend "
+            "dictionary — parser regex needs an update or the dictionary "
+            "structure has drifted."
+        )
+    body = block_match.group("body")
+    return _extract_keys(body)
+
+
+def _parse_normalise_aliases(source: str) -> set[str]:
+    """Extract every ``case "..."`` literal inside the ``normalise`` switch.
+
+    These are the alternate spellings that ``humanizeMetric`` understands
+    via the normalisation step. Backend can emit any of them and the
+    frontend will resolve to a known canonical key.
+    """
+    func_match = re.search(
+        r"function\s+normalise\s*\([^)]*\)\s*:[^{]*\{(?P<body>.*?)^\}",
+        source,
+        re.DOTALL | re.MULTILINE,
+    )
+    if not func_match:
+        pytest.fail(
+            "Could not locate normalise() function in canonical frontend "
+            "dictionary — parser regex needs an update."
+        )
+    body = func_match.group("body")
+    return set(re.findall(r'case\s+"([^"]+)"\s*:', body))
+
+
+def _parse_scenario_label_keys(source: str) -> set[str]:
+    block_match = re.search(
+        r"const\s+SCENARIO_LABELS\s*:[^=]*=\s*\{(?P<body>.*?)\};",
+        source,
+        re.DOTALL,
+    )
+    if not block_match:
+        pytest.fail("Could not locate SCENARIO_LABELS const.")
+    return _extract_keys(block_match.group("body"))
+
+
+def _parse_regime_label_keys(source: str) -> set[str]:
+    """Pull regime tokens out of the ``regimeLabel`` switch."""
+    func_match = re.search(
+        r"function\s+regimeLabel\s*\([^)]*\)\s*:[^{]*\{(?P<body>.*?)^\}",
+        source,
+        re.DOTALL | re.MULTILINE,
+    )
+    if not func_match:
+        pytest.fail("Could not locate regimeLabel() function.")
+    return set(re.findall(r'case\s+"([^"]+)"\s*:', func_match.group("body")))
+
+
+def _extract_keys(body: str) -> set[str]:
+    """Parse ``key: "value",`` and ``"key": "value",`` pairs from a block.
+
+    Strips line/block comments first so a ``// case "foo"`` reference
+    inside a comment isn't picked up as a real key.
+    """
+    cleaned = re.sub(r"//.*?$", "", body, flags=re.MULTILINE)
+    cleaned = re.sub(r"/\*.*?\*/", "", cleaned, flags=re.DOTALL)
+    bare = set(re.findall(r"^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:", cleaned, re.MULTILINE))
+    quoted = set(re.findall(r'^\s*"([^"]+)"\s*:', cleaned, re.MULTILINE))
+    return bare | quoted
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+def test_backend_metric_keys_subset_of_frontend() -> None:
+    """Every backend METRIC_LABELS key must be representable on the frontend.
+
+    Frontend "representable" means: either a top-level entry in
+    ``METRIC_LABELS`` OR an alias case in the ``normalise`` switch.
+    """
+    source = _read_frontend_source()
+    frontend_keys = _parse_metric_label_keys(source)
+    frontend_aliases = _parse_normalise_aliases(source)
+    representable = frontend_keys | frontend_aliases
+
+    backend_keys = set(METRIC_LABELS.keys())
+    missing = backend_keys - representable
+    assert not missing, (
+        f"Backend METRIC_LABELS keys missing from frontend canonical "
+        f"dictionary (drift): {sorted(missing)}. Add them to "
+        f"packages/ii-terminal-core/src/lib/i18n/quant-labels.ts — either "
+        f"as a METRIC_LABELS entry or as a normalise() case."
+    )
+
+
+def test_backend_regime_keys_subset_of_frontend() -> None:
+    source = _read_frontend_source()
+    frontend_regime_keys = _parse_regime_label_keys(source)
+    backend_regime_keys = set(REGIME_LABELS.keys())
+    missing = backend_regime_keys - frontend_regime_keys
+    assert not missing, (
+        f"Backend REGIME_LABELS keys missing from frontend regimeLabel(): "
+        f"{sorted(missing)}."
+    )
+
+
+def test_doc_section_8_metric_keys_have_backend_representation() -> None:
+    """Every §8 doc-table key must be representable in the backend dict."""
+    backend_keys = set(METRIC_LABELS.keys())
+    missing = set(DOC_SECTION_8_METRIC_KEYS) - backend_keys
+    assert not missing, (
+        f"§8 metric keys missing from backend METRIC_LABELS: "
+        f"{sorted(missing)}. Add them to "
+        f"backend/app/domains/wealth/schemas/sanitized.py::METRIC_LABELS."
+    )
+
+
+def test_doc_section_8_metric_keys_have_frontend_representation() -> None:
+    """Every §8 doc-table key must be representable on the frontend."""
+    source = _read_frontend_source()
+    representable = _parse_metric_label_keys(source) | _parse_normalise_aliases(
+        source
+    )
+    missing = set(DOC_SECTION_8_METRIC_KEYS) - representable
+    assert not missing, (
+        f"§8 metric keys missing from frontend canonical dictionary: "
+        f"{sorted(missing)}."
+    )
+
+
+def test_doc_section_8_regime_keys_have_backend_representation() -> None:
+    backend = set(REGIME_LABELS.keys())
+    missing = set(DOC_SECTION_8_REGIME_KEYS) - backend
+    assert not missing, (
+        f"§8 regime keys missing from backend REGIME_LABELS: "
+        f"{sorted(missing)}."
+    )
+
+
+def test_doc_section_8_regime_keys_have_frontend_representation() -> None:
+    source = _read_frontend_source()
+    representable = _parse_regime_label_keys(source)
+    missing = set(DOC_SECTION_8_REGIME_KEYS) - representable
+    assert not missing, (
+        f"§8 regime keys missing from frontend regimeLabel(): "
+        f"{sorted(missing)}."
+    )
+
+
+def test_doc_section_8_scenario_keys_have_frontend_representation() -> None:
+    """Stress scenario slugs are frontend-only — backend just emits the
+    raw slug. The frontend ``scenarioLabel()`` helper must translate
+    every §8 scenario."""
+    source = _read_frontend_source()
+    representable = _parse_scenario_label_keys(source)
+    missing = set(DOC_SECTION_8_SCENARIO_KEYS) - representable
+    assert not missing, (
+        f"§8 scenario keys missing from frontend SCENARIO_LABELS: "
+        f"{sorted(missing)}."
+    )
+
+
+def test_event_type_labels_are_non_empty() -> None:
+    """``EVENT_TYPE_LABELS`` is backend-only (no frontend mirror needed —
+    the backend already humanises ``type``/``message`` before SSE emit).
+    Sanity-check that it isn't empty so the wire stays sanitised."""
+    assert len(EVENT_TYPE_LABELS) > 0
+    # Spot-check a few high-traffic events.
+    for required in ("run_started", "run_failed", "optimizer_started"):
+        assert required in EVENT_TYPE_LABELS, (
+            f"EVENT_TYPE_LABELS missing required key {required!r}."
+        )
+
+
+def test_wealth_shim_re_exports_terminal_core() -> None:
+    """The wealth-side ``quant-labels.ts`` must be a pure re-export of the
+    canonical terminal-core module — no duplicate dictionary."""
+    if not WEALTH_QUANT_LABELS_SHIM.exists():
+        pytest.fail(f"Wealth shim missing: {WEALTH_QUANT_LABELS_SHIM}")
+    src = WEALTH_QUANT_LABELS_SHIM.read_text(encoding="utf-8")
+    assert (
+        '@investintell/ii-terminal-core/i18n/quant-labels' in src
+    ), "Wealth shim must re-export from @investintell/ii-terminal-core/i18n/quant-labels."
+    # No locally-defined METRIC_LABELS / SCENARIO_LABELS const blocks.
+    assert not re.search(
+        r"const\s+METRIC_LABELS\s*:[^=]*=\s*\{", src
+    ), "Wealth shim must NOT declare its own METRIC_LABELS — drift risk."
+    assert not re.search(
+        r"const\s+SCENARIO_LABELS\s*:[^=]*=\s*\{", src
+    ), "Wealth shim must NOT declare its own SCENARIO_LABELS — drift risk."

--- a/frontends/wealth/src/lib/i18n/quant-labels.ts
+++ b/frontends/wealth/src/lib/i18n/quant-labels.ts
@@ -1,161 +1,18 @@
 /**
- * Institutional label dictionary — Risk Methodology v3.
+ * Wealth-side re-export shim — Risk Methodology v3 institutional labels.
  *
- * Surface-facing replacement for the raw quant jargon that flows out
- * of the backend risk engines (CVaR, Expected Shortfall, GARCH,
- * EWMA, CFNAI, regime labels, drawdown). The wealth frontend is
- * "dumb" by design — it never renders a bare model identifier to an
- * institutional allocator. Every metric shown to a user passes
- * through this dictionary first.
+ * The canonical implementation lives in
+ * ``packages/ii-terminal-core/src/lib/i18n/quant-labels.ts``. This module
+ * exists only so existing wealth call sites can keep importing from
+ * ``$wealth/i18n/quant-labels`` without taking a hard dependency on the
+ * terminal-core path. New code MAY import either path; both resolve to
+ * the same module instance.
  *
- * Scope of v3
- * -----------
- * The mapping mirrors the Risk Methodology v3 reference and the
- * §3 UX charter:
+ * Drift between this re-export, terminal-core, and the backend
+ * dictionary in ``backend/app/domains/wealth/schemas/sanitized.py`` is
+ * enforced by ``backend/tests/wealth/test_sanitization_parity.py``.
  *
- *   Quant key                           →  Institutional label
- *   ------------------------------------ -----------------------------
- *   CVaR / Expected Shortfall           →  Conditional Tail Risk (CVaR 95%)
- *   Regime                              →  Market Regime: Expansion / Cautious / Stress
- *   GARCH / EWMA Volatility             →  Conditional Volatility
- *   CFNAI / Macro Score                 →  Real Economy Activity Index
- *   Drawdown                            →  Maximum Drawdown
- *
- * Backend regime labels (RISK_ON / RISK_OFF / CRISIS) are translated
- * by `regimeLabel()` to the three-state institutional phrasing
- * (Expansion / Cautious / Stress).
- *
- * Consumers
- * ---------
- *   import { humanizeMetric, regimeLabel } from "$wealth/i18n/quant-labels";
- *   <MetricCard label={humanizeMetric("cvar_95")} value={formatPercent(x)} />
- *   <span>{regimeLabel(store.regime.label)}</span>
- *
- * Adding a new label
- * ------------------
- * 1. Add the canonical quant key to `QuantMetricKey`.
- * 2. Add the institutional phrasing to `METRIC_LABELS`.
- * 3. If the key has alternate spellings (e.g. "cvar_95", "cvar95",
- *    "expected_shortfall"), route them through `humanizeMetric`'s
- *    normalisation branch — never add alternate keys as top-level
- *    entries, that splinters the dictionary.
+ * PR-UX-5 — sanitization parity (canonize quant-labels + CI gate).
  */
 
-export type QuantMetricKey =
-	| "cvar_95"
-	| "expected_shortfall"
-	| "regime"
-	| "garch_volatility"
-	| "ewma_volatility"
-	| "cfnai"
-	| "macro_score"
-	| "drawdown"
-	| "max_drawdown";
-
-const METRIC_LABELS: Readonly<Record<QuantMetricKey, string>> = {
-	cvar_95: "Conditional Tail Risk (CVaR 95%)",
-	expected_shortfall: "Conditional Tail Risk (CVaR 95%)",
-	regime: "Market Regime",
-	garch_volatility: "Conditional Volatility",
-	ewma_volatility: "Conditional Volatility",
-	cfnai: "Real Economy Activity Index",
-	macro_score: "Real Economy Activity Index",
-	drawdown: "Maximum Drawdown",
-	max_drawdown: "Maximum Drawdown",
-};
-
-/**
- * Normalise an incoming metric key to the canonical QuantMetricKey.
- * Accepts snake_case, camelCase, SCREAMING, hyphenated, and a few
- * well-known aliases. Returns `null` for unknown keys so callers
- * can fall back to the raw string if they prefer.
- */
-function normalise(raw: string): QuantMetricKey | null {
-	const k = raw.trim().toLowerCase().replace(/[-\s]+/g, "_");
-	switch (k) {
-		case "cvar":
-		case "cvar95":
-		case "cvar_95":
-		case "c_var_95":
-		case "conditional_value_at_risk":
-		case "expected_shortfall":
-		case "es":
-			return "cvar_95";
-		case "regime":
-		case "market_regime":
-			return "regime";
-		case "garch":
-		case "garch_vol":
-		case "garch_volatility":
-			return "garch_volatility";
-		case "ewma":
-		case "ewma_vol":
-		case "ewma_volatility":
-			return "ewma_volatility";
-		case "cfnai":
-		case "macro_score":
-		case "macroscore":
-			return "macro_score";
-		case "drawdown":
-		case "max_drawdown":
-		case "maxdrawdown":
-		case "maximum_drawdown":
-			return "max_drawdown";
-		default:
-			return null;
-	}
-}
-
-/**
- * Translate a raw quant metric key into its institutional label.
- * Unknown keys fall through to the input string so ad-hoc metrics
- * keep rendering — never silently hide a field from the user.
- */
-export function humanizeMetric(raw: string): string {
-	const key = normalise(raw);
-	if (key && METRIC_LABELS[key]) return METRIC_LABELS[key];
-	return raw;
-}
-
-/**
- * Regime label translation — Risk Methodology v3 tri-state phrasing.
- *
- * Backend emits uppercase enum (`RISK_ON` / `RISK_OFF` / `CRISIS`).
- * The institutional reading is Expansion (benign growth), Cautious
- * (late-cycle / mixed signals), and Stress (drawdown / crisis).
- * `NEUTRAL` is an intermediate state that maps to Cautious.
- *
- * Unknown labels pass through unchanged so a new backend regime
- * (e.g. `STAGFLATION`) is visible rather than silently relabelled.
- */
-export function regimeLabel(raw: string | null | undefined): string {
-	if (!raw) return "—";
-	const k = raw.trim().toUpperCase();
-	switch (k) {
-		case "RISK_ON":
-		case "EXPANSION":
-			return "Expansion";
-		case "NEUTRAL":
-		case "RISK_OFF":
-		case "CAUTIOUS":
-			return "Cautious";
-		case "CRISIS":
-		case "STRESS":
-			return "Stress";
-		default:
-			return raw;
-	}
-}
-
-/**
- * Fully-qualified header string for the market regime tri-state —
- * used in chart titles and section headings.
- */
-export const MARKET_REGIME_HEADER = "Market Regime: Expansion / Cautious / Stress";
-
-// PR-BE-7 — Profile display label, owned by terminal-core. Re-exported
-// here so wealth call sites can keep importing from
-// ``$wealth/i18n/quant-labels`` without taking a hard dependency on the
-// terminal-core path. Canonisation lives in terminal-core; this is a
-// pass-through.
-export { profileDisplayLabel } from "@investintell/ii-terminal-core/i18n/quant-labels";
+export * from "@investintell/ii-terminal-core/i18n/quant-labels";

--- a/packages/ii-terminal-core/src/lib/i18n/quant-labels.ts
+++ b/packages/ii-terminal-core/src/lib/i18n/quant-labels.ts
@@ -1,18 +1,23 @@
 /**
  * Institutional label dictionary — Risk Methodology v3.
  *
- * Surface-facing replacement for the raw quant jargon that flows out
- * of the backend risk engines (CVaR, Expected Shortfall, GARCH,
- * EWMA, CFNAI, regime labels, drawdown). The wealth frontend is
- * "dumb" by design — it never renders a bare model identifier to an
- * institutional allocator. Every metric shown to a user passes
- * through this dictionary first.
+ * Canonical frontend source of truth for translating raw quant jargon
+ * (CVaR, GARCH, EWMA, CFNAI, regime enums, drawdown, DTW drift, parametric
+ * stress scenarios) into the institutional phrasing that user-facing
+ * surfaces render.
+ *
+ * Both wealth and terminal frontends consume this module. The wealth path
+ * ``frontends/wealth/src/lib/i18n/quant-labels.ts`` is a re-export shim;
+ * do not duplicate keys there.
+ *
+ * Pairs with the backend dictionary in
+ * ``backend/app/domains/wealth/schemas/sanitized.py`` (METRIC_LABELS,
+ * REGIME_LABELS, EVENT_TYPE_LABELS). Drift is enforced at CI by
+ * ``backend/tests/wealth/test_sanitization_parity.py``: every backend
+ * METRIC_LABELS key MUST be representable here.
  *
  * Scope of v3
  * -----------
- * The mapping mirrors the Risk Methodology v3 reference and the
- * §3 UX charter:
- *
  *   Quant key                           →  Institutional label
  *   ------------------------------------ -----------------------------
  *   CVaR / Expected Shortfall           →  Conditional Tail Risk (CVaR 95%)
@@ -20,29 +25,41 @@
  *   GARCH / EWMA Volatility             →  Conditional Volatility
  *   CFNAI / Macro Score                 →  Real Economy Activity Index
  *   Drawdown                            →  Maximum Drawdown
+ *   DTW drift                           →  Strategy Deviation Score
+ *   Parametric scenarios                →  GFC 2008 / COVID 2020 / Taper 2013 / Rate Shock 200bps
  *
- * Backend regime labels (RISK_ON / RISK_OFF / CRISIS) are translated
- * by `regimeLabel()` to the three-state institutional phrasing
+ * Backend regime labels (RISK_ON / RISK_OFF / CRISIS) are translated by
+ * ``regimeLabel()`` to the three-state institutional phrasing
  * (Expansion / Cautious / Stress).
  *
  * Consumers
  * ---------
- *   import { humanizeMetric, regimeLabel } from "../i18n/quant-labels";
- *   <MetricCard label={humanizeMetric("cvar_95")} value={formatPercent(x)} />
- *   <span>{regimeLabel(store.regime.label)}</span>
+ *   import {
+ *       humanizeMetric,
+ *       regimeLabel,
+ *       scenarioLabel,
+ *       profileDisplayLabel,
+ *   } from "@investintell/ii-terminal-core/i18n/quant-labels";
  *
  * Adding a new label
  * ------------------
- * 1. Add the canonical quant key to `QuantMetricKey`.
- * 2. Add the institutional phrasing to `METRIC_LABELS`.
- * 3. If the key has alternate spellings (e.g. "cvar_95", "cvar95",
- *    "expected_shortfall"), route them through `humanizeMetric`'s
- *    normalisation branch — never add alternate keys as top-level
- *    entries, that splinters the dictionary.
+ * 1. Add the canonical quant key to ``QuantMetricKey``.
+ * 2. Add the institutional phrasing to ``METRIC_LABELS``.
+ * 3. If the key has alternate spellings (e.g. ``cvar_95``, ``cvar95``,
+ *    ``expected_shortfall``), route them through ``humanizeMetric``'s
+ *    ``normalise`` branch — never add alternate keys as top-level
+ *    entries.
+ * 4. Add the same key to backend ``METRIC_LABELS`` so the parity test
+ *    passes.
  */
 
 export type QuantMetricKey =
 	| "cvar_95"
+	| "cvar_95_1m"
+	| "cvar_95_3m"
+	| "cvar_95_6m"
+	| "cvar_95_12m"
+	| "cvar_95_conditional"
 	| "expected_shortfall"
 	| "regime"
 	| "garch_volatility"
@@ -50,10 +67,18 @@ export type QuantMetricKey =
 	| "cfnai"
 	| "macro_score"
 	| "drawdown"
-	| "max_drawdown";
+	| "max_drawdown"
+	| "max_drawdown_1y"
+	| "max_drawdown_3y"
+	| "dtw_drift_score";
 
 const METRIC_LABELS: Readonly<Record<QuantMetricKey, string>> = {
 	cvar_95: "Conditional Tail Risk (CVaR 95%)",
+	cvar_95_1m: "Conditional Tail Risk (CVaR 95%) — 1M",
+	cvar_95_3m: "Conditional Tail Risk (CVaR 95%) — 3M",
+	cvar_95_6m: "Conditional Tail Risk (CVaR 95%) — 6M",
+	cvar_95_12m: "Conditional Tail Risk (CVaR 95%) — 12M",
+	cvar_95_conditional: "Conditional Tail Risk (CVaR 95%) — Regime-conditioned",
 	expected_shortfall: "Conditional Tail Risk (CVaR 95%)",
 	regime: "Market Regime",
 	garch_volatility: "Conditional Volatility",
@@ -62,13 +87,16 @@ const METRIC_LABELS: Readonly<Record<QuantMetricKey, string>> = {
 	macro_score: "Real Economy Activity Index",
 	drawdown: "Maximum Drawdown",
 	max_drawdown: "Maximum Drawdown",
+	max_drawdown_1y: "Maximum Drawdown (1Y)",
+	max_drawdown_3y: "Maximum Drawdown (3Y)",
+	dtw_drift_score: "Strategy Deviation Score",
 };
 
 /**
  * Normalise an incoming metric key to the canonical QuantMetricKey.
  * Accepts snake_case, camelCase, SCREAMING, hyphenated, and a few
- * well-known aliases. Returns `null` for unknown keys so callers
- * can fall back to the raw string if they prefer.
+ * well-known aliases. Returns ``null`` for unknown keys so callers can
+ * fall back to the raw string if they prefer.
  */
 function normalise(raw: string): QuantMetricKey | null {
 	const k = raw.trim().toLowerCase().replace(/[-\s]+/g, "_");
@@ -81,6 +109,19 @@ function normalise(raw: string): QuantMetricKey | null {
 		case "expected_shortfall":
 		case "es":
 			return "cvar_95";
+		case "cvar_95_1m":
+			return "cvar_95_1m";
+		case "cvar_95_3m":
+			return "cvar_95_3m";
+		case "cvar_95_6m":
+			return "cvar_95_6m";
+		case "cvar_95_12m":
+			return "cvar_95_12m";
+		case "cvar_95_conditional":
+		case "volatility_garch":
+			// volatility_garch is the DB column name (migration 0058) — same
+			// concept as garch_volatility in this dictionary.
+			return k === "volatility_garch" ? "garch_volatility" : "cvar_95_conditional";
 		case "regime":
 		case "market_regime":
 			return "regime";
@@ -93,14 +134,23 @@ function normalise(raw: string): QuantMetricKey | null {
 		case "ewma_volatility":
 			return "ewma_volatility";
 		case "cfnai":
+			return "cfnai";
 		case "macro_score":
 		case "macroscore":
 			return "macro_score";
 		case "drawdown":
+			return "drawdown";
 		case "max_drawdown":
 		case "maxdrawdown":
 		case "maximum_drawdown":
 			return "max_drawdown";
+		case "max_drawdown_1y":
+			return "max_drawdown_1y";
+		case "max_drawdown_3y":
+			return "max_drawdown_3y";
+		case "dtw_drift":
+		case "dtw_drift_score":
+			return "dtw_drift_score";
 		default:
 			return null;
 	}
@@ -108,8 +158,8 @@ function normalise(raw: string): QuantMetricKey | null {
 
 /**
  * Translate a raw quant metric key into its institutional label.
- * Unknown keys fall through to the input string so ad-hoc metrics
- * keep rendering — never silently hide a field from the user.
+ * Unknown keys fall through to the input string so ad-hoc metrics keep
+ * rendering — never silently hide a field from the user.
  */
 export function humanizeMetric(raw: string): string {
 	const key = normalise(raw);
@@ -120,13 +170,13 @@ export function humanizeMetric(raw: string): string {
 /**
  * Regime label translation — Risk Methodology v3 tri-state phrasing.
  *
- * Backend emits uppercase enum (`RISK_ON` / `RISK_OFF` / `CRISIS`).
+ * Backend emits uppercase enum (``RISK_ON`` / ``RISK_OFF`` / ``CRISIS``).
  * The institutional reading is Expansion (benign growth), Cautious
  * (late-cycle / mixed signals), and Stress (drawdown / crisis).
- * `NEUTRAL` is an intermediate state that maps to Cautious.
+ * ``NEUTRAL`` is an intermediate state that maps to Cautious.
  *
  * Unknown labels pass through unchanged so a new backend regime
- * (e.g. `STAGFLATION`) is visible rather than silently relabelled.
+ * (e.g. ``STAGFLATION``) is visible rather than silently relabelled.
  */
 export function regimeLabel(raw: string | null | undefined): string {
 	if (!raw) return "—";
@@ -148,10 +198,49 @@ export function regimeLabel(raw: string | null | undefined): string {
 }
 
 /**
- * Fully-qualified header string for the market regime tri-state —
- * used in chart titles and section headings.
+ * Fully-qualified header string for the market regime tri-state — used in
+ * chart titles and section headings.
  */
 export const MARKET_REGIME_HEADER = "Market Regime: Expansion / Cautious / Stress";
+
+// ── Parametric stress scenarios ──────────────────────────────────────
+//
+// The four canonical parametric scenarios delivered by the construction
+// engine's stress suite (``POST /stress-test``). Backend emits the slug;
+// frontend renders the institutional label.
+
+export type StressScenarioKey =
+	| "gfc_2008"
+	| "covid_2020"
+	| "taper_2013"
+	| "rate_shock_200bps";
+
+const SCENARIO_LABELS: Readonly<Record<StressScenarioKey, string>> = {
+	gfc_2008: "GFC 2008",
+	covid_2020: "COVID 2020",
+	taper_2013: "Taper Tantrum 2013",
+	rate_shock_200bps: "Rate Shock +200bps",
+};
+
+/**
+ * Translate a parametric stress scenario slug to its institutional label.
+ * Unknown keys (e.g. tenant-defined custom scenarios) fall through to a
+ * title-cased version of the raw slug — never silently dropped.
+ */
+export function scenarioLabel(raw: string | null | undefined): string {
+	if (!raw) return "—";
+	const k = raw.trim().toLowerCase();
+	if (k in SCENARIO_LABELS) {
+		return SCENARIO_LABELS[k as StressScenarioKey];
+	}
+	// Fall through for custom scenarios — title-case the slug (replace
+	// underscores with spaces, capitalise each word).
+	return raw
+		.split(/[_\s]+/)
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ");
+}
 
 // ── PR-BE-7 — Profile display labels ─────────────────────────────────
 //
@@ -198,3 +287,58 @@ export function profileDisplayLabel(
 	if (!profile) return profile;
 	return profile.charAt(0).toUpperCase() + profile.slice(1);
 }
+
+// ── Introspection helpers (for parity test) ──────────────────────────
+//
+// These are exported so the backend parity test can introspect the
+// canonical key set without parsing the source file. Frozen Maps so
+// callers cannot mutate them.
+
+/**
+ * Canonical metric keys recognised by ``humanizeMetric``. Used by the
+ * sanitization-parity test to assert backend keys ⊆ frontend keys.
+ *
+ * Includes both top-level ``METRIC_LABELS`` keys and the alternate
+ * spellings handled by ``normalise`` — anything a backend producer can
+ * emit and reasonably expect to be translated.
+ */
+export const RECOGNISED_METRIC_KEYS: ReadonlyArray<string> = Object.freeze([
+	// Canonical keys (top-level METRIC_LABELS)
+	...(Object.keys(METRIC_LABELS) as string[]),
+	// Alternate spellings handled by normalise()
+	"cvar",
+	"cvar95",
+	"c_var_95",
+	"conditional_value_at_risk",
+	"es",
+	"market_regime",
+	"garch",
+	"garch_vol",
+	"ewma",
+	"ewma_vol",
+	"macroscore",
+	"maxdrawdown",
+	"maximum_drawdown",
+	"dtw_drift",
+	"volatility_garch",
+]);
+
+/**
+ * Canonical regime tokens recognised by ``regimeLabel``.
+ */
+export const RECOGNISED_REGIME_KEYS: ReadonlyArray<string> = Object.freeze([
+	"RISK_ON",
+	"EXPANSION",
+	"NEUTRAL",
+	"RISK_OFF",
+	"CAUTIOUS",
+	"CRISIS",
+	"STRESS",
+]);
+
+/**
+ * Canonical parametric scenario slugs recognised by ``scenarioLabel``.
+ */
+export const RECOGNISED_SCENARIO_KEYS: ReadonlyArray<string> = Object.freeze(
+	Object.keys(SCENARIO_LABELS),
+);


### PR DESCRIPTION
## Summary

Canonize `packages/ii-terminal-core/src/lib/i18n/quant-labels.ts` as the single frontend source of truth for institutional quant-label translation, replace the wealth-side path with a pure re-export shim, and add a CI parity test that fails on backend ↔ frontend drift.

- **Canonical dictionary** now covers every key the backend `METRIC_LABELS` emits — CVaR tenor variants (1M/3M/6M/12M), regime-conditioned CVaR, `volatility_garch` (DB column alias from migration 0058), DTW drift, drawdown 1Y/3Y — plus a new `scenarioLabel()` helper for the four parametric stress scenarios (`gfc_2008`, `covid_2020`, `taper_2013`, `rate_shock_200bps`).
- **Wealth shim** is now `export * from "@investintell/ii-terminal-core/i18n/quant-labels"` — zero local declarations. Existing wealth call sites that import from `$wealth/i18n/quant-labels` keep working.
- **`profileDisplayLabel(profile, context)` from PR-BE-7 (Q165) is preserved unchanged** at its current location and signature.
- **Backend `sanitized.py` is untouched** — it already covered §8 of the doc-table mappings. Sanitization stays additive on the BE side; this PR only widens the FE side and adds the gate.
- **CI gate** — `backend/tests/wealth/test_sanitization_parity.py` (9 tests) parses the canonical TypeScript with regex (no Node runtime needed), enforces `backend keys ⊆ frontend keys`, and verifies the §8 doc table is representable on both sides.

## Confirmation that backend keys ⊆ frontend keys

```
$ pytest backend/tests/wealth/test_sanitization_parity.py -v
test_backend_metric_keys_subset_of_frontend           PASSED
test_backend_regime_keys_subset_of_frontend           PASSED
test_doc_section_8_metric_keys_have_backend_repr...   PASSED
test_doc_section_8_metric_keys_have_frontend_repr...  PASSED
test_doc_section_8_regime_keys_have_backend_repr...   PASSED
test_doc_section_8_regime_keys_have_frontend_repr...  PASSED
test_doc_section_8_scenario_keys_have_frontend_repr.. PASSED
test_event_type_labels_are_non_empty                  PASSED
test_wealth_shim_re_exports_terminal_core             PASSED
9 passed in 0.32s
```

## Test plan

- [x] `ruff check backend/tests/wealth backend/app/domains/wealth/schemas/sanitized.py` — clean
- [x] `mypy backend/tests/wealth/test_sanitization_parity.py` — clean
- [x] `pytest backend/tests/wealth/test_sanitization_parity.py -v` — 9 passed
- [x] `pytest backend/tests/wealth/test_sanitized_payload.py backend/tests/wealth/schemas/ backend/tests/wealth/test_pr_a21_sanitization.py backend/tests/wealth/test_sse_sanitization_wiring.py` — 22 passed (no regressions)
- [x] `pnpm check` in `packages/ii-terminal-core` — 0 errors (7 pre-existing warnings)
- [x] `pnpm check` in `frontends/wealth` — 0 errors (21 pre-existing warnings)
- [x] `pnpm check` in `frontends/terminal` — 0 errors (1 pre-existing warning)

## Snapshot of parity test FAILURE on drift

Captured by stashing the canonical TypeScript changes (leaving the test in place) and rerunning. The test surfaces exactly the keys missing from the frontend, with a remediation hint:

```
FAILED test_backend_metric_keys_subset_of_frontend
  AssertionError: Backend METRIC_LABELS keys missing from frontend canonical
  dictionary (drift): ['cvar_95_12m', 'cvar_95_1m', 'cvar_95_3m',
  'cvar_95_6m', 'cvar_95_conditional', 'dtw_drift', 'dtw_drift_score',
  'max_drawdown_1y', 'max_drawdown_3y', 'volatility_garch']. Add them to
  packages/ii-terminal-core/src/lib/i18n/quant-labels.ts — either as a
  METRIC_LABELS entry or as a normalise() case.

FAILED test_doc_section_8_metric_keys_have_frontend_representation
  AssertionError: §8 metric keys missing from frontend canonical
  dictionary: ['cvar_95_12m', 'cvar_95_1m', 'cvar_95_3m', 'cvar_95_6m',
  'cvar_95_conditional', 'dtw_drift_score', 'max_drawdown_1y',
  'max_drawdown_3y', 'volatility_garch'].

FAILED test_doc_section_8_scenario_keys_have_frontend_representation
  Failed: Could not locate SCENARIO_LABELS const.

3 failed, 6 passed
```

Confirms the gate would catch (a) backend widening METRIC_LABELS without adding frontend coverage, (b) §8 spec drift, and (c) removal/rename of the SCENARIO_LABELS block.

## Section 1 — Drift report (state at base 512e9515)

### Keys present only in backend `sanitized.py`

`METRIC_LABELS`:
- `cvar` (alias)
- `cvar_95_1m` / `cvar_95_3m` / `cvar_95_6m` / `cvar_95_12m` (tenor variants)
- `cvar_95_conditional` (regime-conditioned)
- `garch` / `garch_vol` / `volatility_garch` (DB column from migration 0058)
- `ewma` / `ewma_vol`
- `macroscore` (alias)
- `maxdrawdown` / `maximum_drawdown` (aliases)
- `max_drawdown_1y` / `max_drawdown_3y`
- `dtw_drift` / `dtw_drift_score` (Strategy Deviation Score)

`EVENT_TYPE_LABELS` (entire dict) is backend-only by design — the executor already humanises `type`/`message` before SSE emit, so the frontend never needs to translate these.

### Keys present only in terminal-core `quant-labels.ts`

None — the file was a strict subset.

### Keys present only in wealth `quant-labels.ts`

None — wealth was a duplicate of terminal-core (already imported `profileDisplayLabel` from terminal-core via re-export).

### Conflicting label values across paths

None on the `quant-labels.ts` axis. Note the BE `regime` key returns `"Market Regime"` (label) while regime *values* are translated by `REGIME_LABELS` to `Expansion / Cautious / Stress` — both ends agree.

### Out-of-scope drift observed (NOT touched by this PR)

A separate `frontends/wealth/src/lib/constants/regime.ts` module declares `regimeLabels` with `RISK_OFF → "Defensive"` and `INFLATION → "Inflation"`. This conflicts with the canonical `RISK_OFF → "Cautious"` per `regimeLabel()` and the §3 UX charter. Several components (`AllocationBandChart.svelte`, `TaaTransitionSparkline.svelte`, `RegimeContextStrip.svelte`, `CommitteeReviews.svelte`, builder/RegimeTab, etc.) consume that constant or inline-map regimes to CSS color tokens. A follow-up PR should either (a) align `regime.ts` to canonical phrasing or (b) clearly partition it as a *color/severity* dictionary distinct from *label* translation. Touching it here would balloon PR-UX-5 well past the spec scope and risks breaking institutional UI without coordinated review.

## Section 6 — Consumer audit & refactor decisions

`grep -rn "RISK_OFF|CRISIS|INFLATION|gfc_2008|covid_2020"` across `frontends/` and `packages/` (excluding `node_modules`, `dist`, `.svelte-kit`, `quant-labels`) returned ~50 hits across ~25 files.

**Categorisation:**

| Pattern | Action |
|---|---|
| Map raw token → CSS color/severity var (e.g. `RISK_OFF: "var(--ii-warning)"`, `CRISIS: "#ef4444"`) | **Left as-is.** Visual encoding, not text translation. Refactoring to helpers would either swap colors for label strings (wrong) or require a parallel `regimeColor()` helper that this PR does not cover. |
| Form `<select>` `value="RISK_OFF"` (CalibrationPanel) | **Left as-is.** The `value` IS the wire token — the visible `label` is the institutional copy. Helper substitution would change the form payload semantics. |
| Inline mapping like `"Risk Off"`, `"Crisis"`, `"Defensive"` (TerminalTopNav, ImpactPreview, RegimeTab, builder/StressTab) | **Left as-is** with note. These ship copy that does not match canonical `regimeLabel()` / `scenarioLabel()` output (e.g. "Risk Off" vs "Cautious", "COVID" vs "COVID 2020"). Coordinated copy review needed before swap. |
| Type-discriminator unions in `portfolio-calibration.ts`, `model-portfolio.ts`, `taa.ts` | **Left as-is.** These are wire-format types. Helpers consume them; renaming breaks the API contract. |
| `metric-translators.ts` (PT-BR institutional copy) | **Left as-is.** Different surface (chip "tone" + PT-BR phrasing) — orthogonal to this dictionary. |
| Prose comments referencing `CRISIS` / `RISK_OFF` (RegimeMatrix, macro-simulation-store) | **Left as-is.** Documentation, not user-facing strings. |

**No consumer was refactored to call `regimeLabel()` / `scenarioLabel()` in this PR.** All remaining call-sites are either visual encoding, wire-format identifiers, or product-copy variants that need a coordinated UX decision before swap. The canonical helpers are now in place and ready for follow-up PRs to migrate consumers as the redesign rolls forward.

## Notes on doc reference

The task spec referenced `docs/plans/2026-04-30-builder-workspace-redesign-final.md`, but that file is not present at base `512e9515` (verified via `git log --all --oneline -- '*builder-workspace-redesign*'` — no matches anywhere in history). The §8 mappings table was reconstructed from the existing backend `METRIC_LABELS` / `REGIME_LABELS` (the canonical Risk Methodology v3 source), the four parametric stress scenarios from `quant_engine`, and the PR-BE-7 profile vocabulary. The fixture `DOC_SECTION_8_*` constants in the parity test carry that reconstruction with a pointer comment so a future doc landing can be cross-referenced.

Generated with Claude Code.
