### PR TITLE
feat(terminal): PR-UX-3 — IPSGateNotice + PortfolioGateNotice empty states

### DIFF
--- a/frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
+++ b/frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
@@ -44,13 +44,31 @@
 	import ActivationBar from "@investintell/ii-terminal-core/components/terminal/builder/ActivationBar.svelte";
 	import CalibrationPanel from "@investintell/ii-terminal-core/components/portfolio/CalibrationPanel.svelte";
 	import PortfolioPicker from "@investintell/ii-terminal-core/components/portfolio/PortfolioPicker.svelte";
+	import IPSGateNotice from "@investintell/ii-terminal-core/components/portfolio/IPSGateNotice.svelte";
 
 	interface Props {
 		portfolios: ModelPortfolio[];
+		/** Active allocation profile slug — drives IPS gate copy. */
+		profile: string;
+		/**
+		 * IPS approval gate signal. Today derived from
+		 * `strategic.has_active_approval`; PR-BE-6 will introduce the
+		 * canonical `ips_state` taxonomy and the parent will collapse
+		 * it into this boolean before passing it down.
+		 */
+		ipsApproved: boolean;
+		/** Invoked when the IPS gate CTA is clicked. */
+		onOpenStrategic: () => void;
 		onCreatePortfolio?: () => void;
 	}
 
-	let { portfolios, onCreatePortfolio }: Props = $props();
+	let {
+		portfolios,
+		profile,
+		ipsApproved,
+		onOpenStrategic,
+		onCreatePortfolio,
+	}: Props = $props();
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 
@@ -149,6 +167,15 @@
 	});
 </script>
 
+{#if !ipsApproved}
+	<!-- TODO(PR-BE-6): consume canonical `ips_state` taxonomy here.
+	     Today the parent collapses `strategic.has_active_approval`
+	     into `ipsApproved`; once PR-BE-6 lands the gate switches to
+	     `data.strategic.data?.ips_state === "approved"`. -->
+	<div class="builder-gate">
+		<IPSGateNotice {profile} {onOpenStrategic} />
+	</div>
+{:else}
 <div class="builder-shell">
 	<!-- LEFT COLUMN (40%) — Command Panel -->
 	<div class="builder-left">
@@ -236,6 +263,7 @@
 		<ActivationBar />
 	</div>
 </div>
+{/if}
 
 <style>
 	/*
@@ -251,6 +279,19 @@
 		background: var(--terminal-bg-void);
 		font-family: var(--terminal-font-mono);
 		color: var(--terminal-fg-secondary);
+	}
+
+	/* Gate wrapper — owns the full builder-shell footprint when the
+	   profile's IPS is not yet approved, so the empty-state notice
+	   replaces (not overlays) the 40/60 command-center grid. */
+	.builder-gate {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		min-height: 0;
+		padding: var(--terminal-space-3);
+		background: var(--terminal-bg-void);
 	}
 
 	.builder-left {

--- a/frontends/terminal/src/lib/components/builder/StressTabContent.svelte
+++ b/frontends/terminal/src/lib/components/builder/StressTabContent.svelte
@@ -14,12 +14,15 @@
 	import { workspace } from "@investintell/ii-terminal-core/state/portfolio-workspace.svelte";
 	import type { ModelPortfolio } from "@investintell/ii-terminal-core/types/model-portfolio";
 	import StressTab from "@investintell/ii-terminal-core/components/terminal/builder/StressTab.svelte";
+	import PortfolioGateNotice from "@investintell/ii-terminal-core/components/portfolio/PortfolioGateNotice.svelte";
 
 	interface Props {
 		portfolios: ModelPortfolio[];
+		/** Active allocation profile slug — drives empty-state copy. */
+		profile: string;
 	}
 
-	let { portfolios }: Props = $props();
+	let { portfolios, profile }: Props = $props();
 
 	const getToken = getContext<() => Promise<string>>("netz:getToken");
 
@@ -42,9 +45,7 @@
 
 <div class="stress">
 	{#if portfolios.length === 0}
-		<div class="stress__empty">
-			No portfolios available — create one in PORTFOLIO tab first.
-		</div>
+		<PortfolioGateNotice {profile} />
 	{:else}
 		<StressTab />
 	{/if}
@@ -58,17 +59,5 @@
 		padding: var(--terminal-space-3);
 		font-family: var(--terminal-font-mono);
 		color: var(--terminal-fg-primary);
-	}
-	.stress__empty {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		min-height: 200px;
-		color: var(--terminal-fg-tertiary);
-		font-size: var(--terminal-text-11);
-		letter-spacing: var(--terminal-tracking-caps);
-		text-transform: uppercase;
-		border: var(--terminal-border-hairline);
-		background: var(--terminal-bg-panel);
 	}
 </style>

--- a/frontends/terminal/src/routes/allocation/[profile]/+page.svelte
+++ b/frontends/terminal/src/routes/allocation/[profile]/+page.svelte
@@ -178,9 +178,24 @@
 					/>
 				</div>
 			{:else if activeTab === "portfolio"}
-				<PortfolioTabContent portfolios={data.portfolios} />
+				<!--
+				  TODO(PR-BE-6): replace `has_active_approval` with the
+				  canonical `ips_state` taxonomy once the backend ships
+				  it on `StrategicAllocationResponse`. Until then we
+				  collapse the legacy boolean into `ipsApproved` so the
+				  PortfolioTabContent gate stays a single signal.
+				-->
+				<PortfolioTabContent
+					portfolios={data.portfolios}
+					profile={profile ?? "moderate"}
+					ipsApproved={!!strategic?.has_active_approval}
+					onOpenStrategic={() => setTab("strategic")}
+				/>
 			{:else if activeTab === "stress"}
-				<StressTabContent portfolios={data.portfolios} />
+				<StressTabContent
+					portfolios={data.portfolios}
+					profile={profile ?? "moderate"}
+				/>
 			{/if}
 		</div>
 	{/if}

--- a/packages/ii-terminal-core/package.json
+++ b/packages/ii-terminal-core/package.json
@@ -64,7 +64,8 @@
   "scripts": {
     "build": "svelte-package -i ./src/lib -o ./dist",
     "prepublishOnly": "pnpm build",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "@investintell/ui": "workspace:*",
@@ -82,10 +83,12 @@
     "@investintell/ui": "workspace:*"
   },
   "devDependencies": {
+    "@sveltejs/kit": "^2.0.0",
     "@sveltejs/package": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@testing-library/svelte": "^5.3.1",
     "@types/uuid": "^10.0.0",
+    "happy-dom": "^20.8.4",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "typescript": "^5.5.0",

--- a/packages/ii-terminal-core/src/lib/components/portfolio/IPSGateNotice.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/IPSGateNotice.svelte
@@ -1,0 +1,135 @@
+<!--
+  IPSGateNotice — PORTFOLIO-stage empty state.
+
+  Rendered on the Builder workspace's PORTFOLIO tab when the active
+  profile's Strategic IPS has not been approved yet. Blocks portfolio
+  construction with a single-action CTA back to the Strategic IPS
+  surface.
+
+  Pure presentation:
+    - No fetch, no store reads, no localStorage. The parent owns the
+      gate condition (today: `!has_active_approval`; post PR-BE-6:
+      `ips_state !== "approved"`) and the navigation callback.
+    - Profile display copy routes through `profileDisplayLabel` (the
+      canonical, Q165 / PR-BE-7 helper) so "Dynamic" vs "Dynamic
+      Growth" never gets hardcoded here.
+    - Token discipline: every visual property is a `var(--terminal-*)`
+      custom property (mirrors PR-UX-1 ProposeButton).
+    - Stability Guardrails P3 Isolated: wrapped in `<svelte:boundary>`
+      so a render error in the empty-state copy cannot blank the
+      entire workspace tab.
+
+  Consumed by:
+    - frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte
+    - PR-UX-4 (dialog wiring) will add a richer onOpenStrategic handler
+    - PR-UX-6 (StageProgressStrip lock state) will mirror this gate
+-->
+<script lang="ts">
+	import { profileDisplayLabel } from "../../i18n/quant-labels";
+
+	interface Props {
+		/** Profile slug (`conservative` / `moderate` / `growth`). */
+		profile: string;
+		/** Invoked when the operator clicks "Open Strategic IPS". */
+		onOpenStrategic: () => void;
+	}
+
+	let { profile, onOpenStrategic }: Props = $props();
+
+	const label = $derived(profileDisplayLabel(profile, "full"));
+</script>
+
+<svelte:boundary>
+	<div class="ips-gate" role="status" data-testid="ips-gate-notice">
+		<div class="ips-gate__body">
+			<p class="ips-gate__title">
+				Strategic IPS not approved for {label} profile.
+			</p>
+			<p class="ips-gate__copy">
+				Approve a Strategic IPS proposal before constructing portfolios.
+			</p>
+		</div>
+		<button
+			type="button"
+			class="ips-gate__cta"
+			onclick={() => onOpenStrategic()}
+		>
+			Open Strategic IPS
+		</button>
+	</div>
+</svelte:boundary>
+
+<style>
+	/* Empty-state shell — terminal token styling.
+	   Mirrors the layout discipline of `.builder-empty-zone` in
+	   PortfolioTabContent.svelte and the CTA token spec from PR-UX-1
+	   (`.propose-cta`). All colour, spacing, border, font tokens come
+	   from the terminal design system — never Tailwind utility classes.
+	*/
+	.ips-gate {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: var(--terminal-space-3);
+		min-height: 240px;
+		padding: var(--terminal-space-4);
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.ips-gate__body {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		text-align: center;
+		max-width: 60ch;
+	}
+
+	.ips-gate__title {
+		margin: 0;
+		font-size: var(--terminal-text-12);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-primary);
+	}
+
+	.ips-gate__copy {
+		margin: 0;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-tertiary);
+	}
+
+	/* CTA — mirrors `.propose-cta` (PR-UX-1) for cross-surface
+	   consistency: transparent ground, status-success border + text,
+	   color-mix hover tint. */
+	.ips-gate__cta {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--terminal-space-2);
+		padding: var(--terminal-space-2) var(--terminal-space-4);
+		background: transparent;
+		border: 1px solid var(--terminal-status-success);
+		color: var(--terminal-status-success);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+	.ips-gate__cta:hover {
+		background: color-mix(
+			in srgb,
+			var(--terminal-status-success) 10%,
+			transparent
+		);
+	}
+	.ips-gate__cta:focus-visible {
+		outline: var(--terminal-border-focus);
+		outline-offset: 2px;
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/PortfolioGateNotice.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/PortfolioGateNotice.svelte
@@ -1,0 +1,78 @@
+<!--
+  PortfolioGateNotice — STRESS-stage empty state.
+
+  Rendered on the Builder workspace's STRESS tab when the active
+  profile has no portfolios (model_portfolios) yet. Replaces the
+  inline empty `<div>` previously hardcoded in StressTabContent
+  (lines 43-47 pre-PR-UX-3).
+
+  Pure presentation:
+    - No CTA — operator switches stages via the BuilderTabStrip.
+    - Profile copy via the canonical `profileDisplayLabel` helper.
+    - Token discipline + svelte:boundary per PR-UX-1 / Stability §P3.
+-->
+<script lang="ts">
+	import { profileDisplayLabel } from "../../i18n/quant-labels";
+
+	interface Props {
+		/** Profile slug (`conservative` / `moderate` / `growth`). */
+		profile: string;
+	}
+
+	let { profile }: Props = $props();
+
+	const label = $derived(profileDisplayLabel(profile, "full"));
+</script>
+
+<svelte:boundary>
+	<div class="pf-gate" role="status" data-testid="portfolio-gate-notice">
+		<div class="pf-gate__body">
+			<p class="pf-gate__title">No portfolios yet for {label}.</p>
+			<p class="pf-gate__copy">
+				Create a portfolio in the Portfolio stage first.
+			</p>
+		</div>
+	</div>
+</svelte:boundary>
+
+<style>
+	/* Empty-state shell — terminal token styling, same primitive
+	   layout as IPSGateNotice but without a CTA (the stage strip
+	   carries the navigation affordance). */
+	.pf-gate {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: var(--terminal-space-3);
+		min-height: 200px;
+		padding: var(--terminal-space-4);
+		background: var(--terminal-bg-panel);
+		border: var(--terminal-border-hairline);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	.pf-gate__body {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-1);
+		text-align: center;
+		max-width: 60ch;
+	}
+
+	.pf-gate__title {
+		margin: 0;
+		font-size: var(--terminal-text-12);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+		text-transform: uppercase;
+		color: var(--terminal-fg-primary);
+	}
+
+	.pf-gate__copy {
+		margin: 0;
+		font-size: var(--terminal-text-11);
+		color: var(--terminal-fg-tertiary);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/IPSGateNotice.test.ts
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/IPSGateNotice.test.ts
@@ -1,0 +1,75 @@
+/**
+ * IPSGateNotice — empty state shown on PORTFOLIO stage when the
+ * profile's Strategic IPS has not been approved.
+ *
+ * Specs:
+ *   - Title resolves the profile via `profileDisplayLabel(_, "full")`
+ *     so all 3 default profiles render their canonical marketing
+ *     phrasing ("Conservative", "Moderate", "Dynamic Growth").
+ *   - CTA "Open Strategic IPS" fires the `onOpenStrategic` callback.
+ *   - Wrapper is `role="status"` so screen readers pick it up as a
+ *     live region.
+ *
+ * The component never hardcodes display strings — all profile copy
+ * routes through the canonical helper extended in PR-Q165 / PR-BE-7.
+ */
+import { render, fireEvent } from "@testing-library/svelte";
+import { describe, expect, test, vi } from "vitest";
+import IPSGateNotice from "../IPSGateNotice.svelte";
+
+describe("IPSGateNotice", () => {
+	test("renders title with profileDisplayLabel('conservative', 'full')", () => {
+		const { container } = render(IPSGateNotice, {
+			props: { profile: "conservative", onOpenStrategic: () => {} },
+		});
+		const text = container.textContent ?? "";
+		expect(text).toContain("Conservative");
+		expect(text).toContain("Strategic IPS not approved");
+		expect(text).toContain("Approve a Strategic IPS proposal");
+	});
+
+	test("renders title with profileDisplayLabel('moderate', 'full')", () => {
+		const { container } = render(IPSGateNotice, {
+			props: { profile: "moderate", onOpenStrategic: () => {} },
+		});
+		expect(container.textContent ?? "").toContain("Moderate");
+	});
+
+	test("renders title with profileDisplayLabel('growth', 'full') = 'Dynamic Growth'", () => {
+		const { container } = render(IPSGateNotice, {
+			props: { profile: "growth", onOpenStrategic: () => {} },
+		});
+		const text = container.textContent ?? "";
+		// Full-context profile copy — must use the marketing phrase
+		// from `profileDisplayLabel(_, "full")`, never the dense
+		// chip form ("Dynamic") or the legacy slug ("aggressive").
+		expect(text).toMatch(/Dynamic Growth/);
+		expect(text).not.toContain("aggressive");
+	});
+
+	test("renders CTA 'Open Strategic IPS' button", () => {
+		const { container } = render(IPSGateNotice, {
+			props: { profile: "growth", onOpenStrategic: () => {} },
+		});
+		const btn = container.querySelector("button");
+		expect(btn).not.toBeNull();
+		expect(btn?.textContent?.trim()).toBe("Open Strategic IPS");
+	});
+
+	test("clicking CTA fires onOpenStrategic callback", async () => {
+		const onOpenStrategic = vi.fn();
+		const { container } = render(IPSGateNotice, {
+			props: { profile: "moderate", onOpenStrategic },
+		});
+		const btn = container.querySelector("button");
+		await fireEvent.click(btn!);
+		expect(onOpenStrategic).toHaveBeenCalledOnce();
+	});
+
+	test("wrapper exposes role='status' for a11y", () => {
+		const { container } = render(IPSGateNotice, {
+			props: { profile: "conservative", onOpenStrategic: () => {} },
+		});
+		expect(container.querySelector('[role="status"]')).not.toBeNull();
+	});
+});

--- a/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/PortfolioGateNotice.test.ts
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/PortfolioGateNotice.test.ts
@@ -1,0 +1,45 @@
+/**
+ * PortfolioGateNotice — empty state shown on STRESS stage when the
+ * tenant has no portfolios for the active profile.
+ *
+ * Specs:
+ *   - Title resolves the profile via `profileDisplayLabel(_, "full")`.
+ *   - No CTA — operator navigates back via the stage strip.
+ *   - Wrapper is `role="status"`.
+ */
+import { render } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+import PortfolioGateNotice from "../PortfolioGateNotice.svelte";
+
+describe("PortfolioGateNotice", () => {
+	test("renders title with profileDisplayLabel('growth', 'full')", () => {
+		const { container } = render(PortfolioGateNotice, {
+			props: { profile: "growth" },
+		});
+		const text = container.textContent ?? "";
+		expect(text).toContain("Dynamic Growth");
+		expect(text).toContain("No portfolios yet");
+		expect(text).toContain("Create a portfolio in the Portfolio stage first.");
+	});
+
+	test("renders title with profileDisplayLabel('conservative', 'full')", () => {
+		const { container } = render(PortfolioGateNotice, {
+			props: { profile: "conservative" },
+		});
+		expect(container.textContent ?? "").toContain("Conservative");
+	});
+
+	test("does not render any CTA button", () => {
+		const { container } = render(PortfolioGateNotice, {
+			props: { profile: "moderate" },
+		});
+		expect(container.querySelector("button")).toBeNull();
+	});
+
+	test("wrapper exposes role='status' for a11y", () => {
+		const { container } = render(PortfolioGateNotice, {
+			props: { profile: "moderate" },
+		});
+		expect(container.querySelector('[role="status"]')).not.toBeNull();
+	});
+});

--- a/packages/ii-terminal-core/vitest.config.ts
+++ b/packages/ii-terminal-core/vitest.config.ts
@@ -1,0 +1,26 @@
+/**
+ * vitest config — ii-terminal-core
+ *
+ * Mirrors `packages/investintell-ui/vitest.config.ts`. Lets the
+ * package run its co-located component tests in a happy-dom
+ * environment with the SvelteKit Vite plugin so .svelte files
+ * compile inside vitest.
+ *
+ * The `browser` resolve condition under VITEST is the SvelteKit
+ * recommended workaround for the "Cannot find package $app" error
+ * when component code touches $app/state or similar virtual modules.
+ */
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	plugins: [sveltekit()],
+	resolve: {
+		conditions: process.env.VITEST ? ["browser"] : undefined,
+	},
+	test: {
+		environment: "happy-dom",
+		include: ["src/lib/**/*.{test,spec}.{js,ts}"],
+		globals: false,
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,9 +350,6 @@ importers:
       '@investintell/ui':
         specifier: workspace:*
         version: link:../investintell-ui
-      '@sveltejs/kit':
-        specifier: ^2.0.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2))
       '@tanstack/svelte-virtual':
         specifier: ^3.0.0
         version: 3.13.23(svelte@5.53.12)
@@ -375,6 +372,9 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0
     devDependencies:
+      '@sveltejs/kit':
+        specifier: ^2.0.0
+        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.12)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2)))(svelte@5.53.12)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.2))
       '@sveltejs/package':
         specifier: ^2.0.0
         version: 2.5.7(svelte@5.53.12)(typescript@5.9.3)
@@ -387,6 +387,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      happy-dom:
+        specifier: ^20.8.4
+        version: 20.8.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       svelte:
         specifier: ^5.0.0
         version: 5.53.12
@@ -5075,6 +5078,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valibot@1.3.1:
@@ -6373,7 +6377,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       invariant: 2.2.4
       metro: 0.83.5(bufferutil@4.1.0)
-      metro-config: 0.83.5(bufferutil@4.1.0)
+      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.5
       semver: 7.7.4
     transitivePeerDependencies:
@@ -9295,21 +9299,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.83.5(bufferutil@4.1.0):
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.5(bufferutil@4.1.0)
-      metro-cache: 0.83.5
-      metro-core: 0.83.5
-      metro-runtime: 0.83.5
-      yaml: 2.8.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   metro-config@0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -9461,7 +9450,7 @@ snapshots:
       metro-babel-transformer: 0.83.5
       metro-cache: 0.83.5
       metro-cache-key: 0.83.5
-      metro-config: 0.83.5(bufferutil@4.1.0)
+      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.5
       metro-file-map: 0.83.5
       metro-resolver: 0.83.5


### PR DESCRIPTION
## Summary

- Adds two terminal-tokenized empty-state components (`IPSGateNotice`, `PortfolioGateNotice`) in `@investintell/ii-terminal-core` so the X3.1 Builder workspace stops dead-ending on PORTFOLIO when the IPS isn't approved and on STRESS when no portfolios exist for the active profile.
- Both components consume the canonical `profileDisplayLabel(_, "full")` helper (Q165 / PR-BE-7) — zero hardcoded "Conservative" / "Moderate" / "Dynamic Growth" strings.
- Wires `PortfolioTabContent` (gate condition + Open Strategic IPS callback) and `StressTabContent` (replaces the inline empty `<div>` at lines 43-47 pre-PR-UX-3); the parent page collapses `strategic.has_active_approval` into a single `ipsApproved` boolean and routes the CTA to `setTab("strategic")`.

## Test plan

- [x] `cd packages/ii-terminal-core && pnpm test` → 31/31 tests pass (6 files)
  - `IPSGateNotice.test.ts` (6 tests): snapshot of title + CTA for `conservative` / `moderate` / `growth` profiles, CTA fires `onOpenStrategic`, wrapper has `role="status"`.
  - `PortfolioGateNotice.test.ts` (4 tests): snapshot of title for `growth` / `conservative`, no CTA present, wrapper has `role="status"`.
- [x] `cd packages/ii-terminal-core && pnpm build` → builds clean.
- [x] `cd packages/ii-terminal-core && pnpm check` → no new errors in the touched files (pre-existing workspace alias errors unrelated to this PR).
- [x] `cd frontends/terminal && pnpm lint` → no new errors in the touched files (the one `PortfolioTabContent.svelte:117` `SvelteSet $state wrap` finding is pre-existing, untouched by this PR).

## Notes for reviewers

- **Token discipline:** every visual is `var(--terminal-*)`; no Tailwind utility classes. Mirrors PR-UX-1 `.propose-cta` for cross-surface consistency.
- **P3 Isolated:** both components wrap their body in `<svelte:boundary>` so a render error in the empty-state copy can never blank the workspace tab.
- **Pure presentational:** no fetch, no store reads, no localStorage, no state machine. The parent owns the gate condition and the navigation callback. Stable API for downstream PR-UX-4 (dialog wiring) and PR-UX-6 (StageProgressStrip lock state).
- **Vitest config added:** `ii-terminal-core` had latent `.test.ts` files in `terminal/primitives/__tests__/` but no vitest config or `test` script. Added the minimal config (mirrors `packages/investintell-ui/vitest.config.ts`) plus `happy-dom` and `@sveltejs/kit` devDeps. The pre-existing primitive tests now run too.
- **`TODO(PR-BE-6)` markers:** placed at both gate sites in `PortfolioTabContent.svelte` and the parent `+page.svelte`, calling out the eventual swap from `has_active_approval` to the canonical `ips_state` taxonomy once PR-BE-6 ships it on `StrategicAllocationResponse`.

## Refs

`docs/plans/2026-04-30-builder-workspace-redesign-final.md`
- §3.3 — `ips_state` taxonomy preview (full payload arrives in PR-BE-6)
- §6.1 — workspace tree (IPSGateNotice + PortfolioGateNotice positioning)
- §6.2.2 — `StressTabContent` row (replace inline empty div)
- §6.2.3 — component creation table (props + responsibility)
- §7.2 — wireframe "Portfolio stage when IPS not approved"
- §7.4 — CTA token spec (mirror PR-UX-1 token discipline)
- §9 — PR-UX-3

---

## Stability Guardrails Checklist

### Backend
N/A — frontend-only PR (no backend code touched).

### Frontend
- [x] New `+page.{ts,server.ts}` load fetches pass an explicit `AbortSignal.timeout(...)` — N/A, no new loaders introduced.
- [x] New `\$derived` expressions reading async-loaded data use optional chaining + safe defaults — `profile ?? "moderate"` fallback at the consumer.
- [x] New top-level panels are wrapped in `<svelte:boundary>` — both new components do.
- [x] All numeric/date/currency formatting uses formatters from `@investintell/ui` — N/A, no formatting introduced; copy is plain text.
- [x] New event sources / WS / mutating calls — N/A, pure presentational components.

### Tests & verification
- [x] Regression test added — 10 new tests covering snapshot, interaction, and a11y for both components.
- [x] `make check` passes locally — backend untouched; frontend lint/check pre-existing errors unchanged by this PR (verified by line-level diff).
- [x] No `eslint-disable` / stability-guardrails-exception added.

### Observability
N/A — no background jobs, provider gates, or async tasks introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)