### PR TITLE
feat(wealth): PR-BE-4 — multi-portfolio constraints + idempotent create

### DIFF
--- a/backend/app/core/db/migrations/versions/0201_q_multi_portfolio_constraints.py
+++ b/backend/app/core/db/migrations/versions/0201_q_multi_portfolio_constraints.py
@@ -80,15 +80,82 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Drop the new constraints in reverse order, then restore the
-    # legacy partial unique exactly as migration 0008 created it so a
-    # rollback returns the schema to the pre-0201 shape.
+    """Refuse downgrade if multi-active state exists (Codex P2 fix).
+
+    The legacy ``uq_model_portfolios_org_profile_active`` partial unique
+    keyed on ``status IN ('draft','backtesting','live')`` cannot coexist
+    with the post-0201 multi-draft pattern: re-creating it on a DB that
+    has accumulated two or more drafts per ``(organization_id, profile)``
+    would fail with a duplicate-key error and leave the rollback halfway
+    applied (legacy unique missing, new constraints already dropped).
+
+    Rather than silently mutate or destroy production data — which would
+    be opaque to the operator and irrecoverable — we refuse the
+    downgrade with a structured ``RuntimeError`` listing the offending
+    ``(organization_id, profile)`` pair. The operator must consciously
+    archive the duplicate non-live rows (or delete drafts) before
+    retrying the rollback. Suggested cleanup:
+
+    .. code-block:: sql
+
+        -- Inspect the duplicates
+        SELECT organization_id, profile, COUNT(*) AS dup
+        FROM model_portfolios
+        WHERE status IN ('draft', 'backtesting', 'live')
+        GROUP BY 1, 2
+        HAVING COUNT(*) > 1;
+
+        -- Archive duplicates per (org, profile), keeping the most recent
+        UPDATE model_portfolios SET status = 'archived'
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT id, ROW_NUMBER() OVER (
+                    PARTITION BY organization_id, profile
+                    ORDER BY created_at DESC
+                ) AS rn
+                FROM model_portfolios
+                WHERE status IN ('draft', 'backtesting', 'live')
+            ) ranked WHERE rn > 1
+        );
+
+    On a fresh DB (no model_portfolios rows) this pre-check returns no
+    rows and the downgrade proceeds normally — preserving symmetry with
+    upgrade for dev / CI workflows.
+    """
     op.execute(
         "DROP INDEX IF EXISTS uq_model_portfolios_org_display_name"
     )
     op.execute(
         "DROP INDEX IF EXISTS uq_model_portfolios_primary_live"
     )
+
+    # ── Pre-check: refuse on multi-active state ──────────────────────
+    conn = op.get_bind()
+    duplicate = conn.execute(
+        sa.text(
+            """
+            SELECT organization_id, profile, COUNT(*) AS dup
+            FROM model_portfolios
+            WHERE status IN ('draft', 'backtesting', 'live')
+            GROUP BY 1, 2
+            HAVING COUNT(*) > 1
+            ORDER BY dup DESC
+            LIMIT 1
+            """
+        )
+    ).fetchone()
+    if duplicate is not None:
+        raise RuntimeError(
+            "Cannot downgrade migration 0201 — multi-active portfolios "
+            f"detected (organization_id={duplicate[0]}, "
+            f"profile={duplicate[1]!r}, count={duplicate[2]}). "
+            "Recreating the legacy uq_model_portfolios_org_profile_active "
+            "unique index would fail on duplicate keys. "
+            "Manual cleanup required: archive the duplicate non-live rows "
+            "before retrying the rollback. See the docstring of this "
+            "migration for the cleanup SQL."
+        )
+
     op.create_index(
         "uq_model_portfolios_org_profile_active",
         "model_portfolios",

--- a/backend/app/core/db/migrations/versions/0201_q_multi_portfolio_constraints.py
+++ b/backend/app/core/db/migrations/versions/0201_q_multi_portfolio_constraints.py
@@ -1,0 +1,100 @@
+"""PR-BE-4 — multi-portfolio per profile + UNIQUE display_name.
+
+Replaces the legacy ``uq_model_portfolios_org_profile_active`` partial
+unique index (introduced in migration 0008) with a narrower
+``uq_model_portfolios_primary_live`` index keyed on the new state
+machine column (``state='live'``). This allows multiple
+``draft``/``constructed``/``validated``/``approved``/``paused``
+portfolios per ``(organization_id, profile)`` while still enforcing a
+single ``primary_live`` portfolio per profile per org (Andrei v1
+decision 2026-04-30, doc §1.1 + §4.4).
+
+Adds a second tenant-scoped UNIQUE index on
+``(organization_id, display_name)`` so the create handler can map a
+duplicate-name conflict to a structured 409 (the PR-UX-4 dialog
+renders this inline). RLS makes the constraint org-isolated by
+construction; cross-org duplicate names are accepted.
+
+Pre-flight DB audits performed against local Docker DB
+(``netz-analysis-engine-db-1``) before authoring this migration:
+
+- ``SELECT organization_id, display_name, COUNT(*) FROM model_portfolios
+  GROUP BY 1,2 HAVING COUNT(*) > 1;`` → 0 rows.
+- ``SELECT organization_id, profile, COUNT(*) FROM model_portfolios
+  WHERE state='live' GROUP BY 1,2 HAVING COUNT(*) > 1;`` → 0 rows.
+- Total rows in ``model_portfolios`` at audit time: 0.
+
+Forward-only — no data migration required because every existing row
+that passed the legacy ``status``-based check would also pass the new
+``state``-based check (state machine post-0098 keeps the two columns
+in sync at create time and only ``state`` is mutated by the lifecycle
+transition helper afterwards).
+
+Revision: 0201_q_multi_portfolio_constraints
+Down-revision: 0200_q_self_approval_bootstrap_config
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0201_q_multi_portfolio_constraints"
+down_revision = "0200_q_self_approval_bootstrap_config"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── 1. Drop the legacy ``status``-based partial unique ───────────
+    # The legacy index (migration 0008) prevented multiple non-archived
+    # portfolios per profile. v1 multi-portfolio explicitly relaxes
+    # that — only the live (state='live') row is unique per profile.
+    op.execute(
+        "DROP INDEX IF EXISTS uq_model_portfolios_org_profile_active"
+    )
+
+    # ── 2. Narrower partial unique on state='live' ───────────────────
+    # Single primary_live portfolio per (org, profile). Other states
+    # (draft/constructed/validated/approved/paused) are not constrained
+    # so the user can stage a new candidate alongside the live one.
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_model_portfolios_primary_live
+            ON model_portfolios (organization_id, profile)
+            WHERE state = 'live'
+        """
+    )
+
+    # ── 3. UNIQUE (organization_id, display_name) ────────────────────
+    # Tenant-scoped. PR-UX-4 dialog catches the IntegrityError at the
+    # create handler and surfaces a structured 409 with
+    # ``error="duplicate_display_name"``. Cross-org dupes are allowed
+    # because RLS already isolates each tenant.
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_model_portfolios_org_display_name
+            ON model_portfolios (organization_id, display_name)
+        """
+    )
+
+
+def downgrade() -> None:
+    # Drop the new constraints in reverse order, then restore the
+    # legacy partial unique exactly as migration 0008 created it so a
+    # rollback returns the schema to the pre-0201 shape.
+    op.execute(
+        "DROP INDEX IF EXISTS uq_model_portfolios_org_display_name"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS uq_model_portfolios_primary_live"
+    )
+    op.create_index(
+        "uq_model_portfolios_org_profile_active",
+        "model_portfolios",
+        ["organization_id", "profile"],
+        unique=True,
+        postgresql_where=sa.text(
+            "status IN ('draft', 'backtesting', 'live')"
+        ),
+    )

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -256,7 +256,7 @@ async def create_model_portfolio(
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
     org_id: uuid.UUID = Depends(get_org_id),
-) -> ModelPortfolioRead:
+) -> dict[str, Any]:
     """Create a new model portfolio (Phase 5 Task 5.1).
 
     Requires IC role. The new row starts in ``state='draft'`` (column
@@ -393,7 +393,23 @@ async def create_model_portfolio(
         copy_from=str(body.copy_from) if body.copy_from else None,
     )
 
-    return await _serialize_with_actions(db, portfolio)
+    # ── @idempotent + orjson serialization contract (Codex P1 fix) ──
+    # The ``@idempotent`` decorator persists the return value via
+    # ``orjson.dumps(result)`` so a retry within the 600s TTL replays
+    # the same response. ``orjson`` cannot encode Pydantic models,
+    # ``Decimal``, ``datetime`` or ``UUID`` directly — passing a
+    # ``ModelPortfolioRead`` here would raise ``TypeError``, the
+    # decorator would log ``idempotency_store_result_failed`` and
+    # skip the cache write, and the *next* call within TTL would
+    # re-execute the handler and trip the duplicate display_name 409
+    # — silently degrading idempotency.
+    #
+    # ``model_dump(mode='json')`` produces a fully orjson-safe dict
+    # (Decimals → strings, datetimes → ISO, UUIDs → strings) which
+    # FastAPI re-validates against ``response_model=ModelPortfolioRead``
+    # transparently — the wire format is identical.
+    rendered = await _serialize_with_actions(db, portfolio)
+    return rendered.model_dump(mode="json")
 
 
 # PR-BE-2 — bounded list ceiling (Stability Guardrails §3 P1 Bounded).

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -22,10 +22,13 @@ from typing import Any, Final
 import numpy as np
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config.config_service import ConfigService
+from app.core.runtime.gates import get_idempotency_storage
+from app.core.runtime.idempotency import idempotent
 from app.core.security.clerk_auth import Actor, CurrentUser, get_actor, get_current_user
 from app.core.tenancy.middleware import get_db_with_rls, get_org_id
 from app.domains.wealth.models.allocation import StrategicAllocation
@@ -202,11 +205,50 @@ _DEFAULT_MAX_SINGLE_FUND: dict[str, float] = {
 router = APIRouter(prefix="/model-portfolios", tags=["model-portfolios"])
 
 
+def _create_portfolio_idempotency_key(
+    body: ModelPortfolioCreate,
+    *_args: Any,
+    **kwargs: Any,
+) -> str:
+    """Derive an idempotency key for ``POST /model-portfolios``.
+
+    Two creates with the same ``(org_id, display_name)`` are logically
+    the same mutation — a retry. ``display_name`` is unique per org
+    (migration 0201 ``uq_model_portfolios_org_display_name``) so it is
+    a safe natural key. ``copy_from`` is intentionally excluded from
+    the key: a retry that omits ``copy_from`` after a network glitch
+    must still hit the cache and return the original portfolio.
+    """
+    org_id = kwargs["org_id"]
+    return f"create_portfolio:{org_id}:{body.display_name}"
+
+
+def _create_portfolio_advisory_lock_key(
+    org_id: uuid.UUID,
+    display_name: str,
+) -> int:
+    """CRC32 of ``(org_id, display_name)`` for ``pg_advisory_xact_lock``.
+
+    Per Stability Guardrails §3, advisory lock keys MUST use
+    ``zlib.crc32`` rather than Python's built-in ``hash()`` (which is
+    non-deterministic across processes). The lock provides the third
+    layer of dedup behind Redis (decorator) and ``SingleFlightLock``
+    (in-process).
+    """
+    payload = f"create_portfolio:{org_id}:{display_name}".encode("utf-8")
+    return zlib.crc32(payload) & 0xFFFFFFFF
+
+
 @router.post(
     "",
     response_model=ModelPortfolioRead,
     status_code=status.HTTP_201_CREATED,
     summary="Create a model portfolio",
+)
+@idempotent(
+    key=_create_portfolio_idempotency_key,
+    ttl_s=600,
+    storage=get_idempotency_storage(),
 )
 async def create_model_portfolio(
     body: ModelPortfolioCreate,
@@ -231,6 +273,19 @@ async def create_model_portfolio(
     (the source must belong to the same org — RLS guarantees that).
     """
     _require_ic_role(actor)
+
+    # ── Triple-layer dedup (Stability Guardrails §3 P5 Idempotent) ──
+    # The ``@idempotent`` decorator above provides Redis-backed result
+    # caching (cross-process, 600s TTL). The transaction-scoped
+    # advisory lock here is the third layer that serialises
+    # concurrent inserts that miss the Redis cache (e.g. two app
+    # instances behind a load balancer that both lose the cache race).
+    # Lock auto-releases at commit/rollback.
+    advisory_key = _create_portfolio_advisory_lock_key(org_id, body.display_name)
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(:k)"),
+        {"k": advisory_key},
+    )
 
     # Optional clone source — fetch first so a 404 happens before any
     # writes hit the DB.
@@ -269,7 +324,25 @@ async def create_model_portfolio(
         # so the optimizer cascade will re-run before activation.
         portfolio.fund_selection_schema = dict(source_portfolio.fund_selection_schema)
     db.add(portfolio)
-    await db.flush()
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        # Map the migration 0201 UNIQUE (org_id, display_name) violation
+        # to a structured 409 the PR-UX-4 dialog can render inline.
+        # Other integrity errors (FK, CHECK) are propagated unchanged.
+        msg = str(exc.orig) if exc.orig is not None else str(exc)
+        if "uq_model_portfolios_org_display_name" in msg:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "duplicate_display_name",
+                    "message": (
+                        f"Portfolio name '{body.display_name}' already "
+                        "exists in this organization."
+                    ),
+                },
+            ) from exc
+        raise
     await db.refresh(portfolio)
 
     # Seed the paired calibration row. Default values come from
@@ -4449,8 +4522,6 @@ async def get_current_regime_endpoint(
 # Shadow OMS — Phase 9 Block D
 # ──────────────────────────────────────────────────────────────────
 
-from app.core.runtime.gates import get_idempotency_storage
-from app.core.runtime.idempotency import idempotent
 from app.core.security.clerk_auth import require_role
 from app.domains.wealth.models.shadow_oms import (
     PortfolioActualHoldings,

--- a/backend/tests/wealth/test_idempotent_create_portfolio.py
+++ b/backend/tests/wealth/test_idempotent_create_portfolio.py
@@ -1,0 +1,331 @@
+"""PR-BE-4 — idempotent ``POST /model-portfolios`` create handler.
+
+Three dimensions of coverage:
+
+1. **Key derivation** — the idempotency key is stable across calls
+   that share ``(org_id, display_name)`` and varies otherwise. The
+   advisory-lock helper returns a deterministic ``zlib.crc32`` hash
+   (Stability Guardrails §3 — never Python's built-in ``hash()``).
+2. **Decorator wiring** — ``create_model_portfolio`` is wrapped by
+   ``@idempotent`` so a second call within the TTL returns the
+   cached result without re-entering the handler body.
+3. **IntegrityError → 409 mapping** — when the migration 0201
+   ``uq_model_portfolios_org_display_name`` constraint fires, the
+   handler raises ``HTTPException(409)`` with a structured
+   ``error="duplicate_display_name"`` payload that the PR-UX-4
+   dialog can render inline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import zlib
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+
+from app.core.runtime.idempotency import (
+    InMemoryIdempotencyStorage,
+    idempotent,
+)
+from app.domains.wealth.routes.model_portfolios import (
+    _create_portfolio_advisory_lock_key,
+    _create_portfolio_idempotency_key,
+    create_model_portfolio,
+)
+from app.domains.wealth.schemas.model_portfolio import ModelPortfolioCreate
+
+_ORG_A = uuid.UUID("0be40000-0000-0000-0000-000000000001")
+_ORG_B = uuid.UUID("0be40000-0000-0000-0000-000000000002")
+
+
+# ── Key derivation ────────────────────────────────────────────────
+
+
+def test_idempotency_key_stable_for_same_org_and_name() -> None:
+    body = ModelPortfolioCreate(
+        profile="growth",
+        display_name="Core Growth",
+    )
+    a = _create_portfolio_idempotency_key(body, org_id=_ORG_A)
+    b = _create_portfolio_idempotency_key(body, org_id=_ORG_A)
+    assert a == b
+    assert a == f"create_portfolio:{_ORG_A}:Core Growth"
+
+
+def test_idempotency_key_varies_by_org() -> None:
+    body = ModelPortfolioCreate(
+        profile="growth",
+        display_name="Core Growth",
+    )
+    assert (
+        _create_portfolio_idempotency_key(body, org_id=_ORG_A)
+        != _create_portfolio_idempotency_key(body, org_id=_ORG_B)
+    )
+
+
+def test_idempotency_key_varies_by_display_name() -> None:
+    a_body = ModelPortfolioCreate(profile="growth", display_name="Alpha")
+    b_body = ModelPortfolioCreate(profile="growth", display_name="Beta")
+    assert (
+        _create_portfolio_idempotency_key(a_body, org_id=_ORG_A)
+        != _create_portfolio_idempotency_key(b_body, org_id=_ORG_A)
+    )
+
+
+def test_idempotency_key_ignores_copy_from() -> None:
+    """Retries that drop ``copy_from`` must still hit the cache."""
+    src = uuid.uuid4()
+    a = _create_portfolio_idempotency_key(
+        ModelPortfolioCreate(
+            profile="growth", display_name="Core Growth", copy_from=src,
+        ),
+        org_id=_ORG_A,
+    )
+    b = _create_portfolio_idempotency_key(
+        ModelPortfolioCreate(
+            profile="growth", display_name="Core Growth",
+        ),
+        org_id=_ORG_A,
+    )
+    assert a == b
+
+
+def test_advisory_lock_key_is_crc32_not_hash() -> None:
+    """Advisory locks MUST use ``zlib.crc32`` for cross-process stability.
+
+    Python's built-in ``hash()`` is salted per-interpreter, so two
+    workers on the same Postgres would compute different keys for the
+    same payload — the second worker could then INSERT alongside the
+    first under the (wrongly held) impression that the lock is free.
+    """
+    key = _create_portfolio_advisory_lock_key(_ORG_A, "Core Growth")
+    expected = (
+        zlib.crc32(
+            f"create_portfolio:{_ORG_A}:Core Growth".encode("utf-8")
+        )
+        & 0xFFFFFFFF
+    )
+    assert key == expected
+    assert 0 <= key <= 0xFFFFFFFF
+
+
+def test_advisory_lock_key_deterministic_across_calls() -> None:
+    a = _create_portfolio_advisory_lock_key(_ORG_A, "Core Growth")
+    b = _create_portfolio_advisory_lock_key(_ORG_A, "Core Growth")
+    assert a == b
+
+
+def test_advisory_lock_key_varies_by_input() -> None:
+    a = _create_portfolio_advisory_lock_key(_ORG_A, "Core Growth")
+    b = _create_portfolio_advisory_lock_key(_ORG_B, "Core Growth")
+    c = _create_portfolio_advisory_lock_key(_ORG_A, "Different Name")
+    assert a != b
+    assert a != c
+
+
+# ── Decorator wiring ──────────────────────────────────────────────
+
+
+def test_create_handler_is_wrapped_by_idempotent() -> None:
+    """The handler exposes the decorator's wrapper signature.
+
+    ``functools.wraps`` makes ``create_model_portfolio`` look like the
+    original async function but the wrapper short-circuits on cache
+    hits. We assert that ``__wrapped__`` is exposed (set by
+    ``functools.wraps``) so we know the decorator actually ran.
+    """
+    assert hasattr(create_model_portfolio, "__wrapped__")
+    assert asyncio.iscoroutinefunction(create_model_portfolio)
+
+
+async def test_idempotent_decorator_caches_within_ttl() -> None:
+    """Validate the documented contract on a synthetic handler.
+
+    The route handler itself is hard to invoke inline because it
+    depends on FastAPI ``Depends(...)`` injection — we verify the
+    primitive's behaviour with the same key extractor and a fake
+    body to lock down the contract that the route now relies on.
+    """
+    storage = InMemoryIdempotencyStorage()
+    calls = 0
+
+    @idempotent(
+        key=_create_portfolio_idempotency_key, ttl_s=600, storage=storage,
+    )
+    async def fake_create(
+        body: ModelPortfolioCreate, *, org_id: uuid.UUID,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {"id": str(uuid.uuid4()), "name": body.display_name}
+
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    first = await fake_create(body, org_id=_ORG_A)
+    second = await fake_create(body, org_id=_ORG_A)
+
+    assert calls == 1
+    assert first == second
+
+
+async def test_idempotent_decorator_concurrent_collapses_to_one_call() -> None:
+    """Ten concurrent ``POST`` retries must execute the body once.
+
+    This is the load-balancer retry storm scenario: the user clicks
+    "Create" and the browser fires ten parallel fetches before the
+    first response lands. Without the decorator, all ten reach the
+    DB, the first wins ``uq_model_portfolios_org_display_name`` and
+    the rest 409. With the decorator, exactly one body runs and the
+    other nine get the cached result.
+    """
+    storage = InMemoryIdempotencyStorage()
+    calls = 0
+    started = asyncio.Event()
+
+    @idempotent(
+        key=_create_portfolio_idempotency_key,
+        ttl_s=600,
+        storage=storage,
+        wait_poll_s=0.005,
+    )
+    async def fake_create(
+        body: ModelPortfolioCreate, *, org_id: uuid.UUID,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        # Hold the lock briefly so the other coroutines all queue up
+        # behind the in-flight execution before the cache is populated.
+        await started.wait()
+        return {"name": body.display_name, "calls": calls}
+
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+
+    async def fire() -> dict[str, Any]:
+        return await fake_create(body, org_id=_ORG_A)
+
+    tasks = [asyncio.create_task(fire()) for _ in range(10)]
+    # Let every task hit the decorator before releasing the body.
+    await asyncio.sleep(0.02)
+    started.set()
+    results = await asyncio.gather(*tasks)
+
+    assert calls == 1
+    assert all(r == results[0] for r in results)
+
+
+async def test_idempotent_decorator_expires_after_ttl() -> None:
+    storage = InMemoryIdempotencyStorage()
+    calls = 0
+
+    @idempotent(
+        key=_create_portfolio_idempotency_key, ttl_s=1, storage=storage,
+    )
+    async def fake_create(
+        body: ModelPortfolioCreate, *, org_id: uuid.UUID,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {"call": calls}
+
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    first = await fake_create(body, org_id=_ORG_A)
+    # Force expiry by clearing the in-memory storage manually — equivalent
+    # to TTL elapse, without making the test sleep for real seconds.
+    storage._results.clear()  # type: ignore[attr-defined]
+    storage._locks.clear()  # type: ignore[attr-defined]
+    second = await fake_create(body, org_id=_ORG_A)
+
+    assert calls == 2
+    assert first["call"] == 1
+    assert second["call"] == 2
+
+
+# ── IntegrityError → 409 mapping ─────────────────────────────────
+
+
+def _build_integrity_error(constraint_name: str) -> IntegrityError:
+    """Construct an IntegrityError whose ``orig`` mentions a constraint.
+
+    The handler matches on ``str(exc.orig)``; we inject a sentinel
+    so the mapping branch fires deterministically without needing a
+    real DB to actually raise.
+    """
+    orig = Exception(
+        f'duplicate key value violates unique constraint "{constraint_name}"'
+    )
+    return IntegrityError("INSERT INTO ...", params=None, orig=orig)
+
+
+async def _invoke_create(
+    body: ModelPortfolioCreate,
+    *,
+    flush_exc: Exception | None = None,
+) -> Any:
+    """Drive the create handler past dependency injection.
+
+    Stubs ``AsyncSession.execute`` (advisory lock + later queries),
+    ``flush``, ``refresh``, ``add``, and the helper that resolves
+    ``allowed_actions``. The body raises on flush when ``flush_exc``
+    is supplied so the IntegrityError mapping branch is exercised.
+    """
+    from app.core.security.clerk_auth import Actor
+    from app.shared.enums import Role
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock())
+    db.refresh = AsyncMock()
+
+    if flush_exc is not None:
+        db.flush = AsyncMock(side_effect=flush_exc)
+    else:
+        db.flush = AsyncMock()
+    db.add = MagicMock()
+
+    actor = Actor(
+        actor_id="be4-tester",
+        name="Tester",
+        email="tester@example.com",
+        roles=[Role.INVESTMENT_TEAM],
+        organization_id=_ORG_A,
+        fund_ids=[],
+    )
+    user = MagicMock()
+    user.name = "be4-tester"
+
+    return await create_model_portfolio.__wrapped__(
+        body=body, db=db, user=user, actor=actor, org_id=_ORG_A,
+    )
+
+
+async def test_duplicate_display_name_returns_structured_409() -> None:
+    """The migration 0201 constraint maps to a 409 the dialog can render."""
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    exc = _build_integrity_error("uq_model_portfolios_org_display_name")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await _invoke_create(body, flush_exc=exc)
+
+    assert excinfo.value.status_code == 409
+    detail = excinfo.value.detail
+    assert isinstance(detail, dict)
+    assert detail["error"] == "duplicate_display_name"
+    assert "Core Growth" in detail["message"]
+
+
+async def test_other_integrity_errors_propagate_unchanged() -> None:
+    """A non-display-name IntegrityError must surface as the original 500.
+
+    The handler only owns the duplicate-name mapping; any other
+    constraint (e.g. a fresh CHECK or FK violation) must bubble up to
+    FastAPI as-is so an institutional incident is not swallowed by a
+    misleading 409.
+    """
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    exc = _build_integrity_error("chk_model_portfolio_status")
+
+    with pytest.raises(IntegrityError):
+        await _invoke_create(body, flush_exc=exc)

--- a/backend/tests/wealth/test_idempotent_create_portfolio.py
+++ b/backend/tests/wealth/test_idempotent_create_portfolio.py
@@ -329,3 +329,151 @@ async def test_other_integrity_errors_propagate_unchanged() -> None:
 
     with pytest.raises(IntegrityError):
         await _invoke_create(body, flush_exc=exc)
+
+
+# ── orjson serialisation contract (Codex P1 regression) ─────────────
+
+
+async def test_idempotent_decorator_caches_decimal_datetime_uuid_payload() -> None:
+    """The cache MUST round-trip a payload with Decimal/datetime/UUID.
+
+    Codex Auto Review (PR #474) flagged that ``ModelPortfolioRead``
+    contains ``Decimal``, ``datetime`` and ``UUID`` fields which
+    ``orjson.dumps`` cannot encode without a ``default=`` handler. A
+    failed encode would log ``idempotency_store_result_failed`` and
+    skip the cache write, so a retry within the 600s TTL would
+    re-execute the handler and trip the duplicate display_name 409 —
+    silently degrading idempotency to "first call wins, second 409s",
+    the opposite of the contract.
+
+    The fix is to return the result of ``model_dump(mode='json')``
+    from the create handler so the value handed to ``orjson.dumps``
+    is always a JSON-safe dict. This test pins that contract by
+    exercising the decorator with a payload shaped exactly like
+    ``ModelPortfolioRead.model_dump(mode='json')`` and asserting:
+
+    1. The first call's body executes once.
+    2. The second call returns the cached body byte-for-byte.
+    3. The cached payload is the JSON-safe dict (Decimals as strings,
+       datetimes/UUIDs as strings) — never the underlying Pydantic
+       model.
+    """
+    from datetime import datetime
+    from decimal import Decimal
+
+    storage = InMemoryIdempotencyStorage()
+    calls = 0
+
+    @idempotent(
+        key=_create_portfolio_idempotency_key, ttl_s=600, storage=storage,
+    )
+    async def fake_create(
+        body: ModelPortfolioCreate, *, org_id: uuid.UUID,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        # Mirror the post-fix handler shape: every Decimal / datetime /
+        # UUID has been pre-coerced via ``model_dump(mode='json')`` to
+        # a JSON-safe primitive before ``orjson.dumps`` ever runs.
+        del org_id  # used only to derive the cache key
+        rendered = {
+            "id": str(uuid.uuid4()),
+            "profile": body.profile,
+            "display_name": body.display_name,
+            "inception_nav": str(Decimal("1000.00")),
+            "created_at": datetime(2026, 5, 1, 12, 0, 0).isoformat(),
+        }
+        return rendered
+
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    first = await fake_create(body, org_id=_ORG_A)
+    second = await fake_create(body, org_id=_ORG_A)
+
+    # Body executed exactly once — the second call is a cache hit.
+    assert calls == 1
+    # Full body equality, not just id — proves Decimal/datetime survived.
+    assert first == second
+    # And every field is a primitive orjson can encode (no Pydantic, no
+    # Decimal, no datetime, no UUID).
+    for value in second.values():
+        assert isinstance(value, str), (
+            f"Cached payload must be JSON-primitives only; got {type(value)}"
+        )
+
+    # The decorator's storage must hold the serialised payload.
+    cached_bytes = await storage.get_result(
+        _create_portfolio_idempotency_key(body, org_id=_ORG_A)
+    )
+    assert cached_bytes is not None, (
+        "Cache miss after first call — orjson.dumps must have failed "
+        "silently. Did the handler return a Pydantic model instead of "
+        "model_dump(mode='json')?"
+    )
+    import orjson  # local import — already a project dep
+    assert orjson.loads(cached_bytes) == first
+
+
+async def test_idempotent_decorator_rejects_pydantic_model_return() -> None:
+    """Pin the negative case: returning a Pydantic model from the handler.
+
+    Without the P1 fix, the handler returned a ``ModelPortfolioRead``
+    Pydantic instance directly. ``orjson.dumps`` raises ``TypeError``
+    on such inputs, the decorator catches it, logs
+    ``idempotency_store_result_failed`` and silently moves on — and
+    the next call within TTL re-executes the body. This test pins
+    that exact failure mode so a regression to "return the Pydantic
+    model" surfaces immediately instead of silently downgrading
+    idempotency in production.
+    """
+    from datetime import datetime
+    from decimal import Decimal
+
+    from app.domains.wealth.schemas.model_portfolio import (
+        ModelPortfolioRead,
+    )
+
+    storage = InMemoryIdempotencyStorage()
+    calls = 0
+
+    @idempotent(
+        key=_create_portfolio_idempotency_key, ttl_s=600, storage=storage,
+    )
+    async def buggy_create(
+        body: ModelPortfolioCreate, *, org_id: uuid.UUID,
+    ) -> Any:
+        nonlocal calls
+        calls += 1
+        # Return the Pydantic model directly — the *pre*-P1 shape.
+        del org_id  # unused; schema does not expose organization_id
+        return ModelPortfolioRead(
+            id=uuid.uuid4(),
+            profile=body.profile,
+            display_name=body.display_name,
+            inception_nav=Decimal("1000.00"),
+            status="draft",
+            state="draft",
+            created_at=datetime(2026, 5, 1, 12, 0, 0),
+            created_by="test",
+        )
+
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    await buggy_create(body, org_id=_ORG_A)
+
+    # The cache write must have failed silently — proving why the P1
+    # fix is needed. The cache is empty, so a retry will re-execute.
+    cached_bytes = await storage.get_result(
+        _create_portfolio_idempotency_key(body, org_id=_ORG_A)
+    )
+    assert cached_bytes is None, (
+        "orjson.dumps unexpectedly accepted a Pydantic model. If orjson "
+        "added native Pydantic support, this test is now stale and the "
+        "P1 contract can be relaxed."
+    )
+
+    # Second call re-executes — the silent-degradation pattern.
+    await buggy_create(body, org_id=_ORG_A)
+    assert calls == 2, (
+        "Expected re-execution because cache write failed; got cache "
+        "hit. Either orjson started serialising Pydantic, or the "
+        "decorator changed its serialisation path."
+    )

--- a/backend/tests/wealth/test_multi_portfolio_constraints.py
+++ b/backend/tests/wealth/test_multi_portfolio_constraints.py
@@ -1,0 +1,250 @@
+"""PR-BE-4 — multi-portfolio constraint redesign.
+
+Verifies the migration 0201 partial unique index
+``uq_model_portfolios_primary_live`` and the per-org UNIQUE
+``uq_model_portfolios_org_display_name`` against a live PostgreSQL.
+
+Layout of this suite:
+
+1. ``test_multi_drafts_per_profile_succeed`` — three drafts +
+   constructed/validated/approved variants for the same
+   ``(org, profile=growth)`` all coexist.
+2. ``test_single_live_per_profile_enforced`` — a single
+   ``state='live'`` row inserts; the second is rejected by
+   ``uq_model_portfolios_primary_live``.
+3. ``test_duplicate_display_name_within_org_rejected`` — two
+   portfolios with the same ``display_name`` in the same org
+   collide on ``uq_model_portfolios_org_display_name``.
+4. ``test_duplicate_display_name_cross_org_allowed`` — same
+   ``display_name`` in two different orgs is fine; RLS isolates
+   each tenant and the unique key carries ``organization_id``.
+
+Convention: ``growth`` is the canonical post-Q165 profile (the
+``aggressive`` legacy alias was removed in migration 0199). Tests
+seed and tear down their own rows with deterministic UUIDs so
+they are safely re-runnable.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from app.core.db.engine import async_session_factory
+
+# Deterministic test UUIDs — be4 prefix so they cannot conflict with
+# real tenants or other test suites.
+_ORG_A = uuid.UUID("0be40000-0000-0000-0000-000000000001")
+_ORG_B = uuid.UUID("0be40000-0000-0000-0000-000000000002")
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+async def _set_org(db, org_id: uuid.UUID) -> None:
+    await db.execute(
+        text("SELECT set_config('app.current_organization_id', :oid, true)"),
+        {"oid": str(org_id)},
+    )
+
+
+async def _insert_portfolio(
+    db,
+    *,
+    org_id: uuid.UUID,
+    profile: str,
+    display_name: str,
+    state: str,
+    status: str = "draft",
+) -> uuid.UUID:
+    """Insert a model_portfolios row directly via SQL.
+
+    Bypasses the ORM so the test focuses on the DB-level constraints;
+    we want the partial unique to fire on raw INSERT, not at any
+    application validation layer.
+    """
+    pid = uuid.uuid4()
+    await db.execute(
+        text(
+            """
+            INSERT INTO model_portfolios (
+                id, organization_id, profile, display_name,
+                status, state, state_metadata, inception_nav, created_by
+            ) VALUES (
+                :id, :oid, :profile, :name,
+                :status, :state, '{}'::jsonb, 1000.0, 'be4-test'
+            )
+            """
+        ),
+        {
+            "id": pid,
+            "oid": org_id,
+            "profile": profile,
+            "name": display_name,
+            "status": status,
+            "state": state,
+        },
+    )
+    return pid
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_be4_rows():
+    """Drop any rows left from a previous run before and after each test."""
+    async with async_session_factory() as db:
+        for org in (_ORG_A, _ORG_B):
+            await _set_org(db, org)
+            await db.execute(
+                text("DELETE FROM model_portfolios WHERE created_by = 'be4-test'")
+            )
+        await db.commit()
+    yield
+    async with async_session_factory() as db:
+        for org in (_ORG_A, _ORG_B):
+            await _set_org(db, org)
+            await db.execute(
+                text("DELETE FROM model_portfolios WHERE created_by = 'be4-test'")
+            )
+        await db.commit()
+
+
+async def test_multi_drafts_per_profile_succeed():
+    """Multiple non-live portfolios per (org, profile) must coexist.
+
+    The migration 0201 partial unique only constrains ``state='live'``;
+    every earlier lifecycle stage may have arbitrarily many rows so
+    the user can stage several candidate portfolios at once.
+    """
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth A", state="draft",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth B", state="draft",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth C", state="draft",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth D", state="constructed",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth E", state="validated",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth F", state="approved",
+        )
+        await db.commit()
+
+        count = (
+            await db.execute(
+                text(
+                    "SELECT COUNT(*) FROM model_portfolios "
+                    "WHERE organization_id = :oid AND profile = 'growth'"
+                ),
+                {"oid": _ORG_A},
+            )
+        ).scalar_one()
+    assert count == 6
+
+
+async def test_single_live_per_profile_enforced():
+    """``state='live'`` is unique per (organization_id, profile).
+
+    asyncpg raises ``UniqueViolationError`` on the INSERT itself
+    (not deferred to commit) because the partial unique index is
+    immediate. Both the second INSERT and the subsequent
+    rollback recovery are exercised here.
+    """
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth Live 1", state="live", status="live",
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        with pytest.raises(IntegrityError) as excinfo:
+            await _insert_portfolio(
+                db, org_id=_ORG_A, profile="growth",
+                display_name="Growth Live 2", state="live", status="live",
+            )
+        assert "uq_model_portfolios_primary_live" in str(excinfo.value)
+        await db.rollback()
+
+
+async def test_duplicate_display_name_within_org_rejected():
+    """``(organization_id, display_name)`` must be unique per tenant."""
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Identical Name", state="draft",
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        with pytest.raises(IntegrityError) as excinfo:
+            await _insert_portfolio(
+                db, org_id=_ORG_A, profile="moderate",
+                display_name="Identical Name", state="draft",
+            )
+        assert "uq_model_portfolios_org_display_name" in str(excinfo.value)
+        await db.rollback()
+
+
+async def test_duplicate_display_name_cross_org_allowed():
+    """Two tenants may use the same ``display_name``.
+
+    The unique key is composite ``(organization_id, display_name)``;
+    cross-org duplicates are allowed because the index carries
+    ``organization_id`` as the leading column. This is the
+    institutional norm — every family office can have its own
+    "Core Growth" portfolio. RLS enforces tenant isolation at the
+    routes layer; this test asserts only the index semantics
+    because the dev ``netz`` role is a superuser and bypasses RLS.
+    """
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Core Growth", state="draft",
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_B)
+        await _insert_portfolio(
+            db, org_id=_ORG_B, profile="growth",
+            display_name="Core Growth", state="draft",
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        for org in (_ORG_A, _ORG_B):
+            await _set_org(db, org)
+            count = (
+                await db.execute(
+                    text(
+                        "SELECT COUNT(*) FROM model_portfolios "
+                        "WHERE display_name = 'Core Growth' "
+                        "AND organization_id = :oid"
+                    ),
+                    {"oid": org},
+                )
+            ).scalar_one()
+            assert count == 1, (
+                f"Expected exactly one 'Core Growth' for org {org}, got {count}"
+            )

--- a/backend/tests/wealth/test_multi_portfolio_constraints.py
+++ b/backend/tests/wealth/test_multi_portfolio_constraints.py
@@ -248,3 +248,125 @@ async def test_duplicate_display_name_cross_org_allowed():
             assert count == 1, (
                 f"Expected exactly one 'Core Growth' for org {org}, got {count}"
             )
+
+
+# ── Downgrade safety (Codex P2 regression) ──────────────────────────
+
+
+async def test_downgrade_pre_check_refuses_on_multi_active():
+    """The migration 0201 downgrade pre-check must refuse multi-active state.
+
+    Codex Auto Review (PR #474) flagged that the downgrade body
+    re-creates the legacy ``uq_model_portfolios_org_profile_active``
+    partial unique on ``status IN ('draft','backtesting','live')`` —
+    but the post-0201 system now allows multiple non-live rows per
+    ``(organization_id, profile)``. Re-creating that index after
+    duplicates accumulate would raise a duplicate-key error and leave
+    rollback halfway applied (the new constraints already dropped,
+    the legacy one missing). The downgrade was therefore unusable in
+    exactly the scenario the upgrade enables.
+
+    The fix is a pre-check that raises ``RuntimeError`` listing the
+    offending pair before any structural change happens. Operator
+    must consciously archive the duplicates before retrying.
+
+    This test exercises the same SQL the migration uses, against
+    seeded multi-active state, and asserts the pre-check returns the
+    expected diagnostic row.
+    """
+    pre_check_sql = text(
+        """
+        SELECT organization_id, profile, COUNT(*) AS dup
+        FROM model_portfolios
+        WHERE status IN ('draft', 'backtesting', 'live')
+        GROUP BY 1, 2
+        HAVING COUNT(*) > 1
+        ORDER BY dup DESC
+        LIMIT 1
+        """
+    )
+
+    # Seed two drafts for the same (org, profile) — exactly the
+    # multi-active state that the post-0201 system permits but the
+    # legacy unique cannot tolerate.
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Multi A", state="draft", status="draft",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Multi B", state="draft", status="draft",
+        )
+        await db.commit()
+
+    # Pre-check fires — operator sees a structured row.
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        result = (await db.execute(pre_check_sql)).fetchone()
+    assert result is not None, (
+        "Pre-check missed the seeded multi-active state — downgrade "
+        "would silently corrupt rollback by recreating a unique index "
+        "on top of duplicates."
+    )
+    assert result[0] == _ORG_A
+    assert result[1] == "growth"
+    assert result[2] == 2
+
+    # Cleanup: archive one, pre-check now passes (no duplicates).
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await db.execute(
+            text(
+                "UPDATE model_portfolios SET status='archived', "
+                "state='archived' WHERE display_name = 'Multi B' "
+                "AND created_by = 'be4-test'"
+            )
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        result_after = (await db.execute(pre_check_sql)).fetchone()
+    assert result_after is None, (
+        "After archiving the duplicate, the pre-check should return "
+        "no rows so the downgrade can proceed."
+    )
+
+
+async def test_downgrade_pre_check_passes_on_clean_state():
+    """Empty / single-active DB — pre-check returns no rows, downgrade safe.
+
+    On a fresh dev DB or a tenant with no multi-portfolio state, the
+    pre-check must allow the downgrade through so CI can roll the
+    migration forward and back without manual cleanup. Pins the
+    no-op-on-clean contract.
+    """
+    pre_check_sql = text(
+        """
+        SELECT organization_id, profile, COUNT(*) AS dup
+        FROM model_portfolios
+        WHERE status IN ('draft', 'backtesting', 'live')
+        GROUP BY 1, 2
+        HAVING COUNT(*) > 1
+        LIMIT 1
+        """
+    )
+
+    # Single draft — not a duplicate.
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Solo", state="draft", status="draft",
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        result = (await db.execute(pre_check_sql)).fetchone()
+    assert result is None, (
+        "Single draft per (org, profile) should not trigger the "
+        "pre-check — only multi-active state must refuse downgrade."
+    )


### PR DESCRIPTION
## Summary

- Replaces `uq_model_portfolios_org_profile_active` (migration 0008) with `uq_model_portfolios_primary_live` keyed on the new state machine column (`state='live'`) — allows multiple draft/constructed/validated/approved/paused portfolios per `(org, profile)` while still enforcing single primary_live per profile (Andrei v1 decision 2026-04-30, doc §1.1 + §4.4).
- Adds tenant-scoped UNIQUE `(organization_id, display_name)` so the create handler can map duplicate-name violations to a structured 409 the PR-UX-4 dialog renders inline.
- Wraps `POST /model-portfolios` with the `@idempotent` decorator (Redis-backed, 600s TTL) plus `pg_advisory_xact_lock` (`zlib.crc32` key) — triple-layer dedup contract per Stability Guardrails §3 P5.
- Migration `0201_q_multi_portfolio_constraints` (down-revision: `0200_q_self_approval_bootstrap_config`).

## Pre-flight DB audit (mandatory per memory `feedback_pre_flight_dry_run`)

Performed against local Docker DB (`netz-analysis-engine-db-1`) per memory `reference_companyfacts_path` / Q11 *Source of truth during dev*. Timescale Cloud is deprecated for identity work.

```text
1. Display_name dedup audit
   SELECT organization_id, display_name, COUNT(*)
   FROM model_portfolios GROUP BY 1,2 HAVING COUNT(*) > 1;
   → 0 rows ✅

2. Live-state audit
   SELECT organization_id, profile, COUNT(*)
   FROM model_portfolios WHERE state = 'live' GROUP BY 1,2 HAVING COUNT(*) > 1;
   → 0 rows ✅

3. State column name confirmation
   `state` (text) — added in migration 0098, distinct from legacy `status` (varchar(20))
   The new partial unique gates on `state` per the doc.

4. Full unique-index audit pre-migration (per `feedback_enum_consolidation_unique_index_audit`)
   - model_portfolios_pkey                      PRIMARY KEY (id)
   - uq_model_portfolios_org_profile_active     UNIQUE (org_id, profile) WHERE status IN ('draft','backtesting','live')   ← dropped
   - ix_model_portfolios_organization_id        non-unique (org_id)
   - ix_model_portfolios_profile_live           non-unique (profile) WHERE status='live'                                  ← kept (legacy `status` index, separate from `state`)
   No partial unique was hidden.

5. Total rows in model_portfolios at audit time: 0 (forward-only safe)
```

### `alembic upgrade --sql` output (sanitized)

```sql
BEGIN;
-- Running upgrade 0200_q_self_approval_bootstrap_config -> 0201_q_multi_portfolio_constraints
DROP INDEX IF EXISTS uq_model_portfolios_org_profile_active;

CREATE UNIQUE INDEX IF NOT EXISTS uq_model_portfolios_primary_live
    ON model_portfolios (organization_id, profile)
    WHERE state = 'live';

CREATE UNIQUE INDEX IF NOT EXISTS uq_model_portfolios_org_display_name
    ON model_portfolios (organization_id, display_name);

UPDATE alembic_version SET version_num='0201_q_multi_portfolio_constraints'
    WHERE alembic_version.version_num = '0200_q_self_approval_bootstrap_config';
COMMIT;
```

Down/up symmetry verified end-to-end (`alembic downgrade -1` → `alembic upgrade head` restores the new state cleanly; downgrade restores the legacy `status`-based partial unique exactly as 0008 created it).

## Subsumption note

PR-UX-4 (NewPortfolioDialog) consumes the structured 409 from this PR's UNIQUE display_name. PR-UX-4 is dispatched in parallel — landing order doesn't matter (UX-4 handles 4xx generically until the UNIQUE constraint exists, then upgrades to inline error via `error="duplicate_display_name"`).

## Expected merge conflict (PR-BE-3 in parallel)

PR-BE-3 adds `write_audit_event()` calls inside the same `create_model_portfolio` handler. Text-level merge conflict expected at land time — orchestrator-managed manual resolution.

## CHECK-constraint sibling audit (per `feedback_check_constraint_sibling_audit`)

This PR does not widen any enum or CHECK constraint. The migration is index-only.

## Tests

17 new tests:

**Integration (4, hit live PG)** — `backend/tests/wealth/test_multi_portfolio_constraints.py`
- 3 drafts + constructed + validated + approved per (org, profile) coexist.
- Single `state='live'` per profile enforced (`uq_model_portfolios_primary_live`).
- Duplicate `display_name` within org rejected (`uq_model_portfolios_org_display_name`).
- Duplicate `display_name` across orgs allowed.

**Unit (13)** — `backend/tests/wealth/test_idempotent_create_portfolio.py`
- Idempotency key derivation (4 cases — stable, varies by org, varies by name, ignores `copy_from`).
- Advisory lock key (3 cases — `zlib.crc32` not `hash()`, deterministic, varies by input).
- Decorator wiring (3 cases — wrapped, caches within TTL, expires after TTL).
- Concurrent collapse (1 case — 10 parallel calls collapse to 1 body execution).
- IntegrityError → structured 409 (1 case) + non-display-name IntegrityError propagates unchanged (1 case).

```text
============================ 17 passed in 1.27s ============================
```

29 related tests in the area (`test_list_model_portfolios_filter` + `test_model_portfolios_allowed_actions`) still pass.

## Test plan

- [x] `make lint` — passes
- [x] Full ruff on changed files — passes
- [x] `make architecture` — 31 contracts kept, 0 broken
- [x] `mypy` on changed file — no new errors (pre-existing errors in unrelated workers / data_providers aren't surfaced by my changes)
- [x] `alembic upgrade --sql 0200:0201` — clean output
- [x] `alembic upgrade head` then `alembic downgrade -1` then `alembic upgrade head` — symmetric
- [x] All 17 new tests pass
- [x] 29 related model_portfolios tests still pass

## Codex Auto Review

Wait window mandatory — do NOT merge until Codex Auto Review completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)