### PR TITLE
PR-BE-5: gate builds on approved IPS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,123 @@
+# Railway deploy strategy
+#
+# Railway watches this repository directly and auto-deploys the configured
+# services on pushes to the deployment branch. GitLab CI intentionally has no
+# deploy jobs: push pipelines re-run validation only, matching the former
+# GitHub Actions deploy workflow behavior.
+
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"'
+    - when: never
+
+stages:
+  - test
+
+.backend_rules:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      changes:
+        - backend/**
+        - pyproject.toml
+        - .gitlab-ci.yml
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"'
+      changes:
+        - backend/**
+        - pyproject.toml
+        - .gitlab-ci.yml
+    - when: never
+
+.frontend_rules:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      changes:
+        - frontends/**
+        - packages/**
+        - pnpm-lock.yaml
+        - .gitlab-ci.yml
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"'
+      changes:
+        - frontends/**
+        - packages/**
+        - pnpm-lock.yaml
+        - .gitlab-ci.yml
+    - when: never
+
+test-backend:
+  stage: test
+  image: python:3.12-bookworm
+  extends: .backend_rules
+  services:
+    - name: timescale/timescaledb:latest-pg16
+      alias: postgres
+    - name: redis:7
+      alias: redis
+  variables:
+    POSTGRES_USER: netz
+    POSTGRES_PASSWORD: password
+    POSTGRES_DB: netz_engine_test
+    DATABASE_URL: postgresql+asyncpg://netz:password@postgres:5432/netz_engine_test
+    DATABASE_URL_SYNC: postgresql+psycopg://netz:password@postgres:5432/netz_engine_test
+    REDIS_URL: redis://redis:6379/0
+    APP_ENV: development
+    PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+  cache:
+    key: "pip-${CI_JOB_IMAGE}"
+    paths:
+      - .cache/pip/
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends postgresql-client redis-tools
+    - python --version
+    - |
+      until pg_isready -h postgres -U netz -d netz_engine_test; do
+        echo "Waiting for postgres..."
+        sleep 2
+      done
+    - |
+      until redis-cli -h redis ping | grep -q PONG; do
+        echo "Waiting for redis..."
+        sleep 2
+      done
+    - PGPASSWORD=password psql -h postgres -U netz -d netz_engine_test -c "CREATE EXTENSION IF NOT EXISTS vector;"
+  script:
+    - pip install -e ".[dev,ai,quant]"
+    - cd backend
+    - python -m alembic upgrade head
+    - python -m ruff check .
+    # Unit + route tests and integration tests run in separate pytest
+    # invocations so SQLAlchemy async pools bind to separate event loops.
+    - python -m pytest tests/ -v --tb=short --ignore=tests/test_macro_committee.py -m "not integration"
+    - python -m pytest tests/ -v --tb=short --ignore=tests/test_macro_committee.py -m "integration"
+
+check-frontends:
+  stage: test
+  image: node:22-bookworm
+  extends: .frontend_rules
+  variables:
+    NODE_OPTIONS: --max-old-space-size=4096
+    PNPM_STORE_PATH: "$CI_PROJECT_DIR/.pnpm-store"
+  cache:
+    key:
+      files:
+        - pnpm-lock.yaml
+    paths:
+      - .pnpm-store/
+  before_script:
+    - corepack enable
+    - corepack prepare pnpm@10.28.1 --activate
+    - pnpm config set store-dir "$PNPM_STORE_PATH"
+    - node --version
+    - pnpm --version
+  script:
+    - pnpm install --frozen-lockfile
+    - pnpm --filter @netz/ui build
+    - pnpm --filter @investintell/ui build
+    - pnpm --filter @investintell/ii-terminal-core build
+    - pnpm --filter "./frontends/*" exec svelte-kit sync
+    - pnpm --filter netz-wealth-os --filter ii-terminal check
+    # GitLab supports allow_failure at job level, not per command. Keep only
+    # the credit type-check non-blocking until issue #277 is resolved.
+    - pnpm --filter netz-credit-intelligence check || true
+    - pnpm --filter "./frontends/*" build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,6 +388,8 @@ Portfolio is asset-centric post-conversion. Tenor/basis/covenant are deal-level 
 
 Immutable audit logging via `write_audit_event()` in `backend/app/core/db/audit.py`. Records CREATE/UPDATE/DELETE with before/after JSONB snapshots, correlated via `request_id`. Model: `AuditEvent` in `backend/app/core/db/models.py` (RLS-scoped). Used across 17+ modules for entity-level change tracking.
 
+- **`audit_events` is a TimescaleDB hypertable with columnstore (compression) enabled** — RLS state cannot be toggled while compression is on (PR-Q11 Phase 5 incompatibility, same constraint as `fund_risk_metrics`). The table is treated as **Option A: WHERE-clause-filtered, helper-enforced**. All writers MUST use `write_audit_event()`, which injects `organization_id` from the active RLS `SET LOCAL` context (or accepts it explicitly for global pipelines via `allow_global=True` per migration 0195). All readers MUST filter by `WHERE organization_id = (SELECT current_setting('app.current_organization_id', true))::uuid` — every callsite is enforced by code review, since the policy that the table carries (migration 0195) is not guaranteed to be active. Direct `INSERT INTO audit_events` outside the helper is forbidden.
+
 ## Instrument Identity Layer (PR-Q11, 2026-04-26)
 
 Canonical resolver for CIK / CUSIP / ticker / ISIN / FIGI / series_id / class_id / CRD / private_fund_id / LEI lookups. Lives at `backend/data_providers/identity/resolver.py`. Backed by global table `instrument_identity` (current state, listing/share-class grain) plus append-only `instrument_identity_history` for SCD audit.

--- a/backend/app/core/db/migrations/versions/0201_q_multi_portfolio_constraints.py
+++ b/backend/app/core/db/migrations/versions/0201_q_multi_portfolio_constraints.py
@@ -1,0 +1,167 @@
+"""PR-BE-4 — multi-portfolio per profile + UNIQUE display_name.
+
+Replaces the legacy ``uq_model_portfolios_org_profile_active`` partial
+unique index (introduced in migration 0008) with a narrower
+``uq_model_portfolios_primary_live`` index keyed on the new state
+machine column (``state='live'``). This allows multiple
+``draft``/``constructed``/``validated``/``approved``/``paused``
+portfolios per ``(organization_id, profile)`` while still enforcing a
+single ``primary_live`` portfolio per profile per org (Andrei v1
+decision 2026-04-30, doc §1.1 + §4.4).
+
+Adds a second tenant-scoped UNIQUE index on
+``(organization_id, display_name)`` so the create handler can map a
+duplicate-name conflict to a structured 409 (the PR-UX-4 dialog
+renders this inline). RLS makes the constraint org-isolated by
+construction; cross-org duplicate names are accepted.
+
+Pre-flight DB audits performed against local Docker DB
+(``netz-analysis-engine-db-1``) before authoring this migration:
+
+- ``SELECT organization_id, display_name, COUNT(*) FROM model_portfolios
+  GROUP BY 1,2 HAVING COUNT(*) > 1;`` → 0 rows.
+- ``SELECT organization_id, profile, COUNT(*) FROM model_portfolios
+  WHERE state='live' GROUP BY 1,2 HAVING COUNT(*) > 1;`` → 0 rows.
+- Total rows in ``model_portfolios`` at audit time: 0.
+
+Forward-only — no data migration required because every existing row
+that passed the legacy ``status``-based check would also pass the new
+``state``-based check (state machine post-0098 keeps the two columns
+in sync at create time and only ``state`` is mutated by the lifecycle
+transition helper afterwards).
+
+Revision: 0201_q_multi_portfolio_constraints
+Down-revision: 0200_q_self_approval_bootstrap_config
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0201_q_multi_portfolio_constraints"
+down_revision = "0200_q_self_approval_bootstrap_config"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── 1. Drop the legacy ``status``-based partial unique ───────────
+    # The legacy index (migration 0008) prevented multiple non-archived
+    # portfolios per profile. v1 multi-portfolio explicitly relaxes
+    # that — only the live (state='live') row is unique per profile.
+    op.execute(
+        "DROP INDEX IF EXISTS uq_model_portfolios_org_profile_active"
+    )
+
+    # ── 2. Narrower partial unique on state='live' ───────────────────
+    # Single primary_live portfolio per (org, profile). Other states
+    # (draft/constructed/validated/approved/paused) are not constrained
+    # so the user can stage a new candidate alongside the live one.
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_model_portfolios_primary_live
+            ON model_portfolios (organization_id, profile)
+            WHERE state = 'live'
+        """
+    )
+
+    # ── 3. UNIQUE (organization_id, display_name) ────────────────────
+    # Tenant-scoped. PR-UX-4 dialog catches the IntegrityError at the
+    # create handler and surfaces a structured 409 with
+    # ``error="duplicate_display_name"``. Cross-org dupes are allowed
+    # because RLS already isolates each tenant.
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_model_portfolios_org_display_name
+            ON model_portfolios (organization_id, display_name)
+        """
+    )
+
+
+def downgrade() -> None:
+    """Refuse downgrade if multi-active state exists (Codex P2 fix).
+
+    The legacy ``uq_model_portfolios_org_profile_active`` partial unique
+    keyed on ``status IN ('draft','backtesting','live')`` cannot coexist
+    with the post-0201 multi-draft pattern: re-creating it on a DB that
+    has accumulated two or more drafts per ``(organization_id, profile)``
+    would fail with a duplicate-key error and leave the rollback halfway
+    applied (legacy unique missing, new constraints already dropped).
+
+    Rather than silently mutate or destroy production data — which would
+    be opaque to the operator and irrecoverable — we refuse the
+    downgrade with a structured ``RuntimeError`` listing the offending
+    ``(organization_id, profile)`` pair. The operator must consciously
+    archive the duplicate non-live rows (or delete drafts) before
+    retrying the rollback. Suggested cleanup:
+
+    .. code-block:: sql
+
+        -- Inspect the duplicates
+        SELECT organization_id, profile, COUNT(*) AS dup
+        FROM model_portfolios
+        WHERE status IN ('draft', 'backtesting', 'live')
+        GROUP BY 1, 2
+        HAVING COUNT(*) > 1;
+
+        -- Archive duplicates per (org, profile), keeping the most recent
+        UPDATE model_portfolios SET status = 'archived'
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT id, ROW_NUMBER() OVER (
+                    PARTITION BY organization_id, profile
+                    ORDER BY created_at DESC
+                ) AS rn
+                FROM model_portfolios
+                WHERE status IN ('draft', 'backtesting', 'live')
+            ) ranked WHERE rn > 1
+        );
+
+    On a fresh DB (no model_portfolios rows) this pre-check returns no
+    rows and the downgrade proceeds normally — preserving symmetry with
+    upgrade for dev / CI workflows.
+    """
+    op.execute(
+        "DROP INDEX IF EXISTS uq_model_portfolios_org_display_name"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS uq_model_portfolios_primary_live"
+    )
+
+    # ── Pre-check: refuse on multi-active state ──────────────────────
+    conn = op.get_bind()
+    duplicate = conn.execute(
+        sa.text(
+            """
+            SELECT organization_id, profile, COUNT(*) AS dup
+            FROM model_portfolios
+            WHERE status IN ('draft', 'backtesting', 'live')
+            GROUP BY 1, 2
+            HAVING COUNT(*) > 1
+            ORDER BY dup DESC
+            LIMIT 1
+            """
+        )
+    ).fetchone()
+    if duplicate is not None:
+        raise RuntimeError(
+            "Cannot downgrade migration 0201 — multi-active portfolios "
+            f"detected (organization_id={duplicate[0]}, "
+            f"profile={duplicate[1]!r}, count={duplicate[2]}). "
+            "Recreating the legacy uq_model_portfolios_org_profile_active "
+            "unique index would fail on duplicate keys. "
+            "Manual cleanup required: archive the duplicate non-live rows "
+            "before retrying the rollback. See the docstring of this "
+            "migration for the cleanup SQL."
+        )
+
+    op.create_index(
+        "uq_model_portfolios_org_profile_active",
+        "model_portfolios",
+        ["organization_id", "profile"],
+        unique=True,
+        postgresql_where=sa.text(
+            "status IN ('draft', 'backtesting', 'live')"
+        ),
+    )

--- a/backend/app/domains/credit/deals/routes/provenance.py
+++ b/backend/app/domains/credit/deals/routes/provenance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -179,9 +179,19 @@ async def get_decision_audit(
 ) -> DecisionAuditOut:
     await _get_deal_or_404(db, fund_id, deal_id)
 
+    # PR-BE-3 — explicit ``organization_id`` filter on audit_events.
+    # The table has RLS DISABLED (TimescaleDB columnstore incompatible),
+    # so the institutional pattern is helper-write + WHERE-filter-read.
+    # CLAUDE.md §audit_events.
+    if actor.organization_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Organization required",
+        )
     result = await db.execute(
         select(AuditEvent)
         .where(
+            AuditEvent.organization_id == actor.organization_id,
             AuditEvent.entity_type == "Deal",
             AuditEvent.entity_id == str(deal_id),
             AuditEvent.fund_id == fund_id,

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -26,6 +26,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config.config_service import ConfigService
+from app.core.db.audit import write_audit_event
 from app.core.security.clerk_auth import Actor, CurrentUser, get_actor, get_current_user
 from app.core.tenancy.middleware import get_db_with_rls, get_org_id
 from app.domains.wealth.models.allocation import StrategicAllocation
@@ -313,6 +314,33 @@ async def create_model_portfolio(
     db.add(calibration)
     await db.flush()
 
+    # PR-BE-3 — emit audit row inside the same transaction as the
+    # ModelPortfolio + PortfolioCalibration insert. Forensic record for
+    # who created which portfolio, when, and from which optional source.
+    await write_audit_event(
+        db,
+        action="model_portfolio_created",
+        entity_type="ModelPortfolio",
+        entity_id=str(portfolio.id),
+        actor_id=actor.actor_id,
+        actor_roles=[r.value for r in actor.roles],
+        organization_id=org_id,
+        after={
+            "portfolio_id": str(portfolio.id),
+            "profile": portfolio.profile,
+            "display_name": portfolio.display_name,
+            "description": portfolio.description,
+            "benchmark_composite": portfolio.benchmark_composite,
+            "inception_date": portfolio.inception_date,
+            "backtest_start_date": portfolio.backtest_start_date,
+            "status": portfolio.status,
+            "state": portfolio.state,
+            "copy_from": (
+                str(body.copy_from) if body.copy_from is not None else None
+            ),
+        },
+    )
+
     logger.info(
         "model_portfolio_created",
         portfolio_id=str(portfolio.id),
@@ -514,11 +542,35 @@ async def update_model_portfolio(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Portfolio not found")
 
     update_data = body.model_dump(exclude_none=True)
+
+    # PR-BE-3 — capture before-state for the diff snapshot. Only the
+    # fields the client actually sent are recorded so the audit row is
+    # a focused diff, not a noisy dump of every column.
+    before_state = {field: getattr(portfolio, field) for field in update_data}
+
     for field, value in update_data.items():
         setattr(portfolio, field, value)
 
     await db.flush()
     await db.refresh(portfolio)
+
+    # PR-BE-3 — emit audit row in the same transaction. Skip if nothing
+    # actually changed so re-runs of an idempotent client don't emit
+    # spurious "no-op" rows.
+    after_state = {field: getattr(portfolio, field) for field in update_data}
+    if before_state != after_state:
+        await write_audit_event(
+            db,
+            action="model_portfolio_updated",
+            entity_type="ModelPortfolio",
+            entity_id=str(portfolio.id),
+            actor_id=actor.actor_id,
+            actor_roles=[r.value for r in actor.roles],
+            organization_id=portfolio.organization_id,
+            before=before_state,
+            after=after_state,
+        )
+
     return ModelPortfolioRead.model_validate(portfolio)
 
 
@@ -956,6 +1008,15 @@ async def update_portfolio_calibration(
 
     data = payload.model_dump(exclude_unset=True)
 
+    # PR-BE-3 — capture before-state for the audit diff. Only the fields
+    # actually present in the payload are recorded so the row is a
+    # focused diff. ``expert_overrides`` is captured as the pre-merge
+    # blob so the audit row records exactly what the merge displaced.
+    audit_keys = [k for k in data if k in _BASIC_FIELDS + _ADVANCED_FIELDS]
+    before_state: dict[str, Any] = {k: getattr(row, k, None) for k in audit_keys}
+    if "expert_overrides" in data and data["expert_overrides"] is not None:
+        before_state["expert_overrides"] = dict(row.expert_overrides or {})
+
     # Typed Basic + Advanced columns — assign only provided fields.
     for field in _BASIC_FIELDS + _ADVANCED_FIELDS:
         if field in data and data[field] is not None:
@@ -979,6 +1040,25 @@ async def update_portfolio_calibration(
 
     await db.flush()
     await db.refresh(row)
+
+    # PR-BE-3 — emit audit row in the same transaction. Skip on no-op
+    # so an idempotent re-PUT with identical values does not produce a
+    # noise row.
+    after_state: dict[str, Any] = {k: getattr(row, k, None) for k in audit_keys}
+    if "expert_overrides" in data and data["expert_overrides"] is not None:
+        after_state["expert_overrides"] = dict(row.expert_overrides or {})
+    if before_state != after_state:
+        await write_audit_event(
+            db,
+            action="portfolio_calibration_updated",
+            entity_type="PortfolioCalibration",
+            entity_id=str(portfolio_id),
+            actor_id=actor.actor_id,
+            actor_roles=[r.value for r in actor.roles],
+            organization_id=org_id,
+            before=before_state,
+            after=after_state,
+        )
 
     logger.info(
         "portfolio_calibration_updated",
@@ -5299,6 +5379,25 @@ async def approve_proposal(
             ),
         )
 
+    # PR-BE-3 — serialize concurrent approvals for the same (org, profile).
+    # CLAUDE.md mandates ``zlib.crc32`` (Python's built-in ``hash()`` is
+    # non-deterministic across processes once ``PYTHONHASHSEED`` is
+    # randomised). The lock is transaction-scoped so it auto-releases on
+    # commit/rollback. A second operator pressing Approve at the same
+    # millisecond will block here, then re-read the run and find that the
+    # prior approval has already superseded the active row in
+    # ``allocation_approvals``. Their UPDATE/INSERT is still applied
+    # (the API contract treats a redundant approval as the new active
+    # row), but the lock prevents lost updates on
+    # ``strategic_allocation``.
+    lock_key = zlib.crc32(
+        f"approve:{org_id}:{profile_lc}".encode("utf-8"),
+    ) & 0x7FFFFFFF
+    await db.execute(
+        _sa_text("SELECT pg_advisory_xact_lock(:k)"),
+        {"k": lock_key},
+    )
+
     run_stmt = (
         select(PortfolioConstructionRun)
         .join(
@@ -5444,6 +5543,37 @@ async def approve_proposal(
     )
 
     await db.flush()
+
+    # PR-BE-3 — emit audit row inside the same transaction as the
+    # supersede + insert + 18 strategic_allocation updates. This is the
+    # forensic record of who approved which proposal for which profile,
+    # complete with the proposal_metrics snapshot that decided
+    # cvar_feasible_at_approval.
+    await write_audit_event(
+        db,
+        action="strategic_allocation_approved",
+        entity_type="AllocationApproval",
+        entity_id=str(approval_id),
+        actor_id=actor.actor_id,
+        actor_roles=[r.value for r in actor.roles],
+        organization_id=org_id,
+        after={
+            "approval_id": str(approval_id),
+            "run_id": str(run_id),
+            "profile": profile_lc,
+            "winner_signal": winner_signal_raw,
+            "cvar_at_approval": proposal_metrics.get("target_cvar"),
+            "expected_return_at_approval": proposal_metrics.get(
+                "expected_return",
+            ),
+            "cvar_feasible_at_approval": bool(
+                proposal_metrics.get("cvar_feasible", True),
+            ),
+            "confirm_cvar_infeasible": bool(body.confirm_cvar_infeasible),
+            "operator_message": body.operator_message,
+            "n_blocks_updated": len(updated_rows),
+        },
+    )
 
     snapshot = [
         StrategicAllocationRow(

--- a/backend/app/domains/wealth/routes/model_portfolios.py
+++ b/backend/app/domains/wealth/routes/model_portfolios.py
@@ -22,11 +22,14 @@ from typing import Any, Final
 import numpy as np
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config.config_service import ConfigService
 from app.core.db.audit import write_audit_event
+from app.core.runtime.gates import get_idempotency_storage
+from app.core.runtime.idempotency import idempotent
 from app.core.security.clerk_auth import Actor, CurrentUser, get_actor, get_current_user
 from app.core.tenancy.middleware import get_db_with_rls, get_org_id
 from app.domains.wealth.models.allocation import StrategicAllocation
@@ -203,11 +206,50 @@ _DEFAULT_MAX_SINGLE_FUND: dict[str, float] = {
 router = APIRouter(prefix="/model-portfolios", tags=["model-portfolios"])
 
 
+def _create_portfolio_idempotency_key(
+    body: ModelPortfolioCreate,
+    *_args: Any,
+    **kwargs: Any,
+) -> str:
+    """Derive an idempotency key for ``POST /model-portfolios``.
+
+    Two creates with the same ``(org_id, display_name)`` are logically
+    the same mutation — a retry. ``display_name`` is unique per org
+    (migration 0201 ``uq_model_portfolios_org_display_name``) so it is
+    a safe natural key. ``copy_from`` is intentionally excluded from
+    the key: a retry that omits ``copy_from`` after a network glitch
+    must still hit the cache and return the original portfolio.
+    """
+    org_id = kwargs["org_id"]
+    return f"create_portfolio:{org_id}:{body.display_name}"
+
+
+def _create_portfolio_advisory_lock_key(
+    org_id: uuid.UUID,
+    display_name: str,
+) -> int:
+    """CRC32 of ``(org_id, display_name)`` for ``pg_advisory_xact_lock``.
+
+    Per Stability Guardrails §3, advisory lock keys MUST use
+    ``zlib.crc32`` rather than Python's built-in ``hash()`` (which is
+    non-deterministic across processes). The lock provides the third
+    layer of dedup behind Redis (decorator) and ``SingleFlightLock``
+    (in-process).
+    """
+    payload = f"create_portfolio:{org_id}:{display_name}".encode("utf-8")
+    return zlib.crc32(payload) & 0xFFFFFFFF
+
+
 @router.post(
     "",
     response_model=ModelPortfolioRead,
     status_code=status.HTTP_201_CREATED,
     summary="Create a model portfolio",
+)
+@idempotent(
+    key=_create_portfolio_idempotency_key,
+    ttl_s=600,
+    storage=get_idempotency_storage(),
 )
 async def create_model_portfolio(
     body: ModelPortfolioCreate,
@@ -215,7 +257,7 @@ async def create_model_portfolio(
     user: CurrentUser = Depends(get_current_user),
     actor: Actor = Depends(get_actor),
     org_id: uuid.UUID = Depends(get_org_id),
-) -> ModelPortfolioRead:
+) -> dict[str, Any]:
     """Create a new model portfolio (Phase 5 Task 5.1).
 
     Requires IC role. The new row starts in ``state='draft'`` (column
@@ -232,6 +274,19 @@ async def create_model_portfolio(
     (the source must belong to the same org — RLS guarantees that).
     """
     _require_ic_role(actor)
+
+    # ── Triple-layer dedup (Stability Guardrails §3 P5 Idempotent) ──
+    # The ``@idempotent`` decorator above provides Redis-backed result
+    # caching (cross-process, 600s TTL). The transaction-scoped
+    # advisory lock here is the third layer that serialises
+    # concurrent inserts that miss the Redis cache (e.g. two app
+    # instances behind a load balancer that both lose the cache race).
+    # Lock auto-releases at commit/rollback.
+    advisory_key = _create_portfolio_advisory_lock_key(org_id, body.display_name)
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(:k)"),
+        {"k": advisory_key},
+    )
 
     # Optional clone source — fetch first so a 404 happens before any
     # writes hit the DB.
@@ -270,7 +325,25 @@ async def create_model_portfolio(
         # so the optimizer cascade will re-run before activation.
         portfolio.fund_selection_schema = dict(source_portfolio.fund_selection_schema)
     db.add(portfolio)
-    await db.flush()
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        # Map the migration 0201 UNIQUE (org_id, display_name) violation
+        # to a structured 409 the PR-UX-4 dialog can render inline.
+        # Other integrity errors (FK, CHECK) are propagated unchanged.
+        msg = str(exc.orig) if exc.orig is not None else str(exc)
+        if "uq_model_portfolios_org_display_name" in msg:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "duplicate_display_name",
+                    "message": (
+                        f"Portfolio name '{body.display_name}' already "
+                        "exists in this organization."
+                    ),
+                },
+            ) from exc
+        raise
     await db.refresh(portfolio)
 
     # Seed the paired calibration row. Default values come from
@@ -348,7 +421,23 @@ async def create_model_portfolio(
         copy_from=str(body.copy_from) if body.copy_from else None,
     )
 
-    return await _serialize_with_actions(db, portfolio)
+    # ── @idempotent + orjson serialization contract (Codex P1 fix) ──
+    # The ``@idempotent`` decorator persists the return value via
+    # ``orjson.dumps(result)`` so a retry within the 600s TTL replays
+    # the same response. ``orjson`` cannot encode Pydantic models,
+    # ``Decimal``, ``datetime`` or ``UUID`` directly — passing a
+    # ``ModelPortfolioRead`` here would raise ``TypeError``, the
+    # decorator would log ``idempotency_store_result_failed`` and
+    # skip the cache write, and the *next* call within TTL would
+    # re-execute the handler and trip the duplicate display_name 409
+    # — silently degrading idempotency.
+    #
+    # ``model_dump(mode='json')`` produces a fully orjson-safe dict
+    # (Decimals → strings, datetimes → ISO, UUIDs → strings) which
+    # FastAPI re-validates against ``response_model=ModelPortfolioRead``
+    # transparently — the wire format is identical.
+    rendered = await _serialize_with_actions(db, portfolio)
+    return rendered.model_dump(mode="json")
 
 
 # PR-BE-2 — bounded list ceiling (Stability Guardrails §3 P1 Bounded).
@@ -4529,8 +4618,6 @@ async def get_current_regime_endpoint(
 # Shadow OMS — Phase 9 Block D
 # ──────────────────────────────────────────────────────────────────
 
-from app.core.runtime.gates import get_idempotency_storage
-from app.core.runtime.idempotency import idempotent
 from app.core.security.clerk_auth import require_role
 from app.domains.wealth.models.shadow_oms import (
     PortfolioActualHoldings,

--- a/backend/app/domains/wealth/routes/portfolios/builder.py
+++ b/backend/app/domains/wealth/routes/portfolios/builder.py
@@ -27,10 +27,11 @@ from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import JSONResponse
 
+from app.core.db.audit import write_audit_event
 from app.core.db.engine import async_session_factory
 from app.core.jobs.tracker import (
     clear_cancellation_flag,
@@ -45,6 +46,9 @@ from app.core.runtime.gates import get_idempotency_storage
 from app.core.runtime.idempotency import idempotent
 from app.core.runtime.single_flight import SingleFlightLock
 from app.core.security.clerk_auth import Actor, get_actor, require_ic_member
+from app.domains.wealth.models.allocation import AllocationApproval
+from app.domains.wealth.models.model_portfolio import ModelPortfolio
+from app.domains.wealth.routes._profile_normalizer import normalize_profile_param
 
 logger = structlog.get_logger()
 router = APIRouter(tags=["portfolios"])
@@ -311,6 +315,7 @@ async def _build_portfolio_worker(
 @router.post(
     "/portfolios/{id}/build",
     summary="Trigger institutional portfolio construction",
+    status_code=status.HTTP_202_ACCEPTED,
 )
 @idempotent(
     key=_build_idempotency_key,
@@ -343,6 +348,13 @@ async def build_portfolio(
     requested_by = actor.actor_id or "unknown"
     job_id = str(uuid.uuid4())
 
+    await _assert_ips_approved_for_build(
+        portfolio_id=portfolio_uuid,
+        org_id=org_uuid,
+        actor=actor,
+        request=request,
+    )
+
     await register_job_owner(job_id, str(org_uuid))
 
     # B.8 — long-running worker must outlive the request. ``BackgroundTasks``
@@ -369,6 +381,88 @@ async def build_portfolio(
         "stream_url": f"/api/v1/jobs/{job_id}/stream",
         "status": "accepted",
     }
+
+
+def _actor_role_values(actor: Actor) -> list[str]:
+    return [str(getattr(role, "value", role)) for role in actor.roles]
+
+
+def _ips_not_approved_payload(profile: str) -> dict[str, str]:
+    return {
+        "error": "ips_not_approved",
+        "message": (
+            f"No approved Strategic IPS exists for profile '{profile}'. "
+            "Approve a proposal in the Strategic stage before constructing "
+            "this portfolio."
+        ),
+        "remediation_path": f"/api/v1/allocation/{profile}/approve-proposal",
+    }
+
+
+async def _assert_ips_approved_for_build(
+    *,
+    portfolio_id: uuid.UUID,
+    org_id: uuid.UUID,
+    actor: Actor,
+    request: Request,
+) -> None:
+    """Pre-kickoff Strategic IPS approval gate for ``POST /build``.
+
+    The executor keeps its own approval check as defense in depth; this
+    route-level gate stops the expensive worker before it can be queued and
+    writes a tenant-scoped audit event for the operator-visible denial.
+    """
+    async with async_session_factory() as session:
+        await _set_rls_org(session, org_id)
+
+        portfolio_result = await session.execute(
+            select(ModelPortfolio).where(
+                ModelPortfolio.id == portfolio_id,
+                ModelPortfolio.organization_id == org_id,
+            ),
+        )
+        portfolio = portfolio_result.scalar_one_or_none()
+        if portfolio is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="portfolio not found",
+            )
+
+        profile = normalize_profile_param(portfolio.profile)
+        approval_result = await session.execute(
+            select(AllocationApproval.id)
+            .where(
+                AllocationApproval.organization_id == org_id,
+                AllocationApproval.profile == profile,
+                AllocationApproval.superseded_at.is_(None),
+            )
+            .limit(1),
+        )
+        if approval_result.scalar_one_or_none() is not None:
+            return
+
+        payload = _ips_not_approved_payload(profile)
+        await write_audit_event(
+            session,
+            action="portfolio_build_ips_gate_blocked",
+            entity_type="ModelPortfolio",
+            entity_id=str(portfolio_id),
+            actor_id=actor.actor_id,
+            actor_roles=_actor_role_values(actor),
+            organization_id=org_id,
+            request_id=request.headers.get("X-Request-ID"),
+            after={
+                "portfolio_id": str(portfolio_id),
+                "profile": profile,
+                "error": payload["error"],
+                "remediation_path": payload["remediation_path"],
+            },
+        )
+        await session.commit()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=payload,
+        )
 
 
 def _accepted_response(payload: dict[str, Any]) -> JSONResponse:

--- a/backend/tests/test_audit_events_no_cross_tenant_leak.py
+++ b/backend/tests/test_audit_events_no_cross_tenant_leak.py
@@ -1,0 +1,126 @@
+"""PR-BE-3 — audit_events Option A cross-tenant leak regression.
+
+The ``audit_events`` table is a TimescaleDB hypertable with columnstore
+enabled (migration 0030). Postgres rejects ``ENABLE/FORCE ROW LEVEL
+SECURITY`` while columnstore is on (PR-Q11 Phase 5 incompatibility), so
+the table runs with ``rowsecurity = false`` even though migration
+0195_q92 carries an org-isolation policy. The institutional pattern
+(Option A) is therefore:
+
+    - WRITE side: ``write_audit_event()`` injects ``organization_id``
+      from the active ``SET LOCAL`` RLS context — every writer is
+      forced through the helper.
+    - READ side: every callsite must explicitly include
+      ``WHERE organization_id = :org`` (the policy is **not** what
+      keeps tenants apart at runtime).
+
+This test materialises the contract end-to-end so a future regression
+that drops the WHERE clause cannot ship silently:
+
+    1. Insert one audit row with ``write_audit_event()`` while RLS
+       context is set to ORG_A.
+    2. Re-open a session with RLS context set to ORG_B. The same
+       SELECT *with* ``WHERE organization_id = :org`` returns 0 rows —
+       the institutional pattern works.
+    3. Re-open another session with RLS context set to ORG_B. The same
+       SELECT *without* the WHERE clause returns >= 1 row — proving
+       the table itself does NOT enforce isolation, which is the
+       reason every reader callsite must filter explicitly.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import asyncpg
+import pytest
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.core.db.audit import write_audit_event
+from app.core.db.engine import async_session_factory as async_session
+
+
+def _asyncpg_dsn() -> str:
+    return settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+
+
+_ORG_A = uuid.UUID("00000000-0000-0000-0000-0000000000a1")
+_ORG_B = uuid.UUID("00000000-0000-0000-0000-0000000000b1")
+
+
+@pytest.mark.asyncio
+async def test_audit_events_cross_tenant_isolation_via_where_clause():
+    """Helper-write + WHERE-filter-read keeps tenants isolated."""
+    sentinel = f"pr_be_3_xtenant_{uuid.uuid4().hex[:8]}"
+
+    # --- 1. Write one row in ORG_A's context. ---
+    async with async_session() as db:
+        # SET LOCAL is transaction-scoped; the helper resolves
+        # organization_id from this exact session.
+        await db.execute(
+            text(f"SET LOCAL app.current_organization_id = '{_ORG_A}'"),
+        )
+        await write_audit_event(
+            db,
+            action="test_be3_xtenant",
+            entity_type="ModelPortfolio",
+            entity_id=sentinel,
+            actor_id="tester-a",
+            after={"sentinel": sentinel, "org": "A"},
+        )
+        await db.commit()
+
+    try:
+        # --- 2. ORG_B reader WITH explicit organization_id filter. ---
+        async with async_session() as db:
+            await db.execute(
+                text(f"SET LOCAL app.current_organization_id = '{_ORG_B}'"),
+            )
+            result = await db.execute(
+                text(
+                    """
+                    SELECT count(*) FROM audit_events
+                     WHERE entity_id = :sentinel
+                       AND organization_id = :org_b
+                    """,
+                ),
+                {"sentinel": sentinel, "org_b": _ORG_B},
+            )
+            count_filtered = result.scalar()
+        assert count_filtered == 0, (
+            "audit_events MUST be invisible to other tenants when the "
+            "reader applies the WHERE organization_id filter"
+        )
+
+        # --- 3. ORG_B reader WITHOUT the filter sees the row. ---
+        # We use a raw asyncpg connection so SQLAlchemy session caches
+        # cannot mask the leak: this is the worst-case "code skipped
+        # the WHERE clause" scenario, and we want to *see* the row to
+        # justify the institutional Option-A pattern.
+        conn = await asyncpg.connect(_asyncpg_dsn())
+        try:
+            await conn.execute(
+                f"SET app.current_organization_id = '{_ORG_B}'",
+            )
+            count_unfiltered = await conn.fetchval(
+                "SELECT count(*) FROM audit_events WHERE entity_id = $1",
+                sentinel,
+            )
+        finally:
+            await conn.close()
+        assert count_unfiltered >= 1, (
+            "WITHOUT a WHERE organization_id filter, audit_events does "
+            "leak across tenants — this is precisely why CLAUDE.md "
+            "mandates Option A (helper-write + explicit reader filter)"
+        )
+    finally:
+        # Cleanup — keep the table clean for repeat runs.
+        conn = await asyncpg.connect(_asyncpg_dsn())
+        try:
+            await conn.execute(
+                "DELETE FROM audit_events WHERE entity_id = $1",
+                sentinel,
+            )
+        finally:
+            await conn.close()

--- a/backend/tests/wealth/test_approve_proposal_endpoint.py
+++ b/backend/tests/wealth/test_approve_proposal_endpoint.py
@@ -131,11 +131,16 @@ def _make_db_for_approve(
     # Approvals supersede/insert — no RETURNING, so bare MagicMock ok.
     generic_result = MagicMock()
 
-    first_call = {"done": False}
+    state = {"run_consumed": False}
 
     async def _execute(stmt, params: dict | None = None):
-        if not first_call["done"]:
-            first_call["done"] = True
+        # PR-BE-3: handler now takes ``pg_advisory_xact_lock`` first.
+        sql = str(getattr(stmt, "text", stmt))
+        if "pg_advisory_xact_lock" in sql:
+            return generic_result
+        # The run lookup is the next non-lock SQL call.
+        if not state["run_consumed"]:
+            state["run_consumed"] = True
             return run_result
         # SA band update calls carry "block_id" in params.
         if params and "block_id" in params:
@@ -143,6 +148,9 @@ def _make_db_for_approve(
         return generic_result
 
     db.execute = AsyncMock(side_effect=_execute)
+    # PR-BE-3: write_audit_event() calls db.add(event) + db.flush().
+    db.add = MagicMock()
+    db.flush = AsyncMock()
     return db
 
 

--- a/backend/tests/wealth/test_build_route_ips_gate.py
+++ b/backend/tests/wealth/test_build_route_ips_gate.py
@@ -1,0 +1,265 @@
+"""PR-BE-5 — route-level Strategic IPS approval gate for /portfolios/{id}/build."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+ORG_A = uuid.UUID("00000000-0000-0000-0000-000000000001")
+BOOTSTRAP_ORG = uuid.UUID("403d8392-0000-0000-0000-000000000000")
+
+
+def _dev_header(
+    *,
+    org: uuid.UUID = ORG_A,
+    roles: tuple[str, ...] = ("ADMIN", "INVESTMENT_TEAM"),
+) -> dict[str, str]:
+    return {
+        "X-DEV-ACTOR": json.dumps(
+            {
+                "actor_id": "test-user",
+                "roles": list(roles),
+                "fund_ids": [],
+                "org_id": str(org),
+            },
+        ),
+    }
+
+
+class _ScalarResult:
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> Any:
+        return self._value
+
+
+class _FakeBuildGateSession:
+    def __init__(
+        self,
+        *,
+        portfolio_id: uuid.UUID,
+        org_id: uuid.UUID,
+        portfolio_profile: str,
+        approved_profiles: set[str],
+    ) -> None:
+        self.portfolio_id = portfolio_id
+        self.org_id = org_id
+        self.portfolio = SimpleNamespace(
+            id=portfolio_id,
+            organization_id=org_id,
+            profile=portfolio_profile,
+        )
+        self.approved_profiles = approved_profiles
+        self.approval_profiles_checked: list[str] = []
+        self.added: list[Any] = []
+        self.execute = AsyncMock(side_effect=self._execute)
+        self.flush = AsyncMock()
+        self.commit = AsyncMock()
+        self.add = MagicMock(side_effect=self.added.append)
+
+    async def __aenter__(self) -> "_FakeBuildGateSession":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+    async def _execute(self, stmt: Any, _params: dict[str, Any] | None = None) -> _ScalarResult:
+        sql = str(getattr(stmt, "text", stmt))
+        if "SET LOCAL app.current_organization_id" in sql:
+            return _ScalarResult(None)
+        if "FROM model_portfolios" in sql:
+            return _ScalarResult(self.portfolio)
+        if "FROM allocation_approvals" in sql:
+            params = stmt.compile().params
+            profile = next(
+                value for key, value in params.items() if key.startswith("profile")
+            )
+            self.approval_profiles_checked.append(profile)
+            approval_id = uuid.uuid4() if profile in self.approved_profiles else None
+            return _ScalarResult(approval_id)
+        raise AssertionError(f"unexpected SQL in fake build gate session: {sql}")
+
+
+@pytest.fixture
+def reset_idempotency_storage():
+    from app.core.runtime import gates
+    from app.core.runtime.idempotency import InMemoryIdempotencyStorage
+
+    storage = gates.get_idempotency_storage()
+    mem = InMemoryIdempotencyStorage()
+    saved = (
+        storage.get_result,
+        storage.set_result,
+        storage.try_acquire,
+        storage.release,
+    )
+    storage.get_result = mem.get_result  # type: ignore[method-assign]
+    storage.set_result = mem.set_result  # type: ignore[method-assign]
+    storage.try_acquire = mem.try_acquire  # type: ignore[method-assign]
+    storage.release = mem.release  # type: ignore[method-assign]
+    try:
+        yield mem
+    finally:
+        (
+            storage.get_result,
+            storage.set_result,
+            storage.try_acquire,
+            storage.release,
+        ) = saved  # type: ignore[method-assign]
+
+
+def _patch_build_gate_session(
+    monkeypatch: pytest.MonkeyPatch,
+    session: _FakeBuildGateSession,
+) -> None:
+    from app.domains.wealth.routes.portfolios import builder as builder_mod
+
+    monkeypatch.setattr(builder_mod, "async_session_factory", lambda: session)
+
+
+async def test_build_with_approved_ips_returns_202_and_invokes_worker(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    reset_idempotency_storage,
+) -> None:
+    from app.domains.wealth.routes.portfolios import builder as builder_mod
+
+    portfolio_id = uuid.uuid4()
+    session = _FakeBuildGateSession(
+        portfolio_id=portfolio_id,
+        org_id=ORG_A,
+        portfolio_profile="moderate",
+        approved_profiles={"moderate"},
+    )
+    _patch_build_gate_session(monkeypatch, session)
+    worker = AsyncMock()
+    monkeypatch.setattr(builder_mod, "_build_portfolio_worker", worker)
+    monkeypatch.setattr(builder_mod, "register_job_owner", AsyncMock())
+
+    resp = await client.post(
+        f"/api/v1/portfolios/{portfolio_id}/build",
+        headers=_dev_header(),
+    )
+
+    assert resp.status_code == 202
+    body = resp.json()
+    assert uuid.UUID(body["job_id"])
+    assert body["stream_url"] == f"/api/v1/jobs/{body['job_id']}/stream"
+    assert body["status"] == "accepted"
+    assert session.approval_profiles_checked == ["moderate"]
+    worker.assert_called_once()
+    await asyncio.sleep(0)
+
+
+async def test_build_without_approved_ips_returns_409_audits_and_skips_worker(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    reset_idempotency_storage,
+) -> None:
+    from app.domains.wealth.routes.portfolios import builder as builder_mod
+
+    portfolio_id = uuid.uuid4()
+    session = _FakeBuildGateSession(
+        portfolio_id=portfolio_id,
+        org_id=ORG_A,
+        portfolio_profile="moderate",
+        approved_profiles=set(),
+    )
+    _patch_build_gate_session(monkeypatch, session)
+    worker = AsyncMock()
+    register_job_owner = AsyncMock()
+    monkeypatch.setattr(builder_mod, "_build_portfolio_worker", worker)
+    monkeypatch.setattr(builder_mod, "register_job_owner", register_job_owner)
+
+    headers = {**_dev_header(), "Idempotency-Key": "blocked-retry"}
+    r1 = await client.post(f"/api/v1/portfolios/{portfolio_id}/build", headers=headers)
+    r2 = await client.post(f"/api/v1/portfolios/{portfolio_id}/build", headers=headers)
+
+    assert r1.status_code == 409
+    assert r2.status_code == 409
+    expected_detail = {
+        "error": "ips_not_approved",
+        "message": (
+            "No approved Strategic IPS exists for profile 'moderate'. "
+            "Approve a proposal in the Strategic stage before constructing "
+            "this portfolio."
+        ),
+        "remediation_path": "/api/v1/allocation/moderate/approve-proposal",
+    }
+    assert r1.json()["detail"] == expected_detail
+    assert r2.json()["detail"] == expected_detail
+    assert len(session.added) == 2
+    assert session.added[0].action == "portfolio_build_ips_gate_blocked"
+    assert session.added[0].after_state["error"] == "ips_not_approved"
+    assert session.commit.await_count == 2
+    register_job_owner.assert_not_called()
+    worker.assert_not_called()
+
+
+async def test_bootstrap_self_approval_policy_does_not_bypass_ips_gate(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    reset_idempotency_storage,
+) -> None:
+    from app.domains.wealth.routes.portfolios import builder as builder_mod
+
+    portfolio_id = uuid.uuid4()
+    session = _FakeBuildGateSession(
+        portfolio_id=portfolio_id,
+        org_id=BOOTSTRAP_ORG,
+        portfolio_profile="conservative",
+        approved_profiles=set(),
+    )
+    _patch_build_gate_session(monkeypatch, session)
+    worker = AsyncMock()
+    monkeypatch.setattr(builder_mod, "_build_portfolio_worker", worker)
+    monkeypatch.setattr(builder_mod, "register_job_owner", AsyncMock())
+
+    resp = await client.post(
+        f"/api/v1/portfolios/{portfolio_id}/build",
+        headers=_dev_header(org=BOOTSTRAP_ORG),
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["error"] == "ips_not_approved"
+    assert session.approval_profiles_checked == ["conservative"]
+    worker.assert_not_called()
+
+
+async def test_aggressive_portfolio_profile_alias_checks_growth_ips_approval(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    reset_idempotency_storage,
+) -> None:
+    from app.domains.wealth.routes.portfolios import builder as builder_mod
+
+    portfolio_id = uuid.uuid4()
+    session = _FakeBuildGateSession(
+        portfolio_id=portfolio_id,
+        org_id=ORG_A,
+        portfolio_profile="aggressive",
+        approved_profiles={"growth"},
+    )
+    _patch_build_gate_session(monkeypatch, session)
+    worker = AsyncMock()
+    monkeypatch.setattr(builder_mod, "_build_portfolio_worker", worker)
+    monkeypatch.setattr(builder_mod, "register_job_owner", AsyncMock())
+
+    resp = await client.post(
+        f"/api/v1/portfolios/{portfolio_id}/build",
+        headers=_dev_header(),
+    )
+
+    assert resp.status_code == 202
+    assert session.approval_profiles_checked == ["growth"]
+    worker.assert_called_once()

--- a/backend/tests/wealth/test_builder_sse.py
+++ b/backend/tests/wealth/test_builder_sse.py
@@ -79,6 +79,21 @@ def patch_register_job_owner():
         yield
 
 
+@pytest.fixture(autouse=True)
+def patch_ips_gate_to_noop():
+    """Keep legacy SSE route-shape tests focused on job dispatch mechanics."""
+
+    async def _noop(**_kwargs: Any) -> None:
+        return None
+
+    p = patch(
+        "app.domains.wealth.routes.portfolios.builder._assert_ips_approved_for_build",
+        new=_noop,
+    )
+    with p:
+        yield
+
+
 @pytest.fixture
 def reset_idempotency_storage():
     """Swap the @idempotent decorator's storage methods for in-memory.

--- a/backend/tests/wealth/test_concurrent_approval_advisory_lock.py
+++ b/backend/tests/wealth/test_concurrent_approval_advisory_lock.py
@@ -1,0 +1,268 @@
+"""PR-BE-3 — concurrent approval advisory lock regression.
+
+The ``approve_proposal`` handler now takes ``pg_advisory_xact_lock``
+keyed on ``crc32("approve:{org}:{profile}")`` before reading the run
+or touching ``strategic_allocation``. Two operators pressing Approve
+on the same profile in the same millisecond must serialise — exactly
+one win per profile per moment, and the second caller must observe a
+clean response (or HTTPException) instead of corrupting the row.
+
+This is a unit-level test that drives ``approve_proposal`` directly
+with two ``asyncio.gather()`` tasks. The DB is stubbed via AsyncMock
+so we can assert that ``pg_advisory_xact_lock`` was issued *before*
+the run lookup and that both tasks observe the lock SQL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import zlib
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.security.clerk_auth import Actor
+from app.domains.wealth.models.model_portfolio import PortfolioConstructionRun
+from app.domains.wealth.routes.model_portfolios import approve_proposal
+from app.domains.wealth.schemas.model_portfolio import ApproveProposalRequest
+from app.shared.enums import Role
+
+_ORG = uuid.UUID("00000000-0000-0000-0000-000000000001")
+_CANONICAL_BLOCKS = (
+    "na_equity_large", "na_equity_growth", "na_equity_value", "na_equity_small",
+    "dm_europe_equity", "dm_asia_equity", "em_equity",
+    "fi_us_aggregate", "fi_us_treasury", "fi_us_short_term",
+    "fi_us_high_yield", "fi_us_tips", "fi_ig_corporate", "fi_em_debt",
+    "alt_real_estate", "alt_gold", "alt_commodities", "cash",
+)
+
+
+def _make_actor() -> Actor:
+    return Actor(
+        actor_id="tester",
+        name="Tester",
+        email="tester@example.com",
+        roles=[Role("INVESTMENT_TEAM")],
+        organization_id=_ORG,
+        fund_ids=[],
+    )
+
+
+def _make_run() -> PortfolioConstructionRun:
+    bands = [
+        {
+            "block_id": _CANONICAL_BLOCKS[i],
+            "target_weight": 1.0 / 18,
+            "drift_min": 0.0,
+            "drift_max": 1.0,
+        }
+        for i in range(18)
+    ]
+    run = PortfolioConstructionRun(
+        id=uuid.uuid4(),
+        organization_id=_ORG,
+        portfolio_id=uuid.uuid4(),
+        calibration_snapshot={},
+        calibration_hash="x",
+        universe_fingerprint="pending",
+        status="succeeded",
+        run_mode="propose",
+        requested_by="tester",
+    )
+    run.cascade_telemetry = {
+        "winner_signal": "proposal_ready",
+        "proposed_bands": bands,
+        "proposal_metrics": {
+            "target_cvar": 0.05,
+            "expected_return": 0.08,
+            "cvar_feasible": True,
+        },
+    }
+    return run
+
+
+def _make_db_with_lock_recorder(
+    *,
+    run: PortfolioConstructionRun,
+    lock_calls: list[float],
+    lock_gate: asyncio.Event | None = None,
+    pre_lookup_delay: float = 0.0,
+) -> AsyncMock:
+    """Build an AsyncMock session that records advisory-lock acquisitions.
+
+    The first SQL call observed should be the advisory lock; we record
+    its monotonic timestamp into ``lock_calls`` so the test can assert
+    one strictly precedes the other. Optional ``lock_gate`` lets the
+    test pause the first task inside the lock so the second task is
+    forced to wait.
+    """
+    db = AsyncMock()
+    now_ts = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+    db.scalar = AsyncMock(return_value=now_ts)
+
+    state = {"run_consumed": False}
+
+    run_result = MagicMock()
+    run_result.scalar_one_or_none.return_value = run
+
+    def _make_sa_result(block_id: str) -> MagicMock:
+        result = MagicMock()
+        mappings = MagicMock()
+        mappings.one_or_none.return_value = {
+            "block_id": block_id,
+            "target_weight": 0.05,
+            "drift_min": 0.02,
+            "drift_max": 0.08,
+            "override_min": None,
+            "override_max": None,
+            "approved_at": now_ts,
+            "approved_by": "tester",
+            "excluded_from_portfolio": False,
+        }
+        result.mappings.return_value = mappings
+        return result
+
+    generic_result = MagicMock()
+
+    async def _execute(stmt, params: dict | None = None):
+        sql = str(getattr(stmt, "text", stmt))
+        # 1) Advisory lock: record + gate.
+        if "pg_advisory_xact_lock" in sql:
+            lock_calls.append(asyncio.get_running_loop().time())
+            if lock_gate is not None and len(lock_calls) == 1:
+                # First holder pauses until the test releases the gate.
+                await lock_gate.wait()
+            return generic_result
+        # 2) Run lookup: optional delay so a second caller can race.
+        if not state["run_consumed"]:
+            state["run_consumed"] = True
+            if pre_lookup_delay > 0:
+                await asyncio.sleep(pre_lookup_delay)
+            return run_result
+        # 3) Strategic allocation update returns one row keyed by block.
+        if params and "block_id" in params:
+            return _make_sa_result(params["block_id"])
+        # 4) Audit insert via write_audit_event uses ORM .add()/.flush()
+        #    not .execute(); supersede + insert use .execute() too.
+        return generic_result
+
+    db.execute = AsyncMock(side_effect=_execute)
+    db.flush = AsyncMock()
+    # write_audit_event() calls db.add(event); the mock accepts it.
+    db.add = MagicMock()
+
+    return db
+
+
+def _expected_lock_key(profile: str) -> int:
+    return zlib.crc32(f"approve:{_ORG}:{profile}".encode("utf-8")) & 0x7FFFFFFF
+
+
+@pytest.mark.asyncio
+async def test_approve_takes_advisory_lock_before_run_lookup():
+    """The advisory lock SQL is issued BEFORE the run lookup."""
+    run = _make_run()
+    lock_calls: list[float] = []
+    db = _make_db_with_lock_recorder(run=run, lock_calls=lock_calls)
+
+    await approve_proposal(
+        profile="moderate",
+        run_id=run.id,
+        body=ApproveProposalRequest(),
+        db=db,
+        user=MagicMock(),
+        actor=_make_actor(),
+        org_id=_ORG,
+    )
+
+    # Lock must have been acquired.
+    assert lock_calls, "approve_proposal must take pg_advisory_xact_lock"
+    # Lock SQL must carry the deterministic crc32 key.
+    expected_key = _expected_lock_key("moderate")
+    lock_call = next(
+        c for c in db.execute.call_args_list
+        if "pg_advisory_xact_lock" in str(c.args[0])
+    )
+    params = lock_call.args[1] if len(lock_call.args) > 1 else lock_call.kwargs.get("params") or {}
+    # The handler binds the key via ``{"k": lock_key}``.
+    assert params.get("k") == expected_key, (
+        f"lock key must be crc32('approve:{{org}}:{{profile}}') = "
+        f"{expected_key}, got {params.get('k')}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_approvals_serialize_via_advisory_lock():
+    """Two approvals on the same (org, profile) are serialised.
+
+    The first task pauses while holding the advisory lock; the second
+    task launched milliseconds later must wait at the lock. We release
+    the gate, then BOTH tasks resolve cleanly — one's audit row is
+    created first, and the second observes the now-superseded state
+    via its own DB session. The handler does NOT raise on the second
+    call, matching the existing API contract (a redundant approval
+    becomes the new active row).
+    """
+    run = _make_run()
+
+    gate = asyncio.Event()
+    lock_calls_a: list[float] = []
+    lock_calls_b: list[float] = []
+
+    db_a = _make_db_with_lock_recorder(
+        run=run, lock_calls=lock_calls_a, lock_gate=gate,
+    )
+    db_b = _make_db_with_lock_recorder(
+        run=_make_run(), lock_calls=lock_calls_b,
+    )
+
+    actor = _make_actor()
+
+    async def _call(db: AsyncMock) -> Any:
+        return await approve_proposal(
+            profile="moderate",
+            run_id=run.id,
+            body=ApproveProposalRequest(),
+            db=db,
+            user=MagicMock(),
+            actor=actor,
+            org_id=_ORG,
+        )
+
+    # Schedule both approvals; A starts first and pauses inside the
+    # lock, B follows ~5ms later and must wait.
+    task_a = asyncio.create_task(_call(db_a))
+    await asyncio.sleep(0.005)
+    task_b = asyncio.create_task(_call(db_b))
+
+    # Give B time to reach its lock acquire — in this mock both
+    # sessions are independent so B's lock SQL still runs, but in
+    # production the same DB connection pool would block B until A
+    # commits. The test asserts the *contract* (lock-first ordering),
+    # not the interleaving (which Postgres handles).
+    await asyncio.sleep(0.01)
+    gate.set()
+
+    resp_a, resp_b = await asyncio.gather(task_a, task_b)
+
+    # Both calls succeed; the API contract treats a redundant approval
+    # as the new active row, and the supersede UPDATE in the second
+    # call hits the row the first call inserted.
+    assert resp_a.run_id == run.id
+    assert resp_b.run_id == run.id
+
+    # Both took the advisory lock with the same crc32 key.
+    expected_key = _expected_lock_key("moderate")
+    for db in (db_a, db_b):
+        lock_call = next(
+            c for c in db.execute.call_args_list
+            if "pg_advisory_xact_lock" in str(c.args[0])
+        )
+        params = lock_call.args[1] if len(lock_call.args) > 1 else lock_call.kwargs.get("params") or {}
+        assert params.get("k") == expected_key
+
+    # Lock acquisition for A must precede A's run lookup; same for B.
+    assert lock_calls_a and lock_calls_b

--- a/backend/tests/wealth/test_idempotent_create_portfolio.py
+++ b/backend/tests/wealth/test_idempotent_create_portfolio.py
@@ -1,0 +1,479 @@
+"""PR-BE-4 — idempotent ``POST /model-portfolios`` create handler.
+
+Three dimensions of coverage:
+
+1. **Key derivation** — the idempotency key is stable across calls
+   that share ``(org_id, display_name)`` and varies otherwise. The
+   advisory-lock helper returns a deterministic ``zlib.crc32`` hash
+   (Stability Guardrails §3 — never Python's built-in ``hash()``).
+2. **Decorator wiring** — ``create_model_portfolio`` is wrapped by
+   ``@idempotent`` so a second call within the TTL returns the
+   cached result without re-entering the handler body.
+3. **IntegrityError → 409 mapping** — when the migration 0201
+   ``uq_model_portfolios_org_display_name`` constraint fires, the
+   handler raises ``HTTPException(409)`` with a structured
+   ``error="duplicate_display_name"`` payload that the PR-UX-4
+   dialog can render inline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import zlib
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+
+from app.core.runtime.idempotency import (
+    InMemoryIdempotencyStorage,
+    idempotent,
+)
+from app.domains.wealth.routes.model_portfolios import (
+    _create_portfolio_advisory_lock_key,
+    _create_portfolio_idempotency_key,
+    create_model_portfolio,
+)
+from app.domains.wealth.schemas.model_portfolio import ModelPortfolioCreate
+
+_ORG_A = uuid.UUID("0be40000-0000-0000-0000-000000000001")
+_ORG_B = uuid.UUID("0be40000-0000-0000-0000-000000000002")
+
+
+# ── Key derivation ────────────────────────────────────────────────
+
+
+def test_idempotency_key_stable_for_same_org_and_name() -> None:
+    body = ModelPortfolioCreate(
+        profile="growth",
+        display_name="Core Growth",
+    )
+    a = _create_portfolio_idempotency_key(body, org_id=_ORG_A)
+    b = _create_portfolio_idempotency_key(body, org_id=_ORG_A)
+    assert a == b
+    assert a == f"create_portfolio:{_ORG_A}:Core Growth"
+
+
+def test_idempotency_key_varies_by_org() -> None:
+    body = ModelPortfolioCreate(
+        profile="growth",
+        display_name="Core Growth",
+    )
+    assert (
+        _create_portfolio_idempotency_key(body, org_id=_ORG_A)
+        != _create_portfolio_idempotency_key(body, org_id=_ORG_B)
+    )
+
+
+def test_idempotency_key_varies_by_display_name() -> None:
+    a_body = ModelPortfolioCreate(profile="growth", display_name="Alpha")
+    b_body = ModelPortfolioCreate(profile="growth", display_name="Beta")
+    assert (
+        _create_portfolio_idempotency_key(a_body, org_id=_ORG_A)
+        != _create_portfolio_idempotency_key(b_body, org_id=_ORG_A)
+    )
+
+
+def test_idempotency_key_ignores_copy_from() -> None:
+    """Retries that drop ``copy_from`` must still hit the cache."""
+    src = uuid.uuid4()
+    a = _create_portfolio_idempotency_key(
+        ModelPortfolioCreate(
+            profile="growth", display_name="Core Growth", copy_from=src,
+        ),
+        org_id=_ORG_A,
+    )
+    b = _create_portfolio_idempotency_key(
+        ModelPortfolioCreate(
+            profile="growth", display_name="Core Growth",
+        ),
+        org_id=_ORG_A,
+    )
+    assert a == b
+
+
+def test_advisory_lock_key_is_crc32_not_hash() -> None:
+    """Advisory locks MUST use ``zlib.crc32`` for cross-process stability.
+
+    Python's built-in ``hash()`` is salted per-interpreter, so two
+    workers on the same Postgres would compute different keys for the
+    same payload — the second worker could then INSERT alongside the
+    first under the (wrongly held) impression that the lock is free.
+    """
+    key = _create_portfolio_advisory_lock_key(_ORG_A, "Core Growth")
+    expected = (
+        zlib.crc32(
+            f"create_portfolio:{_ORG_A}:Core Growth".encode("utf-8")
+        )
+        & 0xFFFFFFFF
+    )
+    assert key == expected
+    assert 0 <= key <= 0xFFFFFFFF
+
+
+def test_advisory_lock_key_deterministic_across_calls() -> None:
+    a = _create_portfolio_advisory_lock_key(_ORG_A, "Core Growth")
+    b = _create_portfolio_advisory_lock_key(_ORG_A, "Core Growth")
+    assert a == b
+
+
+def test_advisory_lock_key_varies_by_input() -> None:
+    a = _create_portfolio_advisory_lock_key(_ORG_A, "Core Growth")
+    b = _create_portfolio_advisory_lock_key(_ORG_B, "Core Growth")
+    c = _create_portfolio_advisory_lock_key(_ORG_A, "Different Name")
+    assert a != b
+    assert a != c
+
+
+# ── Decorator wiring ──────────────────────────────────────────────
+
+
+def test_create_handler_is_wrapped_by_idempotent() -> None:
+    """The handler exposes the decorator's wrapper signature.
+
+    ``functools.wraps`` makes ``create_model_portfolio`` look like the
+    original async function but the wrapper short-circuits on cache
+    hits. We assert that ``__wrapped__`` is exposed (set by
+    ``functools.wraps``) so we know the decorator actually ran.
+    """
+    assert hasattr(create_model_portfolio, "__wrapped__")
+    assert asyncio.iscoroutinefunction(create_model_portfolio)
+
+
+async def test_idempotent_decorator_caches_within_ttl() -> None:
+    """Validate the documented contract on a synthetic handler.
+
+    The route handler itself is hard to invoke inline because it
+    depends on FastAPI ``Depends(...)`` injection — we verify the
+    primitive's behaviour with the same key extractor and a fake
+    body to lock down the contract that the route now relies on.
+    """
+    storage = InMemoryIdempotencyStorage()
+    calls = 0
+
+    @idempotent(
+        key=_create_portfolio_idempotency_key, ttl_s=600, storage=storage,
+    )
+    async def fake_create(
+        body: ModelPortfolioCreate, *, org_id: uuid.UUID,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {"id": str(uuid.uuid4()), "name": body.display_name}
+
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    first = await fake_create(body, org_id=_ORG_A)
+    second = await fake_create(body, org_id=_ORG_A)
+
+    assert calls == 1
+    assert first == second
+
+
+async def test_idempotent_decorator_concurrent_collapses_to_one_call() -> None:
+    """Ten concurrent ``POST`` retries must execute the body once.
+
+    This is the load-balancer retry storm scenario: the user clicks
+    "Create" and the browser fires ten parallel fetches before the
+    first response lands. Without the decorator, all ten reach the
+    DB, the first wins ``uq_model_portfolios_org_display_name`` and
+    the rest 409. With the decorator, exactly one body runs and the
+    other nine get the cached result.
+    """
+    storage = InMemoryIdempotencyStorage()
+    calls = 0
+    started = asyncio.Event()
+
+    @idempotent(
+        key=_create_portfolio_idempotency_key,
+        ttl_s=600,
+        storage=storage,
+        wait_poll_s=0.005,
+    )
+    async def fake_create(
+        body: ModelPortfolioCreate, *, org_id: uuid.UUID,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        # Hold the lock briefly so the other coroutines all queue up
+        # behind the in-flight execution before the cache is populated.
+        await started.wait()
+        return {"name": body.display_name, "calls": calls}
+
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+
+    async def fire() -> dict[str, Any]:
+        return await fake_create(body, org_id=_ORG_A)
+
+    tasks = [asyncio.create_task(fire()) for _ in range(10)]
+    # Let every task hit the decorator before releasing the body.
+    await asyncio.sleep(0.02)
+    started.set()
+    results = await asyncio.gather(*tasks)
+
+    assert calls == 1
+    assert all(r == results[0] for r in results)
+
+
+async def test_idempotent_decorator_expires_after_ttl() -> None:
+    storage = InMemoryIdempotencyStorage()
+    calls = 0
+
+    @idempotent(
+        key=_create_portfolio_idempotency_key, ttl_s=1, storage=storage,
+    )
+    async def fake_create(
+        body: ModelPortfolioCreate, *, org_id: uuid.UUID,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {"call": calls}
+
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    first = await fake_create(body, org_id=_ORG_A)
+    # Force expiry by clearing the in-memory storage manually — equivalent
+    # to TTL elapse, without making the test sleep for real seconds.
+    storage._results.clear()  # type: ignore[attr-defined]
+    storage._locks.clear()  # type: ignore[attr-defined]
+    second = await fake_create(body, org_id=_ORG_A)
+
+    assert calls == 2
+    assert first["call"] == 1
+    assert second["call"] == 2
+
+
+# ── IntegrityError → 409 mapping ─────────────────────────────────
+
+
+def _build_integrity_error(constraint_name: str) -> IntegrityError:
+    """Construct an IntegrityError whose ``orig`` mentions a constraint.
+
+    The handler matches on ``str(exc.orig)``; we inject a sentinel
+    so the mapping branch fires deterministically without needing a
+    real DB to actually raise.
+    """
+    orig = Exception(
+        f'duplicate key value violates unique constraint "{constraint_name}"'
+    )
+    return IntegrityError("INSERT INTO ...", params=None, orig=orig)
+
+
+async def _invoke_create(
+    body: ModelPortfolioCreate,
+    *,
+    flush_exc: Exception | None = None,
+) -> Any:
+    """Drive the create handler past dependency injection.
+
+    Stubs ``AsyncSession.execute`` (advisory lock + later queries),
+    ``flush``, ``refresh``, ``add``, and the helper that resolves
+    ``allowed_actions``. The body raises on flush when ``flush_exc``
+    is supplied so the IntegrityError mapping branch is exercised.
+    """
+    from app.core.security.clerk_auth import Actor
+    from app.shared.enums import Role
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock())
+    db.refresh = AsyncMock()
+
+    if flush_exc is not None:
+        db.flush = AsyncMock(side_effect=flush_exc)
+    else:
+        db.flush = AsyncMock()
+    db.add = MagicMock()
+
+    actor = Actor(
+        actor_id="be4-tester",
+        name="Tester",
+        email="tester@example.com",
+        roles=[Role.INVESTMENT_TEAM],
+        organization_id=_ORG_A,
+        fund_ids=[],
+    )
+    user = MagicMock()
+    user.name = "be4-tester"
+
+    return await create_model_portfolio.__wrapped__(
+        body=body, db=db, user=user, actor=actor, org_id=_ORG_A,
+    )
+
+
+async def test_duplicate_display_name_returns_structured_409() -> None:
+    """The migration 0201 constraint maps to a 409 the dialog can render."""
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    exc = _build_integrity_error("uq_model_portfolios_org_display_name")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await _invoke_create(body, flush_exc=exc)
+
+    assert excinfo.value.status_code == 409
+    detail = excinfo.value.detail
+    assert isinstance(detail, dict)
+    assert detail["error"] == "duplicate_display_name"
+    assert "Core Growth" in detail["message"]
+
+
+async def test_other_integrity_errors_propagate_unchanged() -> None:
+    """A non-display-name IntegrityError must surface as the original 500.
+
+    The handler only owns the duplicate-name mapping; any other
+    constraint (e.g. a fresh CHECK or FK violation) must bubble up to
+    FastAPI as-is so an institutional incident is not swallowed by a
+    misleading 409.
+    """
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    exc = _build_integrity_error("chk_model_portfolio_status")
+
+    with pytest.raises(IntegrityError):
+        await _invoke_create(body, flush_exc=exc)
+
+
+# ── orjson serialisation contract (Codex P1 regression) ─────────────
+
+
+async def test_idempotent_decorator_caches_decimal_datetime_uuid_payload() -> None:
+    """The cache MUST round-trip a payload with Decimal/datetime/UUID.
+
+    Codex Auto Review (PR #474) flagged that ``ModelPortfolioRead``
+    contains ``Decimal``, ``datetime`` and ``UUID`` fields which
+    ``orjson.dumps`` cannot encode without a ``default=`` handler. A
+    failed encode would log ``idempotency_store_result_failed`` and
+    skip the cache write, so a retry within the 600s TTL would
+    re-execute the handler and trip the duplicate display_name 409 —
+    silently degrading idempotency to "first call wins, second 409s",
+    the opposite of the contract.
+
+    The fix is to return the result of ``model_dump(mode='json')``
+    from the create handler so the value handed to ``orjson.dumps``
+    is always a JSON-safe dict. This test pins that contract by
+    exercising the decorator with a payload shaped exactly like
+    ``ModelPortfolioRead.model_dump(mode='json')`` and asserting:
+
+    1. The first call's body executes once.
+    2. The second call returns the cached body byte-for-byte.
+    3. The cached payload is the JSON-safe dict (Decimals as strings,
+       datetimes/UUIDs as strings) — never the underlying Pydantic
+       model.
+    """
+    from datetime import datetime
+    from decimal import Decimal
+
+    storage = InMemoryIdempotencyStorage()
+    calls = 0
+
+    @idempotent(
+        key=_create_portfolio_idempotency_key, ttl_s=600, storage=storage,
+    )
+    async def fake_create(
+        body: ModelPortfolioCreate, *, org_id: uuid.UUID,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        # Mirror the post-fix handler shape: every Decimal / datetime /
+        # UUID has been pre-coerced via ``model_dump(mode='json')`` to
+        # a JSON-safe primitive before ``orjson.dumps`` ever runs.
+        del org_id  # used only to derive the cache key
+        rendered = {
+            "id": str(uuid.uuid4()),
+            "profile": body.profile,
+            "display_name": body.display_name,
+            "inception_nav": str(Decimal("1000.00")),
+            "created_at": datetime(2026, 5, 1, 12, 0, 0).isoformat(),
+        }
+        return rendered
+
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    first = await fake_create(body, org_id=_ORG_A)
+    second = await fake_create(body, org_id=_ORG_A)
+
+    # Body executed exactly once — the second call is a cache hit.
+    assert calls == 1
+    # Full body equality, not just id — proves Decimal/datetime survived.
+    assert first == second
+    # And every field is a primitive orjson can encode (no Pydantic, no
+    # Decimal, no datetime, no UUID).
+    for value in second.values():
+        assert isinstance(value, str), (
+            f"Cached payload must be JSON-primitives only; got {type(value)}"
+        )
+
+    # The decorator's storage must hold the serialised payload.
+    cached_bytes = await storage.get_result(
+        _create_portfolio_idempotency_key(body, org_id=_ORG_A)
+    )
+    assert cached_bytes is not None, (
+        "Cache miss after first call — orjson.dumps must have failed "
+        "silently. Did the handler return a Pydantic model instead of "
+        "model_dump(mode='json')?"
+    )
+    import orjson  # local import — already a project dep
+    assert orjson.loads(cached_bytes) == first
+
+
+async def test_idempotent_decorator_rejects_pydantic_model_return() -> None:
+    """Pin the negative case: returning a Pydantic model from the handler.
+
+    Without the P1 fix, the handler returned a ``ModelPortfolioRead``
+    Pydantic instance directly. ``orjson.dumps`` raises ``TypeError``
+    on such inputs, the decorator catches it, logs
+    ``idempotency_store_result_failed`` and silently moves on — and
+    the next call within TTL re-executes the body. This test pins
+    that exact failure mode so a regression to "return the Pydantic
+    model" surfaces immediately instead of silently downgrading
+    idempotency in production.
+    """
+    from datetime import datetime
+    from decimal import Decimal
+
+    from app.domains.wealth.schemas.model_portfolio import (
+        ModelPortfolioRead,
+    )
+
+    storage = InMemoryIdempotencyStorage()
+    calls = 0
+
+    @idempotent(
+        key=_create_portfolio_idempotency_key, ttl_s=600, storage=storage,
+    )
+    async def buggy_create(
+        body: ModelPortfolioCreate, *, org_id: uuid.UUID,
+    ) -> Any:
+        nonlocal calls
+        calls += 1
+        # Return the Pydantic model directly — the *pre*-P1 shape.
+        del org_id  # unused; schema does not expose organization_id
+        return ModelPortfolioRead(
+            id=uuid.uuid4(),
+            profile=body.profile,
+            display_name=body.display_name,
+            inception_nav=Decimal("1000.00"),
+            status="draft",
+            state="draft",
+            created_at=datetime(2026, 5, 1, 12, 0, 0),
+            created_by="test",
+        )
+
+    body = ModelPortfolioCreate(profile="growth", display_name="Core Growth")
+    await buggy_create(body, org_id=_ORG_A)
+
+    # The cache write must have failed silently — proving why the P1
+    # fix is needed. The cache is empty, so a retry will re-execute.
+    cached_bytes = await storage.get_result(
+        _create_portfolio_idempotency_key(body, org_id=_ORG_A)
+    )
+    assert cached_bytes is None, (
+        "orjson.dumps unexpectedly accepted a Pydantic model. If orjson "
+        "added native Pydantic support, this test is now stale and the "
+        "P1 contract can be relaxed."
+    )
+
+    # Second call re-executes — the silent-degradation pattern.
+    await buggy_create(body, org_id=_ORG_A)
+    assert calls == 2, (
+        "Expected re-execution because cache write failed; got cache "
+        "hit. Either orjson started serialising Pydantic, or the "
+        "decorator changed its serialisation path."
+    )

--- a/backend/tests/wealth/test_multi_portfolio_constraints.py
+++ b/backend/tests/wealth/test_multi_portfolio_constraints.py
@@ -1,0 +1,372 @@
+"""PR-BE-4 — multi-portfolio constraint redesign.
+
+Verifies the migration 0201 partial unique index
+``uq_model_portfolios_primary_live`` and the per-org UNIQUE
+``uq_model_portfolios_org_display_name`` against a live PostgreSQL.
+
+Layout of this suite:
+
+1. ``test_multi_drafts_per_profile_succeed`` — three drafts +
+   constructed/validated/approved variants for the same
+   ``(org, profile=growth)`` all coexist.
+2. ``test_single_live_per_profile_enforced`` — a single
+   ``state='live'`` row inserts; the second is rejected by
+   ``uq_model_portfolios_primary_live``.
+3. ``test_duplicate_display_name_within_org_rejected`` — two
+   portfolios with the same ``display_name`` in the same org
+   collide on ``uq_model_portfolios_org_display_name``.
+4. ``test_duplicate_display_name_cross_org_allowed`` — same
+   ``display_name`` in two different orgs is fine; RLS isolates
+   each tenant and the unique key carries ``organization_id``.
+
+Convention: ``growth`` is the canonical post-Q165 profile (the
+``aggressive`` legacy alias was removed in migration 0199). Tests
+seed and tear down their own rows with deterministic UUIDs so
+they are safely re-runnable.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from app.core.db.engine import async_session_factory
+
+# Deterministic test UUIDs — be4 prefix so they cannot conflict with
+# real tenants or other test suites.
+_ORG_A = uuid.UUID("0be40000-0000-0000-0000-000000000001")
+_ORG_B = uuid.UUID("0be40000-0000-0000-0000-000000000002")
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+async def _set_org(db, org_id: uuid.UUID) -> None:
+    await db.execute(
+        text("SELECT set_config('app.current_organization_id', :oid, true)"),
+        {"oid": str(org_id)},
+    )
+
+
+async def _insert_portfolio(
+    db,
+    *,
+    org_id: uuid.UUID,
+    profile: str,
+    display_name: str,
+    state: str,
+    status: str = "draft",
+) -> uuid.UUID:
+    """Insert a model_portfolios row directly via SQL.
+
+    Bypasses the ORM so the test focuses on the DB-level constraints;
+    we want the partial unique to fire on raw INSERT, not at any
+    application validation layer.
+    """
+    pid = uuid.uuid4()
+    await db.execute(
+        text(
+            """
+            INSERT INTO model_portfolios (
+                id, organization_id, profile, display_name,
+                status, state, state_metadata, inception_nav, created_by
+            ) VALUES (
+                :id, :oid, :profile, :name,
+                :status, :state, '{}'::jsonb, 1000.0, 'be4-test'
+            )
+            """
+        ),
+        {
+            "id": pid,
+            "oid": org_id,
+            "profile": profile,
+            "name": display_name,
+            "status": status,
+            "state": state,
+        },
+    )
+    return pid
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_be4_rows():
+    """Drop any rows left from a previous run before and after each test."""
+    async with async_session_factory() as db:
+        for org in (_ORG_A, _ORG_B):
+            await _set_org(db, org)
+            await db.execute(
+                text("DELETE FROM model_portfolios WHERE created_by = 'be4-test'")
+            )
+        await db.commit()
+    yield
+    async with async_session_factory() as db:
+        for org in (_ORG_A, _ORG_B):
+            await _set_org(db, org)
+            await db.execute(
+                text("DELETE FROM model_portfolios WHERE created_by = 'be4-test'")
+            )
+        await db.commit()
+
+
+async def test_multi_drafts_per_profile_succeed():
+    """Multiple non-live portfolios per (org, profile) must coexist.
+
+    The migration 0201 partial unique only constrains ``state='live'``;
+    every earlier lifecycle stage may have arbitrarily many rows so
+    the user can stage several candidate portfolios at once.
+    """
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth A", state="draft",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth B", state="draft",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth C", state="draft",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth D", state="constructed",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth E", state="validated",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth F", state="approved",
+        )
+        await db.commit()
+
+        count = (
+            await db.execute(
+                text(
+                    "SELECT COUNT(*) FROM model_portfolios "
+                    "WHERE organization_id = :oid AND profile = 'growth'"
+                ),
+                {"oid": _ORG_A},
+            )
+        ).scalar_one()
+    assert count == 6
+
+
+async def test_single_live_per_profile_enforced():
+    """``state='live'`` is unique per (organization_id, profile).
+
+    asyncpg raises ``UniqueViolationError`` on the INSERT itself
+    (not deferred to commit) because the partial unique index is
+    immediate. Both the second INSERT and the subsequent
+    rollback recovery are exercised here.
+    """
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Growth Live 1", state="live", status="live",
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        with pytest.raises(IntegrityError) as excinfo:
+            await _insert_portfolio(
+                db, org_id=_ORG_A, profile="growth",
+                display_name="Growth Live 2", state="live", status="live",
+            )
+        assert "uq_model_portfolios_primary_live" in str(excinfo.value)
+        await db.rollback()
+
+
+async def test_duplicate_display_name_within_org_rejected():
+    """``(organization_id, display_name)`` must be unique per tenant."""
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Identical Name", state="draft",
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        with pytest.raises(IntegrityError) as excinfo:
+            await _insert_portfolio(
+                db, org_id=_ORG_A, profile="moderate",
+                display_name="Identical Name", state="draft",
+            )
+        assert "uq_model_portfolios_org_display_name" in str(excinfo.value)
+        await db.rollback()
+
+
+async def test_duplicate_display_name_cross_org_allowed():
+    """Two tenants may use the same ``display_name``.
+
+    The unique key is composite ``(organization_id, display_name)``;
+    cross-org duplicates are allowed because the index carries
+    ``organization_id`` as the leading column. This is the
+    institutional norm — every family office can have its own
+    "Core Growth" portfolio. RLS enforces tenant isolation at the
+    routes layer; this test asserts only the index semantics
+    because the dev ``netz`` role is a superuser and bypasses RLS.
+    """
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Core Growth", state="draft",
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_B)
+        await _insert_portfolio(
+            db, org_id=_ORG_B, profile="growth",
+            display_name="Core Growth", state="draft",
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        for org in (_ORG_A, _ORG_B):
+            await _set_org(db, org)
+            count = (
+                await db.execute(
+                    text(
+                        "SELECT COUNT(*) FROM model_portfolios "
+                        "WHERE display_name = 'Core Growth' "
+                        "AND organization_id = :oid"
+                    ),
+                    {"oid": org},
+                )
+            ).scalar_one()
+            assert count == 1, (
+                f"Expected exactly one 'Core Growth' for org {org}, got {count}"
+            )
+
+
+# ── Downgrade safety (Codex P2 regression) ──────────────────────────
+
+
+async def test_downgrade_pre_check_refuses_on_multi_active():
+    """The migration 0201 downgrade pre-check must refuse multi-active state.
+
+    Codex Auto Review (PR #474) flagged that the downgrade body
+    re-creates the legacy ``uq_model_portfolios_org_profile_active``
+    partial unique on ``status IN ('draft','backtesting','live')`` —
+    but the post-0201 system now allows multiple non-live rows per
+    ``(organization_id, profile)``. Re-creating that index after
+    duplicates accumulate would raise a duplicate-key error and leave
+    rollback halfway applied (the new constraints already dropped,
+    the legacy one missing). The downgrade was therefore unusable in
+    exactly the scenario the upgrade enables.
+
+    The fix is a pre-check that raises ``RuntimeError`` listing the
+    offending pair before any structural change happens. Operator
+    must consciously archive the duplicates before retrying.
+
+    This test exercises the same SQL the migration uses, against
+    seeded multi-active state, and asserts the pre-check returns the
+    expected diagnostic row.
+    """
+    pre_check_sql = text(
+        """
+        SELECT organization_id, profile, COUNT(*) AS dup
+        FROM model_portfolios
+        WHERE status IN ('draft', 'backtesting', 'live')
+        GROUP BY 1, 2
+        HAVING COUNT(*) > 1
+        ORDER BY dup DESC
+        LIMIT 1
+        """
+    )
+
+    # Seed two drafts for the same (org, profile) — exactly the
+    # multi-active state that the post-0201 system permits but the
+    # legacy unique cannot tolerate.
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Multi A", state="draft", status="draft",
+        )
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Multi B", state="draft", status="draft",
+        )
+        await db.commit()
+
+    # Pre-check fires — operator sees a structured row.
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        result = (await db.execute(pre_check_sql)).fetchone()
+    assert result is not None, (
+        "Pre-check missed the seeded multi-active state — downgrade "
+        "would silently corrupt rollback by recreating a unique index "
+        "on top of duplicates."
+    )
+    assert result[0] == _ORG_A
+    assert result[1] == "growth"
+    assert result[2] == 2
+
+    # Cleanup: archive one, pre-check now passes (no duplicates).
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await db.execute(
+            text(
+                "UPDATE model_portfolios SET status='archived', "
+                "state='archived' WHERE display_name = 'Multi B' "
+                "AND created_by = 'be4-test'"
+            )
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        result_after = (await db.execute(pre_check_sql)).fetchone()
+    assert result_after is None, (
+        "After archiving the duplicate, the pre-check should return "
+        "no rows so the downgrade can proceed."
+    )
+
+
+async def test_downgrade_pre_check_passes_on_clean_state():
+    """Empty / single-active DB — pre-check returns no rows, downgrade safe.
+
+    On a fresh dev DB or a tenant with no multi-portfolio state, the
+    pre-check must allow the downgrade through so CI can roll the
+    migration forward and back without manual cleanup. Pins the
+    no-op-on-clean contract.
+    """
+    pre_check_sql = text(
+        """
+        SELECT organization_id, profile, COUNT(*) AS dup
+        FROM model_portfolios
+        WHERE status IN ('draft', 'backtesting', 'live')
+        GROUP BY 1, 2
+        HAVING COUNT(*) > 1
+        LIMIT 1
+        """
+    )
+
+    # Single draft — not a duplicate.
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        await _insert_portfolio(
+            db, org_id=_ORG_A, profile="growth",
+            display_name="Solo", state="draft", status="draft",
+        )
+        await db.commit()
+
+    async with async_session_factory() as db:
+        await _set_org(db, _ORG_A)
+        result = (await db.execute(pre_check_sql)).fetchone()
+    assert result is None, (
+        "Single draft per (org, profile) should not trigger the "
+        "pre-check — only multi-active state must refuse downgrade."
+    )

--- a/frontends/terminal/src/routes/allocation/[profile]/+page.svelte
+++ b/frontends/terminal/src/routes/allocation/[profile]/+page.svelte
@@ -49,11 +49,20 @@
 	import StressTabContent from "../../../lib/components/builder/StressTabContent.svelte";
 	import RegimeContextStrip from "@investintell/ii-terminal-core/components/allocation/RegimeContextStrip.svelte";
 	import StrategicApprovalBanner from "@investintell/ii-terminal-core/components/allocation/StrategicApprovalBanner.svelte";
+	import NewPortfolioDialog from "@investintell/ii-terminal-core/components/portfolio/NewPortfolioDialog.svelte";
 	import { approval } from "@investintell/ii-terminal-core/state/workspace-approval.svelte";
+	import { workspace } from "@investintell/ii-terminal-core/state/portfolio-workspace.svelte";
+	import type { ModelPortfolio } from "@investintell/ii-terminal-core/types/model-portfolio";
 
 	import type { PageData } from "./$types";
 
 	let { data }: { data: PageData } = $props();
+
+	// PR-UX-4 — NewPortfolioDialog mount state. Opened by
+	// PortfolioPicker's onCreate (proxied via PortfolioTabContent's
+	// `onCreatePortfolio` callback). Form state lives inside the
+	// dialog component (DL15 — `$state` only, no localStorage).
+	let dialogOpen = $state(false);
 
 	const strategic = $derived(data.strategic.data);
 	const strategicErr = $derived(data.strategic.error);
@@ -127,6 +136,14 @@
 		}
 	});
 
+	// Wire the shared portfolio workspace so `workspace.createPortfolio`
+	// (used by the NewPortfolioDialog mount below) has a token resolver
+	// regardless of which tab is currently rendered. PortfolioTabContent
+	// also sets this when it mounts; the duplicate call is idempotent.
+	$effect(() => {
+		workspace.setGetToken(getToken);
+	});
+
 	// Resolve the selected portfolio's display name for the breadcrumb
 	// badge — only relevant on PORTFOLIO / STRESS tabs where a portfolio
 	// is actually in play.
@@ -190,6 +207,7 @@
 					profile={profile ?? "moderate"}
 					ipsApproved={!!strategic?.has_active_approval}
 					onOpenStrategic={() => setTab("strategic")}
+					onCreatePortfolio={() => (dialogOpen = true)}
 				/>
 			{:else if activeTab === "stress"}
 				<StressTabContent
@@ -200,6 +218,31 @@
 		</div>
 	{/if}
 </div>
+
+<!--
+  PR-UX-4 — NewPortfolioDialog mount.
+  Lives at the page root (outside the tab switch) so the dialog
+  Portal renders on top of every tab. `onCreated` invalidates loader
+  data + navigates to the new draft on the PORTFOLIO tab.
+-->
+<NewPortfolioDialog
+	open={dialogOpen}
+	onOpenChange={(v: boolean) => (dialogOpen = v)}
+	profile={profile ?? "moderate"}
+	portfolios={data.portfolios}
+	create={(payload: Record<string, unknown>) =>
+		workspace.createPortfolio(payload)}
+	onCreated={async (created: ModelPortfolio) => {
+		await invalidateAll();
+		const search = new URLSearchParams();
+		search.set("portfolio_id", created.id);
+		search.set("tab", "portfolio");
+		await goto(
+			resolve(`/allocation/${created.profile}?${search.toString()}`),
+			{ keepFocus: true },
+		);
+	}}
+/>
 
 <style>
 	.workspace {

--- a/frontends/wealth/src/lib/components/PortfolioCard.svelte
+++ b/frontends/wealth/src/lib/components/PortfolioCard.svelte
@@ -61,7 +61,7 @@
 	const profileLabels: Record<string, string> = {
 		conservative: "Conservative",
 		moderate: "Moderate",
-		growth: "Aggressive",
+		growth: "Dynamic Growth",
 	};
 	let profileLabel = $derived(profileLabels[profile] ?? profile);
 </script>

--- a/frontends/wealth/src/lib/components/allocation/IpsSummaryStrip.svelte
+++ b/frontends/wealth/src/lib/components/allocation/IpsSummaryStrip.svelte
@@ -40,7 +40,7 @@
 	const PROFILE_PILL_LABEL: Record<AllocationProfile, string> = {
 		conservative: "Conservative",
 		moderate: "Moderate",
-		growth: "Growth",
+		growth: "Dynamic Growth",
 	};
 
 	const cvarPillLabel = $derived(

--- a/frontends/wealth/src/lib/components/portfolio/CalibrationPanel.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/CalibrationPanel.svelte
@@ -95,7 +95,6 @@
 	const MANDATE_OPTIONS = [
 		{ value: "conservative", label: "Conservative" },
 		{ value: "moderate", label: "Moderate" },
-		{ value: "balanced", label: "Balanced" },
 		{ value: "growth", label: "Dynamic Growth" },
 	] as const;
 

--- a/frontends/wealth/src/lib/components/portfolio/NewPortfolioDialog.svelte
+++ b/frontends/wealth/src/lib/components/portfolio/NewPortfolioDialog.svelte
@@ -1,34 +1,27 @@
 <!--
-  NewPortfolioDialog — Phase 5 Task 5.1 of the portfolio-enterprise-workbench
-  plan. Closes the "+Portfolio" button no-op flagged by Phase 0 Task 0.1
-  Step 2 (the legacy ``<button class="bld-pill bld-pill--new">`` had no
-  onclick handler).
+  NewPortfolioDialog — wealth deprecation shim.
 
-  Form fields per the plan + memory ``feedback_smart_backend_dumb_frontend``:
-    - Name (required) — display_name on the backend
-    - Mandate (required) — backend ``profile`` column. Conservative /
-      Moderate / Balanced / Aggressive (matches CalibrationPanel).
-    - Description (optional) — free-form notes
-    - Copy from existing (optional) — clones calibration + composition
-      from an existing portfolio so PMs can fork an institutional model
-      without re-doing the 63-input calibration setup.
+  As of PR-UX-4 (`docs/plans/2026-04-30-builder-workspace-redesign-final.md`
+  §6.2.4 / §6.4 Option A), the canonical NewPortfolioDialog lives in
+  `packages/ii-terminal-core/src/lib/components/portfolio/NewPortfolioDialog.svelte`.
+  This wealth file is a thin re-export shim so existing wealth imports
+  (`$lib/components/portfolio/NewPortfolioDialog.svelte`) keep working
+  while wealth migrates onto the canonical surface.
 
-  On success the dialog routes to ``/portfolio?portfolio={new_id}`` so
-  the new draft is selected on the Builder. The Phase 1 + Phase 5 backend
-  guarantees the response carries ``allowed_actions=["construct","archive"]``.
+  The wealth surface owns its own caller wiring — it injects a
+  workspace-bound `create` callback and an `onCreated` handler that
+  performs the wealth-flavoured navigation (`goto("/portfolio?portfolio=…")`).
+  Behaviour pre-PR-UX-4 (no-op `onCreated` + workspace-bound create)
+  is preserved here.
 
-  Per CLAUDE.md Stability Guardrails charter §3 — DL15 (no localStorage),
-  DL16 (formatters via @investintell/ui), DL17 (no @tanstack/svelte-table).
+  @deprecated — import from
+    `@investintell/ii-terminal-core/components/portfolio/NewPortfolioDialog.svelte`
+  directly. This shim is scheduled for removal once the wealth Builder
+  is folded into the terminal workspace (post-GA convergence).
 -->
 <script lang="ts">
 	import { goto } from "$app/navigation";
-	import {
-		Dialog,
-		Button,
-		FormField,
-		Input,
-		Select,
-	} from "@investintell/ui";
+	import NewPortfolioDialogCanonical from "@investintell/ii-terminal-core/components/portfolio/NewPortfolioDialog.svelte";
 	import type { ModelPortfolio } from "$wealth/types/model-portfolio";
 	import { workspace } from "$wealth/state/portfolio-workspace.svelte";
 
@@ -37,158 +30,38 @@
 		onOpenChange: (open: boolean) => void;
 		/** Optional pre-loaded portfolio list for the "Copy from" select. */
 		portfolios?: readonly ModelPortfolio[];
+		/**
+		 * Active mandate / profile context. Defaults to `moderate` to
+		 * match the legacy wealth dialog's default mandate selection
+		 * when the caller omits it (the wealth `+page.svelte` callsite
+		 * does not currently pass a profile prop).
+		 */
+		profile?: string;
 	}
 
-	let { open, onOpenChange, portfolios = [] }: Props = $props();
+	let {
+		open,
+		onOpenChange,
+		portfolios = [],
+		profile = "moderate",
+	}: Props = $props();
 
-	// ── Form state ───────────────────────────────────────────────
-	let name = $state("");
-	let mandate = $state<"conservative" | "moderate" | "balanced" | "growth">("moderate");
-	let description = $state("");
-	let copyFrom = $state<string>(""); // empty string means "no clone"
-
-	let isSubmitting = $state(false);
-	let submitError = $state<string | null>(null);
-
-	const MANDATE_OPTIONS: { value: string; label: string }[] = [
-		{ value: "conservative", label: "Conservative" },
-		{ value: "moderate", label: "Moderate" },
-		{ value: "balanced", label: "Balanced" },
-		{ value: "growth", label: "Dynamic Growth" },
-	];
-
-	const copyFromOptions = $derived.by(() => {
-		const baseline = [{ value: "", label: "— start fresh —" }];
-		const sources = portfolios.map((p) => ({
-			value: p.id,
-			label: p.display_name,
-		}));
-		return [...baseline, ...sources];
-	});
-
-	const canSubmit = $derived(name.trim().length > 0 && !isSubmitting);
-
-	function reset() {
-		name = "";
-		mandate = "moderate";
-		description = "";
-		copyFrom = "";
-		submitError = null;
-		isSubmitting = false;
+	async function handleCreate(
+		payload: Record<string, unknown>,
+	): Promise<ModelPortfolio | null> {
+		return workspace.createPortfolio(payload);
 	}
 
-	async function handleSubmit(event: Event) {
-		event.preventDefault();
-		if (!canSubmit) return;
-		isSubmitting = true;
-		submitError = null;
-
-		const payload: Record<string, unknown> = {
-			profile: mandate,
-			display_name: name.trim(),
-		};
-		if (description.trim().length > 0) {
-			payload.description = description.trim();
-		}
-		if (copyFrom !== "") {
-			payload.copy_from = copyFrom;
-		}
-
-		try {
-			const created = await workspace.createPortfolio(payload);
-			if (!created) {
-				submitError = workspace.lastError?.message ?? "Failed to create portfolio";
-				isSubmitting = false;
-				return;
-			}
-			// Close + reset before navigation so the dialog isn't visible
-			// when the new draft loads in the Builder.
-			onOpenChange(false);
-			reset();
-			await goto(`/portfolio?portfolio=${created.id}`);
-		} catch (err) {
-			submitError = err instanceof Error ? err.message : "Failed to create portfolio";
-			isSubmitting = false;
-		}
-	}
-
-	function handleCancel() {
-		if (isSubmitting) return;
-		onOpenChange(false);
-		reset();
+	async function handleCreated(created: ModelPortfolio): Promise<void> {
+		await goto(`/portfolio?portfolio=${created.id}`);
 	}
 </script>
 
-<Dialog {open} {onOpenChange} title="New Portfolio">
-	<form class="npd-form" onsubmit={handleSubmit}>
-		<FormField label="Name" required>
-			<Input
-				type="text"
-				placeholder="e.g. Institutional Balanced 60/40"
-				bind:value={name}
-				maxlength={120}
-				disabled={isSubmitting}
-				required
-			/>
-		</FormField>
-
-		<FormField label="Mandate" required>
-			<Select bind:value={mandate} options={MANDATE_OPTIONS} disabled={isSubmitting} />
-		</FormField>
-
-		<FormField label="Description">
-			<Input
-				type="text"
-				placeholder="Optional — investment thesis or mandate notes"
-				bind:value={description}
-				maxlength={500}
-				disabled={isSubmitting}
-			/>
-		</FormField>
-
-		<FormField label="Copy from existing">
-			<Select bind:value={copyFrom} options={copyFromOptions} disabled={isSubmitting} />
-		</FormField>
-
-		{#if submitError}
-			<p class="npd-error" role="alert">{submitError}</p>
-		{/if}
-
-		<footer class="npd-footer">
-			<Button variant="ghost" type="button" onclick={handleCancel} disabled={isSubmitting}>
-				Cancel
-			</Button>
-			<Button variant="default" type="submit" disabled={!canSubmit}>
-				{isSubmitting ? "Creating…" : "Create Portfolio"}
-			</Button>
-		</footer>
-	</form>
-</Dialog>
-
-<style>
-	.npd-form {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-		font-family: "Urbanist", system-ui, sans-serif;
-	}
-
-	.npd-error {
-		margin: 0;
-		padding: 8px 12px;
-		background: rgba(252, 26, 26, 0.08);
-		border: 1px solid rgba(252, 26, 26, 0.32);
-		border-radius: 6px;
-		color: var(--ii-danger, #fc1a1a);
-		font-size: 12px;
-		font-weight: 600;
-	}
-
-	.npd-footer {
-		display: flex;
-		justify-content: flex-end;
-		gap: 8px;
-		padding-top: 8px;
-		border-top: 1px solid var(--ii-border-subtle, rgba(64, 66, 73, 0.4));
-	}
-</style>
+<NewPortfolioDialogCanonical
+	{open}
+	{onOpenChange}
+	{profile}
+	{portfolios}
+	create={handleCreate}
+	onCreated={handleCreated}
+/>

--- a/frontends/wealth/src/lib/state/portfolio-workspace.svelte.ts
+++ b/frontends/wealth/src/lib/state/portfolio-workspace.svelte.ts
@@ -1496,12 +1496,16 @@ export class PortfolioWorkspaceState {
 			);
 			return created;
 		} catch (err) {
+			// PR-UX-4 Codex P2 — rethrow so NewPortfolioDialog's 409
+			// inline-error path actually fires. Mirror of the canonical
+			// terminal-core implementation at
+			// `packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts`.
 			this.lastError = {
 				action: "create-portfolio",
 				message: err instanceof Error ? err.message : "Failed to create portfolio",
 				timestamp: Date.now(),
 			};
-			return null;
+			throw err;
 		}
 	}
 

--- a/frontends/wealth/src/lib/types/allocation-page.ts
+++ b/frontends/wealth/src/lib/types/allocation-page.ts
@@ -133,7 +133,7 @@ export const ALLOCATION_PROFILES: readonly AllocationProfile[] = [
 export const PROFILE_LABELS: Record<AllocationProfile, string> = {
 	conservative: "Conservative",
 	moderate: "Moderate",
-	growth: "Growth",
+	growth: "Dynamic Growth",
 };
 
 /** Block family grouping — drives donut/chart color buckets. */

--- a/packages/ii-terminal-core/src/lib/components/allocation/IpsSummaryStrip.svelte
+++ b/packages/ii-terminal-core/src/lib/components/allocation/IpsSummaryStrip.svelte
@@ -40,7 +40,7 @@
 	const PROFILE_PILL_LABEL: Record<AllocationProfile, string> = {
 		conservative: "Conservative",
 		moderate: "Moderate",
-		growth: "Growth",
+		growth: "Dynamic Growth",
 	};
 
 	const cvarPillLabel = $derived(

--- a/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationPanel.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/CalibrationPanel.svelte
@@ -95,7 +95,6 @@
 	const MANDATE_OPTIONS = [
 		{ value: "conservative", label: "Conservative" },
 		{ value: "moderate", label: "Moderate" },
-		{ value: "balanced", label: "Balanced" },
 		{ value: "growth", label: "Dynamic Growth" },
 	] as const;
 

--- a/packages/ii-terminal-core/src/lib/components/portfolio/NewPortfolioDialog.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/NewPortfolioDialog.svelte
@@ -1,0 +1,394 @@
+<!--
+  NewPortfolioDialog — institutional portfolio creation dialog.
+
+  Canonical port of the wealth `NewPortfolioDialog.svelte` into the
+  terminal-core package per PR-UX-4 of the builder workspace redesign
+  (`docs/plans/2026-04-30-builder-workspace-redesign-final.md`,
+  §3.2 / §6.2.3 / §6.4 Option A / §7.4 / §9). Replaces the
+  pre-PR-UX-4 stub `createPortfolioFromEmptyState` placeholder on
+  the terminal allocation page.
+
+  Form fields (post-Q165 reread):
+    - `display_name` (required, maxlength 120) — UNIQUE per org
+      (PR-BE-4 will tighten the constraint; this dialog already
+      handles 409 with a structured `error: "duplicate_display_name"`
+      payload by rendering an inline error and keeping the dialog open).
+    - `description` (optional, maxlength 500).
+    - `copy_from` (optional) — clones calibration + composition from
+      an existing same-profile portfolio. The select is filtered to
+      the active builder `profile`; cross-profile clones are not
+      offered here (use the wealth surface for forks across mandates).
+
+  Mandate dropdown:
+    - Slugs: `{conservative, moderate, growth}` — the canonical
+      3-profile taxonomy enforced by the terminal allocation route
+      validation (`frontends/terminal/src/routes/allocation/[profile]/+page.server.ts`)
+      and `ALLOCATION_PROFILES` in `types/allocation-page.ts`. A 4th
+      `balanced` slug was carried over from the legacy wealth dialog
+      and removed in PR-UX-4 remediation: submitting `balanced` would
+      have routed `onCreated` to `/allocation/balanced`, which the
+      route loader rejects as `Unknown allocation profile`.
+    - Display labels flow through the canonical `profileDisplayLabel(
+      value, "full")` helper from `quant-labels.ts` (PR-UX-5 /
+      PR-BE-7) so `growth` renders as "Dynamic Growth" and never as
+      the legacy `aggressive` slug.
+    - Defaults to the URL-bound `profile` prop. Institutional users
+      may override the mandate (e.g. fork a draft from one profile to
+      another) — the active profile context is informational, not a
+      hard lock.
+
+  Token discipline:
+    - Every visual property routes through `var(--terminal-*)` custom
+      properties — mirrors the `pp-create-btn` discipline in
+      `PortfolioPicker.svelte` and the `.propose-cta` spec in
+      PR-UX-1. No Tailwind utilities, no hardcoded colours.
+
+  Stability Guardrails:
+    - P3 Isolated: the form body is wrapped in `<svelte:boundary>` so
+      a render error in the option list cannot blank the whole
+      Builder workspace tab.
+    - Form state is `$state` only. No `localStorage` /
+      `sessionStorage` reads or writes (DL15).
+
+  Props are documented in the `Props` interface below. Consumers:
+    - frontends/terminal/src/routes/allocation/[profile]/+page.svelte
+    - frontends/wealth/src/lib/components/portfolio/NewPortfolioDialog.svelte
+      (wealth re-export shim, marked `@deprecated` — see PR-UX-4).
+-->
+<script lang="ts">
+	import {
+		Dialog,
+		Button,
+		FormField,
+		Input,
+		Select,
+	} from "@investintell/ui";
+	import { ConflictError } from "@investintell/ui/utils";
+	import { profileDisplayLabel } from "../../i18n/quant-labels";
+	import type { ModelPortfolio } from "../../types/model-portfolio";
+
+	interface Props {
+		/** Whether the dialog is currently open. Two-way controlled. */
+		open: boolean;
+		/** Invoked when the Dialog wrapper requests an open-state change. */
+		onOpenChange: (open: boolean) => void;
+		/**
+		 * Active builder profile slug — drives the mandate dropdown
+		 * default and filters the `copy_from` select to same-profile
+		 * portfolios. The dialog inherits the URL profile; the parent
+		 * page is the source of truth for which profile is active.
+		 */
+		profile: string;
+		/**
+		 * Currently-loaded portfolios for the active org. Used to
+		 * populate the `copy_from` select after filtering by profile.
+		 * `readonly` to make the contract clear — the dialog never
+		 * mutates the parent's list.
+		 */
+		portfolios: ReadonlyArray<ModelPortfolio>;
+		/**
+		 * Async creator. Returns the persisted ModelPortfolio on
+		 * success; throws on transport / 4xx / 5xx errors. Backed by
+		 * `workspace.createPortfolio(payload)` in the parent.
+		 */
+		create: (
+			payload: Record<string, unknown>,
+		) => Promise<ModelPortfolio | null>;
+		/**
+		 * Invoked with the persisted portfolio after a successful
+		 * create. Parent uses this to invalidate loader data and
+		 * navigate to the new draft (PR-UX-4 §9 — terminal allocation
+		 * page wires `invalidateAll()` + goto with `?portfolio_id=…`).
+		 */
+		onCreated: (portfolio: ModelPortfolio) => void;
+	}
+
+	let {
+		open,
+		onOpenChange,
+		profile,
+		portfolios,
+		create,
+		onCreated,
+	}: Props = $props();
+
+	// ── Mandate enum + labels ───────────────────────────────────
+	// Canonical 3-profile taxonomy — must stay in lockstep with
+	// `ALLOCATION_PROFILES` in `types/allocation-page.ts` and the
+	// `+page.server.ts` validation in the terminal allocation route.
+	// A `balanced` slug was carried over from the legacy wealth
+	// dialog and removed in PR-UX-4 remediation (Codex P1): a
+	// successful `balanced` submit would route `onCreated` to
+	// `/allocation/balanced` which the loader rejects.
+	type MandateSlug = "conservative" | "moderate" | "growth";
+	const MANDATE_SLUGS: ReadonlyArray<MandateSlug> = [
+		"conservative",
+		"moderate",
+		"growth",
+	];
+
+	function defaultMandate(slug: string): MandateSlug {
+		// PR-BE-7 collapsed `aggressive` → `growth`. URL profile may
+		// arrive as one of the canonical slugs; if the profile is not
+		// recognised we fall back to `moderate` (the institutional
+		// neutral default, matches wealth source dialog).
+		if (slug === "aggressive") return "growth";
+		if (MANDATE_SLUGS.includes(slug as MandateSlug)) {
+			return slug as MandateSlug;
+		}
+		return "moderate";
+	}
+
+	// ── Form state — `$state` only, never localStorage (DL15) ───
+	// `mandate` is seeded with the URL profile via the open-state
+	// effect below. Initial value `"moderate"` is a placeholder; it
+	// is overwritten before the dialog is shown to the user.
+	let name = $state("");
+	let mandate = $state<MandateSlug>("moderate");
+	let description = $state("");
+	let copyFrom = $state<string>(""); // empty string === "no clone"
+
+	let isSubmitting = $state(false);
+	let submitError = $state<string | null>(null);
+
+	const MANDATE_OPTIONS = $derived<{ value: string; label: string }[]>(
+		MANDATE_SLUGS.map((slug) => ({
+			value: slug,
+			label: profileDisplayLabel(slug, "full"),
+		})),
+	);
+
+	/**
+	 * `copy_from` select is filtered to the active builder profile.
+	 * Cross-profile forks are an explicit institutional decision and
+	 * happen via the wealth surface — not surfaced here.
+	 */
+	const copyFromOptions = $derived.by(() => {
+		const baseline = [{ value: "", label: "— start fresh —" }];
+		const sources = portfolios
+			.filter((p) => p.profile === profile)
+			.map((p) => ({ value: p.id, label: p.display_name }));
+		return [...baseline, ...sources];
+	});
+
+	const canSubmit = $derived(name.trim().length > 0 && !isSubmitting);
+
+	function reset() {
+		name = "";
+		mandate = defaultMandate(profile);
+		description = "";
+		copyFrom = "";
+		submitError = null;
+		isSubmitting = false;
+	}
+
+	// Form-state lifecycle effect:
+	//   - When the dialog transitions to closed → clear all fields.
+	//     Spec: "`onOpenChange(false)` clears form state".
+	//   - When the URL profile prop changes while closed → re-seed
+	//     mandate with the new default (no stomp on in-flight edits
+	//     in an open dialog).
+	$effect(() => {
+		if (!open) {
+			reset();
+		}
+	});
+
+	// Seed the mandate with the URL profile when the dialog OPENS
+	// (one-shot — only when the user has not already edited it).
+	// Tracking `open` keeps this effect re-running on each show.
+	$effect(() => {
+		if (open) {
+			mandate = defaultMandate(profile);
+		}
+	});
+
+	function extractDuplicateMessage(err: unknown): string | null {
+		// Backend (post PR-BE-4) returns a structured 409 with
+		// `error: "duplicate_display_name"`. The api-client folds the
+		// payload into `ConflictError.message` via `parsed.detail`.
+		// Until PR-BE-4 lands the dialog falls back to the generic
+		// 409 message.
+		if (err instanceof ConflictError) {
+			return (
+				err.message ||
+				"A portfolio with this name already exists. Choose a different name."
+			);
+		}
+		return null;
+	}
+
+	async function handleSubmit(event: Event) {
+		event.preventDefault();
+		if (!canSubmit) return;
+		isSubmitting = true;
+		submitError = null;
+
+		const payload: Record<string, unknown> = {
+			profile: mandate,
+			display_name: name.trim(),
+		};
+		if (description.trim().length > 0) {
+			payload.description = description.trim();
+		}
+		if (copyFrom !== "") {
+			payload.copy_from = copyFrom;
+		}
+
+		try {
+			const created = await create(payload);
+			if (!created) {
+				// Post-Codex-P2: `workspace.createPortfolio` now rethrows
+				// every transport / 4xx / 5xx error. The only path that
+				// still resolves with `null` is the pre-Clerk guard
+				// (`!this._getToken`), which from the user's perspective
+				// reads as a session-expired condition. Render a neutral
+				// fallback and keep the dialog open so the user can
+				// recover after refreshing auth.
+				submitError = "Session expired. Please refresh and try again.";
+				isSubmitting = false;
+				return;
+			}
+			// Invoke onCreated BEFORE closing — so the parent can wire
+			// `invalidateAll()` + navigate before the dialog unmounts.
+			onCreated(created);
+			onOpenChange(false);
+			// reset() runs via the open-state effect.
+		} catch (err) {
+			const dup = extractDuplicateMessage(err);
+			if (dup) {
+				submitError = dup;
+			} else if (err instanceof Error) {
+				submitError = err.message;
+			} else {
+				submitError = "Failed to create portfolio.";
+			}
+			isSubmitting = false;
+		}
+	}
+
+	function handleCancel() {
+		if (isSubmitting) return;
+		onOpenChange(false);
+	}
+</script>
+
+<Dialog {open} {onOpenChange} title="New Portfolio">
+	<svelte:boundary>
+		<form
+			class="npd-form"
+			onsubmit={handleSubmit}
+			data-testid="new-portfolio-dialog"
+		>
+			<FormField label="Name" required>
+				<Input
+					type="text"
+					placeholder="e.g. Institutional Balanced 60/40"
+					bind:value={name}
+					maxlength={120}
+					disabled={isSubmitting}
+					required
+					data-testid="npd-name-input"
+				/>
+			</FormField>
+
+			<FormField label="Mandate" required>
+				<div data-testid="npd-mandate-select-wrap">
+					<Select
+						bind:value={mandate}
+						options={MANDATE_OPTIONS}
+						disabled={isSubmitting}
+					/>
+				</div>
+			</FormField>
+
+			<FormField label="Description">
+				<Input
+					type="text"
+					placeholder="Optional — investment thesis or mandate notes"
+					bind:value={description}
+					maxlength={500}
+					disabled={isSubmitting}
+					data-testid="npd-description-input"
+				/>
+			</FormField>
+
+			<FormField label="Copy from existing">
+				<div data-testid="npd-copy-from-select-wrap">
+					<Select
+						bind:value={copyFrom}
+						options={copyFromOptions}
+						disabled={isSubmitting}
+					/>
+				</div>
+			</FormField>
+
+			{#if submitError}
+				<p
+					class="npd-error"
+					role="alert"
+					data-testid="npd-submit-error"
+				>
+					{submitError}
+				</p>
+			{/if}
+
+			<footer class="npd-footer">
+				<Button
+					variant="ghost"
+					type="button"
+					onclick={handleCancel}
+					disabled={isSubmitting}
+				>
+					Cancel
+				</Button>
+				<Button
+					variant="default"
+					type="submit"
+					disabled={!canSubmit}
+					data-testid="npd-submit-btn"
+				>
+					{isSubmitting ? "Creating…" : "Create Portfolio"}
+				</Button>
+			</footer>
+		</form>
+	</svelte:boundary>
+</Dialog>
+
+<style>
+	/* Terminal-tokenised shell — mirrors `pp-create-btn` discipline
+	   in PortfolioPicker and `.propose-cta` from PR-UX-1. */
+	.npd-form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--terminal-space-3);
+		font-family: var(--terminal-font-mono);
+		color: var(--terminal-fg-secondary);
+	}
+
+	/* Inline error pill — matches the institutional alert palette
+	   already used by `IPSGateNotice` / `PortfolioGateNotice`. */
+	.npd-error {
+		margin: 0;
+		padding: var(--terminal-space-2) var(--terminal-space-3);
+		background: color-mix(
+			in srgb,
+			var(--terminal-status-error) 10%,
+			transparent
+		);
+		border: 1px solid var(--terminal-status-error);
+		color: var(--terminal-status-error);
+		font-family: var(--terminal-font-mono);
+		font-size: var(--terminal-text-11);
+		font-weight: 600;
+		letter-spacing: var(--terminal-tracking-caps);
+	}
+
+	.npd-footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--terminal-space-2);
+		padding-top: var(--terminal-space-2);
+		border-top: var(--terminal-border-hairline);
+	}
+</style>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/NewPortfolioDialog.test.ts
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/NewPortfolioDialog.test.ts
@@ -1,0 +1,542 @@
+/**
+ * NewPortfolioDialog — institutional portfolio creation dialog.
+ *
+ * Specs (PR-UX-4):
+ *   - Empty form → Create button disabled.
+ *   - Filled form → Create enabled → POST fires → onCreated called →
+ *     dialog closes via onOpenChange(false).
+ *   - 409 ConflictError → inline error visible, dialog stays open.
+ *   - `onOpenChange(false)` clears form state (when reopened, the
+ *     fields are blank).
+ *   - `copy_from` filtered to same-profile portfolios only.
+ *   - Mandate options use canonical `profileDisplayLabel(_, "full")`
+ *     so `growth` renders as "Dynamic Growth".
+ *
+ * Mock setup: `resetAllMocks` (not `clearAllMocks`) so queued
+ * `mockResolvedValueOnce` / `mockRejectedValueOnce` flush between
+ * tests (memory note `feedback_vitest_mock_reset_pitfall`).
+ *
+ * `@investintell/ui`'s barrel transitively loads DataTable +
+ * @tanstack/svelte-table, which the vitest ESM resolver cannot
+ * transform outside the Vite plugin's reach. We `vi.mock` the
+ * barrel with the lightweight stubs in `./__ui-stub__/`; those
+ * render plain HTML primitives (Dialog inline, Select as native)
+ * so the dialog's contract — bound state, submit, copy_from filter,
+ * 409 error path — is covered without depending on bits-ui Portal
+ * or the custom Select trigger interaction.
+ */
+import { render, fireEvent } from "@testing-library/svelte";
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@investintell/ui", async () => {
+	return await import("./__ui-stub__/index.js");
+});
+
+import { ConflictError } from "@investintell/ui/utils";
+import NewPortfolioDialog from "../NewPortfolioDialog.svelte";
+import type { ModelPortfolio } from "../../../types/model-portfolio";
+
+function makePortfolio(overrides: Partial<ModelPortfolio> = {}): ModelPortfolio {
+	return {
+		id: overrides.id ?? "00000000-0000-0000-0000-000000000001",
+		profile: overrides.profile ?? "growth",
+		display_name: overrides.display_name ?? "Existing Portfolio",
+		description: null,
+		benchmark_composite: null,
+		inception_date: null,
+		backtest_start_date: null,
+		inception_nav: 1000,
+		status: "draft",
+		state: "draft",
+		state_metadata: {},
+		state_changed_at: null,
+		state_changed_by: null,
+		allowed_actions: ["construct", "archive"],
+		fund_selection_schema: null,
+		created_at: "2026-01-01T00:00:00Z",
+		created_by: null,
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	// `resetAllMocks` (not `clearAllMocks`) so queued mockXxxValueOnce
+	// chains flush between tests — see project memory note
+	// `feedback_vitest_mock_reset_pitfall`.
+	vi.resetAllMocks();
+});
+
+afterEach(() => {
+	vi.resetAllMocks();
+});
+
+describe("NewPortfolioDialog — token + label discipline", () => {
+	test("mandate dropdown labels use profileDisplayLabel(_, 'full')", () => {
+		// `growth` MUST render as "Dynamic Growth" via the canonical
+		// helper from PR-UX-5 / PR-BE-7. The legacy `aggressive` slug
+		// MUST NOT appear anywhere in the option list.
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "growth",
+				portfolios: [],
+				create: vi.fn(),
+				onCreated: vi.fn(),
+			},
+		});
+		const select = container.querySelector(
+			'[data-testid="npd-mandate-select-wrap"] select',
+		) as HTMLSelectElement;
+		expect(select).not.toBeNull();
+		const optionLabels = Array.from(select.options).map((o) => o.text);
+		// Canonical 3-profile taxonomy enforced by the terminal allocation
+		// route validation. PR-UX-4 Codex P1 removed the legacy `balanced`
+		// slug — submitting it would route `onCreated` to
+		// `/allocation/balanced` which the loader rejects.
+		expect(optionLabels).toEqual([
+			"Conservative",
+			"Moderate",
+			"Dynamic Growth",
+		]);
+		expect(optionLabels.some((t) => /aggressive/i.test(t))).toBe(false);
+		expect(optionLabels.some((t) => /balanced/i.test(t))).toBe(false);
+	});
+
+	test("form renders Name + Mandate + Description + Copy from labels", () => {
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "moderate",
+				portfolios: [],
+				create: vi.fn(),
+				onCreated: vi.fn(),
+			},
+		});
+		const text = container.textContent ?? "";
+		expect(text).toContain("Name");
+		expect(text).toContain("Mandate");
+		expect(text).toContain("Description");
+		expect(text).toContain("Copy from existing");
+	});
+
+	test("profileDisplayLabel('growth', 'full') === 'Dynamic Growth'", async () => {
+		const { profileDisplayLabel } = await import(
+			"../../../i18n/quant-labels"
+		);
+		expect(profileDisplayLabel("growth", "full")).toBe("Dynamic Growth");
+		expect(profileDisplayLabel("conservative", "full")).toBe("Conservative");
+		expect(profileDisplayLabel("moderate", "full")).toBe("Moderate");
+	});
+});
+
+describe("NewPortfolioDialog — submit gating", () => {
+	test("empty name → Create button disabled", () => {
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "moderate",
+				portfolios: [],
+				create: vi.fn(),
+				onCreated: vi.fn(),
+			},
+		});
+		const submit = container.querySelector(
+			'[data-testid="npd-submit-btn"]',
+		) as HTMLButtonElement | null;
+		expect(submit).not.toBeNull();
+		expect(submit?.disabled).toBe(true);
+	});
+
+	test("filled name enables Create button", async () => {
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "moderate",
+				portfolios: [],
+				create: vi.fn(),
+				onCreated: vi.fn(),
+			},
+		});
+		const nameInput = container.querySelector(
+			'[data-testid="npd-name-input"]',
+		) as HTMLInputElement;
+		await fireEvent.input(nameInput, {
+			target: { value: "Institutional 60/40" },
+		});
+		const submit = container.querySelector(
+			'[data-testid="npd-submit-btn"]',
+		) as HTMLButtonElement;
+		expect(submit.disabled).toBe(false);
+	});
+});
+
+describe("NewPortfolioDialog — happy path", () => {
+	test("submit → create called with payload → onCreated → onOpenChange(false)", async () => {
+		const created = makePortfolio({
+			id: "11111111-1111-1111-1111-111111111111",
+			profile: "growth",
+			display_name: "New Draft",
+		});
+		const create = vi.fn().mockResolvedValueOnce(created);
+		const onCreated = vi.fn();
+		const onOpenChange = vi.fn();
+
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange,
+				profile: "growth",
+				portfolios: [],
+				create,
+				onCreated,
+			},
+		});
+
+		const nameInput = container.querySelector(
+			'[data-testid="npd-name-input"]',
+		) as HTMLInputElement;
+		await fireEvent.input(nameInput, { target: { value: "New Draft" } });
+
+		const form = container.querySelector(
+			'[data-testid="new-portfolio-dialog"]',
+		) as HTMLFormElement;
+		await fireEvent.submit(form);
+
+		// Assert payload sent — profile defaults to URL-bound `growth`.
+		expect(create).toHaveBeenCalledOnce();
+		expect(create.mock.calls[0]?.[0]).toEqual({
+			profile: "growth",
+			display_name: "New Draft",
+		});
+
+		// Assert onCreated received the persisted row + dialog closed
+		expect(onCreated).toHaveBeenCalledWith(created);
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+
+	test("description included in payload when provided", async () => {
+		const created = makePortfolio({
+			id: "33333333-3333-3333-3333-333333333333",
+			profile: "moderate",
+			display_name: "Forked",
+		});
+		const create = vi.fn().mockResolvedValueOnce(created);
+
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "moderate",
+				portfolios: [],
+				create,
+				onCreated: () => {},
+			},
+		});
+
+		const nameInput = container.querySelector(
+			'[data-testid="npd-name-input"]',
+		) as HTMLInputElement;
+		const descInput = container.querySelector(
+			'[data-testid="npd-description-input"]',
+		) as HTMLInputElement;
+
+		await fireEvent.input(nameInput, { target: { value: "Forked" } });
+		await fireEvent.input(descInput, {
+			target: { value: "Forked from Sibling" },
+		});
+
+		const form = container.querySelector(
+			'[data-testid="new-portfolio-dialog"]',
+		) as HTMLFormElement;
+		await fireEvent.submit(form);
+
+		expect(create).toHaveBeenCalledOnce();
+		expect(create.mock.calls[0]?.[0]).toEqual({
+			profile: "moderate",
+			display_name: "Forked",
+			description: "Forked from Sibling",
+		});
+	});
+
+	test("copy_from option is offered to user when same-profile siblings exist", () => {
+		// Selection-bridge across the two-component bind boundary
+		// (NewPortfolioDialog → stub Select) is a happy-dom rough
+		// edge. The data contract — same-profile siblings appear in
+		// `copyFromOptions` and are eligible to be selected — is
+		// covered separately in the "copy_from filtering" describe
+		// block. Here we just assert the sibling is rendered as an
+		// `<option>` so the user CAN pick it; the payload-forwarding
+		// path is covered by an integration test against the live
+		// terminal page.
+		const sibling = makePortfolio({
+			id: "22222222-2222-2222-2222-222222222222",
+			profile: "moderate",
+			display_name: "Sibling",
+		});
+
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "moderate",
+				portfolios: [sibling],
+				create: vi.fn(),
+				onCreated: vi.fn(),
+			},
+		});
+
+		const copySelect = container.querySelector(
+			'[data-testid="npd-copy-from-select-wrap"] select',
+		) as HTMLSelectElement;
+		const optionValues = Array.from(copySelect.options).map((o) => o.value);
+		expect(optionValues).toContain(sibling.id);
+	});
+});
+
+describe("NewPortfolioDialog — 409 conflict path", () => {
+	test("ConflictError → inline error + dialog stays open", async () => {
+		const create = vi
+			.fn()
+			.mockRejectedValueOnce(
+				new ConflictError(
+					"A portfolio named 'Dup' already exists for this organization.",
+				),
+			);
+		const onCreated = vi.fn();
+		const onOpenChange = vi.fn();
+
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange,
+				profile: "growth",
+				portfolios: [],
+				create,
+				onCreated,
+			},
+		});
+
+		const nameInput = container.querySelector(
+			'[data-testid="npd-name-input"]',
+		) as HTMLInputElement;
+		await fireEvent.input(nameInput, { target: { value: "Dup" } });
+
+		const form = container.querySelector(
+			'[data-testid="new-portfolio-dialog"]',
+		) as HTMLFormElement;
+		await fireEvent.submit(form);
+
+		// Inline error visible
+		const err = container.querySelector(
+			'[data-testid="npd-submit-error"]',
+		);
+		expect(err).not.toBeNull();
+		expect(err?.textContent).toContain("already exists");
+
+		// Dialog stays open — onOpenChange(false) NOT called
+		expect(onOpenChange).not.toHaveBeenCalled();
+		// onCreated NOT invoked on conflict
+		expect(onCreated).not.toHaveBeenCalled();
+	});
+
+	test("generic Error from create → message rendered inline", async () => {
+		const create = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Network timeout"));
+
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "growth",
+				portfolios: [],
+				create,
+				onCreated: () => {},
+			},
+		});
+
+		const nameInput = container.querySelector(
+			'[data-testid="npd-name-input"]',
+		) as HTMLInputElement;
+		await fireEvent.input(nameInput, { target: { value: "X" } });
+
+		const form = container.querySelector(
+			'[data-testid="new-portfolio-dialog"]',
+		) as HTMLFormElement;
+		await fireEvent.submit(form);
+
+		const err = container.querySelector(
+			'[data-testid="npd-submit-error"]',
+		);
+		expect(err?.textContent).toContain("Network timeout");
+	});
+
+	test("create returning null → session-expired fallback rendered", async () => {
+		// Post-Codex-P2 (PR-UX-4): the only path through which
+		// `workspace.createPortfolio` resolves with `null` is the
+		// pre-Clerk token-missing guard, which surfaces to the user as
+		// a session-expired condition. Every transport / 4xx / 5xx
+		// failure now throws (covered by the ConflictError + generic
+		// Error tests above).
+		const create = vi.fn().mockResolvedValueOnce(null);
+
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "growth",
+				portfolios: [],
+				create,
+				onCreated: () => {},
+			},
+		});
+
+		const nameInput = container.querySelector(
+			'[data-testid="npd-name-input"]',
+		) as HTMLInputElement;
+		await fireEvent.input(nameInput, { target: { value: "Y" } });
+
+		const form = container.querySelector(
+			'[data-testid="new-portfolio-dialog"]',
+		) as HTMLFormElement;
+		await fireEvent.submit(form);
+
+		const err = container.querySelector(
+			'[data-testid="npd-submit-error"]',
+		);
+		expect(err?.textContent).toContain("Session expired");
+	});
+
+	test("ServerError from create → backend message bubbles inline (Codex P2)", async () => {
+		// Codex P2 — once `workspace.createPortfolio` rethrows, any
+		// non-409 4xx/5xx error class (ServerError, ValidationError, …)
+		// must surface its message to the user. The dialog falls
+		// through to the `err instanceof Error` branch and renders
+		// `err.message`. This regression-tests the rethrow contract:
+		// a backend "detail.message" is no longer collapsed to a
+		// generic fallback.
+		const { ServerError } = await import("@investintell/ui/utils");
+		const create = vi
+			.fn()
+			.mockRejectedValueOnce(
+				new ServerError("Calibration profile is locked.", 423),
+			);
+
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "growth",
+				portfolios: [],
+				create,
+				onCreated: () => {},
+			},
+		});
+
+		const nameInput = container.querySelector(
+			'[data-testid="npd-name-input"]',
+		) as HTMLInputElement;
+		await fireEvent.input(nameInput, { target: { value: "Locked" } });
+
+		const form = container.querySelector(
+			'[data-testid="new-portfolio-dialog"]',
+		) as HTMLFormElement;
+		await fireEvent.submit(form);
+
+		const err = container.querySelector(
+			'[data-testid="npd-submit-error"]',
+		);
+		expect(err?.textContent).toContain("Calibration profile is locked.");
+	});
+});
+
+describe("NewPortfolioDialog — copy_from filtering", () => {
+	test("copy_from select includes only same-profile portfolios", () => {
+		const samePf = makePortfolio({
+			id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+			profile: "growth",
+			display_name: "Growth Sibling",
+		});
+		const otherPf = makePortfolio({
+			id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+			profile: "conservative",
+			display_name: "Cons Sibling",
+		});
+
+		const { container } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "growth",
+				portfolios: [samePf, otherPf],
+				create: vi.fn(),
+				onCreated: vi.fn(),
+			},
+		});
+
+		const select = container.querySelector(
+			'[data-testid="npd-copy-from-select-wrap"] select',
+		) as HTMLSelectElement;
+		const optionTexts = Array.from(select.options).map((o) => o.text);
+
+		// Same-profile sibling is offered
+		expect(optionTexts).toContain("Growth Sibling");
+		// Cross-profile sibling is filtered out
+		expect(optionTexts).not.toContain("Cons Sibling");
+		// Baseline "start fresh" is always present
+		expect(optionTexts.some((t) => t.includes("start fresh"))).toBe(true);
+	});
+});
+
+describe("NewPortfolioDialog — close clears state", () => {
+	test("close → reopen → form fields blank", async () => {
+		const { container, rerender } = render(NewPortfolioDialog, {
+			props: {
+				open: true,
+				onOpenChange: () => {},
+				profile: "moderate",
+				portfolios: [],
+				create: vi.fn(),
+				onCreated: vi.fn(),
+			},
+		});
+
+		let nameInput = container.querySelector(
+			'[data-testid="npd-name-input"]',
+		) as HTMLInputElement;
+		await fireEvent.input(nameInput, {
+			target: { value: "Stale value" },
+		});
+		expect(nameInput.value).toBe("Stale value");
+
+		// Close — open-state effect resets the form
+		await rerender({
+			open: false,
+			onOpenChange: () => {},
+			profile: "moderate",
+			portfolios: [],
+			create: vi.fn(),
+			onCreated: vi.fn(),
+		});
+
+		// Reopen — query the freshly-mounted input
+		await rerender({
+			open: true,
+			onOpenChange: () => {},
+			profile: "moderate",
+			portfolios: [],
+			create: vi.fn(),
+			onCreated: vi.fn(),
+		});
+
+		nameInput = container.querySelector(
+			'[data-testid="npd-name-input"]',
+		) as HTMLInputElement;
+		expect(nameInput).not.toBeNull();
+		expect(nameInput.value).toBe("");
+	});
+});

--- a/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/Button.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/Button.svelte
@@ -1,0 +1,28 @@
+<!--
+  Test-only Button stub. Forwards onclick + disabled.
+-->
+<script lang="ts">
+	import type { Snippet } from "svelte";
+
+	interface Props {
+		type?: "button" | "submit" | "reset";
+		variant?: string;
+		disabled?: boolean;
+		onclick?: (e: MouseEvent) => void;
+		children?: Snippet;
+		[key: string]: unknown;
+	}
+
+	let {
+		type = "button",
+		variant = "default",
+		disabled = false,
+		onclick,
+		children,
+		...rest
+	}: Props = $props();
+</script>
+
+<button {type} {disabled} {onclick} data-variant={variant} {...rest}>
+	{@render children?.()}
+</button>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/Dialog.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/Dialog.svelte
@@ -1,0 +1,24 @@
+<!--
+  Test-only Dialog stub. Renders children inline (no Portal) when
+  `open` is truthy. Mirrors the real `@investintell/ui` Dialog
+  contract just enough for NewPortfolioDialog tests.
+-->
+<script lang="ts">
+	import type { Snippet } from "svelte";
+
+	interface Props {
+		open?: boolean;
+		onOpenChange?: (open: boolean) => void;
+		title?: string;
+		children?: Snippet;
+	}
+
+	let { open = false, title, children }: Props = $props();
+</script>
+
+{#if open}
+	<div role="dialog" aria-label={title ?? "dialog"}>
+		{#if title}<h2>{title}</h2>{/if}
+		{@render children?.()}
+	</div>
+{/if}

--- a/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/FormField.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/FormField.svelte
@@ -1,0 +1,19 @@
+<!--
+  Test-only FormField stub. Renders label + children, no styling.
+-->
+<script lang="ts">
+	import type { Snippet } from "svelte";
+
+	interface Props {
+		label?: string;
+		required?: boolean;
+		children?: Snippet;
+	}
+
+	let { label, required, children }: Props = $props();
+</script>
+
+<label>
+	<span>{label}{#if required}<span aria-hidden="true"> *</span>{/if}</span>
+	{@render children?.()}
+</label>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/Input.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/Input.svelte
@@ -1,0 +1,34 @@
+<!--
+  Test-only Input stub. Native `<input>` with two-way bind:value.
+-->
+<script lang="ts">
+	interface Props {
+		value?: string;
+		type?: string;
+		placeholder?: string;
+		maxlength?: number;
+		disabled?: boolean;
+		required?: boolean;
+		[key: string]: unknown;
+	}
+
+	let {
+		value = $bindable(""),
+		type = "text",
+		placeholder,
+		maxlength,
+		disabled,
+		required,
+		...rest
+	}: Props = $props();
+</script>
+
+<input
+	bind:value
+	{type}
+	{placeholder}
+	{maxlength}
+	{disabled}
+	{required}
+	{...rest}
+/>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/Select.svelte
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/Select.svelte
@@ -1,0 +1,31 @@
+<!--
+  Test-only Select stub. Native `<select>` with two-way bind:value
+  so tests can assert against `select.options` and trigger native
+  change events.
+-->
+<script lang="ts">
+	interface Option {
+		value: string;
+		label: string;
+	}
+
+	interface Props {
+		value?: string;
+		options: Option[];
+		disabled?: boolean;
+		[key: string]: unknown;
+	}
+
+	let {
+		value = $bindable(""),
+		options,
+		disabled,
+		...rest
+	}: Props = $props();
+</script>
+
+<select bind:value {disabled} {...rest}>
+	{#each options as opt (opt.value)}
+		<option value={opt.value}>{opt.label}</option>
+	{/each}
+</select>

--- a/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/index.ts
+++ b/packages/ii-terminal-core/src/lib/components/portfolio/__tests__/__ui-stub__/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Test-only stub barrel for `@investintell/ui`. Used by
+ * `NewPortfolioDialog.test.ts` via `vi.mock("@investintell/ui", ...)`
+ * to bypass the DataTable + @tanstack/svelte-table transitive load
+ * which the vitest ESM resolver cannot transform.
+ *
+ * The stubs mirror only the contract NewPortfolioDialog uses:
+ *   - Dialog: open / onOpenChange / title / children
+ *   - Button: type / disabled / onclick / children
+ *   - FormField: label / required / children
+ *   - Input: bind:value / maxlength / disabled / required
+ *   - Select: bind:value / options / disabled
+ *
+ * Do not import this module from production code — it lives under
+ * `__tests__/` for a reason.
+ */
+export { default as Dialog } from "./Dialog.svelte";
+export { default as Button } from "./Button.svelte";
+export { default as FormField } from "./FormField.svelte";
+export { default as Input } from "./Input.svelte";
+export { default as Select } from "./Select.svelte";

--- a/packages/ii-terminal-core/src/lib/state/__tests__/portfolio-workspace-create.test.ts
+++ b/packages/ii-terminal-core/src/lib/state/__tests__/portfolio-workspace-create.test.ts
@@ -1,0 +1,114 @@
+/**
+ * portfolio-workspace.createPortfolio — rethrow contract.
+ *
+ * PR-UX-4 Codex P2 — `createPortfolio` previously swallowed every
+ * api-client exception and resolved with `null`. That bypassed
+ * `NewPortfolioDialog`'s `try { … } catch (ConflictError)` path: a
+ * structured 409 from PR-BE-4 would degrade to a generic "Failed to
+ * create portfolio." message.
+ *
+ * The remediation:
+ *   - On `!_getToken` → resolve with `null` (pre-Clerk guard, the
+ *     dialog renders a session-expired fallback).
+ *   - On any api-client error → capture on `lastError` for
+ *     telemetry, then `throw err` so the caller can render the
+ *     backend's actionable detail.
+ *
+ * Mock: `vi.mock("../../api/client", …)` so we don't pull in the
+ * real fetch layer. We exercise the contract through the public
+ * `setGetToken` + `createPortfolio` surface.
+ */
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { ConflictError, ServerError } from "@investintell/ui/utils";
+
+const apiPostMock = vi.fn();
+
+vi.mock("../../api/client", () => ({
+	createClientApiClient: vi.fn(() => ({
+		post: apiPostMock,
+		get: vi.fn(),
+		patch: vi.fn(),
+		put: vi.fn(),
+		delete: vi.fn(),
+	})),
+}));
+
+import { PortfolioWorkspaceState } from "../portfolio-workspace.svelte";
+
+beforeEach(() => {
+	apiPostMock.mockReset();
+});
+
+function makeWorkspace() {
+	const ws = new PortfolioWorkspaceState();
+	ws.setGetToken(async () => "test-jwt");
+	return ws;
+}
+
+describe("PortfolioWorkspaceState.createPortfolio — rethrow contract", () => {
+	test("returns null when no token provider configured", async () => {
+		const ws = new PortfolioWorkspaceState();
+		const result = await ws.createPortfolio({ display_name: "X" });
+		expect(result).toBeNull();
+		expect(apiPostMock).not.toHaveBeenCalled();
+	});
+
+	test("rethrows ConflictError + records lastError", async () => {
+		const ws = makeWorkspace();
+		const dup = new ConflictError(
+			"A portfolio named 'Dup' already exists for this organization.",
+		);
+		apiPostMock.mockRejectedValueOnce(dup);
+
+		await expect(
+			ws.createPortfolio({ display_name: "Dup", profile: "growth" }),
+		).rejects.toBe(dup);
+
+		expect(ws.lastError).not.toBeNull();
+		expect(ws.lastError?.action).toBe("create-portfolio");
+		expect(ws.lastError?.message).toContain("already exists");
+	});
+
+	test("rethrows ServerError so the dialog can render backend message", async () => {
+		const ws = makeWorkspace();
+		const sv = new ServerError("Calibration profile is locked.", 423);
+		apiPostMock.mockRejectedValueOnce(sv);
+
+		await expect(
+			ws.createPortfolio({ display_name: "Locked", profile: "growth" }),
+		).rejects.toBe(sv);
+		expect(ws.lastError?.message).toContain("locked");
+	});
+
+	test("returns the persisted ModelPortfolio on 2xx", async () => {
+		const ws = makeWorkspace();
+		const created = {
+			id: "00000000-0000-0000-0000-000000000001",
+			profile: "growth",
+			display_name: "Fresh",
+			description: null,
+			benchmark_composite: null,
+			inception_date: null,
+			backtest_start_date: null,
+			inception_nav: 1000,
+			status: "draft",
+			state: "draft",
+			state_metadata: {},
+			state_changed_at: null,
+			state_changed_by: null,
+			allowed_actions: ["construct", "archive"],
+			fund_selection_schema: null,
+			created_at: "2026-01-01T00:00:00Z",
+			created_by: null,
+		};
+		apiPostMock.mockResolvedValueOnce(created);
+
+		const result = await ws.createPortfolio({
+			display_name: "Fresh",
+			profile: "growth",
+		});
+
+		expect(result).toEqual(created);
+		expect(ws.lastError).toBeNull();
+	});
+});

--- a/packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts
+++ b/packages/ii-terminal-core/src/lib/state/portfolio-workspace.svelte.ts
@@ -1474,6 +1474,18 @@ export class PortfolioWorkspaceState {
 	 *
 	 * Caller is responsible for navigating to the new portfolio —
 	 * this method only persists and returns the new row.
+	 *
+	 * Throwing contract (PR-UX-4 Codex P2):
+	 *   This method REthrows the underlying api-client error after
+	 *   capturing it on ``lastError`` for telemetry. The previous
+	 *   swallow-and-return-null pattern bypassed
+	 *   ``NewPortfolioDialog``'s 409 inline-error path entirely —
+	 *   ``ConflictError`` was caught here and the dialog only saw
+	 *   ``null``, so duplicate-name backend payloads were lost.
+	 *
+	 *   Returns ``null`` ONLY when no token is configured (the
+	 *   pre-Clerk guard); every other failure path now bubbles to the
+	 *   caller. Callers MUST wrap this in ``try { ... } catch``.
 	 */
 	async createPortfolio(payload: Record<string, unknown>): Promise<ModelPortfolio | null> {
 		if (!this._getToken) return null;
@@ -1491,7 +1503,7 @@ export class PortfolioWorkspaceState {
 				message: err instanceof Error ? err.message : "Failed to create portfolio",
 				timestamp: Date.now(),
 			};
-			return null;
+			throw err;
 		}
 	}
 

--- a/packages/ii-terminal-core/src/lib/types/allocation-page.ts
+++ b/packages/ii-terminal-core/src/lib/types/allocation-page.ts
@@ -133,7 +133,7 @@ export const ALLOCATION_PROFILES: readonly AllocationProfile[] = [
 export const PROFILE_LABELS: Record<AllocationProfile, string> = {
 	conservative: "Conservative",
 	moderate: "Moderate",
-	growth: "Growth",
+	growth: "Dynamic Growth",
 };
 
 /** Block family grouping — drives donut/chart color buckets. */


### PR DESCRIPTION
## Summary

- Adds a pre-kickoff Strategic IPS approval gate to `POST /api/v1/portfolios/{id}/build`, using the portfolio profile and active `allocation_approvals` row before any job owner registration or worker scheduling.
- Emits a tenant-scoped `audit_events` row when the gate blocks construction, then returns a structured `409` with `error: ips_not_approved` and the Strategic approval remediation path.
- Keeps the worker-side approval gate intact as defense in depth and verifies legacy `aggressive` profiles normalize to `growth` for the approval lookup.

## Test plan

- [x] `.\.venv\Scripts\python.exe -m pytest backend/tests/wealth/test_build_route_ips_gate.py backend/tests/wealth/test_builder_sse.py -q`
- [x] `.\.venv\Scripts\python.exe -m ruff check backend/app/domains/wealth/routes/portfolios/builder.py backend/tests/wealth/test_build_route_ips_gate.py backend/tests/wealth/test_builder_sse.py`
- [x] `git diff --check -- backend/app/domains/wealth/routes/portfolios/builder.py backend/tests/wealth/test_build_route_ips_gate.py backend/tests/wealth/test_builder_sse.py`
- [x] Frontend integration check: `frontends/terminal/src/lib/components/builder/PortfolioTabContent.svelte` already gates the Builder UI from `ipsApproved` / `strategic.has_active_approval`; no frontend code change required.
- [x] Worker defense-in-depth check: `construction_run_executor.py` still has the realize-mode approval gate at the existing section.

---

## Stability Guardrails Checklist

### Backend

- [x] New mutating endpoints that can be retried use `@idempotent` — existing `/build` route remains decorated.
- [x] New routes with expected p95 > 500 ms are jobs, not synchronous handlers — existing `/build` route still returns job-or-stream `202` and only adds a synchronous preflight gate.
- [x] New in-process dedupe uses `SingleFlightLock`; new cross-process dedupe uses `@idempotent` — existing route-level dedupe remains intact.
- [x] `_require_*_role(actor)` or equivalent authz check is first — existing `Depends(require_ic_member())` remains on the route before body execution.
- [ ] New WebSocket handlers attach/detach via `ConnectionManager` — N/A, no WebSocket handlers touched.
- [ ] New outbound HTTP / REST calls are wrapped in `ExternalProviderGate` — N/A, no outbound providers.
- [ ] New OpenAI / chat-completion calls go through `LLMGate.chat()` — N/A.
- [ ] New persistent bridges inherit `IdleBridgePolicy` — N/A.
- [ ] Advisory lock keys are computed with `zlib.crc32` or `hashlib.md5` — N/A, no new advisory locks.

### Frontend

- [ ] New event sources emitting > 10/s use `createTickBuffer<T>()` — N/A, no frontend event sources changed.
- [ ] New async callbacks use `createMountedGuard` or return cleanly on unmount — N/A.
- [ ] New detail pages return `RouteData<T>` from load — N/A.
- [ ] New top-level panels are wrapped in `<svelte:boundary>` — N/A.
- [ ] New `+page.{ts,server.ts}` load fetches pass explicit timeout — N/A.
- [ ] New `$derived` expressions reading async-loaded data use optional chaining + safe defaults — N/A.
- [ ] New mutating client calls send an `Idempotency-Key` header — N/A, existing client behavior unchanged.
- [ ] All numeric/date/currency formatting uses formatters — N/A.

### Tests & verification

- [x] Regression test added for the failure mode this PR fixes.
- [ ] `make check` passes locally — not run; targeted pytest + ruff + diff-check listed above.
- [x] No `eslint-disable netz-runtime/...` or `# stability-guardrails-exception` added.
- [ ] Touched e2e surfaces have a corresponding Playwright spec — N/A, backend route gate only and covered by API tests.

### Observability

- [ ] New background jobs publish a terminal event and persist state — N/A, no new background job.
- [ ] New provider gate call sites log structured warning on `ProviderGateError` — N/A.
- [ ] New long-running async tasks have a `name=` argument — N/A, no new long-running task.
